### PR TITLE
feat(segments): POST /api/v1/sessions/{id}/segments — Track 1 smallest scope

### DIFF
--- a/app/api/api_v1/endpoints/sessions/__init__.py
+++ b/app/api/api_v1/endpoints/sessions/__init__.py
@@ -19,14 +19,15 @@ Combines:
 """
 from fastapi import APIRouter
 
-from . import crud, queries, checkin, availability
+from . import crud, queries, checkin, availability, segments
 
 # Create main router
 router = APIRouter()
 
 # Include sub-routers
 # IMPORTANT: Order matters! CRUD routes with path parameters must come after specific routes
-router.include_router(queries.router)  # Includes /recommendations, /instructor/my, /calendar first
+router.include_router(queries.router)    # Includes /recommendations, /instructor/my, /calendar first
 router.include_router(availability.router)  # Includes /availability (batch queries)
-router.include_router(checkin.router)  # Includes /{session_id}/check-in (instructor check-in)
-router.include_router(crud.router)     # Then includes /{session_id} routes
+router.include_router(checkin.router)    # Includes /{session_id}/check-in (instructor check-in)
+router.include_router(segments.router)   # Includes /{session_id}/segments (before /{session_id} CRUD)
+router.include_router(crud.router)       # Then includes /{session_id} routes

--- a/app/api/api_v1/endpoints/sessions/segments.py
+++ b/app/api/api_v1/endpoints/sessions/segments.py
@@ -1,0 +1,86 @@
+"""
+Session segment creation endpoint.
+
+POST /api/v1/sessions/{session_id}/segments
+  — Admin or Instructor only.
+  — Instructors may only add segments to sessions they own (instructor_id == current user).
+  — Returns 409 if the (session_id, position) pair already exists.
+"""
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from .....database import get_db
+from .....dependencies import get_current_admin_or_instructor_user
+from .....models.session import Session as SessionModel
+from .....models.session_segment import SessionSegment
+from .....models.user import User, UserRole
+from .....schemas.session_segment import SessionSegmentCreate, SessionSegmentRead
+
+router = APIRouter()
+
+
+@router.post(
+    "/{session_id}/segments",
+    response_model=SessionSegmentRead,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create a session segment",
+    tags=["session-segments"],
+)
+def create_session_segment(
+    session_id: int,
+    segment_data: SessionSegmentCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_admin_or_instructor_user),
+) -> Any:
+    """
+    Add a single drill/exercise segment to an existing session.
+
+    - **Admin**: may add segments to any session.
+    - **Instructor**: may only add segments to sessions they own
+      (`session.instructor_id == current_user.id`).
+    - Returns **409** if a segment at the given `position` already exists for this session.
+    """
+    session = (
+        db.query(SessionModel)
+        .filter(SessionModel.id == session_id)
+        .first()
+    )
+    if session is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Session not found",
+        )
+
+    # Instructors may only modify their own sessions
+    if current_user.role == UserRole.INSTRUCTOR:
+        if session.instructor_id != current_user.id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="You can only add segments to sessions you own.",
+            )
+
+    segment = SessionSegment(
+        session_id=session_id,
+        position=segment_data.position,
+        label=segment_data.label,
+        duration_minutes=segment_data.duration_minutes,
+        skill_targets=segment_data.skill_targets,
+        is_active=True,
+    )
+    db.add(segment)
+
+    try:
+        db.flush()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"A segment at position {segment_data.position} already exists for this session.",
+        )
+
+    db.commit()
+    db.refresh(segment)
+    return segment

--- a/app/schemas/session_segment.py
+++ b/app/schemas/session_segment.py
@@ -1,0 +1,68 @@
+"""
+Pydantic schemas for session segments.
+
+SessionSegmentCreate — input for POST /api/v1/sessions/{id}/segments
+SessionSegmentRead   — output for the same endpoint
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class SessionSegmentCreate(BaseModel):
+    """Input schema for creating a single session segment."""
+
+    label: str = Field(
+        ...,
+        min_length=1,
+        max_length=200,
+        description="Human-readable name for this drill/exercise.",
+    )
+    position: int = Field(
+        ...,
+        ge=0,
+        le=32767,
+        description="Zero-based display order within the session. Must be unique per session.",
+    )
+    duration_minutes: Optional[int] = Field(
+        None,
+        ge=1,
+        le=300,
+        description="Planned duration in minutes (informational only).",
+    )
+    skill_targets: Optional[Dict[str, float]] = Field(
+        None,
+        description=(
+            "Map of skill_key → weight. NULL = inherit from session game_preset at result time. "
+            "All weights must be > 0."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def validate_skill_targets(self) -> "SessionSegmentCreate":
+        if self.skill_targets is not None:
+            for key, val in self.skill_targets.items():
+                if val <= 0:
+                    raise ValueError(
+                        f"skill_targets['{key}'] must be > 0, got {val}"
+                    )
+        return self
+
+
+class SessionSegmentRead(BaseModel):
+    """Output schema for a session segment."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    session_id: int
+    position: int
+    label: str
+    duration_minutes: Optional[int] = None
+    skill_targets: Optional[Dict[str, float]] = None
+    is_active: bool
+    created_at: datetime
+    updated_at: datetime

--- a/tests/integration/api_smoke/test_sessions_smoke.py
+++ b/tests/integration/api_smoke/test_sessions_smoke.py
@@ -767,5 +767,72 @@ class TestSessionsSmoke:
         assert response.status_code in [400, 401, 403, 404, 422], (
             f"POST /{session_id}/check-in should validate input: {response.status_code}"
         )
-        
+
+    # ── POST /{session_id}/segments ──────────────────────
+
+    def test_create_session_segment_happy_path(self, api_client: TestClient, admin_token: str):
+        """
+        Happy path: POST /{session_id}/segments
+        Source: app/api/api_v1/endpoints/sessions/segments.py:create_session_segment
+        """
+        headers = {"Authorization": f"Bearer {admin_token}"}
+        payload = {
+            "label": "Smoke Test Drill",
+            "position": 0,
+            "duration_minutes": 15,
+        }
+
+        response = api_client.post("/{session_id}/segments", json=payload, headers=headers)
+
+        assert response.status_code in [200, 201, 202, 204, 400, 401, 403, 404, 405, 409, 422], (
+            f"POST /{{session_id}}/segments failed: {response.status_code} {response.text}"
+        )
+
+    def test_create_session_segment_auth_required(self, api_client: TestClient):
+        """
+        Auth validation: POST /{session_id}/segments requires authentication
+        """
+        payload = {"label": "No Auth Drill", "position": 0}
+
+        response = api_client.post("/{session_id}/segments", json=payload)
+
+        assert response.status_code in [200, 400, 401, 403, 404, 405, 422], (
+            f"POST /{{session_id}}/segments should require auth: {response.status_code}"
+        )
+
+    def test_create_session_segment_input_validation(self, api_client: TestClient, admin_token: str):
+        """
+        Input validation: POST /{session_id}/segments rejects invalid payloads
+        """
+        headers = {"Authorization": f"Bearer {admin_token}"}
+
+        # Empty label must be rejected
+        response = api_client.post(
+            "/{session_id}/segments",
+            json={"label": "", "position": 0},
+            headers=headers,
+        )
+        assert response.status_code in [400, 401, 403, 404, 422], (
+            f"Empty label should be rejected: {response.status_code}"
+        )
+
+    def test_create_session_segment_negative_skill_target_rejected(
+        self, api_client: TestClient, admin_token: str
+    ):
+        """
+        Input validation: skill_targets with value <= 0 must be rejected (422)
+        """
+        headers = {"Authorization": f"Bearer {admin_token}"}
+        payload = {
+            "label": "Bad Skill Drill",
+            "position": 0,
+            "skill_targets": {"passing": -1.0},
+        }
+
+        response = api_client.post("/{session_id}/segments", json=payload, headers=headers)
+
+        assert response.status_code in [400, 401, 403, 404, 422], (
+            f"Negative skill_target weight should be rejected: {response.status_code}"
+        )
+
 

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -15944,6 +15944,131 @@
         "title": "SessionList",
         "type": "object"
       },
+      "SessionSegmentCreate": {
+        "description": "Input schema for creating a single session segment.",
+        "properties": {
+          "duration_minutes": {
+            "anyOf": [
+              {
+                "maximum": 300.0,
+                "minimum": 1.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Planned duration in minutes (informational only).",
+            "title": "Duration Minutes"
+          },
+          "label": {
+            "description": "Human-readable name for this drill/exercise.",
+            "maxLength": 200,
+            "minLength": 1,
+            "title": "Label",
+            "type": "string"
+          },
+          "position": {
+            "description": "Zero-based display order within the session. Must be unique per session.",
+            "maximum": 32767.0,
+            "minimum": 0.0,
+            "title": "Position",
+            "type": "integer"
+          },
+          "skill_targets": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "number"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Map of skill_key \u2192 weight. NULL = inherit from session game_preset at result time. All weights must be > 0.",
+            "title": "Skill Targets"
+          }
+        },
+        "required": [
+          "label",
+          "position"
+        ],
+        "title": "SessionSegmentCreate",
+        "type": "object"
+      },
+      "SessionSegmentRead": {
+        "description": "Output schema for a session segment.",
+        "properties": {
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "duration_minutes": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Duration Minutes"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "is_active": {
+            "title": "Is Active",
+            "type": "boolean"
+          },
+          "label": {
+            "title": "Label",
+            "type": "string"
+          },
+          "position": {
+            "title": "Position",
+            "type": "integer"
+          },
+          "session_id": {
+            "title": "Session Id",
+            "type": "integer"
+          },
+          "skill_targets": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "number"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Skill Targets"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "title": "Updated At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "session_id",
+          "position",
+          "label",
+          "is_active",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "SessionSegmentRead",
+        "type": "object"
+      },
       "SessionSummaryResponse": {
         "properties": {
           "correct_answers": {
@@ -48049,6 +48174,65 @@
         "tags": [
           "sessions",
           "game-results"
+        ]
+      }
+    },
+    "/api/v1/sessions/{session_id}/segments": {
+      "post": {
+        "description": "Add a single drill/exercise segment to an existing session.\n\n- **Admin**: may add segments to any session.\n- **Instructor**: may only add segments to sessions they own\n  (`session.instructor_id == current_user.id`).\n- Returns **409** if a segment at the given `position` already exists for this session.",
+        "operationId": "create_session_segment_api_v1_sessions__session_id__segments_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "title": "Session Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SessionSegmentCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionSegmentRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Create a session segment",
+        "tags": [
+          "sessions",
+          "session-segments"
         ]
       }
     },

--- a/tests/unit/api/test_create_session_segment.py
+++ b/tests/unit/api/test_create_session_segment.py
@@ -1,0 +1,229 @@
+"""
+Unit tests for POST /api/v1/sessions/{session_id}/segments.
+
+Coverage:
+  Schema validation (no DB access):
+    - valid payload accepted
+    - label empty → ValidationError
+    - label too long (>200 chars) → ValidationError
+    - position negative → ValidationError
+    - position > 32767 → ValidationError
+    - duration_minutes 0 → ValidationError
+    - skill_targets with value == 0 → ValidationError
+    - skill_targets with value < 0 → ValidationError
+    - skill_targets with value > 0 → accepted
+    - skill_targets=None → accepted (inherit from preset)
+
+  Endpoint logic (MagicMock db):
+    - session not found → 404
+    - instructor owns the session → 201
+    - instructor does not own the session → 403
+    - duplicate position (IntegrityError) → 409
+"""
+
+import pytest
+from pydantic import ValidationError
+from unittest.mock import MagicMock, patch
+from sqlalchemy.exc import IntegrityError
+from fastapi import HTTPException
+
+from app.schemas.session_segment import SessionSegmentCreate
+from app.api.api_v1.endpoints.sessions.segments import create_session_segment
+from app.models.user import UserRole
+
+_BASE = "app.api.api_v1.endpoints.sessions.segments"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Pydantic schema validation — pure, no DB
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestSessionSegmentCreateSchema:
+    def test_valid_minimal(self):
+        s = SessionSegmentCreate(label="Passing Drill", position=0)
+        assert s.label == "Passing Drill"
+        assert s.position == 0
+        assert s.duration_minutes is None
+        assert s.skill_targets is None
+
+    def test_valid_full(self):
+        s = SessionSegmentCreate(
+            label="Finishing Drill",
+            position=2,
+            duration_minutes=20,
+            skill_targets={"finishing": 1.5, "passing": 0.5},
+        )
+        assert s.skill_targets == {"finishing": 1.5, "passing": 0.5}
+
+    def test_empty_label_rejected(self):
+        with pytest.raises(ValidationError):
+            SessionSegmentCreate(label="", position=0)
+
+    def test_label_too_long_rejected(self):
+        with pytest.raises(ValidationError):
+            SessionSegmentCreate(label="x" * 201, position=0)
+
+    def test_negative_position_rejected(self):
+        with pytest.raises(ValidationError):
+            SessionSegmentCreate(label="Drill", position=-1)
+
+    def test_position_over_max_rejected(self):
+        with pytest.raises(ValidationError):
+            SessionSegmentCreate(label="Drill", position=32768)
+
+    def test_duration_zero_rejected(self):
+        with pytest.raises(ValidationError):
+            SessionSegmentCreate(label="Drill", position=0, duration_minutes=0)
+
+    def test_skill_target_zero_rejected(self):
+        with pytest.raises(ValidationError):
+            SessionSegmentCreate(
+                label="Drill", position=0, skill_targets={"passing": 0.0}
+            )
+
+    def test_skill_target_negative_rejected(self):
+        with pytest.raises(ValidationError):
+            SessionSegmentCreate(
+                label="Drill", position=0, skill_targets={"passing": -0.1}
+            )
+
+    def test_skill_targets_positive_accepted(self):
+        s = SessionSegmentCreate(
+            label="Drill", position=0, skill_targets={"passing": 0.01}
+        )
+        assert s.skill_targets == {"passing": 0.01}
+
+    def test_skill_targets_none_accepted(self):
+        s = SessionSegmentCreate(label="Drill", position=0, skill_targets=None)
+        assert s.skill_targets is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Endpoint logic — MagicMock db
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _make_user(role=UserRole.ADMIN, user_id=1):
+    u = MagicMock()
+    u.id = user_id
+    u.role = role
+    return u
+
+
+def _make_session(session_id=10, instructor_id=2):
+    s = MagicMock()
+    s.id = session_id
+    s.instructor_id = instructor_id
+    return s
+
+
+def _make_segment(segment_id=99, session_id=10, position=0):
+    seg = MagicMock()
+    seg.id = segment_id
+    seg.session_id = session_id
+    seg.position = position
+    seg.label = "Test Drill"
+    seg.duration_minutes = None
+    seg.skill_targets = None
+    seg.is_active = True
+    from datetime import datetime, timezone
+    seg.created_at = datetime.now(timezone.utc)
+    seg.updated_at = datetime.now(timezone.utc)
+    return seg
+
+
+def _valid_input(**kwargs):
+    defaults = {"label": "Test Drill", "position": 0}
+    defaults.update(kwargs)
+    return SessionSegmentCreate(**defaults)
+
+
+class TestCreateSessionSegmentEndpoint:
+    def _db(self):
+        return MagicMock()
+
+    def test_session_not_found_returns_404(self):
+        db = self._db()
+        db.query.return_value.filter.return_value.first.return_value = None
+
+        with pytest.raises(HTTPException) as exc:
+            create_session_segment(
+                session_id=999,
+                segment_data=_valid_input(),
+                db=db,
+                current_user=_make_user(),
+            )
+        assert exc.value.status_code == 404
+        assert "not found" in exc.value.detail.lower()
+
+    def test_admin_can_create_on_any_session(self):
+        db = self._db()
+        session = _make_session(instructor_id=99)  # different owner
+        segment = _make_segment()
+
+        # db.query().filter().first() returns session on first call
+        q = MagicMock()
+        q.filter.return_value.first.return_value = session
+        db.query.return_value = q
+        db.refresh.side_effect = lambda obj: setattr(obj, "__dict__", segment.__dict__)
+
+        result = create_session_segment(
+            session_id=10,
+            segment_data=_valid_input(),
+            db=db,
+            current_user=_make_user(role=UserRole.ADMIN, user_id=1),
+        )
+        db.add.assert_called_once()
+        db.flush.assert_called_once()
+        db.commit.assert_called_once()
+
+    def test_instructor_owns_session_allowed(self):
+        db = self._db()
+        session = _make_session(instructor_id=5)
+
+        q = MagicMock()
+        q.filter.return_value.first.return_value = session
+        db.query.return_value = q
+
+        create_session_segment(
+            session_id=10,
+            segment_data=_valid_input(),
+            db=db,
+            current_user=_make_user(role=UserRole.INSTRUCTOR, user_id=5),
+        )
+        db.add.assert_called_once()
+
+    def test_instructor_does_not_own_session_returns_403(self):
+        db = self._db()
+        session = _make_session(instructor_id=99)  # owned by user 99
+
+        q = MagicMock()
+        q.filter.return_value.first.return_value = session
+        db.query.return_value = q
+
+        with pytest.raises(HTTPException) as exc:
+            create_session_segment(
+                session_id=10,
+                segment_data=_valid_input(),
+                db=db,
+                current_user=_make_user(role=UserRole.INSTRUCTOR, user_id=5),
+            )
+        assert exc.value.status_code == 403
+
+    def test_duplicate_position_returns_409(self):
+        db = self._db()
+        session = _make_session(instructor_id=1)
+
+        q = MagicMock()
+        q.filter.return_value.first.return_value = session
+        db.query.return_value = q
+        db.flush.side_effect = IntegrityError("stmt", {}, Exception("unique"))
+
+        with pytest.raises(HTTPException) as exc:
+            create_session_segment(
+                session_id=10,
+                segment_data=_valid_input(position=0),
+                db=db,
+                current_user=_make_user(role=UserRole.ADMIN),
+            )
+        assert exc.value.status_code == 409
+        assert "position 0" in exc.value.detail


### PR DESCRIPTION
## Summary

- New `POST /api/v1/sessions/{session_id}/segments` endpoint (Admin + Instructor only)
- New Pydantic schemas: `SessionSegmentCreate` / `SessionSegmentRead`
- Router registered in `sessions/__init__.py` before CRUD to avoid path-parameter swallowing
- OpenAPI snapshot updated: 661 → 662 routes

## Endpoint contract

```
POST /api/v1/sessions/{session_id}/segments
Authorization: Bearer <admin|instructor token>
Content-Type: application/json
```

**Request body** (`SessionSegmentCreate`):
| Field | Type | Required | Constraints |
|---|---|---|---|
| `label` | string | yes | 1–200 chars |
| `position` | int | yes | 0–32767, unique per session |
| `duration_minutes` | int | no | 1–300 |
| `skill_targets` | dict[str, float] | no | all values > 0; `null` = inherit from preset |

**Responses**:
| Code | Condition |
|---|---|
| 201 | Created — returns `SessionSegmentRead` |
| 403 | Instructor doesn't own the session |
| 404 | Session not found |
| 409 | Segment at that position already exists |
| 422 | Pydantic validation failure |

## Tests added

- `tests/unit/api/test_create_session_segment.py` — 16 tests
  - 11 schema validation (pure Pydantic, no DB)
  - 5 endpoint logic (MagicMock db): 404, admin bypass, instructor owns, instructor 403, duplicate 409
- `tests/integration/api_smoke/test_sessions_smoke.py` — 4 new smoke tests appended

## Validation results

```
tests/unit/api/test_create_session_segment.py    16 passed
tests/unit/ + tests/database/                  7242 passed, 0 failed
OpenAPI routes: 661 → 662
```

## No existing routes or schemas changed

- `app/schemas/session_segment.py` — new file only
- `app/api/api_v1/endpoints/sessions/segments.py` — new file only
- `app/api/api_v1/endpoints/sessions/__init__.py` — one import + one `include_router` added
- No other session endpoints, no other schemas, no models, no migrations touched

## Out of scope (next PRs, require explicit approval)

- Segment PATCH / DELETE / reorder
- Admin UI for segment management
- Track 2 demo seeds
- Track 3 read-model/UX exposure

## Test plan

- [ ] CI unit tests green
- [ ] CI API smoke tests green
- [ ] Manual: `POST /api/v1/sessions/{id}/segments` with admin token → 201
- [ ] Manual: repeat same position → 409
- [ ] Manual: instructor token on foreign session → 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)