### PR TITLE
feat(adaptive-learning): AL-3 category selection + XP ledger integration

### DIFF
--- a/app/api/web_routes/adaptive_learning.py
+++ b/app/api/web_routes/adaptive_learning.py
@@ -1,4 +1,4 @@
-"""Adaptive Learning web routes — entry page, session page, session lifecycle (AL-2)."""
+"""Adaptive Learning web routes — entry page, session page, session lifecycle (AL-3)."""
 from pathlib import Path
 
 from fastapi import APIRouter, Depends, Query, Request
@@ -9,9 +9,11 @@ from sqlalchemy.orm import Session
 
 from ...database import get_db
 from ...dependencies import get_current_user_web
-from ...models.quiz import AdaptiveLearningSession, QuizAnswerOption, QuizCategory, QuizQuestion
+from ...models.quiz import AdaptiveLearningSession, Quiz, QuizAnswerOption, QuizCategory, QuizQuestion
 from ...models.user import User
+from ...models.xp_transaction import XPTransaction
 from ...services.adaptive_learning import AdaptiveLearningService
+from ...services.gamification.xp_service import award_xp
 from .helpers import require_student_onboarding
 from .student_features import _spec_ctx
 
@@ -82,12 +84,21 @@ async def adaptive_learning_session_page(
     if guard:
         return guard
 
+    available_categories = (
+        db.query(Quiz.category)
+        .filter(Quiz.is_active == True)
+        .distinct()
+        .all()
+    )
+    category_values = [row[0] for row in available_categories]
+
     return templates.TemplateResponse(
         "adaptive_learning_session.html",
         {
             "request": request,
             "user": user,
             **_spec_ctx(user, db),
+            "available_categories": category_values,
         },
     )
 
@@ -119,6 +130,7 @@ def _session_guard(db: Session, session_id: int, user_id: int):
 @router.post("/adaptive-learning/session/start")
 async def al_session_start(
     request: Request,
+    category: str = Query("LESSON", description="QuizCategory value for this session"),
     db: Session = Depends(get_db),
     user: User = Depends(get_current_user_web),
 ):
@@ -126,6 +138,15 @@ async def al_session_start(
     guard = require_student_onboarding(user)
     if guard:
         return JSONResponse({"error": "onboarding required"}, status_code=403)
+
+    try:
+        quiz_category = QuizCategory[category.upper()]
+    except KeyError:
+        valid = [c.value for c in QuizCategory]
+        return JSONResponse(
+            {"error": f"invalid category {category!r}. Valid values: {valid}"},
+            status_code=422,
+        )
 
     # Return existing active session rather than creating a duplicate
     existing = (
@@ -146,9 +167,8 @@ async def al_session_start(
         })
 
     service = AdaptiveLearningService(db)
-    # GENERAL category — 2 questions; LESSON — 12 questions (most content available)
     session = service.start_adaptive_session(
-        user.id, QuizCategory.LESSON, session_duration_seconds=600
+        user.id, quiz_category, session_duration_seconds=600
     )
     return JSONResponse({
         "session_id": session.id,
@@ -287,26 +307,63 @@ async def al_session_complete(
     db: Session = Depends(get_db),
     user: User = Depends(get_current_user_web),
 ):
-    """Finalise the session and return the summary."""
+    """Finalise the session and write XP to the ledger."""
     guard = require_student_onboarding(user)
     if guard:
         return JSONResponse({"error": "onboarding required"}, status_code=403)
 
-    session, err = _session_guard(db, session_id, user.id)
-    if err:
-        return err
+    # SELECT FOR UPDATE serialises concurrent complete calls on the same session row.
+    # The first call proceeds; any concurrent duplicate blocks here, then sees
+    # ended_at IS NOT NULL and returns 410 — award_xp is never reached twice.
+    session = (
+        db.query(AdaptiveLearningSession)
+        .filter(
+            AdaptiveLearningSession.id == session_id,
+            AdaptiveLearningSession.user_id == user.id,
+        )
+        .with_for_update()
+        .first()
+    )
+    if not session:
+        return JSONResponse({"error": "session not found"}, status_code=404)
+    if session.ended_at is not None:
+        return JSONResponse(
+            {"error": "session already completed", "session_complete": True},
+            status_code=410,
+        )
 
     service = AdaptiveLearningService(db)
-    summary = service.end_session(session_id)
+    summary = service.end_session(session_id)  # sets ended_at, commits → releases lock
 
     presented = summary.get("questions_answered", 0)
     correct = summary.get("correct_answers", 0)
     accuracy_pct = round(correct / presented * 100, 1) if presented > 0 else 0.0
+    xp = summary.get("xp_earned") or 0
+
+    if xp > 0:
+        idempotency_key = f"adaptive_session_{session_id}_xp"
+        # Secondary guard: skip award_xp if a ledger row already exists for this key.
+        # Primary guard is the SELECT FOR UPDATE above; this catches any edge case
+        # where award_xp was called but end_session commit was delayed.
+        already_awarded = (
+            db.query(XPTransaction)
+            .filter(XPTransaction.idempotency_key == idempotency_key)
+            .first()
+        )
+        if not already_awarded:
+            award_xp(
+                db,
+                user_id=user.id,
+                xp_amount=xp,
+                reason=f"Adaptive Learning session #{session_id}",
+                idempotency_key=idempotency_key,
+                transaction_type="ADAPTIVE_LEARNING_XP",
+            )
 
     return JSONResponse({
         "session_id": session_id,
         "questions_presented": presented,
         "questions_correct": correct,
-        "xp_earned": summary.get("xp_earned") or 0,
+        "xp_earned": xp,
         "accuracy_pct": accuracy_pct,
     })

--- a/app/templates/adaptive_learning_session.html
+++ b/app/templates/adaptive_learning_session.html
@@ -224,6 +224,65 @@
     .als-btn-primary:hover   { background: #5a67d8; }
     .als-btn-secondary:hover { background: #e5e7eb; }
 
+    /* ── Category picker ─────────────────────────────────────────────────────── */
+    .als-picker-card {
+        background: var(--app-card);
+        border-radius: 14px;
+        padding: 1.75rem 2rem;
+        box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+    }
+    .als-picker-title {
+        font-size: 1.15rem;
+        font-weight: 700;
+        color: var(--app-text);
+        margin: 0 0 0.35rem;
+    }
+    .als-picker-sub {
+        font-size: 0.88rem;
+        color: var(--app-text-muted);
+        margin: 0 0 1.25rem;
+    }
+    .als-cat-grid {
+        display: flex;
+        flex-direction: column;
+        gap: 0.6rem;
+        margin-bottom: 1.25rem;
+    }
+    .als-cat-btn {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        background: var(--app-card);
+        border: 2px solid var(--app-border, #e2e8f0);
+        border-radius: 10px;
+        padding: 0.85rem 1rem;
+        cursor: pointer;
+        text-align: left;
+        width: 100%;
+        font-size: 0.97rem;
+        font-weight: 600;
+        color: var(--app-text);
+        transition: border-color 0.15s, background 0.15s;
+    }
+    .als-cat-btn:hover { border-color: #667eea; background: #f0f4ff; }
+    .als-cat-btn.selected { border-color: #4f46e5; background: #eef2ff; color: #3730a3; }
+    .als-cat-icon { font-size: 1.4rem; flex-shrink: 0; }
+    .als-cat-label { font-weight: 700; }
+    .als-cat-desc  { font-size: 0.8rem; font-weight: 400; color: var(--app-text-muted); margin-top: 0.1rem; }
+    .als-start-btn {
+        background: #4f46e5;
+        color: white;
+        border: none;
+        border-radius: 8px;
+        padding: 0.75rem 1.75rem;
+        font-size: 1rem;
+        font-weight: 700;
+        cursor: pointer;
+        width: 100%;
+        transition: background 0.15s;
+    }
+    .als-start-btn:hover { background: #4338ca; }
+
     /* ── Loading / error ─────────────────────────────────────────────────────── */
     .als-loading {
         text-align: center;
@@ -255,8 +314,40 @@
 {% block student_content %}
 <div class="als-container">
 
+    {# ── Category picker phase ─────────────────────────────────────────────── #}
+    <div id="als-phase-category" class="als-phase active">
+        <div class="als-picker-card">
+            <p class="als-picker-title">🧠 Choose a category</p>
+            <p class="als-picker-sub">Select a topic for your adaptive session.</p>
+            <div class="als-cat-grid" id="als-cat-grid">
+                {% set cat_meta = {
+                    'LESSON':           ('📖', 'Football Lessons',  'Rules, tactics, and game understanding'),
+                    'SPORTS_PHYSIOLOGY':('💪', 'Sports Physiology', 'Conditioning, fitness, and the athletic body'),
+                    'GENERAL':          ('⚽', 'General Knowledge', 'Broad football topics'),
+                    'NUTRITION':        ('🥗', 'Nutrition',         'Diet and fuelling for performance'),
+                    'MARKETING':        ('📣', 'Marketing',         'Sports marketing and branding'),
+                    'ECONOMICS':        ('📈', 'Economics',         'Football business and finance'),
+                    'INFORMATICS':      ('💻', 'Informatics',       'Data and technology in football')
+                } %}
+                {% for cat in available_categories %}
+                    {% set icon, label, desc = cat_meta.get(cat.value, ('🎓', cat.value.replace('_',' ').title(), '')) %}
+                    <button class="als-cat-btn{% if cat.value == 'LESSON' %} selected{% endif %}"
+                            data-cat="{{ cat.value }}"
+                            onclick="alsCatSelect(this)">
+                        <span class="als-cat-icon">{{ icon }}</span>
+                        <span>
+                            <span class="als-cat-label">{{ label }}</span><br>
+                            <span class="als-cat-desc">{{ desc }}</span>
+                        </span>
+                    </button>
+                {% endfor %}
+            </div>
+            <button class="als-start-btn" onclick="alsStartFromPicker()">🚀 Start Session</button>
+        </div>
+    </div>
+
     {# ── Loading phase ─────────────────────────────────────────────────────── #}
-    <div id="als-phase-loading" class="als-phase active als-loading">
+    <div id="als-phase-loading" class="als-phase als-loading">
         ⏳ Starting your session…
     </div>
 
@@ -265,7 +356,7 @@
         <div class="als-error-card">
             <h3>Something went wrong</h3>
             <p id="als-error-msg" style="margin: 0; font-size: 0.9rem;"></p>
-            <button class="als-error-retry" onclick="alsInit()">Try Again</button>
+            <button class="als-error-retry" onclick="showPhase('category')">← Choose Category</button>
         </div>
     </div>
 
@@ -337,23 +428,24 @@
        a server-side question log table. Not a permanent API contract.
     ─────────────────────────────────────────────────────────────────────────── */
     var state = {
-        sessionId:   null,
-        questionNum: 0,
-        totalTarget: 10,
-        seenIds:     [],   // exclude_ids compat layer (see note above)
-        totalXp:     0,
-        correctCount:0,
-        phase:       'loading'
+        sessionId:    null,
+        questionNum:  0,
+        totalTarget:  10,
+        seenIds:      [],   // exclude_ids compat layer (see note above)
+        totalXp:      0,
+        correctCount: 0,
+        phase:        'category',
+        category:     'LESSON'
     };
 
     /* ── Phase management ──────────────────────────────────────────────────── */
-    function showPhase(name) {
-        ['loading','error','question','result'].forEach(function (p) {
+    window.showPhase = function (name) {
+        ['category','loading','error','question','result'].forEach(function (p) {
             var el = document.getElementById('als-phase-' + p);
             if (el) el.classList.toggle('active', p === name);
         });
         state.phase = name;
-    }
+    };
 
     function showError(msg) {
         document.getElementById('als-error-msg').textContent = msg || 'Unknown error.';
@@ -545,6 +637,22 @@
         showPhase('result');
     }
 
+    /* ── Category picker helpers ───────────────────────────────────────────── */
+    window.alsCatSelect = function (btn) {
+        document.querySelectorAll('.als-cat-btn').forEach(function (b) {
+            b.classList.remove('selected');
+        });
+        btn.classList.add('selected');
+        state.category = btn.dataset.cat;
+    };
+
+    window.alsStartFromPicker = function () {
+        var selected = document.querySelector('.als-cat-btn.selected');
+        if (selected) state.category = selected.dataset.cat;
+        showPhase('loading');
+        alsInit(state.category);
+    };
+
     /* ── Restart ───────────────────────────────────────────────────────────── */
     window.alsRestart = function () {
         state.sessionId    = null;
@@ -552,13 +660,14 @@
         state.seenIds      = [];
         state.totalXp      = 0;
         state.correctCount = 0;
-        showPhase('loading');
-        alsInit();
+        document.getElementById('als-resume-notice').style.display = 'none';
+        showPhase('category');
     };
 
     /* ── Init ──────────────────────────────────────────────────────────────── */
-    window.alsInit = function () {
-        post('/adaptive-learning/session/start')
+    window.alsInit = function (category) {
+        var cat = category || state.category || 'LESSON';
+        post('/adaptive-learning/session/start?category=' + encodeURIComponent(cat))
             .then(function (res) {
                 if (!res) return;
                 if (!res.ok) {
@@ -577,8 +686,6 @@
                 showError('Could not connect to the server. Please check your connection.');
             });
     };
-
-    alsInit();
 })();
 </script>
 {% endblock %}

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -22822,6 +22822,20 @@
       "post": {
         "description": "Start a new adaptive learning session, or return the existing active one.",
         "operationId": "al_session_start_adaptive_learning_session_start_post",
+        "parameters": [
+          {
+            "description": "QuizCategory value for this session",
+            "in": "query",
+            "name": "category",
+            "required": false,
+            "schema": {
+              "default": "LESSON",
+              "description": "QuizCategory value for this session",
+              "title": "Category",
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -22830,6 +22844,16 @@
               }
             },
             "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
           }
         },
         "summary": "Al Session Start",
@@ -22883,7 +22907,7 @@
     },
     "/adaptive-learning/session/{session_id}/complete": {
       "post": {
-        "description": "Finalise the session and return the summary.",
+        "description": "Finalise the session and write XP to the ledger.",
         "operationId": "al_session_complete_adaptive_learning_session__session_id__complete_post",
         "parameters": [
           {

--- a/tests/unit/test_adaptive_learning_service.py
+++ b/tests/unit/test_adaptive_learning_service.py
@@ -1,5 +1,5 @@
 """
-Unit tests for AdaptiveLearningService (AL-1 backend core).
+Unit tests for AdaptiveLearningService (AL-1/AL-3 backend core).
 
 Scope:
   - end_session: GamificationService coupling removed — no external side-effects
@@ -7,14 +7,16 @@ Scope:
   - start_adaptive_session: creates session row, returns ORM object
   - record_answer correct/incorrect: increments session counts, returns xp_earned
   - _get_candidate_questions fallback: returns questions even when QuestionMetadata is absent
-  - _session_guard (route helper): returns 404 / 410 for invalid / completed sessions
+  - al_session_complete route (AL-3): XP ledger write, idempotency, SELECT FOR UPDATE guard
+  - al_session_start route (AL-3): category param validation, default, passthrough
 
 All tests use MagicMock DB — no real DB connection required.
 """
 from datetime import datetime, timezone
-from unittest.mock import MagicMock, patch, PropertyMock
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
+from fastapi.testclient import TestClient
 
 from app.services.adaptive_learning import AdaptiveLearningService
 from app.models.quiz import (
@@ -216,3 +218,163 @@ class TestRecordAnswer:
         )
         assert session.questions_presented == 3
         assert session.questions_correct == 1  # unchanged
+
+
+# ── AL-3: al_session_start — category validation ──────────────────────────────
+
+_START_BASE = "app.api.web_routes.adaptive_learning"
+
+
+def _make_user(uid=99):
+    u = MagicMock()
+    u.id = uid
+    return u
+
+
+def _make_db_no_existing():
+    """DB mock that returns no active session (existing=None)."""
+    db = MagicMock()
+    q = MagicMock()
+    q.filter.return_value = q
+    q.order_by.return_value = q
+    q.first.return_value = None
+    db.query.return_value = q
+    return db
+
+
+class TestAl3SessionStart:
+    """Route-level tests for al_session_start category parameter."""
+
+    def _call_start(self, category_param, db=None, user=None):
+        import asyncio
+        from app.api.web_routes.adaptive_learning import al_session_start
+
+        db = db or _make_db_no_existing()
+        user = user or _make_user()
+        req = MagicMock()
+
+        with patch(f"{_START_BASE}.require_student_onboarding", return_value=None), \
+             patch(f"{_START_BASE}.AdaptiveLearningService") as MockSvc:
+
+            mock_session = MagicMock()
+            mock_session.id = 42
+            mock_session.session_start_time = None
+            MockSvc.return_value.start_adaptive_session.return_value = mock_session
+
+            response = asyncio.run(al_session_start(
+                request=req,
+                category=category_param,
+                db=db,
+                user=user,
+            ))
+            return response, MockSvc
+
+    def test_valid_category_passed_to_service(self):
+        response, MockSvc = self._call_start("SPORTS_PHYSIOLOGY")
+        assert response.status_code == 200
+        MockSvc.return_value.start_adaptive_session.assert_called_once()
+        args = MockSvc.return_value.start_adaptive_session.call_args[0]
+        assert args[1] == QuizCategory.SPORTS_PHYSIOLOGY
+
+    def test_default_category_is_lesson(self):
+        response, MockSvc = self._call_start("LESSON")
+        assert response.status_code == 200
+        args = MockSvc.return_value.start_adaptive_session.call_args[0]
+        assert args[1] == QuizCategory.LESSON
+
+    def test_invalid_category_returns_422(self):
+        response, _ = self._call_start("NONSENSE")
+        assert response.status_code == 422
+
+    def test_category_case_insensitive(self):
+        response, MockSvc = self._call_start("lesson")
+        assert response.status_code == 200
+        args = MockSvc.return_value.start_adaptive_session.call_args[0]
+        assert args[1] == QuizCategory.LESSON
+
+
+# ── AL-3: al_session_complete — XP ledger idempotency ────────────────────────
+
+_COMPLETE_BASE = "app.api.web_routes.adaptive_learning"
+
+
+def _make_active_session(session_id=1, xp_earned=80):
+    s = MagicMock(spec=AdaptiveLearningSession)
+    s.id = session_id
+    s.user_id = 99
+    s.ended_at = None
+    return s
+
+
+def _make_ended_session(session_id=1):
+    s = MagicMock(spec=AdaptiveLearningSession)
+    s.id = session_id
+    s.user_id = 99
+    s.ended_at = datetime(2026, 4, 24, 10, 0, 0, tzinfo=timezone.utc)
+    return s
+
+
+def _call_complete(session_id, db_session_obj, summary, xp_tx_exists=False):
+    import asyncio
+    from app.api.web_routes.adaptive_learning import al_session_complete
+
+    db = MagicMock()
+    # .with_for_update().first() returns the session object
+    db.query.return_value.filter.return_value.with_for_update.return_value.first.return_value = db_session_obj
+    # XPTransaction pre-check: second query chain
+    xp_tx_mock = MagicMock() if xp_tx_exists else None
+    db.query.return_value.filter.return_value.first.return_value = xp_tx_mock
+
+    user = _make_user(uid=99)
+    req = MagicMock()
+
+    with patch(f"{_COMPLETE_BASE}.require_student_onboarding", return_value=None), \
+         patch(f"{_COMPLETE_BASE}.AdaptiveLearningService") as MockSvc, \
+         patch(f"{_COMPLETE_BASE}.award_xp") as mock_award:
+
+        MockSvc.return_value.end_session.return_value = summary
+
+        response = asyncio.run(al_session_complete(
+            session_id=session_id,
+            request=req,
+            db=db,
+            user=user,
+        ))
+        return response, mock_award
+
+
+class TestAl3SessionComplete:
+    """Route-level tests for al_session_complete XP idempotency."""
+
+    def test_first_complete_awards_xp_once(self):
+        summary = {"questions_answered": 5, "correct_answers": 4, "xp_earned": 80}
+        response, mock_award = _call_complete(1, _make_active_session(xp_earned=80), summary)
+
+        assert response.status_code == 200
+        mock_award.assert_called_once()
+        call_kwargs = mock_award.call_args[1]
+        assert call_kwargs["idempotency_key"] == "adaptive_session_1_xp"
+        assert call_kwargs["transaction_type"] == "ADAPTIVE_LEARNING_XP"
+        assert call_kwargs["xp_amount"] == 80
+
+    def test_second_complete_returns_410(self):
+        summary = {"questions_answered": 5, "correct_answers": 4, "xp_earned": 80}
+        response, mock_award = _call_complete(1, _make_ended_session(), summary)
+
+        assert response.status_code == 410
+        mock_award.assert_not_called()
+
+    def test_existing_xp_transaction_skips_award_xp(self):
+        summary = {"questions_answered": 5, "correct_answers": 4, "xp_earned": 80}
+        response, mock_award = _call_complete(
+            1, _make_active_session(xp_earned=80), summary, xp_tx_exists=True
+        )
+        assert response.status_code == 200
+        mock_award.assert_not_called()
+
+    def test_zero_xp_skips_award_xp(self):
+        summary = {"questions_answered": 3, "correct_answers": 0, "xp_earned": 0}
+        response, mock_award = _call_complete(1, _make_active_session(xp_earned=0), summary)
+
+        assert response.status_code == 200
+        mock_award.assert_not_called()


### PR DESCRIPTION
## Summary

- **Category selection:** players choose a topic before each session; category passed to `/session/start`
- **XP ledger integration:** session completion writes one `XPTransaction` row (`ADAPTIVE_LEARNING_XP`) with idempotency protection via `SELECT FOR UPDATE` + XPTransaction pre-check
- **No new DB tables, no migrations, no dashboard/nav changes**

## Route changes

| Route | Change |
|---|---|
| `GET /adaptive-learning/session` | Now passes `available_categories` to template |
| `POST /adaptive-learning/session/start` | Accepts `?category=` query param (default: `LESSON`); validates enum; returns 422 on unknown value |
| `POST /adaptive-learning/session/{id}/complete` | Replaced `_session_guard` with `SELECT FOR UPDATE`; XPTransaction pre-check; calls `award_xp` with `ADAPTIVE_LEARNING_XP` + stable idempotency key |

## Idempotency strategy

1. **Primary guard:** `SELECT FOR UPDATE` on `AdaptiveLearningSession` serialises concurrent complete calls — second call sees `ended_at` set, returns 410
2. **Secondary guard:** pre-check `XPTransaction` for `idempotency_key = adaptive_session_{id}_xp` before calling `award_xp`
3. **Deferred:** global `award_xp` concurrency hardening (`xp_balance` pre-increment before savepoint) — separate follow-up issue, not introduced by AL-3

## Tests

17/17 pass (9 pre-existing + 8 new AL-3 tests):
- valid category passed to service ✅
- invalid category returns 422 ✅
- default is LESSON ✅
- case-insensitive category input ✅
- first complete awards XP once with correct key/type/amount ✅
- second complete returns 410, `award_xp` not called ✅
- existing XPTransaction skips `award_xp` ✅
- zero XP skips `award_xp` ✅

## OpenAPI

Route count: 684 (unchanged). One schema addition: `category` query param on `POST /session/start`.

## Test plan

- [ ] Open `/adaptive-learning/session` — category picker renders, LESSON pre-selected
- [ ] Select SPORTS_PHYSIOLOGY → Start → questions are from sports physiology
- [ ] Complete session → `xp_transactions` has exactly one row with `transaction_type=ADAPTIVE_LEARNING_XP`
- [ ] `users.xp_balance` and `UserStats.total_xp` reflect the gain
- [ ] Re-POST `/session/{id}/complete` → 410, no duplicate `xp_transactions` row
- [ ] POST `/session/start?category=NONSENSE` → 422

🤖 Generated with [Claude Code](https://claude.com/claude-code)