### PR TITLE
refactor(skill-svc): Layer 2 — extract config/mapping layer into _config.py

### DIFF
--- a/app/services/skill_progression/__init__.py
+++ b/app/services/skill_progression/__init__.py
@@ -1,9 +1,11 @@
 """
-skill_progression sub-package — Layer 1 (pure formulas) only.
+skill_progression sub-package — Layers 1 + 2.
 
-Future layers (config resolution, DB helpers, EMA engine, views) will be
-added to this package in subsequent PRs.  The canonical import surface
-remains app.services.skill_progression_service (thin shim).
+Layer 1 (_formulas):  pure math, constants
+Layer 2 (_config):    skill key enumeration, baseline lookup, tournament mapping
+
+Future layers (DB helpers, EMA engine, views) will be added in subsequent PRs.
+The canonical import surface remains app.services.skill_progression_service (thin shim).
 """
 from ._formulas import (
     MIN_SKILL_VALUE,
@@ -13,6 +15,11 @@ from ._formulas import (
     calculate_skill_value_from_placement,
     get_skill_tier,
 )
+from ._config import (
+    get_all_skill_keys,
+    get_baseline_skills,
+    _extract_tournament_skills,
+)
 
 __all__ = [
     "MIN_SKILL_VALUE",
@@ -21,4 +28,7 @@ __all__ = [
     "DEFAULT_BASELINE",
     "calculate_skill_value_from_placement",
     "get_skill_tier",
+    "get_all_skill_keys",
+    "get_baseline_skills",
+    "_extract_tournament_skills",
 ]

--- a/app/services/skill_progression/_config.py
+++ b/app/services/skill_progression/_config.py
@@ -1,0 +1,135 @@
+"""
+Config/mapping resolution layer for skill progression.
+
+Handles skill key enumeration (from skills_config), baseline lookup
+(from UserLicense.football_skills), and tournament-to-skill mapping
+resolution (from reward_config JSON or TournamentSkillMapping table).
+
+No EMA formula logic, no view building.  Minimal DB access (1 query per
+function at most).
+
+Extracted from skill_progression_service.py (Layer 2).
+"""
+from typing import Dict, List
+
+from sqlalchemy.orm import Session
+
+from app.models.license import UserLicense
+from app.models.tournament_achievement import TournamentSkillMapping
+from app.skills_config import SKILL_CATEGORIES
+from ._formulas import DEFAULT_BASELINE
+
+
+def get_all_skill_keys() -> List[str]:
+    """
+    Get list of all skill keys from skills_config.
+
+    Returns:
+        List of skill keys (e.g., ["ball_control", "dribbling", ...])
+    """
+    skill_keys = []
+    for category in SKILL_CATEGORIES:
+        for skill in category["skills"]:
+            skill_keys.append(skill["key"])
+    return skill_keys
+
+
+def get_baseline_skills(db: Session, user_id: int) -> Dict[str, float]:
+    """
+    Get baseline skill values from UserLicense.football_skills (onboarding).
+
+    Args:
+        db: Database session
+        user_id: User ID
+
+    Returns:
+        Dict of skill_key → baseline_value (0-100)
+
+    ⚠️ FALLBACK BEHAVIOR FOR MISSING SKILLS:
+        If a skill is NOT found in UserLicense.football_skills, it defaults to DEFAULT_BASELINE (50.0).
+        This is INTENTIONAL and handles cases where:
+        - User completed onboarding with old skill set (before migration to 29 skills)
+        - User's onboarding data is incomplete
+        - New skills were added to system after user onboarding
+
+        The DEFAULT_BASELINE (50.0) represents "neutral" skill level - neither strong nor weak.
+        Tournament placements will then adjust this value up or down based on performance.
+
+    Example:
+        User has onboarding data: {"ball_control": 70, "dribbling": 65}
+        System now has 29 skills total.
+        Result: {"ball_control": 70.0, "dribbling": 65.0, "speed": 50.0, ...other skills... → 50.0}
+    """
+    # Get active LFA_FOOTBALL_PLAYER license
+    license = db.query(UserLicense).filter(
+        UserLicense.user_id == user_id,
+        UserLicense.specialization_type == "LFA_FOOTBALL_PLAYER",
+        UserLicense.is_active == True
+    ).first()
+
+    if not license or not license.football_skills:
+        # 🔒 GUARD: No onboarding data at all → return all skills at DEFAULT_BASELINE
+        return {skill_key: DEFAULT_BASELINE for skill_key in get_all_skill_keys()}
+
+    # 🔒 GUARD: Ensure football_skills is a dict
+    if not isinstance(license.football_skills, dict):
+        return {skill_key: DEFAULT_BASELINE for skill_key in get_all_skill_keys()}
+
+    baseline_skills = {}
+    for skill_key in get_all_skill_keys():
+        # ⚠️ FALLBACK: Missing skill defaults to DEFAULT_BASELINE (50.0)
+        # This is INTENTIONAL - allows graceful handling of skill migrations
+        skill_value = license.football_skills.get(skill_key, DEFAULT_BASELINE)
+
+        if isinstance(skill_value, dict):
+            # New format: {"baseline": 70, "current_level": 85, ...}
+            baseline_skills[skill_key] = float(skill_value.get("baseline", DEFAULT_BASELINE))
+        else:
+            # Old format: {"ball_control": 70, ...}
+            baseline_skills[skill_key] = float(skill_value)
+
+    return baseline_skills
+
+
+def _extract_tournament_skills(
+    db: Session,
+    tournament,
+    skill_keys: set,
+) -> Dict[str, float]:
+    """
+    Resolve which skills (with weights) a tournament affects.
+
+    Priority 1: reward_config.skill_mappings (V2 config-based)
+    Priority 2: TournamentSkillMapping table (legacy / E2E seeded tournaments)
+
+    Returns a dict of {skill_name: weight} for enabled skills that are present in
+    ``skill_keys``.  Returns an empty dict if no skills could be resolved.
+    """
+    result: Dict[str, float] = {}
+
+    reward_config = tournament.reward_config or {}
+    skill_mappings = reward_config.get("skill_mappings", [])
+
+    if isinstance(skill_mappings, list) and skill_mappings:
+        # V2 format: [{"skill": "passing", "enabled": true, "weight": 1.0}, ...]
+        for mapping in skill_mappings:
+            if mapping.get("enabled", False) and mapping.get("skill") in skill_keys:
+                result[mapping["skill"]] = mapping.get("weight", 1.0)
+    elif isinstance(skill_mappings, dict) and skill_mappings:
+        # Legacy dict format: {"passing": {...}, ...}
+        for sk in skill_mappings:
+            if sk in skill_keys:
+                result[sk] = 1.0
+
+    # Fallback: TournamentSkillMapping table (covers tournaments without reward_config skill_mappings)
+    if not result:
+        table_mappings = (
+            db.query(TournamentSkillMapping)
+            .filter(TournamentSkillMapping.semester_id == tournament.id)
+            .all()
+        )
+        for tm in table_mappings:
+            if tm.skill_name in skill_keys:
+                result[tm.skill_name] = float(tm.weight) if tm.weight else 1.0
+
+    return result

--- a/app/services/skill_progression_service.py
+++ b/app/services/skill_progression_service.py
@@ -38,6 +38,9 @@ from .skill_progression import (
     DEFAULT_BASELINE,
     calculate_skill_value_from_placement,
     get_skill_tier,
+    get_all_skill_keys,
+    get_baseline_skills,
+    _extract_tournament_skills,
 )
 
 
@@ -187,121 +190,6 @@ def _compute_match_performance_modifier(
     modifier = raw_signal * confidence
 
     return round(max(-1.0, min(1.0, modifier)), 4)
-
-
-def _extract_tournament_skills(
-    db: Session,
-    tournament,
-    skill_keys: set,
-) -> Dict[str, float]:
-    """
-    Resolve which skills (with weights) a tournament affects.
-
-    Priority 1: reward_config.skill_mappings (V2 config-based)
-    Priority 2: TournamentSkillMapping table (legacy / E2E seeded tournaments)
-
-    Returns a dict of {skill_name: weight} for enabled skills that are present in
-    ``skill_keys``.  Returns an empty dict if no skills could be resolved.
-    """
-    result: Dict[str, float] = {}
-
-    reward_config = tournament.reward_config or {}
-    skill_mappings = reward_config.get("skill_mappings", [])
-
-    if isinstance(skill_mappings, list) and skill_mappings:
-        # V2 format: [{"skill": "passing", "enabled": true, "weight": 1.0}, ...]
-        for mapping in skill_mappings:
-            if mapping.get("enabled", False) and mapping.get("skill") in skill_keys:
-                result[mapping["skill"]] = mapping.get("weight", 1.0)
-    elif isinstance(skill_mappings, dict) and skill_mappings:
-        # Legacy dict format: {"passing": {...}, ...}
-        for sk in skill_mappings:
-            if sk in skill_keys:
-                result[sk] = 1.0
-
-    # Fallback: TournamentSkillMapping table (covers tournaments without reward_config skill_mappings)
-    if not result:
-        table_mappings = (
-            db.query(TournamentSkillMapping)
-            .filter(TournamentSkillMapping.semester_id == tournament.id)
-            .all()
-        )
-        for tm in table_mappings:
-            if tm.skill_name in skill_keys:
-                result[tm.skill_name] = float(tm.weight) if tm.weight else 1.0
-
-    return result
-
-
-def get_all_skill_keys() -> List[str]:
-    """
-    Get list of all skill keys from skills_config.
-
-    Returns:
-        List of skill keys (e.g., ["ball_control", "dribbling", ...])
-    """
-    skill_keys = []
-    for category in SKILL_CATEGORIES:
-        for skill in category["skills"]:
-            skill_keys.append(skill["key"])
-    return skill_keys
-
-
-def get_baseline_skills(db: Session, user_id: int) -> Dict[str, float]:
-    """
-    Get baseline skill values from UserLicense.football_skills (onboarding).
-
-    Args:
-        db: Database session
-        user_id: User ID
-
-    Returns:
-        Dict of skill_key → baseline_value (0-100)
-
-    ⚠️ FALLBACK BEHAVIOR FOR MISSING SKILLS:
-        If a skill is NOT found in UserLicense.football_skills, it defaults to DEFAULT_BASELINE (50.0).
-        This is INTENTIONAL and handles cases where:
-        - User completed onboarding with old skill set (before migration to 29 skills)
-        - User's onboarding data is incomplete
-        - New skills were added to system after user onboarding
-
-        The DEFAULT_BASELINE (50.0) represents "neutral" skill level - neither strong nor weak.
-        Tournament placements will then adjust this value up or down based on performance.
-
-    Example:
-        User has onboarding data: {"ball_control": 70, "dribbling": 65}
-        System now has 29 skills total.
-        Result: {"ball_control": 70.0, "dribbling": 65.0, "speed": 50.0, ...other skills... → 50.0}
-    """
-    # Get active LFA_FOOTBALL_PLAYER license
-    license = db.query(UserLicense).filter(
-        UserLicense.user_id == user_id,
-        UserLicense.specialization_type == "LFA_FOOTBALL_PLAYER",
-        UserLicense.is_active == True
-    ).first()
-
-    if not license or not license.football_skills:
-        # 🔒 GUARD: No onboarding data at all → return all skills at DEFAULT_BASELINE
-        return {skill_key: DEFAULT_BASELINE for skill_key in get_all_skill_keys()}
-
-    # 🔒 GUARD: Ensure football_skills is a dict
-    if not isinstance(license.football_skills, dict):
-        return {skill_key: DEFAULT_BASELINE for skill_key in get_all_skill_keys()}
-
-    baseline_skills = {}
-    for skill_key in get_all_skill_keys():
-        # ⚠️ FALLBACK: Missing skill defaults to DEFAULT_BASELINE (50.0)
-        # This is INTENTIONAL - allows graceful handling of skill migrations
-        skill_value = license.football_skills.get(skill_key, DEFAULT_BASELINE)
-
-        if isinstance(skill_value, dict):
-            # New format: {"baseline": 70, "current_level": 85, ...}
-            baseline_skills[skill_key] = float(skill_value.get("baseline", DEFAULT_BASELINE))
-        else:
-            # Old format: {"ball_control": 70, ...}
-            baseline_skills[skill_key] = float(skill_value)
-
-    return baseline_skills
 
 
 def calculate_tournament_skill_contribution(


### PR DESCRIPTION
## Summary

- Create `app/services/skill_progression/_config.py` (Layer 2 — config/mapping resolution)
- Move `get_all_skill_keys`, `get_baseline_skills`, `_extract_tournament_skills` verbatim
- Update `__init__.py` to re-export all three symbols
- `skill_progression_service.py` (1,129 → 1,017 lines): 3 function bodies removed, 3 names added to existing package import block

## Zero-behavior-change validation

- Import smoke test: all symbols resolve through unchanged `skill_progression_service` surface
- `get_all_skill_keys.__module__` = `app.services.skill_progression._config` ✓
- `get_baseline_skills.__module__` = `app.services.skill_progression._config` ✓
- `_extract_tournament_skills.__module__` = `app.services.skill_progression._config` ✓
- `get_all_skill_keys()` → 29 keys (identical to pre-refactor) ✓

## mock.patch safety

All three symbols are patched at `"app.services.skill_progression_service.*"` in the test suite. After this PR, patching the shim attribute continues to work because all Layer 4/5 callers (`calculate_tournament_skill_contribution`, `compute_single_tournament_skill_delta`, `get_skill_profile`, etc.) still live in the shim and resolve these names via LOAD_GLOBAL against the shim's `__dict__`.

The internal `get_baseline_skills → get_all_skill_keys` call now executes in `_config.py`'s namespace (not patchable via shim) — this is safe because every test that patches `get_all_skill_keys` also patches `get_baseline_skills` directly, so the internal call never executes in those tests.

## What was NOT changed

- `get_all_skill_keys` in `app/skills_config.py` left untouched (separate implementation, identical output)
- Layer 3+ symbols untouched
- No import cleanup, no repeated-logic deduplication

## Local test results

`pytest tests/unit/ tests/integration/tournament/` → **7220 passed, 0 failures**

🤖 Generated with [Claude Code](https://claude.com/claude-code)