### PR TITLE
ci(baseline): add tests/database/ to required unit-tests job

### DIFF
--- a/.github/workflows/test-baseline-check.yml
+++ b/.github/workflows/test-baseline-check.yml
@@ -61,7 +61,7 @@ jobs:
         DATABASE_URL: postgresql://postgres:postgres@localhost:5432/lfa_intern_system_test
         SECRET_KEY: test-secret-key-for-ci-only-not-production
       run: |
-        pytest tests/unit/ tests/integration/tournament/ tests/integration/web_flows/ tests/integration/domain/ \
+        pytest tests/unit/ tests/database/ tests/integration/tournament/ tests/integration/web_flows/ tests/integration/domain/ \
           -q --tb=line -v \
           --cov=app \
           --cov-branch \

--- a/tests/database/test_db_constraints.py
+++ b/tests/database/test_db_constraints.py
@@ -5,12 +5,16 @@ This test verifies that the unique constraints added in Phase 1
 successfully prevent dual-path bugs at the database level.
 """
 
+import os
 import sys
 import pytest
 from sqlalchemy import create_engine, text
 from sqlalchemy.exc import IntegrityError
 
-DATABASE_URL = "postgresql://postgres:postgres@localhost:5432/lfa_intern_system"
+DATABASE_URL = os.environ.get(
+    "DATABASE_URL",
+    "postgresql://postgres:postgres@localhost:5432/lfa_intern_system"
+)
 
 @pytest.mark.xfail(reason="Requires user_id=2 in dev DB; not present in test environment")
 def test_xp_transactions_constraint():

--- a/tests/database/test_enrollment_db_constraints.py
+++ b/tests/database/test_enrollment_db_constraints.py
@@ -19,11 +19,15 @@ Safety: All inserts are inside explicit transactions that are rolled back
 after each test — no persistent data is written.
 """
 
+import os
 import pytest
 from sqlalchemy import create_engine, text
 from sqlalchemy.exc import IntegrityError
 
-DATABASE_URL = "postgresql://postgres:postgres@localhost:5432/lfa_intern_system"
+DATABASE_URL = os.environ.get(
+    "DATABASE_URL",
+    "postgresql://postgres:postgres@localhost:5432/lfa_intern_system"
+)
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
## Summary

- Adds `tests/database/` to the `pytest` invocation in the `unit-tests` job of `test-baseline-check.yml`
- Fixes `tests/database/test_db_constraints.py` to read `DATABASE_URL` from the environment rather than using a hardcoded dev DB name

## Why

Diagnosed during PR-A review: `tests/database/` was entirely absent from all CI workflows, and the hardcoded `lfa_intern_system` database name made the test unreachable in CI regardless of workflow configuration.

Both required checks (`api-smoke-tests`, `performance-regression-gate`) are path-filtered to `app/api/**` and specific performance files. Any PR touching `app/services/**` or `alembic/versions/**` received **zero required CI signal**. The `test-baseline-check.yml` job covers those paths but was not a required check.

## Effect

After this PR merges and branch protection is updated:
- `"Unit Tests (Baseline: 0 failed, 0 errors)"` will be added to required status checks
- That job runs on ALL PRs (no path filter) — every service-layer or migration PR gets a hard gate
- `tests/database/` is included in the run; all three constraint tests remain `xfail` (require seeded `user_id=2`) — they report as expected failures, not errors
- The `xfail` markers will be upgraded in PR-A when the migration ships with CI-compatible test user seeding

## Test plan

- [ ] `"Unit Tests (Baseline: 0 failed, 0 errors)"` check appears and passes on this PR
- [ ] `tests/database/` tests run: 0 failed, 3 xfailed
- [ ] Branch protection updated: check appears in required contexts

🤖 Generated with [Claude Code](https://claude.com/claude-code)