### PR TITLE
refactor(session): Group 7 — remove is_tournament_game hybrid_property

### DIFF
--- a/app/api/api_v1/endpoints/sessions/crud.py
+++ b/app/api/api_v1/endpoints/sessions/crud.py
@@ -87,7 +87,6 @@ def create_session(
 
     # Translate is_tournament_game → event_category at the API boundary.
     # The Pydantic field is kept for external callers; the DB column was dropped in M-10.
-    # The hybrid_property currently handles this, but will be removed in a later phase.
     session_dict = session_data.model_dump()
     itg = session_dict.pop("is_tournament_game", False)
     session_dict["event_category"] = EventCategory.MATCH if itg else EventCategory.TRAINING

--- a/app/models/session.py
+++ b/app/models/session.py
@@ -1,5 +1,4 @@
 from sqlalchemy import Column, Integer, SmallInteger, String, Text, DateTime, ForeignKey, Enum, Boolean, ARRAY, case
-from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship
 from sqlalchemy.dialects.postgresql import JSONB
 from datetime import datetime, timezone
@@ -18,7 +17,7 @@ class SessionType(enum.Enum):
 
 
 class EventCategory(str, enum.Enum):
-    """What kind of event this session is — replaces boolean is_tournament_game (M-03)."""
+    """What kind of event this session is."""
     TRAINING = "TRAINING"  # Practice, drill, skills session
     MATCH = "MATCH"        # Competitive game / tournament match
 
@@ -116,33 +115,6 @@ class Session(Base):
         nullable=False,
         comment="Number of credits required to book this session (default: 1, workshops may cost more)"
     )
-
-    # 🏆 DEPRECATED — is_tournament_game (backward-compat bridge, scheduled for removal)
-    # ────────────────────────────────────────────────────────────────────────────
-    # The DB column was dropped in M-10 (2026-03-15). This hybrid_property
-    # provides a transparent compatibility bridge so existing callers continue
-    # to work without changes.
-    #
-    # Replacement: use `event_category` / `EventCategory` directly.
-    #   Read:   session.event_category == EventCategory.MATCH
-    #   Filter: SessionModel.event_category == EventCategory.MATCH
-    #   Write:  session.event_category = EventCategory.MATCH
-    #
-    # TODO: remove after all call-sites have been migrated to event_category.
-    @hybrid_property
-    def is_tournament_game(self) -> bool:
-        """DEPRECATED — use event_category == EventCategory.MATCH instead."""
-        return self.event_category == EventCategory.MATCH
-
-    @is_tournament_game.setter
-    def is_tournament_game(self, value: bool) -> None:
-        """DEPRECATED — use event_category = EventCategory.MATCH instead."""
-        self.event_category = EventCategory.MATCH if value else EventCategory.TRAINING
-
-    @is_tournament_game.expression
-    def is_tournament_game(cls):  # noqa: N805
-        """DEPRECATED — use SessionModel.event_category == EventCategory.MATCH instead."""
-        return cls.event_category == EventCategory.MATCH
 
     game_type = Column(
         String(100),
@@ -273,7 +245,7 @@ class Session(Base):
 
     # ─── NEW SEMANTIC DIMENSIONS (M-03 to M-06, 2026-03-15) ───────────────────
 
-    # M-03: Replaces is_tournament_game boolean with a proper categorical discriminator
+    # M-03
     event_category = Column(
         Enum(EventCategory, name='event_category_type'),
         nullable=True,

--- a/scripts/migrate_tournament_sessions.py
+++ b/scripts/migrate_tournament_sessions.py
@@ -14,7 +14,7 @@ import os
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from app.database import SessionLocal
-from app.models.session import Session
+from app.models.session import Session, EventCategory
 from app.models.semester import Semester
 
 
@@ -50,8 +50,8 @@ def migrate_tournament_sessions():
             # Update each session
             updated_count = 0
             for session in sessions:
-                if not session.is_tournament_game:
-                    session.is_tournament_game = True
+                if session.event_category != EventCategory.MATCH:
+                    session.event_category = EventCategory.MATCH
                     updated_count += 1
                 # game_type and game_results remain NULL (can be filled later by instructor)
 


### PR DESCRIPTION
## Summary

- Remove the `is_tournament_game` `hybrid_property` (getter/setter/expression) from `app/models/session.py` — all call sites migrated in Groups 1–6
- Drop the now-unused `hybrid_property` import from `session.py`
- Clean up 2 stale comments in `session.py` (EventCategory docstring, M-03 column comment)
- Remove 1 stale comment in `crud.py` (obsolete hybrid_property reference)
- Update `scripts/migrate_tournament_sessions.py` to use `event_category` directly — prevents `AttributeError` after hybrid removal

## What is NOT changed
- `app/schemas/session.py` — Pydantic `is_tournament_game` fields kept (external API input contract)
- `crud.py` boundary translation — `itg = session_dict.pop("is_tournament_game")` → `event_category` kept
- `generate_sessions.py` / `session_response_builder.py` response dict keys kept
- All `tests/` files untouched

## Test results
`pytest tests/unit/ tests/integration/tournament/` → **7220 passed, 0 failures**

## Migration history
| Group | Scope | PR |
|-------|-------|----|
| P1 | CRUD boundary translation | #60 |
| P2 | Direct ORM setters in repositories.py | #61 |
| G1 | Dual-setter cleanup in test helpers | #62 |
| G2A | ORM constructor kwargs (15 test files) | #63 |
| G2B | Dead non-ORM attrs + carry-over ORM fix | #64 |
| G3 | Assertion/getter replacements | #65 |
| G6 | ORM filter expression | #66 |
| **G7** | **Hybrid property removal (this PR)** | **#67** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)