### PR TITLE
fix(contract): regenerate OpenAPI snapshot — preview query param drift

### DIFF
--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -57315,6 +57315,22 @@
               "title": "User Id",
               "type": "integer"
             }
+          },
+          {
+            "in": "query",
+            "name": "preview",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Preview"
+            }
           }
         ],
         "responses": {


### PR DESCRIPTION
## Summary

- OpenAPI snapshot drift: `preview` query param was added to `GET /players/{user_id}/card` in hotfix commit `4e2246f` but snapshot was not updated
- Single hunk change: new optional `preview` parameter on `/players/{user_id}/card`
- No logic change, no code change — snapshot file only

## Audit

Snapshot diff verified before commit:
- Only 1 hunk: `preview` query param added ✅
- AL description changes (exclude_ids "unbounded" + docstring) are NOT included — main already has correct descriptions

## Test plan
- [ ] Test Baseline Check passes (OpenAPI snapshot matches live schema)
- [ ] All other CI checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)