### PR TITLE
feat(dashboard): restore player card functionality lost in 125f508 squash

### DIFF
--- a/app/api/web_routes/dashboard.py
+++ b/app/api/web_routes/dashboard.py
@@ -339,6 +339,91 @@ def get_lfa_age_category(date_of_birth):
         return None, None, None, f"Age {age} - Below minimum age requirement (5 years)"
 
 
+@router.get("/dashboard/lfa-football-player/card-editor", response_class=HTMLResponse)
+async def lfa_player_card_editor(
+    request: Request,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user_web),
+):
+    """Dedicated sub-page for LFA Football Player card editing (Phase 1 extraction)."""
+    spec_enum = "LFA_FOOTBALL_PLAYER"
+
+    # Same license guard as spec_dashboard
+    user_license = db.query(UserLicense).filter(
+        UserLicense.user_id == user.id,
+        UserLicense.specialization_type == spec_enum,
+    ).first()
+
+    if not user_license:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You don't have access to LFA Football Player. Please unlock it first.",
+        )
+
+    # Same onboarding guard as spec_dashboard
+    has_enrollment = db.query(SemesterEnrollment.id).filter(
+        SemesterEnrollment.user_license_id == user_license.id
+    ).first() is not None
+    effective_onboarding = (
+        user_license.onboarding_completed
+        or user_license.football_skills is not None
+        or has_enrollment
+    )
+    if not effective_onboarding:
+        return RedirectResponse(url="/specialization/lfa-player/onboarding", status_code=303)
+
+    credit_balance = user.credit_balance if hasattr(user, "credit_balance") else 0
+
+    # Card theme picker data — identical logic to spec_dashboard
+    from ...services.card_theme_service import get_all_themes as _get_all_themes, is_unlocked as _is_theme_unlocked
+    card_themes = [
+        {
+            "id": t.id,
+            "label": t.label,
+            "dot_color": t.dot_color,
+            "is_premium": t.is_premium,
+            "credit_cost": t.credit_cost,
+            "unlocked": _is_theme_unlocked(user_license, t.id),
+        }
+        for t in _get_all_themes()
+    ]
+    active_card_theme = user_license.card_theme or "default"
+
+    # Card variant picker data — identical logic to spec_dashboard
+    from ...services.card_variant_service import (  # noqa: E402
+        get_all_variants as _get_all_variants,
+        is_variant_unlocked as _is_variant_unlocked,
+    )
+    card_variants = [
+        {
+            "id": v.id,
+            "label": v.label,
+            "description": v.description,
+            "is_premium": v.is_premium,
+            "credit_cost": v.credit_cost,
+            "available": v.available,
+            "unlocked": _is_variant_unlocked(user_license, v.id),
+        }
+        for v in _get_all_variants()
+    ]
+    active_card_variant = user_license.card_variant or "fifa"
+
+    return templates.TemplateResponse(
+        "dashboard_card_editor.html",
+        {
+            "request": request,
+            "user": user,
+            "user_license": user_license,
+            "credit_balance": credit_balance,
+            "card_themes": card_themes,
+            "active_card_theme": active_card_theme,
+            "card_variants": card_variants,
+            "active_card_variant": active_card_variant,
+            "show_variant_picker": True,  # page is LFA Football Player only
+        },
+    )
+
+
 @router.get("/dashboard/{spec_type}", response_class=HTMLResponse)
 async def spec_dashboard(
     request: Request,
@@ -514,7 +599,7 @@ async def spec_dashboard(
             "age_range": age_range,
             "age_description": age_description,
             "user_age": user_age,
-            "spec_header_class": spec_header_class
+            "spec_header_class": spec_header_class,
         }
     )
 
@@ -528,6 +613,14 @@ from fastapi.responses import JSONResponse  # noqa: E402
 from ...services.player_photo_service import (  # noqa: E402
     save_player_photo,
     delete_player_photo,
+    save_portrait_photo,
+    delete_portrait_photo,
+    save_landscape_photo,
+    delete_landscape_photo,
+    save_compact_bg_photo,
+    delete_compact_bg_photo,
+    save_showcase_bg_photo,
+    delete_showcase_bg_photo,
 )
 
 
@@ -570,3 +663,298 @@ async def student_delete_player_photo(
         lfa_license.player_card_photo_url = None
         db.commit()
     return JSONResponse({"ok": True})
+
+
+@router.post("/dashboard/lfa-player-photo-portrait")
+async def student_upload_portrait_photo(
+    request: Request,
+    file: UploadFile = File(...),
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user_web),
+):
+    lfa_license = db.query(UserLicense).filter(
+        UserLicense.user_id == user.id,
+        UserLicense.specialization_type == "LFA_FOOTBALL_PLAYER",
+        UserLicense.is_active == True,
+    ).first()
+    if not lfa_license:
+        return JSONResponse({"ok": False, "error": "Nincs aktív LFA Football Player licensz"}, status_code=404)
+    try:
+        url = save_portrait_photo(await file.read(), file.content_type or "", user.id)
+        lfa_license.card_photo_portrait_url = url
+        db.commit()
+        return JSONResponse({"ok": True, "photo_url": url})
+    except ValueError as e:
+        return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
+
+
+@router.post("/dashboard/lfa-player-photo-portrait/delete")
+async def student_delete_portrait_photo(
+    request: Request,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user_web),
+):
+    lfa_license = db.query(UserLicense).filter(
+        UserLicense.user_id == user.id,
+        UserLicense.specialization_type == "LFA_FOOTBALL_PLAYER",
+        UserLicense.is_active == True,
+    ).first()
+    if lfa_license:
+        delete_portrait_photo(user.id)
+        lfa_license.card_photo_portrait_url = None
+        db.commit()
+    return JSONResponse({"ok": True})
+
+
+@router.post("/dashboard/lfa-player-photo-landscape")
+async def student_upload_landscape_photo(
+    request: Request,
+    file: UploadFile = File(...),
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user_web),
+):
+    lfa_license = db.query(UserLicense).filter(
+        UserLicense.user_id == user.id,
+        UserLicense.specialization_type == "LFA_FOOTBALL_PLAYER",
+        UserLicense.is_active == True,
+    ).first()
+    if not lfa_license:
+        return JSONResponse({"ok": False, "error": "Nincs aktív LFA Football Player licensz"}, status_code=404)
+    try:
+        url = save_landscape_photo(await file.read(), file.content_type or "", user.id)
+        lfa_license.card_photo_landscape_url = url
+        db.commit()
+        return JSONResponse({"ok": True, "photo_url": url})
+    except ValueError as e:
+        return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
+
+
+@router.post("/dashboard/lfa-player-photo-landscape/delete")
+async def student_delete_landscape_photo(
+    request: Request,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user_web),
+):
+    lfa_license = db.query(UserLicense).filter(
+        UserLicense.user_id == user.id,
+        UserLicense.specialization_type == "LFA_FOOTBALL_PLAYER",
+        UserLicense.is_active == True,
+    ).first()
+    if lfa_license:
+        delete_landscape_photo(user.id)
+        lfa_license.card_photo_landscape_url = None
+        db.commit()
+    return JSONResponse({"ok": True})
+
+
+@router.post("/dashboard/lfa-player-photo-compact-bg")
+async def student_upload_compact_bg_photo(
+    request: Request,
+    file: UploadFile = File(...),
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user_web),
+):
+    lfa_license = db.query(UserLicense).filter(
+        UserLicense.user_id == user.id,
+        UserLicense.specialization_type == "LFA_FOOTBALL_PLAYER",
+        UserLicense.is_active == True,
+    ).first()
+    if not lfa_license:
+        return JSONResponse({"ok": False, "error": "Nincs aktív LFA Football Player licensz"}, status_code=404)
+    try:
+        url = save_compact_bg_photo(await file.read(), file.content_type or "", user.id)
+        lfa_license.card_bg_compact_url = url
+        db.commit()
+        return JSONResponse({"ok": True, "photo_url": url})
+    except ValueError as e:
+        return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
+
+
+@router.post("/dashboard/lfa-player-photo-compact-bg/delete")
+async def student_delete_compact_bg_photo(
+    request: Request,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user_web),
+):
+    lfa_license = db.query(UserLicense).filter(
+        UserLicense.user_id == user.id,
+        UserLicense.specialization_type == "LFA_FOOTBALL_PLAYER",
+        UserLicense.is_active == True,
+    ).first()
+    if lfa_license:
+        delete_compact_bg_photo(user.id)
+        lfa_license.card_bg_compact_url = None
+        db.commit()
+    return JSONResponse({"ok": True})
+
+
+@router.post("/dashboard/lfa-player-photo-showcase-bg")
+async def student_upload_showcase_bg_photo(
+    request: Request,
+    file: UploadFile = File(...),
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user_web),
+):
+    lfa_license = db.query(UserLicense).filter(
+        UserLicense.user_id == user.id,
+        UserLicense.specialization_type == "LFA_FOOTBALL_PLAYER",
+        UserLicense.is_active == True,
+    ).first()
+    if not lfa_license:
+        return JSONResponse({"ok": False, "error": "Nincs aktív LFA Football Player licensz"}, status_code=404)
+    try:
+        url = save_showcase_bg_photo(await file.read(), file.content_type or "", user.id)
+        lfa_license.card_bg_showcase_url = url
+        db.commit()
+        return JSONResponse({"ok": True, "photo_url": url})
+    except ValueError as e:
+        return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
+
+
+@router.post("/dashboard/lfa-player-photo-showcase-bg/delete")
+async def student_delete_showcase_bg_photo(
+    request: Request,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user_web),
+):
+    lfa_license = db.query(UserLicense).filter(
+        UserLicense.user_id == user.id,
+        UserLicense.specialization_type == "LFA_FOOTBALL_PLAYER",
+        UserLicense.is_active == True,
+    ).first()
+    if lfa_license:
+        delete_showcase_bg_photo(user.id)
+        lfa_license.card_bg_showcase_url = None
+        db.commit()
+    return JSONResponse({"ok": True})
+
+
+@router.post("/dashboard/card-photo-focus")
+async def student_set_card_photo_focus(
+    request: Request,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user_web),
+):
+    """Save photo focus point (X%, Y%) for a specific card variant."""
+    try:
+        body = await request.json()
+        variant = body.get("variant")
+        x = int(body.get("x", 50))
+        y = int(body.get("y", 50))
+    except Exception:
+        return JSONResponse({"ok": False, "error": "Invalid request body"}, status_code=400)
+    if variant not in ("compact", "showcase"):
+        return JSONResponse({"ok": False, "error": "Invalid variant"}, status_code=400)
+    x = max(0, min(100, x))
+    y = max(0, min(100, y))
+    lfa_license = db.query(UserLicense).filter(
+        UserLicense.user_id == user.id,
+        UserLicense.specialization_type == "LFA_FOOTBALL_PLAYER",
+        UserLicense.is_active == True,
+    ).first()
+    if not lfa_license:
+        return JSONResponse({"ok": False, "error": "Nincs aktív LFA Football Player licensz"}, status_code=404)
+    if variant == "compact":
+        lfa_license.card_compact_focus_x = x
+        lfa_license.card_compact_focus_y = y
+    else:
+        lfa_license.card_showcase_focus_x = x
+        lfa_license.card_showcase_focus_y = y
+    db.commit()
+    return JSONResponse({"ok": True, "x": x, "y": y})
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# PLAYER CARD THEME  (student self-service)
+# ══════════════════════════════════════════════════════════════════════════════
+
+from ...services.card_theme_service import apply_theme as _apply_theme, unlock_theme as _unlock_theme  # noqa: E402
+from ...services.card_variant_service import apply_variant as _apply_variant, unlock_variant as _unlock_variant  # noqa: E402
+from pydantic import BaseModel as _BaseModel  # noqa: E402
+
+
+class _CardThemeRequest(_BaseModel):
+    theme: str
+
+
+class _CardVariantRequest(_BaseModel):
+    variant: str
+
+
+def _get_lfa_license(db, user_id: int):
+    """Return the active LFA Football Player license, or None."""
+    return db.query(UserLicense).filter(
+        UserLicense.user_id == user_id,
+        UserLicense.specialization_type == "LFA_FOOTBALL_PLAYER",
+        UserLicense.is_active == True,
+    ).first()
+
+
+@router.post("/dashboard/card-theme")
+async def student_set_card_theme(
+    payload: _CardThemeRequest,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user_web),
+):
+    """Update the active colour theme for the authenticated student's player card."""
+    lfa_license = _get_lfa_license(db, user.id)
+    if not lfa_license:
+        return JSONResponse({"ok": False, "error": "No active LFA Football Player license"}, status_code=404)
+    try:
+        _apply_theme(db, lfa_license, payload.theme)
+        return JSONResponse({"ok": True, "theme": payload.theme})
+    except ValueError as e:
+        return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
+
+
+@router.post("/dashboard/unlock-theme")
+async def student_unlock_theme(
+    payload: _CardThemeRequest,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user_web),
+):
+    """Unlock a premium card theme by spending credits."""
+    lfa_license = _get_lfa_license(db, user.id)
+    if not lfa_license:
+        return JSONResponse({"ok": False, "error": "No active LFA Football Player license"}, status_code=404)
+    try:
+        _unlock_theme(db, user, lfa_license, payload.theme)
+        return JSONResponse({"ok": True, "theme": payload.theme,
+                             "new_balance": user.credit_balance})
+    except ValueError as e:
+        return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
+
+
+@router.post("/dashboard/card-variant")
+async def student_set_card_variant(
+    payload: _CardVariantRequest,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user_web),
+):
+    """Apply a card layout variant (must already be unlocked for premium variants)."""
+    lfa_license = _get_lfa_license(db, user.id)
+    if not lfa_license:
+        return JSONResponse({"ok": False, "error": "No active LFA Football Player license"}, status_code=404)
+    try:
+        _apply_variant(db, lfa_license, payload.variant)
+        return JSONResponse({"ok": True, "variant": payload.variant})
+    except ValueError as e:
+        return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
+
+
+@router.post("/dashboard/unlock-variant")
+async def student_unlock_variant(
+    payload: _CardVariantRequest,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user_web),
+):
+    """Unlock a premium card layout variant by spending credits."""
+    lfa_license = _get_lfa_license(db, user.id)
+    if not lfa_license:
+        return JSONResponse({"ok": False, "error": "No active LFA Football Player license"}, status_code=404)
+    try:
+        _unlock_variant(db, user, lfa_license, payload.variant)
+        return JSONResponse({"ok": True, "variant": payload.variant,
+                             "new_balance": user.credit_balance})
+    except ValueError as e:
+        return JSONResponse({"ok": False, "error": str(e)}, status_code=400)

