### PR TITLE
refactor(session): replace is_tournament_game setter with event_category in repositories.py

### DIFF
--- a/app/services/tournament/repositories.py
+++ b/app/services/tournament/repositories.py
@@ -380,7 +380,7 @@ class FakeSessionRepository(SessionRepository):
         mock_session.tournament_round = session_data["tournament_round"]
         mock_session.participant_user_ids = session_data.get("participant_user_ids", [])
         mock_session.game_results = None
-        mock_session.is_tournament_game = True
+        mock_session.event_category = EventCategory.MATCH
 
         # Store for verification
         self.created_sessions.append(mock_session)


### PR DESCRIPTION
## Summary

Phase 2 of staged `is_tournament_game` hybrid_property migration.

**Single change — 1 file, 1 line:**

| File | Line | Before | After |
|---|---|---|---|
| `app/services/tournament/repositories.py` | 383 | `mock_session.is_tournament_game = True` | `mock_session.event_category = EventCategory.MATCH` |

`EventCategory` was already imported at the top of the file — no new import needed.

## What is NOT touched

- `hybrid_property` in `session.py` — untouched
- Pydantic schema fields (`SessionCreate`, `SessionUpdate`) — untouched
- Test call sites (`app/tests/`) — untouched
- All other production call sites (`generate_sessions.py`, `session_response_builder.py`) — already use `event_category` directly, no change needed

## Test plan

- [x] `pytest tests/unit/ tests/integration/tournament/` — 7,220 / 7,220 passed ✅
- [ ] CI: API Smoke Tests + Query Budget gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)