### PR TITLE
refactor(ux): refine skill card training/tournament meta display

### DIFF
--- a/app/templates/skills.html
+++ b/app/templates/skills.html
@@ -319,11 +319,13 @@
     function trainingMetaHtml(s) {
         const td = s.training_delta || 0;
         const ts = s.training_sessions || 0;
-        if (ts === 0) return '<span style="color:#bbb;">no training</span>';
+        if (ts === 0) return '<span style="color:#bbb;">not trained</span>';
+        const sessLabel = `${ts} session${ts !== 1 ? 's' : ''}`;
+        if (Math.abs(td) < 0.05) return `<span style="color:#95a5a6;">${sessLabel}</span>`;
         const sign  = td > 0 ? '+' : '';
-        const color = td > 0.05 ? '#27ae60' : (td < -0.05 ? '#e74c3c' : '#95a5a6');
-        return `<span style="color:${color};">${sign}${td.toFixed(1)} training</span>`
-             + ` <span style="color:#bbb;">(${ts} session${ts !== 1 ? 's' : ''})</span>`;
+        const color = td > 0.05 ? '#27ae60' : '#e74c3c';
+        return `<span style="color:${color};">${sign}${td.toFixed(1)}</span>`
+             + ` <span style="color:#95a5a6;">· ${sessLabel}</span>`;
     }
 
     function renderStats(data) {
@@ -405,7 +407,7 @@
                 <div class="skill-meta">
                     <span>Baseline: ${s.baseline.toFixed(1)}</span>
                     <span>·</span>
-                    <span>${s.tournament_count || 0} tournament${s.tournament_count !== 1 ? 's' : ''}</span>
+                    <span>${(s.tournament_delta || 0) > 0.05 ? `+${s.tournament_delta.toFixed(1)} events` : `${s.tournament_count || 0} tournament${s.tournament_count !== 1 ? 's' : ''}`}</span>
                     <span>·</span>
                     <span>${trainingMetaHtml(s)}</span>
                     <span>·</span>


### PR DESCRIPTION
## Summary

Option C UX refinement on the `.skill-meta` row of each skill card.

### Changes

| Before | After |
|---|---|
| `no training` | `not trained` |
| `+0.0 training (2 sessions)` | `2 sessions` |
| `+4.3 training (2 sessions)` | `+4.3 · 2 sessions` |
| `0 tournaments` | `0 tournaments` (unchanged) |
| `3 tournaments` (with delta) | `+12.0 events` |

### Scenario validation (local DB)

| Scenario | Rendered output |
|---|---|
| Zero training, zero tournament | `0 tournaments · not trained` |
| Sessions, no skill delta | `0 tournaments · 2 sessions` |
| Positive training delta | `0 tournaments · +0.9 · 2 sessions` |
| Tournament delta only | `+6.4 events · 2 sessions` |
| Tournament + training | `+4.7 events · +4.3 · 2 sessions` |

All 5 scenarios confirmed live against `report_490c3e64` (has both tournament_delta and training_delta on several skills) and `smoke-batch-*` (zero everything).

## Scope

- Single file: `app/templates/skills.html` (7 insertions, 5 deletions)
- No backend, API, schema, service, route, seed, or test changes

## Test plan

- [ ] CI: Unit Tests, API Smoke Tests pass
- [ ] Manual: `/skills` as `report_490c3e64` — mixed event+training cards render correctly
- [ ] Manual: `/skills` as zero-training user — all 29 cards show `not trained`

🤖 Generated with [Claude Code](https://claude.com/claude-code)