### PR TITLE
fix(al-content): add language: "en" to 13 legacy EN JSON files

### DIFF
--- a/content/adaptive_learning/_shared/sports_physiology/conditioning_easy.json
+++ b/content/adaptive_learning/_shared/sports_physiology/conditioning_easy.json
@@ -1,5 +1,6 @@
 {
   "schema_version": "1.0",
+  "language": "en",
   "specializations": ["LFA_FOOTBALL_PLAYER"],
   "category": "SPORTS_PHYSIOLOGY",
   "difficulty": "EASY",

--- a/content/adaptive_learning/_shared/sports_physiology/conditioning_hard.json
+++ b/content/adaptive_learning/_shared/sports_physiology/conditioning_hard.json
@@ -1,5 +1,6 @@
 {
   "schema_version": "1.0",
+  "language": "en",
   "specializations": ["LFA_FOOTBALL_PLAYER"],
   "category": "SPORTS_PHYSIOLOGY",
   "difficulty": "HARD",

--- a/content/adaptive_learning/_shared/sports_physiology/conditioning_medium.json
+++ b/content/adaptive_learning/_shared/sports_physiology/conditioning_medium.json
@@ -1,5 +1,6 @@
 {
   "schema_version": "1.0",
+  "language": "en",
   "specializations": ["LFA_FOOTBALL_PLAYER"],
   "category": "SPORTS_PHYSIOLOGY",
   "difficulty": "MEDIUM",

--- a/content/adaptive_learning/lfa_football_player/general/football_awareness_easy.json
+++ b/content/adaptive_learning/lfa_football_player/general/football_awareness_easy.json
@@ -1,5 +1,6 @@
 {
   "schema_version": "1.0",
+  "language": "en",
   "specializations": ["LFA_FOOTBALL_PLAYER"],
   "category": "GENERAL",
   "difficulty": "EASY",

--- a/content/adaptive_learning/lfa_football_player/general/football_awareness_medium.json
+++ b/content/adaptive_learning/lfa_football_player/general/football_awareness_medium.json
@@ -1,5 +1,6 @@
 {
   "schema_version": "1.0",
+  "language": "en",
   "specializations": ["LFA_FOOTBALL_PLAYER"],
   "category": "GENERAL",
   "difficulty": "MEDIUM",

--- a/content/adaptive_learning/lfa_football_player/lesson/rules_easy.json
+++ b/content/adaptive_learning/lfa_football_player/lesson/rules_easy.json
@@ -1,5 +1,6 @@
 {
   "schema_version": "1.0",
+  "language": "en",
   "specializations": ["LFA_FOOTBALL_PLAYER"],
   "category": "LESSON",
   "difficulty": "EASY",

--- a/content/adaptive_learning/lfa_football_player/lesson/rules_hard.json
+++ b/content/adaptive_learning/lfa_football_player/lesson/rules_hard.json
@@ -1,5 +1,6 @@
 {
   "schema_version": "1.0",
+  "language": "en",
   "specializations": ["LFA_FOOTBALL_PLAYER"],
   "category": "LESSON",
   "difficulty": "HARD",

--- a/content/adaptive_learning/lfa_football_player/lesson/rules_medium.json
+++ b/content/adaptive_learning/lfa_football_player/lesson/rules_medium.json
@@ -1,5 +1,6 @@
 {
   "schema_version": "1.0",
+  "language": "en",
   "specializations": ["LFA_FOOTBALL_PLAYER"],
   "category": "LESSON",
   "difficulty": "MEDIUM",

--- a/content/adaptive_learning/lfa_football_player/lesson/tactics_easy.json
+++ b/content/adaptive_learning/lfa_football_player/lesson/tactics_easy.json
@@ -1,5 +1,6 @@
 {
   "schema_version": "1.0",
+  "language": "en",
   "specializations": ["LFA_FOOTBALL_PLAYER"],
   "category": "LESSON",
   "difficulty": "EASY",

--- a/content/adaptive_learning/lfa_football_player/lesson/tactics_hard.json
+++ b/content/adaptive_learning/lfa_football_player/lesson/tactics_hard.json
@@ -1,5 +1,6 @@
 {
   "schema_version": "1.0",
+  "language": "en",
   "specializations": ["LFA_FOOTBALL_PLAYER"],
   "category": "LESSON",
   "difficulty": "HARD",

--- a/content/adaptive_learning/lfa_football_player/lesson/tactics_medium.json
+++ b/content/adaptive_learning/lfa_football_player/lesson/tactics_medium.json
@@ -1,5 +1,6 @@
 {
   "schema_version": "1.0",
+  "language": "en",
   "specializations": ["LFA_FOOTBALL_PLAYER"],
   "category": "LESSON",
   "difficulty": "MEDIUM",

--- a/content/adaptive_learning/lfa_football_player/nutrition/athlete_nutrition_easy.json
+++ b/content/adaptive_learning/lfa_football_player/nutrition/athlete_nutrition_easy.json
@@ -1,5 +1,6 @@
 {
   "schema_version": "1.0",
+  "language": "en",
   "specializations": ["LFA_FOOTBALL_PLAYER"],
   "category": "NUTRITION",
   "difficulty": "EASY",

--- a/content/adaptive_learning/lfa_football_player/nutrition/athlete_nutrition_medium.json
+++ b/content/adaptive_learning/lfa_football_player/nutrition/athlete_nutrition_medium.json
@@ -1,5 +1,6 @@
 {
   "schema_version": "1.0",
+  "language": "en",
   "specializations": ["LFA_FOOTBALL_PLAYER"],
   "category": "NUTRITION",
   "difficulty": "MEDIUM",


### PR DESCRIPTION
## Summary

- Adds `\"language\": \"en\"` to 13 English content JSON files that existed before PR #101 introduced language filtering
- No question text, answers, explanations, or metadata changed — only the `language` field is added (1 line per file)
- Required for `--lang en` seed filter to include the full intended EN category set

**Affected files (13):**
- `_shared/sports_physiology/`: conditioning_easy, conditioning_hard, conditioning_medium
- `lfa_football_player/lesson/`: rules_easy, rules_hard, rules_medium, tactics_easy, tactics_hard, tactics_medium
- `lfa_football_player/general/`: football_awareness_easy, football_awareness_medium
- `lfa_football_player/nutrition/`: athlete_nutrition_easy, athlete_nutrition_medium

**Expected EN dry-run after merge:**
- Would create: 14 quizzes, 177 questions
- Categories covered: LESSON + SPORTS_PHYSIOLOGY + GENERAL + NUTRITION
- Validation errors: 0

## Scope

- No live seed
- No DB write
- No code change (app/, alembic/, scripts/ untouched)
- No content generation — metadata correction only

🤖 Generated with [Claude Code](https://claude.com/claude-code)