### PR TITLE
feat(p9): deployment readiness — labeled metrics, env config, health 503, deployment runbook

### DIFF
--- a/app/api/api_v1/endpoints/bookings/student.py
+++ b/app/api/api_v1/endpoints/bookings/student.py
@@ -124,6 +124,9 @@ def create_booking(
             and_(Booking.session_id == booking_data.session_id, Booking.status == BookingStatus.WAITLISTED)
         ).scalar() + 1
         metrics.increment("bookings_waitlisted")
+        _cat = getattr(session, "event_category", None)
+        if _cat is not None:
+            metrics.increment_labeled("bookings_waitlisted", {"event_category": _cat.value})
 
     booking = Booking(
         user_id=current_user.id,
@@ -137,6 +140,9 @@ def create_booking(
     try:
         db.commit()
         metrics.increment("bookings_created")
+        _cat = getattr(session, "event_category", None)
+        if _cat is not None:
+            metrics.increment_labeled("bookings_created", {"event_category": _cat.value})
     except IntegrityError as e:
         db.rollback()
         orig = str(getattr(e, "orig", e))

--- a/app/config.py
+++ b/app/config.py
@@ -150,6 +150,19 @@ class Settings(BaseSettings):
     ALERT_ENROLLMENT_GATE_BLOCK_RATE: float = 0.20  # >20 % enrollments gate-blocked → warning
     ALERT_SLOW_QUERY_TOTAL: int = 10               # >10 slow queries since start → warning
 
+    # ── Logging configuration ──────────────────────────────────────────────────
+    # All settings are read from environment variables; override in .env or
+    # the container environment for deployment-specific paths and retention needs.
+    LOG_DIR: str = "logs"                    # directory for rotating log files
+    LOG_MAX_BYTES: int = 10 * 1024 * 1024   # max size per log file (10 MB default)
+    LOG_BACKUP_COUNT: int = 5               # rotated backups to keep (app.log.1–5)
+
+    # ── Slow-query monitoring ──────────────────────────────────────────────────
+    # Queries slower than SLOW_QUERY_THRESHOLD_MS are logged to app.slow_query
+    # and counted in the slow_queries_total metric.  Raise this value if normal
+    # reporting queries regularly exceed the default (e.g. large dashboards).
+    SLOW_QUERY_THRESHOLD_MS: float = 200.0  # milliseconds
+
     # Payment configuration (override via environment variables in production)
     PAYMENT_AMOUNT_HUF: int = 50000
     PAYMENT_BANK_ACCOUNT_HOLDER: str = "LFA Education Center Kft."

--- a/app/core/metrics.py
+++ b/app/core/metrics.py
@@ -20,20 +20,31 @@ enrollment_attempts     ``create_enrollment()`` endpoint calls
 enrollment_gate_blocked enrollment attempts blocked by parent-semester hierarchy gate
 slow_queries_total      SQL queries that exceeded the slow-query threshold (200 ms)
 
+Labeled counters
+----------------
+The same counters above can also be broken down by label using
+``increment_labeled()``.  Labels are low-cardinality key/value pairs such as
+``event_category`` (TRAINING | MATCH | …).  Use ``get_labeled_snapshot()`` or
+the Prometheus export to see per-label breakdowns.
+
 Usage::
 
     from app.core.metrics import metrics
 
     metrics.increment("rewards_generated")
-    metrics.increment("rewards_failed")
+    metrics.increment_labeled("rewards_generated", {"event_category": "TRAINING"})
 
     snapshot = metrics.get_snapshot()
-    # → {"rewards_generated": 42, "rewards_failed": 0, ...}
+    # → {"rewards_generated": 42, ...}
+
+    labeled = metrics.get_labeled_snapshot()
+    # → {"rewards_generated": {"event_category=TRAINING": 42}, ...}
 
 Prometheus export::
 
     text = metrics.format_prometheus()
-    # → "# HELP rewards_generated_total ...\\n# TYPE ...\\nrewards_generated_total 42\\n"
+    # → "# HELP rewards_generated_total ...\\n...\\nrewards_generated_total 42\\n"
+    # → "rewards_generated_total{event_category=\\"TRAINING\\"} 42\\n"
 
 Alert evaluation::
 
@@ -74,26 +85,65 @@ _COUNTER_HELP: Dict[str, str] = {
 
 
 class DomainMetrics:
-    """Thread-safe in-process counter store."""
+    """Thread-safe in-process counter store with optional label support."""
 
     def __init__(self) -> None:
         self._lock = threading.Lock()
         self._counters: Dict[str, int] = defaultdict(int)
+        # Labeled counters: name → {label_string → count}
+        # label_string is "key1=val1,key2=val2" (sorted by key)
+        self._labeled_counters: Dict[str, Dict[str, int]] = defaultdict(
+            lambda: defaultdict(int)
+        )
+
+    # ── Flat counters ──────────────────────────────────────────────────────────
 
     def increment(self, name: str, by: int = 1) -> None:
-        """Atomically increment counter ``name`` by ``by`` (default 1)."""
+        """Atomically increment flat counter ``name`` by ``by`` (default 1)."""
         with self._lock:
             self._counters[name] += by
 
     def get_snapshot(self) -> Dict[str, int]:
-        """Return a point-in-time copy of all counters."""
+        """Return a point-in-time copy of all flat counters."""
         with self._lock:
             return dict(self._counters)
 
+    # ── Labeled counters ───────────────────────────────────────────────────────
+
+    def increment_labeled(
+        self, name: str, labels: Dict[str, str], by: int = 1
+    ) -> None:
+        """
+        Atomically increment a labeled counter.
+
+        Labels are low-cardinality key/value pairs, e.g.
+        ``{"event_category": "TRAINING"}``.  The label dict is serialised as
+        sorted ``key=value`` pairs so callers do not need to pre-sort.
+
+        Typically called *in addition* to ``increment()`` so both the flat
+        total and the per-label breakdown are kept up-to-date.
+        """
+        label_str = ",".join(
+            f"{k}={v}" for k, v in sorted(labels.items())
+        )
+        with self._lock:
+            self._labeled_counters[name][label_str] += by
+
+    def get_labeled_snapshot(self) -> Dict[str, Dict[str, int]]:
+        """Return a point-in-time copy of all labeled counters."""
+        with self._lock:
+            return {
+                name: dict(label_counts)
+                for name, label_counts in self._labeled_counters.items()
+            }
+
+    # ── Lifecycle ──────────────────────────────────────────────────────────────
+
     def reset(self) -> None:
-        """Reset all counters to zero.  Intended for test isolation only."""
+        """Reset all counters (flat and labeled).  Intended for test isolation."""
         with self._lock:
             self._counters.clear()
+            self._labeled_counters.clear()
 
     # ── Prometheus exposition format ──────────────────────────────────────────
 
@@ -102,24 +152,40 @@ class DomainMetrics:
         Return metrics in Prometheus text exposition format.
 
         Output is ``text/plain; version=0.0.4`` compatible.  Each counter is
-        emitted with a ``# HELP`` line, a ``# TYPE counter`` line and a metric
-        line with a ``_total`` suffix (Prometheus naming convention for counters).
-        Counter names that already end with ``_total`` are not doubled.
+        emitted with a ``# HELP`` line, a ``# TYPE counter`` line, and metric
+        lines with a ``_total`` suffix (Prometheus naming convention).
+
+        Flat totals appear first (no labels), followed by labeled breakdowns
+        for any counter that has been incremented via ``increment_labeled()``.
+        Counter names already ending with ``_total`` are not doubled.
 
         Returns an empty-comment line when no counters have been recorded yet.
         """
-        snapshot = self.get_snapshot()
-        if not snapshot:
+        flat = self.get_snapshot()
+        labeled = self.get_labeled_snapshot()
+        all_names = sorted(set(flat) | set(labeled))
+
+        if not all_names:
             return "# No counters registered yet\n"
 
         lines: list[str] = []
-        for name in sorted(snapshot):
-            # Prometheus counter names must end with _total
+        for name in all_names:
             prom_name = name if name.endswith("_total") else f"{name}_total"
             help_text = _COUNTER_HELP.get(name, f"Counter: {name}.")
             lines.append(f"# HELP {prom_name} {help_text}")
             lines.append(f"# TYPE {prom_name} counter")
-            lines.append(f"{prom_name} {snapshot[name]}")
+            # Flat total (if present)
+            if name in flat:
+                lines.append(f"{prom_name} {flat[name]}")
+            # Labeled breakdowns (if present)
+            for label_str, count in sorted(labeled.get(name, {}).items()):
+                # Convert "key=val,key2=val2" → {key="val",key2="val2"} syntax
+                pairs = []
+                for part in label_str.split(","):
+                    k, v = part.split("=", 1)
+                    pairs.append(f'{k}="{v}"')
+                labels_rendered = "{" + ",".join(pairs) + "}"
+                lines.append(f"{prom_name}{labels_rendered} {count}")
 
         return "\n".join(lines) + "\n"
 

--- a/app/database.py
+++ b/app/database.py
@@ -20,9 +20,8 @@ SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 Base = declarative_base()
 
 # ── Slow-query monitoring ──────────────────────────────────────────────────────
-# Queries slower than this threshold are logged to ``app.slow_query`` with
-# the current request_id for easy correlation in production log aggregators.
-_SLOW_QUERY_THRESHOLD_MS: float = 200.0
+# Threshold is read from settings (SLOW_QUERY_THRESHOLD_MS, default 200 ms) so
+# it can be raised in .env without a code change (e.g. for reporting workloads).
 _sq_logger = logging.getLogger("app.slow_query")
 
 
@@ -34,7 +33,7 @@ def _sq_before_execute(conn, cursor, statement, params, context, executemany):
 @sa_event.listens_for(engine, "after_cursor_execute")
 def _sq_after_execute(conn, cursor, statement, params, context, executemany):
     elapsed_ms = (time.perf_counter() - conn.info["_sq_start"].pop()) * 1000
-    if elapsed_ms >= _SLOW_QUERY_THRESHOLD_MS:
+    if elapsed_ms >= settings.SLOW_QUERY_THRESHOLD_MS:
         # Deferred imports to avoid circular dependency at module load time
         from app.core.metrics import metrics
         from app.core.structured_log import log_warn

--- a/app/main.py
+++ b/app/main.py
@@ -2,7 +2,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.exceptions import RequestValidationError
-from fastapi.responses import PlainTextResponse
+from fastapi.responses import JSONResponse, PlainTextResponse
 from fastapi.templating import Jinja2Templates
 from fastapi.staticfiles import StaticFiles
 from starlette.exceptions import HTTPException as StarletteHTTPException
@@ -160,12 +160,20 @@ async def detailed_health_check():
 
 @app.get("/health/ready")
 async def readiness_check():
-    """Kubernetes-style readiness probe"""
+    """
+    Kubernetes-style readiness probe.
+
+    Returns HTTP 200 when the service is ready to accept traffic (database
+    reachable and responding).  Returns HTTP 503 when the database is unhealthy
+    so orchestrators remove the pod from the load-balancer rotation.
+    """
     db_health = await HealthChecker.get_database_health()
-    return {
-        "status": "ready" if db_health["status"] != "unhealthy" else "not_ready",
-        "database": db_health["status"]
+    is_ready = db_health["status"] != "unhealthy"
+    content = {
+        "status": "ready" if is_ready else "not_ready",
+        "database": db_health["status"],
     }
+    return JSONResponse(content=content, status_code=200 if is_ready else 503)
 
 
 @app.get("/health/live")
@@ -176,8 +184,16 @@ async def liveness_check():
 
 @app.get("/health/worker")
 async def worker_health_check():
-    """Redis broker and Celery worker liveness probe."""
-    return await HealthChecker.get_worker_health()
+    """
+    Redis broker and Celery worker liveness probe.
+
+    Returns HTTP 200 when Redis is reachable (workers may be degraded but
+    the app is still operational).  Returns HTTP 503 only when Redis itself
+    is unreachable, which prevents background job enqueueing entirely.
+    """
+    result = await HealthChecker.get_worker_health()
+    status_code = 503 if result.get("status") == "unhealthy" else 200
+    return JSONResponse(content=result, status_code=status_code)
 
 
 @app.get("/metrics")
@@ -203,7 +219,10 @@ async def domain_metrics(
             content=metrics.format_prometheus(),
             media_type="text/plain; version=0.0.4; charset=utf-8",
         )
-    return {"counters": metrics.get_snapshot()}
+    return {
+        "counters": metrics.get_snapshot(),
+        "labeled_counters": metrics.get_labeled_snapshot(),
+    }
 
 
 @app.get("/metrics/alerts")

--- a/app/middleware/logging.py
+++ b/app/middleware/logging.py
@@ -15,22 +15,27 @@ from starlette.responses import StreamingResponse
 # read it without importing from middleware (avoids circular imports).
 from app.core.request_context import request_id_var
 
+# Log directory and rotation settings — all overridable via environment variables
+# (LOG_DIR, LOG_MAX_BYTES, LOG_BACKUP_COUNT).  Defaults match app/config.py Settings.
+_log_dir = os.getenv('LOG_DIR', 'logs')
+_log_max_bytes = int(os.getenv('LOG_MAX_BYTES', str(10 * 1024 * 1024)))
+_log_backup_count = int(os.getenv('LOG_BACKUP_COUNT', '5'))
+
 # Create logs directory if it doesn't exist
-log_dir = 'logs'
-os.makedirs(log_dir, exist_ok=True)
+os.makedirs(_log_dir, exist_ok=True)
 
 # Configure structured logging
 handlers = [logging.StreamHandler()]
 
 # Only add file handler if not in test environment.
-# RotatingFileHandler caps each log file at 10 MB and keeps 5 rotated backups,
-# giving ~50 MB maximum disk usage before the oldest file is overwritten.
+# RotatingFileHandler caps each log file at LOG_MAX_BYTES (default 10 MB) and
+# keeps LOG_BACKUP_COUNT rotated backups (default 5) — ~50 MB max disk usage.
 if not os.getenv('TESTING', '').lower() == 'true':
     handlers.append(
         RotatingFileHandler(
-            os.path.join(log_dir, 'app.log'),
-            maxBytes=10 * 1024 * 1024,  # 10 MB per file
-            backupCount=5,              # keep app.log.1 … app.log.5
+            os.path.join(_log_dir, 'app.log'),
+            maxBytes=_log_max_bytes,
+            backupCount=_log_backup_count,
             encoding='utf-8',
         )
     )

--- a/app/services/reward_service.py
+++ b/app/services/reward_service.py
@@ -95,6 +95,10 @@ def award_session_completion(
     except Exception as exc:
         db.rollback()
         metrics.increment("rewards_failed")
+        if session.event_category is not None:
+            metrics.increment_labeled(
+                "rewards_failed", {"event_category": session.event_category.value}
+            )
         log_error(
             _logger, "reward_failed",
             user_id=user_id, session_id=session.id,
@@ -108,6 +112,10 @@ def award_session_completion(
     ).one()
 
     metrics.increment("rewards_generated")
+    if session.event_category is not None:
+        metrics.increment_labeled(
+            "rewards_generated", {"event_category": session.event_category.value}
+        )
     log_info(
         _logger, "reward_awarded",
         user_id=user_id, session_id=session.id,

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -6,6 +6,7 @@ Last updated: 2026-03-15
 
 ## Table of Contents
 
+0. [Deployment Guide](#0-deployment-guide)
 1. [Metrics Endpoint](#1-metrics-endpoint)
 2. [Counter Definitions](#2-counter-definitions)
 3. [Prometheus Integration](#3-prometheus-integration)
@@ -14,6 +15,178 @@ Last updated: 2026-03-15
 6. [Migration Rollback Procedure](#6-migration-rollback-procedure)
 7. [Log Files and Retention](#7-log-files-and-retention)
 8. [Health Endpoints](#8-health-endpoints)
+
+---
+
+## 0. Deployment Guide
+
+### Required environment variables
+
+Set these in `.env` or your container environment.  The application refuses to
+start in production without **SECRET_KEY**, **DATABASE_URL**, **ADMIN_EMAIL**,
+**ADMIN_PASSWORD**, and **CORS_ALLOWED_ORIGINS**.
+
+| Variable | Required | Description | Example |
+|---|---|---|---|
+| `SECRET_KEY` | **Yes** | JWT signing key (≥32 random bytes) | `openssl rand -base64 32` |
+| `DATABASE_URL` | **Yes** | PostgreSQL DSN | `postgresql://user:pass@db:5432/gancuju` |
+| `REDIS_URL` | Yes (for workers) | Redis DSN for Celery broker | `redis://redis:6379/0` |
+| `CELERY_BROKER_URL` | Yes (for workers) | Celery broker URL | `redis://redis:6379/0` |
+| `CELERY_RESULT_BACKEND` | Yes (for workers) | Celery result backend | `redis://redis:6379/1` |
+| `ADMIN_EMAIL` | **Yes (prod)** | Initial admin email | `admin@company.com` |
+| `ADMIN_PASSWORD` | **Yes (prod)** | Initial admin password (strong) | `$(pwgen -s 20 1)` |
+| `CORS_ALLOWED_ORIGINS` | **Yes (prod)** | Comma-separated allowed origins | `https://app.example.com` |
+| `ENVIRONMENT` | No | `development` / `production` | `production` |
+| `DEBUG` | No | Must be `false` in production | `false` |
+| `COOKIE_SECURE` | No | `true` enforces HTTPS cookies | `true` |
+
+#### Operational settings (all optional — defaults match below)
+
+| Variable | Default | Description |
+|---|---|---|
+| `LOG_DIR` | `logs` | Directory for rotating log files |
+| `LOG_MAX_BYTES` | `10485760` | Max log file size in bytes (10 MB) |
+| `LOG_BACKUP_COUNT` | `5` | Rotating backups to keep |
+| `SLOW_QUERY_THRESHOLD_MS` | `200.0` | SQL slow-query alert threshold (ms) |
+| `ALERT_REWARD_FAILURE_RATE` | `0.05` | Reward failure rate threshold (5 %) |
+| `ALERT_BOOKING_WAITLIST_RATE` | `0.30` | Booking waitlist rate threshold (30 %) |
+| `ALERT_ENROLLMENT_GATE_BLOCK_RATE` | `0.20` | Enrollment gate block rate threshold (20 %) |
+| `ALERT_SLOW_QUERY_TOTAL` | `10` | Absolute slow-query count threshold |
+| `RATE_LIMIT_CALLS` | `100` | Requests per rate-limit window |
+| `RATE_LIMIT_WINDOW_SECONDS` | `60` | Rate-limit window in seconds |
+| `ENABLE_RATE_LIMITING` | `true` (non-test) | Toggle rate limiting |
+| `ENABLE_STRUCTURED_LOGGING` | `true` | Toggle HTTP access logging middleware |
+
+### Database migration procedure
+
+Always run migrations **before** deploying new application code:
+
+```bash
+# 1. Verify you are pointing at the correct database
+echo $DATABASE_URL
+
+# 2. Check current migration state
+alembic current
+
+# 3. Preview what will run
+alembic upgrade head --sql | head -40
+
+# 4. Apply migrations
+alembic upgrade head
+
+# 5. Verify
+alembic current
+```
+
+For zero-downtime index creation, add `postgresql_concurrently=True` to
+`op.create_index()` in the migration — this avoids table locks on large tables.
+
+### First-time setup
+
+```bash
+# 1. Install dependencies
+pip install -r requirements.txt
+
+# 2. Copy and populate environment file
+cp .env.example .env
+# Edit .env with production values
+
+# 3. Run migrations
+alembic upgrade head
+
+# 4. Start the application
+uvicorn app.main:app --host 0.0.0.0 --port 8000 --workers 4
+
+# 5. Verify health
+curl http://localhost:8000/health/ready
+# Expected: {"status": "ready", "database": "healthy"}
+```
+
+### Docker deployment (example)
+
+```yaml
+# docker-compose.yml
+version: "3.9"
+services:
+  app:
+    image: gancuju-education-center:latest
+    environment:
+      - SECRET_KEY=${SECRET_KEY}
+      - DATABASE_URL=postgresql://user:pass@db:5432/gancuju
+      - REDIS_URL=redis://redis:6379/0
+      - ADMIN_EMAIL=${ADMIN_EMAIL}
+      - ADMIN_PASSWORD=${ADMIN_PASSWORD}
+      - CORS_ALLOWED_ORIGINS=https://app.example.com
+      - ENVIRONMENT=production
+      - DEBUG=false
+      - LOG_DIR=/app/logs
+    volumes:
+      - ./logs:/app/logs
+    ports:
+      - "8000:8000"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health/ready"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: gancuju
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: pass
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U user -d gancuju"]
+      interval: 10s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      retries: 5
+
+  worker:
+    image: gancuju-education-center:latest
+    command: celery -A app.celery_app worker --loglevel=info
+    environment:
+      - DATABASE_URL=postgresql://user:pass@db:5432/gancuju
+      - CELERY_BROKER_URL=redis://redis:6379/0
+      - CELERY_RESULT_BACKEND=redis://redis:6379/1
+    depends_on:
+      - db
+      - redis
+```
+
+### Kubernetes readiness/liveness probes
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /health/live
+    port: 8000
+  initialDelaySeconds: 10
+  periodSeconds: 30
+
+readinessProbe:
+  httpGet:
+    path: /health/ready
+    port: 8000
+  initialDelaySeconds: 15
+  periodSeconds: 10
+  failureThreshold: 3
+```
+
+`/health/ready` returns **HTTP 503** when the database is unreachable, causing
+Kubernetes to remove the pod from the Service endpoint slice until the database
+recovers.  `/health/live` always returns **HTTP 200** as long as the process is
+running (a 5xx here triggers a pod restart).
 
 ---
 
@@ -32,16 +205,31 @@ Response:
 ```json
 {
   "counters": {
-    "rewards_generated": 142,
+    "rewards_generated": 157,
     "rewards_failed": 3,
     "bookings_created": 512,
     "bookings_waitlisted": 18,
     "enrollment_attempts": 87,
     "enrollment_gate_blocked": 7,
     "slow_queries_total": 2
+  },
+  "labeled_counters": {
+    "bookings_created": {
+      "event_category=TRAINING": 430,
+      "event_category=MATCH": 82
+    },
+    "rewards_generated": {
+      "event_category=TRAINING": 130,
+      "event_category=MATCH": 27
+    }
   }
 }
 ```
+
+`counters` contains flat lifetime totals.  `labeled_counters` contains
+per-label breakdowns for counters that were also incremented with
+``increment_labeled()`` — currently `bookings_created`, `bookings_waitlisted`,
+`rewards_generated`, and `rewards_failed` carry an `event_category` label.
 
 Counters are **lifetime totals since the process started**.  In a multi-process
 deployment (multiple uvicorn workers) each process maintains its own counters;

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -50168,7 +50168,7 @@
     },
     "/health/ready": {
       "get": {
-        "description": "Kubernetes-style readiness probe",
+        "description": "Kubernetes-style readiness probe.\n\nReturns HTTP 200 when the service is ready to accept traffic (database\nreachable and responding).  Returns HTTP 503 when the database is unhealthy\nso orchestrators remove the pod from the load-balancer rotation.",
         "operationId": "readiness_check_health_ready_get",
         "responses": {
           "200": {
@@ -50185,7 +50185,7 @@
     },
     "/health/worker": {
       "get": {
-        "description": "Redis broker and Celery worker liveness probe.",
+        "description": "Redis broker and Celery worker liveness probe.\n\nReturns HTTP 200 when Redis is reachable (workers may be degraded but\nthe app is still operational).  Returns HTTP 503 only when Redis itself\nis unreachable, which prevents background job enqueueing entirely.",
         "operationId": "worker_health_check_health_worker_get",
         "responses": {
           "200": {

--- a/tests/unit/core/test_metrics.py
+++ b/tests/unit/core/test_metrics.py
@@ -23,6 +23,13 @@ Tests
   MTR-17  evaluate_alerts() returns "warning" on slow_queries_total exceeding threshold
   MTR-18  evaluate_alerts() does not emit ratio alerts when denominator is zero
   MTR-19  evaluate_alerts() status "ok" when all ratios are below threshold
+  MTR-20  increment_labeled() stores count under label string
+  MTR-21  increment_labeled() multiple label values tracked independently
+  MTR-22  get_labeled_snapshot() returns a copy (mutations don't affect store)
+  MTR-23  reset() clears labeled counters as well as flat counters
+  MTR-24  format_prometheus() includes labeled metrics with {key="val"} syntax
+  MTR-25  format_prometheus() labels appear under same HELP/TYPE block as flat total
+  MTR-26  increment_labeled() label keys are sorted (consistent label_str)
 """
 from __future__ import annotations
 
@@ -278,3 +285,79 @@ class TestDomainMetricsAlerts:
             assert alert_data["firing"] is False, (
                 f"Alert '{alert_key}' unexpectedly firing: {alert_data}"
             )
+
+
+# ── Tests — Labeled counters ───────────────────────────────────────────────────
+
+class TestDomainMetricsLabeled:
+
+    def test_mtr20_increment_labeled_stores_count(self, m: DomainMetrics):
+        """MTR-20: increment_labeled() stores count under the correct label string."""
+        m.increment_labeled("bookings_created", {"event_category": "TRAINING"})
+        m.increment_labeled("bookings_created", {"event_category": "TRAINING"})
+        m.increment_labeled("bookings_created", {"event_category": "MATCH"})
+
+        snap = m.get_labeled_snapshot()
+        assert snap["bookings_created"]["event_category=TRAINING"] == 2
+        assert snap["bookings_created"]["event_category=MATCH"] == 1
+
+    def test_mtr21_increment_labeled_independent_counters(self, m: DomainMetrics):
+        """MTR-21: different counter names with same labels are tracked independently."""
+        m.increment_labeled("bookings_created", {"event_category": "TRAINING"}, by=5)
+        m.increment_labeled("bookings_waitlisted", {"event_category": "TRAINING"}, by=2)
+
+        snap = m.get_labeled_snapshot()
+        assert snap["bookings_created"]["event_category=TRAINING"] == 5
+        assert snap["bookings_waitlisted"]["event_category=TRAINING"] == 2
+
+    def test_mtr22_get_labeled_snapshot_returns_copy(self, m: DomainMetrics):
+        """MTR-22: mutating the returned labeled snapshot does not affect the store."""
+        m.increment_labeled("rewards_generated", {"event_category": "TRAINING"})
+        snap = m.get_labeled_snapshot()
+        snap["rewards_generated"]["event_category=TRAINING"] = 999
+
+        fresh = m.get_labeled_snapshot()
+        assert fresh["rewards_generated"]["event_category=TRAINING"] == 1
+
+    def test_mtr23_reset_clears_labeled_counters(self, m: DomainMetrics):
+        """MTR-23: reset() clears both flat and labeled counters."""
+        m.increment("bookings_created", by=3)
+        m.increment_labeled("bookings_created", {"event_category": "TRAINING"}, by=3)
+        m.reset()
+
+        assert m.get_snapshot() == {}
+        assert m.get_labeled_snapshot() == {}
+
+    def test_mtr24_format_prometheus_labeled_with_braces(self, m: DomainMetrics):
+        """MTR-24: labeled metrics appear with {key="val"} Prometheus syntax."""
+        m.increment("bookings_created", by=10)
+        m.increment_labeled("bookings_created", {"event_category": "TRAINING"}, by=8)
+        m.increment_labeled("bookings_created", {"event_category": "MATCH"}, by=2)
+
+        text = m.format_prometheus()
+
+        assert 'bookings_created_total{event_category="TRAINING"} 8' in text
+        assert 'bookings_created_total{event_category="MATCH"} 2' in text
+
+    def test_mtr25_format_prometheus_labeled_under_same_help_type_block(self, m: DomainMetrics):
+        """MTR-25: flat total and labeled breakdowns appear under one HELP/TYPE block."""
+        m.increment("bookings_created", by=10)
+        m.increment_labeled("bookings_created", {"event_category": "TRAINING"}, by=8)
+
+        text = m.format_prometheus()
+        # Only one HELP line for the metric
+        help_count = text.count("# HELP bookings_created_total")
+        assert help_count == 1
+        # Flat total present
+        assert "bookings_created_total 10" in text
+        # Labeled breakdown present
+        assert 'bookings_created_total{event_category="TRAINING"} 8' in text
+
+    def test_mtr26_increment_labeled_keys_sorted(self, m: DomainMetrics):
+        """MTR-26: label keys are sorted — calling order doesn't change label_str."""
+        m.increment_labeled("rewards_generated", {"b_key": "2", "a_key": "1"})
+        m.increment_labeled("rewards_generated", {"a_key": "1", "b_key": "2"})
+
+        snap = m.get_labeled_snapshot()
+        # Both calls should map to the same sorted label string
+        assert snap["rewards_generated"].get("a_key=1,b_key=2") == 2

--- a/tests/unit/core/test_metrics_endpoints.py
+++ b/tests/unit/core/test_metrics_endpoints.py
@@ -11,6 +11,12 @@ Tests
   EP-05  GET /metrics/alerts returns status and thresholds keys
   EP-06  GET /metrics/alerts status is "ok" when counters are zero
   EP-07  GET /metrics/alerts status is "warning" when slow_queries_total exceeded
+  EP-08  GET /metrics JSON includes labeled_counters key
+  EP-09  GET /metrics JSON labeled_counters populated after increment_labeled()
+  EP-10  GET /health/ready returns 200 when DB healthy
+  EP-11  GET /health/ready returns 503 when DB unhealthy
+  EP-12  GET /health/worker returns 503 when Redis is down
+  EP-13  GET /health/worker returns 200 when Redis is healthy (degraded worker)
 """
 from __future__ import annotations
 
@@ -103,3 +109,75 @@ class TestMetricsAlertsEndpoint:
         body = resp.json()
         assert body["status"] == "warning"
         assert body["thresholds"]["slow_queries_total"]["firing"] is True
+
+
+class TestMetricsLabeledEndpoint:
+
+    def test_ep08_json_includes_labeled_counters_key(self, client: TestClient):
+        """EP-08: GET /metrics JSON always includes 'labeled_counters' key."""
+        resp = client.get("/metrics")
+        assert resp.status_code == 200
+        assert "labeled_counters" in resp.json()
+
+    def test_ep09_labeled_counters_populated_after_increment(self, client: TestClient):
+        """EP-09: labeled_counters reflects increment_labeled() calls."""
+        from app.core.metrics import metrics
+        metrics.increment_labeled("bookings_created", {"event_category": "TRAINING"}, by=4)
+
+        resp = client.get("/metrics")
+        assert resp.status_code == 200
+        labeled = resp.json()["labeled_counters"]
+        assert labeled["bookings_created"]["event_category=TRAINING"] == 4
+
+
+class TestHealthEndpointStatusCodes:
+    """Health endpoints return correct HTTP status codes for orchestrators."""
+
+    def test_ep10_health_ready_200_when_db_healthy(self, client: TestClient):
+        """EP-10: /health/ready returns 200 when database health check passes."""
+        from unittest.mock import AsyncMock, patch
+        with patch(
+            "app.main.HealthChecker.get_database_health",
+            new_callable=AsyncMock,
+            return_value={"status": "healthy"},
+        ):
+            resp = client.get("/health/ready")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ready"
+
+    def test_ep11_health_ready_503_when_db_unhealthy(self, client: TestClient):
+        """EP-11: /health/ready returns 503 when database is unreachable."""
+        from unittest.mock import AsyncMock, patch
+        with patch(
+            "app.main.HealthChecker.get_database_health",
+            new_callable=AsyncMock,
+            return_value={"status": "unhealthy"},
+        ):
+            resp = client.get("/health/ready")
+        assert resp.status_code == 503
+        assert resp.json()["status"] == "not_ready"
+        assert resp.json()["database"] == "unhealthy"
+
+    def test_ep12_health_worker_503_when_redis_down(self, client: TestClient):
+        """EP-12: /health/worker returns 503 when Redis is unreachable."""
+        from unittest.mock import AsyncMock, patch
+        with patch(
+            "app.main.HealthChecker.get_worker_health",
+            new_callable=AsyncMock,
+            return_value={"status": "unhealthy", "redis": "unhealthy", "workers": None},
+        ):
+            resp = client.get("/health/worker")
+        assert resp.status_code == 503
+        assert resp.json()["status"] == "unhealthy"
+
+    def test_ep13_health_worker_200_when_degraded(self, client: TestClient):
+        """EP-13: /health/worker returns 200 when Redis ok but no workers registered."""
+        from unittest.mock import AsyncMock, patch
+        with patch(
+            "app.main.HealthChecker.get_worker_health",
+            new_callable=AsyncMock,
+            return_value={"status": "degraded", "redis": "healthy", "workers": []},
+        ):
+            resp = client.get("/health/worker")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "degraded"


### PR DESCRIPTION
## Summary

- **Health endpoint status codes**: `/health/ready` returns HTTP 503 when DB is unreachable (Kubernetes removes pod from rotation); `/health/worker` returns 503 only when Redis is down
- **Metrics labeling**: `increment_labeled(name, labels)` adds per-label breakdowns (e.g. `event_category=TRAINING`) to booking and reward counters; Prometheus format emits `{key="val"}` syntax; JSON includes `labeled_counters` key
- **Environment configuration**: `LOG_DIR`, `LOG_MAX_BYTES`, `LOG_BACKUP_COUNT`, `SLOW_QUERY_THRESHOLD_MS` added to Settings — all overridable via env vars or `.env` file
- **Deployment runbook**: §0 added to `docs/operations/runbook.md` — required env vars table, optional operational settings, migration procedure, first-time setup, Docker Compose example, K8s probe config

## Test plan

- [x] `pytest tests/unit/core/ -v` → 40/40 pass (MTR-20–26, EP-08–13 new)
- [x] Full suite `pytest tests/unit/ tests/integration/ -q` → **9138 passed, 1 xfailed** (+13)
- [x] OpenAPI snapshot unchanged at 555 routes (no new routes)
- [x] `/health/ready` 200 ↔ 503 verified via AsyncMock patches in EP-10/11
- [x] `/health/worker` 503 ↔ 200 verified via AsyncMock patches in EP-12/13
- [x] Labeled counter Prometheus output: `bookings_created_total{event_category="TRAINING"} N`

## Files changed

| File | Change |
|---|---|
| `app/config.py` | `LOG_DIR`, `LOG_MAX_BYTES`, `LOG_BACKUP_COUNT`, `SLOW_QUERY_THRESHOLD_MS` settings |
| `app/core/metrics.py` | `increment_labeled()`, `get_labeled_snapshot()`, updated `format_prometheus()` |
| `app/database.py` | `SLOW_QUERY_THRESHOLD_MS` from `settings` instead of hardcoded constant |
| `app/middleware/logging.py` | `LOG_*` from `os.getenv()` with config-matching defaults |
| `app/services/reward_service.py` | `increment_labeled("rewards_generated/failed", {event_category})` |
| `app/api/api_v1/endpoints/bookings/student.py` | `increment_labeled("bookings_created/waitlisted", {event_category})` |
| `app/main.py` | 503 for `/health/ready` + `/health/worker`; `labeled_counters` in `/metrics` JSON |
| `docs/operations/runbook.md` | §0 Deployment Guide added |
| `tests/unit/core/test_metrics.py` | MTR-20–26: labeled counter unit tests |
| `tests/unit/core/test_metrics_endpoints.py` | EP-08–13: labeled + health status tests |

🤖 Generated with [Claude Code](https://claude.com/claude-code)