### PR TITLE
refactor(nav): simplify header to spec-switching only

### DIFF
--- a/app/templates/dashboard_student_new.html
+++ b/app/templates/dashboard_student_new.html
@@ -10,11 +10,6 @@
         <div class="student-brand">{{ spec_config.icon }} {{ spec_config.name }}</div>
         <nav class="student-nav" id="student-nav" aria-label="Student navigation">
             <a href="/dashboard/lfa-football-player" class="nav-item active">⚽ LFA Player</a>
-            <a href="/sessions"     class="nav-item">📅 Sessions</a>
-            <a href="/progress"     class="nav-item">📊 Progress</a>
-            <a href="/skills"       class="nav-item">⚡ Skills</a>
-            <a href="/achievements" class="nav-item">🏆 Achievements</a>
-            <a href="/calendar"     class="nav-item">📆 Calendar</a>
         </nav>
         <div class="student-header-actions">
             <span class="credit-pill">💰 {{ user.credit_balance if user else 0 }}</span>

--- a/app/templates/student_base.html
+++ b/app/templates/student_base.html
@@ -10,8 +10,7 @@
            <h1>Page content here</h1>
        {% endblock %}
 
-   Active page values: hub | lfa-player | sessions | progress | skills |
-                       achievements | calendar | credits
+   Active page values: hub | lfa-player | credits
 
    Context expected from route handler (at minimum):
        user       — User ORM object (for credit_balance, name, email, role)
@@ -39,23 +38,13 @@
         <button class="student-hamburger" id="student-hamburger-btn"
                 onclick="toggleStudentNav()" aria-label="Toggle navigation" aria-expanded="false">☰</button>
 
-        {# Nav links — show_spec_nav=False on hub-level pages (credits, profile, etc.) #}
+        {# Nav links — spec switching only; module navigation lives on dashboard cards #}
         <nav class="student-nav" id="student-nav" aria-label="Student navigation">
             <a href="/dashboard"
                class="nav-item{% if _active == 'hub' or p == '/dashboard' %} active{% endif %}">🏠 Hub</a>
             {% if show_spec_nav | default(true) %}
             <a href="/dashboard/lfa-football-player"
                class="nav-item{% if _active == 'lfa-player' or p.startswith('/dashboard/lfa') %} active{% endif %}">⚽ LFA Player</a>
-            <a href="/sessions"
-               class="nav-item{% if _active == 'sessions' or p.startswith('/sessions') %} active{% endif %}">📅 Sessions</a>
-            <a href="/progress"
-               class="nav-item{% if _active == 'progress' or p == '/progress' %} active{% endif %}">📊 Progress</a>
-            <a href="/skills"
-               class="nav-item{% if _active == 'skills' or p == '/skills' %} active{% endif %}">⚡ Skills</a>
-            <a href="/achievements"
-               class="nav-item{% if _active == 'achievements' or p == '/achievements' %} active{% endif %}">🏆 Achievements</a>
-            <a href="/calendar"
-               class="nav-item{% if _active == 'calendar' or p == '/calendar' %} active{% endif %}">📆 Calendar</a>
             {% endif %}
         </nav>
 


### PR DESCRIPTION
## Summary
- Removes `Sessions`, `Progress`, `Skills`, `Achievements`, `Calendar` from the global header nav in `student_base.html`
- Removes the same 5 module links from the spec dashboard's `{% block student_header %}` override in `dashboard_student_new.html`
- Header now carries `🏠 Hub` and `⚽ LFA Player` only; all utility actions (Credits, Messages, Notifications, Profile, Logout) are unchanged
- Module navigation is fully delegated to the dashboard card surface (addressed in PR-5)

## Scope
Two templates only:
- `app/templates/student_base.html` — global nav block
- `app/templates/dashboard_student_new.html` — spec header block (lines 11–17)

No backend, route, service, or CSS changes.

## Test plan
- [ ] Unit Tests CI green
- [ ] Cypress student suite — `STU-JOURNEY-08`: `.student-nav a[href="/dashboard/lfa-football-player"]` still present ✓
- [ ] Cypress student suite — no assertion on removed header links (Sessions/Progress/Skills/Achievements/Calendar were never asserted in header)

🤖 Generated with [Claude Code](https://claude.com/claude-code)