### PR TITLE
feat(demo): add scripts/demo/ — Phase 1 demo information architecture

### DIFF
--- a/scripts/demo/README.md
+++ b/scripts/demo/README.md
@@ -1,0 +1,171 @@
+# Demo Scenarios
+
+Canonical demo seeds for stakeholder presentations and local development walkthroughs.
+
+## Quick start
+
+```bash
+# From the project root:
+python scripts/demo/run_demo.py           # full (default)
+python scripts/demo/run_demo.py skill
+python scripts/demo/run_demo.py events
+python scripts/demo/run_demo.py minimal
+```
+
+---
+
+## Scenarios
+
+### `full` — Full platform walkthrough
+**File:** `reset_full.py` (copy of `scripts/reset_and_seed_full.py`)
+
+| Property | Value |
+|----------|-------|
+| **Destructive** | YES — drops and recreates the entire schema |
+| **Idempotent** | YES — always produces the same state |
+| **Runtime** | ~30–60 s |
+| **Recommended for** | First-time setup, stakeholder demos, investor walkthroughs |
+
+**What it creates:**
+- 2 locations: Budapest (CENTER), Debrecen (PARTNER)
+- 10 users: 1 admin, 1 grandmaster/SD, 4 Budapest students, 4 Debrecen students
+- 13 events: 1 completed tournament per city (with placement + skill delta), 2 open tournaments, 2 camps, 1 mini-season, 1 academy season per city
+- Full enrollment matrix (APPROVED + payment_verified for every event-user pair)
+- Invitation codes: 13 event-specific + 4 general unredeemed, 2 redeemed
+
+**Credentials:**
+
+| Role | Email | Password |
+|------|-------|----------|
+| Admin | `admin@lfa.com` | `Admin1234!` |
+| Grandmaster / Sport Director | `grandmaster@lfa.com` | `Admin1234!` |
+| Student (Budapest) | `kovacs.peter@lfa-bdpst.hu` | `Player1234!` |
+| Student (Budapest) | `nagy.balazs@lfa-bdpst.hu` | `Player1234!` |
+| Student (Budapest) | `horvath.daniel@lfa-bdpst.hu` | `Player1234!` |
+| Student (Budapest) | `szabo.adam@lfa-bdpst.hu` | `Player1234!` |
+| Student (Debrecen) | `fekete.tamas@lfa-debr.hu` | `Player1234!` |
+| Student (Debrecen) | `varga.laszlo@lfa-debr.hu` | `Player1234!` |
+| Student (Debrecen) | `kiss.gabor@lfa-debr.hu` | `Player1234!` |
+| Student (Debrecen) | `toth.bence@lfa-debr.hu` | `Player1234!` |
+
+---
+
+### `skill` — Skill progression arc
+**File:** `seed_skill_progression.py` (copy of `scripts/seed_full_playable.py`)
+
+| Property | Value |
+|----------|-------|
+| **Destructive** | NO — additive; safe on any existing DB state |
+| **Idempotent** | YES — keyed by unique codes; re-running is safe |
+| **Runtime** | ~10–20 s |
+| **Recommended for** | EMA algorithm demos, skill report walkthroughs, technical audiences |
+| **Prerequisite** | `report_*` users must exist — run `seed_report_users_login.py` first if they are missing, or run `full` which creates all users from scratch |
+
+**What it creates:**
+- Activates 4 archetype `report_*` players with distinct skill profiles
+- 3 completed historical tournaments (Jan–Mar 2026): league, score-based, time-based
+- EMA placement arc: T1 (940c wins) → T2 (7b85 wins) → T3 (490c wins)
+- `TournamentParticipation` rows with `skill_rating_delta` written by the EMA engine
+- 3 ENROLLMENT_OPEN tournaments + 2 ENROLLMENT_OPEN camps for live enrollment demo
+
+**Player archetypes:**
+
+| Email | Archetype | Highlight skill |
+|-------|-----------|----------------|
+| `report_940c5c73@t.com` | Shooter / attacking specialist | `finishing` 81, `shot_power` 78 |
+| `report_7b85cdfa@t.com` | Playmaker / passer | `passing` 80, `vision` 78 |
+| `report_490c3e64@t.com` | All-rounder — best development arc | Balanced (70–75 range) |
+| `report_9ab12d42@t.com` | Developing player (beginner) | All skills 48–63 |
+
+**Credentials:** All 4 players: password `Player1234!`
+
+**Best demo entry point:** `report_490c3e64@t.com / Player1234!` — shows the most dramatic upward arc (3rd → 2nd → 1st across 3 tournaments).
+
+---
+
+### `events` — Frontend event calendar
+**File:** `seed_events.py` (copy of `scripts/seed_events_demo.py`)
+
+| Property | Value |
+|----------|-------|
+| **Destructive** | PARTIAL — truncates operational tables (semesters, sessions, campuses, locations, enrollments, tournament data) but **preserves user accounts** |
+| **Idempotent** | YES — truncate → recreate always produces same state |
+| **Runtime** | ~5–15 s |
+| **Recommended for** | UX / design walkthroughs, frontend calendar demo, session scheduling review |
+
+**What it creates:**
+- 2 locations: Budapest (CENTER), Debrecen (PARTNER)
+- 4 campuses: 3 × Budapest, 1 × Debrecen
+- 10 semesters: 3 Academy, 4 Tournament, 3 Camp
+- 33 sessions: 16 MATCH, 17 TRAINING
+
+**Credentials:** 8 demo players created (if not already present):
+`demo.youth.player1@lfa-seed.hu` through `demo.youth.player8@lfa-seed.hu` — password `Player123!`
+
+---
+
+### `minimal` — Quick-start (live demo safe)
+**File:** `seed_minimal.py` (copy of `scripts/seed_minimum_playable.py`)
+
+| Property | Value |
+|----------|-------|
+| **Destructive** | NO — purely additive, never truncates |
+| **Idempotent** | YES — all objects keyed by unique codes |
+| **Runtime** | ~3–8 s |
+| **Recommended for** | Live demos when DB already has users; fast "add open events" without reset; quick local re-seeding |
+| **Prerequisite** | `report_*` users must exist (same as `skill`) |
+
+**What it creates:**
+- Fixes `report_*` user licenses: 29 football skills, `onboarding_completed=True`, `credit_balance=900`
+- 1 Location + 1 Campus (reuses existing if already present)
+- 3 ENROLLMENT_OPEN tournaments: league H2H, score-based, time-based
+- 2 ENROLLMENT_OPEN camps
+
+**Credentials:** `report_490c3e64@t.com / Player1234!` (and the other 3 `report_*` players)
+
+---
+
+## Scenario decision guide
+
+```
+Is this the first run on a fresh DB?
+  → full
+
+Do you need to show EMA skill progression / skill report?
+  → skill  (or full — it includes a completed tournament too)
+
+Is the DB already set up with users and you only need open events?
+  → minimal
+
+Are you validating frontend UI / calendar layout only?
+  → events
+```
+
+---
+
+## File structure
+
+```
+scripts/demo/
+├── README.md                    ← this file
+├── run_demo.py                  ← single dispatcher entrypoint
+├── reset_full.py                ← copy of scripts/reset_and_seed_full.py
+├── seed_skill_progression.py    ← copy of scripts/seed_full_playable.py
+├── seed_events.py               ← copy of scripts/seed_events_demo.py
+└── seed_minimal.py              ← copy of scripts/seed_minimum_playable.py
+```
+
+The originals in `scripts/` are unchanged. If the original is updated, re-copy it here.
+
+---
+
+## Naming convention
+
+| Prefix | Purpose | Location |
+|--------|---------|----------|
+| `demo/reset_*.py` | Destructive full-reset demo seeds | `scripts/demo/` |
+| `demo/seed_*.py` | Additive/idempotent demo seeds | `scripts/demo/` |
+| `demo/run_demo.py` | Single scenario dispatcher | `scripts/demo/` |
+| `reset_e2e_web_db.py` | CI scenario fixtures | `scripts/` root |
+| `validate_*.py` / `audit_*.py` | Operational verification tooling | `scripts/` root |
+| `maintenance/` | Long-term DB maintenance | `scripts/maintenance/` |