--- a/app/services/card_theme_service.py
+++ b/app/services/card_theme_service.py
@@ -1,0 +1,156 @@
+"""
+Player Card Theme Service
+=========================
+Manages colour themes for the public LFA Football Player card.
+
+Free themes (default, midnight, arctic) are always available.
+Premium themes (gold, emerald, crimson) require credit purchase.
+
+Adding a new theme requires only:
+  1. A new entry in THEMES below
+  2. A new .theme-<id> CSS block in player_card.html
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from .credit_service import CreditService
+
+
+@dataclass(frozen=True)
+class ThemeDefinition:
+    id: str
+    label: str
+    is_premium: bool
+    credit_cost: int
+    # CSS custom-property values sent to the template
+    panel_bg: str       # --card-panel-bg  (fifa-left gradient)
+    body_bg: str        # --card-body-bg   (skills + events section)
+    tab_bg: str         # --card-tab-bg    (tab bar)
+    accent: str         # --card-accent    (active tab underline, badge tints)
+    # Dot colour shown in the dashboard theme picker
+    dot_color: str
+
+
+# ── Theme registry ────────────────────────────────────────────────────────────
+THEMES: dict[str, ThemeDefinition] = {
+    "default": ThemeDefinition(
+        id="default", label="Slate", is_premium=False, credit_cost=0,
+        panel_bg="linear-gradient(155deg, #1a2744 0%, #2a3a5c 60%, #1e3a4a 100%)",
+        body_bg="#1a202c", tab_bg="#2d3748", accent="#667eea",
+        dot_color="#667eea",
+    ),
+    "midnight": ThemeDefinition(
+        id="midnight", label="Midnight", is_premium=False, credit_cost=0,
+        panel_bg="linear-gradient(155deg, #0d0d0d 0%, #1a1a2e 60%, #16213e 100%)",
+        body_bg="#0f0f0f", tab_bg="#1a1a1a", accent="#00d4ff",
+        dot_color="#00d4ff",
+    ),
+    "arctic": ThemeDefinition(
+        id="arctic", label="Arctic", is_premium=False, credit_cost=0,
+        panel_bg="linear-gradient(155deg, #1a2744 0%, #2a3a5c 60%, #1e3a4a 100%)",
+        body_bg="#f7fafc", tab_bg="#edf2f7", accent="#4299e1",
+        dot_color="#4299e1",
+    ),
+    "gold": ThemeDefinition(
+        id="gold", label="Gold", is_premium=True, credit_cost=500,
+        panel_bg="linear-gradient(155deg, #3d2200 0%, #5c3500 60%, #3d2200 100%)",
+        body_bg="#1e1500", tab_bg="#2d1f00", accent="#f6ad3c",
+        dot_color="#f6ad3c",
+    ),
+    "emerald": ThemeDefinition(
+        id="emerald", label="Emerald", is_premium=True, credit_cost=500,
+        panel_bg="linear-gradient(155deg, #0a2d0a 0%, #144d1e 60%, #0a2d14 100%)",
+        body_bg="#0d1f0d", tab_bg="#142b14", accent="#4cde82",
+        dot_color="#4cde82",
+    ),
+    "crimson": ThemeDefinition(
+        id="crimson", label="Crimson", is_premium=True, credit_cost=500,
+        panel_bg="linear-gradient(155deg, #3d0a0a 0%, #5c1414 60%, #3d0a14 100%)",
+        body_bg="#1e0d0d", tab_bg="#2d1010", accent="#ff6b6b",
+        dot_color="#ff6b6b",
+    ),
+}
+
+# Ordered list for the picker UI (free first, then premium)
+THEME_ORDER = ["default", "midnight", "arctic", "gold", "emerald", "crimson"]
+
+
+# ── Public API ────────────────────────────────────────────────────────────────
+
+def get_theme(theme_id: str) -> ThemeDefinition:
+    """Return theme by ID, falling back to 'default' for unknown IDs."""
+    return THEMES.get(theme_id, THEMES["default"])
+
+
+def get_all_themes() -> list[ThemeDefinition]:
+    """Return all themes in display order."""
+    return [THEMES[tid] for tid in THEME_ORDER if tid in THEMES]
+
+
+def is_unlocked(user_license, theme_id: str) -> bool:
+    """
+    Return True if the user may use this theme.
+    Free themes are always unlocked.
+    Premium themes require the theme_id to be in user_license.unlocked_card_themes.
+    """
+    theme = THEMES.get(theme_id)
+    if theme is None:
+        return False
+    if not theme.is_premium:
+        return True
+    unlocked = user_license.unlocked_card_themes or []
+    return theme_id in unlocked
+
+
+def apply_theme(db, user_license, theme_id: str) -> None:
+    """
+    Set the active theme on user_license and commit.
+    Raises ValueError if theme unknown or not yet unlocked.
+    """
+    if theme_id not in THEMES:
+        raise ValueError(f"Unknown theme: {theme_id!r}")
+    if not is_unlocked(user_license, theme_id):
+        theme = THEMES[theme_id]
+        raise ValueError(
+            f"Theme '{theme.label}' is locked. Required: {theme.credit_cost} CR"
+        )
+    user_license.card_theme = theme_id
+    db.commit()
+
+
+def unlock_theme(db, user, user_license, theme_id: str) -> None:
+    """
+    Unlock a premium theme for the user.
+
+    Uses CreditService.deduct() which wraps the balance UPDATE and the CT INSERT
+    inside a single SAVEPOINT — both succeed or both roll back together.
+
+    Raises ValueError (InsufficientCreditsError) if theme unknown, already
+    unlocked, or insufficient balance.
+    """
+    if theme_id not in THEMES:
+        raise ValueError(f"Unknown theme: {theme_id!r}")
+    theme = THEMES[theme_id]
+    if not theme.is_premium:
+        return  # free themes don't need unlocking
+    unlocked: list = list(user_license.unlocked_card_themes or [])
+    if theme_id in unlocked:
+        return  # already unlocked — idempotent
+
+    # Atomic deduction + CT insert (SAVEPOINT guarantees coupling).
+    # InsufficientCreditsError propagates to the caller unchanged.
+    CreditService(db).deduct(
+        user=user,
+        amount=theme.credit_cost,
+        transaction_type="THEME_UNLOCK",
+        description=f"Card theme unlock: {theme.label}",
+        idempotency_key=f"theme_unlock_{user.id}_{theme_id}",
+    )
+
+    # Update unlocked themes list (same outer transaction)
+    unlocked.append(theme_id)
+    user_license.unlocked_card_themes = unlocked
+
+    db.commit()

--- a/app/services/card_variant_service.py
+++ b/app/services/card_variant_service.py
@@ -1,0 +1,160 @@
+"""
+Player Card Variant Service
+===========================
+Manages layout variants for the public LFA Football Player card.
+
+A *variant* controls the card's visual structure (layout, component arrangement).
+It is orthogonal to the colour *theme* — any variant × theme combination is valid.
+
+Free variants (fifa) are always available.
+Premium variants (compact, showcase) require credit purchase.
+
+Adding a new variant requires only:
+  1. A new entry in VARIANTS below
+  2. A new template at the path listed in VariantDefinition.template
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .credit_service import CreditService
+
+
+@dataclass(frozen=True)
+class VariantDefinition:
+    id:          str
+    label:       str          # dashboard picker label
+    description: str          # tooltip / preview text
+    is_premium:  bool
+    credit_cost: int          # 0 for free variants
+    template:    str          # path relative to templates/ directory
+    available:   bool = True  # False = coming soon; blocks unlock/apply/preview
+
+
+# ── Variant registry ──────────────────────────────────────────────────────────
+VARIANTS: dict[str, VariantDefinition] = {
+    "fifa": VariantDefinition(
+        id="fifa",
+        label="FIFA Classic",
+        description="The original LFA player card with full skill breakdown and event history.",
+        is_premium=False,
+        credit_cost=0,
+        template="public/player_card_fifa.html",
+    ),
+    "compact": VariantDefinition(
+        id="compact",
+        label="Compact",
+        description="Mobile-first card designed for sharing. Shows category averages at a glance.",
+        is_premium=True,
+        credit_cost=300,
+        template="public/player_card_compact.html",
+    ),
+    "showcase": VariantDefinition(
+        id="showcase",
+        label="Showcase",
+        description="Premium landscape trading card with category highlights and recent events strip.",
+        is_premium=True,
+        credit_cost=500,
+        template="public/player_card_showcase.html",
+    ),
+    "compact_bg": VariantDefinition(
+        id="compact_bg",
+        label="Compact + BG",
+        description="Compact layout with a custom background image behind your player photo.",
+        is_premium=True,
+        credit_cost=400,
+        template="public/player_card_compact_bg.html",
+    ),
+    "showcase_bg": VariantDefinition(
+        id="showcase_bg",
+        label="Showcase + BG",
+        description="Showcase layout with a custom background image behind your player photo.",
+        is_premium=True,
+        credit_cost=600,
+        template="public/player_card_showcase_bg.html",
+    ),
+}
+
+# Display order for the dashboard picker (free first, then premium)
+VARIANT_ORDER = ["fifa", "compact", "compact_bg", "showcase", "showcase_bg"]
+
+
+# ── Public API ────────────────────────────────────────────────────────────────
+
+def get_variant(variant_id: str) -> VariantDefinition:
+    """Return variant by ID, falling back to 'fifa' for unknown IDs.
+    The available flag is NOT used here — render path must never be feature-gated.
+    """
+    return VARIANTS.get(variant_id, VARIANTS["fifa"])
+
+
+def get_all_variants() -> list[VariantDefinition]:
+    """Return all variants in display order."""
+    return [VARIANTS[vid] for vid in VARIANT_ORDER if vid in VARIANTS]
+
+
+def is_variant_unlocked(user_license, variant_id: str) -> bool:
+    """
+    Return True if the user may use this variant.
+    Free variants are always unlocked.
+    Premium variants require variant_id in user_license.unlocked_card_variants.
+    """
+    variant = VARIANTS.get(variant_id)
+    if variant is None:
+        return False
+    if not variant.is_premium:
+        return True
+    unlocked = user_license.unlocked_card_variants or []
+    return variant_id in unlocked
+
+
+def apply_variant(db, user_license, variant_id: str) -> None:
+    """
+    Set the active variant on user_license and commit.
+    Raises ValueError if variant unknown, not yet available, or not yet unlocked.
+    """
+    if variant_id not in VARIANTS:
+        raise ValueError(f"Unknown variant: {variant_id!r}")
+    if not VARIANTS[variant_id].available:
+        raise ValueError(f"Variant '{VARIANTS[variant_id].label}' is not yet available")
+    if not is_variant_unlocked(user_license, variant_id):
+        variant = VARIANTS[variant_id]
+        raise ValueError(
+            f"Variant '{variant.label}' is locked. Required: {variant.credit_cost} CR"
+        )
+    user_license.card_variant = variant_id
+    db.commit()
+
+
+def unlock_variant(db, user, user_license, variant_id: str) -> None:
+    """
+    Unlock a premium variant for the user.
+
+    Uses CreditService.deduct() which wraps the balance UPDATE and the CT INSERT
+    inside a single SAVEPOINT — both succeed or both roll back together.
+
+    Raises ValueError (InsufficientCreditsError) if variant unknown, already
+    unlocked, or insufficient credit balance.
+    """
+    if variant_id not in VARIANTS:
+        raise ValueError(f"Unknown variant: {variant_id!r}")
+    variant = VARIANTS[variant_id]
+    if not variant.available:
+        raise ValueError(f"Variant '{variant.label}' is not yet available")
+    if not variant.is_premium:
+        return  # free variants don't need unlocking
+    unlocked: list = list(user_license.unlocked_card_variants or [])
+    if variant_id in unlocked:
+        return  # already unlocked — idempotent
+
+    CreditService(db).deduct(
+        user=user,
+        amount=variant.credit_cost,
+        transaction_type="VARIANT_UNLOCK",
+        description=f"Card variant unlock: {variant.label}",
+        idempotency_key=f"variant_unlock_{user.id}_{variant_id}",
+    )
+
+    unlocked.append(variant_id)
+    user_license.unlocked_card_variants = unlocked
+    db.commit()

