### PR TITLE
feat(dashboard): Events hub, Adaptive Learning entry, 2×3 mod-nav redesign (#94)

### DIFF
--- a/app/api/web_routes/__init__.py
+++ b/app/api/web_routes/__init__.py
@@ -17,6 +17,8 @@ from . import (
     instructor,
     instructor_dashboard,
     programs,
+    events,
+    adaptive_learning,
     communications,
     teams,
     tournament_live,
@@ -45,6 +47,8 @@ router.include_router(instructor_dashboard.router)
 router.include_router(admin_router)
 router.include_router(tournaments_router)
 router.include_router(programs.router)       # 📅 MINI_SEASON / ACADEMY_SEASON student enrollment
+router.include_router(events.router)         # 📅 Events hub (/events)
+router.include_router(adaptive_learning.router)  # 🧠 Adaptive Learning entry point
 router.include_router(communications.router)
 router.include_router(teams.router)
 router.include_router(tournament_live.router)  # ✅ Live monitoring (WebSocket + admin page)

--- a/app/api/web_routes/adaptive_learning.py
+++ b/app/api/web_routes/adaptive_learning.py
@@ -1,0 +1,68 @@
+"""Adaptive Learning entry point — shows XP history from adaptive_learning_sessions."""
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from ...database import get_db
+from ...dependencies import get_current_user_web
+from ...models.quiz import AdaptiveLearningSession
+from ...models.user import User
+from .helpers import require_student_onboarding
+from .student_features import _spec_ctx
+
+BASE_DIR = Path(__file__).resolve().parent.parent.parent
+templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
+
+router = APIRouter(tags=["adaptive-learning"])
+
+
+@router.get("/adaptive-learning", response_class=HTMLResponse)
+async def adaptive_learning_page(
+    request: Request,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user_web),
+):
+    """Adaptive Learning entry point — XP summary + disabled CTA until full engine lands."""
+    guard = require_student_onboarding(user)
+    if guard:
+        return guard
+
+    # ── Stats from adaptive_learning_sessions (safe — table exists) ──────────
+    total_xp = (
+        db.query(func.sum(AdaptiveLearningSession.xp_earned))
+        .filter(AdaptiveLearningSession.user_id == user.id)
+        .scalar()
+    ) or 0
+
+    session_count = (
+        db.query(func.count(AdaptiveLearningSession.id))
+        .filter(AdaptiveLearningSession.user_id == user.id)
+        .scalar()
+    ) or 0
+
+    recent_sessions = (
+        db.query(AdaptiveLearningSession)
+        .filter(AdaptiveLearningSession.user_id == user.id)
+        .order_by(AdaptiveLearningSession.started_at.desc())
+        .limit(5)
+        .all()
+    )
+
+    last_session = recent_sessions[0] if recent_sessions else None
+
+    return templates.TemplateResponse(
+        "adaptive_learning.html",
+        {
+            "request": request,
+            "user": user,
+            **_spec_ctx(user, db),
+            "total_xp": total_xp,
+            "session_count": session_count,
+            "recent_sessions": recent_sessions,
+            "last_session": last_session,
+        },
+    )

--- a/app/api/web_routes/events.py
+++ b/app/api/web_routes/events.py
@@ -1,0 +1,91 @@
+"""Events hub route — navigation-only landing page for all event types."""
+from datetime import date
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+from sqlalchemy.orm import Session
+
+from ...database import get_db
+from ...dependencies import get_current_user_web
+from ...models.semester import Semester, SemesterCategory, SemesterStatus
+from ...models.semester_enrollment import SemesterEnrollment, EnrollmentStatus
+from ...models.user import User
+from .helpers import require_student_onboarding
+from .student_features import _spec_ctx
+
+BASE_DIR = Path(__file__).resolve().parent.parent.parent
+templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
+
+router = APIRouter(tags=["events"])
+
+_BROWSE_STATUSES = {SemesterStatus.ONGOING, SemesterStatus.READY_FOR_ENROLLMENT}
+
+
+@router.get("/events", response_class=HTMLResponse)
+async def events_hub(
+    request: Request,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user_web),
+):
+    """Events hub — navigation hub for Camps, Tournaments, Academy Season, Mini Season."""
+    guard = require_student_onboarding(user)
+    if guard:
+        return guard
+
+    today = date.today()
+
+    # ── Counters (display only — no enrollment logic) ────────────────────────
+    camps_open = db.query(Semester).filter(
+        Semester.semester_category == SemesterCategory.CAMP,
+        Semester.tournament_status == "ENROLLMENT_OPEN",
+        Semester.status != SemesterStatus.CANCELLED,
+        Semester.end_date >= today,
+    ).count()
+
+    tournaments_open = db.query(Semester).filter(
+        Semester.semester_category == SemesterCategory.TOURNAMENT,
+        Semester.tournament_status.in_(["ENROLLMENT_OPEN", "IN_PROGRESS"]),
+        Semester.specialization_type == "LFA_FOOTBALL_PLAYER",
+        Semester.status != SemesterStatus.CANCELLED,
+        Semester.end_date >= today,
+    ).count()
+
+    spec_value = user.specialization.value if user.specialization else None
+
+    academy_available = 0
+    mini_available = 0
+    if spec_value:
+        academy_available = db.query(Semester).filter(
+            Semester.semester_category == SemesterCategory.ACADEMY_SEASON,
+            Semester.status.in_(_BROWSE_STATUSES),
+            Semester.specialization_type == spec_value,
+        ).count()
+
+        mini_available = db.query(Semester).filter(
+            Semester.semester_category == SemesterCategory.MINI_SEASON,
+            Semester.status.in_(_BROWSE_STATUSES),
+            Semester.specialization_type == spec_value,
+        ).count()
+
+    # ── User's active enrollments count (for context) ────────────────────────
+    my_active = db.query(SemesterEnrollment).filter(
+        SemesterEnrollment.user_id == user.id,
+        SemesterEnrollment.is_active == True,
+        SemesterEnrollment.request_status == EnrollmentStatus.APPROVED,
+    ).count()
+
+    return templates.TemplateResponse(
+        "events_hub.html",
+        {
+            "request": request,
+            "user": user,
+            **_spec_ctx(user, db),
+            "camps_open": camps_open,
+            "tournaments_open": tournaments_open,
+            "academy_available": academy_available,
+            "mini_available": mini_available,
+            "my_active_enrollments": my_active,
+        },
+    )

