### PR TITLE
fix(model): add 8 card fields to UserLicense + idempotent migration

### DIFF
--- a/alembic/versions/2026_04_26_1000_card_fields_to_user_licenses.py
+++ b/alembic/versions/2026_04_26_1000_card_fields_to_user_licenses.py
@@ -1,0 +1,62 @@
+"""Add card customisation + multi-photo fields to user_licenses.
+
+Adds eight columns required by the card editor, card theme/variant
+services, and the public player card render route.  All columns are
+nullable so existing rows need no backfill.
+
+The upgrade() is idempotent: it inspects the live schema and only adds
+columns that are genuinely absent.  This is safe on production databases
+that may already have some columns from earlier local-only migrations
+(.pyc artefacts 2026_04_01 / 2026_04_06).
+
+Columns added
+-------------
+  card_theme               VARCHAR(50)  — active theme ID (default → "default")
+  card_variant             VARCHAR(50)  — active variant ID (default → "fifa")
+  unlocked_card_themes     JSON         — list of unlocked theme IDs
+  unlocked_card_variants   JSON         — list of unlocked variant IDs
+  card_photo_portrait_url  VARCHAR(512) — portrait-crop photo
+  card_photo_landscape_url VARCHAR(512) — landscape-crop photo
+  card_bg_compact_url      VARCHAR(512) — compact-variant background
+  card_bg_showcase_url     VARCHAR(512) — showcase-variant background
+
+Revision ID: 2026_04_26_1000
+Revises: 2026_04_25_0900
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import inspect
+
+revision = "2026_04_26_1000"
+down_revision = "2026_04_25_0900"
+branch_labels = None
+depends_on = None
+
+_TABLE = "user_licenses"
+
+_NEW_COLUMNS = [
+    ("card_theme",               sa.Column("card_theme",               sa.String(50),  nullable=True)),
+    ("card_variant",             sa.Column("card_variant",             sa.String(50),  nullable=True)),
+    ("unlocked_card_themes",     sa.Column("unlocked_card_themes",     sa.JSON(),      nullable=True)),
+    ("unlocked_card_variants",   sa.Column("unlocked_card_variants",   sa.JSON(),      nullable=True)),
+    ("card_photo_portrait_url",  sa.Column("card_photo_portrait_url",  sa.String(512), nullable=True)),
+    ("card_photo_landscape_url", sa.Column("card_photo_landscape_url", sa.String(512), nullable=True)),
+    ("card_bg_compact_url",      sa.Column("card_bg_compact_url",      sa.String(512), nullable=True)),
+    ("card_bg_showcase_url",     sa.Column("card_bg_showcase_url",     sa.String(512), nullable=True)),
+]
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    existing = {c["name"] for c in inspect(bind).get_columns(_TABLE)}
+    for col_name, col_def in _NEW_COLUMNS:
+        if col_name not in existing:
+            op.add_column(_TABLE, col_def)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    existing = {c["name"] for c in inspect(bind).get_columns(_TABLE)}
+    for col_name, _ in reversed(_NEW_COLUMNS):
+        if col_name in existing:
+            op.drop_column(_TABLE, col_name)

--- a/app/models/license.py
+++ b/app/models/license.py
@@ -171,6 +171,25 @@ class UserLicense(Base):
                              comment="6 football skill percentages for LFA Player specializations (heading, shooting, crossing, passing, dribbling, ball_control)")
     player_card_photo_url = Column(String(512), nullable=True,
                                    comment="LFA Football Player spec-specific card photo URL (not global avatar)")
+    card_photo_portrait_url = Column(String(512), nullable=True,
+                                     comment="Portrait-crop photo for player card variants")
+    card_photo_landscape_url = Column(String(512), nullable=True,
+                                      comment="Landscape-crop photo for player card variants")
+    card_bg_compact_url = Column(String(512), nullable=True,
+                                 comment="Background image for compact card variant")
+    card_bg_showcase_url = Column(String(512), nullable=True,
+                                  comment="Background image for showcase card variant")
+
+    # 🎨 CARD CUSTOMISATION: active theme/variant + unlocked lists
+    card_theme = Column(String(50), nullable=True, default="default",
+                        comment="Active card theme ID (default/midnight/arctic/gold/emerald/crimson)")
+    card_variant = Column(String(50), nullable=True, default="fifa",
+                          comment="Active card variant ID (fifa/compact/showcase)")
+    unlocked_card_themes = Column(JSON, nullable=True, default=list,
+                                  comment="List of unlocked card theme IDs")
+    unlocked_card_variants = Column(JSON, nullable=True, default=list,
+                                    comment="List of unlocked card variant IDs")
+
     skills_last_updated_at = Column(DateTime, nullable=True,
                                     comment="When skills were last updated")
     skills_updated_by = Column(Integer, ForeignKey("users.id"), nullable=True,


### PR DESCRIPTION
## Summary

- **Root cause**: card editor / services / public render route access 8 `UserLicense` fields that were absent from the ORM model and had no committed migration (only `.pyc` artefacts from earlier local runs)
- **Symptom**: `test_public_player_card_renders` → `AttributeError: 'UserLicense' object has no attribute 'card_theme'`

## Changes

**`app/models/license.py`** — 8 new nullable columns on `UserLicense`:
- `card_theme`, `card_variant` — active theme/variant IDs
- `unlocked_card_themes`, `unlocked_card_variants` — JSON lists
- `card_photo_portrait_url`, `card_photo_landscape_url` — photo variants
- `card_bg_compact_url`, `card_bg_showcase_url` — background images

**`alembic/versions/2026_04_26_1000_card_fields_to_user_licenses.py`** — idempotent migration: inspects live schema, only adds missing columns (safe on prod DB)

## Audit

Full card-field audit performed before implementation:
- `player_card_photo_url` already existed in model + migration ✅ — not touched
- All 8 new fields verified used across `dashboard.py`, `public_player.py`, `card_theme_service.py`, `card_variant_service.py`

## Test plan
- [x] `test_public_player_card_renders` passes locally (1 passed, 0.55s)
- [ ] Test Baseline Check green on main
- [ ] Migration Chain Integrity passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)