--- a/app/services/player_photo_service.py
+++ b/app/services/player_photo_service.py
@@ -1,53 +1,190 @@
 """
 LFA Football Player card photo service.
 
-Stores spec-specific photos in app/static/uploads/lfa_player_photos/{user_id}.jpg
-— completely separate from any global User avatar/profile picture.
+Stores spec-specific photos in app/static/uploads/lfa_player_photos/:
+  {user_id}_orig_{epoch}.png — card photo (full-figure, aspect-ratio preserved, alpha kept)
+  {user_id}_portrait.png     — variant portrait photo (9:16, alpha preserved)
+  {user_id}_landscape.png    — variant landscape photo (16:9, alpha preserved)
+
+All slots are completely separate from any global User avatar/profile picture.
 """
 import io
+import time
 from pathlib import Path
 
 from PIL import Image
 
 ALLOWED_MIME: set[str] = {"image/jpeg", "image/png", "image/webp"}
-MAX_BYTES: int = 2 * 1024 * 1024          # 2 MB hard limit
-PHOTO_SIZE: tuple[int, int] = (400, 400)  # center-crop target
+MAX_BYTES:    int = 2 * 1024 * 1024          # 2 MB — cutout/card photos
+MAX_BG_BYTES: int = 8 * 1024 * 1024          # 8 MB — background photos
+MAX_CARD_SIZE: tuple[int, int] = (800, 1200) # max fit box — no crop, aspect ratio preserved
 PHOTO_DIR: Path = Path("app/static/uploads/lfa_player_photos")
 
-
-def get_photo_url(user_id: int) -> str:
-    return f"/static/uploads/lfa_player_photos/{user_id}.jpg"
+# Variant photo target dimensions
+_PORTRAIT_SIZE:  tuple[int, int] = (450, 800)   # 9:16
+_LANDSCAPE_SIZE: tuple[int, int] = (800, 450)   # 16:9
 
 
 def save_player_photo(file_bytes: bytes, content_type: str, user_id: int) -> str:
-    """Validate, center-crop to 400×400, save as JPEG. Returns static URL."""
+    """Validate, fit inside MAX_CARD_SIZE, save as PNG preserving alpha. Returns static URL.
+
+    No cropping — the full player figure is always retained.
+    thumbnail() fits the image inside (800, 1200) while keeping the original
+    aspect ratio and never upscaling.  Alpha channel is preserved end-to-end
+    so background-removed PNGs render transparently on the card.
+
+    Filename: {user_id}_orig_{epoch}.png — unique per upload (cache-bust),
+    _orig_ prefix avoids collisions with _portrait.png/_landscape.png.
+    """
     if content_type not in ALLOWED_MIME:
         raise ValueError(f"Nem támogatott képformátum: {content_type}. Elfogadott: JPEG, PNG, WEBP")
     if len(file_bytes) > MAX_BYTES:
         raise ValueError("A fájl mérete meghaladja a 2 MB-os korlátot")
 
     try:
-        img = Image.open(io.BytesIO(file_bytes)).convert("RGB")
+        img = Image.open(io.BytesIO(file_bytes))
     except Exception:
         raise ValueError("Érvénytelen képfájl")
 
-    # Center-crop to square, then resize
-    w, h = img.size
-    side = min(w, h)
-    left = (w - side) // 2
-    top = (h - side) // 2
-    img = img.crop((left, top, left + side, top + side))
-    img = img.resize(PHOTO_SIZE, Image.LANCZOS)
+    # Preserve alpha: palette (P) must be converted first to keep transparent index
+    if img.mode == "P":
+        img = img.convert("RGBA")
+    elif img.mode not in ("RGBA", "RGB"):
+        img = img.convert("RGBA")
+    # RGB and RGBA pass through unchanged — no alpha destruction
+
+    # Fit inside max box — NO crop, aspect ratio preserved, never upscales
+    img.thumbnail(MAX_CARD_SIZE, Image.LANCZOS)
 
     PHOTO_DIR.mkdir(parents=True, exist_ok=True)
-    out_path = PHOTO_DIR / f"{user_id}.jpg"
-    img.save(out_path, "JPEG", quality=85, optimize=True)
 
-    return get_photo_url(user_id)
+    # Delete any previous card photo files for this user before saving the new one
+    delete_player_photo(user_id)
+
+    ts = int(time.time())
+    out_path = PHOTO_DIR / f"{user_id}_orig_{ts}.png"
+    img.save(out_path, "PNG", optimize=True)
+
+    return f"/static/uploads/lfa_player_photos/{user_id}_orig_{ts}.png"
 
 
 def delete_player_photo(user_id: int) -> None:
-    """Remove the photo file if it exists (silent no-op if missing)."""
-    path = PHOTO_DIR / f"{user_id}.jpg"
+    """Remove card photo files for this user (_orig_ prefix only). Silent no-op if missing.
+
+    Explicitly does NOT touch _portrait.png or _landscape.png — those are
+    managed by delete_portrait_photo()/delete_landscape_photo() separately.
+    """
+    if not PHOTO_DIR.exists():
+        return
+    # New-style PNG card photos
+    for f in PHOTO_DIR.glob(f"{user_id}_orig_*.png"):
+        f.unlink()
+    # Old-style timestamped JPEG card photos (digit-only suffix, e.g. 42_1712345678.jpg)
+    for f in PHOTO_DIR.glob(f"{user_id}_*.jpg"):
+        stem_suffix = f.stem[len(f"{user_id}_"):]
+        if stem_suffix.isdigit():
+            f.unlink()
+    # Legacy pre-timestamp file
+    legacy = PHOTO_DIR / f"{user_id}.jpg"
+    if legacy.exists():
+        legacy.unlink()
+
+
+# ── Variant photo helpers ──────────────────────────────────────────────────
+
+
+def _save_variant_photo(
+    file_bytes: bytes,
+    content_type: str,
+    user_id: int,
+    target_size: tuple[int, int],
+    suffix: str,
+    max_bytes: int = MAX_BYTES,
+) -> str:
+    """
+    Save a PNG for a card variant.
+
+    Strategy: fit (no aggressive crop). The uploaded PNG is already a prepared
+    cutout — we preserve the full image by fitting it inside target_size with
+    thumbnail() (aspect-ratio-safe). Alpha channel is preserved throughout.
+    Only a mild soft-crop is applied if one dimension is more than 10% larger
+    than the target ratio after fit — in practice this is a no-op for properly
+    prepared cutouts.
+
+    Returns the static URL.
+    """
+    if content_type not in ALLOWED_MIME:
+        raise ValueError(f"Nem támogatott képformátum: {content_type}. Elfogadott: JPEG, PNG, WEBP")
+    if len(file_bytes) > max_bytes:
+        raise ValueError(f"A fájl mérete meghaladja a {max_bytes // (1024 * 1024)} MB-os korlátot")
+
+    try:
+        img = Image.open(io.BytesIO(file_bytes))
+    except Exception:
+        raise ValueError("Érvénytelen képfájl")
+
+    # Ensure RGBA so alpha is available (JPEG input → treat as fully opaque)
+    if img.mode != "RGBA":
+        img = img.convert("RGBA")
+
+    # Fit inside target box — thumbnail() keeps aspect ratio, never upscales
+    img.thumbnail(target_size, Image.LANCZOS)
+
+    PHOTO_DIR.mkdir(parents=True, exist_ok=True)
+    out_path = PHOTO_DIR / f"{user_id}_{suffix}.png"
+    img.save(out_path, "PNG", optimize=True)
+
+    return f"/static/uploads/lfa_player_photos/{user_id}_{suffix}.png"
+
+
+def save_portrait_photo(file_bytes: bytes, content_type: str, user_id: int) -> str:
+    """Fit into 9:16 box, preserve alpha, save as PNG. Returns static URL."""
+    return _save_variant_photo(file_bytes, content_type, user_id, _PORTRAIT_SIZE, "portrait")
+
+
+def delete_portrait_photo(user_id: int) -> None:
+    """Remove portrait PNG if it exists."""
+    path = PHOTO_DIR / f"{user_id}_portrait.png"
+    if path.exists():
+        path.unlink()
+
+
+def save_landscape_photo(file_bytes: bytes, content_type: str, user_id: int) -> str:
+    """Fit into 16:9 box, preserve alpha, save as PNG. Returns static URL."""
+    return _save_variant_photo(file_bytes, content_type, user_id, _LANDSCAPE_SIZE, "landscape")
+
+
+def delete_landscape_photo(user_id: int) -> None:
+    """Remove landscape PNG if it exists."""
+    path = PHOTO_DIR / f"{user_id}_landscape.png"
+    if path.exists():
+        path.unlink()
+
+
+# ── Variant background photo helpers ──────────────────────────────────────────
+
+_BG_SIZE: tuple[int, int] = (800, 800)  # max fit box for background images
+
+
+def save_compact_bg_photo(file_bytes: bytes, content_type: str, user_id: int) -> str:
+    """Fit into 800×800 box, preserve alpha, save as PNG. Returns static URL."""
+    return _save_variant_photo(file_bytes, content_type, user_id, _BG_SIZE, "bg_compact", max_bytes=MAX_BG_BYTES)
+
+
+def delete_compact_bg_photo(user_id: int) -> None:
+    """Remove compact background PNG if it exists."""
+    path = PHOTO_DIR / f"{user_id}_bg_compact.png"
+    if path.exists():
+        path.unlink()
+
+
+def save_showcase_bg_photo(file_bytes: bytes, content_type: str, user_id: int) -> str:
+    """Fit into 800×800 box, preserve alpha, save as PNG. Returns static URL."""
+    return _save_variant_photo(file_bytes, content_type, user_id, _BG_SIZE, "bg_showcase", max_bytes=MAX_BG_BYTES)
+
+
+def delete_showcase_bg_photo(user_id: int) -> None:
+    """Remove showcase background PNG if it exists."""
+    path = PHOTO_DIR / f"{user_id}_bg_showcase.png"
     if path.exists():
         path.unlink()

