### PR TITLE
cleanup(skill-progression): remove unused MAX/MIN_SKILL_VALUE from _ema_engine.py

### DIFF
--- a/app/services/skill_progression/_ema_engine.py
+++ b/app/services/skill_progression/_ema_engine.py
@@ -17,8 +17,6 @@ from sqlalchemy.orm import Session
 from app.models.tournament_achievement import TournamentParticipation
 from ._formulas import (
     DEFAULT_BASELINE,
-    MAX_SKILL_VALUE,
-    MIN_SKILL_VALUE,
     calculate_skill_value_from_placement,
 )
 from ._config import (


### PR DESCRIPTION
## Summary

- Removes `MAX_SKILL_VALUE` and `MIN_SKILL_VALUE` from the `._formulas` import block in `_ema_engine.py` (lines 20–21 before this change)
- Both constants were carried over verbatim from the original shim during Layer 4 extraction but are never referenced in the `_ema_engine.py` function bodies
- They are used inside `calculate_skill_value_from_placement` (which lives in `_formulas.py`) — the engine calls that function but does not need the constants in its own namespace

## Scope

One file, 2 lines removed, zero behaviour change.

## Validation

- 69/69 unit tests (`test_skill_progression_service.py`) ✅
- Identity check: shim re-exports for `calculate_tournament_skill_contribution` and `compute_single_tournament_skill_delta` still resolve correctly ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)