### PR TITLE
refactor(tests): Group 6 — replace is_tournament_game ORM filter expression with event_category

### DIFF
--- a/tests/unit/services/test_ops_scenario.py
+++ b/tests/unit/services/test_ops_scenario.py
@@ -3734,7 +3734,7 @@ class TestOpsScenarioIntegration:
           - At least 1 session generated (real TSG with ≥2 enrolled players)
           - _finalize_tournament_with_rewards called once (lifecycle hook fired)
         """
-        from app.models.session import Session as SessionModel
+        from app.models.session import Session as SessionModel, EventCategory
         from app.models.semester import Semester
         from app.models.tournament_ranking import TournamentRanking
 
@@ -3778,7 +3778,7 @@ class TestOpsScenarioIntegration:
         # Real TSG generated at least 1 session (4 enrolled players → ≥ 1 IR session)
         sessions = test_db.query(SessionModel).filter(
             SessionModel.semester_id == tid,
-            SessionModel.is_tournament_game == True,
+            SessionModel.event_category == EventCategory.MATCH,
         ).all()
         assert len(sessions) >= 1, (
             f"Real TSG must generate ≥1 session for 4 players; got {len(sessions)}"


### PR DESCRIPTION
## Summary

Replaces the last remaining `SessionModel.is_tournament_game` ORM filter-expression call site with the direct `event_category` equivalent. 1 file, 2 lines changed.

## Change

**`tests/unit/services/test_ops_scenario.py`** — `test_full_pipeline_four_players_real_tsg`:

```python
# Before
from app.models.session import Session as SessionModel
...
sessions = test_db.query(SessionModel).filter(
    SessionModel.semester_id == tid,
    SessionModel.is_tournament_game == True,   # hybrid @expression
).all()

# After
from app.models.session import Session as SessionModel, EventCategory
...
sessions = test_db.query(SessionModel).filter(
    SessionModel.semester_id == tid,
    SessionModel.event_category == EventCategory.MATCH,
).all()
```

`SessionModel.is_tournament_game == True` invoked the hybrid `@expression` which returned `cls.event_category == EventCategory.MATCH` as SQL — the replacement is a direct, semantically identical substitution.

## Significance

After this change, all three aspects of the hybrid property have zero remaining call sites:

| Hybrid aspect | Cleared by |
|--------------|------------|
| `@setter` | Phase 1 (crud.py), Phase 2 (repositories.py), Groups 1/2A/2B |
| `@getter` | Group 3 (assertions) |
| `@expression` | **This PR (Group 6)** |

The hybrid property in `app/models/session.py` is now dead code. Removal is gated on a separate Group 7 audit (schema fields + hybrid definition).

## Scope

Raw SQL string tests, API response keys, schemas, helper parameter names, and the hybrid property definition are untouched.

## Validation

Local: `pytest tests/unit/services/test_ops_scenario.py` — **132/132 passed** (including `test_full_pipeline_four_players_real_tsg`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)