--- a/app/templates/dashboard_card_editor.html
+++ b/app/templates/dashboard_card_editor.html
@@ -1,0 +1,442 @@
+{% extends "student_base.html" %}
+
+{% block title %}My Player Card — LFA{% endblock %}
+
+{# ── Spec header: utility bar only — mirrors /dashboard/lfa-football-player ── #}
+{% block student_header %}
+<div class="student-header spec-pg-hdr">
+    <div class="student-header-inner">
+        <a href="/dashboard" class="s-hdr-btn" title="Back to Hub">🏠</a>
+        <div class="student-brand">⚽ LFA Football Player</div>
+        <div class="student-header-actions">
+            <span class="credit-pill">💰 {{ user.credit_balance if user else 0 }}</span>
+            <a href="/credits" class="s-hdr-btn" title="Credits">💳</a>
+            <div class="badge-wrap">
+                <a href="/messages" class="s-hdr-btn" title="Messages" aria-label="Messages">✉️</a>
+                <span class="badge-dot" id="hdr-msg-badge">0</span>
+            </div>
+            <div class="badge-wrap">
+                <a href="/notifications" class="s-hdr-btn" title="Notifications" aria-label="Notifications">🔔</a>
+                <span class="badge-dot" id="hdr-notif-badge">0</span>
+            </div>
+            <a href="/profile" class="s-hdr-btn" title="Profile">👤</a>
+            <a href="/logout"  class="s-hdr-btn" title="Logout">🚪</a>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block extra_styles %}
+<style>
+    /* ── Container ──────────────────────────────────────────────────────────── */
+    .container {
+        max-width: 900px;
+        margin: 0 auto;
+        padding: 1.25rem 2rem 2rem;
+    }
+    .page-title { font-size: 1.4rem; color: var(--app-text); margin: 0; }
+
+    /* ── Section block ───────────────────────────────────────────────────────── */
+    .section-block {
+        background: var(--app-card);
+        border-radius: 16px;
+        padding: 1.75rem 2rem;
+        box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+        margin-bottom: 1.5rem;
+    }
+    .section-link { color: #667eea; font-size: 0.88rem; text-decoration: none; font-weight: 600; white-space: nowrap; }
+    .section-link:hover { text-decoration: underline; }
+
+    /* ── Player Card embed ────────────────────────────────────────────────────── */
+    .player-card-embed-wrap { border-radius: 16px; overflow: hidden; box-shadow: 0 4px 24px rgba(0,0,0,0.13); }
+    .player-card-embed-wrap iframe { display: block; width: 100%; border: none; }
+
+    /* ── Theme picker ─────────────────────────────────────────────────────────── */
+    .theme-picker { display: flex; align-items: center; gap: 0.45rem; flex-wrap: nowrap; }
+    .theme-dot {
+        width: 18px; height: 18px; border-radius: 50%; cursor: pointer;
+        border: 2px solid transparent; transition: border-color .15s, transform .15s;
+        position: relative; flex-shrink: 0;
+    }
+    .theme-dot:hover { transform: scale(1.2); }
+    .theme-dot.active { border-color: white; box-shadow: 0 0 0 2px rgba(255,255,255,0.35); }
+    .theme-dot.locked { opacity: 0.55; cursor: pointer; }
+    .theme-dot.locked:hover { transform: scale(1.15); opacity: 0.8; }
+    .theme-dot .lock-icon {
+        position: absolute; top: -5px; right: -5px;
+        font-size: 0.5rem; line-height: 1; pointer-events: none;
+    }
+
+    /* ── Variant picker ───────────────────────────────────────────────────────── */
+    .variant-picker { display: flex; gap: 0.5rem; flex-wrap: wrap; margin-top: 0.5rem; }
+    .variant-btn {
+        font-size: 0.68rem; font-weight: 700; padding: 4px 10px; border-radius: 99px;
+        cursor: pointer; border: 1.5px solid transparent; transition: all .15s;
+        background: rgba(255,255,255,0.07); color: rgba(255,255,255,0.65);
+        display: flex; align-items: center; gap: 0.3rem; white-space: nowrap;
+    }
+    .variant-btn:hover { background: rgba(255,255,255,0.12); color: rgba(255,255,255,0.88); }
+    .variant-btn.active {
+        background: rgba(102,126,234,0.2); border-color: rgba(102,126,234,0.6);
+        color: #a3b3f7;
+    }
+    .variant-btn.locked { opacity: 0.6; }
+    .variant-btn.unavailable { opacity: 0.55; cursor: pointer; }
+    .variant-btn.previewing {
+        border-color: rgba(102,126,234,0.35);
+        background: rgba(102,126,234,0.1);
+        color: rgba(163,179,247,0.8);
+    }
+    .variant-btn .var-cost { font-size: 0.6rem; opacity: 0.75; }
+
+    /* ── Player photo widget ─────────────────────────────────────────────── */
+    .player-photo-section {
+        margin: 1.25rem 0 0;
+        background: rgba(255,255,255,0.04);
+        border-radius: 12px;
+        padding: 1.1rem 1.25rem;
+        border: 1px solid rgba(255,255,255,0.08);
+    }
+    .player-photo-section-title {
+        font-size: 0.65rem; font-weight: 800; text-transform: uppercase;
+        letter-spacing: 0.1em; color: rgba(255,255,255,0.45); margin-bottom: 0.9rem;
+    }
+    .player-photo-body {
+        display: flex; flex-direction: column; align-items: center; gap: 0.75rem;
+    }
+    .player-photo-preview {
+        width: 96px; height: 96px; border-radius: 50%; object-fit: cover;
+        border: 3px solid rgba(255,255,255,0.2);
+    }
+    .player-photo-placeholder {
+        width: 96px; height: 96px; border-radius: 50%;
+        background: rgba(255,255,255,0.08); border: 2px dashed rgba(255,255,255,0.2);
+        display: flex; align-items: center; justify-content: center;
+        font-size: 2rem; color: rgba(255,255,255,0.3);
+    }
+    .player-photo-hint { font-size: 0.7rem; color: rgba(255,255,255,0.35); text-align: center; }
+    .player-photo-empty { font-size: 0.78rem; color: rgba(255,255,255,0.45); text-align: center; }
+    .btn-photo-upload-student {
+        cursor: pointer; font-size: 0.72rem; font-weight: 600;
+        padding: 6px 16px; border-radius: 99px;
+        background: rgba(102,126,234,0.7); color: white;
+        border: 1px solid rgba(102,126,234,0.4); transition: background 0.15s;
+    }
+    .btn-photo-upload-student:hover { background: rgba(102,126,234,1); }
+    .btn-photo-delete-student {
+        font-size: 0.7rem; padding: 5px 12px; border-radius: 99px;
+        background: rgba(220,53,69,0.4); border: none; color: rgba(255,255,255,0.8); cursor: pointer;
+    }
+    .btn-photo-delete-student:hover { background: rgba(220,53,69,0.7); }
+
+    /* ── Light mode overrides — system preference OR explicit .light class ─── */
+    @media (prefers-color-scheme: light) {
+        .variant-btn {
+            background: rgba(0,0,0,0.06); color: rgba(0,0,0,0.72);
+            border-color: rgba(0,0,0,0.12);
+        }
+        .variant-btn:hover { background: rgba(0,0,0,0.10); color: rgba(0,0,0,0.9); }
+        .variant-btn.active {
+            background: rgba(102,126,234,0.15); border-color: rgba(102,126,234,0.5);
+            color: #3730a3;
+        }
+        .player-photo-section { background: rgba(0,0,0,0.04); border-color: rgba(0,0,0,0.08); }
+        .player-photo-section-title { color: rgba(0,0,0,0.45); }
+        .player-photo-hint, .player-photo-empty { color: rgba(0,0,0,0.45); }
+        .player-photo-placeholder {
+            background: rgba(0,0,0,0.06); border-color: rgba(0,0,0,0.2);
+            color: rgba(0,0,0,0.3);
+        }
+        .btn-photo-delete-student { background: rgba(220,53,69,0.15); color: rgba(220,53,69,0.9); }
+        .btn-photo-delete-student:hover { background: rgba(220,53,69,0.25); }
+    }
+    .light .variant-btn {
+        background: rgba(0,0,0,0.06); color: rgba(0,0,0,0.72);
+        border-color: rgba(0,0,0,0.12);
+    }
+    .light .variant-btn:hover { background: rgba(0,0,0,0.10); color: rgba(0,0,0,0.9); }
+    .light .variant-btn.active {
+        background: rgba(102,126,234,0.15); border-color: rgba(102,126,234,0.5);
+        color: #3730a3;
+    }
+    .light .player-photo-section { background: rgba(0,0,0,0.04); border-color: rgba(0,0,0,0.08); }
+    .light .player-photo-section-title { color: rgba(0,0,0,0.45); }
+    .light .player-photo-hint, .light .player-photo-empty { color: rgba(0,0,0,0.45); }
+    .light .player-photo-placeholder {
+        background: rgba(0,0,0,0.06); border-color: rgba(0,0,0,0.2);
+        color: rgba(0,0,0,0.3);
+    }
+    .light .btn-photo-delete-student { background: rgba(220,53,69,0.15); color: rgba(220,53,69,0.9); }
+    .light .btn-photo-delete-student:hover { background: rgba(220,53,69,0.25); }
+
+    @media (max-width: 768px) { .container { padding: 1rem; } }
+</style>
+{% endblock %}
+
+{% block student_content %}
+
+{# ── Breadcrumb ─────────────────────────────────────────────────────────────── #}
+<nav class="s-breadcrumb" aria-label="Breadcrumb">
+    <a href="/dashboard" class="s-breadcrumb-item">🏠 Hub</a>
+    <span class="s-breadcrumb-sep">›</span>
+    <a href="/dashboard/lfa-football-player" class="s-breadcrumb-item">⚽ LFA Football Player</a>
+    <span class="s-breadcrumb-sep">›</span>
+    <span class="s-breadcrumb-item active">🪪 My Player Card</span>
+</nav>
+
+<div class="container">
+
+    <section class="section-block" style="padding: 1.25rem; margin-bottom: 1.5rem;">
+        <div style="margin-bottom: 0.75rem;">
+            <h2 class="page-title" style="margin-bottom: 0.6rem;">🪪 My Player Card</h2>
+            <div style="display:flex; align-items:center; justify-content:space-between; gap:0.75rem;">
+                {# ── Theme picker ── #}
+                <div class="theme-picker" id="theme-picker">
+                    {% for t in card_themes %}
+                    <button class="theme-dot {% if t.id == active_card_theme %}active{% endif %} {% if not t.unlocked %}locked{% endif %}"
+                            style="background: {{ t.dot_color }};"
+                            title="{{ t.label }}{% if t.is_premium and not t.unlocked %} · 🔓 Unlock for {{ t.credit_cost }} CR{% endif %}"
+                            onclick="setCardTheme('{{ t.id }}', {{ 'true' if t.unlocked else 'false' }}, '{{ t.label }}', {{ t.credit_cost }})">
+                        {% if t.is_premium and not t.unlocked %}<span class="lock-icon">🔒</span>{% endif %}
+                    </button>
+                    {% endfor %}
+                </div>
+                <a href="/players/{{ user.id }}/card" target="_blank" class="section-link">🌐 Open full screen →</a>
+            </div>
+            {# ── Variant picker ── #}
+            {% if show_variant_picker and card_variants is defined %}
+            <div class="variant-picker" id="variant-picker">
+                {% for v in card_variants %}
+                <button class="variant-btn {% if v.id == active_card_variant %}active{% endif %} {% if not v.unlocked %}locked{% endif %} {% if not v.available %}unavailable{% endif %}"
+                        data-variant="{{ v.id }}"
+                        title="{{ v.description }}{% if not v.available %} · Preview only{% elif v.is_premium and not v.unlocked %} · Unlock for {{ v.credit_cost }} CR{% endif %}"
+                        onclick="{% if v.available %}setCardVariant('{{ v.id }}', {{ 'true' if v.unlocked else 'false' }}, '{{ v.label }}', {{ v.credit_cost }}){% else %}previewVariant('{{ v.id }}'){% endif %}">
+                    {% if not v.available %}⏳{% elif v.is_premium and not v.unlocked %}🔒{% endif %}
+                    {{ v.label }}
+                    {% if v.is_premium and not v.unlocked and v.available %}<span class="var-cost">{{ v.credit_cost }} CR</span>{% endif %}
+                    <a href="/players/{{ user.id }}/card?preview={{ v.id }}" target="_blank"
+                       onclick="event.stopPropagation();" title="Preview {{ v.label }} layout in new tab"
+                       style="font-size:0.6rem; opacity:0.6; text-decoration:none; color:inherit;">↗</a>
+                </button>
+                {% endfor %}
+            </div>
+            {% endif %}
+        </div>
+        <div class="player-card-embed-wrap">
+            <iframe id="player-card-iframe" src="/players/{{ user.id }}/card" height="920" scrolling="no"
+                    title="My Player Card"></iframe>
+        </div>
+    </section>
+
+    {# ── Photo upload sections ── #}
+    <div class="player-photo-section">
+        <div class="player-photo-section-title">⚽ Player Card Photo</div>
+        <div class="player-photo-body">
+            {% if user_license.player_card_photo_url %}
+            <img src="{{ user_license.player_card_photo_url }}"
+                 class="player-photo-preview" alt="Player card photo">
+            {% else %}
+            <div class="player-photo-placeholder">📷</div>
+            <p class="player-photo-empty">Még nincs profilkép — tölts fel egyet a kártyádhoz!</p>
+            {% endif %}
+            <label class="btn-photo-upload-student">
+                📷 Fotó feltöltése
+                <input type="file" accept="image/jpeg,image/png,image/webp"
+                       onchange="uploadMyPhoto(this)" hidden>
+            </label>
+            {% if user_license.player_card_photo_url %}
+            <button class="btn-photo-delete-student" onclick="deleteMyPhoto()">✕ Törlés</button>
+            {% endif %}
+            <p class="player-photo-hint">Max 2 MB · JPEG/PNG/WEBP · automatikus 400×400 vágás</p>
+        </div>
+    </div>
+
+    {# ── Compact BG photo (only when compact_bg is unlocked) ── #}
+    {% set _unlocked = user_license.unlocked_card_variants or [] %}
+    {% if 'compact_bg' in _unlocked %}
+    <div class="player-photo-section">
+        <div class="player-photo-section-title">🎨 Compact+BG — Background Photo</div>
+        <div class="player-photo-body">
+            {% if user_license.card_bg_compact_url %}
+            <img src="{{ user_license.card_bg_compact_url }}"
+                 class="player-photo-preview" alt="Compact BG photo">
+            {% else %}
+            <div class="player-photo-placeholder">🖼️</div>
+            <p class="player-photo-empty">Háttérkép hiányzik — tölts fel egyet!</p>
+            {% endif %}
+            <label class="btn-photo-upload-student">
+                🖼️ Háttér feltöltése
+                <input type="file" accept="image/jpeg,image/png,image/webp"
+                       onchange="uploadCompactBg(this)" hidden>
+            </label>
+            {% if user_license.card_bg_compact_url %}
+            <button class="btn-photo-delete-student" onclick="deleteCompactBg()">✕ Törlés</button>
+            {% endif %}
+            <p class="player-photo-hint">Max 8 MB · JPEG/PNG/WEBP · 800×800 px max</p>
+        </div>
+    </div>
+    {% endif %}
+
+    {# ── Showcase BG photo (only when showcase_bg is unlocked) ── #}
+    {% if 'showcase_bg' in _unlocked %}
+    <div class="player-photo-section">
+        <div class="player-photo-section-title">🎨 Showcase+BG — Background Photo</div>
+        <div class="player-photo-body">
+            {% if user_license.card_bg_showcase_url %}
+            <img src="{{ user_license.card_bg_showcase_url }}"
+                 class="player-photo-preview" alt="Showcase BG photo">
+            {% else %}
+            <div class="player-photo-placeholder">🖼️</div>
+            <p class="player-photo-empty">Háttérkép hiányzik — tölts fel egyet!</p>
+            {% endif %}
+            <label class="btn-photo-upload-student">
+                🖼️ Háttér feltöltése
+                <input type="file" accept="image/jpeg,image/png,image/webp"
+                       onchange="uploadShowcaseBg(this)" hidden>
+            </label>
+            {% if user_license.card_bg_showcase_url %}
+            <button class="btn-photo-delete-student" onclick="deleteShowcaseBg()">✕ Törlés</button>
+            {% endif %}
+            <p class="player-photo-hint">Max 8 MB · JPEG/PNG/WEBP · 800×800 px max</p>
+        </div>
+    </div>
+    {% endif %}
+
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+async function unlockTheme(themeId, label, cost) {
+    if (!confirm(`Unlock "${label}" for ${cost} CR from your credit balance?`)) return;
+    const csrf = (document.cookie.split('; ').find(r => r.startsWith('csrf_token=')) || '').split('=')[1];
+    const r = await fetch('/dashboard/unlock-theme', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrf },
+        body: JSON.stringify({ theme: themeId }),
+    });
+    const data = await r.json();
+    if (data.ok) { location.reload(); }
+    else { alert('❌ ' + (data.error || 'Could not unlock theme.')); }
+}
+
+async function setCardTheme(themeId, unlocked, label, cost) {
+    if (!unlocked) { await unlockTheme(themeId, label, cost); return; }
+    const csrf = (document.cookie.split('; ').find(r => r.startsWith('csrf_token=')) || '').split('=')[1];
+    const r = await fetch('/dashboard/card-theme', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrf },
+        body: JSON.stringify({ theme: themeId }),
+    });
+    const data = await r.json();
+    if (data.ok) {
+        document.querySelectorAll('.theme-dot').forEach(d => d.classList.remove('active'));
+        const active = document.querySelector(`.theme-dot[onclick*="'${themeId}'"]`);
+        if (active) active.classList.add('active');
+        const iframe = document.getElementById('player-card-iframe');
+        if (iframe) { iframe.src = iframe.src; }
+    } else { alert(data.error || 'Could not apply theme.'); }
+}
+
+async function unlockVariant(variantId, label, cost) {
+    if (!confirm(`Unlock "${label}" layout for ${cost} CR from your credit balance?`)) return;
+    const csrf = (document.cookie.split('; ').find(r => r.startsWith('csrf_token=')) || '').split('=')[1];
+    const r = await fetch('/dashboard/unlock-variant', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrf },
+        body: JSON.stringify({ variant: variantId }),
+    });
+    const data = await r.json();
+    if (data.ok) { location.reload(); }
+    else { alert('❌ ' + (data.error || 'Could not unlock variant.')); }
+}
+
+const _cardUserId = {{ user.id }};
+
+function previewVariant(variantId) {
+    const iframe = document.getElementById('player-card-iframe');
+    if (iframe) { iframe.src = `/players/${_cardUserId}/card?preview=${variantId}`; }
+    document.querySelectorAll('.variant-btn').forEach(b => b.classList.remove('previewing'));
+    const btn = document.querySelector(`.variant-btn[data-variant="${variantId}"]`);
+    if (btn) btn.classList.add('previewing');
+}
+
+async function setCardVariant(variantId, unlocked, label, cost) {
+    if (!unlocked) { await unlockVariant(variantId, label, cost); return; }
+    const csrf = (document.cookie.split('; ').find(r => r.startsWith('csrf_token=')) || '').split('=')[1];
+    const r = await fetch('/dashboard/card-variant', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrf },
+        body: JSON.stringify({ variant: variantId }),
+    });
+    const data = await r.json();
+    if (data.ok) {
+        document.querySelectorAll('.variant-btn').forEach(b => b.classList.remove('active', 'previewing'));
+        const active = document.querySelector(`.variant-btn[data-variant="${variantId}"]`);
+        if (active) active.classList.add('active');
+        const iframe = document.getElementById('player-card-iframe');
+        if (iframe) { iframe.src = `/players/${_cardUserId}/card`; }
+    } else { alert(data.error || 'Could not apply variant.'); }
+}
+
+async function uploadMyPhoto(input) {
+    if (!input.files[0]) return;
+    const fd = new FormData(); fd.append('file', input.files[0]);
+    const csrf = (document.cookie.split('; ').find(r => r.startsWith('csrf_token=')) || '').split('=')[1];
+    const r = await fetch('/dashboard/lfa-player-photo', {
+        method: 'POST', body: fd, headers: { 'X-CSRF-Token': csrf }
+    });
+    const data = await r.json();
+    if (data.ok) location.reload(); else alert('Hiba a feltöltésnél: ' + data.error);
+}
+async function deleteMyPhoto() {
+    if (!confirm('Törli a profilképet?')) return;
+    const csrf = (document.cookie.split('; ').find(r => r.startsWith('csrf_token=')) || '').split('=')[1];
+    const r = await fetch('/dashboard/lfa-player-photo/delete', {
+        method: 'POST', headers: { 'X-CSRF-Token': csrf, 'Content-Type': 'application/json' }
+    });
+    const data = await r.json();
+    if (data.ok) location.reload();
+}
+
+async function uploadCompactBg(input) {
+    if (!input.files[0]) return;
+    const fd = new FormData(); fd.append('file', input.files[0]);
+    const csrf = (document.cookie.split('; ').find(r => r.startsWith('csrf_token=')) || '').split('=')[1];
+    const r = await fetch('/dashboard/lfa-player-photo-compact-bg', {
+        method: 'POST', body: fd, headers: { 'X-CSRF-Token': csrf }
+    });
+    const data = await r.json();
+    if (data.ok) location.reload(); else alert('Hiba a feltöltésnél: ' + data.error);
+}
+async function deleteCompactBg() {
+    if (!confirm('Törli a Compact+BG háttérképet?')) return;
+    const csrf = (document.cookie.split('; ').find(r => r.startsWith('csrf_token=')) || '').split('=')[1];
+    const r = await fetch('/dashboard/lfa-player-photo-compact-bg/delete', {
+        method: 'POST', headers: { 'X-CSRF-Token': csrf, 'Content-Type': 'application/json' }
+    });
+    const data = await r.json();
+    if (data.ok) location.reload();
+}
+
+async function uploadShowcaseBg(input) {
+    if (!input.files[0]) return;
+    const fd = new FormData(); fd.append('file', input.files[0]);
+    const csrf = (document.cookie.split('; ').find(r => r.startsWith('csrf_token=')) || '').split('=')[1];
+    const r = await fetch('/dashboard/lfa-player-photo-showcase-bg', {
+        method: 'POST', body: fd, headers: { 'X-CSRF-Token': csrf }
+    });
+    const data = await r.json();
+    if (data.ok) location.reload(); else alert('Hiba a feltöltésnél: ' + data.error);
+}
+async function deleteShowcaseBg() {
+    if (!confirm('Törli a Showcase+BG háttérképet?')) return;
+    const csrf = (document.cookie.split('; ').find(r => r.startsWith('csrf_token=')) || '').split('=')[1];
+    const r = await fetch('/dashboard/lfa-player-photo-showcase-bg/delete', {
+        method: 'POST', headers: { 'X-CSRF-Token': csrf, 'Content-Type': 'application/json' }
+    });
+    const data = await r.json();
+    if (data.ok) location.reload();
+}
+</script>
+{% endblock %}