--- a/scripts/demo/reset_full.py
+++ b/scripts/demo/reset_full.py
@@ -1,0 +1,957 @@
+#!/usr/bin/env python3
+"""
+Full Database Reset & Seed — Frontend Validation
+=================================================
+
+RESET: drops all tables, recreates schema via Base.metadata.create_all.
+
+SEED (LFA_FOOTBALL_PLAYER, YOUTH):
+  Locations:
+    Budapest  (CENTER)  — 7 events
+    Debrecen  (PARTNER) — 6 events
+
+  Event types per location:
+    TOURNAMENT league    — COMPLETED  (placement + skill delta)
+    TOURNAMENT score     — ENROLLMENT_OPEN
+    TOURNAMENT time      — ENROLLMENT_OPEN
+    CAMP summer          — READY_FOR_ENROLLMENT
+    CAMP autumn          — READY_FOR_ENROLLMENT
+    MINI_SEASON          — READY_FOR_ENROLLMENT
+    ACADEMY_SEASON       — READY_FOR_ENROLLMENT  (Budapest CENTER only)
+
+  Users (10 total):
+    1 admin, 1 instructor, 4 Budapest students, 4 Debrecen students
+    — full profiles, all 29 football skills, onboarding complete
+
+  Enrollments:
+    APPROVED + payment_verified for every event-user pair
+
+  Completed-tournament results:
+    TournamentParticipation with placements (1/2/3/NULL) + skill_rating_delta
+    Updated license.football_skills to reflect post-tournament levels
+
+  Invitation codes:
+    1 event-specific code per event   (unredeemed)
+    2 general codes                   (unredeemed)
+    2 sample redeemed codes           (used by bdpst_1 and debr_1)
+
+Run:
+    python scripts/reset_and_seed_full.py
+"""
+
+import sys
+import uuid
+from pathlib import Path
+from datetime import date, datetime, timedelta, timezone
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from app.database import SessionLocal, engine, Base
+from app.models import *  # noqa: F401,F403 — registers all SQLAlchemy models
+from app.models.user import User, UserRole
+from app.models.license import UserLicense
+from app.models.location import Location, LocationType
+from app.models.campus import Campus
+from app.models.semester import Semester, SemesterStatus, SemesterCategory
+from app.models.semester_enrollment import SemesterEnrollment, EnrollmentStatus
+from app.models.tournament_configuration import TournamentConfiguration
+from app.models.tournament_type import TournamentType
+from app.models.game_configuration import GameConfiguration
+from app.models.tournament_reward_config import TournamentRewardConfig
+from app.models.game_preset import GamePreset
+from app.models.tournament_achievement import TournamentParticipation
+from app.models.credit_transaction import CreditTransaction
+from app.models.invitation_code import InvitationCode
+from sqlalchemy import text
+from app.core.security import get_password_hash
+
+NOW = datetime.now(timezone.utc)
+TODAY = date.today()
+
+SPEC = "LFA_FOOTBALL_PLAYER"
+AGE_GROUP = "YOUTH"
+DEFAULT_PASSWORD = "Player1234!"
+ADMIN_PASSWORD = "Admin1234!"
+
+# ── 29 football skills (all keys must be lowercase snake_case) ─────────────────
+
+def _skills(
+    *,
+    ball_control=65, dribbling=65, finishing=65, shot_power=65,
+    long_shots=60, volleys=58, crossing=62, passing=65,
+    heading=62, tackle=60, marking=58,
+    free_kicks=58, corners=60, penalties=62,
+    positioning_off=62, positioning_def=60, vision=63,
+    aggression=58, reactions=65, composure=63,
+    consistency=60, tactical_awareness=62,
+    acceleration=65, sprint_speed=65, agility=65,
+    jumping=62, strength=62, stamina=65, balance=63,
+):
+    return {
+        "ball_control": float(ball_control), "dribbling": float(dribbling),
+        "finishing": float(finishing), "shot_power": float(shot_power),
+        "long_shots": float(long_shots), "volleys": float(volleys),
+        "crossing": float(crossing), "passing": float(passing),
+        "heading": float(heading), "tackle": float(tackle), "marking": float(marking),
+        "free_kicks": float(free_kicks), "corners": float(corners),
+        "penalties": float(penalties),
+        "positioning_off": float(positioning_off), "positioning_def": float(positioning_def),
+        "vision": float(vision), "aggression": float(aggression),
+        "reactions": float(reactions), "composure": float(composure),
+        "consistency": float(consistency), "tactical_awareness": float(tactical_awareness),
+        "acceleration": float(acceleration), "sprint_speed": float(sprint_speed),
+        "agility": float(agility), "jumping": float(jumping),
+        "strength": float(strength), "stamina": float(stamina), "balance": float(balance),
+    }
+
+
+# ── Student definitions ────────────────────────────────────────────────────────
+
+_STUDENTS = [
+    # ── Budapest players ──────────────────────────────────────────────────
+    {
+        "key": "bdpst_1",
+        "first_name": "Péter",  "last_name": "Kovács",
+        "email": "kovacs.peter@lfa-bdpst.hu",
+        "dob": date(2008, 3, 15),
+        "position": "midfielder",
+        "nationality": "Hungarian",
+        "location_key": "budapest",
+        "skills": _skills(
+            passing=80, vision=78, ball_control=74, dribbling=72, finishing=68,
+            tactical_awareness=76, composure=73, reactions=70, sprint_speed=68,
+        ),
+    },
+    {
+        "key": "bdpst_2",
+        "first_name": "Balázs",  "last_name": "Nagy",
+        "email": "nagy.balazs@lfa-bdpst.hu",
+        "dob": date(2007, 8, 22),
+        "position": "forward",
+        "nationality": "Hungarian",
+        "location_key": "budapest",
+        "skills": _skills(
+            finishing=82, shot_power=79, dribbling=76, ball_control=74,
+            acceleration=78, sprint_speed=80, agility=74, volleys=68,
+            positioning_off=75,
+        ),
+    },
+    {
+        "key": "bdpst_3",
+        "first_name": "Dániel",  "last_name": "Horváth",
+        "email": "horvath.daniel@lfa-bdpst.hu",
+        "dob": date(2008, 11, 5),
+        "position": "defender",
+        "nationality": "Hungarian",
+        "location_key": "budapest",
+        "skills": _skills(
+            tackle=80, marking=78, heading=77, strength=76, jumping=74,
+            positioning_def=78, aggression=72, composure=68,
+        ),
+    },
+    {
+        "key": "bdpst_4",
+        "first_name": "Ádám",  "last_name": "Szabó",
+        "email": "szabo.adam@lfa-bdpst.hu",
+        "dob": date(2009, 6, 18),
+        "position": "forward",
+        "nationality": "Hungarian",
+        "location_key": "budapest",
+        "skills": _skills(
+            sprint_speed=82, acceleration=80, dribbling=74, crossing=72,
+            agility=78, stamina=76, ball_control=70,
+        ),
+    },
+    # ── Debrecen players ─────────────────────────────────────────────────
+    {
+        "key": "debr_1",
+        "first_name": "Tamás",  "last_name": "Fekete",
+        "email": "fekete.tamas@lfa-debr.hu",
+        "dob": date(2007, 2, 10),
+        "position": "midfielder",
+        "nationality": "Hungarian",
+        "location_key": "debrecen",
+        "skills": _skills(
+            passing=74, stamina=78, tactical_awareness=72, ball_control=70,
+            reactions=70, consistency=68, vision=68,
+        ),
+    },
+    {
+        "key": "debr_2",
+        "first_name": "László",  "last_name": "Varga",
+        "email": "varga.laszlo@lfa-debr.hu",
+        "dob": date(2008, 5, 29),
+        "position": "midfielder",
+        "nationality": "Hungarian",
+        "location_key": "debrecen",
+        "skills": _skills(
+            vision=80, passing=78, free_kicks=74, corners=72, composure=76,
+            ball_control=74, tactical_awareness=75, crossing=70,
+        ),
+    },
+    {
+        "key": "debr_3",
+        "first_name": "Gábor",  "last_name": "Kiss",
+        "email": "kiss.gabor@lfa-debr.hu",
+        "dob": date(2009, 9, 3),
+        "position": "midfielder",
+        "nationality": "Hungarian",
+        "location_key": "debrecen",
+        "skills": _skills(
+            tackle=76, marking=72, aggression=70, strength=74,
+            positioning_def=74, stamina=72, consistency=68,
+        ),
+    },
+    {
+        "key": "debr_4",
+        "first_name": "Bence",  "last_name": "Tóth",
+        "email": "toth.bence@lfa-debr.hu",
+        "dob": date(2010, 1, 20),
+        "position": "forward",
+        "nationality": "Hungarian",
+        "location_key": "debrecen",
+        "skills": _skills(
+            agility=76, dribbling=72, acceleration=74, sprint_speed=73,
+            crossing=68, ball_control=68,
+        ),
+    },
+]
+
+# ── Football reward config ─────────────────────────────────────────────────────
+
+_FOOTBALL_REWARD = {
+    "template_name": "LFA Football Standard",
+    "custom_config": False,
+    "skill_mappings": [
+        {"skill": "passing",   "weight": 1.0, "category": "TECHNICAL", "enabled": True},
+        {"skill": "dribbling", "weight": 1.5, "category": "TECHNICAL", "enabled": True},
+        {"skill": "finishing", "weight": 1.3, "category": "TECHNICAL", "enabled": True},
+    ],
+    "first_place":   {"credits": 500, "xp_multiplier": 2.0, "badges": []},
+    "second_place":  {"credits": 250, "xp_multiplier": 1.5, "badges": []},
+    "third_place":   {"credits": 100, "xp_multiplier": 1.2, "badges": []},
+    "participation": {"credits":  50, "xp_multiplier": 1.0, "badges": []},
+}
+
+_GAME_CONFIG = {
+    "version": "1.0",
+    "metadata": {"min_players": 4, "game_category": "FOOTBALL", "difficulty_level": "INTERMEDIATE"},
+    "skill_config": {
+        "skills_tested": ["passing", "dribbling", "finishing"],
+        "weights": {"passing": 1.0, "dribbling": 1.5, "finishing": 1.3},
+    },
+    "simulation_config": {"variation": 0.15},
+    "format_config": {},
+    "match_rules": {"scoring": "goals", "overtime": False},
+}
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Seed functions
+# ═══════════════════════════════════════════════════════════════════════════════
+
+def _create_game_presets(db) -> dict:
+    presets = {}
+    for code, name, tested_skills in [
+        ("outfield_default", "Outfield Football (Default)", ["passing", "dribbling", "finishing", "ball_control", "sprint_speed"]),
+        ("passing_focus",    "Passing & Vision Focus",     ["passing", "vision", "ball_control", "crossing", "tactical_awareness", "free_kicks"]),
+        ("shooting_focus",   "Finishing & Shooting Focus", ["finishing", "sprint_speed", "dribbling", "shot_power", "long_shots", "volleys"]),
+    ]:
+        cfg = dict(_GAME_CONFIG)
+        cfg["skill_config"] = {"skills_tested": tested_skills, "weights": {s: 1.0 for s in tested_skills}}
+        p = GamePreset(code=code, name=name, description=f"{name} game configuration",
+                       game_config=cfg, is_active=True, is_recommended=(code == "outfield_default"))
+        db.add(p)
+        db.flush()
+        presets[code] = p
+    print(f"   ✅ {len(presets)} game presets")
+    return presets
+
+
+def _create_tournament_types(db) -> dict:
+    types = {}
+    _default_cfg = {"rounds": None, "group_size": None, "third_place_match": False}
+    for code, display, fmt, min_p, max_p in [
+        ("league",      "League (Round Robin)",        "HEAD_TO_HEAD",        2, 1024),
+        ("score_based", "Score-Based Ranking",         "INDIVIDUAL_RANKING",  2, None),
+        ("time_based",  "Time-Based Ranking",          "INDIVIDUAL_RANKING",  2, None),
+        ("placement",   "Placement Ranking",           "INDIVIDUAL_RANKING",  2, None),
+    ]:
+        t = TournamentType(
+            code=code, display_name=display, format=fmt,
+            min_players=min_p, max_players=max_p,
+            requires_power_of_two=False,
+            session_duration_minutes=90,
+            break_between_sessions_minutes=15,
+            config=_default_cfg,
+        )
+        db.add(t)
+        db.flush()
+        types[code] = t
+    print(f"   ✅ {len(types)} tournament types")
+    return types
+
+
+def _create_admin_and_instructor(db) -> tuple:
+    admin = User(
+        name="LFA Admin",
+        first_name="LFA", last_name="Admin",
+        email="admin@lfa.com",
+        password_hash=get_password_hash(ADMIN_PASSWORD),
+        role=UserRole.ADMIN,
+        is_active=True, onboarding_completed=True,
+        nationality="Hungarian", country="Hungary",
+    )
+    db.add(admin)
+
+    instructor = User(
+        name="Nagymester Ferenc",
+        first_name="Ferenc", last_name="Nagymester",
+        email="grandmaster@lfa.com",
+        password_hash=get_password_hash(ADMIN_PASSWORD),
+        role=UserRole.INSTRUCTOR,
+        is_active=True, onboarding_completed=True,
+        nationality="Hungarian", country="Hungary",
+    )
+    db.add(instructor)
+    db.flush()
+    print(f"   ✅ admin (id={admin.id})  instructor (id={instructor.id})")
+    return admin, instructor
+
+
+def _create_locations(db) -> dict:
+    locs = {}
+    campuses = {}
+
+    budapest = Location(
+        name="LFA IK Education Center Budapest",
+        city="Budapest", country="Hungary", country_code="HU",
+        location_code="BDPST-IK", postal_code="1146",
+        address="Istvánmezei út 1-3, Budapest",
+        location_type=LocationType.CENTER, is_active=True,
+    )
+    db.add(budapest)
+    db.flush()
+    locs["budapest"] = budapest
+
+    bdpst_campus = Campus(
+        location_id=budapest.id, name="IK Main Campus",
+        venue="Outdoor fields + indoor gym",
+        address="Istvánmezei út 1-3, Budapest", is_active=True,
+    )
+    db.add(bdpst_campus)
+    db.flush()
+    campuses["budapest"] = bdpst_campus
+
+    debrecen = Location(
+        name="LFA Debrecen Partner Center",
+        city="Debrecen", country="Hungary", country_code="HU",
+        location_code="DEBR-01", postal_code="4032",
+        address="Nagyerdei körút 98, Debrecen",
+        location_type=LocationType.PARTNER, is_active=True,
+    )
+    db.add(debrecen)
+    db.flush()
+    locs["debrecen"] = debrecen
+
+    debr_campus = Campus(
+        location_id=debrecen.id, name="Debrecen Main Campus",
+        venue="Outdoor pitch + changing rooms",
+        address="Nagyerdei körút 98, Debrecen", is_active=True,
+    )
+    db.add(debr_campus)
+    db.flush()
+    campuses["debrecen"] = debr_campus
+
+    print(f"   ✅ Budapest CENTER (id={budapest.id}, campus={bdpst_campus.id})")
+    print(f"   ✅ Debrecen PARTNER (id={debrecen.id}, campus={debr_campus.id})")
+    return locs, campuses
+
+
+def _create_students(db, admin) -> dict:
+    users = {}
+    for s in _STUDENTS:
+        age = TODAY.year - s["dob"].year - ((TODAY.month, TODAY.day) < (s["dob"].month, s["dob"].day))
+        u = User(
+            name=f"{s['first_name']} {s['last_name']}",
+            first_name=s["first_name"], last_name=s["last_name"],
+            email=s["email"],
+            password_hash=get_password_hash(DEFAULT_PASSWORD),
+            role=UserRole.STUDENT,
+            is_active=True, onboarding_completed=True,
+            date_of_birth=datetime.combine(s["dob"], datetime.min.time()),
+            nationality=s["nationality"],
+            position=s.get("position"),
+            country="Hungary",
+            credit_balance=2000, credit_purchased=2000,
+            payment_verified=True,
+            created_by=admin.id,
+        )
+        db.add(u)
+        db.flush()
+
+        age_cat = "YOUTH" if 14 <= age <= 18 else ("AMATEUR" if age > 18 else "PRE")
+
+        lic = UserLicense(
+            user_id=u.id,
+            specialization_type=SPEC,
+            current_level=1,
+            is_active=True,
+            onboarding_completed=True,
+            onboarding_completed_at=NOW - timedelta(days=30),
+            payment_verified=True,
+            payment_verified_at=NOW - timedelta(days=35),
+            started_at=NOW - timedelta(days=90),
+            football_skills=s["skills"],
+            skills_last_updated_at=NOW - timedelta(days=10),
+            credit_balance=0,
+            credit_purchased=0,
+        )
+        db.add(lic)
+        db.flush()
+
+        users[s["key"]] = {"user": u, "license": lic, "age_cat": age_cat}
+        print(f"   ✅ {u.name} [{s['key']}]  email={u.email}  age={age}({age_cat})  lic={lic.id}")
+
+    return users
+
+
+def _make_semester(
+    db, *, code, name, category, loc, campus, instructor,
+    start_offset, duration,
+    t_status=None, status=SemesterStatus.READY_FOR_ENROLLMENT,
+    enrollment_cost=0,
+) -> Semester:
+    s = Semester(
+        code=code, name=name,
+        semester_category=category,
+        status=status,
+        tournament_status=t_status,
+        age_group=AGE_GROUP,
+        location_id=loc.id, campus_id=campus.id,
+        master_instructor_id=instructor.id,
+        start_date=TODAY + timedelta(days=start_offset) if start_offset >= 0 else TODAY - timedelta(days=-start_offset),
+        end_date=TODAY + timedelta(days=start_offset + duration) if start_offset >= 0 else TODAY - timedelta(days=-start_offset - duration),
+        enrollment_cost=enrollment_cost,
+        specialization_type=SPEC,
+    )
+    db.add(s)
+    db.flush()
+    return s
+
+
+def _add_tournament_config(db, semester, tt_code, tt_map, scoring_type=None, measurement_unit=None, ranking_direction="DESC", preset=None):
+    # HEAD_TO_HEAD (e.g. league) → link tournament_type; INDIVIDUAL_RANKING → NULL (format derived implicitly)
+    tt = tt_map[tt_code]
+    is_h2h = (tt.format == "HEAD_TO_HEAD")
+    db.add(TournamentConfiguration(
+        semester_id=semester.id,
+        tournament_type_id=tt.id if is_h2h else None,
+        scoring_type=scoring_type if scoring_type else "PLACEMENT",
+        measurement_unit=measurement_unit,
+        ranking_direction=ranking_direction,
+        participant_type="INDIVIDUAL",
+        is_multi_day=False,
+        max_players=32, parallel_fields=1,
+        sessions_generated=False,
+    ))
+    db.add(GameConfiguration(
+        semester_id=semester.id,
+        game_preset_id=preset.id if preset else None,
+        game_config=_GAME_CONFIG,
+    ))
+    db.add(TournamentRewardConfig(
+        semester_id=semester.id,
+        reward_policy_name=_FOOTBALL_REWARD["template_name"],
+        reward_config=_FOOTBALL_REWARD,
+    ))
+
+
+def _create_events(db, locs, campuses, instructor, tt_map, presets) -> dict:
+    """Create all events for both locations. Returns dict of code → Semester."""
+    events = {}
+    preset = presets["outfield_default"]
+
+    # ── Budapest ──────────────────────────────────────────────────────────────
+    loc, campus = locs["budapest"], campuses["budapest"]
+
+    # TOURNAMENT league — COMPLETED (past)
+    s = _make_semester(db, code="BDPST-TOURN-LEAGUE-2026",
+        name="Budapest League Tournament 2026 — COMPLETED",
+        category=SemesterCategory.TOURNAMENT,
+        status=SemesterStatus.COMPLETED,
+        t_status="COMPLETED",
+        loc=loc, campus=campus, instructor=instructor,
+        start_offset=-60, duration=14)
+    _add_tournament_config(db, s, "league", tt_map, ranking_direction="DESC", preset=preset)
+    events["bdpst_league"] = s
+
+    # TOURNAMENT score — ENROLLMENT_OPEN
+    s = _make_semester(db, code="BDPST-TOURN-SCORE-2026",
+        name="Budapest Score Challenge 2026",
+        category=SemesterCategory.TOURNAMENT,
+        t_status="ENROLLMENT_OPEN",
+        loc=loc, campus=campus, instructor=instructor,
+        start_offset=14, duration=14)
+    _add_tournament_config(db, s, "score_based", tt_map, scoring_type="SCORE_BASED",
+                           measurement_unit="goals", ranking_direction="DESC", preset=presets["shooting_focus"])
+    events["bdpst_score"] = s
+
+    # TOURNAMENT time — ENROLLMENT_OPEN
+    s = _make_semester(db, code="BDPST-TOURN-TIME-2026",
+        name="Budapest Time Trial Series 2026",
+        category=SemesterCategory.TOURNAMENT,
+        t_status="ENROLLMENT_OPEN",
+        loc=loc, campus=campus, instructor=instructor,
+        start_offset=21, duration=14)
+    _add_tournament_config(db, s, "time_based", tt_map, scoring_type="TIME_BASED",
+                           measurement_unit="seconds", ranking_direction="ASC", preset=presets["passing_focus"])
+    events["bdpst_time"] = s
+
+    # CAMP summer
+    s = _make_semester(db, code="BDPST-CAMP-SUMMER-2026",
+        name="Budapest Summer Football Camp 2026 — YOUTH",
+        category=SemesterCategory.CAMP,
+        loc=loc, campus=campus, instructor=instructor,
+        start_offset=30, duration=7, enrollment_cost=500)
+    events["bdpst_camp_summer"] = s
+
+    # CAMP autumn
+    s = _make_semester(db, code="BDPST-CAMP-AUTUMN-2026",
+        name="Budapest Autumn Football Camp 2026 — YOUTH",
+        category=SemesterCategory.CAMP,
+        loc=loc, campus=campus, instructor=instructor,
+        start_offset=120, duration=7, enrollment_cost=500)
+    events["bdpst_camp_autumn"] = s
+
+    # MINI_SEASON
+    s = _make_semester(db, code="BDPST-MINI-2026",
+        name="Budapest Mini Season YOUTH 2026",
+        category=SemesterCategory.MINI_SEASON,
+        loc=loc, campus=campus, instructor=instructor,
+        start_offset=45, duration=60, enrollment_cost=500)
+    events["bdpst_mini"] = s
+
+    # ACADEMY_SEASON (CENTER only)
+    s = _make_semester(db, code="BDPST-ACADEMY-2026",
+        name="Budapest Academy Season YOUTH 2026/27",
+        category=SemesterCategory.ACADEMY_SEASON,
+        loc=loc, campus=campus, instructor=instructor,
+        start_offset=90, duration=300, enrollment_cost=1000)
+    events["bdpst_academy"] = s
+
+    print(f"   ✅ Budapest: {len([k for k in events if k.startswith('bdpst')])} events")
+
+    # ── Debrecen ──────────────────────────────────────────────────────────────
+    loc, campus = locs["debrecen"], campuses["debrecen"]
+
+    # TOURNAMENT league — COMPLETED (past)
+    s = _make_semester(db, code="DEBR-TOURN-LEAGUE-2026",
+        name="Debrecen League Tournament 2026 — COMPLETED",
+        category=SemesterCategory.TOURNAMENT,
+        status=SemesterStatus.COMPLETED,
+        t_status="COMPLETED",
+        loc=loc, campus=campus, instructor=instructor,
+        start_offset=-45, duration=14)
+    _add_tournament_config(db, s, "league", tt_map, ranking_direction="DESC", preset=preset)
+    events["debr_league"] = s
+
+    # TOURNAMENT score — ENROLLMENT_OPEN
+    s = _make_semester(db, code="DEBR-TOURN-SCORE-2026",
+        name="Debrecen Score Challenge 2026",
+        category=SemesterCategory.TOURNAMENT,
+        t_status="ENROLLMENT_OPEN",
+        loc=loc, campus=campus, instructor=instructor,
+        start_offset=14, duration=14)
+    _add_tournament_config(db, s, "score_based", tt_map, scoring_type="SCORE_BASED",
+                           measurement_unit="goals", ranking_direction="DESC", preset=presets["shooting_focus"])
+    events["debr_score"] = s
+
+    # TOURNAMENT time — ENROLLMENT_OPEN
+    s = _make_semester(db, code="DEBR-TOURN-TIME-2026",
+        name="Debrecen Time Trial Series 2026",
+        category=SemesterCategory.TOURNAMENT,
+        t_status="ENROLLMENT_OPEN",
+        loc=loc, campus=campus, instructor=instructor,
+        start_offset=21, duration=14)
+    _add_tournament_config(db, s, "time_based", tt_map, scoring_type="TIME_BASED",
+                           measurement_unit="seconds", ranking_direction="ASC", preset=presets["passing_focus"])
+    events["debr_time"] = s
+
+    # CAMP summer
+    s = _make_semester(db, code="DEBR-CAMP-SUMMER-2026",
+        name="Debrecen Summer Football Camp 2026 — YOUTH",
+        category=SemesterCategory.CAMP,
+        loc=loc, campus=campus, instructor=instructor,
+        start_offset=30, duration=7, enrollment_cost=500)
+    events["debr_camp_summer"] = s
+
+    # CAMP autumn
+    s = _make_semester(db, code="DEBR-CAMP-AUTUMN-2026",
+        name="Debrecen Autumn Football Camp 2026 — YOUTH",
+        category=SemesterCategory.CAMP,
+        loc=loc, campus=campus, instructor=instructor,
+        start_offset=120, duration=7, enrollment_cost=500)
+    events["debr_camp_autumn"] = s
+
+    # MINI_SEASON (no ACADEMY for PARTNER)
+    s = _make_semester(db, code="DEBR-MINI-2026",
+        name="Debrecen Mini Season YOUTH 2026",
+        category=SemesterCategory.MINI_SEASON,
+        loc=loc, campus=campus, instructor=instructor,
+        start_offset=45, duration=60, enrollment_cost=500)
+    events["debr_mini"] = s
+
+    print(f"   ✅ Debrecen: {len([k for k in events if k.startswith('debr')])} events")
+    return events
+
+
+def _enroll(db, admin, user_data, semester, event_key) -> SemesterEnrollment:
+    """Create APPROVED + payment_verified enrollment."""
+    u = user_data["user"]
+    lic = user_data["license"]
+    age_cat = user_data["age_cat"]
+
+    ref_code = f"ENRL-{u.id:04d}-{semester.id:04d}-{uuid.uuid4().hex[:6].upper()}"
+
+    enr = SemesterEnrollment(
+        user_id=u.id,
+        semester_id=semester.id,
+        user_license_id=lic.id,
+        request_status=EnrollmentStatus.APPROVED,
+        requested_at=NOW - timedelta(days=20),
+        approved_at=NOW - timedelta(days=18),
+        approved_by=admin.id,
+        payment_reference_code=ref_code,
+        payment_verified=True,
+        payment_verified_at=NOW - timedelta(days=17),
+        payment_verified_by=admin.id,
+        is_active=True,
+        enrolled_at=NOW - timedelta(days=18),
+        age_category=age_cat,
+    )
+    db.add(enr)
+    db.flush()
+
+    # Deduct enrollment cost if > 0
+    cost = semester.enrollment_cost or 0
+    if cost > 0:
+        u.credit_balance -= cost
+        db.add(CreditTransaction(
+            user_license_id=lic.id,   # enrollment is a license-level op (XOR constraint)
+            transaction_type="ENROLLMENT",
+            amount=-cost,
+            balance_after=u.credit_balance,
+            description=f"Enrollment: {semester.name}",
+            idempotency_key=f"enroll-{enr.id}",
+            semester_id=semester.id,
+            enrollment_id=enr.id,
+            performed_by_user_id=admin.id,
+        ))
+        db.flush()
+
+    return enr
+
+
+def _create_enrollments(db, admin, users, events) -> dict:
+    """Create APPROVED enrollments for every event-user pair."""
+    # event_key → [student_keys]
+    matrix = {
+        # Budapest
+        "bdpst_league":       ["bdpst_1", "bdpst_2", "bdpst_3", "bdpst_4"],
+        "bdpst_score":        ["bdpst_1", "bdpst_2", "bdpst_3", "debr_1"],
+        "bdpst_time":         ["bdpst_2", "bdpst_3", "bdpst_4", "debr_2"],
+        "bdpst_camp_summer":  ["bdpst_1", "bdpst_3"],
+        "bdpst_camp_autumn":  ["bdpst_2", "bdpst_4"],
+        "bdpst_mini":         ["bdpst_1", "bdpst_2", "bdpst_3", "bdpst_4"],
+        "bdpst_academy":      ["bdpst_1", "bdpst_2"],
+        # Debrecen
+        "debr_league":        ["debr_1", "debr_2", "debr_3", "debr_4"],
+        "debr_score":         ["debr_1", "debr_2", "debr_3", "bdpst_3"],
+        "debr_time":          ["debr_2", "debr_3", "debr_4", "bdpst_4"],
+        "debr_camp_summer":   ["debr_1", "debr_3"],
+        "debr_camp_autumn":   ["debr_2", "debr_4"],
+        "debr_mini":          ["debr_1", "debr_2", "debr_3", "debr_4"],
+    }
+
+    enrollments = {}
+    total = 0
+    for event_key, student_keys in matrix.items():
+        semester = events[event_key]
+        for sk in student_keys:
+            enr = _enroll(db, admin, users[sk], semester, event_key)
+            enrollments[f"{event_key}__{sk}"] = enr
+            total += 1
+    print(f"   ✅ {total} enrollments (all APPROVED + payment_verified)")
+    return enrollments
+
+
+def _create_tournament_results(db, admin, users, events):
+    """Create TournamentParticipation for COMPLETED tournaments + update skills."""
+
+    # placement → (credits_reward, skill_delta_factor)
+    REWARD = {1: (500, +4.0), 2: (250, +2.0), 3: (100, +1.0), None: (50, 0.0)}
+
+    for tourn_key, placement_map in [
+        ("bdpst_league", {
+            "bdpst_1": 1,     # 1st place → skill up
+            "bdpst_2": 2,     # 2nd place
+            "bdpst_3": 3,     # 3rd place
+            "bdpst_4": None,  # participant only
+        }),
+        ("debr_league", {
+            "debr_1": 1,
+            "debr_2": 2,
+            "debr_3": 3,
+            "debr_4": None,
+        }),
+    ]:
+        semester = events[tourn_key]
+        for sk, placement in placement_map.items():
+            u = users[sk]["user"]
+            lic = users[sk]["license"]
+            credits_reward, delta_factor = REWARD[placement]
+
+            # Skill delta (top 3 skills from preset)
+            skill_delta = {}
+            if delta_factor > 0:
+                skill_delta = {
+                    "passing":   round(delta_factor * 1.0, 2),
+                    "dribbling": round(delta_factor * 1.5, 2),
+                    "finishing": round(delta_factor * 0.8, 2),
+                }
+                # Apply delta to football_skills on license
+                new_skills = dict(lic.football_skills)
+                for skill_key, delta in skill_delta.items():
+                    new_skills[skill_key] = round(new_skills.get(skill_key, 65.0) + delta, 2)
+                lic.football_skills = new_skills
+                lic.skills_last_updated_at = NOW - timedelta(days=5)
+                db.flush()
+
+            # skill_points_awarded — aggregate raw points
+            skill_points = {k: round(abs(v) * 10, 1) for k, v in skill_delta.items()} if skill_delta else {}
+
+            tp = TournamentParticipation(
+                user_id=u.id,
+                semester_id=semester.id,
+                placement=placement,
+                skill_points_awarded=skill_points,
+                skill_rating_delta=skill_delta,
+                xp_awarded=credits_reward,
+                credits_awarded=credits_reward,
+                achieved_at=semester.end_date,
+            )
+            db.add(tp)
+            db.flush()
+
+            # Credit reward transaction
+            u.credit_balance += credits_reward
+            db.add(CreditTransaction(
+                user_id=u.id,
+                transaction_type="TOURNAMENT_REWARD",
+                amount=credits_reward,
+                balance_after=u.credit_balance,
+                description=f"Placement reward: {semester.name} — {'#' + str(placement) if placement else 'Participant'}",
+                idempotency_key=f"tourney-reward-{semester.id}-{u.id}",
+                semester_id=semester.id,
+                performed_by_user_id=admin.id,
+            ))
+            db.flush()
+
+            place_str = f"#{placement}" if placement else "participant"
+            print(f"      {place_str:12s}  {u.name}  +{credits_reward} cr  delta={skill_delta}")
+
+    print(f"   ✅ Tournament results recorded")
+
+
+def _create_invitation_codes(db, admin, users, events):
+    """Create event-specific + general + sample-redeemed invitation codes."""
+    codes = []
+
+    # 1) One entry code per event
+    for event_key, semester in events.items():
+        loc_prefix = "BDPST" if event_key.startswith("bdpst") else "DEBR"
+        type_suffix = event_key.upper().replace("_", "-")
+        code_str = f"LFA-{type_suffix}-ENTRY"
+        c = InvitationCode(
+            code=code_str,
+            invited_name=f"Entry pass — {semester.name}",
+            bonus_credits=100,
+            is_used=False,
+            created_by_admin_id=admin.id,
+            notes=f"Event entry code for: {semester.code}",
+        )
+        db.add(c)
+        codes.append(code_str)
+
+    # 2) Two general codes per location (unredeemed)
+    for loc, bonus in [("BDPST-GENERAL-A", 200), ("BDPST-GENERAL-B", 300),
+                        ("DEBR-GENERAL-A", 200),  ("DEBR-GENERAL-B", 300)]:
+        c = InvitationCode(
+            code=f"LFA-{loc}-2026",
+            invited_name=f"General entry — {loc.split('-')[0]}",
+            bonus_credits=bonus,
+            is_used=False,
+            created_by_admin_id=admin.id,
+            notes="General invitation code — location wide",
+        )
+        db.add(c)
+        codes.append(f"LFA-{loc}-2026")
+
+    # 3) Two sample redeemed codes (already used by bdpst_1 and debr_1)
+    for redeemed_by_key, code_str, bonus in [
+        ("bdpst_1", "LFA-WELCOME-BDPST-001", 300),
+        ("debr_1",  "LFA-WELCOME-DEBR-001",  300),
+    ]:
+        redeemed_user = users[redeemed_by_key]["user"]
+        c = InvitationCode(
+            code=code_str,
+            invited_name=f"{redeemed_user.name} — welcome bonus",
+            bonus_credits=bonus,
+            is_used=True,
+            used_by_user_id=redeemed_user.id,
+            used_at=NOW - timedelta(days=60),
+            created_by_admin_id=admin.id,
+            notes="Welcome bonus code — already redeemed",
+        )
+        db.add(c)
+        codes.append(code_str)
+        # Credit transaction for the redemption
+        redeemed_user.credit_balance += bonus
+        db.add(CreditTransaction(
+            user_id=redeemed_user.id,
+            transaction_type="ADMIN_ADJUSTMENT",
+            amount=bonus,
+            balance_after=redeemed_user.credit_balance,
+            description=f"Invitation code bonus: {code_str}",
+            idempotency_key=f"invitation-code-{code_str}-user-{redeemed_user.id}",
+            performed_by_user_id=admin.id,
+        ))
+        db.flush()
+
+    db.flush()
+    print(f"   ✅ {len(codes)} invitation codes ({len(events)} event-specific, 4 general, 2 redeemed)")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Main
+# ═══════════════════════════════════════════════════════════════════════════════
+
+def main():
+    print("\n" + "=" * 70)
+    print("  Full Database Reset & Seed — Frontend Validation")
+    print("=" * 70)
+
+    # ── 1. Reset DB ───────────────────────────────────────────────────────────
+    print("\n🗑️  Dropping schema (CASCADE) and recreating…")
+    with engine.connect() as conn:
+        conn.execute(text("DROP SCHEMA public CASCADE"))
+        conn.execute(text("CREATE SCHEMA public"))
+        conn.execute(text("GRANT ALL ON SCHEMA public TO postgres"))
+        conn.execute(text("GRANT ALL ON SCHEMA public TO public"))
+        conn.commit()
+    print("📐 Creating tables…")
+    Base.metadata.create_all(bind=engine)
+    print("✅ Clean schema ready\n")
+
+    db = SessionLocal()
+    try:
+        # ── 2. Game presets + tournament types ────────────────────────────────
+        print("🎮 Game presets & tournament types")
+        presets = _create_game_presets(db)
+        tt_map = _create_tournament_types(db)
+        db.commit()
+
+        # ── 3. Admin + Instructor ─────────────────────────────────────────────
+        print("\n👤 Admin & Instructor")
+        admin, instructor = _create_admin_and_instructor(db)
+        db.commit()
+
+        # ── 4. Locations + Campuses ───────────────────────────────────────────
+        print("\n📍 Locations & Campuses")
+        locs, campuses = _create_locations(db)
+        db.commit()
+
+        # ── 5. Students ───────────────────────────────────────────────────────
+        print("\n👥 Students (8)")
+        users = _create_students(db, admin)
+        db.commit()
+
+        # ── 6. Events ─────────────────────────────────────────────────────────
+        print("\n📅 Events (13 total)")
+        events = _create_events(db, locs, campuses, instructor, tt_map, presets)
+        db.commit()
+
+        # ── 7. Enrollments ────────────────────────────────────────────────────
+        print("\n📝 Enrollments")
+        _create_enrollments(db, admin, users, events)
+        db.commit()
+
+        # ── 8. Tournament results ─────────────────────────────────────────────
+        print("\n🏆 Completed tournament results")
+        print("   Budapest League:")
+        _create_tournament_results.__wrapped__ = False  # prevent wrapping
+        _create_tournament_results(db, admin, users, events)
+        db.commit()
+
+        # ── 9. Invitation codes ───────────────────────────────────────────────
+        print("\n🔑 Invitation codes")
+        _create_invitation_codes(db, admin, users, events)
+        db.commit()
+
+        # ── Final summary ─────────────────────────────────────────────────────
+        print("\n" + "=" * 70)
+        print("  ✅ Seed complete — Final state")
+        print("=" * 70)
+
+        print(f"""
+  Credentials:
+    admin@lfa.com            {ADMIN_PASSWORD}
+    grandmaster@lfa.com      {ADMIN_PASSWORD}
+
+  Budapest students (password: {DEFAULT_PASSWORD}):
+    kovacs.peter@lfa-bdpst.hu   — midfielder
+    nagy.balazs@lfa-bdpst.hu    — forward
+    horvath.daniel@lfa-bdpst.hu — defender
+    szabo.adam@lfa-bdpst.hu     — forward
+
+  Debrecen students (password: {DEFAULT_PASSWORD}):
+    fekete.tamas@lfa-debr.hu    — midfielder
+    varga.laszlo@lfa-debr.hu    — midfielder
+    kiss.gabor@lfa-debr.hu      — midfielder
+    toth.bence@lfa-debr.hu      — forward
+
+  Budapest events (7):
+    BDPST-TOURN-LEAGUE-2026    TOURNAMENT  league     COMPLETED
+    BDPST-TOURN-SCORE-2026     TOURNAMENT  score      ENROLLMENT_OPEN
+    BDPST-TOURN-TIME-2026      TOURNAMENT  time       ENROLLMENT_OPEN
+    BDPST-CAMP-SUMMER-2026     CAMP                   READY_FOR_ENROLLMENT
+    BDPST-CAMP-AUTUMN-2026     CAMP                   READY_FOR_ENROLLMENT
+    BDPST-MINI-2026            MINI_SEASON            READY_FOR_ENROLLMENT
+    BDPST-ACADEMY-2026         ACADEMY_SEASON         READY_FOR_ENROLLMENT
+
+  Debrecen events (6):
+    DEBR-TOURN-LEAGUE-2026     TOURNAMENT  league     COMPLETED
+    DEBR-TOURN-SCORE-2026      TOURNAMENT  score      ENROLLMENT_OPEN
+    DEBR-TOURN-TIME-2026       TOURNAMENT  time       ENROLLMENT_OPEN
+    DEBR-CAMP-SUMMER-2026      CAMP                   READY_FOR_ENROLLMENT
+    DEBR-CAMP-AUTUMN-2026      CAMP                   READY_FOR_ENROLLMENT
+    DEBR-MINI-2026             MINI_SEASON            READY_FOR_ENROLLMENT
+
+  Invitation codes:
+    13 event-specific  (1 per event, unredeemed)
+     4 general         (2 Budapest, 2 Debrecen, unredeemed)
+     2 redeemed        (LFA-WELCOME-BDPST-001, LFA-WELCOME-DEBR-001)
+""")
+
+    except Exception as exc:
+        db.rollback()
+        print(f"\n❌ Error during seed: {exc}")
+        import traceback; traceback.print_exc()
+        raise
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/demo/run_demo.py
+++ b/scripts/demo/run_demo.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""
+Demo scenario dispatcher.
+
+Runs one of the four canonical demo seeds by name.  Each seed is a verbatim
+copy of the corresponding script in scripts/ — no logic lives here.
+
+Usage:
+    python scripts/demo/run_demo.py [scenario]
+
+Scenarios (default: full):
+    full     Full DB reset + complete dataset.              [DESTRUCTIVE]
+    skill    Skill-progression arc (4 players, 3 tournaments). [ADDITIVE]
+    events   Frontend event calendar (10 semesters, 33 sessions). [DESTRUCTIVE*]
+    minimal  Quick-start open tournaments + camps.          [ADDITIVE]
+
+* events truncates operational tables but preserves user accounts.
+
+Examples:
+    python scripts/demo/run_demo.py           # runs 'full'
+    python scripts/demo/run_demo.py skill
+    python scripts/demo/run_demo.py minimal
+"""
+import runpy
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+
+_SCENARIOS: dict[str, str] = {
+    "full":    "reset_full.py",
+    "skill":   "seed_skill_progression.py",
+    "events":  "seed_events.py",
+    "minimal": "seed_minimal.py",
+}
+
+
+def main() -> None:
+    scenario = sys.argv[1] if len(sys.argv) > 1 else "full"
+
+    if scenario in ("-h", "--help"):
+        print(__doc__)
+        return
+
+    if scenario not in _SCENARIOS:
+        print(f"Unknown scenario: {scenario!r}")
+        print(f"Available: {', '.join(_SCENARIOS)}")
+        sys.exit(1)
+
+    script_path = _HERE / _SCENARIOS[scenario]
+    print(f"[run_demo] Running scenario '{scenario}' → {script_path.name}\n")
+
+    # runpy.run_path with run_name='__main__' executes the script exactly as if
+    # invoked directly (triggers the `if __name__ == '__main__':` guard).
+    runpy.run_path(str(script_path), run_name="__main__")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/demo/seed_events.py
+++ b/scripts/demo/seed_events.py
@@ -1,0 +1,680 @@
+#!/usr/bin/env python3
+"""
+Events module demo seed — creates realistic event data for frontend validation.
+
+Usage:
+    python scripts/seed_events_demo.py
+
+⚠️  DESTRUCTIVE: truncates all operational tables (semesters, sessions, campuses,
+    locations, enrollments, tournament data, etc.) while preserving user accounts.
+
+The seed is IDEMPOTENT — running it multiple times always produces the same
+clean state (truncate → recreate).
+
+Result dataset:
+  2 Locations  :  Budapest (CENTER)  ·  Debrecen (PARTNER)
+  4 Campuses   :  3 × Budapest  ·  1 × Debrecen
+  10 Semesters :  3 Academy  ·  4 Tournament  ·  3 Camp
+  33 Sessions  :  16 MATCH  ·  17 TRAINING
+"""
+import sys
+from pathlib import Path
+from datetime import date, datetime, timedelta
+
+# Make sure project root is on sys.path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from sqlalchemy import text
+from app.database import SessionLocal
+from app.models.location import Location, LocationType
+from app.models.campus import Campus
+from app.models.semester import Semester, SemesterStatus, SemesterCategory
+from app.models.session import Session as SessionModel, SessionType, EventCategory
+from app.models.tournament_configuration import TournamentConfiguration
+from app.models.tournament_type import TournamentType
+from app.models.game_configuration import GameConfiguration
+from app.models.tournament_reward_config import TournamentRewardConfig
+from app.models.semester_enrollment import SemesterEnrollment, EnrollmentStatus
+from app.models.tournament_ranking import TournamentRanking
+from app.models.user import User, UserRole
+from app.models.license import UserLicense
+from app.core.security import get_password_hash
+from app.services.tournament.session_generation.session_generator import TournamentSessionGenerator
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def _dt(d: date, hour: int, minute: int = 0) -> datetime:
+    return datetime(d.year, d.month, d.day, hour, minute, 0)
+
+
+TRUNCATE_SQL = """
+    TRUNCATE TABLE
+        bookings,
+        event_reward_logs,
+        semester_enrollments,
+        semester_instructors,
+        tournament_participations,
+        tournament_configurations,
+        tournament_status_history,
+        tournament_stats,
+        tournament_rankings,
+        tournament_team_enrollments,
+        tournament_badges,
+        tournament_reward_configs,
+        match_results,
+        match_structures,
+        sessions,
+        semesters,
+        campus_schedule_configs,
+        campuses,
+        location_master_instructors,
+        locations,
+        system_events,
+        audit_logs
+    CASCADE
+"""
+
+
+# ── main seed ─────────────────────────────────────────────────────────────────
+
+def seed():
+    db = SessionLocal()
+    try:
+        # ── 0. Reset ──────────────────────────────────────────────────────────
+        print("🗑  Truncating operational tables (preserving users)…")
+        db.execute(text(TRUNCATE_SQL))
+        db.commit()
+        print("   ✓ Done\n")
+
+        today = date.today()
+
+        # ── 1. Locations ──────────────────────────────────────────────────────
+        print("📍 Locations…")
+        budapest = Location(
+            name="LFA Budapest Education Center",
+            city="Budapest",
+            country="Hungary",
+            country_code="HU",
+            location_code="BDPST",
+            postal_code="1146",
+            address="Istvánmezei út 1-3, Budapest",
+            location_type=LocationType.CENTER,
+            is_active=True,
+        )
+        debrecen = Location(
+            name="LFA Debrecen Partner",
+            city="Debrecen",
+            country="Hungary",
+            country_code="HU",
+            location_code="DEBR",
+            postal_code="4031",
+            address="Oláh Gábor u. 5, Debrecen",
+            location_type=LocationType.PARTNER,
+            is_active=True,
+        )
+        db.add_all([budapest, debrecen])
+        db.flush()
+        print(f"   ✓ Budapest  (CENTER)  id={budapest.id}")
+        print(f"   ✓ Debrecen  (PARTNER) id={debrecen.id}\n")
+
+        # ── 1b. Demo players (idempotent — keyed by email) ────────────────────
+        print("👤 Players…")
+        _pw = get_password_hash("Player123!")
+        _player_emails = [f"demo.youth.player{i}@lfa-seed.hu" for i in range(1, 9)]
+        players = []
+        for i, email in enumerate(_player_emails, 1):
+            u = db.query(User).filter(User.email == email).first()
+            if not u:
+                u = User(
+                    name=f"Demo Youth Player {i}",
+                    email=email,
+                    password_hash=_pw,
+                    role=UserRole.STUDENT,
+                    is_active=True,
+                )
+                db.add(u)
+            players.append(u)
+        db.flush()
+        print(f"   ✓ {len(players)} demo youth players (emails: demo.youth.player1-8@lfa-seed.hu)\n")
+
+        # ── 2. Campuses ───────────────────────────────────────────────────────
+        print("🏫 Campuses…")
+        buda_main = Campus(
+            location_id=budapest.id,
+            name="Buda Training Complex",
+            venue="Outdoor fields + gym",
+            address="Vérmező út 1, 1012 Budapest",
+            is_active=True,
+        )
+        buda_indoor = Campus(
+            location_id=budapest.id,
+            name="Indoor Arena — Pest",
+            venue="3 indoor courts, capacity 120",
+            address="Stefánia út 3-5, 1143 Budapest",
+            is_active=True,
+        )
+        buda_youth = Campus(
+            location_id=budapest.id,
+            name="Youth Development Hub",
+            venue="Small-sided pitches + classroom",
+            address="Hungária krt. 44, 1087 Budapest",
+            is_active=True,
+        )
+        debr_main = Campus(
+            location_id=debrecen.id,
+            name="Főnix Sportközpont",
+            venue="Community sport centre — 2 pitches",
+            address="Oláh Gábor u. 5, 4031 Debrecen",
+            is_active=True,
+        )
+        db.add_all([buda_main, buda_indoor, buda_youth, debr_main])
+        db.flush()
+        print(f"   ✓ Budapest: {buda_main.name} · {buda_indoor.name} · {buda_youth.name}")
+        print(f"   ✓ Debrecen: {debr_main.name}\n")
+
+        # ── 3. Academy seasons (training-session parents) ─────────────────────
+        print("🎓 Academy semesters…")
+        acad_youth = Semester(
+            code="ACAD-YOUTH-BUD-2026-S1",
+            name="Youth Academy Season — Budapest Spring 2026",
+            semester_category=SemesterCategory.ACADEMY_SEASON,
+            status=SemesterStatus.ONGOING,
+            age_group="YOUTH",
+            location_id=budapest.id,
+            campus_id=buda_main.id,
+            start_date=today - timedelta(days=30),
+            end_date=today + timedelta(days=60),
+            enrollment_cost=2500,
+            specialization_type="LFA_PLAYER_YOUTH",
+        )
+        acad_pre = Semester(
+            code="ACAD-PRE-BUD-2026-S1",
+            name="Pre-Academy Season — Budapest Spring 2026",
+            semester_category=SemesterCategory.ACADEMY_SEASON,
+            status=SemesterStatus.ONGOING,
+            age_group="PRE",
+            location_id=budapest.id,
+            campus_id=buda_youth.id,
+            start_date=today - timedelta(days=30),
+            end_date=today + timedelta(days=60),
+            enrollment_cost=2000,
+            specialization_type="LFA_PLAYER_PRE",
+        )
+        acad_debr = Semester(
+            code="MINI-YOUTH-DEB-2026-S1",
+            name="Youth Mini Season — Debrecen Spring 2026",
+            semester_category=SemesterCategory.MINI_SEASON,
+            status=SemesterStatus.READY_FOR_ENROLLMENT,
+            age_group="YOUTH",
+            location_id=debrecen.id,
+            campus_id=debr_main.id,
+            start_date=today + timedelta(days=14),
+            end_date=today + timedelta(days=74),
+            enrollment_cost=1800,
+            specialization_type="LFA_PLAYER_YOUTH",
+        )
+        db.add_all([acad_youth, acad_pre, acad_debr])
+
+        # ── 4. Tournaments ────────────────────────────────────────────────────
+        print("🏆 Tournaments…")
+
+        # T1: H2H YOUTH/LEAGUE — ONGOING (Budapest CENTER) — 3/8 checked-in
+        t1 = Semester(
+            code="TOURN-YOUTH-H2H-2026-Q1",
+            name="LFA Youth Cup 2026 — Q1 Budapest",
+            semester_category=SemesterCategory.TOURNAMENT,
+            status=SemesterStatus.ONGOING,
+            tournament_status="IN_PROGRESS",
+            age_group="YOUTH",
+            location_id=budapest.id,
+            campus_id=buda_main.id,
+            start_date=today - timedelta(days=7),
+            end_date=today + timedelta(days=14),
+            enrollment_cost=0,
+            specialization_type="LFA_FOOTBALL_PLAYER",
+        )
+        # T2: INDIVIDUAL RANKING PRO — ONGOING (Budapest Indoor)
+        t2 = Semester(
+            code="TOURN-PRO-IR-2026-Q1",
+            name="LFA Pro Ranking Series — Spring 2026",
+            semester_category=SemesterCategory.TOURNAMENT,
+            status=SemesterStatus.ONGOING,
+            tournament_status="IN_PROGRESS",
+            age_group="PRO",
+            location_id=budapest.id,
+            campus_id=buda_indoor.id,
+            start_date=today - timedelta(days=3),
+            end_date=today + timedelta(days=14),
+            enrollment_cost=500,
+            specialization_type="LFA_FOOTBALL_PLAYER",
+        )
+        # T3: H2H/KNOCKOUT — ONGOING (Budapest Youth Hub) — 8/8 checked-in
+        t3 = Semester(
+            code="TOURN-YOUTH-KO-2026-Q1",
+            name="LFA Youth Knockout Cup 2026 — Budapest",
+            semester_category=SemesterCategory.TOURNAMENT,
+            status=SemesterStatus.ONGOING,
+            tournament_status="IN_PROGRESS",
+            age_group="YOUTH",
+            location_id=budapest.id,
+            campus_id=buda_youth.id,
+            start_date=today - timedelta(days=5),
+            end_date=today + timedelta(days=10),
+            enrollment_cost=0,
+            specialization_type="LFA_FOOTBALL_PLAYER",
+        )
+        # T4: H2H/SWISS — ONGOING (Budapest Indoor) — 8/8 checked-in
+        t4 = Semester(
+            code="TOURN-AMT-SWISS-2026-Q1",
+            name="LFA Amateur Swiss Open 2026 — Budapest",
+            semester_category=SemesterCategory.TOURNAMENT,
+            status=SemesterStatus.ONGOING,
+            tournament_status="IN_PROGRESS",
+            age_group="AMATEUR",
+            location_id=budapest.id,
+            campus_id=buda_indoor.id,
+            start_date=today - timedelta(days=4),
+            end_date=today + timedelta(days=12),
+            enrollment_cost=250,
+            specialization_type="LFA_FOOTBALL_PLAYER",
+        )
+        # T5: H2H/GROUP_KNOCKOUT — ONGOING (Buda Main) — 8/8 checked-in
+        t5 = Semester(
+            code="TOURN-AMT-GK-2026-Q1",
+            name="LFA Groups & Knockout Championship 2026 — Budapest",
+            semester_category=SemesterCategory.TOURNAMENT,
+            status=SemesterStatus.ONGOING,
+            tournament_status="IN_PROGRESS",
+            age_group="AMATEUR",
+            location_id=budapest.id,
+            campus_id=buda_main.id,
+            start_date=today - timedelta(days=6),
+            end_date=today + timedelta(days=15),
+            enrollment_cost=0,
+            specialization_type="LFA_FOOTBALL_PLAYER",
+        )
+        # T6: H2H YOUTH/LEAGUE — COMPLETED (Budapest, historical)
+        t6 = Semester(
+            code="TOURN-YOUTH-H2H-2025-Q4",
+            name="LFA Youth Cup 2025 — Q4 Budapest",
+            semester_category=SemesterCategory.TOURNAMENT,
+            status=SemesterStatus.COMPLETED,
+            tournament_status="COMPLETED",
+            age_group="YOUTH",
+            location_id=budapest.id,
+            campus_id=buda_main.id,
+            start_date=today - timedelta(days=90),
+            end_date=today - timedelta(days=60),
+            enrollment_cost=0,
+            specialization_type="LFA_FOOTBALL_PLAYER",
+        )
+        db.add_all([t1, t2, t3, t4, t5, t6])
+        db.flush()  # get IDs for TournamentConfiguration FK
+
+        # ── 4b. TournamentConfigurations ──────────────────────────────────────
+        print("⚙️  Tournament configurations…")
+        tt_league        = db.query(TournamentType).filter(TournamentType.code == "league").first()
+        tt_knockout      = db.query(TournamentType).filter(TournamentType.code == "knockout").first()
+        tt_swiss         = db.query(TournamentType).filter(TournamentType.code == "swiss").first()
+        tt_group_knockout= db.query(TournamentType).filter(TournamentType.code == "group_knockout").first()
+        tt_score_based   = db.query(TournamentType).filter(TournamentType.code == "score_based").first()
+
+        # T1: ONGOING H2H/LEAGUE — 3/8 checked-in (split-brain demo)
+        if tt_league:
+            db.add(TournamentConfiguration(
+                semester_id=t1.id,
+                tournament_type_id=tt_league.id,
+                participant_type="INDIVIDUAL",
+                is_multi_day=True,
+                max_players=16,
+                match_duration_minutes=90,
+                break_duration_minutes=15,
+                parallel_fields=2,
+                sessions_generated=False,
+            ))
+        # T2: ONGOING INDIVIDUAL_RANKING / SCORE_BASED — tournament_type_id is now set (Phase 1)
+        # score_based = LFA football player skill challenges (goals, points, repetitions)
+        db.add(TournamentConfiguration(
+            semester_id=t2.id,
+            tournament_type_id=tt_score_based.id if tt_score_based else None,
+            scoring_type="SCORE_BASED",
+            measurement_unit="goals",
+            ranking_direction="DESC",
+            participant_type="INDIVIDUAL",
+            is_multi_day=False,
+            max_players=32,
+            parallel_fields=1,
+        ))
+        # T3: ONGOING H2H/KNOCKOUT — 8/8 checked-in
+        if tt_knockout:
+            db.add(TournamentConfiguration(
+                semester_id=t3.id,
+                tournament_type_id=tt_knockout.id,
+                participant_type="INDIVIDUAL",
+                is_multi_day=True,
+                max_players=8,
+                match_duration_minutes=60,
+                break_duration_minutes=10,
+                parallel_fields=2,
+                sessions_generated=False,
+            ))
+        # T4: ONGOING H2H/SWISS — 8/8 checked-in
+        if tt_swiss:
+            db.add(TournamentConfiguration(
+                semester_id=t4.id,
+                tournament_type_id=tt_swiss.id,
+                participant_type="INDIVIDUAL",
+                is_multi_day=False,
+                max_players=16,
+                match_duration_minutes=75,
+                break_duration_minutes=10,
+                parallel_fields=2,
+                sessions_generated=False,
+            ))
+        # T5: ONGOING H2H/GROUP_KNOCKOUT — 8/8 checked-in
+        if tt_group_knockout:
+            db.add(TournamentConfiguration(
+                semester_id=t5.id,
+                tournament_type_id=tt_group_knockout.id,
+                participant_type="INDIVIDUAL",
+                is_multi_day=True,
+                max_players=16,
+                match_duration_minutes=60,
+                break_duration_minutes=10,
+                parallel_fields=2,
+                sessions_generated=False,
+            ))
+        # T6: COMPLETED H2H/LEAGUE — historical final standings
+        if tt_league:
+            db.add(TournamentConfiguration(
+                semester_id=t6.id,
+                tournament_type_id=tt_league.id,
+                participant_type="INDIVIDUAL",
+                is_multi_day=True,
+                max_players=16,
+                match_duration_minutes=90,
+                break_duration_minutes=15,
+                parallel_fields=2,
+                sessions_generated=False,
+            ))
+
+        # ── 4c. GameConfigurations ─────────────────────────────────────────────
+        print("🎮 Game configurations…")
+        _football_game_config = {
+            "metadata": {"min_players": 4, "game_type": "football"},
+            "match_rules": {"scoring": "goals", "overtime": False},
+            "skill_weights": {"dribbling": 1.5, "shooting": 1.3, "passing": 1.0, "defending": 0.8},
+        }
+        # All H2H tournaments + T6 (COMPLETED) get game configs
+        for _t in [t1, t2, t3, t4, t5, t6]:
+            db.add(GameConfiguration(semester_id=_t.id, game_preset_id=None, game_config=_football_game_config))
+
+        # ── 4d. TournamentRewardConfigs ────────────────────────────────────────
+        print("🎁 Reward configs…")
+        _standard_reward = {
+            "template_name": "Standard Football",
+            "custom_config": False,
+            "skill_mappings": [
+                {"skill": "Dribbling", "weight": 1.5, "category": "TECHNICAL", "enabled": True},
+                {"skill": "Shooting",  "weight": 1.3, "category": "TECHNICAL", "enabled": True},
+                {"skill": "Passing",   "weight": 1.0, "category": "TECHNICAL", "enabled": True},
+                {"skill": "Defending", "weight": 0.8, "category": "PHYSICAL",  "enabled": True},
+            ],
+            "first_place":    {"credits": 500, "xp_multiplier": 2.0, "badges": []},
+            "second_place":   {"credits": 250, "xp_multiplier": 1.5, "badges": []},
+            "third_place":    {"credits": 100, "xp_multiplier": 1.2, "badges": []},
+            "participation":  {"credits":  50, "xp_multiplier": 1.0, "badges": []},
+        }
+        for _t in [t1, t2, t3, t4, t5, t6]:
+            db.add(TournamentRewardConfig(semester_id=_t.id, reward_policy_name="Standard Football", reward_config=_standard_reward))
+
+        # ── 4e. Licenses + Enrollments for all tournaments ────────────────────
+        print("📋 Licenses + Enrollments (all tournaments)…")
+        from datetime import timezone as _tz
+        _now = datetime.now(_tz.utc)
+        for i, player in enumerate(players):
+            # Create LFA_FOOTBALL_PLAYER license if not exists
+            lic = db.query(UserLicense).filter(
+                UserLicense.user_id == player.id,
+                UserLicense.specialization_type == "LFA_FOOTBALL_PLAYER",
+                UserLicense.is_active == True,
+            ).first()
+            if not lic:
+                lic = UserLicense(
+                    user_id=player.id,
+                    specialization_type="LFA_FOOTBALL_PLAYER",
+                    started_at=_now,
+                    is_active=True,
+                )
+                db.add(lic)
+            db.flush()
+            # T1 league: 3/8 checked-in (split-brain demo)
+            db.add(SemesterEnrollment(
+                semester_id=t1.id, user_id=player.id, user_license_id=lic.id,
+                request_status=EnrollmentStatus.APPROVED, is_active=True,
+                tournament_checked_in_at=_now if i < 3 else None,
+            ))
+            # T2 IR, T3 knockout, T4 swiss, T5 group_knockout: all 8 checked-in
+            for _tourn in [t2, t3, t4, t5]:
+                db.add(SemesterEnrollment(
+                    semester_id=_tourn.id, user_id=player.id, user_license_id=lic.id,
+                    request_status=EnrollmentStatus.APPROVED, is_active=True,
+                    tournament_checked_in_at=_now,
+                ))
+            # T6 completed: all 8 checked-in
+            db.add(SemesterEnrollment(
+                semester_id=t6.id, user_id=player.id, user_license_id=lic.id,
+                request_status=EnrollmentStatus.APPROVED, is_active=True,
+                tournament_checked_in_at=_now,
+            ))
+        db.flush()
+
+        # ── 4f. Generate bracket sessions for all ONGOING + T6 ────────────────
+        # Must commit first so the generator can see the enrollments in a fresh query
+        print("⚡ Generating bracket sessions (T1–T5 ONGOING + T6 COMPLETED)…")
+        db.commit()
+        gen = TournamentSessionGenerator(db)
+        _gen_targets = [
+            (t1.id, "T1 league    (3/8 checked-in)"),
+            (t2.id, "T2 ind.rank  (8/8 checked-in)"),
+            (t3.id, "T3 knockout  (8/8 checked-in)"),
+            (t4.id, "T4 swiss     (8/8 checked-in)"),
+            (t5.id, "T5 grp+ko    (8/8 checked-in)"),
+            (t6.id, "T6 league    (COMPLETED)     "),
+        ]
+        for tourn_id, label in _gen_targets:
+            ok, msg, _ = gen.generate_sessions(tourn_id)
+            if ok:
+                db.commit()
+                sc = db.query(SessionModel).filter(SessionModel.semester_id==tourn_id).count()
+                print(f"   ✓ {label}: {sc} bracket sessions")
+            else:
+                print(f"   ⚠ {label}: {msg}")
+
+        # ── 4g. T6 Final Standings (8-player league, COMPLETED) ───────────────
+        print("🏅 T6 final standings…")
+        # 8-player round-robin: 7 rounds × 4 matches = 28 total matches
+        # Points: W=3, D=1, L=0 · All sums balance (wins=losses, draws=draws×2)
+        _t4_standings = [
+            # (rank, player_idx, wins, draws, losses, goals_for, goals_against, points)
+            (1, 0, 6, 0, 1, 18,  6, 18),
+            (2, 1, 5, 2, 0, 14,  5, 17),
+            (3, 2, 5, 0, 2, 13,  8, 15),
+            (4, 3, 4, 0, 3, 11, 10, 12),
+            (5, 4, 2, 2, 3,  8, 10,  8),
+            (6, 5, 1, 2, 4,  6, 12,  5),
+            (7, 6, 1, 0, 6,  4, 15,  3),
+            (8, 7, 0, 2, 5,  5, 13,  2),
+        ]
+        for rank, pidx, w, d, l, gf, ga, pts in _t4_standings:
+            db.add(TournamentRanking(
+                tournament_id=t6.id,
+                user_id=players[pidx].id,
+                participant_type="INDIVIDUAL",
+                rank=rank,
+                points=pts,
+                wins=w,
+                draws=d,
+                losses=l,
+                goals_for=gf,
+                goals_against=ga,
+            ))
+        db.commit()
+        print(f"   ✓ {len(_t4_standings)} final standings seeded for T4\n")
+
+        # ── 5. Camps ──────────────────────────────────────────────────────────
+        print("⛺ Camps…")
+
+        # C1: Summer YOUTH — READY_FOR_ENROLLMENT (Budapest CENTER)
+        c1 = Semester(
+            code="CAMP-SUMMER26-BUDA-YOUTH",
+            name="Summer Football Academy 2026 — Budapest YOUTH",
+            semester_category=SemesterCategory.CAMP,
+            status=SemesterStatus.READY_FOR_ENROLLMENT,
+            age_group="YOUTH",
+            location_id=budapest.id,
+            campus_id=buda_main.id,
+            start_date=today + timedelta(days=60),
+            end_date=today + timedelta(days=67),
+            enrollment_cost=800,
+            specialization_type="LFA_FOOTBALL_PLAYER",
+        )
+        # C2: Spring PRE — ONGOING (Debrecen PARTNER, in progress now)
+        c2 = Semester(
+            code="CAMP-SPRING26-DEB-PRE",
+            name="Spring Pre-Academy Camp — Debrecen 2026",
+            semester_category=SemesterCategory.CAMP,
+            status=SemesterStatus.ONGOING,
+            age_group="PRE",
+            location_id=debrecen.id,
+            campus_id=debr_main.id,
+            start_date=today - timedelta(days=2),
+            end_date=today + timedelta(days=5),
+            enrollment_cost=600,
+            specialization_type="LFA_FOOTBALL_PLAYER",
+        )
+        # C3: Winter AMATEUR — COMPLETED (Budapest CENTER, historical)
+        c3 = Semester(
+            code="CAMP-WINTER25-BUDA-AMT",
+            name="Winter Conditioning Camp 2025 — Budapest AMATEUR",
+            semester_category=SemesterCategory.CAMP,
+            status=SemesterStatus.COMPLETED,
+            age_group="AMATEUR",
+            location_id=budapest.id,
+            campus_id=buda_indoor.id,
+            start_date=today - timedelta(days=55),
+            end_date=today - timedelta(days=48),
+            enrollment_cost=700,
+            specialization_type="LFA_FOOTBALL_PLAYER",
+        )
+        db.add_all([c1, c2, c3])
+        db.flush()  # get IDs before building sessions
+
+        # ── 6. Sessions (Academy + Camp — T1/T4 sessions already generated above) ──
+        print("📅 Sessions (Academy + Camp)…")
+        sessions = []
+
+        # ACAD YOUTH — 8 upcoming TRAINING sessions (Buda Main, every 3 days)
+        for i in range(8):
+            d = today + timedelta(days=i * 3)
+            sessions.append(SessionModel(
+                title=f"Youth Academy — Week {i + 1} Training",
+                date_start=_dt(d, 9),
+                date_end=_dt(d, 11),
+                session_type=SessionType.on_site,
+                event_category=EventCategory.TRAINING,
+                session_status="scheduled",
+                semester_id=acad_youth.id,
+                campus_id=buda_main.id,
+                location="Buda Training Complex",
+                capacity=20,
+                base_xp=75,
+                sport_type="Football",
+                level="YOUTH",
+            ))
+
+        # ACAD PRE — 6 upcoming TRAINING sessions (Youth Hub, every 4 days)
+        for i in range(6):
+            d = today + timedelta(days=i * 4 + 1)
+            sessions.append(SessionModel(
+                title=f"Pre-Academy — Week {i + 1} Skills",
+                date_start=_dt(d, 15),
+                date_end=_dt(d, 17),
+                session_type=SessionType.on_site,
+                event_category=EventCategory.TRAINING,
+                session_status="scheduled",
+                semester_id=acad_pre.id,
+                campus_id=buda_youth.id,
+                location="Youth Development Hub",
+                capacity=15,
+                base_xp=50,
+                sport_type="Football",
+                level="PRE",
+            ))
+
+        # CAMP C2 (ONGOING Debrecen) — 5 daily sessions (2 past + 3 future)
+        for i in range(5):
+            d = today - timedelta(days=2) + timedelta(days=i)
+            status = "completed" if i < 2 else "scheduled"
+            sessions.append(SessionModel(
+                title=f"Spring Pre-Academy Camp — Day {i + 1}",
+                date_start=_dt(d, 9),
+                date_end=_dt(d, 13),
+                session_type=SessionType.on_site,
+                event_category=EventCategory.TRAINING,
+                session_status=status,
+                semester_id=c2.id,
+                campus_id=debr_main.id,
+                location="Főnix Sportközpont",
+                capacity=18,
+                base_xp=100,
+                sport_type="Football",
+                level="PRE",
+            ))
+
+        db.add_all(sessions)
+        db.commit()
+
+        # ── Summary ───────────────────────────────────────────────────────────
+        n_train = sum(1 for s in sessions if s.event_category == EventCategory.TRAINING)
+        _bracket_counts = {
+            label: db.query(SessionModel).filter(SessionModel.semester_id==tid).count()
+            for tid, label in [
+                (t1.id, "T1-league"), (t2.id, "T2-ir"), (t3.id, "T3-ko"),
+                (t4.id, "T4-swiss"), (t5.id, "T5-gk"), (t6.id, "T6-completed"),
+            ]
+        }
+        total_bracket = sum(_bracket_counts.values())
+        total_sessions = len(sessions) + total_bracket
+
+        print(f"\n✅ Seed complete!\n")
+        print(f"   Locations     : 2  (Budapest CENTER · Debrecen PARTNER)")
+        print(f"   Campuses      : 4  (3 × Budapest · 1 × Debrecen)")
+        print(f"   Semesters     : 12 (3 Academy/Mini · 6 Tournament · 3 Camp)")
+        print(f"   Sessions      : {total_sessions}  ({total_bracket} bracket MATCH · {n_train} TRAINING)")
+        for lbl, cnt in _bracket_counts.items():
+            print(f"     {lbl}: {cnt} sessions")
+        print(f"   Game configs  : 6  (all tournaments)")
+        print(f"   Reward cfgs   : 6  (all tournaments)")
+        print(f"   Players       : {len(players)}  (demo.youth.player1-8@lfa-seed.hu)")
+        print(f"   Enrollments   : {len(players)*6}  (T1: 3/8 checked-in · T2–T6: 8/8 checked-in)")
+        print(f"   Standings     : 8  (T6 COMPLETED final rankings)\n")
+        print(f"   → http://localhost:8000/admin/events")
+        print(f"   → http://localhost:8000/admin/camps")
+        print(f"   → http://localhost:8000/admin/events/tournaments")
+        print(f"   → http://localhost:8000/admin/sessions?event_category=TRAINING")
+        print(f"   → http://localhost:8000/admin/sessions?event_category=MATCH")
+
+    except Exception as exc:
+        db.rollback()
+        import traceback
+        print(f"\n❌ Seed failed: {exc}")
+        traceback.print_exc()
+        sys.exit(1)
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    seed()

--- a/scripts/demo/seed_minimal.py
+++ b/scripts/demo/seed_minimal.py
@@ -1,0 +1,491 @@
+#!/usr/bin/env python3
+"""
+Seed Minimum Playable System — activates 4 report_* test users and
+creates 3 ENROLLMENT_OPEN tournaments + 2 camps so the full game loop
+can be exercised without running seed_events_demo.py first.
+
+ADDITIVE and IDEMPOTENT: safe to run multiple times.
+Does NOT truncate any table.
+
+Actions:
+  1. Fix report_* user licenses:
+       - football_skills JSON (all 29 skills, flat format, per-player baselines)
+       - onboarding_completed = True
+       - credit_balance = 900 on the User row
+  2. Ensure a usable Location + Campus exist (reuses existing if found).
+  3. Create 3 ENROLLMENT_OPEN tournaments (league H2H · score_based · time_based)
+     with required TournamentConfiguration + TournamentRewardConfig + GameConfiguration.
+  4. Create 2 ENROLLMENT_OPEN camps.
+
+Run: python scripts/seed_minimum_playable.py
+"""
+import sys
+import os
+import random
+from pathlib import Path
+from datetime import datetime, timezone, date, timedelta
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from sqlalchemy.orm import Session
+from app.database import SessionLocal
+from app.models.user import User, UserRole
+from app.models.license import UserLicense
+from app.models.location import Location, LocationType
+from app.models.campus import Campus
+from app.models.semester import Semester, SemesterStatus, SemesterCategory
+from app.models.tournament_configuration import TournamentConfiguration
+from app.models.tournament_type import TournamentType
+from app.models.game_configuration import GameConfiguration
+from app.models.tournament_reward_config import TournamentRewardConfig
+from app.models.game_preset import GamePreset
+
+# ── Constants ──────────────────────────────────────────────────────────────────
+
+TARGET_EMAILS = [
+    "report_490c3e64@t.com",
+    "report_940c5c73@t.com",
+    "report_7b85cdfa@t.com",
+    "report_9ab12d42@t.com",
+]
+CREDIT_BALANCE = 900
+
+# All 29 skills (flat format) per player — source of truth: app/skills_config.py
+# Keys: outfield(11) + set_pieces(3) + mental(8) + physical(7)
+# get_baseline_skills() in skill_progression_service.py reads both flat and rich formats.
+_PLAYER_SKILLS = {
+    # All-rounder with technical bias
+    "report_490c3e64@t.com": {
+        # Outfield
+        "ball_control": 70.0, "dribbling": 73.0, "finishing": 75.0, "shot_power": 70.0,
+        "long_shots": 62.0, "volleys": 58.0, "crossing": 62.0, "passing": 71.0,
+        "heading": 68.0, "tackle": 55.0, "marking": 52.0,
+        # Set pieces
+        "free_kicks": 60.0, "corners": 63.0, "penalties": 65.0,
+        # Mental
+        "positioning_off": 63.0, "positioning_def": 60.0, "vision": 65.0,
+        "aggression": 55.0, "reactions": 68.0, "composure": 65.0,
+        "consistency": 62.0, "tactical_awareness": 64.0,
+        # Physical
+        "acceleration": 68.0, "sprint_speed": 70.0, "agility": 72.0,
+        "jumping": 65.0, "strength": 60.0, "stamina": 67.0, "balance": 68.0,
+    },
+    # Attacking/shooting specialist
+    "report_940c5c73@t.com": {
+        # Outfield
+        "ball_control": 74.0, "dribbling": 77.0, "finishing": 81.0, "shot_power": 78.0,
+        "long_shots": 68.0, "volleys": 65.0, "crossing": 65.0, "passing": 69.0,
+        "heading": 72.0, "tackle": 52.0, "marking": 48.0,
+        # Set pieces
+        "free_kicks": 70.0, "corners": 62.0, "penalties": 72.0,
+        # Mental
+        "positioning_off": 70.0, "positioning_def": 55.0, "vision": 68.0,
+        "aggression": 65.0, "reactions": 72.0, "composure": 62.0,
+        "consistency": 68.0, "tactical_awareness": 65.0,
+        # Physical
+        "acceleration": 74.0, "sprint_speed": 78.0, "agility": 76.0,
+        "jumping": 68.0, "strength": 65.0, "stamina": 72.0, "balance": 73.0,
+    },
+    # Playmaker/passer
+    "report_7b85cdfa@t.com": {
+        # Outfield
+        "ball_control": 68.0, "dribbling": 65.0, "finishing": 67.0, "shot_power": 60.0,
+        "long_shots": 65.0, "volleys": 55.0, "crossing": 70.0, "passing": 80.0,
+        "heading": 61.0, "tackle": 60.0, "marking": 58.0,
+        # Set pieces
+        "free_kicks": 72.0, "corners": 75.0, "penalties": 65.0,
+        # Mental
+        "positioning_off": 72.0, "positioning_def": 62.0, "vision": 78.0,
+        "aggression": 48.0, "reactions": 68.0, "composure": 75.0,
+        "consistency": 72.0, "tactical_awareness": 76.0,
+        # Physical
+        "acceleration": 62.0, "sprint_speed": 60.0, "agility": 65.0,
+        "jumping": 58.0, "strength": 55.0, "stamina": 70.0, "balance": 68.0,
+    },
+    # Developing player (beginner)
+    "report_9ab12d42@t.com": {
+        # Outfield
+        "ball_control": 60.0, "dribbling": 62.0, "finishing": 60.0, "shot_power": 58.0,
+        "long_shots": 52.0, "volleys": 48.0, "crossing": 58.0, "passing": 63.0,
+        "heading": 55.0, "tackle": 55.0, "marking": 52.0,
+        # Set pieces
+        "free_kicks": 52.0, "corners": 50.0, "penalties": 55.0,
+        # Mental
+        "positioning_off": 52.0, "positioning_def": 55.0, "vision": 55.0,
+        "aggression": 60.0, "reactions": 58.0, "composure": 55.0,
+        "consistency": 52.0, "tactical_awareness": 52.0,
+        # Physical
+        "acceleration": 60.0, "sprint_speed": 62.0, "agility": 58.0,
+        "jumping": 55.0, "strength": 58.0, "stamina": 62.0, "balance": 58.0,
+    },
+}
+
+# All 29 skill keys (used as fallback for unknown emails)
+_SKILL_KEYS = list(_PLAYER_SKILLS["report_490c3e64@t.com"].keys())
+
+# Reward policy used for all seed tournaments
+_STANDARD_REWARD = {
+    "template_name": "Standard Football",
+    "custom_config": False,
+    "skill_mappings": [
+        {"skill": "Dribbling", "weight": 1.5, "category": "TECHNICAL", "enabled": True},
+        {"skill": "Shooting",  "weight": 1.3, "category": "TECHNICAL", "enabled": True},
+        {"skill": "Passing",   "weight": 1.0, "category": "TECHNICAL", "enabled": True},
+    ],
+    "first_place":   {"credits": 500, "xp_multiplier": 2.0, "badges": []},
+    "second_place":  {"credits": 250, "xp_multiplier": 1.5, "badges": []},
+    "third_place":   {"credits": 100, "xp_multiplier": 1.2, "badges": []},
+    "participation": {"credits":  50, "xp_multiplier": 1.0, "badges": []},
+}
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def _get_or_create_location(db: Session) -> Location:
+    """Reuse the first active CENTER location, or create a minimal one."""
+    loc = db.query(Location).filter(Location.location_type == LocationType.CENTER, Location.is_active == True).first()
+    if loc:
+        return loc
+    loc = Location(
+        name="LFA Budapest Education Center",
+        city="Budapest",
+        country="Hungary",
+        country_code="HU",
+        location_code="BDPST-MIN",
+        postal_code="1146",
+        address="Istvánmezei út 1-3, Budapest",
+        location_type=LocationType.CENTER,
+        is_active=True,
+    )
+    db.add(loc)
+    db.flush()
+    print(f"   ✓ Created location: {loc.name} (id={loc.id})")
+    return loc
+
+
+def _get_or_create_campus(db: Session, location: Location) -> Campus:
+    """Reuse first campus at this location, or create one."""
+    campus = db.query(Campus).filter(Campus.location_id == location.id, Campus.is_active == True).first()
+    if campus:
+        return campus
+    campus = Campus(
+        location_id=location.id,
+        name="Main Training Campus",
+        venue="Outdoor fields + gym",
+        address="Istvánmezei út 1-3, Budapest",
+        is_active=True,
+    )
+    db.add(campus)
+    db.flush()
+    print(f"   ✓ Created campus: {campus.name} (id={campus.id})")
+    return campus
+
+
+def _get_preset(db: Session, code: str) -> GamePreset | None:
+    return db.query(GamePreset).filter(GamePreset.code == code, GamePreset.is_active == True).first()
+
+
+def _get_tt(db: Session, code: str) -> TournamentType | None:
+    return db.query(TournamentType).filter(TournamentType.code == code).first()
+
+
+def _ensure_tournament(
+    db: Session,
+    *,
+    code: str,
+    name: str,
+    tt_code: str,
+    scoring_type: str | None,
+    measurement_unit: str | None,
+    ranking_direction: str,
+    preset_code: str,
+    location: Location,
+    campus: Campus,
+    today: date,
+    age_group: str = "YOUTH",
+    max_players: int = 32,
+) -> Semester | None:
+    """Create a READY_FOR_ENROLLMENT tournament if it doesn't exist yet (idempotent by code)."""
+    existing = db.query(Semester).filter(Semester.code == code).first()
+    if existing:
+        print(f"   ⏭️  Already exists: {code}")
+        return existing
+
+    t = Semester(
+        code=code,
+        name=name,
+        semester_category=SemesterCategory.TOURNAMENT,
+        status=SemesterStatus.READY_FOR_ENROLLMENT,
+        tournament_status="ENROLLMENT_OPEN",
+        age_group=age_group,
+        location_id=location.id,
+        campus_id=campus.id,
+        start_date=today + timedelta(days=14),
+        end_date=today + timedelta(days=28),
+        enrollment_cost=0,
+        specialization_type="LFA_FOOTBALL_PLAYER",
+    )
+    db.add(t)
+    db.flush()
+
+    tt = _get_tt(db, tt_code)
+    db.add(TournamentConfiguration(
+        semester_id=t.id,
+        tournament_type_id=tt.id if tt else None,
+        scoring_type=scoring_type,
+        measurement_unit=measurement_unit,
+        ranking_direction=ranking_direction,
+        participant_type="INDIVIDUAL",
+        is_multi_day=False,
+        max_players=max_players,
+        parallel_fields=1,
+        sessions_generated=False,
+    ))
+
+    preset = _get_preset(db, preset_code)
+    game_cfg = {
+        "metadata": {"min_players": 4, "game_type": "football"},
+        "match_rules": {"scoring": "goals", "overtime": False},
+    }
+    db.add(GameConfiguration(
+        semester_id=t.id,
+        game_preset_id=preset.id if preset else None,
+        game_config=game_cfg,
+    ))
+
+    db.add(TournamentRewardConfig(
+        semester_id=t.id,
+        reward_policy_name="Standard Football",
+        reward_config=_STANDARD_REWARD,
+    ))
+
+    print(f"   ✅ Created tournament: {name!r} ({code})")
+    return t
+
+
+def _ensure_camp(
+    db: Session,
+    *,
+    code: str,
+    name: str,
+    location: Location,
+    campus: Campus,
+    today: date,
+    age_group: str = "YOUTH",
+    enrollment_cost: int = 500,
+) -> Semester | None:
+    existing = db.query(Semester).filter(Semester.code == code).first()
+    if existing:
+        print(f"   ⏭️  Already exists: {code}")
+        return existing
+
+    c = Semester(
+        code=code,
+        name=name,
+        semester_category=SemesterCategory.CAMP,
+        status=SemesterStatus.READY_FOR_ENROLLMENT,
+        age_group=age_group,
+        location_id=location.id,
+        campus_id=campus.id,
+        start_date=today + timedelta(days=45),
+        end_date=today + timedelta(days=52),
+        enrollment_cost=enrollment_cost,
+        specialization_type="LFA_FOOTBALL_PLAYER",
+    )
+    db.add(c)
+    db.flush()
+    print(f"   ✅ Created camp: {name!r} ({code})")
+    return c
+
+
+# ── Main ───────────────────────────────────────────────────────────────────────
+
+def seed():
+    db = SessionLocal()
+    try:
+        today = date.today()
+        now = datetime.now(timezone.utc)
+
+        # ── 1. Fix report_* user licenses ──────────────────────────────────────
+        print("👤 Fixing report_* test user licenses…")
+        for email in TARGET_EMAILS:
+            user = db.query(User).filter(User.email == email).first()
+            if not user:
+                print(f"   SKIP {email} — not found in DB (run seed_report_users_login.py first?)")
+                continue
+
+            # Set credit_balance
+            if user.credit_balance != CREDIT_BALANCE:
+                user.credit_balance = CREDIT_BALANCE
+
+            license = db.query(UserLicense).filter(
+                UserLicense.user_id == user.id,
+                UserLicense.specialization_type == "LFA_FOOTBALL_PLAYER",
+                UserLicense.is_active == True,
+            ).first()
+
+            if not license:
+                print(f"   SKIP {email} — no active LFA_FOOTBALL_PLAYER license found")
+                continue
+
+            # Ensure started_at is set (required NOT NULL)
+            if license.started_at is None:
+                license.started_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+            # Set football_skills baseline if not already set
+            if not license.football_skills:
+                license.football_skills = _PLAYER_SKILLS.get(email, {
+                    k: 65.0 for k in _SKILL_KEYS
+                })
+                print(f"   ✅ Set football_skills for {email}")
+            else:
+                print(f"   ⏭️  football_skills already set for {email}")
+
+            # Ensure onboarding completed
+            if not license.onboarding_completed:
+                license.onboarding_completed = True
+                print(f"   ✅ Set onboarding_completed for {email}")
+
+            db.flush()
+
+        db.commit()
+        print()
+
+        # ── 2. Ensure a usable location + campus ───────────────────────────────
+        print("📍 Ensuring location + campus…")
+        location = _get_or_create_location(db)
+        campus = _get_or_create_campus(db, location)
+        db.commit()
+        print(f"   Location: {location.name} (id={location.id})")
+        print(f"   Campus:   {campus.name} (id={campus.id})")
+        print()
+
+        # ── 3. Create 3 ENROLLMENT_OPEN tournaments ────────────────────────────
+        print("🏆 Ensuring 3 ENROLLMENT_OPEN tournaments…")
+
+        _ensure_tournament(
+            db,
+            code="PLAYABLE-TOURN-H2H-LEAGUE-2026",
+            name="YOUTH League Tournament 2026 — Enrollment Open",
+            tt_code="league",
+            scoring_type=None,
+            measurement_unit=None,
+            ranking_direction="DESC",
+            preset_code="outfield_default",
+            location=location,
+            campus=campus,
+            today=today,
+            age_group="YOUTH",
+            max_players=32,
+        )
+
+        _ensure_tournament(
+            db,
+            code="PLAYABLE-TOURN-SCORE-2026",
+            name="YOUTH Score Challenge 2026 — Enrollment Open",
+            tt_code="score_based",
+            scoring_type="SCORE_BASED",
+            measurement_unit="goals",
+            ranking_direction="DESC",
+            preset_code="shooting_focus",
+            location=location,
+            campus=campus,
+            today=today,
+            age_group="YOUTH",
+            max_players=32,
+        )
+
+        _ensure_tournament(
+            db,
+            code="PLAYABLE-TOURN-TIME-2026",
+            name="YOUTH Time Trial Series 2026 — Enrollment Open",
+            tt_code="time_based",
+            scoring_type="TIME_BASED",
+            measurement_unit="seconds",
+            ranking_direction="ASC",
+            preset_code="passing_focus",
+            location=location,
+            campus=campus,
+            today=today,
+            age_group="YOUTH",
+            max_players=24,
+        )
+
+        db.commit()
+        print()
+
+        # ── 4. Create 2 ENROLLMENT_OPEN camps ─────────────────────────────────
+        print("⛺ Ensuring 2 ENROLLMENT_OPEN camps…")
+
+        _ensure_camp(
+            db,
+            code="PLAYABLE-CAMP-SUMMER-2026-YOUTH",
+            name="Summer Football Camp 2026 — YOUTH",
+            location=location,
+            campus=campus,
+            today=today,
+            age_group="YOUTH",
+            enrollment_cost=500,
+        )
+
+        _ensure_camp(
+            db,
+            code="PLAYABLE-CAMP-AUTUMN-2026-YOUTH",
+            name="Autumn Development Camp 2026 — YOUTH",
+            location=location,
+            campus=campus,
+            today=today,
+            age_group="YOUTH",
+            enrollment_cost=350,
+        )
+
+        db.commit()
+        print()
+
+        # ── Summary ────────────────────────────────────────────────────────────
+        open_tourneys = db.query(Semester).filter(
+            Semester.semester_category == SemesterCategory.TOURNAMENT,
+            Semester.tournament_status == "ENROLLMENT_OPEN",
+        ).count()
+        open_camps = db.query(Semester).filter(
+            Semester.semester_category == SemesterCategory.CAMP,
+            Semester.status == SemesterStatus.READY_FOR_ENROLLMENT,
+        ).count()
+
+        print("=" * 70)
+        print("✅ MINIMUM PLAYABLE SYSTEM READY")
+        print(f"   ENROLLMENT_OPEN tournaments : {open_tourneys}")
+        print(f"   ENROLLMENT_OPEN camps       : {open_camps}")
+        print()
+        print("   Test users (password: Player1234!):")
+        for email in TARGET_EMAILS:
+            u = db.query(User).filter(User.email == email).first()
+            if u:
+                lic = db.query(UserLicense).filter(
+                    UserLicense.user_id == u.id,
+                    UserLicense.specialization_type == "LFA_FOOTBALL_PLAYER",
+                    UserLicense.is_active == True,
+                ).first()
+                fs = "✅" if (lic and lic.football_skills) else "❌"
+                oc = "✅" if (lic and lic.onboarding_completed) else "❌"
+                cr = u.credit_balance or 0
+                print(f"   [{email}]  football_skills={fs}  onboarding={oc}  credits={cr}")
+        print()
+        print("   Login: report_490c3e64@t.com / Player1234!")
+        print("   Journey: /dashboard → ENTER → /dashboard/lfa-football-player")
+        print("            → Available Events (Tournaments + Camps tabs)")
+        print("            → [Enroll] → /api/v1/tournaments/{id}/enroll")
+        print("=" * 70)
+
+    except Exception as e:
+        db.rollback()
+        print(f"\n❌ SEED FAILED: {e}")
+        import traceback
+        traceback.print_exc()
+        raise
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    seed()

