### PR TITLE
refactor(tests): Group 3 — replace is_tournament_game assertions with event_category

### DIFF
--- a/app/tests/test_tournament_session_generation_api.py
+++ b/app/tests/test_tournament_session_generation_api.py
@@ -224,7 +224,7 @@ class TestTournamentSessionGenerationAPI:
 
         # Verify each session has correct metadata (HEAD_TO_HEAD 1v1 matches)
         for session in sessions:
-            assert session.is_tournament_game is True
+            assert session.event_category == EventCategory.MATCH
             assert session.auto_generated is True
             assert session.tournament_phase == 'GROUP_STAGE'
             assert session.expected_participants == 2, "HEAD_TO_HEAD matches have 2 participants"
@@ -597,7 +597,7 @@ class TestTournamentSessionGenerationAPI:
         # Verify each session has participant assignments (HEAD_TO_HEAD 1v1)
         for session in sessions:
             assert session.expected_participants == 2, "HEAD_TO_HEAD matches have 2 participants"
-            assert session.is_tournament_game is True
+            assert session.event_category == EventCategory.MATCH
             assert session.auto_generated is True
 
             # Note: Bookings and attendance are created separately, not by generator
@@ -714,7 +714,7 @@ class TestTournamentSessionGenerationAPI:
 
         for session in sessions:
             assert session.expected_participants == 2, "Knockout matches are 1v1"
-            assert session.is_tournament_game is True
+            assert session.event_category == EventCategory.MATCH
             assert session.auto_generated is True
             assert session.group_identifier is None
 
@@ -840,7 +840,7 @@ class TestTournamentSessionGenerationAPI:
         # All sessions should be HEAD_TO_HEAD 1v1 matches
         for session in sessions:
             assert session.expected_participants == 2, "Swiss matches are 1v1 HEAD_TO_HEAD"
-            assert session.is_tournament_game is True
+            assert session.event_category == EventCategory.MATCH
             assert session.auto_generated is True
 
         # Verify round distribution (4 matches per round)

--- a/tests/integration/tournament/test_api_attendance_validation.py
+++ b/tests/integration/tournament/test_api_attendance_validation.py
@@ -80,8 +80,8 @@ class TestTournamentSessionDetection:
         test_db: Session,
         tournament_session_with_bookings: SessionModel
     ):
-        """Tournament session has is_tournament_game=True."""
-        assert tournament_session_with_bookings.is_tournament_game is True
+        """Tournament session has event_category=MATCH."""
+        assert tournament_session_with_bookings.event_category == EventCategory.MATCH
         assert tournament_session_with_bookings.game_type is not None
 
     def test_tournament_semester_has_master_instructor(
@@ -98,7 +98,7 @@ class TestTournamentSessionDetection:
         instructor_user,
         student_user
     ):
-        """Regular session has is_tournament_game=False or NULL."""
+        """Regular session has event_category=TRAINING."""
         from app.models.semester import SemesterStatus
         from app.models.specialization import SpecializationType
         from app.models.session import SessionType
@@ -132,7 +132,7 @@ class TestTournamentSessionDetection:
         test_db.commit()
         test_db.refresh(session)
 
-        assert session.is_tournament_game is False
+        assert session.event_category == EventCategory.TRAINING
         assert session.game_type is None
 
 
@@ -157,7 +157,7 @@ class TestTournamentValidationFlow:
         """
         # Step 1: Check if session is tournament
         session = tournament_session_with_bookings
-        assert session.is_tournament_game is True
+        assert session.event_category == EventCategory.MATCH
 
         # Step 2: If tournament, ONLY present/absent allowed
         valid_statuses = ["present", "absent"]

--- a/tests/unit/tournament/test_core.py
+++ b/tests/unit/tournament/test_core.py
@@ -21,7 +21,7 @@ from app.services.tournament.core import (
     delete_tournament,
 )
 from app.models.semester import Semester, SemesterStatus
-from app.models.session import Session as SessionModel, SessionType
+from app.models.session import Session as SessionModel, SessionType, EventCategory
 from app.models.booking import Booking, BookingStatus
 from app.models.specialization import SpecializationType
 
@@ -181,7 +181,7 @@ class TestCreateTournamentSessions:
         assert session.capacity == 20
         assert session.credit_cost == 1
         assert session.game_type == "Semifinal"
-        assert session.is_tournament_game is True
+        assert session.event_category == EventCategory.MATCH
         assert session.session_type == SessionType.on_site
         assert session.instructor_id is None  # No instructor yet
         assert session.semester_id == tournament_semester.id
@@ -307,7 +307,7 @@ class TestCreateTournamentSessions:
         tournament_semester: Semester,
         tournament_date: date
     ):
-        """All tournament sessions have is_tournament_game=True."""
+        """All tournament sessions have event_category=MATCH."""
         session_configs = [
             {"time": "09:00", "title": "Match 1"},
             {"time": "11:00", "title": "Match 2"},
@@ -321,7 +321,7 @@ class TestCreateTournamentSessions:
         )
 
         for session in sessions:
-            assert session.is_tournament_game is True
+            assert session.event_category == EventCategory.MATCH
 
     def test_all_sessions_on_site_type(
         self,


### PR DESCRIPTION
## Summary

Replaces all 9 `session.is_tournament_game` getter assertions with direct `event_category` equivalents. Test-only change; 3 files, zero net line delta (13 in / 13 out).

## Changes

| File | Assertions replaced | Docstrings updated | Import added |
|------|--------------------|--------------------|--------------|
| `tests/integration/tournament/test_api_attendance_validation.py` | 3 (`is True`×2, `is False`×1) | 2 | — |
| `tests/unit/tournament/test_core.py` | 2 (`is True`×2) | 1 | `EventCategory` |
| `app/tests/test_tournament_session_generation_api.py` | 4 (`is True`×4) | — | — |

All `session` objects are real ORM `SessionModel` instances (fixture-backed or DB-queried). Replacements are strict 1:1 equivalences — hybrid getter returns `event_category == EventCategory.MATCH`; no NULL edge cases exist in scope.

## Replacement pattern

```python
# Before
assert session.is_tournament_game is True
assert session.is_tournament_game is False

# After
assert session.event_category == EventCategory.MATCH
assert session.event_category == EventCategory.TRAINING
```

## Scope

ORM filter expressions (`test_ops_scenario.py:3781`), helper parameter names, schemas, and the hybrid property are untouched — separate later phases.

## Validation

Local: `pytest tests/unit/ tests/integration/tournament/` — **7220 passed, 21 xfailed** (baseline unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)