### PR TITLE
fix(team-ui): rankings show team_name, result modal TEAM branch, edit page team context

### DIFF
--- a/app/api/api_v1/endpoints/tournaments/calculate_rankings.py
+++ b/app/api/api_v1/endpoints/tournaments/calculate_rankings.py
@@ -24,6 +24,7 @@ from app.models.session import Session as SessionModel, EventCategory
 from app.models.booking import Booking
 from app.models.tournament_ranking import TournamentRanking
 from app.models.tournament_achievement import TournamentParticipation
+from app.models.team import Team
 from app.services.tournament.ranking.strategies.factory import RankingStrategyFactory
 
 router = APIRouter()
@@ -273,10 +274,11 @@ def get_tournament_rankings(
     if not tournament:
         raise HTTPException(status_code=404, detail="Tournament not found")
 
-    # Get rankings with player names (prefer nickname for uniqueness)
+    # Get rankings with player names (prefer nickname for uniqueness) and team names
     rows = (
-        db.query(TournamentRanking, User.nickname, User.name)
+        db.query(TournamentRanking, User.nickname, User.name, Team.name.label("team_name"))
         .join(User, User.id == TournamentRanking.user_id, isouter=True)
+        .join(Team, Team.id == TournamentRanking.team_id, isouter=True)
         .filter(TournamentRanking.tournament_id == tournament_id)
         .order_by(TournamentRanking.rank)
         .all()
@@ -369,11 +371,13 @@ def get_tournament_rankings(
 
     # Format response
     rankings_data = []
-    for r, nickname, name in rows:
+    for r, nickname, name, team_name in rows:
         display_name = nickname or name
         points_val = float(r.points) if r.points is not None else 0
         entry = {
             "user_id": r.user_id,
+            "team_id": r.team_id,
+            "team_name": team_name,
             "name": display_name,
             "rank": r.rank,
             "points": points_val,

--- a/app/api/web_routes/tournaments.py
+++ b/app/api/web_routes/tournaments.py
@@ -770,9 +770,25 @@ async def admin_tournament_edit_page(
                 or s.game_results
             ),
             "participant_user_ids": s.participant_user_ids or [],
+            "participant_team_ids": s.participant_team_ids or [],
         }
         for s in all_match_sessions
     ]
+
+    # Team name map for TEAM tournaments (team_id → name)
+    enrolled_teams: dict = {}
+    team_enrollments = (
+        db.query(TournamentTeamEnrollment)
+        .filter(
+            TournamentTeamEnrollment.semester_id == tournament_id,
+            TournamentTeamEnrollment.is_active == True,
+        )
+        .all()
+    )
+    if team_enrollments:
+        team_ids = [e.team_id for e in team_enrollments]
+        teams = db.query(Team).filter(Team.id.in_(team_ids)).all()
+        enrolled_teams = {t.id: t.name for t in teams}
 
     # Existing rankings (for Section 8 — rankings panel)
     existing_rankings = (
@@ -801,6 +817,7 @@ async def admin_tournament_edit_page(
             "sessions": sessions,
             "session_count": session_count,
             "sessions_result_status": sessions_result_status,
+            "enrolled_teams": enrolled_teams,
             "existing_rankings": existing_rankings,
             "ranking_users": ranking_users,
             "game_presets": game_presets,

--- a/app/templates/admin/tournament_edit.html
+++ b/app/templates/admin/tournament_edit.html
@@ -565,7 +565,7 @@ ID {{ t.id }} · {{ t.code }} · <strong>{{ t.tournament_status or t.status.valu
                 {% if t.tournament_status == 'IN_PROGRESS' %}
                 <button class="btn btn-secondary"
                         style="font-size:0.78rem;padding:0.3rem 0.75rem;"
-                        onclick="openResultModal({{ sess.id }}, '{{ sess.match_format }}', {{ sess.participant_user_ids | tojson }})">
+                        onclick="openResultModal({{ sess.id }}, '{{ sess.match_format }}', {{ sess.participant_user_ids | tojson }}, {{ sess.participant_team_ids | tojson }})">
                     ✏️ Enter Results
                 </button>
                 {% endif %}
@@ -988,6 +988,7 @@ async function loadRankings(tournId) {
             return;
         }
         const isH2H = data.tournament_format === 'HEAD_TO_HEAD';
+        const isTeam = data.rankings[0] && data.rankings[0].team_id != null;
         const isRewarded = data.rankings[0] && data.rankings[0].xp_earned !== undefined;
         const rewardHeaders = isRewarded
             ? '<th style="text-align:right">XP</th><th style="text-align:right">Credits</th><th style="text-align:right">Skill Δ</th>'
@@ -999,6 +1000,9 @@ async function loadRankings(tournId) {
             const pts = r.measured_value !== undefined
                 ? parseFloat(r.measured_value).toFixed(2)
                 : (r.points || 0);
+            const displayName = r.team_id != null
+                ? `🏆 ${r.team_name || 'Team #' + r.team_id}`
+                : (r.name || `User #${r.user_id}`);
             const rewardCells = isRewarded
                 ? `<td style="text-align:right">${r.xp_earned || 0}</td>
                    <td style="text-align:right">${r.credits_earned || 0}</td>
@@ -1011,17 +1015,18 @@ async function loadRankings(tournId) {
                 : '';
             return `<tr style="border-bottom:1px solid #f0f0f0;">
                 <td style="padding:0.45rem 0.5rem;">${rankCell}</td>
-                <td style="padding:0.45rem 0.5rem;">${r.name || 'User #' + r.user_id}</td>
+                <td style="padding:0.45rem 0.5rem;">${displayName}</td>
                 <td style="padding:0.45rem 0.5rem;text-align:right;font-weight:600;">${pts}</td>
                 <td style="padding:0.45rem 0.5rem;text-align:right;color:#718096;">${wdl}</td>
                 ${rewardCells}
             </tr>`;
         }).join('');
+        const participantHeader = isTeam ? 'Team' : 'Player';
         container.innerHTML = `
             <table class="rankings-table">
                 <thead><tr>
                     <th style="text-align:left;">#</th>
-                    <th style="text-align:left;">Player</th>
+                    <th style="text-align:left;">${participantHeader}</th>
                     <th style="text-align:right;">Score / Points</th>
                     <th style="text-align:right;">W / D / L</th>
                     ${rewardHeaders}
@@ -1039,6 +1044,7 @@ async function loadRankings(tournId) {
 let _currentSessionId = null;
 let _currentFormat = null;
 let _currentParticipantIds = [];
+let _currentTeamIds = [];
 
 // Enrolled player IDs from server (needed for INDIVIDUAL_RANKING if no participant_user_ids)
 const ENROLLED_USER_IDS = {{ enrollments | map(attribute='user_id') | list | tojson }};
@@ -1047,17 +1053,37 @@ const ENROLLED_USER_NAMES = {
     {{ uid }}: {{ (u.nickname or u.name or '') | tojson }},
     {% endfor %}
 };
+const ENROLLED_TEAM_NAMES = {
+    {% for tid, tname in enrolled_teams.items() %}
+    {{ tid }}: {{ tname | tojson }},
+    {% endfor %}
+};
 
-function openResultModal(sessionId, matchFormat, participantIds) {
+function openResultModal(sessionId, matchFormat, participantIds, teamIds) {
     _currentSessionId = sessionId;
     _currentFormat = matchFormat;
+    _currentTeamIds = teamIds && teamIds.length > 0 ? teamIds : [];
     _currentParticipantIds = participantIds && participantIds.length > 0
         ? participantIds
         : ENROLLED_USER_IDS;
     document.getElementById('result-modal-title').textContent =
         `Enter Results — Session #${sessionId} (${matchFormat})`;
     const body = document.getElementById('result-modal-body');
-    if (matchFormat === 'HEAD_TO_HEAD') {
+    if (_currentTeamIds.length > 0) {
+        // TEAM tournament — score input per team
+        body.innerHTML = `
+            <p style="font-size:0.85rem;color:#718096;margin-bottom:0.75rem;">
+                Enter score for each team:
+            </p>
+            ${_currentTeamIds.map((tid, i) => `
+            <div style="display:flex;align-items:center;gap:0.75rem;margin-bottom:0.5rem;">
+                <span style="flex:1;font-size:0.9rem;">🏆 ${ENROLLED_TEAM_NAMES[tid] || 'Team #' + tid}</span>
+                <input type="number" id="team-score-${i}" data-teamid="${tid}"
+                       min="0" step="0.01" value="0"
+                       style="width:110px;padding:0.4rem;border:1px solid #e2e8f0;border-radius:6px;
+                              text-align:right;font-size:0.95rem;">
+            </div>`).join('')}`;
+    } else if (matchFormat === 'HEAD_TO_HEAD') {
         const [p1, p2] = _currentParticipantIds;
         const n1 = ENROLLED_USER_NAMES[p1] || `Player #${p1}`;
         const n2 = ENROLLED_USER_NAMES[p2] || `Player #${p2}`;
@@ -1106,12 +1132,24 @@ function closeResultModal() {
     document.getElementById('result-modal-overlay').style.display = 'none';
     _currentSessionId = null;
     _currentParticipantIds = [];
+    _currentTeamIds = [];
 }
 
 async function submitResults() {
     if (!_currentSessionId) return;
     try {
-        if (_currentFormat === 'HEAD_TO_HEAD') {
+        if (_currentTeamIds.length > 0) {
+            // TEAM tournament
+            const inputs = document.querySelectorAll('[id^="team-score-"]');
+            const results = Array.from(inputs).map((inp, i) => ({
+                team_id: parseInt(inp.dataset.teamid),
+                score: parseFloat(inp.value) || 0,
+            }));
+            await AdminAPI.patch(`/api/v1/sessions/${_currentSessionId}/team-results`, {
+                results,
+                round_number: 1,
+            });
+        } else if (_currentFormat === 'HEAD_TO_HEAD') {
             const s0 = parseInt(document.getElementById('h2h-score-0').value) || 0;
             const s1 = parseInt(document.getElementById('h2h-score-1').value) || 0;
             const [p1, p2] = _currentParticipantIds;

--- a/tests/integration/web_flows/test_tournament_lifecycle_e2e.py
+++ b/tests/integration/web_flows/test_tournament_lifecycle_e2e.py
@@ -2038,3 +2038,105 @@ class TestTeamTournamentLifecycle:
         assert resp.status_code == 200, resp.text[:400]
         assert "Team Management" in resp.text, "Page must contain 'Team Management' heading"
         assert "Enrolled Teams" in resp.text, "Page must list enrolled teams section"
+
+    # ── TEAM-08: GET /rankings response includes team_id + team_name ──────────
+
+    def test_TEAM08_get_rankings_returns_team_id_and_team_name(
+        self,
+        test_db: Session,
+        admin_client: TestClient,
+    ):
+        """
+        TEAM-08: GET /api/v1/tournaments/{id}/rankings returns team_id and team_name
+        fields for TEAM rankings — user_id is NULL (not rendered as 'User #null').
+
+        Proves:
+        - response["rankings"][i]["team_id"] == team.id
+        - response["rankings"][i]["team_name"] == team.name
+        - response["rankings"][i]["user_id"] is None
+        """
+        from app.models.team import Team, TournamentTeamEnrollment
+
+        t = self._make_team_tournament(test_db)
+        team1, _ = self._make_team_and_members(test_db, 2)
+        team2, _ = self._make_team_and_members(test_db, 2)
+        self._enroll_team(test_db, t, team1)
+        self._enroll_team(test_db, t, team2)
+        self._add_session_with_team_results(test_db, t, [team1.id, team2.id])
+        test_db.flush()
+
+        # Calculate rankings
+        calc = admin_client.post(f"/api/v1/tournaments/{t.id}/calculate-rankings")
+        assert calc.status_code == 200, calc.text[:400]
+
+        # Fetch rankings
+        resp = admin_client.get(f"/api/v1/tournaments/{t.id}/rankings")
+        assert resp.status_code == 200, resp.text[:400]
+        data = resp.json()
+
+        assert data["rankings_count"] == 2, (
+            f"Expected 2 team rankings, got {data['rankings_count']}"
+        )
+        for entry in data["rankings"]:
+            assert entry["team_id"] is not None, (
+                "TEAM ranking must have team_id set (not None)"
+            )
+            assert entry["team_name"] is not None, (
+                f"TEAM ranking must have team_name set, got None for team_id={entry['team_id']}"
+            )
+            assert entry["user_id"] is None, (
+                f"TEAM ranking must have user_id=None (not a user), got {entry['user_id']}"
+            )
+
+        # team1 has highest score (90) → rank 1
+        ranked = sorted(data["rankings"], key=lambda r: r["rank"])
+        assert ranked[0]["team_id"] == team1.id, (
+            f"team1 (highest score) must be rank 1. Got team_id={ranked[0]['team_id']}"
+        )
+        assert ranked[0]["team_name"] == team1.name, (
+            f"team_name must be '{team1.name}', got '{ranked[0]['team_name']}'"
+        )
+
+    # ── TEAM-09: admin edit page renders team context for UI ──────────────────
+
+    def test_TEAM09_edit_page_renders_enrolled_team_names_js_constant(
+        self,
+        test_db: Session,
+        admin_client: TestClient,
+    ):
+        """
+        TEAM-09: GET /admin/tournaments/{id}/edit for a TEAM tournament with
+        enrolled teams renders the ENROLLED_TEAM_NAMES JS constant containing
+        the team names, and sets participant_team_ids on the session card button.
+
+        This proves the openResultModal() TEAM branch receives team data.
+        """
+        t = self._make_team_tournament(test_db)
+        t.tournament_status = "IN_PROGRESS"
+        team1, _ = self._make_team_and_members(test_db, 2)
+        team2, _ = self._make_team_and_members(test_db, 2)
+        self._enroll_team(test_db, t, team1)
+        self._enroll_team(test_db, t, team2)
+        # Add a match session with participant_team_ids set
+        self._add_session_with_team_results(test_db, t, [team1.id, team2.id])
+        test_db.flush()
+
+        resp = admin_client.get(f"/admin/tournaments/{t.id}/edit")
+        assert resp.status_code == 200, resp.text[:400]
+        html = resp.text
+
+        # ENROLLED_TEAM_NAMES must contain both team names
+        assert "ENROLLED_TEAM_NAMES" in html, (
+            "Edit page must render ENROLLED_TEAM_NAMES JS constant for TEAM tournaments"
+        )
+        assert team1.name in html, (
+            f"Team1 name '{team1.name}' must appear in ENROLLED_TEAM_NAMES"
+        )
+        assert team2.name in html, (
+            f"Team2 name '{team2.name}' must appear in ENROLLED_TEAM_NAMES"
+        )
+
+        # participant_team_ids must appear in the session button onclick
+        assert "participant_team_ids" in html or str(team1.id) in html, (
+            "Session button must pass team IDs to openResultModal"
+        )

--- a/tests/unit/test_calculate_rankings.py
+++ b/tests/unit/test_calculate_rankings.py
@@ -472,6 +472,7 @@ class TestGetTournamentRankingsHappy:
     def _ranking_row(self, user_id=10, rank=1, points=85.0):
         r = MagicMock()
         r.user_id = user_id
+        r.team_id = None
         r.rank = rank
         r.points = points
         r.wins = 2
@@ -492,7 +493,7 @@ class TestGetTournamentRankingsHappy:
     def test_response_fields_present(self):
         t = _tournament(format_="HEAD_TO_HEAD")
         r = self._ranking_row()
-        rows = [(r, "nick10", "User 10")]
+        rows = [(r, "nick10", "User 10", None)]
         db = self._make_db(t, rows)
         result = get_tournament_rankings(tournament_id=1, db=db, current_user=_user())
         assert "tournament_id" in result
@@ -502,8 +503,8 @@ class TestGetTournamentRankingsHappy:
 
     def test_rankings_count_matches_rows(self):
         t = _tournament(format_="HEAD_TO_HEAD")
-        rows = [(self._ranking_row(user_id=10, rank=1), "n1", "U1"),
-                (self._ranking_row(user_id=20, rank=2), "n2", "U2")]
+        rows = [(self._ranking_row(user_id=10, rank=1), "n1", "U1", None),
+                (self._ranking_row(user_id=20, rank=2), "n2", "U2", None)]
         db = self._make_db(t, rows)
         result = get_tournament_rankings(tournament_id=1, db=db, current_user=_user())
         assert result["rankings_count"] == 2
@@ -511,7 +512,7 @@ class TestGetTournamentRankingsHappy:
     def test_nickname_used_as_display_name(self):
         t = _tournament(format_="HEAD_TO_HEAD")
         r = self._ranking_row()
-        rows = [(r, "nick10", "Full Name")]
+        rows = [(r, "nick10", "Full Name", None)]
         db = self._make_db(t, rows)
         result = get_tournament_rankings(tournament_id=1, db=db, current_user=_user())
         assert result["rankings"][0]["name"] == "nick10"
@@ -519,7 +520,7 @@ class TestGetTournamentRankingsHappy:
     def test_name_fallback_when_no_nickname(self):
         t = _tournament(format_="HEAD_TO_HEAD")
         r = self._ranking_row()
-        rows = [(r, None, "Full Name")]
+        rows = [(r, None, "Full Name", None)]
         db = self._make_db(t, rows)
         result = get_tournament_rankings(tournament_id=1, db=db, current_user=_user())
         assert result["rankings"][0]["name"] == "Full Name"
@@ -529,7 +530,7 @@ class TestGetTournamentRankingsHappy:
         r = self._ranking_row()
         r.goals_for = 7
         r.goals_against = 3
-        rows = [(r, "n", "U")]
+        rows = [(r, "n", "U", None)]
         db = self._make_db(t, rows)
         result = get_tournament_rankings(tournament_id=1, db=db, current_user=_user())
         assert result["rankings"][0]["goal_difference"] == 4
@@ -537,7 +538,7 @@ class TestGetTournamentRankingsHappy:
     def test_ir_tournament_adds_measured_value(self):
         t = _tournament(format_="INDIVIDUAL_RANKING")
         r = self._ranking_row(points=72.5)
-        rows = [(r, "n", "U")]
+        rows = [(r, "n", "U", None)]
         # ir_sessions query (q4) returns empty list
         db = _db(_q(first=t), _q(all_=rows), _q(all_=[]), _q(all_=[]))
         result = get_tournament_rankings(tournament_id=1, db=db, current_user=_user())
@@ -546,7 +547,7 @@ class TestGetTournamentRankingsHappy:
     def test_non_ir_tournament_no_measured_value(self):
         t = _tournament(format_="HEAD_TO_HEAD")
         r = self._ranking_row()
-        rows = [(r, "n", "U")]
+        rows = [(r, "n", "U", None)]
         db = self._make_db(t, rows)
         result = get_tournament_rankings(tournament_id=1, db=db, current_user=_user())
         assert "measured_value" not in result["rankings"][0]
@@ -557,6 +558,7 @@ class TestGetTournamentRankingsHappy:
 def _rrow(user_id=42, rank=1, points=80.0):
     r = MagicMock()
     r.user_id = user_id
+    r.team_id = None
     r.rank = rank
     r.points = points
     r.wins = 1
@@ -575,7 +577,7 @@ class TestGetTournamentRankingsGroupIdentifier:
         """Lines 277-282: participant_user_ids_raw is already a list → parsed directly."""
         t = _tournament(format_="HEAD_TO_HEAD")
         r = _rrow(user_id=42)
-        rows = [(r, "n42", "User42")]
+        rows = [(r, "n42", "User42", None)]
         group_sess = [("GroupA", [42], 10)]
         db = _db(_q(first=t), _q(all_=rows), _q(all_=group_sess))
         result = get_tournament_rankings(tournament_id=1, db=db, current_user=_user())
@@ -585,7 +587,7 @@ class TestGetTournamentRankingsGroupIdentifier:
         """Lines 279: participant_user_ids_raw is a JSON string → json.loads path."""
         t = _tournament(format_="HEAD_TO_HEAD")
         r = _rrow(user_id=42)
-        rows = [(r, "n42", "User42")]
+        rows = [(r, "n42", "User42", None)]
         group_sess = [("GroupB", '[42]', 10)]
         db = _db(_q(first=t), _q(all_=rows), _q(all_=group_sess))
         result = get_tournament_rankings(tournament_id=1, db=db, current_user=_user())
@@ -595,7 +597,7 @@ class TestGetTournamentRankingsGroupIdentifier:
         """Lines 286-290: participant_user_ids_raw is None → Booking query fallback."""
         t = _tournament(format_="HEAD_TO_HEAD")
         r = _rrow(user_id=42)
-        rows = [(r, "n42", "User42")]
+        rows = [(r, "n42", "User42", None)]
         group_sess = [("GroupC", None, 10)]
         booking_q = _q(all_=[(42,)])
         db = _db(_q(first=t), _q(all_=rows), _q(all_=group_sess), booking_q)
@@ -606,7 +608,7 @@ class TestGetTournamentRankingsGroupIdentifier:
         """Line 274: if not gid: continue — session with None gid leaves user unassigned."""
         t = _tournament(format_="HEAD_TO_HEAD")
         r = _rrow(user_id=42)
-        rows = [(r, "n42", "User42")]
+        rows = [(r, "n42", "User42", None)]
         group_sess = [(None, [42], 10)]  # gid=None → skipped by guard
         db = _db(_q(first=t), _q(all_=rows), _q(all_=group_sess))
         result = get_tournament_rankings(tournament_id=1, db=db, current_user=_user())
@@ -630,7 +632,7 @@ class TestGetTournamentRankingsRewards:
         """Lines 295-308: REWARDS_DISTRIBUTED → participation queried, reward_map built."""
         t = _tournament(format_="HEAD_TO_HEAD", tournament_status="REWARDS_DISTRIBUTED")
         r = _rrow(user_id=42)
-        rows = [(r, "n42", "User42")]
+        rows = [(r, "n42", "User42", None)]
         p = self._part(user_id=42, xp=120, credits=60)
         db = _db(_q(first=t), _q(all_=rows), _q(all_=[]), _q(all_=[p]))
         result = get_tournament_rankings(tournament_id=1, db=db, current_user=_user())
@@ -642,7 +644,7 @@ class TestGetTournamentRankingsRewards:
         """Lines 369-376: user not in reward_map → defaults (xp=0, credits=0) applied."""
         t = _tournament(format_="HEAD_TO_HEAD", tournament_status="REWARDS_DISTRIBUTED")
         r = _rrow(user_id=99)  # user 99 has no participation record
-        rows = [(r, "n99", "User99")]
+        rows = [(r, "n99", "User99", None)]
         p = self._part(user_id=42, xp=100, credits=50)  # different user
         db = _db(_q(first=t), _q(all_=rows), _q(all_=[]), _q(all_=[p]))
         result = get_tournament_rankings(tournament_id=1, db=db, current_user=_user())
@@ -664,7 +666,7 @@ class TestGetTournamentRankingsIRRoundResults:
         """Lines 322-339, 365: IR session with dict round_results → entry gets round_results."""
         t = _tournament(format_="INDIVIDUAL_RANKING")
         r = _rrow(user_id=42, points=88.5)
-        rows = [(r, "n42", "User42")]
+        rows = [(r, "n42", "User42", None)]
         ir_sess = self._ir_sess({"1": {"42": "88.5"}})
         db = _db(_q(first=t), _q(all_=rows), _q(all_=[]), _q(all_=[ir_sess]))
         result = get_tournament_rankings(tournament_id=1, db=db, current_user=_user())
@@ -677,7 +679,7 @@ class TestGetTournamentRankingsIRRoundResults:
         """Lines 325-327: round_results is a list (old format) → isinstance check fails, skipped."""
         t = _tournament(format_="INDIVIDUAL_RANKING")
         r = _rrow(user_id=42, points=75.0)
-        rows = [(r, "n42", "User42")]
+        rows = [(r, "n42", "User42", None)]
         s = MagicMock()
         s.rounds_data = {"round_results": [[42, 75.0]]}  # list, not dict
         db = _db(_q(first=t), _q(all_=rows), _q(all_=[]), _q(all_=[s]))
@@ -688,7 +690,7 @@ class TestGetTournamentRankingsIRRoundResults:
         """Lines 330-331: player_values for a round is a list → isinstance check fails, skipped."""
         t = _tournament(format_="INDIVIDUAL_RANKING")
         r = _rrow(user_id=42, points=75.0)
-        rows = [(r, "n42", "User42")]
+        rows = [(r, "n42", "User42", None)]
         s = MagicMock()
         s.rounds_data = {"round_results": {"1": [42, 75.0]}}  # list pv, not dict
         db = _db(_q(first=t), _q(all_=rows), _q(all_=[]), _q(all_=[s]))


### PR DESCRIPTION
## Summary

- **GET /rankings backend**: join `teams` table, expose `team_id` + `team_name` in each ranking entry (was missing → "User #null" rendered in admin UI)
- **Web route**: `sessions_result_status` dicts include `participant_team_ids`; `enrolled_teams` (team_id→name) added to edit page context
- **Admin UI `openResultModal()`**: new `teamIds` param; TEAM branch renders team score inputs; `submitResults()` calls `PATCH /sessions/{id}/team-results`
- **Admin UI `loadRankings()`**: detects `r.team_id`, displays `team_name` with 🏆 prefix; column header "Player" → "Team" for TEAM tournaments
- **Tests**: TEAM-08 (GET /rankings: team_id + team_name asserted), TEAM-09 (edit page: ENROLLED_TEAM_NAMES rendered)

## Test plan

- [x] `pytest tests/integration/web_flows/test_tournament_lifecycle_e2e.py` → 37/37 pass (was 35)
- [x] `pytest tests/unit/contract/test_openapi_snapshot.py` → 5/5 pass
- [ ] GitHub Actions CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)