### PR TITLE
refactor(session): remove redundant is_tournament_game setter from 3 test helpers

### DIFF
--- a/tests/unit/services/test_sessions_results_endpoint.py
+++ b/tests/unit/services/test_sessions_results_endpoint.py
@@ -65,7 +65,6 @@ def _session(
 ):
     s = MagicMock()
     s.id = session_id
-    s.is_tournament_game = is_tournament_game
     s.event_category = EventCategory.MATCH if is_tournament_game else EventCategory.TRAINING
     s.game_type = "HEAD_TO_HEAD"
     s.game_results = game_results

--- a/tests/unit/services/test_tournament_repositories.py
+++ b/tests/unit/services/test_tournament_repositories.py
@@ -32,7 +32,6 @@ def _session(
     s.tournament_phase = phase
     s.tournament_round = round_num
     s.title = title
-    s.is_tournament_game = is_tournament_game
     s.event_category = EventCategory.MATCH if is_tournament_game else EventCategory.TRAINING
     s.game_results = game_results
     return s

--- a/tests/unit/tournament/test_results_submission.py
+++ b/tests/unit/tournament/test_results_submission.py
@@ -73,7 +73,6 @@ def _session_mock(sid=10, tournament_id=1, is_tournament_game=True,
     s = MagicMock()
     s.id = sid
     s.semester_id = tournament_id
-    s.is_tournament_game = is_tournament_game
     s.event_category = EventCategory.MATCH if is_tournament_game else EventCategory.TRAINING
     s.match_format = match_format
     s.game_results = game_results


### PR DESCRIPTION
## Summary

Phase 3 of staged `is_tournament_game` hybrid_property migration — **Group 1 (dual setter cleanup)**.

**3 files changed, 3 lines deleted.**

Each of the 3 test helper functions already set `event_category` correctly on the immediately following line. The `is_tournament_game = ...` setter line was redundant and is now removed. Behavioural change: zero.

| File | Removed line |
|---|---|
| `tests/unit/tournament/test_results_submission.py:76` | `s.is_tournament_game = is_tournament_game` |
| `tests/unit/services/test_sessions_results_endpoint.py:68` | `s.is_tournament_game = is_tournament_game` |
| `tests/unit/services/test_tournament_repositories.py:35` | `s.is_tournament_game = is_tournament_game` |

## What is NOT touched

- Helper function signatures (`is_tournament_game=True` params) — unchanged
- All callers of these helpers — unchanged
- Constructor kwargs (Group 2), assertions (Group 3), ORM filter expression (Group 6) — unchanged
- `hybrid_property`, schemas — unchanged

## Test plan

- [x] `pytest tests/unit/ tests/integration/tournament/` — 7,220 / 7,220 passed ✅
- [ ] CI: API Smoke Tests + Query Budget gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)