### PR TITLE
feat(p34): final production readiness — DB resilience, cardinality guard, smoke CI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,30 @@ CORS_ALLOWED_ORIGINS=http://localhost:8501,http://localhost:8000
 # COOKIE_SAMESITE=strict
 # COOKIE_HTTPONLY=true
 
+# ── Database Connection Resilience ──────────────────────────────────────────
+# DB_CONNECT_TIMEOUT    — seconds to wait for each connection attempt (default 10)
+# DB_STATEMENT_TIMEOUT_MS — per-statement limit in ms, 0=disabled (default 0)
+# DB_STARTUP_RETRIES    — retries before wait_for_db() aborts (default 5)
+# DB_STARTUP_RETRY_DELAY — initial backoff in seconds, multiplied per attempt (default 2.0)
+# DB_CONNECT_TIMEOUT=10
+# DB_STATEMENT_TIMEOUT_MS=30000
+# DB_STARTUP_RETRIES=5
+# DB_STARTUP_RETRY_DELAY=2.0
+
+# ── Logging ──────────────────────────────────────────────────────────────────
+# LOG_DIR=logs
+# LOG_MAX_BYTES=10485760
+# LOG_BACKUP_COUNT=5
+
+# ── Slow Query Monitoring ────────────────────────────────────────────────────
+# SLOW_QUERY_THRESHOLD_MS=200.0
+
+# ── Alert Thresholds (GET /metrics/alerts) ───────────────────────────────────
+# ALERT_REWARD_FAILURE_RATE=0.05
+# ALERT_BOOKING_WAITLIST_RATE=0.30
+# ALERT_ENROLLMENT_GATE_BLOCK_RATE=0.20
+# ALERT_SLOW_QUERY_TOTAL=10
+
 # ── Rate Limiting ───────────────────────────────────────────────────────────
 ENABLE_RATE_LIMITING=false
 LOGIN_RATE_LIMIT_CALLS=1000

--- a/.github/workflows/test-baseline-check.yml
+++ b/.github/workflows/test-baseline-check.yml
@@ -1926,10 +1926,191 @@ jobs:
         echo "degrades linearly with row count.  Add an index or batch the operation."
         exit 1
 
+  operational-smoke-test:
+    # Starts the full application stack (API + PostgreSQL + Redis) and runs a
+    # short smoke test against the live HTTP endpoints.  Validates that:
+    #   - Migrations apply cleanly on a fresh DB
+    #   - The app becomes ready within 40 s (/health/ready → 200)
+    #   - Core endpoints are reachable and return expected JSON structure
+    #   - Prometheus export is available with text/plain content-type
+    name: "Operational Smoke Test (full stack)"
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: lfa_smoke_test
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+      redis:
+        image: redis:7
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+        cache: 'pip'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Run migrations
+      env:
+        DATABASE_URL: postgresql://postgres:postgres@localhost:5432/lfa_smoke_test
+        SECRET_KEY: test-secret-key-for-ci-only-not-production
+      run: |
+        alembic upgrade head
+        echo "✅ Migrations applied"
+
+    - name: Seed tournament types
+      env:
+        DATABASE_URL: postgresql://postgres:postgres@localhost:5432/lfa_smoke_test
+        SECRET_KEY: test-secret-key-for-ci-only-not-production
+      run: |
+        python scripts/seed_tournament_types.py
+        echo "✅ Tournament types seeded"
+
+    - name: Start application server
+      env:
+        DATABASE_URL: postgresql://postgres:postgres@localhost:5432/lfa_smoke_test
+        REDIS_URL: redis://localhost:6379/0
+        CELERY_BROKER_URL: redis://localhost:6379/0
+        CELERY_RESULT_BACKEND: redis://localhost:6379/1
+        SECRET_KEY: test-secret-key-for-ci-only-not-production
+        ADMIN_EMAIL: smoke@test.com
+        ADMIN_PASSWORD: SmokeTestPass123!
+        ENVIRONMENT: development
+        ENABLE_RATE_LIMITING: "false"
+      run: |
+        nohup uvicorn app.main:app --host 127.0.0.1 --port 8000 --log-level warning &
+        echo "SERVER_PID=$!" >> $GITHUB_ENV
+        echo "Server started with PID $!"
+
+    - name: Wait for /health/ready (up to 40 s)
+      run: |
+        STATUS="000"
+        for i in $(seq 1 20); do
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:8000/health/ready || echo "000")
+          if [ "$STATUS" == "200" ]; then
+            echo "✅ /health/ready returned 200 (attempt $i)"
+            break
+          fi
+          echo "Attempt $i: HTTP $STATUS — retrying in 2 s"
+          sleep 2
+        done
+        if [ "$STATUS" != "200" ]; then
+          echo "::error::Application did not become ready within 40 seconds (last HTTP status: $STATUS)"
+          exit 1
+        fi
+
+    - name: API smoke checks
+      run: |
+        python - <<'PYEOF'
+        import sys, json, urllib.request, urllib.error
+
+        BASE = "http://127.0.0.1:8000"
+        failures = []
+
+        def check(label, url, expected_status, required_keys=None):
+            try:
+                with urllib.request.urlopen(url, timeout=10) as resp:
+                    status = resp.status
+                    body = json.loads(resp.read())
+            except urllib.error.HTTPError as exc:
+                status = exc.code
+                body = {}
+            except Exception as exc:
+                failures.append(f"FAIL {label}: {exc}")
+                return
+            if status != expected_status:
+                failures.append(f"FAIL {label}: expected HTTP {expected_status}, got {status}")
+                return
+            if required_keys:
+                missing = [k for k in required_keys if k not in body]
+                if missing:
+                    failures.append(f"FAIL {label}: missing keys {missing}")
+                    return
+            print(f"  PASS {label}: HTTP {status}")
+
+        # Health endpoints
+        check("GET /health/ready",   f"{BASE}/health/ready",   200, ["status"])
+        check("GET /health/worker",  f"{BASE}/health/worker",  200)
+
+        # Metrics endpoints
+        check("GET /metrics (json)",  f"{BASE}/metrics",         200, ["counters", "labeled_counters"])
+        check("GET /metrics/alerts",  f"{BASE}/metrics/alerts",  200, ["status", "thresholds"])
+
+        # Prometheus text format
+        try:
+            with urllib.request.urlopen(f"{BASE}/metrics?format=prometheus", timeout=10) as resp:
+                ctype = resp.headers.get("Content-Type", "")
+                text = resp.read().decode()
+            if "text/plain" not in ctype:
+                failures.append(f"FAIL GET /metrics?format=prometheus: expected text/plain, got {ctype!r}")
+            else:
+                print(f"  PASS GET /metrics?format=prometheus: content-type OK")
+        except Exception as exc:
+            failures.append(f"FAIL GET /metrics?format=prometheus: {exc}")
+
+        # OpenAPI schema
+        try:
+            with urllib.request.urlopen(f"{BASE}/api/v1/openapi.json", timeout=10) as resp:
+                schema = json.loads(resp.read())
+            path_count = len(schema.get("paths", {}))
+            if path_count < 100:
+                failures.append(f"FAIL GET /api/v1/openapi.json: only {path_count} paths (expected ≥ 100)")
+            else:
+                print(f"  PASS GET /api/v1/openapi.json: {path_count} paths")
+        except Exception as exc:
+            failures.append(f"FAIL GET /api/v1/openapi.json: {exc}")
+
+        if failures:
+            print("\n❌ Smoke check failures:")
+            for f in failures:
+                print(f"  {f}")
+            sys.exit(1)
+        else:
+            print(f"\n✅ All operational smoke checks passed ({6 - len(failures)}/6)")
+        PYEOF
+
+    - name: Collect application logs on failure
+      if: failure()
+      run: |
+        echo "=== Application logs (nohup.out) ==="
+        cat nohup.out 2>/dev/null || echo "(no nohup.out found)"
+
+    - name: Operational smoke test failure annotation
+      if: failure()
+      run: |
+        echo "::error::Operational smoke test failed."
+        echo "The application stack did not start cleanly or a core endpoint returned"
+        echo "an unexpected status code.  Check the 'Collect application logs' step above."
+
   baseline-report:
     name: Generate Baseline Report
     runs-on: ubuntu-latest
-    needs: [unit-tests, smoke-tests, api-module-integrity, hardcoded-id-guard, migration-integrity, migration-volume-test, payment-workflow-gate, core-access-gate, student-lifecycle-gate, instructor-lifecycle-gate, refund-workflow-gate, multi-campus-gate, session-management-gate, skill-assessment-lifecycle-gate, booking-lifecycle-gate, auth-lifecycle-gate, enrollment-workflow-gate, user-account-gate, instructor-assignment-lifecycle-gate]
+    needs: [unit-tests, smoke-tests, api-module-integrity, hardcoded-id-guard, migration-integrity, migration-volume-test, payment-workflow-gate, core-access-gate, student-lifecycle-gate, instructor-lifecycle-gate, refund-workflow-gate, multi-campus-gate, session-management-gate, skill-assessment-lifecycle-gate, booking-lifecycle-gate, auth-lifecycle-gate, enrollment-workflow-gate, user-account-gate, instructor-assignment-lifecycle-gate, operational-smoke-test]
     if: always()
 
     steps:
@@ -1959,8 +2140,9 @@ jobs:
         USER_ACCOUNT="${{ needs.user-account-gate.result }}"
         INSTRUCTOR_ASSIGNMENT="${{ needs.instructor-assignment-lifecycle-gate.result }}"
         MIGRATION_VOLUME="${{ needs.migration-volume-test.result }}"
+        OPERATIONAL_SMOKE="${{ needs.operational-smoke-test.result }}"
 
-        if [ "$UNIT" == "success" ] && [ "$SMOKE" == "success" ] && [ "$INTEGRITY" == "success" ] && [ "$ID_GUARD" == "success" ] && [ "$MIGRATION" == "success" ] && [ "$MIGRATION_VOLUME" == "success" ] && [ "$PAYMENT" == "success" ] && [ "$CORE_ACCESS" == "success" ] && [ "$STUDENT_LIFECYCLE" == "success" ] && [ "$INSTRUCTOR_LIFECYCLE" == "success" ] && [ "$REFUND_WORKFLOW" == "success" ] && [ "$MULTI_CAMPUS" == "success" ] && [ "$SESSION_MANAGEMENT" == "success" ] && [ "$SKILL_LIFECYCLE" == "success" ] && [ "$BOOKING_LIFECYCLE" == "success" ] && [ "$AUTH_LIFECYCLE" == "success" ] && [ "$ENROLLMENT_WORKFLOW" == "success" ] && [ "$USER_ACCOUNT" == "success" ] && [ "$INSTRUCTOR_ASSIGNMENT" == "success" ]; then
+        if [ "$UNIT" == "success" ] && [ "$SMOKE" == "success" ] && [ "$INTEGRITY" == "success" ] && [ "$ID_GUARD" == "success" ] && [ "$MIGRATION" == "success" ] && [ "$MIGRATION_VOLUME" == "success" ] && [ "$OPERATIONAL_SMOKE" == "success" ] && [ "$PAYMENT" == "success" ] && [ "$CORE_ACCESS" == "success" ] && [ "$STUDENT_LIFECYCLE" == "success" ] && [ "$INSTRUCTOR_LIFECYCLE" == "success" ] && [ "$REFUND_WORKFLOW" == "success" ] && [ "$MULTI_CAMPUS" == "success" ] && [ "$SESSION_MANAGEMENT" == "success" ] && [ "$SKILL_LIFECYCLE" == "success" ] && [ "$BOOKING_LIFECYCLE" == "success" ] && [ "$AUTH_LIFECYCLE" == "success" ] && [ "$ENROLLMENT_WORKFLOW" == "success" ] && [ "$USER_ACCOUNT" == "success" ] && [ "$INSTRUCTOR_ASSIGNMENT" == "success" ]; then
           echo "✅ **PASS** - Baseline maintained (100% LIFECYCLE COVERAGE)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Unit & Integration Tests" >> $GITHUB_STEP_SUMMARY
@@ -2002,6 +2184,7 @@ jobs:
           echo "| Hardcoded FK ID guard | $ID_GUARD |" >> $GITHUB_STEP_SUMMARY
           echo "| **Migration chain integrity** | $MIGRATION |" >> $GITHUB_STEP_SUMMARY
           echo "| **Migration volume safety** | $MIGRATION_VOLUME |" >> $GITHUB_STEP_SUMMARY
+          echo "| **Operational smoke test** | $OPERATIONAL_SMOKE |" >> $GITHUB_STEP_SUMMARY
           echo "| Payment workflow E2E | $PAYMENT |" >> $GITHUB_STEP_SUMMARY
           echo "| Core Access E2E | $CORE_ACCESS |" >> $GITHUB_STEP_SUMMARY
           echo "| **Student Lifecycle E2E** | $STUDENT_LIFECYCLE |" >> $GITHUB_STEP_SUMMARY

--- a/app/api/api_v1/endpoints/bookings/student.py
+++ b/app/api/api_v1/endpoints/bookings/student.py
@@ -124,6 +124,9 @@ def create_booking(
             and_(Booking.session_id == booking_data.session_id, Booking.status == BookingStatus.WAITLISTED)
         ).scalar() + 1
         metrics.increment("bookings_waitlisted")
