### PR TITLE
feat(ux): show training_delta and training_sessions on skill cards

### DIFF
--- a/app/templates/skills.html
+++ b/app/templates/skills.html
@@ -316,6 +316,16 @@
         return `<span class="skill-delta-zero">±0</span>`;
     }
 
+    function trainingMetaHtml(s) {
+        const td = s.training_delta || 0;
+        const ts = s.training_sessions || 0;
+        if (ts === 0) return '<span style="color:#bbb;">no training</span>';
+        const sign  = td > 0 ? '+' : '';
+        const color = td > 0.05 ? '#27ae60' : (td < -0.05 ? '#e74c3c' : '#95a5a6');
+        return `<span style="color:${color};">${sign}${td.toFixed(1)} training</span>`
+             + ` <span style="color:#bbb;">(${ts} session${ts !== 1 ? 's' : ''})</span>`;
+    }
+
     function renderStats(data) {
         const el = document.getElementById('skills-stats');
         el.innerHTML = `
@@ -396,6 +406,8 @@
                     <span>Baseline: ${s.baseline.toFixed(1)}</span>
                     <span>·</span>
                     <span>${s.tournament_count || 0} tournament${s.tournament_count !== 1 ? 's' : ''}</span>
+                    <span>·</span>
+                    <span>${trainingMetaHtml(s)}</span>
                     <span>·</span>
                     <span>${s.tier ? s.tier.toLowerCase() : 'beginner'}</span>
                 </div>


### PR DESCRIPTION
## Summary

- Adds `trainingMetaHtml(s)` helper in `skills.html` inline script
- Renders training metadata inside the `.skill-meta` row on each skill card, between the tournament count and the tier label
- Zero-training users: `no training` (light grey)
- Users with training data: `+X.X training (N sessions)` (green/grey)

## Fields used

| Field | Source | Fallback |
|---|---|---|
| `s.training_delta` | Already in `/skills/data` response | `\|\| 0` |
| `s.training_sessions` | Already in `/skills/data` response | `\|\| 0` → "no training" |

## No backend changes

`training_delta` and `training_sessions` were already emitted by `/skills/data` (via `get_skill_profile`). This is a pure client-side rendering addition.

## Visual validation (local)

- `report_490c3e64` (non-zero): 8 skills render `+X.X training (2 sessions)`, 21 render `+0.0 training (2 sessions)` (grey)
- `smoke-batch-*` (zero training): all 29 skills render `no training`

## Scope

- Single file: `app/templates/skills.html` (+12 lines)
- No backend, API, schema, service, route, seed, or test changes

## Test plan

- [ ] CI: Unit Tests, API Smoke Tests pass (no production code changed)
- [ ] Manual: `/skills` page as `report_*` user — 8 skill cards show green training delta, 21 show grey `+0.0 training`
- [ ] Manual: `/skills` page as user with no training — all cards show `no training`

🤖 Generated with [Claude Code](https://claude.com/claude-code)