--- a/app/templates/dashboard_student_new.html
+++ b/app/templates/dashboard_student_new.html
@@ -2,23 +2,23 @@
 
 {% block title %}{{ spec_config.name }} Dashboard - LFA{% endblock %}
 
-{# ── Custom spec header: floating slate card with spec nav ───────────────────── #}
+{# ── Spec header: utility bar only — navbar = global actions, mod-nav cards = feature nav ── #}
 {% block student_header %}
 <div class="student-header spec-pg-hdr">
     <div class="student-header-inner">
         <a href="/dashboard" class="s-hdr-btn" title="Back to Hub">🏠</a>
         <div class="student-brand">{{ spec_config.icon }} {{ spec_config.name }}</div>
-        <nav class="student-nav" id="student-nav" aria-label="Student navigation">
-            <a href="/dashboard/lfa-football-player" class="nav-item active">⚽ LFA Player</a>
-            <a href="/sessions"     class="nav-item">📅 Sessions</a>
-            <a href="/progress"     class="nav-item">📊 Progress</a>
-            <a href="/skills"       class="nav-item">⚡ Skills</a>
-            <a href="/achievements" class="nav-item">🏆 Achievements</a>
-            <a href="/calendar"     class="nav-item">📆 Calendar</a>
-        </nav>
         <div class="student-header-actions">
             <span class="credit-pill">💰 {{ user.credit_balance if user else 0 }}</span>
             <a href="/credits" class="s-hdr-btn" title="Credits">💳</a>
+            <div class="badge-wrap">
+                <a href="/messages" class="s-hdr-btn" title="Messages" aria-label="Messages">✉️</a>
+                <span class="badge-dot" id="hdr-msg-badge">0</span>
+            </div>
+            <div class="badge-wrap">
+                <a href="/notifications" class="s-hdr-btn" title="Notifications" aria-label="Notifications">🔔</a>
+                <span class="badge-dot" id="hdr-notif-badge">0</span>
+            </div>
             <a href="/profile" class="s-hdr-btn" title="Profile">👤</a>
             <a href="/logout"  class="s-hdr-btn" title="Logout">🚪</a>
         </div>
@@ -30,8 +30,8 @@
 <style>
     /* spec-pg-hdr + mod-nav-* → student.css v5 */
 
-    /* ── Spec dashboard: 5-column override (sub-pages use 4-col from student.css) */
-    .mod-nav-grid { grid-template-columns: repeat(5, 1fr); }
+    /* ── Spec dashboard: 6-column override (sub-pages use 4-col from student.css) */
+    .mod-nav-grid { grid-template-columns: repeat(6, 1fr); }
     @media (max-width: 768px) { .mod-nav-grid { grid-template-columns: repeat(3, 1fr); } }
     @media (max-width: 480px) { .mod-nav-grid { grid-template-columns: repeat(3, 1fr); } }
 
@@ -39,11 +39,11 @@
     .container {
         max-width: 1200px;
         margin: 0 auto;
-        padding: 1.25rem 2rem 2rem;
+        padding: 1.25rem 0.5rem 2rem;
     }
 
-    .page-title    { font-size: 1.4rem; color: #2d3748; margin: 0; }
-    .page-subtitle { color: #718096; font-size: 0.95rem; margin-bottom: 1.5rem; }
+    .page-title    { font-size: 1.4rem; color: var(--app-text); margin: 0; }
+    .page-subtitle { color: var(--app-text-muted); font-size: 0.95rem; margin-bottom: 1.5rem; }
 
     .info-banner { background: #e6f7ff; border-left: 4px solid #1890ff; padding: 1rem 1.5rem; border-radius: 8px; margin-bottom: 2rem; }
     .info-banner p { color: #0050b3; margin: 0; }
@@ -57,7 +57,7 @@
     }
 
     .s-kpi-card {
-        background: white;
+        background: var(--app-card);
         border-radius: 8px;
         padding: 1.25rem 1.5rem;
         box-shadow: 0 1px 3px rgba(0,0,0,0.08), 0 4px 12px rgba(0,0,0,0.04);
@@ -71,16 +71,16 @@
     .s-kpi-row .s-kpi-card:nth-child(3) { border-top-color: #f59e0b; }
     .s-kpi-row .s-kpi-card:nth-child(4) { border-top-color: #4299e1; }
 
-    .s-kpi-val { font-size: 2rem; font-weight: 700; color: #2d3748; line-height: 1.1; }
+    .s-kpi-val { font-size: 2rem; font-weight: 700; color: var(--app-text); line-height: 1.1; }
     .s-kpi-row .s-kpi-card:nth-child(1) .s-kpi-val { color: #276749; }
     .s-kpi-row .s-kpi-card:nth-child(2) .s-kpi-val { color: #553c9a; }
     .s-kpi-row .s-kpi-card:nth-child(3) .s-kpi-val { color: #92400e; }
     .s-kpi-row .s-kpi-card:nth-child(4) .s-kpi-val { color: #2b6cb0; }
-    .s-kpi-lbl { font-size: 0.82rem; color: #718096; margin-top: 0.25rem; }
+    .s-kpi-lbl { font-size: 0.82rem; color: var(--app-text-muted); margin-top: 0.25rem; }
 
     /* ── Section block ───────────────────────────────────────────────────────── */
     .section-block {
-        background: white;
+        background: var(--app-card);
         border-radius: 16px;
         padding: 1.75rem 2rem;
         box-shadow: 0 4px 12px rgba(0,0,0,0.08);
@@ -90,45 +90,67 @@
     .section-link { color: #667eea; font-size: 0.88rem; text-decoration: none; font-weight: 600; white-space: nowrap; }
     .section-link:hover { text-decoration: underline; }
 
-    /* ── Skill Snapshot ──────────────────────────────────────────────────────── */
+    /* ── Skill Snapshot (fallback, no LFA license) ───────────────────────────── */
     .s-snapshot-row { display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.65rem; }
-    .s-snap-label   { width: 130px; font-size: 0.85rem; color: #4a5568; text-transform: capitalize; flex-shrink: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-    .s-snap-bar-wrap { flex: 1; height: 10px; background: #e2e8f0; border-radius: 5px; overflow: hidden; }
+    .s-snap-label   { width: 130px; font-size: 0.85rem; color: var(--app-text-muted); text-transform: capitalize; flex-shrink: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .s-snap-bar-wrap { flex: 1; height: 10px; background: var(--app-border); border-radius: 5px; overflow: hidden; }
     .s-snap-bar     { height: 100%; border-radius: 5px; transition: width 0.4s ease; }
-    .s-snap-val     { width: 38px; text-align: right; font-size: 0.82rem; font-weight: 600; color: #2d3748; flex-shrink: 0; }
+    .s-snap-val     { width: 38px; text-align: right; font-size: 0.82rem; font-weight: 600; color: var(--app-text); flex-shrink: 0; }
+
+    /* ── 2-column main layout ─────────────────────────────────────────────────── */
+    .dash-main-grid {
+        display: grid;
+        grid-template-columns: 1.2fr 0.8fr;
+        gap: 1.5rem;
+        align-items: start;
+        margin-bottom: 1.5rem;
+    }
+    .dash-right-col { display: flex; flex-direction: column; gap: 1.5rem; }
+    .dash-right-col .section-block { margin-bottom: 0; }
+    /* mod-nav + KPI inside right col */
+    .dash-right-col .mod-nav-section {
+        background: var(--app-card);
+        border-radius: 16px;
+        padding: 1.1rem 1.1rem 0.6rem;
+        box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+        margin: 0;
+    }
+    .dash-right-col .s-kpi-row { margin-bottom: 0; }
+    @media (max-width: 1024px) {
+        .dash-main-grid { grid-template-columns: 1fr; }
+    }
+
+    /* ── Player Card live preview (left column) ─────────────────────────────── */
+    .player-card-embed-wrap { border-radius: 12px; overflow: hidden; box-shadow: 0 4px 24px rgba(0,0,0,0.13); }
+    .player-card-embed-wrap iframe { display: block; width: 100%; border: none; }
 
     /* ── Last Result ─────────────────────────────────────────────────────────── */
-    .s-last-result-card { background: #f8faff; border-left: 4px solid #667eea; border-radius: 0 10px 10px 0; padding: 1rem 1.25rem; display: flex; align-items: center; gap: 1rem; flex-wrap: wrap; }
-    .s-result-name     { font-weight: 700; color: #2d3748; font-size: 1rem; flex: 1; min-width: 140px; }
+    .s-last-result-card { background: var(--app-card); border-left: 4px solid #667eea; border-radius: 0 10px 10px 0; padding: 1rem 1.25rem; display: flex; align-items: center; gap: 1rem; flex-wrap: wrap; }
+    .s-result-name     { font-weight: 700; color: var(--app-text); font-size: 1rem; flex: 1; min-width: 140px; }
     .s-placement-badge { padding: 0.3rem 0.8rem; border-radius: 20px; font-weight: 700; font-size: 0.85rem; white-space: nowrap; }
     .s-place-1     { background: #fff3cd; color: #856404; }
     .s-place-2     { background: #e2e3e5; color: #383d41; }
     .s-place-3     { background: #fde7c7; color: #7a4200; }
-    .s-place-other { background: #f8f9fa; color: #6c757d; }
-    .s-delta-pos   { color: #2ecc71; font-weight: 700; font-size: 0.95rem; }
-    .s-delta-neg   { color: #e74c3c; font-weight: 700; font-size: 0.95rem; }
-    .s-delta-zero  { color: #718096; font-size: 0.95rem; }
-    .s-result-meta { color: #718096; font-size: 0.82rem; }
+    .s-place-other { background: var(--app-card-alt); color: var(--app-text-muted); }
+    .s-delta-pos   { color: var(--app-success); font-weight: 700; font-size: 0.95rem; }
+    .s-delta-neg   { color: var(--app-error); font-weight: 700; font-size: 0.95rem; }
+    .s-delta-zero  { color: var(--app-text-muted); font-size: 0.95rem; }
+    .s-result-meta { color: var(--app-text-muted); font-size: 0.82rem; }
 
     /* ── Events (semester cards) ─────────────────────────────────────────────── */
     .cards-grid  { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 1.5rem; }
-    .spec-card   { background: white; border-radius: 16px; padding: 1.75rem; box-shadow: 0 4px 12px rgba(0,0,0,0.08); transition: transform 0.3s, box-shadow 0.3s; position: relative; overflow: hidden; }
+    .spec-card   { background: var(--app-card); border-radius: 16px; padding: 1.75rem; box-shadow: 0 4px 12px rgba(0,0,0,0.08); transition: transform 0.3s, box-shadow 0.3s; position: relative; overflow: hidden; }
     .spec-card:hover { transform: translateY(-4px); box-shadow: 0 8px 24px rgba(0,0,0,0.12); }
     .spec-icon   { font-size: 2.5rem; text-align: center; margin-bottom: 0.75rem; }
-    .spec-title  { font-size: 1.2rem; font-weight: 700; color: #2d3748; text-align: center; margin-bottom: 0.4rem; }
-    .spec-age    { text-align: center; color: #718096; font-size: 0.88rem; margin-bottom: 0.9rem; }
-    .spec-description { color: #4a5568; font-size: 0.93rem; line-height: 1.55; margin-bottom: 1.2rem; text-align: center; }
+    .spec-title  { font-size: 1.2rem; font-weight: 700; color: var(--app-text); text-align: center; margin-bottom: 0.4rem; }
+    .spec-age    { text-align: center; color: var(--app-text-muted); font-size: 0.88rem; margin-bottom: 0.9rem; }
+    .spec-description { color: var(--app-text-muted); font-size: 0.93rem; line-height: 1.55; margin-bottom: 1.2rem; text-align: center; }
     .spec-action { text-align: center; }
     .unlock-btn  { width: 100%; padding: 0.85rem; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; border: none; border-radius: 10px; font-size: 0.97rem; font-weight: 600; cursor: pointer; transition: transform 0.2s, box-shadow 0.2s; }
     .unlock-btn:hover    { transform: translateY(-2px); box-shadow: 0 6px 20px rgba(102,126,234,0.4); }
     .unlock-btn:disabled { background: #cbd5e0; cursor: not-allowed; }
     .unlock-btn:disabled:hover { transform: none; box-shadow: none; }
     .cost-badge  { position: absolute; top: 1rem; right: 1rem; background: #ffd700; color: #2d3748; padding: 0.35rem 0.8rem; border-radius: 8px; font-weight: 700; font-size: 0.82rem; box-shadow: 0 2px 8px rgba(0,0,0,0.15); }
-
-    /* ── Footer ──────────────────────────────────────────────────────────────── */
-    .footer-links { text-align: center; margin-top: 2rem; padding-top: 1.5rem; border-top: 1px solid #e2e8f0; }
-    .footer-links a { color: #667eea; text-decoration: none; margin: 0 1rem; font-weight: 600; }
-    .footer-links a:hover { text-decoration: underline; }
 
     /* ── Loading ─────────────────────────────────────────────────────────────── */
     .s-loading { color: #a0aec0; font-size: 0.9rem; padding: 0.5rem 0; }
@@ -150,45 +172,6 @@
         .mod-nav-title  { font-size: 0.76rem; }
     }
 
-    /* ── Player photo widget ─────────────────────────────────────────────── */
-    .player-photo-section {
-        margin: 1.25rem 0 0;
-        background: rgba(255,255,255,0.04);
-        border-radius: 12px;
-        padding: 1.1rem 1.25rem;
-        border: 1px solid rgba(255,255,255,0.08);
-    }
-    .player-photo-section-title {
-        font-size: 0.65rem; font-weight: 800; text-transform: uppercase;
-        letter-spacing: 0.1em; color: rgba(255,255,255,0.45); margin-bottom: 0.9rem;
-    }
-    .player-photo-body {
-        display: flex; flex-direction: column; align-items: center; gap: 0.75rem;
-    }
-    .player-photo-preview {
-        width: 96px; height: 96px; border-radius: 50%; object-fit: cover;
-        border: 3px solid rgba(255,255,255,0.2);
-    }
-    .player-photo-placeholder {
-        width: 96px; height: 96px; border-radius: 50%;
-        background: rgba(255,255,255,0.08); border: 2px dashed rgba(255,255,255,0.2);
-        display: flex; align-items: center; justify-content: center;
-        font-size: 2rem; color: rgba(255,255,255,0.3);
-    }
-    .player-photo-hint { font-size: 0.7rem; color: rgba(255,255,255,0.35); text-align: center; }
-    .player-photo-empty { font-size: 0.78rem; color: rgba(255,255,255,0.45); text-align: center; }
-    .btn-photo-upload-student {
-        cursor: pointer; font-size: 0.72rem; font-weight: 600;
-        padding: 6px 16px; border-radius: 99px;
-        background: rgba(102,126,234,0.7); color: white;
-        border: 1px solid rgba(102,126,234,0.4); transition: background 0.15s;
-    }
-    .btn-photo-upload-student:hover { background: rgba(102,126,234,1); }
-    .btn-photo-delete-student {
-        font-size: 0.7rem; padding: 5px 12px; border-radius: 99px;
-        background: rgba(220,53,69,0.4); border: none; color: rgba(255,255,255,0.8); cursor: pointer;
-    }
-    .btn-photo-delete-student:hover { background: rgba(220,53,69,0.7); }
 </style>
 {% endblock %}
 
@@ -201,160 +184,152 @@
     <span class="s-breadcrumb-item active">{{ spec_config.icon if spec_config else '⚽' }} {{ spec_config.name if spec_config else 'LFA Football Player' }}</span>
 </nav>
 
-{# ── Module Navigation Cards ───────────────────────────────────────────────── #}
-{# All 5 targets have require_student_onboarding guard → redirect /dashboard    #}
-{# if user.onboarding_completed is False. (/sessions & /calendar use inline     #}
-{# equivalent check in sessions.py.)                                            #}
-<section class="mod-nav-section">
-    <div class="mod-nav-grid">
-        <a href="/sessions" class="mod-nav-card">
-            <span class="mod-nav-icon">📅</span>
-            <span class="mod-nav-title">Sessions</span>
-        </a>
-        <a href="/progress" class="mod-nav-card">
-            <span class="mod-nav-icon">📊</span>
-            <span class="mod-nav-title">Progress</span>
-        </a>
-        <a href="/skills" class="mod-nav-card">
-            <span class="mod-nav-icon">⚡</span>
-            <span class="mod-nav-title">Skills</span>
-        </a>
-        <a href="/achievements" class="mod-nav-card">
-            <span class="mod-nav-icon">🏆</span>
-            <span class="mod-nav-title">Achievements</span>
-        </a>
-        <a href="/calendar" class="mod-nav-card">
-            <span class="mod-nav-icon">📆</span>
-            <span class="mod-nav-title">Calendar</span>
-        </a>
-    </div>
-</section>
-
 <div class="container">
 
-    {# ── KPI Row ──────────────────────────────────────────────────────────────── #}
-    <div class="s-kpi-row">
-        <div class="s-kpi-card">
-            <div class="s-kpi-val" id="kpi-avg">—</div>
-            <div class="s-kpi-lbl">Avg Skill Level</div>
-        </div>
-        <div class="s-kpi-card">
-            <div class="s-kpi-val" id="kpi-tournaments">—</div>
-            <div class="s-kpi-lbl">Tournaments</div>
-        </div>
-        <div class="s-kpi-card">
-            <div class="s-kpi-val">{{ credit_balance }}</div>
-            <div class="s-kpi-lbl">Credits</div>
-        </div>
-        <div class="s-kpi-card">
-            <div class="s-kpi-val" style="font-size:1.2rem;">{{ age_category or '—' }}</div>
-            <div class="s-kpi-lbl">{{ age_range or 'Category' }}</div>
-        </div>
-    </div>
+    {# ── 2-column main grid ────────────────────────────────────────────────────── #}
+    <div class="dash-main-grid">
 
-    {# ── Skill Snapshot ───────────────────────────────────────────────────────── #}
-    <section class="section-block">
-        <div class="section-header">
-            <h2 class="page-title">📊 Skill Snapshot</h2>
-            <a href="/skills" class="section-link">View all 29 skills →</a>
-        </div>
-        <div id="s-snapshot">
-            <div class="s-loading"><span class="s-spinner"></span> Loading…</div>
-        </div>
-    </section>
-
-    {# ── Last Skill Event ─────────────────────────────────────────────────────── #}
-    <section class="section-block">
-        <div class="section-header">
-            <h2 class="page-title">📈 Last Skill Event</h2>
-            <a href="/skills/history?skill=passing" class="section-link">Full event history →</a>
-        </div>
-        <div id="s-last-result">
-            <div class="s-loading"><span class="s-spinner"></span> Loading…</div>
-        </div>
-    </section>
-
-    {# ── Available Events ─────────────────────────────────────────────────────── #}
-    <section class="section-block">
-        <div class="section-header">
-            <h2 class="page-title">⚽ Available Events</h2>
-        </div>
-        <p class="page-subtitle">Enroll in semesters to access training sessions and progress through your football development path.</p>
-
-        {% if available_semesters|length == 0 %}
-        <div class="info-banner" style="background: #fff7e6; border-color: #faad14;">
-            <p style="color: #ad6800;">⚠️ <strong>No track semesters available for your age group yet.</strong><br>
-            Check back later, or <a href="/profile" style="color: #ad6800; text-decoration: underline;">update your profile</a> if your age group is incorrect.</p>
-        </div>
+        {# LEFT: My Card teaser (LFA license) / Skill Snapshot fallback ────────── #}
+        {% if user_license %}
+        <section class="section-block" style="margin-bottom: 0; padding: 1.25rem 1.5rem 1.5rem;">
+            <div class="section-header" style="margin-bottom: 1rem;">
+                <h2 class="page-title">🪪 My Player Card</h2>
+                <a href="/dashboard/lfa-football-player/card-editor" class="section-link">✏️ Edit →</a>
+            </div>
+            <div class="player-card-embed-wrap">
+                <iframe src="/players/{{ user.id }}/card" height="680" scrolling="no" title="My Player Card"></iframe>
+            </div>
+        </section>
         {% else %}
-        <div class="info-banner">
-            <p><strong>💡 Available Semesters for {{ age_category_name }} ({{ age_range }})</strong><br>
-            {{ age_description }} — {{ available_semesters|length }} semester(s) available</p>
-        </div>
+        <section class="section-block" style="margin-bottom: 0;">
+            <div class="section-header">
+                <h2 class="page-title">📊 Skill Snapshot</h2>
+                <a href="/skills" class="section-link">View all 29 skills →</a>
+            </div>
+            <div id="s-snapshot">
+                <div class="s-loading"><span class="s-spinner"></span> Loading…</div>
+            </div>
+        </section>
         {% endif %}
 
-        <div class="cards-grid">
-            {% for semester in available_semesters %}
-            <div class="spec-card">
-                <div class="cost-badge">💰 {{ semester.enrollment_cost }} Credits</div>
-                <div class="spec-icon">⚽</div>
-                <h3 class="spec-title">{{ semester.name }}</h3>
-                <p class="spec-age">📅 {{ semester.start_date.strftime('%Y-%m-%d') }} — {{ semester.end_date.strftime('%Y-%m-%d') }}</p>
-                <p class="spec-description">
-                    <strong>Code:</strong> {{ semester.code }}<br>
-                    <strong>Status:</strong> {{ semester.status.value if semester.status else 'Unknown' }}
-                </p>
-                <div class="spec-action">
-                    {% if user.credit_balance < semester.enrollment_cost %}
-                        <button class="unlock-btn" disabled>❌ Insufficient Credits (Need {{ semester.enrollment_cost }})</button>
-                        <p style="margin-top: 0.5rem; font-size: 0.85rem;">
-                            <a href="/credits" style="color: #667eea; font-weight: 600;">Purchase credits →</a>
-                        </p>
-                    {% else %}
-                        <form method="POST" action="/semester/enroll">
-                            <input type="hidden" name="semester_id" value="{{ semester.id }}">
-                            <button type="submit" class="unlock-btn">🎓 Enroll Now ({{ semester.enrollment_cost }} credits)</button>
-                        </form>
-                    {% endif %}
+        {# RIGHT: nav + KPI + Last Skill Event + Available Events ──────────────── #}
+        <div class="dash-right-col">
+
+            {# ── Module Navigation ─────────────────────────────────────────────── #}
+            {# All targets have require_student_onboarding guard                   #}
+            <section class="mod-nav-section">
+                <div class="mod-nav-grid">
+                    <a href="/sessions" class="mod-nav-card">
+                        <span class="mod-nav-icon">📅</span>
+                        <span class="mod-nav-title">Sessions</span>
+                    </a>
+                    <a href="/progress" class="mod-nav-card">
+                        <span class="mod-nav-icon">📊</span>
+                        <span class="mod-nav-title">Progress</span>
+                    </a>
+                    <a href="/skills" class="mod-nav-card">
+                        <span class="mod-nav-icon">⚡</span>
+                        <span class="mod-nav-title">Skills</span>
+                    </a>
+                    <a href="/achievements" class="mod-nav-card">
+                        <span class="mod-nav-icon">🏆</span>
+                        <span class="mod-nav-title">Achievements</span>
+                    </a>
+                    <a href="/calendar" class="mod-nav-card">
+                        <span class="mod-nav-icon">📆</span>
+                        <span class="mod-nav-title">Calendar</span>
+                    </a>
+                    <a href="/dashboard/lfa-football-player/card-editor" class="mod-nav-card">
+                        <span class="mod-nav-icon">🪪</span>
+                        <span class="mod-nav-title">My Card</span>
+                    </a>
+                </div>
+            </section>
+
+            {# ── KPI Row ───────────────────────────────────────────────────────── #}
+            <div class="s-kpi-row">
+                <div class="s-kpi-card">
+                    <div class="s-kpi-val" id="kpi-avg">—</div>
+                    <div class="s-kpi-lbl">Avg Skill Level</div>
+                </div>
+                <div class="s-kpi-card">
+                    <div class="s-kpi-val" id="kpi-tournaments">—</div>
+                    <div class="s-kpi-lbl">Tournaments</div>
+                </div>
+                <div class="s-kpi-card">
+                    <div class="s-kpi-val">{{ credit_balance }}</div>
+                    <div class="s-kpi-lbl">Credits</div>
+                </div>
+                <div class="s-kpi-card">
+                    <div class="s-kpi-val" style="font-size:1.2rem;">{{ age_category or '—' }}</div>
+                    <div class="s-kpi-lbl">{{ age_range or 'Category' }}</div>
                 </div>
             </div>
-            {% endfor %}
-        </div>
-    </section>
 
-    <!-- ⚽ Player Card Photo (LFA Football Player only) -->
-    {% if user_license %}
-    <div class="player-photo-section">
-        <div class="player-photo-section-title">⚽ Player Card Photo</div>
-        <div class="player-photo-body">
-            {% if user_license.player_card_photo_url %}
-            <img src="{{ user_license.player_card_photo_url }}"
-                 class="player-photo-preview" alt="Player card photo">
-            {% else %}
-            <div class="player-photo-placeholder">📷</div>
-            <p class="player-photo-empty">Még nincs profilkép — tölts fel egyet a kártyádhoz!</p>
-            {% endif %}
-            <label class="btn-photo-upload-student">
-                📷 Fotó feltöltése
-                <input type="file" accept="image/jpeg,image/png,image/webp"
-                       onchange="uploadMyPhoto(this)" hidden>
-            </label>
-            {% if user_license.player_card_photo_url %}
-            <button class="btn-photo-delete-student" onclick="deleteMyPhoto()">✕ Törlés</button>
-            {% endif %}
-            <p class="player-photo-hint">Max 2 MB · JPEG/PNG/WEBP · automatikus 400×400 vágás</p>
-        </div>
-    </div>
-    {% endif %}
+            {# ── Last Skill Event ──────────────────────────────────────────────── #}
+            <section class="section-block">
+                <div class="section-header">
+                    <h2 class="page-title">📈 Last Skill Event</h2>
+                    <a href="/skills/history?skill=passing" class="section-link">Full event history →</a>
+                </div>
+                <div id="s-last-result">
+                    <div class="s-loading"><span class="s-spinner"></span> Loading…</div>
+                </div>
+            </section>
 
-    <div class="footer-links">
-        <a href="/dashboard">🏠 Hub</a>
-        <a href="/skills">⚡ Skills</a>
-        <a href="/skills/history?skill=passing">📈 History</a>
-        <a href="/sessions">📅 Sessions</a>
-        <a href="/credits">💳 Credits</a>
-        <a href="/profile">👤 Profile</a>
-    </div>
+            {# ── Available Events ──────────────────────────────────────────────── #}
+            <section class="section-block">
+                <div class="section-header">
+                    <h2 class="page-title">⚽ Available Events</h2>
+                </div>
+                <p class="page-subtitle">Enroll in semesters to access training sessions and progress through your football development path.</p>
+
+                {% if available_semesters|length == 0 %}
+                <div class="info-banner" style="background: #fff7e6; border-color: #faad14;">
+                    <p style="color: #ad6800;">⚠️ <strong>No track semesters available for your age group yet.</strong><br>
+                    Check back later, or <a href="/profile" style="color: #ad6800; text-decoration: underline;">update your profile</a> if your age group is incorrect.</p>
+                </div>
+                {% else %}
+                <div class="info-banner">
+                    <p><strong>💡 Available Semesters for {{ age_category_name }} ({{ age_range }})</strong><br>
+                    {{ age_description }} — {{ available_semesters|length }} semester(s) available</p>
+                </div>
+                {% endif %}
+
+                <div class="cards-grid">
+                    {% for semester in available_semesters %}
+                    <div class="spec-card">
+                        <div class="cost-badge">💰 {{ semester.enrollment_cost }} Credits</div>
+                        <div class="spec-icon">⚽</div>
+                        <h3 class="spec-title">{{ semester.name }}</h3>
+                        <p class="spec-age">📅 {{ semester.start_date.strftime('%Y-%m-%d') }} — {{ semester.end_date.strftime('%Y-%m-%d') }}</p>
+                        <p class="spec-description">
+                            <strong>Code:</strong> {{ semester.code }}<br>
+                            <strong>Status:</strong> {{ semester.status.value if semester.status else 'Unknown' }}
+                        </p>
+                        <div class="spec-action">
+                            {% if user.credit_balance < semester.enrollment_cost %}
+                                <button class="unlock-btn" disabled>❌ Insufficient Credits (Need {{ semester.enrollment_cost }})</button>
+                                <p style="margin-top: 0.5rem; font-size: 0.85rem;">
+                                    <a href="/credits" style="color: #667eea; font-weight: 600;">Purchase credits →</a>
+                                </p>
+                            {% else %}
+                                <form method="POST" action="/semester/enroll">
+                                    <input type="hidden" name="semester_id" value="{{ semester.id }}">
+                                    <button type="submit" class="unlock-btn">🎓 Enroll Now ({{ semester.enrollment_cost }} credits)</button>
+                                </form>
+                            {% endif %}
+                        </div>
+                    </div>
+                    {% endfor %}
+                </div>
+            </section>
+
+        </div>{# /.dash-right-col #}
+
+    </div>{# /.dash-main-grid #}
+
+
 
 </div>
 {% endblock %}
@@ -387,17 +362,20 @@
             document.getElementById('kpi-tournaments').textContent =
                 data.total_tournaments !== undefined ? data.total_tournaments : '—';
 
+            // Fallback snapshot (only rendered when no LFA license)
+            const snapEl = document.getElementById('s-snapshot');
+            if (!snapEl) return;
+
             const sorted = Object.entries(data.skills || {})
                 .sort((a, b) => b[1].current_level - a[1].current_level)
                 .slice(0, 5);
 
             if (sorted.length === 0) {
-                document.getElementById('s-snapshot').innerHTML =
-                    '<p style="color:#a0aec0;font-size:0.9rem;">No skill data available yet.</p>';
+                snapEl.innerHTML = '<p style="color:#a0aec0;font-size:0.9rem;">No skill data available yet.</p>';
                 return;
             }
 
-            const rows = sorted.map(([key, s]) => {
+            snapEl.innerHTML = sorted.map(([key, s]) => {
                 const color = TIER_COLORS[s.tier] || '#667eea';
                 const width = barWidth(s.current_level);
                 return `<div class="s-snapshot-row">
@@ -409,13 +387,11 @@
                 </div>`;
             }).join('');
 
-            document.getElementById('s-snapshot').innerHTML = rows;
-
         } catch (err) {
             document.getElementById('kpi-avg').textContent = '—';
             document.getElementById('kpi-tournaments').textContent = '—';
-            document.getElementById('s-snapshot').innerHTML =
-                '<p style="color:#e74c3c;font-size:0.85rem;">Could not load skill data.</p>';
+            const snapEl = document.getElementById('s-snapshot');
+            if (snapEl) snapEl.innerHTML = '<p style="color:#e74c3c;font-size:0.85rem;">Could not load skill data.</p>';
         }
     }
 
@@ -472,27 +448,4 @@
 })();
 </script>
 
-<script>
-async function uploadMyPhoto(input) {
-    if (!input.files[0]) return;
-    const fd = new FormData();
-    fd.append('file', input.files[0]);
-    const csrf = (document.cookie.split('; ').find(r => r.startsWith('csrf_token=')) || '').split('=')[1];
-    const r = await fetch('/dashboard/lfa-player-photo', {
-        method: 'POST', body: fd, headers: { 'X-CSRF-Token': csrf }
-    });
-    const data = await r.json();
-    if (data.ok) location.reload();
-    else alert('Hiba a feltöltésnél: ' + data.error);
-}
-async function deleteMyPhoto() {
-    if (!confirm('Törli a profilképet?')) return;
-    const csrf = (document.cookie.split('; ').find(r => r.startsWith('csrf_token=')) || '').split('=')[1];
-    const r = await fetch('/dashboard/lfa-player-photo/delete', {
-        method: 'POST', headers: { 'X-CSRF-Token': csrf, 'Content-Type': 'application/json' }
-    });
-    const data = await r.json();
-    if (data.ok) location.reload();
-}
-</script>
 {% endblock %}

--- a/app/templates/dashboard_student_new.html
+++ b/app/templates/dashboard_student_new.html
@@ -8,6 +8,14 @@
     <div class="student-header-inner">
         <a href="/dashboard" class="s-hdr-btn" title="Back to Hub">🏠</a>
         <div class="student-brand">{{ spec_config.icon }} {{ spec_config.name }}</div>
+        <nav class="student-nav" id="student-nav" aria-label="Student navigation">
+            <a href="/dashboard/lfa-football-player" class="nav-item active">⚽ LFA Player</a>
+            <a href="/sessions"     class="nav-item">📅 Sessions</a>
+            <a href="/progress"     class="nav-item">📊 Progress</a>
+            <a href="/skills"       class="nav-item">⚡ Skills</a>
+            <a href="/achievements" class="nav-item">🏆 Achievements</a>
+            <a href="/calendar"     class="nav-item">📆 Calendar</a>
+        </nav>
         <div class="student-header-actions">
             <span class="credit-pill">💰 {{ user.credit_balance if user else 0 }}</span>
             <a href="/credits" class="s-hdr-btn" title="Credits">💳</a>
@@ -265,6 +273,17 @@
                     <div class="s-kpi-lbl">{{ age_range or 'Category' }}</div>
                 </div>
             </div>
+
+            {# ── Skill Snapshot ───────────────────────────────────────────────── #}
+            <section class="section-block">
+                <div class="section-header">
+                    <h2 class="page-title">📊 Skill Snapshot</h2>
+                    <a href="/skills" class="section-link">View all 29 skills →</a>
+                </div>
+                <div id="s-snapshot">
+                    <div class="s-loading"><span class="s-spinner"></span> Loading…</div>
+                </div>
+            </section>
 
             {# ── Last Skill Event ──────────────────────────────────────────────── #}
             <section class="section-block">

--- a/app/templates/dashboard_student_new.html
+++ b/app/templates/dashboard_student_new.html
@@ -160,6 +160,11 @@
     .unlock-btn:disabled:hover { transform: none; box-shadow: none; }
     .cost-badge  { position: absolute; top: 1rem; right: 1rem; background: #ffd700; color: #2d3748; padding: 0.35rem 0.8rem; border-radius: 8px; font-weight: 700; font-size: 0.82rem; box-shadow: 0 2px 8px rgba(0,0,0,0.15); }
 
+    /* ── Footer ──────────────────────────────────────────────────────────────── */
+    .footer-links { text-align: center; margin-top: 2rem; padding-top: 1.5rem; border-top: 1px solid #e2e8f0; }
+    .footer-links a { color: #667eea; text-decoration: none; margin: 0 1rem; font-weight: 600; }
+    .footer-links a:hover { text-decoration: underline; }
+
     /* ── Loading ─────────────────────────────────────────────────────────────── */
     .s-loading { color: #a0aec0; font-size: 0.9rem; padding: 0.5rem 0; }
 
@@ -348,7 +353,14 @@
 
     </div>{# /.dash-main-grid #}
 
-
+    <div class="footer-links">
+        <a href="/dashboard">🏠 Hub</a>
+        <a href="/skills">⚡ Skills</a>
+        <a href="/skills/history?skill=passing">📈 History</a>
+        <a href="/sessions">📅 Sessions</a>
+        <a href="/credits">💳 Credits</a>
+        <a href="/profile">👤 Profile</a>
+    </div>
 
 </div>
 {% endblock %}

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -3490,6 +3490,34 @@
         "title": "Body_specialization_unlock_specialization_unlock_post",
         "type": "object"
       },
+      "Body_student_upload_compact_bg_photo_dashboard_lfa_player_photo_compact_bg_post": {
+        "properties": {
+          "file": {
+            "format": "binary",
+            "title": "File",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file"
+        ],
+        "title": "Body_student_upload_compact_bg_photo_dashboard_lfa_player_photo_compact_bg_post",
+        "type": "object"
+      },
+      "Body_student_upload_landscape_photo_dashboard_lfa_player_photo_landscape_post": {
+        "properties": {
+          "file": {
+            "format": "binary",
+            "title": "File",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file"
+        ],
+        "title": "Body_student_upload_landscape_photo_dashboard_lfa_player_photo_landscape_post",
+        "type": "object"
+      },
       "Body_student_upload_player_photo_dashboard_lfa_player_photo_post": {
         "properties": {
           "file": {
@@ -3502,6 +3530,34 @@
           "file"
         ],
         "title": "Body_student_upload_player_photo_dashboard_lfa_player_photo_post",
+        "type": "object"
+      },
+      "Body_student_upload_portrait_photo_dashboard_lfa_player_photo_portrait_post": {
+        "properties": {
+          "file": {
+            "format": "binary",
+            "title": "File",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file"
+        ],
+        "title": "Body_student_upload_portrait_photo_dashboard_lfa_player_photo_portrait_post",
+        "type": "object"
+      },
+      "Body_student_upload_showcase_bg_photo_dashboard_lfa_player_photo_showcase_bg_post": {
+        "properties": {
+          "file": {
+            "format": "binary",
+            "title": "File",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file"
+        ],
+        "title": "Body_student_upload_showcase_bg_photo_dashboard_lfa_player_photo_showcase_bg_post",
         "type": "object"
       },
       "Body_submit_quiz_quizzes__quiz_id__submit_post": {
@@ -20957,6 +21013,32 @@
           "max_level_reached"
         ],
         "title": "XPResponse",
+        "type": "object"
+      },
+      "_CardThemeRequest": {
+        "properties": {
+          "theme": {
+            "title": "Theme",
+            "type": "string"
+          }
+        },
+        "required": [
+          "theme"
+        ],
+        "title": "_CardThemeRequest",
+        "type": "object"
+      },
+      "_CardVariantRequest": {
+        "properties": {
+          "variant": {
+            "title": "Variant",
+            "type": "string"
+          }
+        },
+        "required": [
+          "variant"
+        ],
+        "title": "_CardVariantRequest",
         "type": "object"
       },
       "app__api__api_v1__endpoints__coach__licenses__LicenseCreate": {
@@ -55556,6 +55638,128 @@
         ]
       }
     },
+    "/dashboard/card-photo-focus": {
+      "post": {
+        "description": "Save photo focus point (X%, Y%) for a specific card variant.",
+        "operationId": "student_set_card_photo_focus_dashboard_card_photo_focus_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Student Set Card Photo Focus",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/dashboard/card-theme": {
+      "post": {
+        "description": "Update the active colour theme for the authenticated student's player card.",
+        "operationId": "student_set_card_theme_dashboard_card_theme_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/_CardThemeRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Student Set Card Theme",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/dashboard/card-variant": {
+      "post": {
+        "description": "Apply a card layout variant (must already be unlocked for premium variants).",
+        "operationId": "student_set_card_variant_dashboard_card_variant_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/_CardVariantRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Student Set Card Variant",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/dashboard/lfa-football-player/card-editor": {
+      "get": {
+        "description": "Dedicated sub-page for LFA Football Player card editing (Phase 1 extraction).",
+        "operationId": "lfa_player_card_editor_dashboard_lfa_football_player_card_editor_get",
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Lfa Player Card Editor",
+        "tags": [
+          "web"
+        ]
+      }
+    },
     "/dashboard/lfa-player-photo": {
       "post": {
         "operationId": "student_upload_player_photo_dashboard_lfa_player_photo_post",
@@ -55595,6 +55799,238 @@
         ]
       }
     },
+    "/dashboard/lfa-player-photo-compact-bg": {
+      "post": {
+        "operationId": "student_upload_compact_bg_photo_dashboard_lfa_player_photo_compact_bg_post",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_student_upload_compact_bg_photo_dashboard_lfa_player_photo_compact_bg_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Student Upload Compact Bg Photo",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/dashboard/lfa-player-photo-compact-bg/delete": {
+      "post": {
+        "operationId": "student_delete_compact_bg_photo_dashboard_lfa_player_photo_compact_bg_delete_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Student Delete Compact Bg Photo",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/dashboard/lfa-player-photo-landscape": {
+      "post": {
+        "operationId": "student_upload_landscape_photo_dashboard_lfa_player_photo_landscape_post",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_student_upload_landscape_photo_dashboard_lfa_player_photo_landscape_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Student Upload Landscape Photo",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/dashboard/lfa-player-photo-landscape/delete": {
+      "post": {
+        "operationId": "student_delete_landscape_photo_dashboard_lfa_player_photo_landscape_delete_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Student Delete Landscape Photo",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/dashboard/lfa-player-photo-portrait": {
+      "post": {
+        "operationId": "student_upload_portrait_photo_dashboard_lfa_player_photo_portrait_post",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_student_upload_portrait_photo_dashboard_lfa_player_photo_portrait_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Student Upload Portrait Photo",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/dashboard/lfa-player-photo-portrait/delete": {
+      "post": {
+        "operationId": "student_delete_portrait_photo_dashboard_lfa_player_photo_portrait_delete_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Student Delete Portrait Photo",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/dashboard/lfa-player-photo-showcase-bg": {
+      "post": {
+        "operationId": "student_upload_showcase_bg_photo_dashboard_lfa_player_photo_showcase_bg_post",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_student_upload_showcase_bg_photo_dashboard_lfa_player_photo_showcase_bg_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Student Upload Showcase Bg Photo",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/dashboard/lfa-player-photo-showcase-bg/delete": {
+      "post": {
+        "operationId": "student_delete_showcase_bg_photo_dashboard_lfa_player_photo_showcase_bg_delete_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Student Delete Showcase Bg Photo",
+        "tags": [
+          "web"
+        ]
+      }
+    },
     "/dashboard/lfa-player-photo/delete": {
       "post": {
         "operationId": "student_delete_player_photo_dashboard_lfa_player_photo_delete_post",
@@ -55609,6 +56045,86 @@
           }
         },
         "summary": "Student Delete Player Photo",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/dashboard/unlock-theme": {
+      "post": {
+        "description": "Unlock a premium card theme by spending credits.",
+        "operationId": "student_unlock_theme_dashboard_unlock_theme_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/_CardThemeRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Student Unlock Theme",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/dashboard/unlock-variant": {
+      "post": {
+        "description": "Unlock a premium card layout variant by spending credits.",
+        "operationId": "student_unlock_variant_dashboard_unlock_variant_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/_CardVariantRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Student Unlock Variant",
         "tags": [
           "web"
         ]


### PR DESCRIPTION
## Summary

Restores 6 files overwritten by the `125f508` squash regression. This is a pure functional restoration — no layout changes, no Events navigation.

### Routes restored (`dashboard.py` — 11 routes)
- `GET /dashboard/lfa-football-player/card-editor` — card editor sub-page
- `POST` ×10 — photo upload/delete (portrait, landscape, compact-bg, showcase-bg), set/unlock theme, set/unlock variant

### Services restored
- `card_theme_service.py` — `ThemeDefinition`, 6 themes (3 free / 3 premium), credit-gated unlock/apply
- `card_variant_service.py` — `VariantDefinition`, 5 variants (1 free / 4 premium), credit-gated unlock/apply
- `player_photo_service.py` — expanded 2 → 10 functions (portrait / landscape / bg variants)

### Templates restored
- `dashboard_card_editor.html` — dedicated card editing page (theme picker, variant picker, 3 photo upload sections)
- `dashboard_student_new.html` — player card iframe, 6-item mod-nav grid (My Card restored), nav dedup, Messages/Notifications badges

### Explicitly deferred
- Stacked Hero layout refactor → PR-3
- Events navigation restoration → future PR

## Scope
- **6 files changed**, no new migrations, no schema changes, no `__init__.py` changes (dashboard router already registered on main)

## Test plan
- [ ] Unit Tests pass
- [ ] API Smoke Tests pass (route count increases by 11)
- [ ] Student dashboard shows player card iframe
- [ ] `/dashboard/lfa-football-player/card-editor` renders correctly
- [ ] Photo upload endpoints respond (POST routes exist)
- [ ] Theme/variant unlock endpoints respond

🤖 Generated with [Claude Code](https://claude.com/claude-code)