### PR TITLE
ci: extend workflow PR triggers to feat/*, fix/*, refactor/* branches

### DIFF
--- a/.github/workflows/attendance-integration.yml
+++ b/.github/workflows/attendance-integration.yml
@@ -2,7 +2,7 @@ name: Attendance Feature Integration (ATT-01..06 + IND-ATT-01..04)
 
 on:
   pull_request:
-    branches: [main, develop, "feature/*", "fix/*"]
+    branches: [main, develop, "feature/*", "feat/*", "fix/*", "refactor/*"]
     paths:
       - 'app/models/team.py'
       - 'app/models/session.py'

--- a/.github/workflows/e2e-admin-menu.yml
+++ b/.github/workflows/e2e-admin-menu.yml
@@ -2,7 +2,7 @@ name: E2E Admin Menu Restructure
 
 on:
   pull_request:
-    branches: [main, develop, "feature/*", "fix/*"]
+    branches: [main, develop, "feature/*", "feat/*", "fix/*", "refactor/*"]
     paths:
       - 'app/**'
       - 'app/templates/admin/**'

--- a/.github/workflows/e2e-clean-db-bootstrap.yml
+++ b/.github/workflows/e2e-clean-db-bootstrap.yml
@@ -6,7 +6,7 @@ name: Clean-DB Bootstrap + E2E Matrix
 
 on:
   pull_request:
-    branches: [main, develop, "feature/*", "fix/*"]
+    branches: [main, develop, "feature/*", "feat/*", "fix/*", "refactor/*"]
     paths:
       - 'scripts/bootstrap_clean.py'
       - 'scripts/validate_seed_state.py'

--- a/.github/workflows/e2e-lifecycle-visibility.yml
+++ b/.github/workflows/e2e-lifecycle-visibility.yml
@@ -9,7 +9,7 @@ name: E2E Lifecycle Visibility (state machine + /events/{id} invariant)
 
 on:
   pull_request:
-    branches: [main, develop, "feature/*", "fix/*"]
+    branches: [main, develop, "feature/*", "feat/*", "fix/*", "refactor/*"]
     paths:
       - 'app/api/web_routes/admin.py'
       - 'app/api/api_v1/endpoints/tournaments/lifecycle.py'

--- a/.github/workflows/e2e-promotion-flow.yml
+++ b/.github/workflows/e2e-promotion-flow.yml
@@ -2,7 +2,7 @@ name: E2E Promotion Flow (Club / CSV Import / Tournaments)
 
 on:
   pull_request:
-    branches: [main, develop, "feature/*", "fix/*"]
+    branches: [main, develop, "feature/*", "feat/*", "fix/*", "refactor/*"]
     paths:
       - 'app/**'
       - 'tests/e2e/admin_ui/test_promotion_flow_e2e.py'

--- a/.github/workflows/e2e-team-flow.yml
+++ b/.github/workflows/e2e-team-flow.yml
@@ -2,7 +2,7 @@ name: E2E Team Flow (Captain / Admin / Auth)
 
 on:
   pull_request:
-    branches: [main, develop, "feature/*", "fix/*"]
+    branches: [main, develop, "feature/*", "feat/*", "fix/*", "refactor/*"]
     paths:
       - 'app/**'
       - 'tests/e2e/admin_ui/test_team_flow_e2e.py'

--- a/.github/workflows/e2e-wizard-coverage.yml
+++ b/.github/workflows/e2e-wizard-coverage.yml
@@ -2,7 +2,7 @@ name: E2E Wizard Coverage
 
 on:
   pull_request:
-    branches: [ main, develop, feature/* ]
+    branches: [ main, develop, "feature/*", "feat/*", "fix/*", "refactor/*" ]
     paths:
       - 'app/**'
       - 'tests/e2e/test_tournament_monitor*.py'

--- a/.github/workflows/session-gen-legs.yml
+++ b/.github/workflows/session-gen-legs.yml
@@ -2,7 +2,7 @@ name: Session Gen — Multi-Leg Round Robin (LEGS-01..05 + SGM-11..12)
 
 on:
   pull_request:
-    branches: [main, develop, "feature/*", "fix/*"]
+    branches: [main, develop, "feature/*", "feat/*", "fix/*", "refactor/*"]
     paths:
       - 'alembic/versions/2026_03_28_1200_number_of_legs.py'
       - 'app/models/tournament_configuration.py'

--- a/.github/workflows/skill-weight-regression.yml
+++ b/.github/workflows/skill-weight-regression.yml
@@ -6,7 +6,7 @@ name: Skill Weight Pipeline — Regression Gate
 # Previous path-based filter removed to support branch protection rules.
 on:
   pull_request:
-    branches: [ main, develop, feature/* ]
+    branches: [ main, develop, "feature/*", "feat/*", "fix/*", "refactor/*" ]
     # REMOVED: paths filter (was blocking PRs that don't touch skill weight files)
     # Reason: Required checks must run on ALL PRs for GitHub branch protection
   push:

--- a/.github/workflows/state-machine-validation.yml
+++ b/.github/workflows/state-machine-validation.yml
@@ -2,7 +2,7 @@ name: State Machine Graph Validation
 
 on:
   pull_request:
-    branches: [ main, develop, feature/* ]
+    branches: [ main, develop, "feature/*", "feat/*", "fix/*", "refactor/*" ]
     paths:
       - 'app/services/tournament/status_validator.py'
       - 'tests/unit/tournament/test_state_machine.py'

--- a/.github/workflows/test-baseline-check.yml
+++ b/.github/workflows/test-baseline-check.yml
@@ -2,7 +2,7 @@ name: Test Baseline Check
 
 on:
   pull_request:
-    branches: [ main, develop, feature/* ]
+    branches: [ main, develop, "feature/*", "feat/*", "fix/*", "refactor/*" ]
   push:
     branches: [ main, develop ]
   workflow_dispatch:  # manual trigger via GitHub UI → Actions → Run workflow

--- a/.github/workflows/tournament-type-matrix.yml
+++ b/.github/workflows/tournament-type-matrix.yml
@@ -2,7 +2,7 @@ name: Tournament Type Matrix (SRL-09..15 + Seed + E2E)
 
 on:
   pull_request:
-    branches: [main, develop, "feature/*", "fix/*"]
+    branches: [main, develop, "feature/*", "feat/*", "fix/*", "refactor/*"]
     paths:
       - 'app/api/api_v1/endpoints/tournaments/calculate_rankings.py'
       - 'app/services/tournament/ranking/**'


### PR DESCRIPTION
## Summary

- Extended `on.pull_request.branches` in all 12 workflow files to include `"feat/*"`, `"fix/*"`, and `"refactor/*"` alongside the existing `"feature/*"`
- No job logic, steps, conditions, matrix definitions, or environment variables changed — only the branch-filter list on each `pull_request` trigger

## Root cause

CI workflows only listed `feature/*` as PR targets. PRs from `feat/*` branches (e.g. `feat/session-segment-patch-endpoint-2026-04-21`) never auto-triggered CI, requiring manual `gh workflow run` calls.

## Files changed (12)

| File | Before | After |
|------|--------|-------|
| `test-baseline-check.yml` | `[ main, develop, feature/* ]` | `[ main, develop, "feature/*", "feat/*", "fix/*", "refactor/*" ]` |
| `e2e-wizard-coverage.yml` | same | same fix |
| `skill-weight-regression.yml` | same | same fix |
| `state-machine-validation.yml` | same | same fix |
| `attendance-integration.yml` | `[main, develop, "feature/*", "fix/*"]` | `[main, develop, "feature/*", "feat/*", "fix/*", "refactor/*"]` |
| `e2e-admin-menu.yml` | same | same fix |
| `e2e-clean-db-bootstrap.yml` | same | same fix |
| `e2e-lifecycle-visibility.yml` | same | same fix |
| `e2e-promotion-flow.yml` | same | same fix |
| `e2e-team-flow.yml` | same | same fix |
| `session-gen-legs.yml` | same | same fix |
| `tournament-type-matrix.yml` | same | same fix |

## Validation

PR #82 (same changes, different base) had all 63 checks pass (62 pass, 1 skip) on the `ci/*` branch before base-branch staleness blocked the merge. This is an identical single-commit cherry-pick onto current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)