### PR TITLE
fix(session): translate is_tournament_game → event_category at CRUD API boundary

### DIFF
--- a/app/api/api_v1/endpoints/sessions/crud.py
+++ b/app/api/api_v1/endpoints/sessions/crud.py
@@ -11,7 +11,7 @@ from .....database import get_db
 from .....dependencies import get_current_user, get_current_admin_or_instructor_user
 from .....models.user import User, UserRole
 from .....models.semester import Semester
-from .....models.session import Session as SessionTypel
+from .....models.session import Session as SessionTypel, EventCategory
 from .....models.booking import Booking, BookingStatus
 from .....models.attendance import Attendance
 from .....models.feedback import Feedback
@@ -85,7 +85,13 @@ def create_session(
                 detail=f"Session end date ({session_end_date}) cannot be after semester end date ({semester.end_date})"
             )
 
-    session = SessionTypel(**session_data.model_dump())
+    # Translate is_tournament_game → event_category at the API boundary.
+    # The Pydantic field is kept for external callers; the DB column was dropped in M-10.
+    # The hybrid_property currently handles this, but will be removed in a later phase.
+    session_dict = session_data.model_dump()
+    itg = session_dict.pop("is_tournament_game")
+    session_dict["event_category"] = EventCategory.MATCH if itg else EventCategory.TRAINING
+    session = SessionTypel(**session_dict)
     db.add(session)
     db.commit()
     db.refresh(session)
@@ -195,6 +201,11 @@ def update_session(
                     status_code=400,
                     detail=f"Session end date ({new_end_date}) cannot be after semester end date ({semester.end_date})"
                 )
+
+    # Translate is_tournament_game → event_category at the API boundary (same as POST).
+    if "is_tournament_game" in update_data:
+        itg = update_data.pop("is_tournament_game")
+        update_data["event_category"] = EventCategory.MATCH if itg else EventCategory.TRAINING
 
     for field, value in update_data.items():
         setattr(session, field, value)

--- a/app/api/api_v1/endpoints/sessions/crud.py
+++ b/app/api/api_v1/endpoints/sessions/crud.py
@@ -89,7 +89,7 @@ def create_session(
     # The Pydantic field is kept for external callers; the DB column was dropped in M-10.
     # The hybrid_property currently handles this, but will be removed in a later phase.
     session_dict = session_data.model_dump()
-    itg = session_dict.pop("is_tournament_game")
+    itg = session_dict.pop("is_tournament_game", False)
     session_dict["event_category"] = EventCategory.MATCH if itg else EventCategory.TRAINING
     session = SessionTypel(**session_dict)
     db.add(session)


### PR DESCRIPTION
## Summary

- Adds explicit `is_tournament_game → event_category` translation inside `crud.py` **before** the value reaches the ORM, so the API is safe regardless of whether the `hybrid_property` bridge is present.
- Zero external contract change: `SessionCreate.is_tournament_game` and `SessionUpdate.is_tournament_game` Pydantic fields are kept as-is.
- `hybrid_property` in `session.py` is intentionally **untouched** — removal is a separate later phase.

## Why

`SessionCreate.model_dump()` includes `is_tournament_game`, which currently hits the hybrid setter. Once the hybrid is removed the call would silently ignore the field, leaving `event_category = NULL`. This PR makes the translation explicit and deterministic at the boundary.

**Phase 1 of a staged migration** (audit doc in prior PR descriptions):
- Phase 1 (this PR) — CRUD boundary translation
- Phases 2–7 — call-site cleanup + hybrid removal (not started)

## Files changed

| File | Change |
|---|---|
| `app/api/api_v1/endpoints/sessions/crud.py` | POST: pop `is_tournament_game`, set `event_category`; PATCH: intercept before `setattr` loop |

## Test plan

- [x] `pytest tests/integration/api_smoke/` — 1 737 / 1 737 ✅
- [x] `pytest tests/unit/ tests/integration/` (excluding load) — 55 / 55 ✅
- [ ] CI: API Smoke Tests + Query Budget gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)