### PR TITLE
refactor(session): Group 2B — remove dead is_tournament_game from non-ORM call sites

### DIFF
--- a/scripts/seed_all_tournament_types.py
+++ b/scripts/seed_all_tournament_types.py
@@ -254,7 +254,6 @@ def _create_tournament(
             date_end=datetime(d.year, d.month, d.day, 18, 0),
             semester_id=sem.id,
             event_category=EventCategory.MATCH,
-            is_tournament_game=True,
         ))
         db.flush()
 

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -289,7 +289,7 @@ def tournament_session_with_bookings(
         instructor_id=tournament_semester_with_instructor.master_instructor_id,
         semester_id=tournament_semester_with_instructor.id,
         credit_cost=1,
-        is_tournament_game=True,
+        event_category=EventCategory.MATCH,
         game_type="Final",
     )
     test_db.add(session)

--- a/tests/unit/services/test_attendance_endpoint.py
+++ b/tests/unit/services/test_attendance_endpoint.py
@@ -145,7 +145,6 @@ def _attendance_data(
 def _session(is_tournament=False):
     s = MagicMock()
     s.id = 1
-    s.is_tournament_game = is_tournament
     s.event_category = EventCategory.MATCH if is_tournament else EventCategory.TRAINING
     return s
 

--- a/tests/unit/services/test_match_performance_modifier.py
+++ b/tests/unit/services/test_match_performance_modifier.py
@@ -54,7 +54,6 @@ def _sess(user_id, result, score_self=0, score_opp=0, tournament_id=1, other_use
     ]
     return SimpleNamespace(
         semester_id=tournament_id,
-        is_tournament_game=True,
         participant_user_ids=[user_id, other_user_id],
         game_results=json.dumps({"participants": participants}),
     )
@@ -206,7 +205,6 @@ def test_malformed_game_results_skipped():
     """game_results with null participants → gracefully skipped, return 0.0."""
     bad_sess = SimpleNamespace(
         semester_id=1,
-        is_tournament_game=True,
         participant_user_ids=[1, 2],
         game_results=json.dumps({"participants": None}),
     )


### PR DESCRIPTION
## Summary

Removes the remaining dead/redundant `is_tournament_game` usages from non-ORM call sites. 4 files, net 5 lines removed.

## Changes

| File | Change | Reason |
|------|--------|--------|
| `tests/api/conftest.py:292` | Replace `is_tournament_game=True` → `event_category=EventCategory.MATCH` | Carry-over Group 2A fix — 8-space-indented kwarg missed by Group 2A's `replace_all` on 12-space instances |
| `tests/unit/services/test_match_performance_modifier.py` | Remove `is_tournament_game=True` from 2 `SimpleNamespace(...)` calls | Production `_compute_match_performance_modifier` filters via `SessionModel.event_category` at query level (ORM filter); never reads `.is_tournament_game` off returned objects; attribute was vestigial |
| `tests/unit/services/test_attendance_endpoint.py` | Remove `s.is_tournament_game = is_tournament` from mock builder | `attendance.py` reads `session.event_category` (lines 46, 271); `s.event_category` already set on the next line; setter was dead |
| `scripts/seed_all_tournament_types.py` | Remove `is_tournament_game=True` | Immediately preceded by `event_category=EventCategory.MATCH` — redundant, same pattern as Group 2A removal-only cases |

## Scope

No production logic changes. Helper parameter names, assertions, ORM filter expressions, schemas, and the hybrid property are untouched.

## Validation

Local: `pytest tests/unit/ tests/integration/tournament/` — **7220 passed, 21 xfailed** (baseline unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)