--- a/scripts/demo/seed_skill_progression.py
+++ b/scripts/demo/seed_skill_progression.py
@@ -1,0 +1,748 @@
+#!/usr/bin/env python3
+"""
+Full Playable System Seed — creates everything from scratch.
+
+Use this script after a DB reset to restore the full playable state:
+  1. Game presets  (outfield_default, shooting_focus, passing_focus)
+  2. Tournament types  (league + 4 IR variants via JSON)
+  3. 4 report_* test users + LFA_FOOTBALL_PLAYER licenses
+  4. 3 COMPLETED tournaments with EMA skill history
+  5. 3 ENROLLMENT_OPEN tournaments + 2 camps (current enrollment)
+
+Placement matrix (creates realistic EMA progression per player):
+  T1 league (Jan 2026):      940→1st  7b85→2nd  490c→3rd  9ab1→NULL
+  T2 score_based (Feb 2026): 7b85→1st  490c→2nd  9ab1→3rd  940→NULL
+  T3 time_based (Mar 2026):  490c→1st  9ab1→2nd  940→3rd  7b85→NULL
+
+Result after run:
+  - Login: report_490c3e64@t.com / Player1234!
+  - /skills/history shows 3-tournament EMA chart
+  - 3 tournaments + 2 camps open for enrollment
+
+IDEMPOTENT: checks before creating, safe to re-run.
+
+Run: python scripts/seed_full_playable.py
+"""
+import sys
+import os
+import json
+from pathlib import Path
+from datetime import datetime, timezone, date, timedelta
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from sqlalchemy.orm import Session
+from app.database import SessionLocal
+from app.models.user import User, UserRole
+from app.models.license import UserLicense
+from app.models.specialization import SpecializationType
+from app.models.location import Location, LocationType
+from app.models.campus import Campus
+from app.models.semester import Semester, SemesterStatus, SemesterCategory
+from app.models.tournament_configuration import TournamentConfiguration
+from app.models.tournament_type import TournamentType
+from app.models.game_configuration import GameConfiguration
+from app.models.tournament_reward_config import TournamentRewardConfig
+from app.models.game_preset import GamePreset
+from app.core.security import get_password_hash
+from app.services.tournament.tournament_participation_service import (
+    calculate_skill_points_for_placement,
+    record_tournament_participation,
+)
+
+# ── Constants ──────────────────────────────────────────────────────────────────
+
+PASSWORD = "Player1234!"
+
+# email → display name
+PLAYERS = {
+    "report_940c5c73@t.com": "P1 Report (940c)",   # Attacking specialist
+    "report_7b85cdfa@t.com": "P2 Report (7b85)",   # Playmaker/passer
+    "report_490c3e64@t.com": "P3 Report (490c)",   # All-rounder (best arc)
+    "report_9ab12d42@t.com": "P4 Report (9ab1)",   # Developing player
+}
+
+# Football skills baselines — flat format (29 keys from skills_config.py)
+_PLAYER_SKILLS = {
+    # Attacking/shooting specialist
+    "report_940c5c73@t.com": {
+        "ball_control": 74.0, "dribbling": 77.0, "finishing": 81.0, "shot_power": 78.0,
+        "long_shots": 68.0, "volleys": 65.0, "crossing": 65.0, "passing": 69.0,
+        "heading": 72.0, "tackle": 52.0, "marking": 48.0,
+        "free_kicks": 70.0, "corners": 62.0, "penalties": 72.0,
+        "positioning_off": 70.0, "positioning_def": 55.0, "vision": 68.0,
+        "aggression": 65.0, "reactions": 72.0, "composure": 62.0,
+        "consistency": 68.0, "tactical_awareness": 65.0,
+        "acceleration": 74.0, "sprint_speed": 78.0, "agility": 76.0,
+        "jumping": 68.0, "strength": 65.0, "stamina": 72.0, "balance": 73.0,
+    },
+    # Playmaker/passer
+    "report_7b85cdfa@t.com": {
+        "ball_control": 68.0, "dribbling": 65.0, "finishing": 67.0, "shot_power": 60.0,
+        "long_shots": 65.0, "volleys": 55.0, "crossing": 70.0, "passing": 80.0,
+        "heading": 61.0, "tackle": 60.0, "marking": 58.0,
+        "free_kicks": 72.0, "corners": 75.0, "penalties": 65.0,
+        "positioning_off": 72.0, "positioning_def": 62.0, "vision": 78.0,
+        "aggression": 48.0, "reactions": 68.0, "composure": 75.0,
+        "consistency": 72.0, "tactical_awareness": 76.0,
+        "acceleration": 62.0, "sprint_speed": 60.0, "agility": 65.0,
+        "jumping": 58.0, "strength": 55.0, "stamina": 70.0, "balance": 68.0,
+    },
+    # All-rounder — best development arc (3rd → 2nd → 1st)
+    "report_490c3e64@t.com": {
+        "ball_control": 70.0, "dribbling": 73.0, "finishing": 75.0, "shot_power": 70.0,
+        "long_shots": 62.0, "volleys": 58.0, "crossing": 62.0, "passing": 71.0,
+        "heading": 68.0, "tackle": 55.0, "marking": 52.0,
+        "free_kicks": 60.0, "corners": 63.0, "penalties": 65.0,
+        "positioning_off": 63.0, "positioning_def": 60.0, "vision": 65.0,
+        "aggression": 55.0, "reactions": 68.0, "composure": 65.0,
+        "consistency": 62.0, "tactical_awareness": 64.0,
+        "acceleration": 68.0, "sprint_speed": 70.0, "agility": 72.0,
+        "jumping": 65.0, "strength": 60.0, "stamina": 67.0, "balance": 68.0,
+    },
+    # Developing player (beginner)
+    "report_9ab12d42@t.com": {
+        "ball_control": 60.0, "dribbling": 62.0, "finishing": 60.0, "shot_power": 58.0,
+        "long_shots": 52.0, "volleys": 48.0, "crossing": 58.0, "passing": 63.0,
+        "heading": 55.0, "tackle": 55.0, "marking": 52.0,
+        "free_kicks": 52.0, "corners": 50.0, "penalties": 55.0,
+        "positioning_off": 52.0, "positioning_def": 55.0, "vision": 55.0,
+        "aggression": 60.0, "reactions": 58.0, "composure": 55.0,
+        "consistency": 52.0, "tactical_awareness": 52.0,
+        "acceleration": 60.0, "sprint_speed": 62.0, "agility": 58.0,
+        "jumping": 55.0, "strength": 58.0, "stamina": 62.0, "balance": 58.0,
+    },
+}
+
+# Placement matrix: tournament_index → { email: placement (None = participant) }
+# Chronological order is critical for correct EMA delta computation.
+PLACEMENTS = [
+    # T1: league — Jan 2026
+    {
+        "report_940c5c73@t.com": 1,
+        "report_7b85cdfa@t.com": 2,
+        "report_490c3e64@t.com": 3,
+        "report_9ab12d42@t.com": None,
+    },
+    # T2: score_based — Feb 2026
+    {
+        "report_7b85cdfa@t.com": 1,
+        "report_490c3e64@t.com": 2,
+        "report_9ab12d42@t.com": 3,
+        "report_940c5c73@t.com": None,
+    },
+    # T3: time_based — Mar 2026
+    {
+        "report_490c3e64@t.com": 1,
+        "report_9ab12d42@t.com": 2,
+        "report_940c5c73@t.com": 3,
+        "report_7b85cdfa@t.com": None,
+    },
+]
+
+# Reward policy for historical tournaments.
+# IMPORTANT: "skill" values must match get_all_skill_keys() (lowercase snake_case)
+# so that _extract_tournament_skills() can match them against the canonical skill set.
+_STANDARD_REWARD = {
+    "template_name": "Standard Football",
+    "custom_config": False,
+    "skill_mappings": [
+        {"skill": "dribbling", "weight": 1.5, "category": "TECHNICAL", "enabled": True},
+        {"skill": "finishing",  "weight": 1.3, "category": "TECHNICAL", "enabled": True},
+        {"skill": "passing",   "weight": 1.0, "category": "TECHNICAL", "enabled": True},
+    ],
+    "first_place":   {"credits": 500, "xp_multiplier": 2.0, "badges": []},
+    "second_place":  {"credits": 250, "xp_multiplier": 1.5, "badges": []},
+    "third_place":   {"credits": 100, "xp_multiplier": 1.2, "badges": []},
+    "participation": {"credits":  50, "xp_multiplier": 1.0, "badges": []},
+}
+
+_HIST_TOURN_CONFIGS = [
+    {
+        "code": "HIST-TOURN-LEAGUE-2026-01",
+        "name": "YOUTH League Cup — January 2026",
+        "tt_code": "league",
+        "scoring_type": None,
+        "ranking_direction": "DESC",
+        "preset_code": "outfield_default",
+        "achieved_at": datetime(2026, 1, 25, 15, 0, 0, tzinfo=timezone.utc),
+    },
+    {
+        "code": "HIST-TOURN-SCORE-2026-02",
+        "name": "YOUTH Score Challenge — February 2026",
+        "tt_code": "score_based",
+        "scoring_type": "SCORE_BASED",
+        "ranking_direction": "DESC",
+        "preset_code": "shooting_focus",
+        "achieved_at": datetime(2026, 2, 20, 14, 0, 0, tzinfo=timezone.utc),
+    },
+    {
+        "code": "HIST-TOURN-TIME-2026-03",
+        "name": "YOUTH Time Trial — March 2026",
+        "tt_code": "time_based",
+        "scoring_type": "TIME_BASED",
+        "ranking_direction": "ASC",
+        "preset_code": "passing_focus",
+        "achieved_at": datetime(2026, 3, 15, 13, 0, 0, tzinfo=timezone.utc),
+    },
+]
+
+
+# ── Phase 1: Game presets ──────────────────────────────────────────────────────
+
+GAME_PRESETS = [
+    {
+        "code": "outfield_default",
+        "name": "Outfield Football (Default)",
+        "is_recommended": True,
+        "is_locked": False,
+        "game_config": {
+            "version": "1.0",
+            "metadata": {"game_category": "FOOTBALL", "difficulty_level": "intermediate", "min_players": 4},
+            "skill_config": {
+                "skills_tested": ["ball_control", "dribbling", "finishing", "passing", "vision",
+                                  "positioning_off", "sprint_speed", "agility", "stamina"],
+                "skill_weights": {
+                    "ball_control": 1.2, "dribbling": 1.5, "finishing": 1.4, "passing": 1.3,
+                    "vision": 1.1, "positioning_off": 1.1, "sprint_speed": 1.0,
+                    "agility": 1.0, "stamina": 0.9,
+                },
+            },
+            "format_config": {}, "simulation_config": {},
+        },
+    },
+    {
+        "code": "passing_focus",
+        "name": "Passing & Vision Focus",
+        "is_recommended": False,
+        "is_locked": False,
+        "game_config": {
+            "version": "1.0",
+            "metadata": {"game_category": "FOOTBALL", "difficulty_level": "intermediate", "min_players": 4},
+            "skill_config": {
+                "skills_tested": ["passing", "vision", "ball_control", "positioning_off", "agility", "stamina"],
+                "skill_weights": {"passing": 1.8, "vision": 1.6, "ball_control": 1.4,
+                                  "positioning_off": 1.3, "agility": 1.0, "stamina": 0.8},
+            },
+            "format_config": {}, "simulation_config": {},
+        },
+    },
+    {
+        "code": "shooting_focus",
+        "name": "Finishing & Shooting Focus",
+        "is_recommended": False,
+        "is_locked": False,
+        "game_config": {
+            "version": "1.0",
+            "metadata": {"game_category": "FOOTBALL", "difficulty_level": "intermediate", "min_players": 4},
+            "skill_config": {
+                "skills_tested": ["finishing", "sprint_speed", "dribbling", "ball_control",
+                                  "agility", "positioning_off"],
+                "skill_weights": {"finishing": 2.0, "sprint_speed": 1.6, "dribbling": 1.5,
+                                  "ball_control": 1.2, "agility": 1.1, "positioning_off": 0.9},
+            },
+            "format_config": {}, "simulation_config": {},
+        },
+    },
+]
+
+
+def _seed_game_presets(db: Session) -> None:
+    print("\n🎮 Phase 1: Game presets…")
+    for defn in GAME_PRESETS:
+        if db.query(GamePreset).filter(GamePreset.code == defn["code"]).first():
+            print(f"   ⏭️  {defn['code']} already exists")
+            continue
+        db.add(GamePreset(
+            code=defn["code"],
+            name=defn["name"],
+            game_config=defn["game_config"],
+            is_active=True,
+            is_recommended=defn["is_recommended"],
+            is_locked=defn["is_locked"],
+        ))
+        print(f"   ✅ Created preset: {defn['code']}")
+    db.flush()
+
+
+# ── Phase 2: Tournament types ──────────────────────────────────────────────────
+
+def _seed_tournament_types(db: Session) -> None:
+    print("\n🏆 Phase 2: Tournament types…")
+    configs_dir = Path(__file__).resolve().parent.parent / "app" / "tournament_types"
+    json_files = sorted(configs_dir.glob("*.json"))
+    for json_file in json_files:
+        config = json.loads(json_file.read_text())
+        code = config["code"]
+        if db.query(TournamentType).filter(TournamentType.code == code).first():
+            print(f"   ⏭️  {code} already exists")
+            continue
+        db.add(TournamentType(
+            code=code,
+            display_name=config["display_name"],
+            description=config.get("description", ""),
+            format=config.get("format", "INDIVIDUAL_RANKING"),
+            min_players=config["min_players"],
+            max_players=config.get("max_players"),
+            requires_power_of_two=config["requires_power_of_two"],
+            session_duration_minutes=config["session_duration_minutes"],
+            break_between_sessions_minutes=config["break_between_sessions_minutes"],
+            config=config,
+        ))
+        print(f"   ✅ Created type: {code}")
+    db.flush()
+
+
+# ── Phase 3: Users + licenses ──────────────────────────────────────────────────
+
+def _seed_users(db: Session) -> dict[str, User]:
+    print("\n👤 Phase 3: Test users + licenses…")
+    password_hash = get_password_hash(PASSWORD)
+    now = datetime.now(timezone.utc)
+    users = {}
+
+    for email, name in PLAYERS.items():
+        user = db.query(User).filter(User.email == email).first()
+        if not user:
+            user = User(
+                email=email,
+                name=name,
+                password_hash=password_hash,
+                role=UserRole.STUDENT,
+                is_active=True,
+                onboarding_completed=True,
+                specialization=SpecializationType.LFA_FOOTBALL_PLAYER,
+                credit_balance=900,
+                payment_verified=True,
+                payment_verified_at=now,
+            )
+            db.add(user)
+            db.flush()
+            print(f"   ✅ Created user: {email} (id={user.id})")
+        else:
+            # Ensure password is correct and attributes are set
+            user.password_hash = password_hash
+            user.specialization = SpecializationType.LFA_FOOTBALL_PLAYER
+            user.onboarding_completed = True
+            user.credit_balance = 900
+            db.flush()
+            print(f"   ⏭️  User exists: {email} (id={user.id}) — updated password+attrs")
+
+        # Ensure license
+        license = db.query(UserLicense).filter(
+            UserLicense.user_id == user.id,
+            UserLicense.specialization_type == "LFA_FOOTBALL_PLAYER",
+        ).first()
+        if not license:
+            license = UserLicense(
+                user_id=user.id,
+                specialization_type="LFA_FOOTBALL_PLAYER",
+                current_level=1,
+                max_achieved_level=1,
+                started_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                is_active=True,
+                onboarding_completed=True,
+                onboarding_completed_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                payment_verified=True,
+                payment_verified_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                football_skills=_PLAYER_SKILLS.get(email, {}),
+            )
+            db.add(license)
+            db.flush()
+            print(f"      ✅ Created license for {email} (id={license.id}, 29 skills set)")
+        else:
+            # Refresh the license attributes
+            license.is_active = True
+            license.onboarding_completed = True
+            if license.started_at is None:
+                license.started_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+            license.football_skills = _PLAYER_SKILLS.get(email, {})
+            db.flush()
+            print(f"      ⏭️  License exists for {email} — refreshed skills")
+
+        users[email] = user
+
+    return users
+
+
+# ── Phase 4: Historical tournaments + EMA history ──────────────────────────────
+
+def _get_preset(db: Session, code: str) -> GamePreset | None:
+    return db.query(GamePreset).filter(GamePreset.code == code, GamePreset.is_active == True).first()
+
+
+def _get_tt(db: Session, code: str) -> TournamentType | None:
+    return db.query(TournamentType).filter(TournamentType.code == code).first()
+
+
+def _ensure_historical_tournament(
+    db: Session,
+    *,
+    code: str,
+    name: str,
+    tt_code: str,
+    scoring_type: str | None,
+    ranking_direction: str,
+    preset_code: str,
+    start_dt: datetime,
+) -> Semester:
+    """Create a COMPLETED tournament for historical EMA data."""
+    existing = db.query(Semester).filter(Semester.code == code).first()
+    if existing:
+        print(f"   ⏭️  Tournament exists: {code}")
+        return existing
+
+    start_date = start_dt.date() - timedelta(days=7)
+    end_date = start_dt.date()
+
+    t = Semester(
+        code=code,
+        name=name,
+        semester_category=SemesterCategory.TOURNAMENT,
+        status=SemesterStatus.COMPLETED,
+        tournament_status="FINALIZED",
+        age_group="YOUTH",
+        location_id=None,   # will be set after location is created
+        campus_id=None,
+        start_date=start_date,
+        end_date=end_date,
+        enrollment_cost=0,
+        specialization_type="LFA_FOOTBALL_PLAYER",
+    )
+    db.add(t)
+    db.flush()
+
+    tt = _get_tt(db, tt_code)
+    db.add(TournamentConfiguration(
+        semester_id=t.id,
+        tournament_type_id=tt.id if tt else None,
+        scoring_type=scoring_type,
+        ranking_direction=ranking_direction,
+        participant_type="INDIVIDUAL",
+        is_multi_day=False,
+        max_players=32,
+        parallel_fields=1,
+        sessions_generated=False,
+    ))
+
+    preset = _get_preset(db, preset_code)
+    db.add(GameConfiguration(
+        semester_id=t.id,
+        game_preset_id=preset.id if preset else None,
+        game_config={"metadata": {"min_players": 4, "game_type": "football"}, "match_rules": {}},
+    ))
+
+    db.add(TournamentRewardConfig(
+        semester_id=t.id,
+        reward_policy_name="Standard Football",
+        reward_config=_STANDARD_REWARD,
+    ))
+
+    db.flush()
+    print(f"   ✅ Created historical tournament: {name!r} (id={t.id})")
+    return t
+
+
+def _seed_history(db: Session, users: dict[str, User]) -> None:
+    print("\n📈 Phase 4: Historical tournaments + EMA skill history…")
+    print("   (calling record_tournament_participation in chronological order)")
+
+    for idx, hist_cfg in enumerate(_HIST_TOURN_CONFIGS):
+        tourn = _ensure_historical_tournament(
+            db,
+            code=hist_cfg["code"],
+            name=hist_cfg["name"],
+            tt_code=hist_cfg["tt_code"],
+            scoring_type=hist_cfg.get("scoring_type"),
+            ranking_direction=hist_cfg["ranking_direction"],
+            preset_code=hist_cfg["preset_code"],
+            start_dt=hist_cfg["achieved_at"],
+        )
+        db.commit()  # Commit so next call can query prior participations for EMA
+
+        placement_map = PLACEMENTS[idx]
+        print(f"\n   [{hist_cfg['code']}]")
+
+        for email, placement in placement_map.items():
+            user = users.get(email)
+            if not user:
+                print(f"      SKIP {email} — not in users dict")
+                continue
+
+            skill_pts = calculate_skill_points_for_placement(db, tourn.id, placement)
+            plabel = f"{placement}st/nd/rd" if placement else "participant"
+
+            # record_tournament_participation upserts + computes EMA delta
+            record_tournament_participation(
+                db=db,
+                user_id=user.id,
+                tournament_id=tourn.id,
+                placement=placement,
+                skill_points=skill_pts,
+                base_xp=0,     # not awarding XP retroactively
+                credits=0,     # not awarding credits retroactively
+            )
+
+            total_pts = round(sum(skill_pts.values()), 1)
+            print(f"      {email}  placement={plabel}  skill_pts={total_pts}")
+
+        db.commit()
+
+    print("\n   ✅ EMA history written for all 3 tournaments.")
+
+
+# ── Phase 5: Enrollment-open tournaments + camps ───────────────────────────────
+
+def _get_or_create_location(db: Session) -> Location:
+    loc = (
+        db.query(Location)
+        .filter(Location.location_type == LocationType.CENTER, Location.is_active == True)
+        .first()
+    )
+    if loc:
+        return loc
+    loc = Location(
+        name="LFA Budapest Education Center",
+        city="Budapest",
+        country="Hungary",
+        country_code="HU",
+        location_code="BDPST-MIN",
+        postal_code="1146",
+        address="Istvánmezei út 1-3",
+        location_type=LocationType.CENTER,
+        is_active=True,
+    )
+    db.add(loc)
+    db.flush()
+    print(f"   ✅ Created location: {loc.name}")
+    return loc
+
+
+def _get_or_create_campus(db: Session, location: Location) -> Campus:
+    campus = (
+        db.query(Campus)
+        .filter(Campus.location_id == location.id, Campus.is_active == True)
+        .first()
+    )
+    if campus:
+        return campus
+    campus = Campus(
+        location_id=location.id,
+        name="Main Training Campus",
+        venue="Outdoor fields + gym",
+        address="Istvánmezei út 1-3, Budapest",
+        is_active=True,
+    )
+    db.add(campus)
+    db.flush()
+    print(f"   ✅ Created campus: {campus.name}")
+    return campus
+
+
+def _ensure_open_tournament(
+    db: Session,
+    *,
+    code: str,
+    name: str,
+    tt_code: str,
+    scoring_type: str | None,
+    ranking_direction: str,
+    preset_code: str,
+    location: Location,
+    campus: Campus,
+    today: date,
+) -> None:
+    if db.query(Semester).filter(Semester.code == code).first():
+        print(f"   ⏭️  {code} already exists")
+        return
+
+    t = Semester(
+        code=code,
+        name=name,
+        semester_category=SemesterCategory.TOURNAMENT,
+        status=SemesterStatus.READY_FOR_ENROLLMENT,
+        tournament_status="ENROLLMENT_OPEN",
+        age_group="YOUTH",
+        location_id=location.id,
+        campus_id=campus.id,
+        start_date=today + timedelta(days=14),
+        end_date=today + timedelta(days=28),
+        enrollment_cost=0,
+        specialization_type="LFA_FOOTBALL_PLAYER",
+    )
+    db.add(t)
+    db.flush()
+
+    tt = _get_tt(db, tt_code)
+    db.add(TournamentConfiguration(
+        semester_id=t.id,
+        tournament_type_id=tt.id if tt else None,
+        scoring_type=scoring_type,
+        ranking_direction=ranking_direction,
+        participant_type="INDIVIDUAL",
+        is_multi_day=False,
+        max_players=32,
+        parallel_fields=1,
+        sessions_generated=False,
+    ))
+    preset = _get_preset(db, preset_code)
+    db.add(GameConfiguration(
+        semester_id=t.id,
+        game_preset_id=preset.id if preset else None,
+        game_config={"metadata": {"min_players": 4, "game_type": "football"}, "match_rules": {}},
+    ))
+    db.add(TournamentRewardConfig(
+        semester_id=t.id,
+        reward_policy_name="Standard Football",
+        reward_config=_STANDARD_REWARD,
+    ))
+    db.flush()
+    print(f"   ✅ Created open tournament: {name!r}")
+
+
+def _ensure_camp(db: Session, *, code: str, name: str, location: Location,
+                 campus: Campus, today: date, cost: int = 500) -> None:
+    if db.query(Semester).filter(Semester.code == code).first():
+        print(f"   ⏭️  {code} already exists")
+        return
+    c = Semester(
+        code=code,
+        name=name,
+        semester_category=SemesterCategory.CAMP,
+        status=SemesterStatus.READY_FOR_ENROLLMENT,
+        age_group="YOUTH",
+        location_id=location.id,
+        campus_id=campus.id,
+        start_date=today + timedelta(days=45),
+        end_date=today + timedelta(days=52),
+        enrollment_cost=cost,
+        specialization_type="LFA_FOOTBALL_PLAYER",
+    )
+    db.add(c)
+    db.flush()
+    print(f"   ✅ Created camp: {name!r}")
+
+
+def _seed_open_events(db: Session) -> None:
+    print("\n🎯 Phase 5: ENROLLMENT_OPEN tournaments + camps…")
+    today = date.today()
+    location = _get_or_create_location(db)
+    campus = _get_or_create_campus(db, location)
+
+    _ensure_open_tournament(
+        db, code="PLAYABLE-TOURN-H2H-LEAGUE-2026", name="YOUTH League Tournament 2026 — Enrollment Open",
+        tt_code="league", scoring_type=None, ranking_direction="DESC",
+        preset_code="outfield_default", location=location, campus=campus, today=today,
+    )
+    _ensure_open_tournament(
+        db, code="PLAYABLE-TOURN-SCORE-2026", name="YOUTH Score Challenge 2026 — Enrollment Open",
+        tt_code="score_based", scoring_type="SCORE_BASED", ranking_direction="DESC",
+        preset_code="shooting_focus", location=location, campus=campus, today=today,
+    )
+    _ensure_open_tournament(
+        db, code="PLAYABLE-TOURN-TIME-2026", name="YOUTH Time Trial Series 2026 — Enrollment Open",
+        tt_code="time_based", scoring_type="TIME_BASED", ranking_direction="ASC",
+        preset_code="passing_focus", location=location, campus=campus, today=today,
+    )
+    _ensure_camp(
+        db, code="PLAYABLE-CAMP-SUMMER-2026-YOUTH", name="Summer Football Camp 2026 — YOUTH",
+        location=location, campus=campus, today=today, cost=500,
+    )
+    _ensure_camp(
+        db, code="PLAYABLE-CAMP-AUTUMN-2026-YOUTH", name="Autumn Development Camp 2026 — YOUTH",
+        location=location, campus=campus, today=today, cost=350,
+    )
+    db.commit()
+
+
+# ── Summary ────────────────────────────────────────────────────────────────────
+
+def _print_summary(db: Session) -> None:
+    from app.models.tournament_achievement import TournamentParticipation
+
+    print("\n" + "=" * 70)
+    print("✅ FULL PLAYABLE SYSTEM READY")
+
+    open_t = db.query(Semester).filter(
+        Semester.semester_category == SemesterCategory.TOURNAMENT,
+        Semester.tournament_status == "ENROLLMENT_OPEN",
+    ).count()
+    open_c = db.query(Semester).filter(
+        Semester.semester_category == SemesterCategory.CAMP,
+        Semester.status == SemesterStatus.READY_FOR_ENROLLMENT,
+    ).count()
+    total_tp = db.query(TournamentParticipation).filter(
+        TournamentParticipation.user_id.in_(
+            [db.query(User.id).filter(User.email == e).scalar() for e in PLAYERS]
+        )
+    ).count()
+
+    print(f"   Game presets in DB        : {db.query(GamePreset).count()}")
+    print(f"   Tournament types in DB    : {db.query(TournamentType).count()}")
+    print(f"   ENROLLMENT_OPEN tournaments: {open_t}")
+    print(f"   ENROLLMENT_OPEN camps     : {open_c}")
+    print(f"   TournamentParticipation rows: {total_tp}")
+    print()
+    print("   Test users (password: Player1234!):")
+    for email in PLAYERS:
+        u = db.query(User).filter(User.email == email).first()
+        if u:
+            lic = db.query(UserLicense).filter(
+                UserLicense.user_id == u.id,
+                UserLicense.specialization_type == "LFA_FOOTBALL_PLAYER",
+            ).first()
+            fs = "✅" if (lic and lic.football_skills) else "❌"
+            tp_count = db.query(TournamentParticipation).filter(
+                TournamentParticipation.user_id == u.id
+            ).count()
+            ema = db.query(TournamentParticipation).filter(
+                TournamentParticipation.user_id == u.id,
+                TournamentParticipation.skill_rating_delta.isnot(None),
+            ).count()
+            print(f"   [{email}]  skills={fs}  participations={tp_count}  EMA_deltas={ema}")
+    print()
+    print("   Journey:")
+    print("     /login  →  report_490c3e64@t.com / Player1234!")
+    print("     /dashboard  →  ENTER  →  /dashboard/lfa-football-player")
+    print("     /skills/history  →  3-tournament EMA chart")
+    print("     Available Events tab  →  3 tournaments + 2 camps")
+    print("=" * 70)
+
+
+# ── Entry point ────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    print("🚀 seed_full_playable.py — Full Playable System Seed")
+    print("=" * 70)
+
+    db = SessionLocal()
+    try:
+        _seed_game_presets(db)
+        db.commit()
+
+        _seed_tournament_types(db)
+        db.commit()
+
+        users = _seed_users(db)
+        db.commit()
+
+        _seed_history(db, users)
+        # _seed_history already commits after each tournament
+
+        _seed_open_events(db)
+        # _seed_open_events commits at the end
+
+        _print_summary(db)
+
+    except Exception as e:
+        db.rollback()
+        print(f"\n❌ SEED FAILED: {e}")
+        import traceback
+        traceback.print_exc()
+        raise
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Creates `scripts/demo/` — a canonical demo subdirectory with a single dispatcher entrypoint and four presentation-ready seed scenarios.  **Phase 1 only: additive, zero behavior change.  No originals deleted or modified.**

