### PR TITLE
fix(card): explicit FIFA template + available=False guard for unimplemented variants

### DIFF
--- a/app/api/web_routes/public_player.py
+++ b/app/api/web_routes/public_player.py
@@ -2,9 +2,11 @@
 Public player card web routes — no authentication required.
 """
 from datetime import date
-
+import logging
 import os
 from typing import Optional
+
+logger = logging.getLogger(__name__)
 
 from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import HTMLResponse
@@ -163,11 +165,23 @@ def public_player_card(
         card_variant_id = preview
     variant = _get_variant(card_variant_id)  # falls back to "fifa" for unknown IDs
 
-    # Template selection: use variant.template if the file exists, else fallback
+    # Template selection: use variant.template if the file exists.
+    # If the selected variant has no template yet (not yet implemented), fall back
+    # to the explicit fifa template, then to the legacy fallback.
+    # Log a warning so missing templates are never silently hidden.
     template_path = _FALLBACK_TEMPLATE
     candidate = os.path.join(_TEMPLATES_DIR, variant.template)
     if os.path.isfile(candidate):
         template_path = variant.template
+    else:
+        if card_variant_id != "fifa":
+            logger.warning(
+                "card variant template missing — rendering fifa fallback",
+                extra={"card_variant_id": card_variant_id, "expected_template": variant.template},
+            )
+        fifa_candidate = os.path.join(_TEMPLATES_DIR, "public/player_card_fifa.html")
+        if os.path.isfile(fifa_candidate):
+            template_path = "public/player_card_fifa.html"
 
     return templates.TemplateResponse(request, template_path, {
         "player": player,

--- a/app/services/card_variant_service.py
+++ b/app/services/card_variant_service.py
@@ -48,6 +48,7 @@ VARIANTS: dict[str, VariantDefinition] = {
         is_premium=True,
         credit_cost=300,
         template="public/player_card_compact.html",
+        available=False,
     ),
     "showcase": VariantDefinition(
         id="showcase",
@@ -56,6 +57,7 @@ VARIANTS: dict[str, VariantDefinition] = {
         is_premium=True,
         credit_cost=500,
         template="public/player_card_showcase.html",
+        available=False,
     ),
     "compact_bg": VariantDefinition(
         id="compact_bg",
@@ -64,6 +66,7 @@ VARIANTS: dict[str, VariantDefinition] = {
         is_premium=True,
         credit_cost=400,
         template="public/player_card_compact_bg.html",
+        available=False,
     ),
     "showcase_bg": VariantDefinition(
         id="showcase_bg",
@@ -72,6 +75,7 @@ VARIANTS: dict[str, VariantDefinition] = {
         is_premium=True,
         credit_cost=600,
         template="public/player_card_showcase_bg.html",
+        available=False,
     ),
 }
 

--- a/app/templates/public/player_card_fifa.html
+++ b/app/templates/public/player_card_fifa.html
@@ -1,0 +1,352 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ player.name }} — LFA Player Card</title>
+    <meta property="og:title" content="{{ player.name }} — LFA Player Card">
+    <meta property="og:description" content="{{ player.position }} · {{ player.nationality }} · {{ tier_label }} {{ overall }}">
+<style>
+:root {
+    --card-panel-bg: {{ theme.panel_bg if theme is defined else 'linear-gradient(155deg, #1a2744 0%, #2a3a5c 60%, #1e3a4a 100%)' }};
+    --card-body-bg:  {{ theme.body_bg  if theme is defined else '#1a202c' }};
+    --card-tab-bg:   {{ theme.tab_bg   if theme is defined else '#2d3748' }};
+    --card-accent:   {{ theme.accent   if theme is defined else '#667eea' }};
+}
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+html { overflow-x: hidden; }
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+    background: #0f1923;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 1.5rem 0.75rem 4rem;
+    color: #e2e8f0;
+    overflow-x: hidden;
+    width: 100%;
+}
+.page-brand {
+    font-size: 0.68rem; font-weight: 700; letter-spacing: 0.16em;
+    text-transform: uppercase; color: rgba(255,255,255,0.35);
+    margin-bottom: 1.25rem; text-align: center;
+}
+.card-wrap {
+    width: 100%;
+    max-width: min(680px, calc(100vw - 1.5rem));
+    border-radius: 14px; overflow: hidden;
+    box-shadow: 0 12px 48px rgba(0,0,0,0.55);
+    border: 1px solid rgba(255,255,255,0.06);
+}
+
+/* ── Split header ─────────────────────────────────────────── */
+.fifa-header {
+    display: grid;
+    grid-template-columns: 170px 1fr;
+}
+.fifa-left {
+    background: var(--card-panel-bg);
+    padding: 1.5rem 1rem;
+    display: flex; flex-direction: column;
+    align-items: center; gap: 0.5rem; text-align: center;
+}
+.fifa-avatar {
+    width: 68px; height: 68px; border-radius: 50%;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 1.55rem; font-weight: 900; color: white;
+    border: 3px solid rgba(255,255,255,0.18); flex-shrink: 0;
+}
+.fifa-overall { font-size: 2.8rem; font-weight: 900; color: white; line-height: 1; margin-top: 0.15rem; }
+.fifa-tier {
+    font-size: 0.58rem; font-weight: 800; text-transform: uppercase;
+    letter-spacing: 0.12em; padding: 3px 10px; border-radius: 99px; color: white;
+    white-space: nowrap;
+}
+.fifa-right {
+    background: #ffffff;
+    padding: 1.25rem 1.25rem 1rem;
+    display: flex; flex-direction: column; gap: 0.7rem;
+    min-width: 0; /* prevent grid blowout */
+}
+.fifa-name {
+    font-size: 1.45rem; font-weight: 800; color: #1a202c; line-height: 1.1;
+    overflow-wrap: break-word; word-break: break-word;
+}
+.fifa-pos-badge {
+    display: inline-block; padding: 3px 11px; border-radius: 6px;
+    font-size: 0.7rem; font-weight: 800; color: white;
+    text-transform: uppercase; letter-spacing: 0.08em;
+}
+.identity-grid {
+    display: grid; grid-template-columns: repeat(3, 1fr);
+    gap: 0.5rem 0.75rem;
+}
+.id-field { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.id-label { font-size: 0.6rem; font-weight: 700; color: #a0aec0; text-transform: uppercase; letter-spacing: 0.07em; }
+.id-value { font-size: 0.84rem; font-weight: 700; color: #2d3748; overflow-wrap: break-word; }
+.fifa-club-pills { display: flex; flex-wrap: wrap; gap: 0.35rem; }
+.club-pill {
+    font-size: 0.7rem; font-weight: 600; color: #4a5568;
+    background: #f0f4ff; border: 1px solid #e2e8f0;
+    border-radius: 99px; padding: 3px 9px;
+    overflow-wrap: anywhere;
+}
+
+/* ── Skills section ───────────────────────────────────────── */
+.skills-section {
+    background: var(--card-body-bg);
+    padding: 1.1rem 1.1rem;
+}
+.skills-title {
+    font-size: 0.63rem; font-weight: 800; text-transform: uppercase;
+    letter-spacing: 0.13em; color: rgba(255,255,255,0.35);
+    margin-bottom: 0.85rem;
+}
+.skill-cats {
+    display: grid; grid-template-columns: repeat(4, 1fr);
+    gap: 0.65rem;
+}
+.skill-cat { background: rgba(255,255,255,0.04); border-radius: 9px; padding: 0.65rem; min-width: 0; }
+.skill-cat-name {
+    font-size: 0.58rem; font-weight: 800; text-transform: uppercase;
+    letter-spacing: 0.09em; color: rgba(255,255,255,0.4); margin-bottom: 0.45rem;
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.skill-row { display: flex; align-items: center; gap: 0.35rem; margin-bottom: 0.3rem; }
+.skill-row:last-child { margin-bottom: 0; }
+.skill-name { font-size: 0.62rem; color: rgba(255,255,255,0.6); flex: 1; min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.skill-val { font-size: 0.67rem; font-weight: 700; width: 28px; text-align: right; flex-shrink: 0; }
+.skill-up { font-size: 0.6rem; color: #48bb78; font-weight: 900; flex-shrink: 0; line-height: 1; }
+.skill-bar-bg { flex: 0 1 36px; height: 4px; background: rgba(255,255,255,0.08); border-radius: 2px; }
+.skill-bar-fill { height: 100%; border-radius: 2px; }
+
+/* ── Tab bar ─────────────────────────────────────────────── */
+.tab-bar {
+    display: flex;
+    background: var(--card-tab-bg);
+    border-bottom: 1px solid rgba(255,255,255,0.08);
+}
+.tab-btn {
+    flex: 1;
+    padding: 0.55rem 1rem;
+    background: none;
+    border: none;
+    color: rgba(255,255,255,0.5);
+    font-size: 0.82rem;
+    font-weight: 600;
+    cursor: pointer;
+    border-bottom: 2px solid transparent;
+    transition: color .15s, border-color .15s;
+}
+.tab-btn.active { color: #fff; border-bottom-color: var(--card-accent); }
+
+/* ── Events section ──────────────────────────────────────── */
+.events-section { background: var(--card-body-bg); padding: 0.75rem 1rem; }
+.ev-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+    padding: 0.55rem 0;
+    border-bottom: 1px solid rgba(255,255,255,0.05);
+}
+.ev-row:last-child { border-bottom: none; }
+.ev-rank { min-width: 2rem; font-size: 1.1rem; text-align: center; padding-top: 0.05rem; }
+.ev-body { flex: 1; min-width: 0; }
+.ev-name { margin-bottom: 0.2rem; }
+.ev-link { color: rgba(255,255,255,0.88); font-size: 0.82rem; font-weight: 600; text-decoration: none; }
+.ev-link:hover { text-decoration: underline; }
+.ev-rewards { display: flex; gap: 0.3rem; margin-bottom: 0.25rem; flex-wrap: wrap; }
+.ev-badge { font-size: 0.68rem; font-weight: 700; padding: 1px 6px; border-radius: 99px; }
+.ev-badge.xp { background: rgba(102,126,234,0.2); color: #a3bffa; }
+.ev-badge.cr { background: rgba(72,187,120,0.15); color: #9ae6b4; }
+.ev-skills { display: flex; flex-wrap: wrap; gap: 0.25rem; }
+.ev-skill-pill { font-size: 0.65rem; padding: 1px 6px; border-radius: 99px; }
+.ev-skill-pill.up { background: rgba(72,187,120,0.15); color: #9ae6b4; }
+.ev-skill-pill.dn { background: rgba(252,129,129,0.15); color: #feb2b2; }
+.ev-empty { text-align: center; color: rgba(255,255,255,0.3); font-size: 0.8rem; padding: 2rem 0; }
+
+/* ── Responsive ─────────────────────────────────────────────
+   Breakpoints:
+   < 560px : tablet/large phone — 2-col skills, 2-col identity, smaller left
+   < 440px : phone portrait    — stack header vertically, 1-col skills
+   < 340px : tiny phone        — extra compact
+───────────────────────────────────────────────────────────── */
+@media (max-width: 560px) {
+    body { padding: 1rem 0.5rem 3rem; }
+    .fifa-header { grid-template-columns: 130px 1fr; }
+    .fifa-left { padding: 1.1rem 0.75rem; }
+    .fifa-avatar { width: 58px; height: 58px; font-size: 1.3rem; }
+    .fifa-overall { font-size: 2.3rem; }
+    .fifa-right { padding: 1rem; gap: 0.6rem; }
+    .fifa-name { font-size: 1.2rem; }
+    .identity-grid { grid-template-columns: 1fr 1fr; }
+    .skill-cats { grid-template-columns: 1fr 1fr; }
+    .skills-section { padding: 0.9rem; }
+}
+@media (max-width: 440px) {
+    .fifa-header { grid-template-columns: 1fr; }
+    .fifa-left {
+        flex-direction: row; justify-content: center;
+        align-items: center; flex-wrap: wrap;
+        gap: 0.6rem 1rem; padding: 1rem 1.25rem;
+    }
+    .fifa-overall { font-size: 2.4rem; }
+    .fifa-right { padding: 1rem; }
+    .identity-grid { grid-template-columns: repeat(3, 1fr); }
+    .skill-cats { grid-template-columns: 1fr 1fr; }
+}
+@media (max-width: 340px) {
+    .identity-grid { grid-template-columns: 1fr 1fr; }
+    .skill-cats { grid-template-columns: 1fr; }
+    .fifa-name { font-size: 1.05rem; }
+}
+</style>
+</head>
+<body>
+
+<div class="page-brand">⚽ LFA Education Center — Player Card</div>
+
+<div class="card-wrap">
+
+    <!-- Split header -->
+    <div class="fifa-header">
+        <div class="fifa-left">
+            {% if photo_url %}
+            <img class="fifa-avatar" src="{{ photo_url }}" alt="{{ initials }}"
+                 style="background: {{ avatar_bg }}; object-fit: cover;">
+            {% else %}
+            <div class="fifa-avatar" style="background: {{ avatar_bg }};">{{ initials }}</div>
+            {% endif %}
+            <div class="fifa-overall">{{ overall }}</div>
+            <span class="fifa-tier" style="background: {{ tier_color }};">{{ tier_label }}</span>
+        </div>
+        <div class="fifa-right">
+            <div>
+                <h2 class="fifa-name">{{ player.name }}</h2>
+                {% if player.position and player.position != "Unknown" %}
+                <span class="fifa-pos-badge" style="background: {{ pos_color }};">{{ player.position }}</span>
+                {% endif %}
+            </div>
+
+            <div class="identity-grid">
+                <div class="id-field">
+                    <span class="id-label">Nationality</span>
+                    <span class="id-value">{{ player.nationality or "—" }}</span>
+                </div>
+                <div class="id-field">
+                    <span class="id-label">Age Group</span>
+                    <span class="id-value">{{ player.age_group or "—" }}</span>
+                </div>
+                <div class="id-field">
+                    <span class="id-label">Tournaments</span>
+                    <span class="id-value">{{ player.total_tournaments }}</span>
+                </div>
+            </div>
+
+            {% if teams_info %}
+            <div class="fifa-club-pills">
+                {% for t in teams_info %}
+                <span class="club-pill">🏟️ {{ t.team_name }}{% if t.club_name %} · {{ t.club_name }}{% endif %}{% if t.age_group_label %} · {{ t.age_group_label }}{% endif %}</span>
+                {% endfor %}
+            </div>
+            {% endif %}
+        </div>
+    </div>
+
+    <!-- Tab bar -->
+    <div class="tab-bar">
+        <button class="tab-btn active" id="btn-skills" onclick="switchTab('skills')">⚽ Skills</button>
+        <button class="tab-btn"        id="btn-events" onclick="switchTab('events')">🏆 Events</button>
+    </div>
+
+    <!-- Skills tab -->
+    {% if skill_categories %}
+    <div class="skills-section" id="tab-skills">
+        <div class="skills-title">Football Skills — {{ overall }} OVR</div>
+        <div class="skill-cats">
+            {% for cat in skill_categories %}
+            <div class="skill-cat">
+                <div class="skill-cat-name">{{ cat.emoji }} {{ cat.name_en }}</div>
+                {% for skill in cat.skills %}
+                {% set sdata = player.skills.get(skill.key, {}) %}
+                {% set sval = sdata.get('current_level', 50) | round(1) %}
+                {% set fill_pct = [sval, 100] | min %}
+                {% set sdelta = last_skill_delta.get(skill.key, 0) %}
+                {# Color driven solely by last-tournament delta, not by level tier.
+                   Neutral = not affected by the most recent tournament. #}
+                {% if sdelta > 0 %}
+                    {% set bar_color = '#48bb78' %}
+                    {% set val_color = '#48bb78' %}
+                {% elif sdelta < 0 %}
+                    {% set bar_color = '#fc8181' %}
+                    {% set val_color = '#fc8181' %}
+                {% else %}
+                    {% set bar_color = 'rgba(255,255,255,0.12)' %}
+                    {% set val_color = 'rgba(255,255,255,0.85)' %}
+                {% endif %}
+                <div class="skill-row">
+                    <span class="skill-name">{{ skill.name_en }}</span>
+                    <div class="skill-bar-bg"><div class="skill-bar-fill" style="width:{{ fill_pct }}%; background:{{ bar_color }};"></div></div>
+                    <span class="skill-val" style="color:{{ val_color }};">{{ sval }}</span>
+                    {% if sdelta > 0 %}<span class="skill-up">↑</span>
+                    {% elif sdelta < 0 %}<span class="skill-up" style="color:#fc8181;">↓</span>
+                    {% else %}<span class="skill-up" style="visibility:hidden">↑</span>{% endif %}
+                </div>
+                {% endfor %}
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+    {% endif %}
+
+    <!-- Events tab -->
+    <div class="events-section" id="tab-events" style="display:none;">
+        {% if participations_history %}
+            {% for ev in participations_history %}
+            <div class="ev-row">
+                <div class="ev-rank">
+                    {% if ev.placement == 1 %}🥇
+                    {% elif ev.placement == 2 %}🥈
+                    {% elif ev.placement == 3 %}🥉
+                    {% elif ev.placement %}#{{ ev.placement }}
+                    {% else %}—{% endif %}
+                </div>
+                <div class="ev-body">
+                    <div class="ev-name">
+                        <a href="/events/{{ ev.event_id }}" class="ev-link">{{ ev.event_name }}</a>
+                    </div>
+                    <div class="ev-rewards">
+                        {% if ev.xp_awarded %}<span class="ev-badge xp">+{{ ev.xp_awarded }} XP</span>{% endif %}
+                        {% if ev.credits_awarded %}<span class="ev-badge cr">+{{ ev.credits_awarded }} CR</span>{% endif %}
+                    </div>
+                    {% if ev.top_skills %}
+                    <div class="ev-skills">
+                        {% for sk, delta in ev.top_skills %}
+                        <span class="ev-skill-pill {% if delta > 0 %}up{% else %}dn{% endif %}">
+                            {{ sk.replace('_',' ') }} {{ '+' if delta > 0 else '' }}{{ delta | round(1) }}
+                        </span>
+                        {% endfor %}
+                    </div>
+                    {% endif %}
+                </div>
+            </div>
+            {% endfor %}
+        {% else %}
+            <div class="ev-empty">Még nincs tornaadat.</div>
+        {% endif %}
+    </div>
+
+</div>
+
+<script>
+function switchTab(name) {
+    document.getElementById('tab-skills').style.display = (name === 'skills') ? '' : 'none';
+    document.getElementById('tab-events').style.display = (name === 'events')  ? '' : 'none';
+    document.getElementById('btn-skills').classList.toggle('active', name === 'skills');
+    document.getElementById('btn-events').classList.toggle('active', name === 'events');
+}
+</script>
+
+</body>
+</html>

--- a/tests/unit/test_card_render_integration.py
+++ b/tests/unit/test_card_render_integration.py
@@ -150,16 +150,28 @@ class TestTemplateSelection:
         fallback = os.path.join(templates_dir, self._FALLBACK)
         assert os.path.isfile(fallback), f"Fallback template missing: {fallback}"
 
-    def test_fifa_variant_template_does_not_exist_yet(self):
+    def test_fifa_variant_template_exists(self):
         templates_dir = os.path.join(
             os.path.dirname(__file__), "..", "..", "app", "templates"
         )
         v = get_variant("fifa")
         candidate = os.path.join(templates_dir, v.template)
-        # Variant templates are not yet created — route must fall back to player_card.html
-        assert not os.path.isfile(candidate), (
-            f"Variant template exists at {candidate} — update this test to validate routing"
+        assert os.path.isfile(candidate), (
+            f"FIFA variant template missing at {candidate} — must exist for explicit (non-fallback) render"
         )
+
+    def test_non_fifa_variant_templates_not_yet_implemented(self):
+        templates_dir = os.path.join(
+            os.path.dirname(__file__), "..", "..", "app", "templates"
+        )
+        for variant_id in ["compact", "showcase", "compact_bg", "showcase_bg"]:
+            v = get_variant(variant_id)
+            assert not v.available, f"{variant_id} must be available=False until template is implemented"
+            candidate = os.path.join(templates_dir, v.template)
+            assert not os.path.isfile(candidate), (
+                f"{variant_id} template exists at {candidate} but variant is still available=False — "
+                "set available=True and update this test when the layout is implemented"
+            )
 
 
 # ── CSS custom property values match service registry ────────────────────────

--- a/tests/unit/test_card_unlock_apply.py
+++ b/tests/unit/test_card_unlock_apply.py
@@ -129,6 +129,20 @@ class TestUnlockThemeAutoApply:
 
 
 # ── Variant: unlock + auto-apply ───────────────────────────────────────────────
+# compact/showcase/compact_bg/showcase_bg are currently available=False (templates
+# not yet implemented).  Mechanism tests patch available=True to test the unlock
+# logic in isolation; a separate class tests the blocking behaviour.
+
+import dataclasses
+import app.services.card_variant_service as _cvsvc
+
+
+def _with_available(variant_id: str):
+    """Context manager: temporarily set VARIANTS[variant_id].available = True."""
+    orig = _cvsvc.VARIANTS[variant_id]
+    patched = dataclasses.replace(orig, available=True)
+    return patch.dict(_cvsvc.VARIANTS, {variant_id: patched})
+
 
 class TestUnlockVariantAutoApply:
 
@@ -138,10 +152,10 @@ class TestUnlockVariantAutoApply:
         user = _make_user(credits=2000)
         ul = _make_license()
 
-        with patch("app.services.card_variant_service.CreditService") as MockCS:
+        with _with_available("compact"), \
+             patch("app.services.card_variant_service.CreditService") as MockCS:
             MockCS.return_value.deduct.return_value = MagicMock()
-            from app.services.card_variant_service import unlock_variant
-            unlock_variant(db, user, ul, "compact")
+            _cvsvc.unlock_variant(db, user, ul, "compact")
 
         assert ul.card_variant == "compact", (
             f"card_variant must be 'compact' after unlock, got {ul.card_variant!r}. "
@@ -153,10 +167,10 @@ class TestUnlockVariantAutoApply:
         user = _make_user()
         ul = _make_license()
 
-        with patch("app.services.card_variant_service.CreditService") as MockCS:
+        with _with_available("showcase"), \
+             patch("app.services.card_variant_service.CreditService") as MockCS:
             MockCS.return_value.deduct.return_value = MagicMock()
-            from app.services.card_variant_service import unlock_variant
-            unlock_variant(db, user, ul, "showcase")
+            _cvsvc.unlock_variant(db, user, ul, "showcase")
 
         assert "showcase" in ul.unlocked_card_variants
 
@@ -174,10 +188,10 @@ class TestUnlockVariantAutoApply:
 
         db.commit.side_effect = check_at_commit
 
-        with patch("app.services.card_variant_service.CreditService") as MockCS:
+        with _with_available("compact"), \
+             patch("app.services.card_variant_service.CreditService") as MockCS:
             MockCS.return_value.deduct.return_value = MagicMock()
-            from app.services.card_variant_service import unlock_variant
-            unlock_variant(db, user, ul, "compact")
+            _cvsvc.unlock_variant(db, user, ul, "compact")
 
         assert captured["variant"] == "compact", "Split-brain: variant not active at commit."
         assert "compact" in captured["unlocked"]
@@ -189,8 +203,7 @@ class TestUnlockVariantAutoApply:
         ul = _make_license()
 
         with patch("app.services.card_variant_service.CreditService") as MockCS:
-            from app.services.card_variant_service import unlock_variant
-            unlock_variant(db, user, ul, "fifa")
+            _cvsvc.unlock_variant(db, user, ul, "fifa")
             MockCS.return_value.deduct.assert_not_called()
 
     def test_already_unlocked_is_idempotent(self):
@@ -198,18 +211,32 @@ class TestUnlockVariantAutoApply:
         user = _make_user()
         ul = _make_license(unlocked_variants=["compact"])
 
-        with patch("app.services.card_variant_service.CreditService") as MockCS:
-            from app.services.card_variant_service import unlock_variant
-            unlock_variant(db, user, ul, "compact")
+        with _with_available("compact"), \
+             patch("app.services.card_variant_service.CreditService") as MockCS:
+            _cvsvc.unlock_variant(db, user, ul, "compact")
             MockCS.return_value.deduct.assert_not_called()
 
         db.commit.assert_not_called()
 
     def test_unknown_variant_raises(self):
         db = _mock_db()
-        from app.services.card_variant_service import unlock_variant
         with pytest.raises(ValueError, match="Unknown variant"):
-            unlock_variant(db, _make_user(), _make_license(), "nonexistent")
+            _cvsvc.unlock_variant(db, _make_user(), _make_license(), "nonexistent")
+
+    def test_unavailable_variant_blocks_unlock(self):
+        """compact/showcase/compact_bg/showcase_bg are available=False — unlock must raise."""
+        db = _mock_db()
+        for vid in ["compact", "showcase", "compact_bg", "showcase_bg"]:
+            with pytest.raises(ValueError, match="not yet available"):
+                _cvsvc.unlock_variant(db, _make_user(), _make_license(), vid)
+
+    def test_unavailable_variant_blocks_apply(self):
+        """apply_variant must also reject unavailable variants."""
+        db = _mock_db()
+        ul = _make_license(unlocked_variants=["compact", "showcase", "compact_bg", "showcase_bg"])
+        for vid in ["compact", "showcase", "compact_bg", "showcase_bg"]:
+            with pytest.raises(ValueError, match="not yet available"):
+                _cvsvc.apply_variant(db, ul, vid)
 
 
 # ── apply_theme / apply_variant: standalone ────────────────────────────────────
@@ -241,14 +268,14 @@ class TestApplyStandalone:
     def test_apply_variant_when_unlocked(self):
         db = _mock_db()
         ul = _make_license(unlocked_variants=["showcase"])
-        from app.services.card_variant_service import apply_variant
-        apply_variant(db, ul, "showcase")
+        with _with_available("showcase"):
+            _cvsvc.apply_variant(db, ul, "showcase")
         assert ul.card_variant == "showcase"
         db.commit.assert_called_once()
 
     def test_apply_variant_locked_raises(self):
         db = _mock_db()
         ul = _make_license()
-        from app.services.card_variant_service import apply_variant
-        with pytest.raises(ValueError, match="locked"):
-            apply_variant(db, ul, "compact")
+        with _with_available("compact"):
+            with pytest.raises(ValueError, match="locked"):
+                _cvsvc.apply_variant(db, ul, "compact")


### PR DESCRIPTION
## Summary

- **Root cause**: all card variants silently fell back to `player_card.html` — no variant templates existed, so every layout looked identical with no error signal
- **Fix**: explicit `player_card_fifa.html` + `available=False` on unimplemented variants + warning log on missing templates

## Changes

| File | Change |
|---|---|
| `player_card_fifa.html` | New explicit FIFA variant template (copy of `player_card.html`) |
| `card_variant_service.py` | compact/showcase/compact_bg/showcase_bg → `available=False` |
| `public_player.py` | Warning log on missing template; fallback chain: variant → fifa → legacy |
| `test_card_render_integration.py` | Updated FIFA template test + gate for unimplemented variants |
| `test_card_unlock_apply.py` | Patched `available=True` for mechanism tests; added block tests |

## Behaviour after this fix

- `fifa` → renders from `player_card_fifa.html` (explicit, not fallback)
- `compact/showcase/compact_bg/showcase_bg` → `available=False`, cannot be purchased/applied
- Dashboard shows ⏳ for unavailable variants (existing template already handles this)
- Users with legacy `compact`/`showcase` DB value → fifa layout + WARNING log (not silent)

## Not in scope

Full compact/showcase layout templates — separate task.

## Test plan
- [x] 41/41 card tests pass locally
- [x] `test_public_player_card_renders` passes
- [ ] Test Baseline Check green on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)