--- a/app/api/web_routes/programs.py
+++ b/app/api/web_routes/programs.py
@@ -13,8 +13,9 @@ import uuid
 from datetime import datetime
 from pathlib import Path
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
+from typing import Optional
 from fastapi.templating import Jinja2Templates
 from sqlalchemy import func, update as sql_update
 from sqlalchemy.exc import IntegrityError
@@ -67,16 +68,23 @@ async def semester_enroll_browse(
     request: Request,
     db: Session = Depends(get_db),
     user: User = Depends(get_current_user_web),
+    category: Optional[str] = Query(None, description="Filter by category: ACADEMY_SEASON or MINI_SEASON"),
 ):
     spec_value = user.specialization.value if user.specialization else None
     color = _SPEC_COLORS.get(spec_value, "#667eea")
+
+    # Resolve which categories to show based on optional ?category= param
+    if category and category in {"ACADEMY_SEASON", "MINI_SEASON"}:
+        cats = {SemesterCategory[category]}
+    else:
+        cats = _PROGRAM_CATEGORIES
 
     available = []
     if spec_value:
         available = (
             db.query(Semester)
             .filter(
-                Semester.semester_category.in_(_PROGRAM_CATEGORIES),
+                Semester.semester_category.in_(cats),
                 Semester.status.in_(_BROWSE_STATUSES),
                 Semester.specialization_type == spec_value,
             )

--- a/app/templates/adaptive_learning.html
+++ b/app/templates/adaptive_learning.html
@@ -1,0 +1,301 @@
+{% extends "student_base.html" %}
+
+{% block title %}Adaptive Learning - LFA{% endblock %}
+{% block active_page %}lfa-player{% endblock %}
+
+{% block student_header %}
+{% set _page_icon = '🧠' %}
+{% set _page_name = 'Adaptive Learning' %}
+{% include "includes/spec_subpage_hdr.html" %}
+{% endblock %}
+
+{% block extra_styles %}
+<style>
+    .al-container {
+        max-width: 780px;
+        margin: 0 auto;
+        padding: 1.5rem 1rem 2.5rem;
+    }
+
+    .al-header {
+        margin-bottom: 2rem;
+    }
+
+    .al-header h1 {
+        font-size: 1.6rem;
+        font-weight: 700;
+        color: var(--app-text);
+        margin: 0 0 0.35rem;
+    }
+
+    .al-header p {
+        color: var(--app-text-muted);
+        font-size: 0.95rem;
+        margin: 0;
+    }
+
+    /* ── Stats block ────────────────────────────────────────────────────────── */
+    .al-stats-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 1rem;
+        margin-bottom: 1.75rem;
+    }
+
+    @media (max-width: 520px) {
+        .al-stats-grid { grid-template-columns: repeat(2, 1fr); }
+    }
+
+    .al-stat-card {
+        background: var(--app-card);
+        border-radius: 12px;
+        padding: 1.25rem 1.5rem;
+        box-shadow: 0 2px 8px rgba(0,0,0,0.07);
+        text-align: center;
+        border-top: 3px solid #667eea;
+    }
+
+    .al-stat-card:nth-child(1) { border-top-color: #9b59b6; }
+    .al-stat-card:nth-child(2) { border-top-color: #2ecc71; }
+    .al-stat-card:nth-child(3) { border-top-color: #3498db; }
+
+    .al-stat-val {
+        font-size: 2rem;
+        font-weight: 700;
+        color: var(--app-text);
+        line-height: 1.1;
+    }
+
+    .al-stat-card:nth-child(1) .al-stat-val { color: #6c3483; }
+    .al-stat-card:nth-child(2) .al-stat-val { color: #1e8449; }
+    .al-stat-card:nth-child(3) .al-stat-val { color: #1a5276; }
+
+    .al-stat-lbl {
+        font-size: 0.82rem;
+        color: var(--app-text-muted);
+        margin-top: 0.3rem;
+    }
+
+    /* ── CTA block ──────────────────────────────────────────────────────────── */
+    .al-cta-block {
+        background: var(--app-card);
+        border-radius: 14px;
+        padding: 1.75rem 2rem;
+        box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+        margin-bottom: 1.75rem;
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+    }
+
+    .al-cta-title {
+        font-size: 1.1rem;
+        font-weight: 700;
+        color: var(--app-text);
+        margin: 0;
+    }
+
+    .al-cta-desc {
+        font-size: 0.9rem;
+        color: var(--app-text-muted);
+        margin: 0;
+        line-height: 1.5;
+    }
+
+    .al-cta-features {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.6rem;
+        margin: 0;
+    }
+
+    .al-feature-chip {
+        background: #f0f4ff;
+        color: #3730a3;
+        border-radius: 20px;
+        padding: 0.3rem 0.85rem;
+        font-size: 0.82rem;
+        font-weight: 600;
+    }
+
+    .al-cta-btn {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        background: #c7d2fe;
+        color: #3730a3;
+        border: 2px solid #a5b4fc;
+        border-radius: 8px;
+        padding: 0.7rem 1.5rem;
+        font-size: 1rem;
+        font-weight: 700;
+        cursor: not-allowed;
+        opacity: 0.7;
+        width: fit-content;
+    }
+
+    .al-cta-notice {
+        font-size: 0.82rem;
+        color: var(--app-text-muted);
+        background: #fafafa;
+        border: 1px solid #e5e7eb;
+        border-radius: 8px;
+        padding: 0.6rem 1rem;
+        margin: 0;
+    }
+
+    /* ── Recent sessions ────────────────────────────────────────────────────── */
+    .al-history-block {
+        background: var(--app-card);
+        border-radius: 14px;
+        padding: 1.5rem 1.75rem;
+        box-shadow: 0 2px 8px rgba(0,0,0,0.07);
+        margin-bottom: 1.75rem;
+    }
+
+    .al-history-title {
+        font-size: 1rem;
+        font-weight: 700;
+        color: var(--app-text);
+        margin: 0 0 1rem;
+    }
+
+    .al-session-row {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+        padding: 0.65rem 0;
+        border-bottom: 1px solid var(--app-border);
+        font-size: 0.88rem;
+        flex-wrap: wrap;
+    }
+
+    .al-session-row:last-child { border-bottom: none; }
+
+    .al-session-date { color: var(--app-text-muted); min-width: 90px; }
+    .al-session-cat  { font-weight: 600; color: var(--app-text); flex: 1; }
+    .al-session-score {
+        font-size: 0.82rem;
+        color: var(--app-text-muted);
+        white-space: nowrap;
+    }
+    .al-session-xp {
+        font-weight: 700;
+        color: #6c3483;
+        white-space: nowrap;
+    }
+
+    .al-empty {
+        color: var(--app-text-muted);
+        font-size: 0.9rem;
+        padding: 0.5rem 0;
+    }
+
+    /* ── Footer cross-links ─────────────────────────────────────────────────── */
+    .al-footer {
+        text-align: center;
+        margin-top: 2rem;
+        padding-top: 1.5rem;
+        border-top: 1px solid #e2e8f0;
+    }
+
+    .al-footer a {
+        color: #667eea;
+        text-decoration: none;
+        margin: 0 1rem;
+        font-weight: 600;
+        font-size: 0.9rem;
+    }
+
+    .al-footer a:hover { text-decoration: underline; }
+</style>
+{% endblock %}
+
+{% block student_content %}
+<div class="al-container">
+
+    <div class="al-header">
+        <h1>🧠 Adaptive Learning</h1>
+        <p>Personalised question sessions that adapt to your level and reward XP based on performance.</p>
+    </div>
+
+    {# ── Stats ─────────────────────────────────────────────────────────────── #}
+    <div class="al-stats-grid">
+        <div class="al-stat-card">
+            <div class="al-stat-val">{{ total_xp }}</div>
+            <div class="al-stat-lbl">XP Earned</div>
+        </div>
+        <div class="al-stat-card">
+            <div class="al-stat-val">{{ session_count }}</div>
+            <div class="al-stat-lbl">Sessions Completed</div>
+        </div>
+        <div class="al-stat-card">
+            <div class="al-stat-val">
+                {% if last_session and last_session.started_at %}
+                    {{ last_session.started_at.strftime('%b %d') }}
+                {% else %}
+                    —
+                {% endif %}
+            </div>
+            <div class="al-stat-lbl">Last Session</div>
+        </div>
+    </div>
+
+    {# ── CTA block ─────────────────────────────────────────────────────────── #}
+    <div class="al-cta-block">
+        <p class="al-cta-title">🚀 Start Adaptive Session</p>
+        <p class="al-cta-desc">
+            Answer questions tailored to your current skill level across football knowledge categories.
+            The difficulty adapts in real-time — correct answers raise the bar, incorrect ones recalibrate it.
+        </p>
+        <div class="al-cta-features">
+            <span class="al-feature-chip">⚡ XP rewards</span>
+            <span class="al-feature-chip">🎯 Dynamic difficulty</span>
+            <span class="al-feature-chip">📊 Skill-linked questions</span>
+            <span class="al-feature-chip">⏱️ Timed sessions</span>
+        </div>
+        <button class="al-cta-btn" disabled title="Full adaptive engine coming soon">
+            🧠 Start Session
+        </button>
+        <p class="al-cta-notice">
+            The adaptive engine is being finalised. Your session history and XP are already tracked —
+            full question sessions will be unlocked in an upcoming update.
+        </p>
+    </div>
+
+    {# ── Recent sessions history ────────────────────────────────────────────── #}
+    <div class="al-history-block">
+        <h2 class="al-history-title">📋 Recent Sessions</h2>
+
+        {% if recent_sessions %}
+            {% for s in recent_sessions %}
+            <div class="al-session-row">
+                <span class="al-session-date">
+                    {{ s.started_at.strftime('%b %d, %Y') if s.started_at else '—' }}
+                </span>
+                <span class="al-session-cat">
+                    {{ s.category.value.replace('_', ' ').title() if s.category else '—' }}
+                </span>
+                <span class="al-session-score">
+                    {% if s.questions_presented and s.questions_presented > 0 %}
+                        {{ s.questions_correct or 0 }} / {{ s.questions_presented }} correct
+                    {% else %}
+                        —
+                    {% endif %}
+                </span>
+                <span class="al-session-xp">+{{ s.xp_earned or 0 }} XP</span>
+            </div>
+            {% endfor %}
+        {% else %}
+            <p class="al-empty">No sessions yet — your history will appear here once sessions are available.</p>
+        {% endif %}
+    </div>
+
+    <div class="al-footer">
+        <a href="/dashboard/lfa-football-player">⚽ Dashboard</a>
+        <a href="/progress">📊 View Progress</a>
+        <a href="/skills/history?skill=passing">📈 Skill History</a>
+    </div>
+
+</div>
+{% endblock %}

--- a/app/templates/camps.html
+++ b/app/templates/camps.html
@@ -1,8 +1,15 @@
-{% extends "base.html" %}
+{% extends "student_base.html" %}
 
 {% block title %}Camps - LFA Education Center{% endblock %}
+{% block active_page %}lfa-player{% endblock %}
 
-{% block content %}
+{% block student_header %}
+{% set _page_icon = '🏕️' %}
+{% set _page_name = 'Camps' %}
+{% include "includes/spec_subpage_hdr.html" %}
+{% endblock %}
+
+{% block extra_styles %}
 <style>
 .camp-card {
     border-radius: 12px;
@@ -75,11 +82,34 @@
     flex-wrap: wrap;
     align-items: center;
 }
+.camps-container {
+    max-width: 860px;
+    margin: 0 auto;
+    padding: 1.5rem 1rem 2rem;
+}
+.camps-page-footer {
+    text-align: center;
+    margin-top: 2rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid #e2e8f0;
+    font-size: 0.9rem;
+}
+.camps-page-footer a {
+    color: #667eea;
+    text-decoration: none;
+    margin: 0 1rem;
+    font-weight: 600;
+}
+.camps-page-footer a:hover { text-decoration: underline; }
 </style>
+{% endblock %}
 
-<div class="welcome-section">
-    <h1>⛺ Camps</h1>
-    <p>Browse open camps and manage your participation</p>
+{% block student_content %}
+<div class="camps-container">
+
+<div style="margin-bottom: 1.5rem;">
+    <h1 style="font-size:1.6rem; font-weight:700; margin:0 0 0.3rem;">🏕️ Camps</h1>
+    <p style="color:#7f8c8d; margin:0;">Browse open camps and manage your participation</p>
 </div>
 
 {% if flash %}
@@ -92,7 +122,7 @@
 {% endif %}
 
 {% if not camps %}
-<div class="card text-center" style="padding: 3rem;">
+<div class="card text-center" style="padding: 3rem; background:white; border-radius:12px; box-shadow:0 2px 8px rgba(0,0,0,0.07);">
     <div style="font-size: 3rem; margin-bottom: 1rem;">⛺</div>
     <h3>No Open Camps</h3>
     <p style="color: #7f8c8d;">There are no camps open for enrollment right now. Check back later!</p>
@@ -173,4 +203,11 @@
 
 {% endif %}
 
+<div class="camps-page-footer">
+    <a href="/events">← All Events</a>
+    <a href="/sessions">📋 My Sessions</a>
+    <a href="/dashboard/lfa-football-player">⚽ Dashboard</a>
+</div>
+
+</div>
 {% endblock %}

--- a/app/templates/dashboard_student_new.html
+++ b/app/templates/dashboard_student_new.html
@@ -33,7 +33,7 @@
 <style>
     /* spec-pg-hdr + mod-nav-* → student.css v5 */
 
-    /* ── Spec dashboard: 3-column module nav grid (Events / Journey / Identity) */
+    /* ── Spec dashboard: 3-column module nav grid (2×3 — 6 primary domains) */
     .mod-nav-grid { grid-template-columns: repeat(3, 1fr); }
     @media (max-width: 768px) { .mod-nav-grid { grid-template-columns: repeat(3, 1fr); } }
     @media (max-width: 480px) { .mod-nav-grid { grid-template-columns: repeat(3, 1fr); } }
@@ -187,48 +187,35 @@
     {% endif %}
 
     {# ── Module Navigation (full-width, below card) ────────────────────────────── #}
-    {# 3×3 grid: Events row / My Journey row / Identity row                         #}
-    {# All targets have require_student_onboarding guard                            #}
+    {# 2×3 grid: 6 primary domains                                                  #}
+    {# Sessions / Progress / Skills accessible via footer + cross-links             #}
     <section class="mod-nav-section">
         <div class="mod-nav-grid">
-            {# Row 1 — Events #}
-            <a href="/semesters/enroll" class="mod-nav-card">
-                <span class="mod-nav-icon">🎓</span>
-                <span class="mod-nav-title">Programs</span>
-            </a>
-            <a href="/camps" class="mod-nav-card">
-                <span class="mod-nav-icon">🏕️</span>
-                <span class="mod-nav-title">Camps</span>
-            </a>
-            <a href="/tournaments" class="mod-nav-card">
-                <span class="mod-nav-icon">🏆</span>
-                <span class="mod-nav-title">Tournaments</span>
-            </a>
-            {# Row 2 — My Journey #}
-            <a href="/sessions" class="mod-nav-card">
+            {# Row 1 #}
+            <a href="/events" class="mod-nav-card">
                 <span class="mod-nav-icon">📅</span>
-                <span class="mod-nav-title">Sessions</span>
+                <span class="mod-nav-title">Events</span>
             </a>
-            <a href="/progress" class="mod-nav-card">
-                <span class="mod-nav-icon">📊</span>
-                <span class="mod-nav-title">Progress</span>
+            <a href="/dashboard/lfa-football-player/card-editor" class="mod-nav-card">
+                <span class="mod-nav-icon">🪪</span>
+                <span class="mod-nav-title">My Card</span>
             </a>
-            <a href="/skills" class="mod-nav-card">
-                <span class="mod-nav-icon">⚡</span>
-                <span class="mod-nav-title">Skills</span>
+            <a href="/adaptive-learning" class="mod-nav-card">
+                <span class="mod-nav-icon">🧠</span>
+                <span class="mod-nav-title">Adaptive Learning</span>
             </a>
-            {# Row 3 — Identity & Tools #}
-            <a href="/achievements" class="mod-nav-card">
-                <span class="mod-nav-icon">🏅</span>
-                <span class="mod-nav-title">Achievements</span>
+            {# Row 2 #}
+            <a href="/skills/history?skill=passing" class="mod-nav-card">
+                <span class="mod-nav-icon">📈</span>
+                <span class="mod-nav-title">Skill History</span>
             </a>
             <a href="/calendar" class="mod-nav-card">
                 <span class="mod-nav-icon">📆</span>
                 <span class="mod-nav-title">Calendar</span>
             </a>
-            <a href="/dashboard/lfa-football-player/card-editor" class="mod-nav-card">
-                <span class="mod-nav-icon">🪪</span>
-                <span class="mod-nav-title">My Card</span>
+            <a href="/achievements" class="mod-nav-card">
+                <span class="mod-nav-icon">🏅</span>
+                <span class="mod-nav-title">Achievements</span>
             </a>
         </div>
     </section>
@@ -277,9 +264,9 @@
 
     <div class="footer-links">
         <a href="/dashboard">🏠 Hub</a>
+        <a href="/sessions">📋 Sessions</a>
+        <a href="/progress">📊 Progress</a>
         <a href="/skills">⚡ Skills</a>
-        <a href="/skills/history?skill=passing">📈 History</a>
-        <a href="/sessions">📅 Sessions</a>
         <a href="/credits">💳 Credits</a>
         <a href="/profile">👤 Profile</a>
     </div>

--- a/app/templates/dashboard_student_new.html
+++ b/app/templates/dashboard_student_new.html
@@ -33,8 +33,8 @@
 <style>
     /* spec-pg-hdr + mod-nav-* → student.css v5 */
 
-    /* ── Spec dashboard: 6-column override (sub-pages use 4-col from student.css) */
-    .mod-nav-grid { grid-template-columns: repeat(6, 1fr); }
+    /* ── Spec dashboard: 3-column module nav grid (Events / Journey / Identity) */
+    .mod-nav-grid { grid-template-columns: repeat(3, 1fr); }
     @media (max-width: 768px) { .mod-nav-grid { grid-template-columns: repeat(3, 1fr); } }
     @media (max-width: 480px) { .mod-nav-grid { grid-template-columns: repeat(3, 1fr); } }
 
@@ -134,21 +134,6 @@
     .s-delta-zero  { color: var(--app-text-muted); font-size: 0.95rem; }
     .s-result-meta { color: var(--app-text-muted); font-size: 0.82rem; }
 
-    /* ── Events (semester cards) ─────────────────────────────────────────────── */
-    .cards-grid  { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 1.5rem; }
-    .spec-card   { background: var(--app-card); border-radius: 16px; padding: 1.75rem; box-shadow: 0 4px 12px rgba(0,0,0,0.08); transition: transform 0.3s, box-shadow 0.3s; position: relative; overflow: hidden; }
-    .spec-card:hover { transform: translateY(-4px); box-shadow: 0 8px 24px rgba(0,0,0,0.12); }
-    .spec-icon   { font-size: 2.5rem; text-align: center; margin-bottom: 0.75rem; }
-    .spec-title  { font-size: 1.2rem; font-weight: 700; color: var(--app-text); text-align: center; margin-bottom: 0.4rem; }
-    .spec-age    { text-align: center; color: var(--app-text-muted); font-size: 0.88rem; margin-bottom: 0.9rem; }
-    .spec-description { color: var(--app-text-muted); font-size: 0.93rem; line-height: 1.55; margin-bottom: 1.2rem; text-align: center; }
-    .spec-action { text-align: center; }
-    .unlock-btn  { width: 100%; padding: 0.85rem; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; border: none; border-radius: 10px; font-size: 0.97rem; font-weight: 600; cursor: pointer; transition: transform 0.2s, box-shadow 0.2s; }
-    .unlock-btn:hover    { transform: translateY(-2px); box-shadow: 0 6px 20px rgba(102,126,234,0.4); }
-    .unlock-btn:disabled { background: #cbd5e0; cursor: not-allowed; }
-    .unlock-btn:disabled:hover { transform: none; box-shadow: none; }
-    .cost-badge  { position: absolute; top: 1rem; right: 1rem; background: #ffd700; color: #2d3748; padding: 0.35rem 0.8rem; border-radius: 8px; font-weight: 700; font-size: 0.82rem; box-shadow: 0 2px 8px rgba(0,0,0,0.15); }
-
     /* ── Footer ──────────────────────────────────────────────────────────────── */
     .footer-links { text-align: center; margin-top: 2rem; padding-top: 1.5rem; border-top: 1px solid #e2e8f0; }
     .footer-links a { color: #667eea; text-decoration: none; margin: 0 1rem; font-weight: 600; }
@@ -202,9 +187,24 @@
     {% endif %}
 
     {# ── Module Navigation (full-width, below card) ────────────────────────────── #}
+    {# 3×3 grid: Events row / My Journey row / Identity row                         #}
     {# All targets have require_student_onboarding guard                            #}
     <section class="mod-nav-section">
         <div class="mod-nav-grid">
+            {# Row 1 — Events #}
+            <a href="/semesters/enroll" class="mod-nav-card">
+                <span class="mod-nav-icon">🎓</span>
+                <span class="mod-nav-title">Programs</span>
+            </a>
+            <a href="/camps" class="mod-nav-card">
+                <span class="mod-nav-icon">🏕️</span>
+                <span class="mod-nav-title">Camps</span>
+            </a>
+            <a href="/tournaments" class="mod-nav-card">
+                <span class="mod-nav-icon">🏆</span>
+                <span class="mod-nav-title">Tournaments</span>
+            </a>
+            {# Row 2 — My Journey #}
             <a href="/sessions" class="mod-nav-card">
                 <span class="mod-nav-icon">📅</span>
                 <span class="mod-nav-title">Sessions</span>
@@ -217,8 +217,9 @@
                 <span class="mod-nav-icon">⚡</span>
                 <span class="mod-nav-title">Skills</span>
             </a>
+            {# Row 3 — Identity & Tools #}
             <a href="/achievements" class="mod-nav-card">
-                <span class="mod-nav-icon">🏆</span>
+                <span class="mod-nav-icon">🏅</span>
                 <span class="mod-nav-title">Achievements</span>
             </a>
             <a href="/calendar" class="mod-nav-card">
@@ -271,54 +272,6 @@
         </div>
         <div id="s-last-result">
             <div class="s-loading"><span class="s-spinner"></span> Loading…</div>
-        </div>
-    </section>
-
-    {# ── Available Events ──────────────────────────────────────────────────────── #}
-    <section class="section-block">
-        <div class="section-header">
-            <h2 class="page-title">⚽ Available Events</h2>
-        </div>
-        <p class="page-subtitle">Enroll in semesters to access training sessions and progress through your football development path.</p>
-
-        {% if available_semesters|length == 0 %}
-        <div class="info-banner" style="background: #fff7e6; border-color: #faad14;">
-            <p style="color: #ad6800;">⚠️ <strong>No track semesters available for your age group yet.</strong><br>
-            Check back later, or <a href="/profile" style="color: #ad6800; text-decoration: underline;">update your profile</a> if your age group is incorrect.</p>
-        </div>
-        {% else %}
-        <div class="info-banner">
-            <p><strong>💡 Available Semesters for {{ age_category_name }} ({{ age_range }})</strong><br>
-            {{ age_description }} — {{ available_semesters|length }} semester(s) available</p>
-        </div>
-        {% endif %}
-
-        <div class="cards-grid">
-            {% for semester in available_semesters %}
-            <div class="spec-card">
-                <div class="cost-badge">💰 {{ semester.enrollment_cost }} Credits</div>
-                <div class="spec-icon">⚽</div>
-                <h3 class="spec-title">{{ semester.name }}</h3>
-                <p class="spec-age">📅 {{ semester.start_date.strftime('%Y-%m-%d') }} — {{ semester.end_date.strftime('%Y-%m-%d') }}</p>
-                <p class="spec-description">
-                    <strong>Code:</strong> {{ semester.code }}<br>
-                    <strong>Status:</strong> {{ semester.status.value if semester.status else 'Unknown' }}
-                </p>
-                <div class="spec-action">
-                    {% if user.credit_balance < semester.enrollment_cost %}
-                        <button class="unlock-btn" disabled>❌ Insufficient Credits (Need {{ semester.enrollment_cost }})</button>
-                        <p style="margin-top: 0.5rem; font-size: 0.85rem;">
-                            <a href="/credits" style="color: #667eea; font-weight: 600;">Purchase credits →</a>
-                        </p>
-                    {% else %}
-                        <form method="POST" action="/semester/enroll">
-                            <input type="hidden" name="semester_id" value="{{ semester.id }}">
-                            <button type="submit" class="unlock-btn">🎓 Enroll Now ({{ semester.enrollment_cost }} credits)</button>
-                        </form>
-                    {% endif %}
-                </div>
-            </div>
-            {% endfor %}
         </div>
     </section>
 

--- a/app/templates/events_hub.html
+++ b/app/templates/events_hub.html
@@ -1,0 +1,205 @@
+{% extends "student_base.html" %}
+
+{% block title %}Events - LFA Education Center{% endblock %}
+{% block active_page %}lfa-player{% endblock %}
+
+{% block student_header %}
+{% set _page_icon = '📅' %}
+{% set _page_name = 'Events' %}
+{% include "includes/spec_subpage_hdr.html" %}
+{% endblock %}
+
+{% block extra_styles %}
+<style>
+    .events-container {
+        max-width: 900px;
+        margin: 0 auto;
+        padding: 1.5rem 1rem 2.5rem;
+    }
+
+    .events-header {
+        margin-bottom: 2rem;
+    }
+
+    .events-header h1 {
+        font-size: 1.6rem;
+        font-weight: 700;
+        color: var(--app-text);
+        margin: 0 0 0.35rem;
+    }
+
+    .events-header p {
+        color: var(--app-text-muted);
+        font-size: 0.95rem;
+        margin: 0;
+    }
+
+    /* ── Active enrollment notice ───────────────────────────────────────────── */
+    .active-notice {
+        background: #e6f7ff;
+        border-left: 4px solid #1890ff;
+        border-radius: 8px;
+        padding: 0.85rem 1.25rem;
+        margin-bottom: 1.75rem;
+        font-size: 0.9rem;
+        color: #0050b3;
+    }
+
+    /* ── Category grid ──────────────────────────────────────────────────────── */
+    .event-cat-grid {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        gap: 1.25rem;
+    }
+
+    @media (max-width: 520px) {
+        .event-cat-grid { grid-template-columns: 1fr; }
+    }
+
+    .event-cat-card {
+        display: flex;
+        flex-direction: column;
+        background: var(--app-card);
+        border-radius: 14px;
+        padding: 1.5rem 1.75rem;
+        box-shadow: 0 2px 8px rgba(0,0,0,0.07);
+        text-decoration: none;
+        color: inherit;
+        border-left: 5px solid var(--cat-color, #667eea);
+        transition: box-shadow 0.2s, transform 0.15s;
+    }
+
+    .event-cat-card:hover {
+        box-shadow: 0 6px 20px rgba(0,0,0,0.13);
+        transform: translateY(-2px);
+    }
+
+    .cat-icon { font-size: 2.2rem; margin-bottom: 0.6rem; line-height: 1; }
+
+    .cat-title {
+        font-size: 1.15rem;
+        font-weight: 700;
+        color: var(--app-text);
+        margin: 0 0 0.3rem;
+    }
+
+    .cat-desc {
+        font-size: 0.85rem;
+        color: var(--app-text-muted);
+        margin: 0 0 1rem;
+        line-height: 1.45;
+    }
+
+    .cat-counter {
+        margin-top: auto;
+        font-size: 0.82rem;
+        font-weight: 600;
+        color: var(--cat-color, #667eea);
+    }
+
+    .cat-counter.none { color: var(--app-text-muted); font-weight: 400; }
+
+    /* ── Footer secondary nav ───────────────────────────────────────────────── */
+    .events-footer {
+        text-align: center;
+        margin-top: 2.5rem;
+        padding-top: 1.5rem;
+        border-top: 1px solid #e2e8f0;
+    }
+
+    .events-footer a {
+        color: #667eea;
+        text-decoration: none;
+        margin: 0 1rem;
+        font-weight: 600;
+        font-size: 0.9rem;
+    }
+
+    .events-footer a:hover { text-decoration: underline; }
+</style>
+{% endblock %}
+
+{% block student_content %}
+<div class="events-container">
+
+    <div class="events-header">
+        <h1>📅 Events</h1>
+        <p>Discover and join events — camps, tournaments, and academy programs.</p>
+    </div>
+
+    {% if my_active_enrollments > 0 %}
+    <div class="active-notice">
+        ✅ You have <strong>{{ my_active_enrollments }} active enrollment{{ 's' if my_active_enrollments != 1 }}</strong>.
+        <a href="/sessions" style="color:#1890ff; font-weight:600; margin-left:0.5rem;">View my sessions →</a>
+    </div>
+    {% endif %}
+
+    <div class="event-cat-grid">
+
+        {# ── Camps ─────────────────────────────────────────────────────────── #}
+        <a href="/camps" class="event-cat-card" style="--cat-color: #f39c12;">
+            <div class="cat-icon">🏕️</div>
+            <div class="cat-title">Camps</div>
+            <div class="cat-desc">Short-term intensive camps. Summer and winter programs with focused training sessions.</div>
+            <div class="cat-counter {% if camps_open == 0 %}none{% endif %}">
+                {% if camps_open > 0 %}
+                    {{ camps_open }} camp{{ 's' if camps_open != 1 }} open for enrollment
+                {% else %}
+                    No camps open right now
+                {% endif %}
+            </div>
+        </a>
+
+        {# ── Tournaments ──────────────────────────────────────────────────── #}
+        <a href="/tournaments" class="event-cat-card" style="--cat-color: #27ae60;">
+            <div class="cat-icon">🏆</div>
+            <div class="cat-title">Tournaments</div>
+            <div class="cat-desc">Competitive formats — head-to-head, group stage, and ranking-based tournaments.</div>
+            <div class="cat-counter {% if tournaments_open == 0 %}none{% endif %}">
+                {% if tournaments_open > 0 %}
+                    {{ tournaments_open }} tournament{{ 's' if tournaments_open != 1 }} open
+                {% else %}
+                    No tournaments open right now
+                {% endif %}
+            </div>
+        </a>
+
+        {# ── Academy Season ───────────────────────────────────────────────── #}
+        <a href="/semesters/enroll?category=ACADEMY_SEASON" class="event-cat-card" style="--cat-color: #3498db;">
+            <div class="cat-icon">🎓</div>
+            <div class="cat-title">Academy Season</div>
+            <div class="cat-desc">Full-length multi-month academy programs with structured skill development tracks.</div>
+            <div class="cat-counter {% if academy_available == 0 %}none{% endif %}">
+                {% if academy_available > 0 %}
+                    {{ academy_available }} program{{ 's' if academy_available != 1 }} available
+                {% else %}
+                    No programs available right now
+                {% endif %}
+            </div>
+        </a>
+
+        {# ── Mini Season ──────────────────────────────────────────────────── #}
+        <a href="/semesters/enroll?category=MINI_SEASON" class="event-cat-card" style="--cat-color: #9b59b6;">
+            <div class="cat-icon">🗓️</div>
+            <div class="cat-title">Mini Season</div>
+            <div class="cat-desc">Short academy seasons (4–8 weeks) for focused skill work between major programs.</div>
+            <div class="cat-counter {% if mini_available == 0 %}none{% endif %}">
+                {% if mini_available > 0 %}
+                    {{ mini_available }} program{{ 's' if mini_available != 1 }} available
+                {% else %}
+                    No programs available right now
+                {% endif %}
+            </div>
+        </a>
+
+    </div>
+
+    <div class="events-footer">
+        <a href="/dashboard/lfa-football-player">⚽ Dashboard</a>
+        <a href="/sessions">📋 My Sessions</a>
+        <a href="/progress">📊 Progress</a>
+        <a href="/calendar">📆 Calendar</a>
+    </div>
+
+</div>
+{% endblock %}

--- a/app/templates/tournaments.html
+++ b/app/templates/tournaments.html
@@ -1,8 +1,15 @@
-{% extends "base.html" %}
+{% extends "student_base.html" %}
 
 {% block title %}Tournaments - LFA Education Center{% endblock %}
+{% block active_page %}lfa-player{% endblock %}
 
-{% block content %}
+{% block student_header %}
+{% set _page_icon = '🏆' %}
+{% set _page_name = 'Tournaments' %}
+{% include "includes/spec_subpage_hdr.html" %}
+{% endblock %}
+
+{% block extra_styles %}
 <style>
 .tournament-card {
     border-radius: 12px;
@@ -95,11 +102,34 @@
     flex-wrap: wrap;
     align-items: center;
 }
+.tournaments-container {
+    max-width: 860px;
+    margin: 0 auto;
+    padding: 1.5rem 1rem 2rem;
+}
+.tournaments-page-footer {
+    text-align: center;
+    margin-top: 2rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid #e2e8f0;
+    font-size: 0.9rem;
+}
+.tournaments-page-footer a {
+    color: #667eea;
+    text-decoration: none;
+    margin: 0 1rem;
+    font-weight: 600;
+}
+.tournaments-page-footer a:hover { text-decoration: underline; }
 </style>
+{% endblock %}
 
-<div class="welcome-section">
-    <h1>⚽ Tournaments</h1>
-    <p>Browse open tournaments and manage your participation</p>
+{% block student_content %}
+<div class="tournaments-container">
+
+<div style="margin-bottom: 1.5rem;">
+    <h1 style="font-size:1.6rem; font-weight:700; margin:0 0 0.3rem;">🏆 Tournaments</h1>
+    <p style="color:#7f8c8d; margin:0;">Browse open tournaments and manage your participation</p>
 </div>
 
 {% if flash %}
@@ -112,7 +142,7 @@
 {% endif %}
 
 {% if not tournaments %}
-<div class="card text-center" style="padding: 3rem;">
+<div class="card text-center" style="padding: 3rem; background:white; border-radius:12px; box-shadow:0 2px 8px rgba(0,0,0,0.07);">
     <div style="font-size: 3rem; margin-bottom: 1rem;">🏆</div>
     <h3>No Open Tournaments</h3>
     <p style="color: #7f8c8d;">There are no tournaments open for enrollment right now. Check back later!</p>
@@ -221,4 +251,11 @@
 
 {% endif %}
 
+<div class="tournaments-page-footer">
+    <a href="/events">← All Events</a>
+    <a href="/sessions">📋 My Sessions</a>
+    <a href="/dashboard/lfa-football-player">⚽ Dashboard</a>
+</div>
+
+</div>
 {% endblock %}

--- a/cypress/cypress/e2e/web/student/student_journey.cy.js
+++ b/cypress/cypress/e2e/web/student/student_journey.cy.js
@@ -225,7 +225,11 @@ describe('A. Student Core Journey — Skill Progression', {
     // Skill Snapshot + Last Result sections visible
     cy.contains('h2', 'Skill Snapshot').should('be.visible');
     cy.contains('h2', 'Last Skill Event').should('be.visible');
-    cy.contains('h2', 'Available Events').should('be.visible');
+
+    // Events row: Programs / Camps / Tournaments cards must be present
+    cy.get('.mod-nav-card[href="/semesters/enroll"]').should('exist');
+    cy.get('.mod-nav-card[href="/camps"]').should('exist');
+    cy.get('.mod-nav-card[href="/tournaments"]').should('exist');
 
     // Quick links in footer
     cy.get('a[href="/skills/history?skill=passing"]').should('exist');

--- a/cypress/cypress/e2e/web/student/student_journey.cy.js
+++ b/cypress/cypress/e2e/web/student/student_journey.cy.js
@@ -226,13 +226,18 @@ describe('A. Student Core Journey — Skill Progression', {
     cy.contains('h2', 'Skill Snapshot').should('be.visible');
     cy.contains('h2', 'Last Skill Event').should('be.visible');
 
-    // Events row: Programs / Camps / Tournaments cards must be present
-    cy.get('.mod-nav-card[href="/semesters/enroll"]').should('exist');
-    cy.get('.mod-nav-card[href="/camps"]').should('exist');
-    cy.get('.mod-nav-card[href="/tournaments"]').should('exist');
+    // 2×3 mod-nav: 6 primary domain cards must be present
+    cy.get('.mod-nav-card[href="/events"]').should('exist');
+    cy.get('.mod-nav-card[href="/dashboard/lfa-football-player/card-editor"]').should('exist');
+    cy.get('.mod-nav-card[href="/adaptive-learning"]').should('exist');
+    cy.get('.mod-nav-card[href="/skills/history?skill=passing"]').should('exist');
+    cy.get('.mod-nav-card[href="/calendar"]').should('exist');
+    cy.get('.mod-nav-card[href="/achievements"]').should('exist');
 
-    // Quick links in footer
-    cy.get('a[href="/skills/history?skill=passing"]').should('exist');
+    // Secondary nav in footer: Sessions / Progress / Skills accessible
+    cy.get('a[href="/sessions"]').should('exist');
+    cy.get('a[href="/progress"]').should('exist');
+    cy.get('a[href="/skills"]').should('exist');
 
     // Page must not show any server error
     cy.get('body').should('not.contain.text', 'Internal Server Error');

--- a/tests/integration/web_flows/test_spec_hub_routing.py
+++ b/tests/integration/web_flows/test_spec_hub_routing.py
@@ -235,7 +235,7 @@ class TestSpecDashboardOnboardingGuard:
         with _client(test_db, student) as c:
             r = c.get("/dashboard/lfa-football-player")
             assert r.status_code == 200
-            assert "Programs" in r.text
+            assert 'href="/events"' in r.text
 
 
 class TestWebFormEnrollmentGuard:
@@ -321,4 +321,4 @@ class TestLegacyEnrollmentSignal:
         with _client(test_db, student) as c:
             r = c.get("/dashboard/lfa-football-player")
             assert r.status_code == 200
-            assert "Programs" in r.text
+            assert 'href="/events"' in r.text

--- a/tests/integration/web_flows/test_spec_hub_routing.py
+++ b/tests/integration/web_flows/test_spec_hub_routing.py
@@ -235,7 +235,7 @@ class TestSpecDashboardOnboardingGuard:
         with _client(test_db, student) as c:
             r = c.get("/dashboard/lfa-football-player")
             assert r.status_code == 200
-            assert "Available Events" in r.text
+            assert "Programs" in r.text
 
 
 class TestWebFormEnrollmentGuard:
@@ -321,4 +321,4 @@ class TestLegacyEnrollmentSignal:
         with _client(test_db, student) as c:
             r = c.get("/dashboard/lfa-football-player")
             assert r.status_code == 200
-            assert "Available Events" in r.text
+            assert "Programs" in r.text

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -22772,6 +22772,29 @@
         ]
       }
     },
+    "/adaptive-learning": {
+      "get": {
+        "description": "Adaptive Learning entry point \u2014 XP summary + disabled CTA until full engine lands.",
+        "operationId": "adaptive_learning_page_adaptive_learning_get",
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Adaptive Learning Page",
+        "tags": [
+          "web",
+          "adaptive-learning"
+        ]
+      }
+    },
     "/admin/analytics": {
       "get": {
         "description": "Admin-only: Analytics and reports page",
@@ -56170,6 +56193,29 @@
         "summary": "Spec Dashboard",
         "tags": [
           "web"
+        ]
+      }
+    },
+    "/events": {
+      "get": {
+        "description": "Events hub \u2014 navigation hub for Camps, Tournaments, Academy Season, Mini Season.",
+        "operationId": "events_hub_events_get",
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Events Hub",
+        "tags": [
+          "web",
+          "events"
         ]
       }
     },


### PR DESCRIPTION
## Summary

- **Events hub** (`/events`): new navigation-only landing page with 4 sub-categories (Camps, Tournaments, Academy Season, Mini Season) + live open-enrollment counters
- **Adaptive Learning** (`/adaptive-learning`): entry point reading from `adaptive_learning_sessions` — shows total XP, session count, recent history; Start Session CTA is disabled (no fake interaction)
- **Dashboard mod-nav redesign**: 3×3 9-card → 2×3 6-card grid (Events · My Card · Adaptive Learning / Skill History · Calendar · Achievements)
- **Template consistency**: `camps.html` + `tournaments.html` migrated from `base.html` → `student_base.html` + `spec_subpage_hdr` — both gain student nav and `← All Events` cross-link
- **Secondary nav preserved**: Sessions · Progress · Skills remain accessible via dashboard footer and cross-links on sub-pages
- **`/semesters/enroll`** gains `?category=` filter param for direct Academy Season / Mini Season deep-links from Events hub

## Files changed (11)

**New (4):** `events.py`, `events_hub.html`, `adaptive_learning.py`, `adaptive_learning.html`

**Modified (7):** `dashboard_student_new.html`, `__init__.py`, `programs.py`, `camps.html`, `tournaments.html`, `test_spec_hub_routing.py`, `student_journey.cy.js`

## Test plan

- [ ] CI Unit Tests — `test_spec_hub_routing.py` SMOKE-34d + SMOKE-37b updated assertions (`href="/events"`)
- [ ] CI Cypress — STU-JOURNEY-08 updated: 6 mod-nav card hrefs + footer secondary nav assertions
- [ ] App startup — 783 routes, no import errors
- [ ] `/events` returns 200 with 4 category cards + correct counters
- [ ] `/adaptive-learning` returns 200, CTA button is `disabled`, XP from DB rendered
- [ ] `/camps` + `/tournaments` render student header (spec_subpage_hdr) with `← All Events` link
- [ ] `/semesters/enroll?category=ACADEMY_SEASON` filters to ACADEMY_SEASON only
- [ ] Dashboard footer contains Sessions, Progress, Skills links

🤖 Generated with [Claude Code](https://claude.com/claude-code)