### PR TITLE
fix(ci): Remove path filter from Skill Weight Pipeline for deterministic gate

### DIFF
--- a/.github/workflows/skill-weight-regression.yml
+++ b/.github/workflows/skill-weight-regression.yml
@@ -2,19 +2,13 @@ name: Skill Weight Pipeline — Regression Gate
 
 # ─── Trigger ────────────────────────────────────────────────────────────────
 # Required check: blocks PR merge to main/develop if any of the 28+ tests fail.
-# Also runs on push to main so the baseline is verified after every merge.
+# Runs on EVERY PR to ensure deterministic required status check.
+# Previous path-based filter removed to support branch protection rules.
 on:
   pull_request:
     branches: [ main, develop, feature/* ]
-    paths:
-      # Run when pipeline code or tests change
-      - 'app/services/skill_progression_service.py'
-      - 'app/services/tournament/tournament_participation_service.py'
-      - 'app/services/tournament/tournament_reward_orchestrator.py'
-      - 'app/api/api_v1/endpoints/tournaments/create.py'
-      - 'tests/unit/tournament/test_skill_weight_pipeline.py'
-      # Always run when workflow itself changes
-      - '.github/workflows/skill-weight-regression.yml'
+    # REMOVED: paths filter (was blocking PRs that don't touch skill weight files)
+    # Reason: Required checks must run on ALL PRs for GitHub branch protection
   push:
     branches: [ main, develop ]
 


### PR DESCRIPTION
## 🎯 Purpose

Makes **Skill Weight Pipeline** a deterministic required check for branch protection by removing path-based trigger filter.

---

## 🚨 Problem

**Current state:**
```yaml
on:
  pull_request:
    paths:  # ← BLOCKS unrelated PRs!
      - 'app/services/skill_progression_service.py'
      - 'app/services/tournament/tournament_participation_service.py'
      [... specific files only ...]
```

**Impact:**
- Workflow only runs when specific files change
- ❌ Cannot be **required check** in branch protection
- ❌ PRs touching RELEASE_POLICY.md → workflow doesn't run → merge blocked!
- ❌ Non-deterministic gate behavior

---

## ✅ Solution

**Remove path filter:**
```yaml
on:
  pull_request:
    branches: [ main, develop, feature/* ]
    # REMOVED: paths filter
    # Runs on EVERY PR
```

**Result:**
- ✅ Workflow runs on ALL PRs
- ✅ Can be required check in branch protection
- ✅ Deterministic gate: always runs, always validates

---

## 📊 Impact Analysis

**CI Runtime:**
- Added time per PR: **~2 minutes** (28 tests, typically <2 min)
- Total PR time: **~7 minutes** (5 min baseline + 2 min skill weight)

**Benefit:**
- Consistent skill progression validation on every code change
- Prevents skill weight regressions from unrelated commits
- Required for: GitHub branch protection setup

---

## 🔍 Validation

**This PR will validate the fix:**
- ✅ Skill Weight Pipeline WILL run (previously would skip)
- ✅ Test Baseline Check WILL run (already runs on all PRs)
- ✅ Both required gates active

**Expected CI status:**
- Test Baseline Check: `Generate Baseline Report` ✅
- Skill Weight Pipeline: `Skill Weight Pipeline — 28 required tests` ✅

---

## 🎯 Branch Protection Setup (Next Step)

After this PR merges and CI validates:

**Required status checks:**
```
✅ Generate Baseline Report
✅ Skill Weight Pipeline — 28 required tests
```

Both gates will run on EVERY PR → deterministic protection.

---

## ✅ Checklist

- [x] Path filter removed from pull_request trigger
- [x] Push trigger unchanged (main, develop)
- [x] Concurrency group preserved
- [x] Comment explains rationale
- [ ] CI validation (waiting for PR run)
- [ ] Merge after both gates PASS

---

**Requires review before merge.**

Related: [RELEASE_POLICY.md](https://github.com/football-investment/practice-booking-system/blob/main/RELEASE_POLICY.md) defines blocking workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)