+        _cat = getattr(session, "event_category", None)
+        if _cat is not None:
+            metrics.increment_labeled("bookings_waitlisted", {"event_category": _cat.value})
 
     booking = Booking(
         user_id=current_user.id,
@@ -137,6 +140,9 @@ def create_booking(
     try:
         db.commit()
         metrics.increment("bookings_created")
+        _cat = getattr(session, "event_category", None)
+        if _cat is not None:
+            metrics.increment_labeled("bookings_created", {"event_category": _cat.value})
     except IntegrityError as e:
         db.rollback()
         orig = str(getattr(e, "orig", e))

--- a/app/config.py
+++ b/app/config.py
@@ -150,6 +150,19 @@ class Settings(BaseSettings):
     ALERT_ENROLLMENT_GATE_BLOCK_RATE: float = 0.20  # >20 % enrollments gate-blocked → warning
     ALERT_SLOW_QUERY_TOTAL: int = 10               # >10 slow queries since start → warning
 
+    # ── Logging configuration ──────────────────────────────────────────────────
+    # All settings are read from environment variables; override in .env or
+    # the container environment for deployment-specific paths and retention needs.
+    LOG_DIR: str = "logs"                    # directory for rotating log files
+    LOG_MAX_BYTES: int = 10 * 1024 * 1024   # max size per log file (10 MB default)
+    LOG_BACKUP_COUNT: int = 5               # rotated backups to keep (app.log.1–5)
+
+    # ── Slow-query monitoring ──────────────────────────────────────────────────
+    # Queries slower than SLOW_QUERY_THRESHOLD_MS are logged to app.slow_query
+    # and counted in the slow_queries_total metric.  Raise this value if normal
+    # reporting queries regularly exceed the default (e.g. large dashboards).
+    SLOW_QUERY_THRESHOLD_MS: float = 200.0  # milliseconds
+
     # Payment configuration (override via environment variables in production)
     PAYMENT_AMOUNT_HUF: int = 50000
     PAYMENT_BANK_ACCOUNT_HOLDER: str = "LFA Education Center Kft."

--- a/app/config.py
+++ b/app/config.py
@@ -137,6 +137,19 @@ class Settings(BaseSettings):
         90: "Expert",
     }
 
+    # ── Alert thresholds for in-process metrics ────────────────────────────────
+    # These control GET /metrics/alerts. Adjust in production .env as traffic
+    # patterns become known.  All ratios are 0–1 (e.g. 0.05 = 5 %).
+    #
+    # ALERT_REWARD_FAILURE_RATE    — rewards_failed / total_rewards
+    # ALERT_BOOKING_WAITLIST_RATE  — bookings_waitlisted / total_bookings
+    # ALERT_ENROLLMENT_GATE_BLOCK_RATE — enrollment_gate_blocked / enrollment_attempts
+    # ALERT_SLOW_QUERY_TOTAL       — absolute count of slow queries (>200 ms) since start
+    ALERT_REWARD_FAILURE_RATE: float = 0.05        # >5 % reward failures → warning
+    ALERT_BOOKING_WAITLIST_RATE: float = 0.30      # >30 % bookings waitlisted → warning
+    ALERT_ENROLLMENT_GATE_BLOCK_RATE: float = 0.20  # >20 % enrollments gate-blocked → warning
+    ALERT_SLOW_QUERY_TOTAL: int = 10               # >10 slow queries since start → warning
+
     # Payment configuration (override via environment variables in production)
     PAYMENT_AMOUNT_HUF: int = 50000
     PAYMENT_BANK_ACCOUNT_HOLDER: str = "LFA Education Center Kft."

--- a/app/config.py
+++ b/app/config.py
@@ -157,6 +157,20 @@ class Settings(BaseSettings):
     LOG_MAX_BYTES: int = 10 * 1024 * 1024   # max size per log file (10 MB default)
     LOG_BACKUP_COUNT: int = 5               # rotated backups to keep (app.log.1–5)
 
+    # ── Database connection resilience ─────────────────────────────────────────
+    # Controls how long the driver waits when opening a new database connection
+    # and how many retries the startup health-check makes before aborting.
+    #
+    # DB_CONNECT_TIMEOUT       — seconds the psycopg2 driver waits per attempt
+    # DB_STATEMENT_TIMEOUT_MS  — per-statement wall-clock limit (0 = disabled).
+    #                            Prevents runaway queries from holding connections.
+    # DB_STARTUP_RETRIES       — how many times wait_for_db() retries before abort
+    # DB_STARTUP_RETRY_DELAY   — initial backoff (seconds); multiplied per attempt
+    DB_CONNECT_TIMEOUT: int = 10           # seconds per connection attempt
+    DB_STATEMENT_TIMEOUT_MS: int = 0       # 0 = disabled; e.g. 30000 = 30 s limit
+    DB_STARTUP_RETRIES: int = 5            # attempts before giving up at startup
+    DB_STARTUP_RETRY_DELAY: float = 2.0    # initial backoff in seconds
+
     # ── Slow-query monitoring ──────────────────────────────────────────────────
     # Queries slower than SLOW_QUERY_THRESHOLD_MS are logged to app.slow_query
     # and counted in the slow_queries_total metric.  Raise this value if normal

--- a/app/core/metrics.py
+++ b/app/core/metrics.py
@@ -53,9 +53,24 @@ Alert evaluation::
 """
 from __future__ import annotations
 
+import logging
 import threading
 from collections import defaultdict
 from typing import Any, Dict
+
+
+# ── Cardinality guard ─────────────────────────────────────────────────────────
+# Maps label key → set of allowed values.  increment_labeled() logs a WARNING
+# when a value outside this set is used, which helps catch typos and prevents
+# monitoring systems from being flooded with unbounded label cardinality.
+#
+# The guard is non-blocking: the counter IS still incremented so production
+# traffic is never dropped.  Add new values here as the domain evolves.
+_ALLOWED_LABEL_VALUES: Dict[str, frozenset] = {
+    "event_category": frozenset({"TRAINING", "MATCH", "ASSESSMENT", "TOURNAMENT"}),
+}
+
+_cardinality_log = logging.getLogger("app.metrics.cardinality")
 
 
 # Human-readable descriptions for Prometheus HELP lines.
@@ -123,6 +138,16 @@ class DomainMetrics:
         Typically called *in addition* to ``increment()`` so both the flat
         total and the per-label breakdown are kept up-to-date.
         """
+        # Cardinality guard: warn on unexpected label values before storing.
+        for k, v in labels.items():
+            allowed = _ALLOWED_LABEL_VALUES.get(k)
+            if allowed is not None and v not in allowed:
+                _cardinality_log.warning(
+                    "metrics cardinality violation: counter=%s label %s=%r "
+                    "not in allowed set %s — increment still recorded",
+                    name, k, v, sorted(allowed),
+                )
+
         label_str = ",".join(
             f"{k}={v}" for k, v in sorted(labels.items())
         )

--- a/app/core/metrics.py
+++ b/app/core/metrics.py
@@ -18,6 +18,7 @@ bookings_created        bookings committed with status CONFIRMED
 bookings_waitlisted     bookings committed with status WAITLISTED (capacity full)
 enrollment_attempts     ``create_enrollment()`` endpoint calls
 enrollment_gate_blocked enrollment attempts blocked by parent-semester hierarchy gate
+slow_queries_total      SQL queries that exceeded the slow-query threshold (200 ms)
 
 Usage::
 
@@ -28,12 +29,48 @@ Usage::
 
     snapshot = metrics.get_snapshot()
     # → {"rewards_generated": 42, "rewards_failed": 0, ...}
+
+Prometheus export::
+
+    text = metrics.format_prometheus()
+    # → "# HELP rewards_generated_total ...\\n# TYPE ...\\nrewards_generated_total 42\\n"
+
+Alert evaluation::
+
+    result = metrics.evaluate_alerts(settings)
+    # → {"status": "ok"|"warning", "thresholds": {...}}
 """
 from __future__ import annotations
 
 import threading
 from collections import defaultdict
-from typing import Dict
+from typing import Any, Dict
+
+
+# Human-readable descriptions for Prometheus HELP lines.
+_COUNTER_HELP: Dict[str, str] = {
+    "rewards_generated": (
+        "Total successful award_session_completion() calls."
+    ),
+    "rewards_failed": (
+        "Total award_session_completion() calls that raised an exception."
+    ),
+    "bookings_created": (
+        "Total bookings committed with status CONFIRMED."
+    ),
+    "bookings_waitlisted": (
+        "Total bookings committed with status WAITLISTED (capacity full)."
+    ),
+    "enrollment_attempts": (
+        "Total create_enrollment() endpoint calls."
+    ),
+    "enrollment_gate_blocked": (
+        "Total enrollment attempts blocked by the parent-semester hierarchy gate."
+    ),
+    "slow_queries_total": (
+        "Total SQL queries that exceeded the slow-query threshold (200 ms)."
+    ),
+}
 
 
 class DomainMetrics:
@@ -57,6 +94,120 @@ class DomainMetrics:
         """Reset all counters to zero.  Intended for test isolation only."""
         with self._lock:
             self._counters.clear()
+
+    # ── Prometheus exposition format ──────────────────────────────────────────
+
+    def format_prometheus(self) -> str:
+        """
+        Return metrics in Prometheus text exposition format.
+
+        Output is ``text/plain; version=0.0.4`` compatible.  Each counter is
+        emitted with a ``# HELP`` line, a ``# TYPE counter`` line and a metric
+        line with a ``_total`` suffix (Prometheus naming convention for counters).
+        Counter names that already end with ``_total`` are not doubled.
+
+        Returns an empty-comment line when no counters have been recorded yet.
+        """
+        snapshot = self.get_snapshot()
+        if not snapshot:
+            return "# No counters registered yet\n"
+
+        lines: list[str] = []
+        for name in sorted(snapshot):
+            # Prometheus counter names must end with _total
+            prom_name = name if name.endswith("_total") else f"{name}_total"
+            help_text = _COUNTER_HELP.get(name, f"Counter: {name}.")
+            lines.append(f"# HELP {prom_name} {help_text}")
+            lines.append(f"# TYPE {prom_name} counter")
+            lines.append(f"{prom_name} {snapshot[name]}")
+
+        return "\n".join(lines) + "\n"
+
+    # ── Alert threshold evaluation ─────────────────────────────────────────────
+
+    def evaluate_alerts(self, settings: Any) -> Dict[str, Any]:
+        """
+        Compare counter ratios against configured thresholds.
+
+        Returns a dict with:
+        - ``status``: ``"ok"`` or ``"warning"`` (warning if any threshold fires)
+        - ``thresholds``: per-alert dict with ``value``, ``threshold``, ``firing``
+
+        Only evaluates a ratio alert when the denominator > 0 (avoids
+        false positives on a freshly started process with zero traffic).
+
+        Parameters
+        ----------
+        settings:
+            The application ``Settings`` instance — provides
+            ``ALERT_REWARD_FAILURE_RATE``, ``ALERT_BOOKING_WAITLIST_RATE``,
+            ``ALERT_ENROLLMENT_GATE_BLOCK_RATE``, ``ALERT_SLOW_QUERY_TOTAL``.
+        """
+        snapshot = self.get_snapshot()
+        overall_status = "ok"
+        thresholds: Dict[str, Any] = {}
+
+        # ── Reward failure rate ────────────────────────────────────────────────
+        total_rewards = (
+            snapshot.get("rewards_generated", 0)
+            + snapshot.get("rewards_failed", 0)
+        )
+        if total_rewards > 0:
+            rate = snapshot.get("rewards_failed", 0) / total_rewards
+            firing = rate > settings.ALERT_REWARD_FAILURE_RATE
+            thresholds["reward_failure_rate"] = {
+                "value": round(rate, 4),
+                "threshold": settings.ALERT_REWARD_FAILURE_RATE,
+                "firing": firing,
+                "description": "rewards_failed / total_rewards",
+            }
+            if firing:
+                overall_status = "warning"
+
+        # ── Booking waitlist rate ──────────────────────────────────────────────
+        total_bookings = (
+            snapshot.get("bookings_created", 0)
+            + snapshot.get("bookings_waitlisted", 0)
+        )
+        if total_bookings > 0:
+            rate = snapshot.get("bookings_waitlisted", 0) / total_bookings
+            firing = rate > settings.ALERT_BOOKING_WAITLIST_RATE
+            thresholds["booking_waitlist_rate"] = {
+                "value": round(rate, 4),
+                "threshold": settings.ALERT_BOOKING_WAITLIST_RATE,
+                "firing": firing,
+                "description": "bookings_waitlisted / total_bookings",
+            }
+            if firing:
+                overall_status = "warning"
+
+        # ── Enrollment gate block rate ─────────────────────────────────────────
+        total_enrollments = snapshot.get("enrollment_attempts", 0)
+        if total_enrollments > 0:
+            rate = snapshot.get("enrollment_gate_blocked", 0) / total_enrollments
+            firing = rate > settings.ALERT_ENROLLMENT_GATE_BLOCK_RATE
+            thresholds["enrollment_gate_block_rate"] = {
+                "value": round(rate, 4),
+                "threshold": settings.ALERT_ENROLLMENT_GATE_BLOCK_RATE,
+                "firing": firing,
+                "description": "enrollment_gate_blocked / enrollment_attempts",
+            }
+            if firing:
+                overall_status = "warning"
+
+        # ── Slow queries (absolute count, not ratio) ───────────────────────────
+        slow_q = snapshot.get("slow_queries_total", 0)
+        firing = slow_q > settings.ALERT_SLOW_QUERY_TOTAL
+        thresholds["slow_queries_total"] = {
+            "value": slow_q,
+            "threshold": settings.ALERT_SLOW_QUERY_TOTAL,
+            "firing": firing,
+            "description": "absolute count of slow SQL queries since process start",
+        }
+        if firing:
+            overall_status = "warning"
+
+        return {"status": overall_status, "thresholds": thresholds}
 
 
 #: Process-wide singleton — import this in service and endpoint modules.

--- a/app/core/metrics.py
+++ b/app/core/metrics.py
@@ -20,20 +20,31 @@ enrollment_attempts     ``create_enrollment()`` endpoint calls
 enrollment_gate_blocked enrollment attempts blocked by parent-semester hierarchy gate
 slow_queries_total      SQL queries that exceeded the slow-query threshold (200 ms)
 
+Labeled counters
+----------------
+The same counters above can also be broken down by label using
+``increment_labeled()``.  Labels are low-cardinality key/value pairs such as
+``event_category`` (TRAINING | MATCH | …).  Use ``get_labeled_snapshot()`` or
+the Prometheus export to see per-label breakdowns.
+
 Usage::
 
     from app.core.metrics import metrics
 
     metrics.increment("rewards_generated")
-    metrics.increment("rewards_failed")
+    metrics.increment_labeled("rewards_generated", {"event_category": "TRAINING"})
 
     snapshot = metrics.get_snapshot()
-    # → {"rewards_generated": 42, "rewards_failed": 0, ...}
+    # → {"rewards_generated": 42, ...}
+
+    labeled = metrics.get_labeled_snapshot()
+    # → {"rewards_generated": {"event_category=TRAINING": 42}, ...}
 
 Prometheus export::
 
     text = metrics.format_prometheus()
-    # → "# HELP rewards_generated_total ...\\n# TYPE ...\\nrewards_generated_total 42\\n"
+    # → "# HELP rewards_generated_total ...\\n...\\nrewards_generated_total 42\\n"
+    # → "rewards_generated_total{event_category=\\"TRAINING\\"} 42\\n"
 
 Alert evaluation::
 
@@ -74,26 +85,65 @@ _COUNTER_HELP: Dict[str, str] = {
 
 
 class DomainMetrics:
-    """Thread-safe in-process counter store."""
+    """Thread-safe in-process counter store with optional label support."""
 
     def __init__(self) -> None:
         self._lock = threading.Lock()
         self._counters: Dict[str, int] = defaultdict(int)
+        # Labeled counters: name → {label_string → count}
+        # label_string is "key1=val1,key2=val2" (sorted by key)
+        self._labeled_counters: Dict[str, Dict[str, int]] = defaultdict(
+            lambda: defaultdict(int)
+        )
+
+    # ── Flat counters ──────────────────────────────────────────────────────────
 
     def increment(self, name: str, by: int = 1) -> None:
-        """Atomically increment counter ``name`` by ``by`` (default 1)."""
+        """Atomically increment flat counter ``name`` by ``by`` (default 1)."""
         with self._lock:
             self._counters[name] += by
 
     def get_snapshot(self) -> Dict[str, int]:
-        """Return a point-in-time copy of all counters."""
+        """Return a point-in-time copy of all flat counters."""
         with self._lock:
             return dict(self._counters)
 
+    # ── Labeled counters ───────────────────────────────────────────────────────
+
+    def increment_labeled(
+        self, name: str, labels: Dict[str, str], by: int = 1
+    ) -> None:
+        """
+        Atomically increment a labeled counter.
+
+        Labels are low-cardinality key/value pairs, e.g.
+        ``{"event_category": "TRAINING"}``.  The label dict is serialised as
+        sorted ``key=value`` pairs so callers do not need to pre-sort.
+
+        Typically called *in addition* to ``increment()`` so both the flat
+        total and the per-label breakdown are kept up-to-date.
+        """
+        label_str = ",".join(
+            f"{k}={v}" for k, v in sorted(labels.items())
+        )
+        with self._lock:
+            self._labeled_counters[name][label_str] += by
+
+    def get_labeled_snapshot(self) -> Dict[str, Dict[str, int]]:
+        """Return a point-in-time copy of all labeled counters."""
+        with self._lock:
+            return {
+                name: dict(label_counts)
+                for name, label_counts in self._labeled_counters.items()
+            }
+
+    # ── Lifecycle ──────────────────────────────────────────────────────────────
+
     def reset(self) -> None:
-        """Reset all counters to zero.  Intended for test isolation only."""
+        """Reset all counters (flat and labeled).  Intended for test isolation."""
         with self._lock:
             self._counters.clear()
+            self._labeled_counters.clear()
 
     # ── Prometheus exposition format ──────────────────────────────────────────
 
@@ -102,24 +152,40 @@ class DomainMetrics:
         Return metrics in Prometheus text exposition format.
 
         Output is ``text/plain; version=0.0.4`` compatible.  Each counter is
-        emitted with a ``# HELP`` line, a ``# TYPE counter`` line and a metric
-        line with a ``_total`` suffix (Prometheus naming convention for counters).
-        Counter names that already end with ``_total`` are not doubled.
+        emitted with a ``# HELP`` line, a ``# TYPE counter`` line, and metric
+        lines with a ``_total`` suffix (Prometheus naming convention).
+
+        Flat totals appear first (no labels), followed by labeled breakdowns
+        for any counter that has been incremented via ``increment_labeled()``.
+        Counter names already ending with ``_total`` are not doubled.
 
         Returns an empty-comment line when no counters have been recorded yet.
         """
-        snapshot = self.get_snapshot()
-        if not snapshot:
+        flat = self.get_snapshot()
+        labeled = self.get_labeled_snapshot()
+        all_names = sorted(set(flat) | set(labeled))
+
+        if not all_names:
             return "# No counters registered yet\n"
 
         lines: list[str] = []
-        for name in sorted(snapshot):
-            # Prometheus counter names must end with _total
+        for name in all_names:
             prom_name = name if name.endswith("_total") else f"{name}_total"
             help_text = _COUNTER_HELP.get(name, f"Counter: {name}.")
             lines.append(f"# HELP {prom_name} {help_text}")
             lines.append(f"# TYPE {prom_name} counter")
-            lines.append(f"{prom_name} {snapshot[name]}")
+            # Flat total (if present)
+            if name in flat:
+                lines.append(f"{prom_name} {flat[name]}")
+            # Labeled breakdowns (if present)
+            for label_str, count in sorted(labeled.get(name, {}).items()):
+                # Convert "key=val,key2=val2" → {key="val",key2="val2"} syntax
+                pairs = []
+                for part in label_str.split(","):
+                    k, v = part.split("=", 1)
+                    pairs.append(f'{k}="{v}"')
+                labels_rendered = "{" + ",".join(pairs) + "}"
+                lines.append(f"{prom_name}{labels_rendered} {count}")
 
         return "\n".join(lines) + "\n"
 

--- a/app/database.py
+++ b/app/database.py
@@ -20,9 +20,8 @@ SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 Base = declarative_base()
 
 # ── Slow-query monitoring ──────────────────────────────────────────────────────
-# Queries slower than this threshold are logged to ``app.slow_query`` with
-# the current request_id for easy correlation in production log aggregators.
-_SLOW_QUERY_THRESHOLD_MS: float = 200.0
+# Threshold is read from settings (SLOW_QUERY_THRESHOLD_MS, default 200 ms) so
+# it can be raised in .env without a code change (e.g. for reporting workloads).
 _sq_logger = logging.getLogger("app.slow_query")
 
 
@@ -34,7 +33,7 @@ def _sq_before_execute(conn, cursor, statement, params, context, executemany):
 @sa_event.listens_for(engine, "after_cursor_execute")
 def _sq_after_execute(conn, cursor, statement, params, context, executemany):
     elapsed_ms = (time.perf_counter() - conn.info["_sq_start"].pop()) * 1000
-    if elapsed_ms >= _SLOW_QUERY_THRESHOLD_MS:
+    if elapsed_ms >= settings.SLOW_QUERY_THRESHOLD_MS:
         # Deferred imports to avoid circular dependency at module load time
         from app.core.metrics import metrics
         from app.core.structured_log import log_warn

--- a/app/database.py
+++ b/app/database.py
@@ -1,9 +1,19 @@
 import logging
 import time
 
-from sqlalchemy import create_engine, event as sa_event
+from sqlalchemy import create_engine, event as sa_event, text
 from sqlalchemy.orm import declarative_base, sessionmaker
 from .config import settings
+
+# ── Connection arguments ───────────────────────────────────────────────────────
+# Passed to the underlying psycopg2 driver on every new connection.
+# connect_timeout prevents the app from hanging indefinitely when PostgreSQL is
+# temporarily unreachable (e.g. during a rolling restart or pod scheduling).
+_connect_args: dict = {"connect_timeout": settings.DB_CONNECT_TIMEOUT}
+if settings.DB_STATEMENT_TIMEOUT_MS > 0:
+    # Per-statement wall-clock limit — kills runaway queries before they fill
+    # the connection pool.  Set DB_STATEMENT_TIMEOUT_MS in .env for production.
+    _connect_args["options"] = f"-c statement_timeout={settings.DB_STATEMENT_TIMEOUT_MS}"
 
 # Production-ready connection pool configuration
 # For 100+ concurrent users, we need larger pool
@@ -13,7 +23,8 @@ engine = create_engine(
     max_overflow=30,       # Extra connections beyond pool_size (total: 50)
     pool_pre_ping=True,    # Verify connections before use (prevents stale connections)
     pool_recycle=3600,     # Recycle connections after 1 hour
-    echo_pool=False        # Set to True for debugging pool issues
+    echo_pool=False,       # Set to True for debugging pool issues
+    connect_args=_connect_args,
 )
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
@@ -59,6 +70,50 @@ def get_db():
         yield db
     finally:
         db.close()
+
+
+def wait_for_db(
+    max_retries: int | None = None,
+    delay_seconds: float | None = None,
+) -> None:
+    """
+    Verify database connectivity with exponential backoff.
+
+    Intended for use during application startup so the process does not
+    begin accepting traffic before the database is reachable.  Raises
+    ``RuntimeError`` when all retries are exhausted.
+
+    Parameters
+    ----------
+    max_retries:
+        Number of connection attempts before aborting.
+        Defaults to ``settings.DB_STARTUP_RETRIES`` (5).
+    delay_seconds:
+        Initial backoff between attempts (multiplied by attempt number).
+        Defaults to ``settings.DB_STARTUP_RETRY_DELAY`` (2.0 s).
+    """
+    _retries = max_retries if max_retries is not None else settings.DB_STARTUP_RETRIES
+    _delay = delay_seconds if delay_seconds is not None else settings.DB_STARTUP_RETRY_DELAY
+    _logger = logging.getLogger("app.database")
+
+    for attempt in range(1, _retries + 1):
+        try:
+            with engine.connect() as conn:
+                conn.execute(text("SELECT 1"))
+            _logger.info("Database connection verified (attempt %d/%d)", attempt, _retries)
+            return
+        except Exception as exc:
+            if attempt == _retries:
+                raise RuntimeError(
+                    f"Database unavailable after {_retries} attempts. "
+                    f"Last error: {exc}"
+                ) from exc
+            wait = _delay * attempt
+            _logger.warning(
+                "Database connection attempt %d/%d failed, retrying in %.1fs: %s",
+                attempt, _retries, wait, exc,
+            )
+            time.sleep(wait)
 
 
 def create_database():

--- a/app/database.py
+++ b/app/database.py
@@ -36,8 +36,10 @@ def _sq_after_execute(conn, cursor, statement, params, context, executemany):
     elapsed_ms = (time.perf_counter() - conn.info["_sq_start"].pop()) * 1000
     if elapsed_ms >= _SLOW_QUERY_THRESHOLD_MS:
         # Deferred imports to avoid circular dependency at module load time
+        from app.core.metrics import metrics
         from app.core.structured_log import log_warn
         from app.core.request_context import get_request_id
+        metrics.increment("slow_queries_total")
         rid = get_request_id()
         extra = {"request_id": rid} if rid else {}
         log_warn(

--- a/app/main.py
+++ b/app/main.py
@@ -2,7 +2,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.exceptions import RequestValidationError
-from fastapi.responses import PlainTextResponse
+from fastapi.responses import JSONResponse, PlainTextResponse
 from fastapi.templating import Jinja2Templates
 from fastapi.staticfiles import StaticFiles
 from starlette.exceptions import HTTPException as StarletteHTTPException
@@ -160,12 +160,20 @@ async def detailed_health_check():
 
 @app.get("/health/ready")
 async def readiness_check():
-    """Kubernetes-style readiness probe"""
+    """
+    Kubernetes-style readiness probe.
+
+    Returns HTTP 200 when the service is ready to accept traffic (database
+    reachable and responding).  Returns HTTP 503 when the database is unhealthy
+    so orchestrators remove the pod from the load-balancer rotation.
+    """
     db_health = await HealthChecker.get_database_health()
-    return {
-        "status": "ready" if db_health["status"] != "unhealthy" else "not_ready",
-        "database": db_health["status"]
+    is_ready = db_health["status"] != "unhealthy"
+    content = {
+        "status": "ready" if is_ready else "not_ready",
+        "database": db_health["status"],
     }
+    return JSONResponse(content=content, status_code=200 if is_ready else 503)
 
 
 @app.get("/health/live")
@@ -176,8 +184,16 @@ async def liveness_check():
 
 @app.get("/health/worker")
 async def worker_health_check():
-    """Redis broker and Celery worker liveness probe."""
-    return await HealthChecker.get_worker_health()
+    """
+    Redis broker and Celery worker liveness probe.
+
+    Returns HTTP 200 when Redis is reachable (workers may be degraded but
+    the app is still operational).  Returns HTTP 503 only when Redis itself
+    is unreachable, which prevents background job enqueueing entirely.
+    """
+    result = await HealthChecker.get_worker_health()
+    status_code = 503 if result.get("status") == "unhealthy" else 200
+    return JSONResponse(content=result, status_code=status_code)
 
 
 @app.get("/metrics")
@@ -203,7 +219,10 @@ async def domain_metrics(
             content=metrics.format_prometheus(),
             media_type="text/plain; version=0.0.4; charset=utf-8",
         )
-    return {"counters": metrics.get_snapshot()}
+    return {
+        "counters": metrics.get_snapshot(),
+        "labeled_counters": metrics.get_labeled_snapshot(),
+    }
 
 
 @app.get("/metrics/alerts")

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,8 @@
 from contextlib import asynccontextmanager
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.exceptions import RequestValidationError
+from fastapi.responses import PlainTextResponse
 from fastapi.templating import Jinja2Templates
 from fastapi.staticfiles import StaticFiles
 from starlette.exceptions import HTTPException as StarletteHTTPException
@@ -180,13 +181,47 @@ async def worker_health_check():
 
 
 @app.get("/metrics")
-async def domain_metrics():
+async def domain_metrics(
+    format: str = Query(
+        default="json",
+        description="Output format: 'json' (default) or 'prometheus'.",
+    ),
+):
     """
     In-process domain event counters.
 
     Returns lifetime totals (since last process start) for key operational
     events: reward generation, booking creation, enrollment gate decisions.
     Intended for internal monitoring and alerting dashboards.
+
+    Set ``?format=prometheus`` to receive Prometheus text exposition format
+    (``text/plain; version=0.0.4``) suitable for a Prometheus scrape target.
     """
     from .core.metrics import metrics
+    if format == "prometheus":
+        return PlainTextResponse(
+            content=metrics.format_prometheus(),
+            media_type="text/plain; version=0.0.4; charset=utf-8",
+        )
     return {"counters": metrics.get_snapshot()}
+
+
+@app.get("/metrics/alerts")
+async def metrics_alerts():
+    """
+    Evaluate in-process counter values against configured alert thresholds.
+
+    Returns ``{"status": "ok"|"warning", "thresholds": {...}}`` where each
+    entry in ``thresholds`` includes ``value``, ``threshold`` and ``firing``.
+    Only ratio-based alerts are emitted when enough traffic has been seen
+    (denominator > 0); the slow-query count is always evaluated.
+
+    Thresholds are configured via the application Settings:
+    - ``ALERT_REWARD_FAILURE_RATE`` (default 0.05)
+    - ``ALERT_BOOKING_WAITLIST_RATE`` (default 0.30)
+    - ``ALERT_ENROLLMENT_GATE_BLOCK_RATE`` (default 0.20)
+    - ``ALERT_SLOW_QUERY_TOTAL`` (default 10)
+    """
+    from .core.metrics import metrics
+    from .config import settings
+    return metrics.evaluate_alerts(settings)

--- a/app/middleware/logging.py
+++ b/app/middleware/logging.py
@@ -2,6 +2,7 @@ import logging
 import time
 import json
 import os
+from logging.handlers import RotatingFileHandler
 from typing import Callable
 from uuid import uuid4
 from datetime import datetime, timezone
@@ -21,9 +22,18 @@ os.makedirs(log_dir, exist_ok=True)
 # Configure structured logging
 handlers = [logging.StreamHandler()]
 
-# Only add file handler if not in test environment
+# Only add file handler if not in test environment.
+# RotatingFileHandler caps each log file at 10 MB and keeps 5 rotated backups,
+# giving ~50 MB maximum disk usage before the oldest file is overwritten.
 if not os.getenv('TESTING', '').lower() == 'true':
-    handlers.append(logging.FileHandler(os.path.join(log_dir, 'app.log'), mode='a'))
+    handlers.append(
+        RotatingFileHandler(
+            os.path.join(log_dir, 'app.log'),
+            maxBytes=10 * 1024 * 1024,  # 10 MB per file
+            backupCount=5,              # keep app.log.1 … app.log.5
+            encoding='utf-8',
+        )
+    )
 
 logging.basicConfig(
     level=logging.INFO,

--- a/app/middleware/logging.py
+++ b/app/middleware/logging.py
@@ -15,22 +15,27 @@ from starlette.responses import StreamingResponse
 # read it without importing from middleware (avoids circular imports).
 from app.core.request_context import request_id_var
 
+# Log directory and rotation settings — all overridable via environment variables
+# (LOG_DIR, LOG_MAX_BYTES, LOG_BACKUP_COUNT).  Defaults match app/config.py Settings.
+_log_dir = os.getenv('LOG_DIR', 'logs')
+_log_max_bytes = int(os.getenv('LOG_MAX_BYTES', str(10 * 1024 * 1024)))
+_log_backup_count = int(os.getenv('LOG_BACKUP_COUNT', '5'))
+
 # Create logs directory if it doesn't exist
-log_dir = 'logs'
-os.makedirs(log_dir, exist_ok=True)
+os.makedirs(_log_dir, exist_ok=True)
 
 # Configure structured logging
 handlers = [logging.StreamHandler()]
 
 # Only add file handler if not in test environment.
-# RotatingFileHandler caps each log file at 10 MB and keeps 5 rotated backups,
-# giving ~50 MB maximum disk usage before the oldest file is overwritten.
+# RotatingFileHandler caps each log file at LOG_MAX_BYTES (default 10 MB) and
+# keeps LOG_BACKUP_COUNT rotated backups (default 5) — ~50 MB max disk usage.
 if not os.getenv('TESTING', '').lower() == 'true':
     handlers.append(
         RotatingFileHandler(
-            os.path.join(log_dir, 'app.log'),
-            maxBytes=10 * 1024 * 1024,  # 10 MB per file
-            backupCount=5,              # keep app.log.1 … app.log.5
+            os.path.join(_log_dir, 'app.log'),
+            maxBytes=_log_max_bytes,
+            backupCount=_log_backup_count,
             encoding='utf-8',
         )
     )

--- a/app/services/reward_service.py
+++ b/app/services/reward_service.py
@@ -95,6 +95,10 @@ def award_session_completion(
     except Exception as exc:
         db.rollback()
         metrics.increment("rewards_failed")
+        if session.event_category is not None:
+            metrics.increment_labeled(
+                "rewards_failed", {"event_category": session.event_category.value}
+            )
         log_error(
             _logger, "reward_failed",
             user_id=user_id, session_id=session.id,
@@ -108,6 +112,10 @@ def award_session_completion(
     ).one()
 
     metrics.increment("rewards_generated")
+    if session.event_category is not None:
+        metrics.increment_labeled(
+            "rewards_generated", {"event_category": session.event_category.value}
+        )
     log_info(
         _logger, "reward_awarded",
         user_id=user_id, session_id=session.id,

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -6,6 +6,7 @@ Last updated: 2026-03-15
 
 ## Table of Contents
 
+0. [Deployment Guide](#0-deployment-guide)
 1. [Metrics Endpoint](#1-metrics-endpoint)
 2. [Counter Definitions](#2-counter-definitions)
 3. [Prometheus Integration](#3-prometheus-integration)
@@ -14,6 +15,178 @@ Last updated: 2026-03-15
 6. [Migration Rollback Procedure](#6-migration-rollback-procedure)
 7. [Log Files and Retention](#7-log-files-and-retention)
 8. [Health Endpoints](#8-health-endpoints)
+
+---
+
+## 0. Deployment Guide
+
+### Required environment variables
+
+Set these in `.env` or your container environment.  The application refuses to
+start in production without **SECRET_KEY**, **DATABASE_URL**, **ADMIN_EMAIL**,
+**ADMIN_PASSWORD**, and **CORS_ALLOWED_ORIGINS**.
+
+| Variable | Required | Description | Example |
+|---|---|---|---|
+| `SECRET_KEY` | **Yes** | JWT signing key (≥32 random bytes) | `openssl rand -base64 32` |
+| `DATABASE_URL` | **Yes** | PostgreSQL DSN | `postgresql://user:pass@db:5432/gancuju` |
+| `REDIS_URL` | Yes (for workers) | Redis DSN for Celery broker | `redis://redis:6379/0` |
+| `CELERY_BROKER_URL` | Yes (for workers) | Celery broker URL | `redis://redis:6379/0` |
+| `CELERY_RESULT_BACKEND` | Yes (for workers) | Celery result backend | `redis://redis:6379/1` |
+| `ADMIN_EMAIL` | **Yes (prod)** | Initial admin email | `admin@company.com` |
+| `ADMIN_PASSWORD` | **Yes (prod)** | Initial admin password (strong) | `$(pwgen -s 20 1)` |
+| `CORS_ALLOWED_ORIGINS` | **Yes (prod)** | Comma-separated allowed origins | `https://app.example.com` |
+| `ENVIRONMENT` | No | `development` / `production` | `production` |
+| `DEBUG` | No | Must be `false` in production | `false` |
+| `COOKIE_SECURE` | No | `true` enforces HTTPS cookies | `true` |
+
+#### Operational settings (all optional — defaults match below)
+
+| Variable | Default | Description |
+|---|---|---|
+| `LOG_DIR` | `logs` | Directory for rotating log files |
+| `LOG_MAX_BYTES` | `10485760` | Max log file size in bytes (10 MB) |
+| `LOG_BACKUP_COUNT` | `5` | Rotating backups to keep |
+| `SLOW_QUERY_THRESHOLD_MS` | `200.0` | SQL slow-query alert threshold (ms) |
+| `ALERT_REWARD_FAILURE_RATE` | `0.05` | Reward failure rate threshold (5 %) |
+| `ALERT_BOOKING_WAITLIST_RATE` | `0.30` | Booking waitlist rate threshold (30 %) |
+| `ALERT_ENROLLMENT_GATE_BLOCK_RATE` | `0.20` | Enrollment gate block rate threshold (20 %) |
+| `ALERT_SLOW_QUERY_TOTAL` | `10` | Absolute slow-query count threshold |
+| `RATE_LIMIT_CALLS` | `100` | Requests per rate-limit window |
+| `RATE_LIMIT_WINDOW_SECONDS` | `60` | Rate-limit window in seconds |
+| `ENABLE_RATE_LIMITING` | `true` (non-test) | Toggle rate limiting |
+| `ENABLE_STRUCTURED_LOGGING` | `true` | Toggle HTTP access logging middleware |
+
+### Database migration procedure
+
+Always run migrations **before** deploying new application code:
+
+```bash
+# 1. Verify you are pointing at the correct database
+echo $DATABASE_URL
+
+# 2. Check current migration state
+alembic current
+
+# 3. Preview what will run
+alembic upgrade head --sql | head -40
+
+# 4. Apply migrations
+alembic upgrade head
+
+# 5. Verify
+alembic current
+```
+
+For zero-downtime index creation, add `postgresql_concurrently=True` to
+`op.create_index()` in the migration — this avoids table locks on large tables.
+
+### First-time setup
+
+```bash
+# 1. Install dependencies
+pip install -r requirements.txt
+
+# 2. Copy and populate environment file
+cp .env.example .env
+# Edit .env with production values
+
+# 3. Run migrations
+alembic upgrade head
+
+# 4. Start the application
+uvicorn app.main:app --host 0.0.0.0 --port 8000 --workers 4
+
+# 5. Verify health
+curl http://localhost:8000/health/ready
+# Expected: {"status": "ready", "database": "healthy"}
+```
+
+### Docker deployment (example)
+
+```yaml
+# docker-compose.yml
+version: "3.9"
+services:
+  app:
+    image: gancuju-education-center:latest
+    environment:
+      - SECRET_KEY=${SECRET_KEY}
+      - DATABASE_URL=postgresql://user:pass@db:5432/gancuju
+      - REDIS_URL=redis://redis:6379/0
+      - ADMIN_EMAIL=${ADMIN_EMAIL}
+      - ADMIN_PASSWORD=${ADMIN_PASSWORD}
+      - CORS_ALLOWED_ORIGINS=https://app.example.com
+      - ENVIRONMENT=production
+      - DEBUG=false
+      - LOG_DIR=/app/logs
+    volumes:
+      - ./logs:/app/logs
+    ports:
+      - "8000:8000"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health/ready"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: gancuju
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: pass
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U user -d gancuju"]
+      interval: 10s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      retries: 5
+
+  worker:
+    image: gancuju-education-center:latest
+    command: celery -A app.celery_app worker --loglevel=info
+    environment:
+      - DATABASE_URL=postgresql://user:pass@db:5432/gancuju
+      - CELERY_BROKER_URL=redis://redis:6379/0
+      - CELERY_RESULT_BACKEND=redis://redis:6379/1
+    depends_on:
+      - db
+      - redis
+```
+
+### Kubernetes readiness/liveness probes
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /health/live
+    port: 8000
+  initialDelaySeconds: 10
+  periodSeconds: 30
+
+readinessProbe:
+  httpGet:
+    path: /health/ready
+    port: 8000
+  initialDelaySeconds: 15
+  periodSeconds: 10
+  failureThreshold: 3
+```
+
+`/health/ready` returns **HTTP 503** when the database is unreachable, causing
+Kubernetes to remove the pod from the Service endpoint slice until the database
+recovers.  `/health/live` always returns **HTTP 200** as long as the process is
+running (a 5xx here triggers a pod restart).
 
 ---
 
@@ -32,16 +205,31 @@ Response:
 ```json
 {
   "counters": {
-    "rewards_generated": 142,
+    "rewards_generated": 157,
     "rewards_failed": 3,
     "bookings_created": 512,
     "bookings_waitlisted": 18,
     "enrollment_attempts": 87,
     "enrollment_gate_blocked": 7,
     "slow_queries_total": 2
+  },
+  "labeled_counters": {
+    "bookings_created": {
+      "event_category=TRAINING": 430,
+      "event_category=MATCH": 82
+    },
+    "rewards_generated": {
+      "event_category=TRAINING": 130,
+      "event_category=MATCH": 27
+    }
   }
 }
 ```
+
+`counters` contains flat lifetime totals.  `labeled_counters` contains
+per-label breakdowns for counters that were also incremented with
+``increment_labeled()`` — currently `bookings_created`, `bookings_waitlisted`,
+`rewards_generated`, and `rewards_failed` carry an `event_category` label.
 
 Counters are **lifetime totals since the process started**.  In a multi-process
 deployment (multiple uvicorn workers) each process maintains its own counters;

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -57,6 +57,49 @@ start in production without **SECRET_KEY**, **DATABASE_URL**, **ADMIN_EMAIL**,
 | `ENABLE_RATE_LIMITING` | `true` (non-test) | Toggle rate limiting |
 | `ENABLE_STRUCTURED_LOGGING` | `true` | Toggle HTTP access logging middleware |
 
+### Deployment sequence
+
+Follow this order strictly to avoid downtime or data inconsistency:
+
+```
+1. Run: alembic upgrade head       ← apply schema changes first
+2. Run: python scripts/seed_tournament_types.py   ← (first deploy only)
+3. Start: uvicorn / gunicorn workers               ← app reads new schema
+4. Poll:  GET /health/ready → 200                  ← orchestrator gate
+5. Enable: load-balancer traffic                   ← serve real requests
+```
+
+**Never reverse steps 3 and 1**: if app code expects columns that do not yet
+exist, every request fails until migrations catch up.
+
+**Zero-downtime upgrade with two app versions (blue/green)**:
+1. Apply migrations on the old (blue) cluster — schema must be backwards-compatible
+2. Deploy new (green) cluster — it starts, runs `wait_for_db()`, reports ready
+3. Shift traffic to green; drain blue
+4. Remove blue cluster
+
+> **Tip**: use `wait_for_db()` at the start of your entrypoint to prevent the
+> app from accepting requests before the database is reachable:
+>
+> ```python
+> # entrypoint / startup script
+> from app.database import wait_for_db
+> wait_for_db()          # raises RuntimeError after DB_STARTUP_RETRIES attempts
+> # then start uvicorn / gunicorn
+> ```
+
+#### Connection resilience settings
+
+| Setting | Default | Purpose |
+|---|---|---|
+| `DB_CONNECT_TIMEOUT` | `10` | Seconds the driver waits per connection attempt |
+| `DB_STATEMENT_TIMEOUT_MS` | `0` (off) | Per-statement wall-clock limit (ms); prevents runaway queries |
+| `DB_STARTUP_RETRIES` | `5` | `wait_for_db()` attempts before aborting |
+| `DB_STARTUP_RETRY_DELAY` | `2.0` | Initial backoff in seconds (multiplied per attempt) |
+
+Set `DB_STATEMENT_TIMEOUT_MS=30000` in production to cap individual queries at
+30 s and protect the connection pool from long-running analytical queries.
+
 ### Database migration procedure
 
 Always run migrations **before** deploying new application code:

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -1,0 +1,377 @@
+# Operations Runbook — GānCuju Education Center
+
+Last updated: 2026-03-15
+
+---
+
+## Table of Contents
+
+1. [Metrics Endpoint](#1-metrics-endpoint)
+2. [Counter Definitions](#2-counter-definitions)
+3. [Prometheus Integration](#3-prometheus-integration)
+4. [Alert Thresholds](#4-alert-thresholds)
+5. [Slow Query Handling](#5-slow-query-handling)
+6. [Migration Rollback Procedure](#6-migration-rollback-procedure)
+7. [Log Files and Retention](#7-log-files-and-retention)
+8. [Health Endpoints](#8-health-endpoints)
+
+---
+
+## 1. Metrics Endpoint
+
+The application exposes in-process domain event counters at two endpoints:
+
+### JSON format (default)
+
+```
+GET /metrics
+```
+
+Response:
+
+```json
+{
+  "counters": {
+    "rewards_generated": 142,
+    "rewards_failed": 3,
+    "bookings_created": 512,
+    "bookings_waitlisted": 18,
+    "enrollment_attempts": 87,
+    "enrollment_gate_blocked": 7,
+    "slow_queries_total": 2
+  }
+}
+```
+
+Counters are **lifetime totals since the process started**.  In a multi-process
+deployment (multiple uvicorn workers) each process maintains its own counters;
+aggregate across workers at the load-balancer or log-aggregation layer.
+
+### Alert evaluation
+
+```
+GET /metrics/alerts
+```
+
+Response (all clear):
+
+```json
+{
+  "status": "ok",
+  "thresholds": {
+    "reward_failure_rate": {"value": 0.0206, "threshold": 0.05, "firing": false, ...},
+    "booking_waitlist_rate": {"value": 0.034, "threshold": 0.30, "firing": false, ...},
+    "enrollment_gate_block_rate": {"value": 0.08, "threshold": 0.20, "firing": false, ...},
+    "slow_queries_total": {"value": 2, "threshold": 10, "firing": false, ...}
+  }
+}
+```
+
+`status` is `"warning"` when at least one threshold is `firing: true`.
+Ratio-based alerts are only emitted after sufficient traffic (denominator > 0),
+so a freshly restarted process with no traffic will not generate false positives.
+
+---
+
+## 2. Counter Definitions
+
+| Counter | Meaning | Incremented in |
+|---|---|---|
+| `rewards_generated` | Successful `award_session_completion()` call — XP and points written to DB | `app/services/reward_service.py` |
+| `rewards_failed` | `award_session_completion()` raised an exception — transaction rolled back | `app/services/reward_service.py` |
+| `bookings_created` | Booking committed with status `CONFIRMED` | `app/api/api_v1/endpoints/bookings/student.py` |
+| `bookings_waitlisted` | Booking committed with status `WAITLISTED` (session at capacity) | `app/api/api_v1/endpoints/bookings/student.py` |
+| `enrollment_attempts` | `create_enrollment()` endpoint was called | `app/api/api_v1/endpoints/semester_enrollments/crud.py` |
+| `enrollment_gate_blocked` | Enrollment blocked by parent-semester hierarchy gate (403 returned) | `app/api/api_v1/endpoints/semester_enrollments/crud.py` |
+| `slow_queries_total` | SQL query exceeded the 200 ms slow-query threshold | `app/database.py` engine event listener |
+
+---
+
+## 3. Prometheus Integration
+
+### Prometheus text format
+
+```
+GET /metrics?format=prometheus
+```
+
+Returns `text/plain; version=0.0.4` compatible output:
+
+```
+# HELP bookings_created_total Total bookings committed with status CONFIRMED.
+# TYPE bookings_created_total counter
+bookings_created_total 512
+# HELP rewards_failed_total Total award_session_completion() calls that raised an exception.
+# TYPE rewards_failed_total counter
+rewards_failed_total 3
+...
+```
+
+Counter names follow the Prometheus naming convention: `_total` suffix for
+counters that were not already named with `_total` (e.g. `slow_queries_total`
+is emitted as-is).
+
+### Prometheus scrape config
+
+Add this to your `prometheus.yml`:
+
+```yaml
+scrape_configs:
+  - job_name: 'gancuju-education-center'
+    scrape_interval: 30s
+    metrics_path: '/metrics'
+    params:
+      format: ['prometheus']
+    static_configs:
+      - targets: ['app:8000']
+        labels:
+          env: 'production'
+```
+
+### Grafana dashboard
+
+Suggested PromQL queries:
+
+```promql
+# Reward failure rate (5-minute window)
+rate(rewards_failed_total[5m]) / (rate(rewards_generated_total[5m]) + rate(rewards_failed_total[5m]))
+
+# Booking waitlist rate
+rate(bookings_waitlisted_total[5m]) / (rate(bookings_created_total[5m]) + rate(bookings_waitlisted_total[5m]))
+
+# Enrollment gate block rate
+rate(enrollment_gate_blocked_total[5m]) / rate(enrollment_attempts_total[5m])
+```
+
+Note: because counters are per-process lifetime totals (not time-series at the
+application level), use `rate()` to compute per-window rates in Prometheus once
+you have multiple scrape samples.
+
+---
+
+## 4. Alert Thresholds
+
+### Configured thresholds (settable in `.env`)
+
+| Alert | Default | Environment variable | Meaning |
+|---|---|---|---|
+| Reward failure rate | 5 % | `ALERT_REWARD_FAILURE_RATE=0.05` | More than 5 % of reward grants fail |
+| Booking waitlist rate | 30 % | `ALERT_BOOKING_WAITLIST_RATE=0.30` | More than 30 % of booking attempts are waitlisted |
+| Enrollment gate block rate | 20 % | `ALERT_ENROLLMENT_GATE_BLOCK_RATE=0.20` | More than 20 % of enrollment attempts are gate-blocked |
+| Slow queries (absolute) | 10 | `ALERT_SLOW_QUERY_TOTAL=10` | More than 10 slow queries since process start |
+
+### Response procedures
+
+#### `reward_failure_rate` firing
+
+1. Check `app/slow_query` logs for recent slow queries that may have caused timeouts.
+2. Inspect `app.services.reward_service` logs for `event=reward_failed` — the `error=` field contains the exception repr.
+3. Common causes: DB connection exhaustion, constraint violations (check `uq_event_reward_log_user_session`), disk I/O saturation.
+4. If the error is transient (e.g. brief DB unavailability), the counter will stabilise automatically as the rate drops below threshold after a process restart.
+
+#### `booking_waitlist_rate` firing
+
+1. High waitlist rate means sessions are at capacity — check current session `capacity` values via admin UI (`/admin/sessions`).
+2. If this is expected peak demand, no action needed.  Consider increasing session capacity or adding sessions.
+3. If unexpected: verify `MAX_BOOKINGS_PER_SEMESTER` has not been lowered accidentally.
+
+#### `enrollment_gate_block_rate` firing
+
+1. Check which parent semester hierarchy gates are being triggered: look for `event=enrollment_gate_blocked` in structured logs with `user_id` and `semester_id`.
+2. Common cause: students attempting to enroll in a child semester without completing the parent.  This is expected behaviour.
+3. If the rate is unexpectedly high (e.g. > 50 %), verify semester prerequisite chains are configured correctly in the admin UI.
+
+#### `slow_queries_total` firing
+
+See [§5 Slow Query Handling](#5-slow-query-handling).
+
+---
+
+## 5. Slow Query Handling
+
+### Detection
+
+Queries exceeding **200 ms** are automatically logged to the `app.slow_query`
+logger at `WARNING` level with the structured format:
+
+```
+event=slow_query duration_ms=342.1 statement=SELECT bookings.id AS bookings_id... request_id=abc123
+```
+
+The `request_id` field allows you to correlate the slow query with the HTTP
+request that triggered it in the `LoggingMiddleware` access log.
+
+### Investigation steps
+
+1. **Identify the query** — search logs for `event=slow_query`.  The
+   `statement` field contains the first 200 characters of the SQL.
+
+2. **Run EXPLAIN ANALYZE** — copy the full statement from the application
+   source and run:
+   ```sql
+   EXPLAIN (ANALYZE, BUFFERS, FORMAT TEXT)
+   SELECT ...;
+   ```
+
+3. **Check for missing indexes** — look for `Seq Scan` on large tables.
+   Common targets: `bookings(session_id)`, `bookings(user_id)`,
+   `sessions(semester_id)`.
+
+4. **Check connection pool** — if many queries are slow simultaneously, the
+   pool may be exhausted.  Check `pool_size` (currently 20) and
+   `max_overflow` (currently 30) in `app/database.py`.
+
+5. **Apply a new index** — create an Alembic migration:
+   ```python
+   op.create_index("ix_table_column", "table", ["column"])
+   ```
+   Then run `alembic upgrade head` on production (zero-downtime for
+   `CREATE INDEX CONCURRENTLY` — add `postgresql_concurrently=True` to the
+   `create_index` call).
+
+### Threshold adjustment
+
+If normal queries regularly exceed 200 ms (e.g. aggregate dashboards), raise
+the threshold in `app/database.py`:
+
+```python
+_SLOW_QUERY_THRESHOLD_MS: float = 500.0  # adjusted for reporting workload
+```
+
+---
+
+## 6. Migration Rollback Procedure
+
+### Safe rollback (one step back)
+
+```bash
+# Identify current revision
+alembic current
+
+# Downgrade exactly one step
+alembic downgrade -1
+
+# Verify
+alembic current
+```
+
+### Rollback to a specific revision
+
+```bash
+alembic downgrade <revision_id>
+# Example:
+alembic downgrade 2026_03_15_1600
+```
+
+### Emergency rollback
+
+If a migration is not safely reversible (e.g. data-destructive `DROP COLUMN`),
+restore from the pre-migration database snapshot:
+
+```bash
+pg_restore -d $DATABASE_URL --clean --if-exists backup_pre_migration.dump
+```
+
+Then redeploy the previous application version.
+
+### Migration volume validation
+
+The CI pipeline runs a `migration-volume-test` job that:
+1. Seeds 2 000 bookings + 500 reward rows on a fresh database.
+2. Runs `EXPLAIN` to validate index usage on key queries.
+3. Times `downgrade -1 + upgrade head` — must complete in ≤ 30 seconds.
+
+This ensures new migrations do not introduce unbounded table scans on
+production-scale data.
+
+### Revision history
+
+| Revision | Date | Description |
+|---|---|---|
+| `2026_03_15_1500` | 2026-03-15 | Unique constraint on EventRewardLog(user_id, session_id) |
+| `2026_03_15_1600` | 2026-03-15 | Five composite indexes on bookings and sessions |
+| `2026_03_13_1500` | 2026-03-13 | `performed_by_user_id` on credit_transactions |
+| `2026_03_13_1400` | 2026-03-13 | SKILL_TIER_REACHED notification type |
+| `2026_03_12_1200` | 2026-03-12 | Drop `location.venue` |
+| `2026_03_12_1100` | 2026-03-12 | Remove legacy CouponType values |
+| `2026_03_12_1000` | 2026-03-12 | Drop `semester.is_active` |
+
+---
+
+## 7. Log Files and Retention
+
+### Log file location
+
+Production log files are written to `logs/app.log` in the application working
+directory (typically `/app/logs/app.log` in Docker).
+
+### Rotation policy
+
+Logs are rotated automatically by `RotatingFileHandler`:
+
+| Parameter | Value |
+|---|---|
+| Max file size | 10 MB |
+| Backup count | 5 |
+| Max total disk | ~60 MB |
+
+When `app.log` reaches 10 MB it is renamed to `app.log.1`, the previous
+`app.log.1` becomes `app.log.2`, and so on up to `app.log.5`.  The oldest
+file is deleted when a new rotation occurs.
+
+### Mounting logs in Docker
+
+```yaml
+# docker-compose.yml
+services:
+  app:
+    volumes:
+      - ./logs:/app/logs
+```
+
+### Log format
+
+Application log lines use structured `key=value` format (via `app/core/structured_log.py`):
+
+```
+event=reward_awarded user_id=42 session_id=7 xp=100 multiplier=1.5 request_id=abc123 operation_id=def456
+```
+
+HTTP access logs from `LoggingMiddleware` are JSON-formatted:
+
+```json
+{"event_type": "request_complete", "request_id": "...", "method": "POST", "url": "...", "status_code": 200, "process_time_ms": 12.4}
+```
+
+### External log shipping
+
+For production log aggregation (ELK, Loki, Datadog), ship from the file:
+
+```yaml
+# Filebeat config
+filebeat.inputs:
+  - type: log
+    paths: ["/app/logs/app.log*"]
+    fields:
+      service: gancuju-education-center
+      env: production
+```
+
+Or configure the application logger to emit JSON to stdout and capture it with
+your container orchestrator.
+
+---
+
+## 8. Health Endpoints
+
+| Endpoint | Purpose | Success response |
+|---|---|---|
+| `GET /health` | Basic liveness | `{"status": "healthy"}` |
+| `GET /health/live` | Kubernetes liveness probe | `{"status": "alive"}` |
+| `GET /health/ready` | Kubernetes readiness probe | `{"status": "ready", "database": "healthy"}` |
+| `GET /health/detailed` | Full system health (DB + workers) | `{"status": "healthy", "checks": {...}}` |
+| `GET /health/worker` | Redis + Celery worker health | `{"status": "degraded"|"healthy"|"unhealthy", ...}` |
+
+A `"degraded"` worker status means Redis is reachable but no Celery workers
+are registered — background tasks (email, notifications) will not execute.
+This is expected in development environments without a running worker.

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -50641,8 +50641,49 @@
     },
     "/metrics": {
       "get": {
-        "description": "In-process domain event counters.\n\nReturns lifetime totals (since last process start) for key operational\nevents: reward generation, booking creation, enrollment gate decisions.\nIntended for internal monitoring and alerting dashboards.",
+        "description": "In-process domain event counters.\n\nReturns lifetime totals (since last process start) for key operational\nevents: reward generation, booking creation, enrollment gate decisions.\nIntended for internal monitoring and alerting dashboards.\n\nSet ``?format=prometheus`` to receive Prometheus text exposition format\n(``text/plain; version=0.0.4``) suitable for a Prometheus scrape target.",
         "operationId": "domain_metrics_metrics_get",
+        "parameters": [
+          {
+            "description": "Output format: 'json' (default) or 'prometheus'.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "default": "json",
+              "description": "Output format: 'json' (default) or 'prometheus'.",
+              "title": "Format",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Domain Metrics"
+      }
+    },
+    "/metrics/alerts": {
+      "get": {
+        "description": "Evaluate in-process counter values against configured alert thresholds.\n\nReturns ``{\"status\": \"ok\"|\"warning\", \"thresholds\": {...}}`` where each\nentry in ``thresholds`` includes ``value``, ``threshold`` and ``firing``.\nOnly ratio-based alerts are emitted when enough traffic has been seen\n(denominator > 0); the slow-query count is always evaluated.\n\nThresholds are configured via the application Settings:\n- ``ALERT_REWARD_FAILURE_RATE`` (default 0.05)\n- ``ALERT_BOOKING_WAITLIST_RATE`` (default 0.30)\n- ``ALERT_ENROLLMENT_GATE_BLOCK_RATE`` (default 0.20)\n- ``ALERT_SLOW_QUERY_TOTAL`` (default 10)",
+        "operationId": "metrics_alerts_metrics_alerts_get",
         "responses": {
           "200": {
             "content": {
@@ -50653,7 +50694,7 @@
             "description": "Successful Response"
           }
         },
-        "summary": "Domain Metrics"
+        "summary": "Metrics Alerts"
       }
     },
     "/notifications": {

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -50168,7 +50168,7 @@
     },
     "/health/ready": {
       "get": {
-        "description": "Kubernetes-style readiness probe",
+        "description": "Kubernetes-style readiness probe.\n\nReturns HTTP 200 when the service is ready to accept traffic (database\nreachable and responding).  Returns HTTP 503 when the database is unhealthy\nso orchestrators remove the pod from the load-balancer rotation.",
         "operationId": "readiness_check_health_ready_get",
         "responses": {
           "200": {
@@ -50185,7 +50185,7 @@
     },
     "/health/worker": {
       "get": {
-        "description": "Redis broker and Celery worker liveness probe.",
+        "description": "Redis broker and Celery worker liveness probe.\n\nReturns HTTP 200 when Redis is reachable (workers may be degraded but\nthe app is still operational).  Returns HTTP 503 only when Redis itself\nis unreachable, which prevents background job enqueueing entirely.",
         "operationId": "worker_health_check_health_worker_get",
         "responses": {
           "200": {

--- a/tests/unit/core/test_db_resilience.py
+++ b/tests/unit/core/test_db_resilience.py
@@ -1,0 +1,112 @@
+"""
+Unit tests — database connection resilience (app/database.py)
+=============================================================
+
+Tests
+-----
+  DB-01  wait_for_db() returns immediately when the DB is reachable
+  DB-02  wait_for_db() retries on transient failure and succeeds on later attempt
+  DB-03  wait_for_db() raises RuntimeError after max_retries exhausted
+  DB-04  _connect_args includes connect_timeout from settings
+  DB-05  DB_STATEMENT_TIMEOUT_MS=0 → options key absent from _connect_args
+  DB-06  wait_for_db() uses DB_STARTUP_RETRIES / DB_STARTUP_RETRY_DELAY defaults
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy.exc import OperationalError
+
+
+# Helper: build a context-manager mock that executes SELECT 1 successfully.
+def _ok_conn() -> MagicMock:
+    conn = MagicMock()
+    conn.__enter__ = MagicMock(return_value=conn)
+    conn.__exit__ = MagicMock(return_value=False)
+    return conn
+
+
+class TestWaitForDb:
+
+    def test_db01_succeeds_immediately(self):
+        """DB-01: wait_for_db() returns without error when the DB is immediately reachable."""
+        from app.database import wait_for_db
+
+        with patch("app.database.engine.connect", return_value=_ok_conn()):
+            wait_for_db(max_retries=3, delay_seconds=0)
+
+    def test_db02_retries_on_transient_failure(self):
+        """DB-02: wait_for_db() retries after a transient failure and returns on success."""
+        from app.database import wait_for_db
+
+        call_count = 0
+
+        def _connect():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise OperationalError("conn", None, Exception("transient"))
+            return _ok_conn()
+
+        with patch("app.database.engine.connect", side_effect=_connect):
+            with patch("time.sleep"):  # prevent actual sleeping in unit tests
+                wait_for_db(max_retries=3, delay_seconds=0.01)
+
+        assert call_count == 2
+
+    def test_db03_raises_after_max_retries(self):
+        """DB-03: wait_for_db() raises RuntimeError when all attempts are exhausted."""
+        from app.database import wait_for_db
+
+        err = OperationalError("conn", None, Exception("db down"))
+        with patch("app.database.engine.connect", side_effect=err):
+            with patch("time.sleep"):
+                with pytest.raises(RuntimeError, match="Database unavailable"):
+                    wait_for_db(max_retries=3, delay_seconds=0.01)
+
+    def test_db06_defaults_come_from_settings(self):
+        """DB-06: wait_for_db() uses DB_STARTUP_RETRIES and DB_STARTUP_RETRY_DELAY when no args given."""
+        from app.database import wait_for_db
+        from app.config import settings
+
+        call_count = 0
+
+        def _always_fail():
+            nonlocal call_count
+            call_count += 1
+            raise OperationalError("conn", None, Exception("down"))
+
+        with patch("app.database.engine.connect", side_effect=_always_fail):
+            with patch("time.sleep"):
+                with pytest.raises(RuntimeError):
+                    wait_for_db()  # uses settings defaults
+
+        assert call_count == settings.DB_STARTUP_RETRIES
+
+
+class TestEngineConnectArgs:
+
+    def test_db04_connect_args_include_timeout(self):
+        """DB-04: _connect_args includes connect_timeout from settings."""
+        from app.database import _connect_args
+        from app.config import settings
+
+        assert "connect_timeout" in _connect_args
+        assert _connect_args["connect_timeout"] == settings.DB_CONNECT_TIMEOUT
+        assert _connect_args["connect_timeout"] > 0
+
+    def test_db05_no_options_when_statement_timeout_disabled(self):
+        """DB-05: When DB_STATEMENT_TIMEOUT_MS=0, the options key is absent."""
+        from app.config import settings
+
+        # In the test environment DB_STATEMENT_TIMEOUT_MS defaults to 0 (disabled).
+        # The options key should not be present in _connect_args.
+        if settings.DB_STATEMENT_TIMEOUT_MS == 0:
+            from app.database import _connect_args
+            assert "options" not in _connect_args
+        else:
+            # If overridden in env, verify the format is correct.
+            from app.database import _connect_args
+            assert "options" in _connect_args
+            assert "statement_timeout" in _connect_args["options"]

--- a/tests/unit/core/test_metrics.py
+++ b/tests/unit/core/test_metrics.py
@@ -30,6 +30,10 @@ Tests
   MTR-24  format_prometheus() includes labeled metrics with {key="val"} syntax
   MTR-25  format_prometheus() labels appear under same HELP/TYPE block as flat total
   MTR-26  increment_labeled() label keys are sorted (consistent label_str)
+  MTR-27  increment_labeled() with allowed label value produces no warning
+  MTR-28  increment_labeled() with unknown label value logs a cardinality warning
+  MTR-29  increment_labeled() with unguarded label key is silently accepted
+  MTR-30  cardinality warning does not block the increment
 """
 from __future__ import annotations
 
@@ -361,3 +365,40 @@ class TestDomainMetricsLabeled:
         snap = m.get_labeled_snapshot()
         # Both calls should map to the same sorted label string
         assert snap["rewards_generated"].get("a_key=1,b_key=2") == 2
+
+
+# ── Tests — Cardinality guard ──────────────────────────────────────────────────
+
+class TestDomainMetricsCardinalityGuard:
+
+    def test_mtr27_known_label_value_no_warning(self, m: DomainMetrics, caplog):
+        """MTR-27: increment_labeled() with an allowed label value produces no warning."""
+        import logging
+        with caplog.at_level(logging.WARNING, logger="app.metrics.cardinality"):
+            m.increment_labeled("bookings_created", {"event_category": "TRAINING"})
+        assert not caplog.records
+
+    def test_mtr28_unknown_label_value_logs_warning(self, m: DomainMetrics, caplog):
+        """MTR-28: increment_labeled() with a high-cardinality value logs a WARNING."""
+        import logging
+        with caplog.at_level(logging.WARNING, logger="app.metrics.cardinality"):
+            m.increment_labeled("bookings_created", {"event_category": "UNKNOWN_TYPE_99"})
+        assert len(caplog.records) == 1
+        msg = caplog.records[0].getMessage()
+        assert "cardinality" in msg.lower()
+        assert "UNKNOWN_TYPE_99" in msg
+
+    def test_mtr29_unguarded_label_key_no_warning(self, m: DomainMetrics, caplog):
+        """MTR-29: increment_labeled() with a label key not in the guard dict is silently accepted."""
+        import logging
+        with caplog.at_level(logging.WARNING, logger="app.metrics.cardinality"):
+            m.increment_labeled("bookings_created", {"custom_dimension": "anything"})
+        assert not caplog.records
+
+    def test_mtr30_cardinality_warning_does_not_block_increment(self, m: DomainMetrics, caplog):
+        """MTR-30: the counter is still incremented even when a cardinality warning fires."""
+        import logging
+        with caplog.at_level(logging.WARNING, logger="app.metrics.cardinality"):
+            m.increment_labeled("bookings_created", {"event_category": "UNKNOWN_TYPE_99"})
+        snap = m.get_labeled_snapshot()
+        assert snap["bookings_created"]["event_category=UNKNOWN_TYPE_99"] == 1

--- a/tests/unit/core/test_metrics.py
+++ b/tests/unit/core/test_metrics.py
@@ -23,6 +23,13 @@ Tests
   MTR-17  evaluate_alerts() returns "warning" on slow_queries_total exceeding threshold
   MTR-18  evaluate_alerts() does not emit ratio alerts when denominator is zero
   MTR-19  evaluate_alerts() status "ok" when all ratios are below threshold
+  MTR-20  increment_labeled() stores count under label string
+  MTR-21  increment_labeled() multiple label values tracked independently
+  MTR-22  get_labeled_snapshot() returns a copy (mutations don't affect store)
+  MTR-23  reset() clears labeled counters as well as flat counters
+  MTR-24  format_prometheus() includes labeled metrics with {key="val"} syntax
+  MTR-25  format_prometheus() labels appear under same HELP/TYPE block as flat total
+  MTR-26  increment_labeled() label keys are sorted (consistent label_str)
 """
 from __future__ import annotations
 
@@ -278,3 +285,79 @@ class TestDomainMetricsAlerts:
             assert alert_data["firing"] is False, (
                 f"Alert '{alert_key}' unexpectedly firing: {alert_data}"
             )
+
+
+# ── Tests — Labeled counters ───────────────────────────────────────────────────
+
+class TestDomainMetricsLabeled:
+
+    def test_mtr20_increment_labeled_stores_count(self, m: DomainMetrics):
+        """MTR-20: increment_labeled() stores count under the correct label string."""
+        m.increment_labeled("bookings_created", {"event_category": "TRAINING"})
+        m.increment_labeled("bookings_created", {"event_category": "TRAINING"})
+        m.increment_labeled("bookings_created", {"event_category": "MATCH"})
+
+        snap = m.get_labeled_snapshot()
+        assert snap["bookings_created"]["event_category=TRAINING"] == 2
+        assert snap["bookings_created"]["event_category=MATCH"] == 1
+
+    def test_mtr21_increment_labeled_independent_counters(self, m: DomainMetrics):
+        """MTR-21: different counter names with same labels are tracked independently."""
+        m.increment_labeled("bookings_created", {"event_category": "TRAINING"}, by=5)
+        m.increment_labeled("bookings_waitlisted", {"event_category": "TRAINING"}, by=2)
+
+        snap = m.get_labeled_snapshot()
+        assert snap["bookings_created"]["event_category=TRAINING"] == 5
+        assert snap["bookings_waitlisted"]["event_category=TRAINING"] == 2
+
+    def test_mtr22_get_labeled_snapshot_returns_copy(self, m: DomainMetrics):
+        """MTR-22: mutating the returned labeled snapshot does not affect the store."""
+        m.increment_labeled("rewards_generated", {"event_category": "TRAINING"})
+        snap = m.get_labeled_snapshot()
+        snap["rewards_generated"]["event_category=TRAINING"] = 999
+
+        fresh = m.get_labeled_snapshot()
+        assert fresh["rewards_generated"]["event_category=TRAINING"] == 1
+
+    def test_mtr23_reset_clears_labeled_counters(self, m: DomainMetrics):
+        """MTR-23: reset() clears both flat and labeled counters."""
+        m.increment("bookings_created", by=3)
+        m.increment_labeled("bookings_created", {"event_category": "TRAINING"}, by=3)
+        m.reset()
+
+        assert m.get_snapshot() == {}
+        assert m.get_labeled_snapshot() == {}
+
+    def test_mtr24_format_prometheus_labeled_with_braces(self, m: DomainMetrics):
+        """MTR-24: labeled metrics appear with {key="val"} Prometheus syntax."""
+        m.increment("bookings_created", by=10)
+        m.increment_labeled("bookings_created", {"event_category": "TRAINING"}, by=8)
+        m.increment_labeled("bookings_created", {"event_category": "MATCH"}, by=2)
+
+        text = m.format_prometheus()
+
+        assert 'bookings_created_total{event_category="TRAINING"} 8' in text
+        assert 'bookings_created_total{event_category="MATCH"} 2' in text
+
+    def test_mtr25_format_prometheus_labeled_under_same_help_type_block(self, m: DomainMetrics):
+        """MTR-25: flat total and labeled breakdowns appear under one HELP/TYPE block."""
+        m.increment("bookings_created", by=10)
+        m.increment_labeled("bookings_created", {"event_category": "TRAINING"}, by=8)
+
+        text = m.format_prometheus()
+        # Only one HELP line for the metric
+        help_count = text.count("# HELP bookings_created_total")
+        assert help_count == 1
+        # Flat total present
+        assert "bookings_created_total 10" in text
+        # Labeled breakdown present
+        assert 'bookings_created_total{event_category="TRAINING"} 8' in text
+
+    def test_mtr26_increment_labeled_keys_sorted(self, m: DomainMetrics):
+        """MTR-26: label keys are sorted — calling order doesn't change label_str."""
+        m.increment_labeled("rewards_generated", {"b_key": "2", "a_key": "1"})
+        m.increment_labeled("rewards_generated", {"a_key": "1", "b_key": "2"})
+
+        snap = m.get_labeled_snapshot()
+        # Both calls should map to the same sorted label string
+        assert snap["rewards_generated"].get("a_key=1,b_key=2") == 2

--- a/tests/unit/core/test_metrics.py
+++ b/tests/unit/core/test_metrics.py
@@ -12,10 +12,23 @@ Tests
   MTR-06  thread-safety: 50 concurrent increments → exactly 50
   MTR-07  canonical counter names accepted without error
   MTR-08  bookings/reward/enrollment counters from service calls
+  MTR-09  format_prometheus() includes HELP + TYPE + _total lines
+  MTR-10  format_prometheus() on empty store returns comment line
+  MTR-11  format_prometheus() does not double _total suffix
+  MTR-12  format_prometheus() emits sorted counter names
+  MTR-13  evaluate_alerts() returns "ok" when no traffic
+  MTR-14  evaluate_alerts() returns "warning" on high reward failure rate
+  MTR-15  evaluate_alerts() returns "warning" on high waitlist rate
+  MTR-16  evaluate_alerts() returns "warning" on high gate block rate
+  MTR-17  evaluate_alerts() returns "warning" on slow_queries_total exceeding threshold
+  MTR-18  evaluate_alerts() does not emit ratio alerts when denominator is zero
+  MTR-19  evaluate_alerts() status "ok" when all ratios are below threshold
 """
 from __future__ import annotations
 
 import threading
+from types import SimpleNamespace
+
 import pytest
 
 from app.core.metrics import DomainMetrics
@@ -29,7 +42,19 @@ def m() -> DomainMetrics:
     return DomainMetrics()
 
 
-# ── Tests ─────────────────────────────────────────────────────────────────────
+def _fake_settings(**overrides) -> SimpleNamespace:
+    """Return a SimpleNamespace that mimics the alert threshold settings."""
+    defaults = dict(
+        ALERT_REWARD_FAILURE_RATE=0.05,
+        ALERT_BOOKING_WAITLIST_RATE=0.30,
+        ALERT_ENROLLMENT_GATE_BLOCK_RATE=0.20,
+        ALERT_SLOW_QUERY_TOTAL=10,
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+# ── Tests — basic behaviour ────────────────────────────────────────────────────
 
 class TestDomainMetricsBasic:
 
@@ -78,6 +103,7 @@ class TestDomainMetricsBasic:
             "bookings_waitlisted",
             "enrollment_attempts",
             "enrollment_gate_blocked",
+            "slow_queries_total",
         ]
         for name in canonical:
             m.increment(name)
@@ -116,3 +142,139 @@ class TestDomainMetricsServiceIntegration:
         metrics.increment("bookings_created")
         assert metrics.get_snapshot()["bookings_created"] == 1
         metrics.reset()
+
+
+# ── Tests — Prometheus format ──────────────────────────────────────────────────
+
+class TestDomainMetricsPrometheus:
+
+    def test_mtr09_format_prometheus_includes_help_type_total(self, m: DomainMetrics):
+        """MTR-09: format_prometheus() emits HELP, TYPE and _total metric line."""
+        m.increment("rewards_generated", by=42)
+        text = m.format_prometheus()
+
+        assert "# HELP rewards_generated_total" in text
+        assert "# TYPE rewards_generated_total counter" in text
+        assert "rewards_generated_total 42" in text
+
+    def test_mtr10_format_prometheus_empty_store_returns_comment(self, m: DomainMetrics):
+        """MTR-10: format_prometheus() on empty store returns a comment line, not an error."""
+        text = m.format_prometheus()
+        assert text.startswith("#")
+        # No metric lines — only the comment
+        non_comment = [l for l in text.splitlines() if l and not l.startswith("#")]
+        assert non_comment == []
+
+    def test_mtr11_format_prometheus_no_double_total_suffix(self, m: DomainMetrics):
+        """MTR-11: counter already named with _total is not doubled."""
+        m.increment("slow_queries_total", by=3)
+        text = m.format_prometheus()
+
+        assert "slow_queries_total 3" in text
+        assert "slow_queries_total_total" not in text
+
+    def test_mtr12_format_prometheus_sorted_output(self, m: DomainMetrics):
+        """MTR-12: Prometheus output is sorted alphabetically by counter name."""
+        m.increment("rewards_generated")
+        m.increment("bookings_created")
+        m.increment("enrollment_attempts")
+
+        text = m.format_prometheus()
+        # Extract metric lines (not HELP/TYPE lines)
+        metric_lines = [
+            l for l in text.splitlines()
+            if l and not l.startswith("#")
+        ]
+        names = [l.split()[0] for l in metric_lines]
+        assert names == sorted(names)
+
+    def test_mtr09b_format_prometheus_ends_with_newline(self, m: DomainMetrics):
+        """Prometheus exposition format must end with a newline."""
+        m.increment("bookings_created")
+        assert m.format_prometheus().endswith("\n")
+
+
+# ── Tests — Alert evaluation ───────────────────────────────────────────────────
+
+class TestDomainMetricsAlerts:
+
+    def test_mtr13_evaluate_alerts_ok_when_no_traffic(self, m: DomainMetrics):
+        """MTR-13: no traffic (all zeros) → status 'ok', ratio alerts absent."""
+        result = m.evaluate_alerts(_fake_settings())
+
+        assert result["status"] == "ok"
+        thresholds = result["thresholds"]
+        # Ratio-based alerts should NOT appear when denominator is zero
+        assert "reward_failure_rate" not in thresholds
+        assert "booking_waitlist_rate" not in thresholds
+        assert "enrollment_gate_block_rate" not in thresholds
+        # slow_queries_total is always present (absolute count)
+        assert thresholds["slow_queries_total"]["firing"] is False
+
+    def test_mtr14_evaluate_alerts_warning_on_high_reward_failure(self, m: DomainMetrics):
+        """MTR-14: rewards_failed / total > threshold → status 'warning'."""
+        m.increment("rewards_generated", by=10)
+        m.increment("rewards_failed", by=2)  # 16.7 % > 5 % default
+
+        result = m.evaluate_alerts(_fake_settings(ALERT_REWARD_FAILURE_RATE=0.05))
+
+        assert result["status"] == "warning"
+        assert result["thresholds"]["reward_failure_rate"]["firing"] is True
+
+    def test_mtr15_evaluate_alerts_warning_on_high_waitlist_rate(self, m: DomainMetrics):
+        """MTR-15: bookings_waitlisted / total > threshold → status 'warning'."""
+        m.increment("bookings_created", by=5)
+        m.increment("bookings_waitlisted", by=5)  # 50 % > 30 % default
+
+        result = m.evaluate_alerts(_fake_settings(ALERT_BOOKING_WAITLIST_RATE=0.30))
+
+        assert result["status"] == "warning"
+        assert result["thresholds"]["booking_waitlist_rate"]["firing"] is True
+
+    def test_mtr16_evaluate_alerts_warning_on_high_gate_block_rate(self, m: DomainMetrics):
+        """MTR-16: enrollment_gate_blocked / attempts > threshold → status 'warning'."""
+        m.increment("enrollment_attempts", by=10)
+        m.increment("enrollment_gate_blocked", by=4)  # 40 % > 20 % default
+
+        result = m.evaluate_alerts(_fake_settings(ALERT_ENROLLMENT_GATE_BLOCK_RATE=0.20))
+
+        assert result["status"] == "warning"
+        assert result["thresholds"]["enrollment_gate_block_rate"]["firing"] is True
+
+    def test_mtr17_evaluate_alerts_warning_on_slow_query_count(self, m: DomainMetrics):
+        """MTR-17: slow_queries_total > ALERT_SLOW_QUERY_TOTAL → status 'warning'."""
+        m.increment("slow_queries_total", by=15)  # > 10 default
+
+        result = m.evaluate_alerts(_fake_settings(ALERT_SLOW_QUERY_TOTAL=10))
+
+        assert result["status"] == "warning"
+        assert result["thresholds"]["slow_queries_total"]["firing"] is True
+        assert result["thresholds"]["slow_queries_total"]["value"] == 15
+
+    def test_mtr18_evaluate_alerts_no_ratio_when_denominator_zero(self, m: DomainMetrics):
+        """MTR-18: ratio alerts absent when denominator is zero (avoids div-by-zero)."""
+        # Only gate_blocked set, but enrollment_attempts = 0
+        m.increment("enrollment_gate_blocked", by=5)
+
+        result = m.evaluate_alerts(_fake_settings())
+
+        # Ratio alert should NOT appear (denominator = 0)
+        assert "enrollment_gate_block_rate" not in result["thresholds"]
+
+    def test_mtr19_evaluate_alerts_ok_when_below_thresholds(self, m: DomainMetrics):
+        """MTR-19: all counters present but ratios within threshold → status 'ok'."""
+        m.increment("rewards_generated", by=100)
+        m.increment("rewards_failed", by=2)          # 1.96 % < 5 %
+        m.increment("bookings_created", by=100)
+        m.increment("bookings_waitlisted", by=10)    # 9.1 % < 30 %
+        m.increment("enrollment_attempts", by=100)
+        m.increment("enrollment_gate_blocked", by=15)  # 15 % < 20 %
+        m.increment("slow_queries_total", by=5)       # 5 ≤ 10
+
+        result = m.evaluate_alerts(_fake_settings())
+
+        assert result["status"] == "ok"
+        for alert_key, alert_data in result["thresholds"].items():
+            assert alert_data["firing"] is False, (
+                f"Alert '{alert_key}' unexpectedly firing: {alert_data}"
+            )

--- a/tests/unit/core/test_metrics_endpoints.py
+++ b/tests/unit/core/test_metrics_endpoints.py
@@ -11,6 +11,12 @@ Tests
   EP-05  GET /metrics/alerts returns status and thresholds keys
   EP-06  GET /metrics/alerts status is "ok" when counters are zero
   EP-07  GET /metrics/alerts status is "warning" when slow_queries_total exceeded
+  EP-08  GET /metrics JSON includes labeled_counters key
+  EP-09  GET /metrics JSON labeled_counters populated after increment_labeled()
+  EP-10  GET /health/ready returns 200 when DB healthy
+  EP-11  GET /health/ready returns 503 when DB unhealthy
+  EP-12  GET /health/worker returns 503 when Redis is down
+  EP-13  GET /health/worker returns 200 when Redis is healthy (degraded worker)
 """
 from __future__ import annotations
 
@@ -103,3 +109,75 @@ class TestMetricsAlertsEndpoint:
         body = resp.json()
         assert body["status"] == "warning"
         assert body["thresholds"]["slow_queries_total"]["firing"] is True
+
+
+class TestMetricsLabeledEndpoint:
+
+    def test_ep08_json_includes_labeled_counters_key(self, client: TestClient):
+        """EP-08: GET /metrics JSON always includes 'labeled_counters' key."""
+        resp = client.get("/metrics")
+        assert resp.status_code == 200
+        assert "labeled_counters" in resp.json()
+
+    def test_ep09_labeled_counters_populated_after_increment(self, client: TestClient):
+        """EP-09: labeled_counters reflects increment_labeled() calls."""
+        from app.core.metrics import metrics
+        metrics.increment_labeled("bookings_created", {"event_category": "TRAINING"}, by=4)
+
+        resp = client.get("/metrics")
+        assert resp.status_code == 200
+        labeled = resp.json()["labeled_counters"]
+        assert labeled["bookings_created"]["event_category=TRAINING"] == 4
+
+
+class TestHealthEndpointStatusCodes:
+    """Health endpoints return correct HTTP status codes for orchestrators."""
+
+    def test_ep10_health_ready_200_when_db_healthy(self, client: TestClient):
+        """EP-10: /health/ready returns 200 when database health check passes."""
+        from unittest.mock import AsyncMock, patch
+        with patch(
+            "app.main.HealthChecker.get_database_health",
+            new_callable=AsyncMock,
+            return_value={"status": "healthy"},
+        ):
+            resp = client.get("/health/ready")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ready"
+
+    def test_ep11_health_ready_503_when_db_unhealthy(self, client: TestClient):
+        """EP-11: /health/ready returns 503 when database is unreachable."""
+        from unittest.mock import AsyncMock, patch
+        with patch(
+            "app.main.HealthChecker.get_database_health",
+            new_callable=AsyncMock,
+            return_value={"status": "unhealthy"},
+        ):
+            resp = client.get("/health/ready")
+        assert resp.status_code == 503
+        assert resp.json()["status"] == "not_ready"
+        assert resp.json()["database"] == "unhealthy"
+
+    def test_ep12_health_worker_503_when_redis_down(self, client: TestClient):
+        """EP-12: /health/worker returns 503 when Redis is unreachable."""
+        from unittest.mock import AsyncMock, patch
+        with patch(
+            "app.main.HealthChecker.get_worker_health",
+            new_callable=AsyncMock,
+            return_value={"status": "unhealthy", "redis": "unhealthy", "workers": None},
+        ):
+            resp = client.get("/health/worker")
+        assert resp.status_code == 503
+        assert resp.json()["status"] == "unhealthy"
+
+    def test_ep13_health_worker_200_when_degraded(self, client: TestClient):
+        """EP-13: /health/worker returns 200 when Redis ok but no workers registered."""
+        from unittest.mock import AsyncMock, patch
+        with patch(
+            "app.main.HealthChecker.get_worker_health",
+            new_callable=AsyncMock,
+            return_value={"status": "degraded", "redis": "healthy", "workers": []},
+        ):
+            resp = client.get("/health/worker")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "degraded"

--- a/tests/unit/core/test_metrics_endpoints.py
+++ b/tests/unit/core/test_metrics_endpoints.py
@@ -1,0 +1,105 @@
+"""
+Unit tests — GET /metrics and GET /metrics/alerts endpoints
+============================================================
+
+Tests
+-----
+  EP-01  GET /metrics returns JSON counters dict
+  EP-02  GET /metrics?format=prometheus returns text/plain
+  EP-03  GET /metrics?format=prometheus contains _total metric lines
+  EP-04  GET /metrics?format=json is same as default JSON response
+  EP-05  GET /metrics/alerts returns status and thresholds keys
+  EP-06  GET /metrics/alerts status is "ok" when counters are zero
+  EP-07  GET /metrics/alerts status is "warning" when slow_queries_total exceeded
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture(autouse=True)
+def reset_metrics():
+    """Reset the process-wide metrics singleton before and after each test."""
+    from app.core.metrics import metrics
+    metrics.reset()
+    yield
+    metrics.reset()
+
+
+@pytest.fixture()
+def client():
+    from app.main import app
+    with TestClient(app, raise_server_exceptions=True) as c:
+        yield c
+
+
+# ── Tests ──────────────────────────────────────────────────────────────────────
+
+class TestMetricsJsonEndpoint:
+
+    def test_ep01_json_response_has_counters_key(self, client: TestClient):
+        """EP-01: GET /metrics returns {"counters": {...}}."""
+        resp = client.get("/metrics")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "counters" in body
+        assert isinstance(body["counters"], dict)
+
+    def test_ep02_prometheus_response_is_text_plain(self, client: TestClient):
+        """EP-02: GET /metrics?format=prometheus returns text/plain content-type."""
+        resp = client.get("/metrics?format=prometheus")
+        assert resp.status_code == 200
+        content_type = resp.headers.get("content-type", "")
+        assert "text/plain" in content_type
+
+    def test_ep03_prometheus_response_contains_total_lines(self, client: TestClient):
+        """EP-03: Prometheus format contains _total metric lines after incrementing."""
+        from app.core.metrics import metrics
+        metrics.increment("bookings_created", by=7)
+
+        resp = client.get("/metrics?format=prometheus")
+        assert resp.status_code == 200
+        text = resp.text
+        assert "bookings_created_total 7" in text
+        assert "# TYPE bookings_created_total counter" in text
+
+    def test_ep04_format_json_param_same_as_default(self, client: TestClient):
+        """EP-04: ?format=json gives same structure as the default response."""
+        from app.core.metrics import metrics
+        metrics.increment("rewards_generated", by=3)
+
+        default_resp = client.get("/metrics")
+        json_resp = client.get("/metrics?format=json")
+
+        assert default_resp.status_code == 200
+        assert json_resp.status_code == 200
+        assert default_resp.json() == json_resp.json()
+
+
+class TestMetricsAlertsEndpoint:
+
+    def test_ep05_alerts_returns_status_and_thresholds(self, client: TestClient):
+        """EP-05: GET /metrics/alerts returns status and thresholds keys."""
+        resp = client.get("/metrics/alerts")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "status" in body
+        assert "thresholds" in body
+
+    def test_ep06_alerts_ok_when_counters_zero(self, client: TestClient):
+        """EP-06: status is 'ok' when no counters have been incremented."""
+        resp = client.get("/metrics/alerts")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"
+
+    def test_ep07_alerts_warning_when_slow_query_exceeded(self, client: TestClient):
+        """EP-07: status becomes 'warning' when slow_queries_total > threshold (default 10)."""
+        from app.core.metrics import metrics
+        metrics.increment("slow_queries_total", by=11)
+
+        resp = client.get("/metrics/alerts")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "warning"
+        assert body["thresholds"]["slow_queries_total"]["firing"] is True


### PR DESCRIPTION
## Summary

- **DB connection resilience**: `connect_args={"connect_timeout": 10}` on the SQLAlchemy engine; new `wait_for_db()` function with configurable exponential backoff for startup health-checks; `DB_STATEMENT_TIMEOUT_MS` (off by default) caps runaway queries
- **Metrics cardinality guard**: `increment_labeled()` now logs a `WARNING` via `app.metrics.cardinality` when a label value is outside the known allowlist — non-blocking (counter still recorded), prevents monitoring system cardinality explosion
- **Operational smoke test CI**: new `operational-smoke-test` job in `test-baseline-check.yml` starts the full stack (PostgreSQL 15 + Redis 7 + uvicorn), polls `/health/ready`, then smoke-checks 6 endpoints; wired into `baseline-report`
- **Runbook**: added §0 Deployment Sequence section with ordered steps, `wait_for_db()` entrypoint example, and connection resilience settings reference table
- **`.env.example`**: all new settings documented with inline comments

## Test plan

- [x] `tests/unit/core/test_db_resilience.py` — DB-01–06 (6 tests): `wait_for_db()` immediate, retry, exhausted, connect_args inspection
- [x] `tests/unit/core/test_metrics.py` — MTR-27–30 (4 tests): cardinality guard warning fires, non-blocking, unguarded key silently accepted
- [x] Full suite: **9148 passed, 1 xfailed** (was 9138, +10 new tests)
- [x] OpenAPI snapshot: 555 routes (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)