## Files created (6)

| File | Description |
|------|-------------|
| `scripts/demo/run_demo.py` | Single dispatcher; `runpy.run_path(..., run_name='__main__')` routes to one of 4 scenarios |
| `scripts/demo/reset_full.py` | Byte-identical copy of `scripts/reset_and_seed_full.py` |
| `scripts/demo/seed_skill_progression.py` | Byte-identical copy of `scripts/seed_full_playable.py` |
| `scripts/demo/seed_events.py` | Byte-identical copy of `scripts/seed_events_demo.py` |
| `scripts/demo/seed_minimal.py` | Byte-identical copy of `scripts/seed_minimum_playable.py` |
| `scripts/demo/README.md` | Scenario docs (purpose, destructive flag, runtime, use-case, credentials) |

## Byte-identical verification

```
diff scripts/reset_and_seed_full.py    scripts/demo/reset_full.py            → identical
diff scripts/seed_full_playable.py     scripts/demo/seed_skill_progression.py → identical
diff scripts/seed_events_demo.py       scripts/demo/seed_events.py            → identical
diff scripts/seed_minimum_playable.py  scripts/demo/seed_minimal.py           → identical
```

## Dispatcher behaviour

`run_demo.py [scenario]` — accepts `full` (default), `skill`, `events`, `minimal`.  Uses `runpy.run_path(script_path, run_name='__main__')` so each script runs exactly as if invoked directly.  Unknown scenario names exit with a clear error message.

## README contents (per scenario)

Each of the 4 scenarios is documented with:
- Purpose and what it creates
- Destructive vs additive flag
- Expected runtime
- Recommended demo use-case
- Credentials / entry users (emails + passwords)
- Prerequisites (if any)

Also includes a scenario decision guide and naming convention table.

## Zero-behavior-change validation

- All 5 Python files pass `python3 -m py_compile` ✅
- All 4 copies are byte-for-byte identical to originals (`diff` confirms) ✅
- Dispatcher imports cleanly; scenario table resolves all 4 keys to correct filenames ✅
- Originals in `scripts/` untouched ✅
- No test files, no models, no routes, no application code modified ✅

## Out of scope (Phase 2 — not started, requires explicit approval)

- Delete originals from `scripts/` root
- Add demo pointer to `scripts/README.md`
- Reorganise CI scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)