### PR TITLE
fix(card): restore compact/showcase variant templates — revert available=False regression

### DIFF
--- a/app/services/card_variant_service.py
+++ b/app/services/card_variant_service.py
@@ -48,7 +48,6 @@ VARIANTS: dict[str, VariantDefinition] = {
         is_premium=True,
         credit_cost=300,
         template="public/player_card_compact.html",
-        available=False,
     ),
     "showcase": VariantDefinition(
         id="showcase",
@@ -57,7 +56,6 @@ VARIANTS: dict[str, VariantDefinition] = {
         is_premium=True,
         credit_cost=500,
         template="public/player_card_showcase.html",
-        available=False,
     ),
     "compact_bg": VariantDefinition(
         id="compact_bg",
@@ -66,7 +64,6 @@ VARIANTS: dict[str, VariantDefinition] = {
         is_premium=True,
         credit_cost=400,
         template="public/player_card_compact_bg.html",
-        available=False,
     ),
     "showcase_bg": VariantDefinition(
         id="showcase_bg",
@@ -75,7 +72,6 @@ VARIANTS: dict[str, VariantDefinition] = {
         is_premium=True,
         credit_cost=600,
         template="public/player_card_showcase_bg.html",
-        available=False,
     ),
 }
 

--- a/app/templates/public/player_card_compact.html
+++ b/app/templates/public/player_card_compact.html
@@ -1,0 +1,299 @@
+{% extends "public/player_card_base.html" %}
+
+{% block extra_styles %}
+<style>
+/* ── Compact variant: header split (photo | identity) + full-width tabs below ── */
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body { background: var(--card-page-bg); }
+
+/* ── Card wrapper — column, not row ── */
+.card-wrap {
+    max-width: min(520px, calc(100vw - 1.5rem));
+    display: flex;
+    flex-direction: column;
+    border-radius: 14px; overflow: hidden;
+    box-shadow: 0 12px 48px rgba(0,0,0,0.55);
+    border: 1px solid var(--card-border);
+}
+
+/* ── Header: photo sidebar + identity side by side ── */
+.cmp-header {
+    display: flex;
+    flex-direction: row;
+}
+.cmp-header.photo-right { flex-direction: row-reverse; }
+
+/* ── Photo sidebar (lives inside header only) ── */
+.cmp-photo-col {
+    flex: 0 0 155px;
+    background: var(--card-panel-bg);
+    position: relative;
+    min-height: 180px;
+}
+.cmp-photo-col img {
+    position: absolute; top: 0; left: 0; right: 0; bottom: 0;
+    width: 100%; height: 100%;
+    object-fit: contain;
+    object-position: center bottom;
+    display: block;
+}
+.cmp-photo-initials {
+    position: absolute; top: 0; left: 0; right: 0; bottom: 0;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 3.5rem; font-weight: 900; color: rgba(255,255,255,0.45);
+}
+.cmp-ovr-badge {
+    position: absolute; bottom: 0; left: 0; right: 0;
+    padding: 1.5rem 0.4rem 0.55rem;
+    background: linear-gradient(to top, rgba(0,0,0,0.72) 0%, transparent 100%);
+    text-align: center;
+}
+.cmp-overall { font-size: 2.6rem; font-weight: 900; line-height: 1; }
+.cmp-tier { font-size: 0.55rem; font-weight: 800; text-transform: uppercase; letter-spacing: 0.1em; margin-top: 1px; }
+
+/* ── Identity block (right side of header) ── */
+.cmp-identity {
+    flex: 1; min-width: 0;
+    background: var(--card-right-bg);
+    padding: 0.85rem 1rem 0.8rem;
+    border-bottom: 1px solid var(--card-border);
+}
+.cmp-name {
+    font-size: 1.2rem; font-weight: 800;
+    color: var(--card-right-text);
+    line-height: 1.15; margin-bottom: 0.35rem;
+    overflow-wrap: break-word;
+}
+.cmp-pos-badge {
+    display: inline-block; padding: 2px 10px;
+    border-radius: 5px; font-size: 0.68rem; font-weight: 800;
+    color: white; text-transform: uppercase; letter-spacing: 0.07em;
+    margin-bottom: 0.45rem;
+}
+.cmp-meta-row {
+    font-size: 0.72rem; color: var(--card-right-subtext);
+    display: flex; flex-wrap: wrap; gap: 0.2rem 0.4rem;
+    align-items: center; margin-bottom: 0.45rem;
+}
+.cmp-meta-sep { opacity: 0.4; }
+.cmp-club-pills { display: flex; flex-wrap: wrap; gap: 0.3rem; }
+.cmp-club-pill {
+    font-size: 0.65rem; font-weight: 600;
+    color: var(--card-pill-text);
+    background: var(--card-pill-bg);
+    border: 1px solid var(--card-pill-border);
+    border-radius: 99px; padding: 2px 8px;
+    overflow-wrap: anywhere;
+}
+
+/* ── Tab bar — full card width ── */
+.tab-bar {
+    display: flex;
+    background: var(--card-tab-bg);
+    border-bottom: 1px solid var(--card-tab-border);
+}
+.tab-btn {
+    flex: 1; padding: 0.55rem 1rem;
+    background: none; border: none;
+    color: var(--card-text-tab);
+    font-size: 0.82rem; font-weight: 600;
+    cursor: pointer;
+    border-bottom: 2px solid transparent;
+    transition: color .15s, border-color .15s;
+}
+.tab-btn.active { color: var(--card-text-primary); border-bottom-color: var(--card-accent); }
+
+/* ── Skills section — full card width, 4-col grid ── */
+.skills-section {
+    background: var(--card-body-bg);
+    padding: 0.85rem 0.9rem;
+}
+.skills-title {
+    font-size: 0.63rem; font-weight: 800; text-transform: uppercase;
+    letter-spacing: 0.13em; color: var(--card-text-faint);
+    margin-bottom: 0.7rem;
+}
+.skill-cats {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.5rem;
+}
+.skill-cat { background: var(--card-cat-bg); border-radius: 9px; padding: 0.55rem 0.65rem; min-width: 0; }
+.skill-cat-name {
+    font-size: 0.58rem; font-weight: 800; text-transform: uppercase;
+    letter-spacing: 0.08em; color: var(--card-text-muted); margin-bottom: 0.38rem;
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.skill-row { display: flex; align-items: center; gap: 0.3rem; margin-bottom: 0.25rem; }
+.skill-row:last-child { margin-bottom: 0; }
+.skill-name { font-size: 0.62rem; color: var(--card-text-secondary); flex: 1; min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.skill-val { font-size: 0.63rem; font-weight: 700; width: 26px; text-align: right; flex-shrink: 0; }
+.skill-up { font-size: 0.58rem; font-weight: 900; flex-shrink: 0; line-height: 1; }
+.skill-bar-bg { flex: 0 1 36px; height: 3px; background: var(--card-bar-bg); border-radius: 2px; }
+.skill-bar-fill { height: 100%; border-radius: 2px; }
+
+/* ── Events section — full card width ── */
+.events-section { background: var(--card-body-bg); padding: 0.75rem 0.9rem; }
+.ev-row {
+    display: flex; align-items: flex-start;
+    gap: 0.6rem; padding: 0.5rem 0;
+    border-bottom: 1px solid var(--card-ev-border);
+}
+.ev-row:last-child { border-bottom: none; }
+.ev-rank { min-width: 1.9rem; font-size: 1rem; text-align: center; padding-top: 0.04rem; }
+.ev-body { flex: 1; min-width: 0; }
+.ev-name { margin-bottom: 0.18rem; }
+.ev-link { color: var(--card-text-primary); font-size: 0.78rem; font-weight: 600; text-decoration: none; }
+.ev-link:hover { text-decoration: underline; }
+.ev-rewards { display: flex; gap: 0.28rem; margin-bottom: 0.18rem; flex-wrap: wrap; }
+.ev-badge { font-size: 0.65rem; font-weight: 700; padding: 1px 6px; border-radius: 99px; }
+.ev-badge.xp { background: var(--card-badge-xp-bg); color: var(--card-badge-xp-text); }
+.ev-badge.cr { background: var(--card-badge-cr-bg); color: var(--card-badge-cr-text); }
+.ev-skills { display: flex; flex-wrap: wrap; gap: 0.2rem; }
+.ev-skill-pill { font-size: 0.62rem; padding: 1px 5px; border-radius: 99px; }
+.ev-skill-pill.up { background: var(--card-pill-up-bg); color: var(--card-pill-up-text); }
+.ev-skill-pill.dn { background: var(--card-pill-dn-bg); color: var(--card-pill-dn-text); }
+.ev-empty { text-align: center; color: var(--card-text-faint); font-size: 0.78rem; padding: 1.5rem 0; }
+
+/* ── Responsive ── */
+@media (max-width: 320px) {
+    .cmp-photo-col { flex: 0 0 120px; }
+    .cmp-name { font-size: 1rem; }
+}
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="card-wrap">
+
+    {# ── HEADER: photo sidebar + identity (side by side) ── #}
+    <div class="cmp-header photo-{{ compact_photo_position }}">
+
+        <div class="cmp-photo-col">
+            {% if photo_url %}
+                <img src="{{ photo_url }}" alt="{{ player.name }}">
+            {% else %}
+                <div class="cmp-photo-initials">{{ initials }}</div>
+            {% endif %}
+            <div class="cmp-ovr-badge">
+                <div class="cmp-overall" style="color: {{ tier_color }};">{{ overall | round(0) | int }}</div>
+                <div class="cmp-tier"    style="color: {{ tier_color }};">{{ tier_label }}</div>
+            </div>
+        </div>
+
+        <div class="cmp-identity">
+            <div class="cmp-name">{{ player.name }}</div>
+            {% if player.position and player.position != "Unknown" %}
+            <span class="cmp-pos-badge" style="background: {{ pos_color }};">{{ player.position }}</span>
+            {% endif %}
+            <div class="cmp-meta-row">
+                {% if player.nationality %}<span>{{ player.nationality }}</span><span class="cmp-meta-sep">·</span>{% endif %}
+                <span>{{ player.age_group }}</span>
+                <span class="cmp-meta-sep">·</span>
+                <span>{{ player.total_tournaments }} events</span>
+            </div>
+            {% if teams_info %}
+            <div class="cmp-club-pills">
+                {% for t in teams_info %}
+                <span class="cmp-club-pill">🏟️ {{ t.team_name }}{% if t.club_name %} · {{ t.club_name }}{% endif %}{% if t.age_group_label %} · {{ t.age_group_label }}{% endif %}</span>
+                {% endfor %}
+            </div>
+            {% endif %}
+        </div>
+
+    </div>{# /cmp-header #}
+
+    {# ── TAB BAR — full width below header ── #}
+    <div class="tab-bar">
+        <button class="tab-btn active" id="btn-skills" onclick="switchTab('skills')">⚽ Skills</button>
+        <button class="tab-btn"        id="btn-events" onclick="switchTab('events')">🏆 Events</button>
+    </div>
+
+    {# ── SKILLS TAB — full width ── #}
+    {% if skill_categories %}
+    <div class="skills-section" id="tab-skills">
+        <div class="skills-title">Football Skills — {{ overall | round(0) | int }} OVR</div>
+        <div class="skill-cats">
+            {% for cat in skill_categories %}
+            <div class="skill-cat">
+                <div class="skill-cat-name">{{ cat.emoji }} {{ cat.name_en }}</div>
+                {% for skill in cat.skills %}
+                {% set sdata = player.skills.get(skill.key, {}) %}
+                {% set sval = sdata.get('current_level', 50) | round(1) %}
+                {% set fill_pct = [sval, 100] | min %}
+                {% set sdelta = last_skill_delta.get(skill.key, 0) %}
+                {% if sdelta > 0 %}
+                    {% set bar_color = 'var(--card-skill-up)' %}
+                    {% set val_color = 'var(--card-skill-up)' %}
+                {% elif sdelta < 0 %}
+                    {% set bar_color = 'var(--card-skill-dn)' %}
+                    {% set val_color = 'var(--card-skill-dn)' %}
+                {% else %}
+                    {% set bar_color = 'var(--card-bar-neutral)' %}
+                    {% set val_color = 'var(--card-val-neutral)' %}
+                {% endif %}
+                <div class="skill-row">
+                    <span class="skill-name">{{ skill.name_en }}</span>
+                    <div class="skill-bar-bg"><div class="skill-bar-fill" style="width:{{ fill_pct }}%; background:{{ bar_color }};"></div></div>
+                    <span class="skill-val" style="color:{{ val_color }};">{{ sval }}</span>
+                    {% if sdelta > 0 %}<span class="skill-up" style="color:var(--card-skill-up);">↑</span>
+                    {% elif sdelta < 0 %}<span class="skill-up" style="color:var(--card-skill-dn);">↓</span>
+                    {% else %}<span class="skill-up" style="visibility:hidden;">↑</span>{% endif %}
+                </div>
+                {% endfor %}
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+    {% endif %}
+
+    {# ── EVENTS TAB — full width ── #}
+    <div class="events-section" id="tab-events" style="display:none;">
+        {% if participations_history %}
+            {% for ev in participations_history %}
+            <div class="ev-row">
+                <div class="ev-rank">
+                    {% if ev.placement == 1 %}🥇
+                    {% elif ev.placement == 2 %}🥈
+                    {% elif ev.placement == 3 %}🥉
+                    {% elif ev.placement %}#{{ ev.placement }}
+                    {% else %}—{% endif %}
+                </div>
+                <div class="ev-body">
+                    <div class="ev-name">
+                        <a href="/events/{{ ev.event_id }}" class="ev-link">{{ ev.event_name }}</a>
+                    </div>
+                    <div class="ev-rewards">
+                        {% if ev.xp_awarded %}<span class="ev-badge xp">+{{ ev.xp_awarded }} XP</span>{% endif %}
+                        {% if ev.credits_awarded %}<span class="ev-badge cr">+{{ ev.credits_awarded }} CR</span>{% endif %}
+                    </div>
+                    {% if ev.top_skills %}
+                    <div class="ev-skills">
+                        {% for sk, delta in ev.top_skills %}
+                        <span class="ev-skill-pill {% if delta > 0 %}up{% else %}dn{% endif %}">
+                            {{ sk.replace('_',' ') }} {{ '+' if delta > 0 else '' }}{{ delta | round(1) }}
+                        </span>
+                        {% endfor %}
+                    </div>
+                    {% endif %}
+                </div>
+            </div>
+            {% endfor %}
+        {% else %}
+            <div class="ev-empty">No tournament data yet.</div>
+        {% endif %}
+    </div>
+
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+function switchTab(name) {
+    document.getElementById('tab-skills').style.display = (name === 'skills') ? '' : 'none';
+    document.getElementById('tab-events').style.display = (name === 'events')  ? '' : 'none';
+    document.getElementById('btn-skills').classList.toggle('active', name === 'skills');
+    document.getElementById('btn-events').classList.toggle('active', name === 'events');
+}
+</script>
+{% endblock %}

--- a/app/templates/public/player_card_compact_bg.html
+++ b/app/templates/public/player_card_compact_bg.html
@@ -1,0 +1,302 @@
+{% extends "public/player_card_base.html" %}
+
+{% block extra_styles %}
+<style>
+/* ── Compact+BG variant: same as Compact, photo column supports custom background ── */
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body { background: var(--card-page-bg); }
+
+/* ── Card wrapper — column, not row ── */
+.card-wrap {
+    max-width: min(520px, calc(100vw - 1.5rem));
+    display: flex;
+    flex-direction: column;
+    border-radius: 14px; overflow: hidden;
+    box-shadow: 0 12px 48px rgba(0,0,0,0.55);
+    border: 1px solid var(--card-border);
+}
+
+/* ── Header: photo sidebar + identity side by side ── */
+.cmp-header {
+    display: flex;
+    flex-direction: row;
+}
+.cmp-header.photo-right { flex-direction: row-reverse; }
+
+/* ── Photo sidebar ── */
+.cmp-photo-col {
+    flex: 0 0 155px;
+    background: var(--card-panel-bg);
+    background-size: cover;
+    background-position: center top;
+    position: relative;
+    min-height: 180px;
+}
+.cmp-photo-col img {
+    position: absolute; top: 0; left: 0; right: 0; bottom: 0;
+    width: 100%; height: 100%;
+    object-fit: contain;
+    object-position: center bottom;
+    display: block;
+}
+.cmp-photo-initials {
+    position: absolute; top: 0; left: 0; right: 0; bottom: 0;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 3.5rem; font-weight: 900; color: rgba(255,255,255,0.45);
+}
+.cmp-ovr-badge {
+    position: absolute; bottom: 0; left: 0; right: 0;
+    padding: 1.5rem 0.4rem 0.55rem;
+    background: linear-gradient(to top, rgba(0,0,0,0.72) 0%, transparent 100%);
+    text-align: center;
+}
+.cmp-overall { font-size: 2.6rem; font-weight: 900; line-height: 1; }
+.cmp-tier { font-size: 0.55rem; font-weight: 800; text-transform: uppercase; letter-spacing: 0.1em; margin-top: 1px; }
+
+/* ── Identity block (right side of header) ── */
+.cmp-identity {
+    flex: 1; min-width: 0;
+    background: var(--card-right-bg);
+    padding: 0.85rem 1rem 0.8rem;
+    border-bottom: 1px solid var(--card-border);
+}
+.cmp-name {
+    font-size: 1.2rem; font-weight: 800;
+    color: var(--card-right-text);
+    line-height: 1.15; margin-bottom: 0.35rem;
+    overflow-wrap: break-word;
+}
+.cmp-pos-badge {
+    display: inline-block; padding: 2px 10px;
+    border-radius: 5px; font-size: 0.68rem; font-weight: 800;
+    color: white; text-transform: uppercase; letter-spacing: 0.07em;
+    margin-bottom: 0.45rem;
+}
+.cmp-meta-row {
+    font-size: 0.72rem; color: var(--card-right-subtext);
+    display: flex; flex-wrap: wrap; gap: 0.2rem 0.4rem;
+    align-items: center; margin-bottom: 0.45rem;
+}
+.cmp-meta-sep { opacity: 0.4; }
+.cmp-club-pills { display: flex; flex-wrap: wrap; gap: 0.3rem; }
+.cmp-club-pill {
+    font-size: 0.65rem; font-weight: 600;
+    color: var(--card-pill-text);
+    background: var(--card-pill-bg);
+    border: 1px solid var(--card-pill-border);
+    border-radius: 99px; padding: 2px 8px;
+    overflow-wrap: anywhere;
+}
+
+/* ── Tab bar — full card width ── */
+.tab-bar {
+    display: flex;
+    background: var(--card-tab-bg);
+    border-bottom: 1px solid var(--card-tab-border);
+}
+.tab-btn {
+    flex: 1; padding: 0.55rem 1rem;
+    background: none; border: none;
+    color: var(--card-text-tab);
+    font-size: 0.82rem; font-weight: 600;
+    cursor: pointer;
+    border-bottom: 2px solid transparent;
+    transition: color .15s, border-color .15s;
+}
+.tab-btn.active { color: var(--card-text-primary); border-bottom-color: var(--card-accent); }
+
+/* ── Skills section — full card width, 4-col grid ── */
+.skills-section {
+    background: var(--card-body-bg);
+    padding: 0.85rem 0.9rem;
+}
+.skills-title {
+    font-size: 0.63rem; font-weight: 800; text-transform: uppercase;
+    letter-spacing: 0.13em; color: var(--card-text-faint);
+    margin-bottom: 0.7rem;
+}
+.skill-cats {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.5rem;
+}
+.skill-cat { background: var(--card-cat-bg); border-radius: 9px; padding: 0.55rem 0.65rem; min-width: 0; }
+.skill-cat-name {
+    font-size: 0.58rem; font-weight: 800; text-transform: uppercase;
+    letter-spacing: 0.08em; color: var(--card-text-muted); margin-bottom: 0.38rem;
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.skill-row { display: flex; align-items: center; gap: 0.3rem; margin-bottom: 0.25rem; }
+.skill-row:last-child { margin-bottom: 0; }
+.skill-name { font-size: 0.62rem; color: var(--card-text-secondary); flex: 1; min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.skill-val { font-size: 0.63rem; font-weight: 700; width: 26px; text-align: right; flex-shrink: 0; }
+.skill-up { font-size: 0.58rem; font-weight: 900; flex-shrink: 0; line-height: 1; }
+.skill-bar-bg { flex: 0 1 36px; height: 3px; background: var(--card-bar-bg); border-radius: 2px; }
+.skill-bar-fill { height: 100%; border-radius: 2px; }
+
+/* ── Events section — full card width ── */
+.events-section { background: var(--card-body-bg); padding: 0.75rem 0.9rem; }
+.ev-row {
+    display: flex; align-items: flex-start;
+    gap: 0.6rem; padding: 0.5rem 0;
+    border-bottom: 1px solid var(--card-ev-border);
+}
+.ev-row:last-child { border-bottom: none; }
+.ev-rank { min-width: 1.9rem; font-size: 1rem; text-align: center; padding-top: 0.04rem; }
+.ev-body { flex: 1; min-width: 0; }
+.ev-name { margin-bottom: 0.18rem; }
+.ev-link { color: var(--card-text-primary); font-size: 0.78rem; font-weight: 600; text-decoration: none; }
+.ev-link:hover { text-decoration: underline; }
+.ev-rewards { display: flex; gap: 0.28rem; margin-bottom: 0.18rem; flex-wrap: wrap; }
+.ev-badge { font-size: 0.65rem; font-weight: 700; padding: 1px 6px; border-radius: 99px; }
+.ev-badge.xp { background: var(--card-badge-xp-bg); color: var(--card-badge-xp-text); }
+.ev-badge.cr { background: var(--card-badge-cr-bg); color: var(--card-badge-cr-text); }
+.ev-skills { display: flex; flex-wrap: wrap; gap: 0.2rem; }
+.ev-skill-pill { font-size: 0.62rem; padding: 1px 5px; border-radius: 99px; }
+.ev-skill-pill.up { background: var(--card-pill-up-bg); color: var(--card-pill-up-text); }
+.ev-skill-pill.dn { background: var(--card-pill-dn-bg); color: var(--card-pill-dn-text); }
+.ev-empty { text-align: center; color: var(--card-text-faint); font-size: 0.78rem; padding: 1.5rem 0; }
+
+/* ── Responsive ── */
+@media (max-width: 320px) {
+    .cmp-photo-col { flex: 0 0 120px; }
+    .cmp-name { font-size: 1rem; }
+}
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="card-wrap">
+
+    {# ── HEADER: photo sidebar + identity (side by side) ── #}
+    <div class="cmp-header photo-{{ compact_photo_position }}">
+
+        {# Background image applied as CSS background-image — player PNG sits on top naturally #}
+        <div class="cmp-photo-col"{% if compact_bg_url %} style="background-image: url('{{ compact_bg_url }}');"{% endif %}>
+            {% if photo_url %}
+                <img src="{{ photo_url }}" alt="{{ player.name }}">
+            {% else %}
+                <div class="cmp-photo-initials">{{ initials }}</div>
+            {% endif %}
+            <div class="cmp-ovr-badge">
+                <div class="cmp-overall" style="color: {{ tier_color }};">{{ overall | round(0) | int }}</div>
+                <div class="cmp-tier"    style="color: {{ tier_color }};">{{ tier_label }}</div>
+            </div>
+        </div>
+
+        <div class="cmp-identity">
+            <div class="cmp-name">{{ player.name }}</div>
+            {% if player.position and player.position != "Unknown" %}
+            <span class="cmp-pos-badge" style="background: {{ pos_color }};">{{ player.position }}</span>
+            {% endif %}
+            <div class="cmp-meta-row">
+                {% if player.nationality %}<span>{{ player.nationality }}</span><span class="cmp-meta-sep">·</span>{% endif %}
+                <span>{{ player.age_group }}</span>
+                <span class="cmp-meta-sep">·</span>
+                <span>{{ player.total_tournaments }} events</span>
+            </div>
+            {% if teams_info %}
+            <div class="cmp-club-pills">
+                {% for t in teams_info %}
+                <span class="cmp-club-pill">🏟️ {{ t.team_name }}{% if t.club_name %} · {{ t.club_name }}{% endif %}{% if t.age_group_label %} · {{ t.age_group_label }}{% endif %}</span>
+                {% endfor %}
+            </div>
+            {% endif %}
+        </div>
+
+    </div>{# /cmp-header #}
+
+    {# ── TAB BAR — full width below header ── #}
+    <div class="tab-bar">
+        <button class="tab-btn active" id="btn-skills" onclick="switchTab('skills')">⚽ Skills</button>
+        <button class="tab-btn"        id="btn-events" onclick="switchTab('events')">🏆 Events</button>
+    </div>
+
+    {# ── SKILLS TAB — full width ── #}
+    {% if skill_categories %}
+    <div class="skills-section" id="tab-skills">
+        <div class="skills-title">Football Skills — {{ overall | round(0) | int }} OVR</div>
+        <div class="skill-cats">
+            {% for cat in skill_categories %}
+            <div class="skill-cat">
+                <div class="skill-cat-name">{{ cat.emoji }} {{ cat.name_en }}</div>
+                {% for skill in cat.skills %}
+                {% set sdata = player.skills.get(skill.key, {}) %}
+                {% set sval = sdata.get('current_level', 50) | round(1) %}
+                {% set fill_pct = [sval, 100] | min %}
+                {% set sdelta = last_skill_delta.get(skill.key, 0) %}
+                {% if sdelta > 0 %}
+                    {% set bar_color = 'var(--card-skill-up)' %}
+                    {% set val_color = 'var(--card-skill-up)' %}
+                {% elif sdelta < 0 %}
+                    {% set bar_color = 'var(--card-skill-dn)' %}
+                    {% set val_color = 'var(--card-skill-dn)' %}
+                {% else %}
+                    {% set bar_color = 'var(--card-bar-neutral)' %}
+                    {% set val_color = 'var(--card-val-neutral)' %}
+                {% endif %}
+                <div class="skill-row">
+                    <span class="skill-name">{{ skill.name_en }}</span>
+                    <div class="skill-bar-bg"><div class="skill-bar-fill" style="width:{{ fill_pct }}%; background:{{ bar_color }};"></div></div>
+                    <span class="skill-val" style="color:{{ val_color }};">{{ sval }}</span>
+                    {% if sdelta > 0 %}<span class="skill-up" style="color:var(--card-skill-up);">↑</span>
+                    {% elif sdelta < 0 %}<span class="skill-up" style="color:var(--card-skill-dn);">↓</span>
+                    {% else %}<span class="skill-up" style="visibility:hidden;">↑</span>{% endif %}
+                </div>
+                {% endfor %}
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+    {% endif %}
+
+    {# ── EVENTS TAB — full width ── #}
+    <div class="events-section" id="tab-events" style="display:none;">
+        {% if participations_history %}
+            {% for ev in participations_history %}
+            <div class="ev-row">
+                <div class="ev-rank">
+                    {% if ev.placement == 1 %}🥇
+                    {% elif ev.placement == 2 %}🥈
+                    {% elif ev.placement == 3 %}🥉
+                    {% elif ev.placement %}#{{ ev.placement }}
+                    {% else %}—{% endif %}
+                </div>
+                <div class="ev-body">
+                    <div class="ev-name">
+                        <a href="/events/{{ ev.event_id }}" class="ev-link">{{ ev.event_name }}</a>
+                    </div>
+                    <div class="ev-rewards">
+                        {% if ev.xp_awarded %}<span class="ev-badge xp">+{{ ev.xp_awarded }} XP</span>{% endif %}
+                        {% if ev.credits_awarded %}<span class="ev-badge cr">+{{ ev.credits_awarded }} CR</span>{% endif %}
+                    </div>
+                    {% if ev.top_skills %}
+                    <div class="ev-skills">
+                        {% for sk, delta in ev.top_skills %}
+                        <span class="ev-skill-pill {% if delta > 0 %}up{% else %}dn{% endif %}">
+                            {{ sk.replace('_',' ') }} {{ '+' if delta > 0 else '' }}{{ delta | round(1) }}
+                        </span>
+                        {% endfor %}
+                    </div>
+                    {% endif %}
+                </div>
+            </div>
+            {% endfor %}
+        {% else %}
+            <div class="ev-empty">No tournament data yet.</div>
+        {% endif %}
+    </div>
+
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+function switchTab(name) {
+    document.getElementById('tab-skills').style.display = (name === 'skills') ? '' : 'none';
+    document.getElementById('tab-events').style.display = (name === 'events')  ? '' : 'none';
+    document.getElementById('btn-skills').classList.toggle('active', name === 'skills');
+    document.getElementById('btn-events').classList.toggle('active', name === 'events');
+}
+</script>
+{% endblock %}

--- a/app/templates/public/player_card_showcase.html
+++ b/app/templates/public/player_card_showcase.html
@@ -1,0 +1,303 @@
+{% extends "public/player_card_base.html" %}
+
+{% block extra_styles %}
+<style>
+/* ── Showcase variant — landscape card, 16:9 banner, tab-based Skills/Events ── */
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body { background: var(--card-page-bg); }
+
+.card-wrap {
+    max-width: min(720px, calc(100vw - 1.5rem));
+    border-radius: 14px; overflow: hidden;
+    box-shadow: 0 12px 48px rgba(0,0,0,0.55);
+    border: 1px solid var(--card-border);
+}
+
+/* ── Banner zone — 16:9 landscape, object-position from focus point ── */
+.sc-banner {
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    background: var(--card-panel-bg);
+    position: relative;
+    overflow: hidden;
+}
+.sc-banner img {
+    width: 100%; height: 100%;
+    object-fit: contain;
+    object-position: center center;
+    display: block;
+}
+.sc-banner-initials {
+    width: 100%; height: 100%;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 6rem; font-weight: 900; color: rgba(255,255,255,0.35);
+    letter-spacing: -0.02em;
+}
+.sc-banner-overlay {
+    position: absolute; bottom: 0; left: 0; right: 0;
+    padding: 2.5rem 1.25rem 0.6rem;
+    background: linear-gradient(to top, rgba(0,0,0,0.7) 0%, transparent 100%);
+}
+
+/* ── Hero identity strip ── */
+.sc-hero {
+    background: var(--card-right-bg);
+    padding: 0.85rem 1.25rem;
+    display: flex; align-items: flex-start;
+    gap: 1rem; flex-wrap: wrap;
+    border-bottom: 1px solid var(--card-border);
+}
+.sc-hero-main { flex: 1; min-width: 200px; }
+.sc-name {
+    font-size: 1.45rem; font-weight: 800;
+    color: var(--card-right-text);
+    line-height: 1.1; margin-bottom: 0.35rem;
+    overflow-wrap: break-word;
+}
+.sc-pos-badge {
+    display: inline-block; padding: 2px 10px;
+    border-radius: 5px; font-size: 0.68rem; font-weight: 800;
+    color: white; text-transform: uppercase; letter-spacing: 0.07em;
+    margin-bottom: 0.45rem;
+}
+.sc-meta-row {
+    font-size: 0.72rem; color: var(--card-right-subtext);
+    display: flex; flex-wrap: wrap; gap: 0.3rem 0.45rem;
+    align-items: center; margin-bottom: 0.45rem;
+}
+.sc-meta-sep { opacity: 0.4; }
+.sc-club-pills { display: flex; flex-wrap: wrap; gap: 0.3rem; }
+.sc-club-pill {
+    font-size: 0.65rem; font-weight: 600;
+    color: var(--card-pill-text);
+    background: var(--card-pill-bg);
+    border: 1px solid var(--card-pill-border);
+    border-radius: 99px; padding: 2px 8px;
+    overflow-wrap: anywhere;
+}
+.sc-overall-block {
+    text-align: right; flex-shrink: 0;
+    padding-top: 0.1rem;
+}
+.sc-overall {
+    font-size: 3.2rem; font-weight: 900; line-height: 1;
+}
+.sc-tier {
+    font-size: 0.6rem; font-weight: 800;
+    text-transform: uppercase; letter-spacing: 0.1em;
+    margin-top: 2px;
+}
+
+/* ── Tab bar ── */
+.tab-bar {
+    display: flex;
+    background: var(--card-tab-bg);
+    border-bottom: 1px solid var(--card-tab-border);
+}
+.tab-btn {
+    flex: 1; padding: 0.55rem 1rem;
+    background: none; border: none;
+    color: var(--card-text-tab);
+    font-size: 0.82rem; font-weight: 600;
+    cursor: pointer;
+    border-bottom: 2px solid transparent;
+    transition: color .15s, border-color .15s;
+}
+.tab-btn.active { color: var(--card-text-primary); border-bottom-color: var(--card-accent); }
+
+/* ── Skills section ── */
+.skills-section {
+    background: var(--card-body-bg);
+    padding: 1.1rem 1.25rem;
+}
+.skills-title {
+    font-size: 0.63rem; font-weight: 800; text-transform: uppercase;
+    letter-spacing: 0.13em; color: var(--card-text-faint);
+    margin-bottom: 0.85rem;
+}
+.skill-cats {
+    display: grid; grid-template-columns: repeat(4, 1fr);
+    gap: 0.65rem;
+}
+.skill-cat { background: var(--card-cat-bg); border-radius: 9px; padding: 0.65rem; min-width: 0; }
+.skill-cat-name {
+    font-size: 0.58rem; font-weight: 800; text-transform: uppercase;
+    letter-spacing: 0.09em; color: var(--card-text-muted); margin-bottom: 0.45rem;
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.skill-row { display: flex; align-items: center; gap: 0.35rem; margin-bottom: 0.3rem; }
+.skill-row:last-child { margin-bottom: 0; }
+.skill-name { font-size: 0.62rem; color: var(--card-text-secondary); flex: 1; min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.skill-val { font-size: 0.67rem; font-weight: 700; width: 28px; text-align: right; flex-shrink: 0; }
+.skill-up { font-size: 0.6rem; font-weight: 900; flex-shrink: 0; line-height: 1; }
+.skill-bar-bg { flex: 0 1 36px; height: 4px; background: var(--card-bar-bg); border-radius: 2px; }
+.skill-bar-fill { height: 100%; border-radius: 2px; }
+
+/* ── Events section ── */
+.events-section { background: var(--card-body-bg); padding: 0.75rem 1.25rem; }
+.ev-row {
+    display: flex; align-items: flex-start;
+    gap: 0.75rem; padding: 0.55rem 0;
+    border-bottom: 1px solid var(--card-ev-border);
+}
+.ev-row:last-child { border-bottom: none; }
+.ev-rank { min-width: 2rem; font-size: 1.1rem; text-align: center; padding-top: 0.05rem; }
+.ev-body { flex: 1; min-width: 0; }
+.ev-name { margin-bottom: 0.2rem; }
+.ev-link { color: var(--card-text-primary); font-size: 0.82rem; font-weight: 600; text-decoration: none; }
+.ev-link:hover { text-decoration: underline; }
+.ev-rewards { display: flex; gap: 0.3rem; margin-bottom: 0.25rem; flex-wrap: wrap; }
+.ev-badge { font-size: 0.68rem; font-weight: 700; padding: 1px 6px; border-radius: 99px; }
+.ev-badge.xp { background: var(--card-badge-xp-bg); color: var(--card-badge-xp-text); }
+.ev-badge.cr { background: var(--card-badge-cr-bg); color: var(--card-badge-cr-text); }
+.ev-skills { display: flex; flex-wrap: wrap; gap: 0.25rem; }
+.ev-skill-pill { font-size: 0.65rem; padding: 1px 6px; border-radius: 99px; }
+.ev-skill-pill.up { background: var(--card-pill-up-bg); color: var(--card-pill-up-text); }
+.ev-skill-pill.dn { background: var(--card-pill-dn-bg); color: var(--card-pill-dn-text); }
+.ev-empty { text-align: center; color: var(--card-text-faint); font-size: 0.8rem; padding: 2rem 0; }
+
+/* ── Responsive ── */
+@media (max-width: 520px) {
+    .skill-cats { grid-template-columns: 1fr 1fr; }
+    .sc-name { font-size: 1.2rem; }
+}
+@media (max-width: 380px) {
+    .skill-cats { grid-template-columns: 1fr; }
+}
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="card-wrap">
+
+    {# ── Banner — 16:9, object-position from saved focus point ── #}
+    <div class="sc-banner">
+        {% if photo_url %}
+            <img src="{{ photo_url }}" alt="{{ player.name }}">
+        {% else %}
+            <div class="sc-banner-initials">{{ initials }}</div>
+        {% endif %}
+        <div class="sc-banner-overlay"></div>
+    </div>
+
+    {# ── Hero identity strip ── #}
+    <div class="sc-hero">
+        <div class="sc-hero-main">
+            <div class="sc-name">{{ player.name }}</div>
+            {% if player.position and player.position != "Unknown" %}
+            <span class="sc-pos-badge" style="background: {{ pos_color }};">{{ player.position }}</span>
+            {% endif %}
+            <div class="sc-meta-row">
+                {% if player.nationality %}<span>{{ player.nationality }}</span><span class="sc-meta-sep">·</span>{% endif %}
+                <span>{{ player.age_group }}</span>
+                <span class="sc-meta-sep">·</span>
+                <span>{{ player.total_tournaments }} events</span>
+            </div>
+            {% if teams_info %}
+            <div class="sc-club-pills">
+                {% for t in teams_info %}
+                <span class="sc-club-pill">🏟️ {{ t.team_name }}{% if t.club_name %} · {{ t.club_name }}{% endif %}{% if t.age_group_label %} · {{ t.age_group_label }}{% endif %}</span>
+                {% endfor %}
+            </div>
+            {% endif %}
+        </div>
+        <div class="sc-overall-block">
+            <div class="sc-overall" style="color: {{ tier_color }};">{{ overall | round(0) | int }}</div>
+            <div class="sc-tier" style="color: {{ tier_color }};">{{ tier_label }}</div>
+        </div>
+    </div>
+
+    {# ── Tab bar ── #}
+    <div class="tab-bar">
+        <button class="tab-btn active" id="btn-skills" onclick="switchTab('skills')">⚽ Skills</button>
+        <button class="tab-btn"        id="btn-events" onclick="switchTab('events')">🏆 Events</button>
+    </div>
+
+    {# ── Skills tab ── #}
+    {% if skill_categories %}
+    <div class="skills-section" id="tab-skills">
+        <div class="skills-title">Football Skills — {{ overall | round(0) | int }} OVR</div>
+        <div class="skill-cats">
+            {% for cat in skill_categories %}
+            <div class="skill-cat">
+                <div class="skill-cat-name">{{ cat.emoji }} {{ cat.name_en }}</div>
+                {% for skill in cat.skills %}
+                {% set sdata = player.skills.get(skill.key, {}) %}
+                {% set sval = sdata.get('current_level', 50) | round(1) %}
+                {% set fill_pct = [sval, 100] | min %}
+                {% set sdelta = last_skill_delta.get(skill.key, 0) %}
+                {% if sdelta > 0 %}
+                    {% set bar_color = 'var(--card-skill-up)' %}
+                    {% set val_color = 'var(--card-skill-up)' %}
+                {% elif sdelta < 0 %}
+                    {% set bar_color = 'var(--card-skill-dn)' %}
+                    {% set val_color = 'var(--card-skill-dn)' %}
+                {% else %}
+                    {% set bar_color = 'var(--card-bar-neutral)' %}
+                    {% set val_color = 'var(--card-val-neutral)' %}
+                {% endif %}
+                <div class="skill-row">
+                    <span class="skill-name">{{ skill.name_en }}</span>
+                    <div class="skill-bar-bg"><div class="skill-bar-fill" style="width:{{ fill_pct }}%; background:{{ bar_color }};"></div></div>
+                    <span class="skill-val" style="color:{{ val_color }};">{{ sval }}</span>
+                    {% if sdelta > 0 %}<span class="skill-up" style="color:var(--card-skill-up);">↑</span>
+                    {% elif sdelta < 0 %}<span class="skill-up" style="color:var(--card-skill-dn);">↓</span>
+                    {% else %}<span class="skill-up" style="visibility:hidden;">↑</span>{% endif %}
+                </div>
+                {% endfor %}
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+    {% endif %}
+
+    {# ── Events tab ── #}
+    <div class="events-section" id="tab-events" style="display:none;">
+        {% if participations_history %}
+            {% for ev in participations_history %}
+            <div class="ev-row">
+                <div class="ev-rank">
+                    {% if ev.placement == 1 %}🥇
+                    {% elif ev.placement == 2 %}🥈
+                    {% elif ev.placement == 3 %}🥉
+                    {% elif ev.placement %}#{{ ev.placement }}
+                    {% else %}—{% endif %}
+                </div>
+                <div class="ev-body">
+                    <div class="ev-name">
+                        <a href="/events/{{ ev.event_id }}" class="ev-link">{{ ev.event_name }}</a>
+                    </div>
+                    <div class="ev-rewards">
+                        {% if ev.xp_awarded %}<span class="ev-badge xp">+{{ ev.xp_awarded }} XP</span>{% endif %}
+                        {% if ev.credits_awarded %}<span class="ev-badge cr">+{{ ev.credits_awarded }} CR</span>{% endif %}
+                    </div>
+                    {% if ev.top_skills %}
+                    <div class="ev-skills">
+                        {% for sk, delta in ev.top_skills %}
+                        <span class="ev-skill-pill {% if delta > 0 %}up{% else %}dn{% endif %}">
+                            {{ sk.replace('_',' ') }} {{ '+' if delta > 0 else '' }}{{ delta | round(1) }}
+                        </span>
+                        {% endfor %}
+                    </div>
+                    {% endif %}
+                </div>
+            </div>
+            {% endfor %}
+        {% else %}
+            <div class="ev-empty">No tournament data yet.</div>
+        {% endif %}
+    </div>
+
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+function switchTab(name) {
+    document.getElementById('tab-skills').style.display = (name === 'skills') ? '' : 'none';
+    document.getElementById('tab-events').style.display = (name === 'events')  ? '' : 'none';
+    document.getElementById('btn-skills').classList.toggle('active', name === 'skills');
+    document.getElementById('btn-events').classList.toggle('active', name === 'events');
+}
+</script>
+{% endblock %}

--- a/app/templates/public/player_card_showcase_bg.html
+++ b/app/templates/public/player_card_showcase_bg.html
@@ -1,0 +1,305 @@
+{% extends "public/player_card_base.html" %}
+
+{% block extra_styles %}
+<style>
+/* ── Showcase+BG variant: same as Showcase, banner supports custom background ── */
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body { background: var(--card-page-bg); }
+
+.card-wrap {
+    max-width: min(720px, calc(100vw - 1.5rem));
+    border-radius: 14px; overflow: hidden;
+    box-shadow: 0 12px 48px rgba(0,0,0,0.55);
+    border: 1px solid var(--card-border);
+}
+
+/* ── Banner zone — 16:9 landscape, supports custom bg photo ── */
+.sc-banner {
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    background: var(--card-panel-bg);
+    background-size: cover;
+    background-position: center center;
+    position: relative;
+    overflow: hidden;
+}
+.sc-banner img {
+    width: 100%; height: 100%;
+    object-fit: contain;
+    object-position: center center;
+    display: block;
+}
+.sc-banner-initials {
+    width: 100%; height: 100%;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 6rem; font-weight: 900; color: rgba(255,255,255,0.35);
+    letter-spacing: -0.02em;
+}
+.sc-banner-overlay {
+    position: absolute; bottom: 0; left: 0; right: 0;
+    padding: 2.5rem 1.25rem 0.6rem;
+    background: linear-gradient(to top, rgba(0,0,0,0.7) 0%, transparent 100%);
+}
+
+/* ── Hero identity strip ── */
+.sc-hero {
+    background: var(--card-right-bg);
+    padding: 0.85rem 1.25rem;
+    display: flex; align-items: flex-start;
+    gap: 1rem; flex-wrap: wrap;
+    border-bottom: 1px solid var(--card-border);
+}
+.sc-hero-main { flex: 1; min-width: 200px; }
+.sc-name {
+    font-size: 1.45rem; font-weight: 800;
+    color: var(--card-right-text);
+    line-height: 1.1; margin-bottom: 0.35rem;
+    overflow-wrap: break-word;
+}
+.sc-pos-badge {
+    display: inline-block; padding: 2px 10px;
+    border-radius: 5px; font-size: 0.68rem; font-weight: 800;
+    color: white; text-transform: uppercase; letter-spacing: 0.07em;
+    margin-bottom: 0.45rem;
+}
+.sc-meta-row {
+    font-size: 0.72rem; color: var(--card-right-subtext);
+    display: flex; flex-wrap: wrap; gap: 0.3rem 0.45rem;
+    align-items: center; margin-bottom: 0.45rem;
+}
+.sc-meta-sep { opacity: 0.4; }
+.sc-club-pills { display: flex; flex-wrap: wrap; gap: 0.3rem; }
+.sc-club-pill {
+    font-size: 0.65rem; font-weight: 600;
+    color: var(--card-pill-text);
+    background: var(--card-pill-bg);
+    border: 1px solid var(--card-pill-border);
+    border-radius: 99px; padding: 2px 8px;
+    overflow-wrap: anywhere;
+}
+.sc-overall-block {
+    text-align: right; flex-shrink: 0;
+    padding-top: 0.1rem;
+}
+.sc-overall {
+    font-size: 3.2rem; font-weight: 900; line-height: 1;
+}
+.sc-tier {
+    font-size: 0.6rem; font-weight: 800;
+    text-transform: uppercase; letter-spacing: 0.1em;
+    margin-top: 2px;
+}
+
+/* ── Tab bar ── */
+.tab-bar {
+    display: flex;
+    background: var(--card-tab-bg);
+    border-bottom: 1px solid var(--card-tab-border);
+}
+.tab-btn {
+    flex: 1; padding: 0.55rem 1rem;
+    background: none; border: none;
+    color: var(--card-text-tab);
+    font-size: 0.82rem; font-weight: 600;
+    cursor: pointer;
+    border-bottom: 2px solid transparent;
+    transition: color .15s, border-color .15s;
+}
+.tab-btn.active { color: var(--card-text-primary); border-bottom-color: var(--card-accent); }
+
+/* ── Skills section ── */
+.skills-section {
+    background: var(--card-body-bg);
+    padding: 1.1rem 1.25rem;
+}
+.skills-title {
+    font-size: 0.63rem; font-weight: 800; text-transform: uppercase;
+    letter-spacing: 0.13em; color: var(--card-text-faint);
+    margin-bottom: 0.85rem;
+}
+.skill-cats {
+    display: grid; grid-template-columns: repeat(4, 1fr);
+    gap: 0.65rem;
+}
+.skill-cat { background: var(--card-cat-bg); border-radius: 9px; padding: 0.65rem; min-width: 0; }
+.skill-cat-name {
+    font-size: 0.58rem; font-weight: 800; text-transform: uppercase;
+    letter-spacing: 0.09em; color: var(--card-text-muted); margin-bottom: 0.45rem;
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.skill-row { display: flex; align-items: center; gap: 0.35rem; margin-bottom: 0.3rem; }
+.skill-row:last-child { margin-bottom: 0; }
+.skill-name { font-size: 0.62rem; color: var(--card-text-secondary); flex: 1; min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.skill-val { font-size: 0.67rem; font-weight: 700; width: 28px; text-align: right; flex-shrink: 0; }
+.skill-up { font-size: 0.6rem; font-weight: 900; flex-shrink: 0; line-height: 1; }
+.skill-bar-bg { flex: 0 1 36px; height: 4px; background: var(--card-bar-bg); border-radius: 2px; }
+.skill-bar-fill { height: 100%; border-radius: 2px; }
+
+/* ── Events section ── */
+.events-section { background: var(--card-body-bg); padding: 0.75rem 1.25rem; }
+.ev-row {
+    display: flex; align-items: flex-start;
+    gap: 0.75rem; padding: 0.55rem 0;
+    border-bottom: 1px solid var(--card-ev-border);
+}
+.ev-row:last-child { border-bottom: none; }
+.ev-rank { min-width: 2rem; font-size: 1.1rem; text-align: center; padding-top: 0.05rem; }
+.ev-body { flex: 1; min-width: 0; }
+.ev-name { margin-bottom: 0.2rem; }
+.ev-link { color: var(--card-text-primary); font-size: 0.82rem; font-weight: 600; text-decoration: none; }
+.ev-link:hover { text-decoration: underline; }
+.ev-rewards { display: flex; gap: 0.3rem; margin-bottom: 0.25rem; flex-wrap: wrap; }
+.ev-badge { font-size: 0.68rem; font-weight: 700; padding: 1px 6px; border-radius: 99px; }
+.ev-badge.xp { background: var(--card-badge-xp-bg); color: var(--card-badge-xp-text); }
+.ev-badge.cr { background: var(--card-badge-cr-bg); color: var(--card-badge-cr-text); }
+.ev-skills { display: flex; flex-wrap: wrap; gap: 0.25rem; }
+.ev-skill-pill { font-size: 0.65rem; padding: 1px 6px; border-radius: 99px; }
+.ev-skill-pill.up { background: var(--card-pill-up-bg); color: var(--card-pill-up-text); }
+.ev-skill-pill.dn { background: var(--card-pill-dn-bg); color: var(--card-pill-dn-text); }
+.ev-empty { text-align: center; color: var(--card-text-faint); font-size: 0.8rem; padding: 2rem 0; }
+
+/* ── Responsive ── */
+@media (max-width: 520px) {
+    .skill-cats { grid-template-columns: 1fr 1fr; }
+    .sc-name { font-size: 1.2rem; }
+}
+@media (max-width: 380px) {
+    .skill-cats { grid-template-columns: 1fr; }
+}
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="card-wrap">
+
+    {# ── Banner — 16:9, custom background-image applied as CSS, player PNG on top ── #}
+    <div class="sc-banner"{% if showcase_bg_url %} style="background-image: url('{{ showcase_bg_url }}');"{% endif %}>
+        {% if photo_url %}
+            <img src="{{ photo_url }}" alt="{{ player.name }}">
+        {% else %}
+            <div class="sc-banner-initials">{{ initials }}</div>
+        {% endif %}
+        <div class="sc-banner-overlay"></div>
+    </div>
+
+    {# ── Hero identity strip ── #}
+    <div class="sc-hero">
+        <div class="sc-hero-main">
+            <div class="sc-name">{{ player.name }}</div>
+            {% if player.position and player.position != "Unknown" %}
+            <span class="sc-pos-badge" style="background: {{ pos_color }};">{{ player.position }}</span>
+            {% endif %}
+            <div class="sc-meta-row">
+                {% if player.nationality %}<span>{{ player.nationality }}</span><span class="sc-meta-sep">·</span>{% endif %}
+                <span>{{ player.age_group }}</span>
+                <span class="sc-meta-sep">·</span>
+                <span>{{ player.total_tournaments }} events</span>
+            </div>
+            {% if teams_info %}
+            <div class="sc-club-pills">
+                {% for t in teams_info %}
+                <span class="sc-club-pill">🏟️ {{ t.team_name }}{% if t.club_name %} · {{ t.club_name }}{% endif %}{% if t.age_group_label %} · {{ t.age_group_label }}{% endif %}</span>
+                {% endfor %}
+            </div>
+            {% endif %}
+        </div>
+        <div class="sc-overall-block">
+            <div class="sc-overall" style="color: {{ tier_color }};">{{ overall | round(0) | int }}</div>
+            <div class="sc-tier" style="color: {{ tier_color }};">{{ tier_label }}</div>
+        </div>
+    </div>
+
+    {# ── Tab bar ── #}
+    <div class="tab-bar">
+        <button class="tab-btn active" id="btn-skills" onclick="switchTab('skills')">⚽ Skills</button>
+        <button class="tab-btn"        id="btn-events" onclick="switchTab('events')">🏆 Events</button>
+    </div>
+
+    {# ── Skills tab ── #}
+    {% if skill_categories %}
+    <div class="skills-section" id="tab-skills">
+        <div class="skills-title">Football Skills — {{ overall | round(0) | int }} OVR</div>
+        <div class="skill-cats">
+            {% for cat in skill_categories %}
+            <div class="skill-cat">
+                <div class="skill-cat-name">{{ cat.emoji }} {{ cat.name_en }}</div>
+                {% for skill in cat.skills %}
+                {% set sdata = player.skills.get(skill.key, {}) %}
+                {% set sval = sdata.get('current_level', 50) | round(1) %}
+                {% set fill_pct = [sval, 100] | min %}
+                {% set sdelta = last_skill_delta.get(skill.key, 0) %}
+                {% if sdelta > 0 %}
+                    {% set bar_color = 'var(--card-skill-up)' %}
+                    {% set val_color = 'var(--card-skill-up)' %}
+                {% elif sdelta < 0 %}
+                    {% set bar_color = 'var(--card-skill-dn)' %}
+                    {% set val_color = 'var(--card-skill-dn)' %}
+                {% else %}
+                    {% set bar_color = 'var(--card-bar-neutral)' %}
+                    {% set val_color = 'var(--card-val-neutral)' %}
+                {% endif %}
+                <div class="skill-row">
+                    <span class="skill-name">{{ skill.name_en }}</span>
+                    <div class="skill-bar-bg"><div class="skill-bar-fill" style="width:{{ fill_pct }}%; background:{{ bar_color }};"></div></div>
+                    <span class="skill-val" style="color:{{ val_color }};">{{ sval }}</span>
+                    {% if sdelta > 0 %}<span class="skill-up" style="color:var(--card-skill-up);">↑</span>
+                    {% elif sdelta < 0 %}<span class="skill-up" style="color:var(--card-skill-dn);">↓</span>
+                    {% else %}<span class="skill-up" style="visibility:hidden;">↑</span>{% endif %}
+                </div>
+                {% endfor %}
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+    {% endif %}
+
+    {# ── Events tab ── #}
+    <div class="events-section" id="tab-events" style="display:none;">
+        {% if participations_history %}
+            {% for ev in participations_history %}
+            <div class="ev-row">
+                <div class="ev-rank">
+                    {% if ev.placement == 1 %}🥇
+                    {% elif ev.placement == 2 %}🥈
+                    {% elif ev.placement == 3 %}🥉
+                    {% elif ev.placement %}#{{ ev.placement }}
+                    {% else %}—{% endif %}
+                </div>
+                <div class="ev-body">
+                    <div class="ev-name">
+                        <a href="/events/{{ ev.event_id }}" class="ev-link">{{ ev.event_name }}</a>
+                    </div>
+                    <div class="ev-rewards">
+                        {% if ev.xp_awarded %}<span class="ev-badge xp">+{{ ev.xp_awarded }} XP</span>{% endif %}
+                        {% if ev.credits_awarded %}<span class="ev-badge cr">+{{ ev.credits_awarded }} CR</span>{% endif %}
+                    </div>
+                    {% if ev.top_skills %}
+                    <div class="ev-skills">
+                        {% for sk, delta in ev.top_skills %}
+                        <span class="ev-skill-pill {% if delta > 0 %}up{% else %}dn{% endif %}">
+                            {{ sk.replace('_',' ') }} {{ '+' if delta > 0 else '' }}{{ delta | round(1) }}
+                        </span>
+                        {% endfor %}
+                    </div>
+                    {% endif %}
+                </div>
+            </div>
+            {% endfor %}
+        {% else %}
+            <div class="ev-empty">No tournament data yet.</div>
+        {% endif %}
+    </div>
+
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+function switchTab(name) {
+    document.getElementById('tab-skills').style.display = (name === 'skills') ? '' : 'none';
+    document.getElementById('tab-events').style.display = (name === 'events')  ? '' : 'none';
+    document.getElementById('btn-skills').classList.toggle('active', name === 'skills');
+    document.getElementById('btn-events').classList.toggle('active', name === 'events');
+}
+</script>
+{% endblock %}

--- a/tests/unit/test_card_render_integration.py
+++ b/tests/unit/test_card_render_integration.py
@@ -150,27 +150,23 @@ class TestTemplateSelection:
         fallback = os.path.join(templates_dir, self._FALLBACK)
         assert os.path.isfile(fallback), f"Fallback template missing: {fallback}"
 
-    def test_fifa_variant_template_exists(self):
+    def test_all_variant_templates_exist(self):
         templates_dir = os.path.join(
             os.path.dirname(__file__), "..", "..", "app", "templates"
         )
-        v = get_variant("fifa")
-        candidate = os.path.join(templates_dir, v.template)
-        assert os.path.isfile(candidate), (
-            f"FIFA variant template missing at {candidate} — must exist for explicit (non-fallback) render"
-        )
-
-    def test_non_fifa_variant_templates_not_yet_implemented(self):
-        templates_dir = os.path.join(
-            os.path.dirname(__file__), "..", "..", "app", "templates"
-        )
-        for variant_id in ["compact", "showcase", "compact_bg", "showcase_bg"]:
+        for variant_id in ["fifa", "compact", "showcase", "compact_bg", "showcase_bg"]:
             v = get_variant(variant_id)
-            assert not v.available, f"{variant_id} must be available=False until template is implemented"
             candidate = os.path.join(templates_dir, v.template)
-            assert not os.path.isfile(candidate), (
-                f"{variant_id} template exists at {candidate} but variant is still available=False — "
-                "set available=True and update this test when the layout is implemented"
+            assert os.path.isfile(candidate), (
+                f"Variant template missing: {candidate} — restore from git history or implement"
+            )
+
+    def test_all_variants_are_available(self):
+        for variant_id in ["fifa", "compact", "showcase", "compact_bg", "showcase_bg"]:
+            v = get_variant(variant_id)
+            assert v.available, (
+                f"Variant '{variant_id}' is marked available=False but has a template — "
+                "set available=True"
             )
 
 

--- a/tests/unit/test_card_unlock_apply.py
+++ b/tests/unit/test_card_unlock_apply.py
@@ -129,19 +129,8 @@ class TestUnlockThemeAutoApply:
 
 
 # ── Variant: unlock + auto-apply ───────────────────────────────────────────────
-# compact/showcase/compact_bg/showcase_bg are currently available=False (templates
-# not yet implemented).  Mechanism tests patch available=True to test the unlock
-# logic in isolation; a separate class tests the blocking behaviour.
 
-import dataclasses
 import app.services.card_variant_service as _cvsvc
-
-
-def _with_available(variant_id: str):
-    """Context manager: temporarily set VARIANTS[variant_id].available = True."""
-    orig = _cvsvc.VARIANTS[variant_id]
-    patched = dataclasses.replace(orig, available=True)
-    return patch.dict(_cvsvc.VARIANTS, {variant_id: patched})
 
 
 class TestUnlockVariantAutoApply:
@@ -152,8 +141,7 @@ class TestUnlockVariantAutoApply:
         user = _make_user(credits=2000)
         ul = _make_license()
 
-        with _with_available("compact"), \
-             patch("app.services.card_variant_service.CreditService") as MockCS:
+        with patch("app.services.card_variant_service.CreditService") as MockCS:
             MockCS.return_value.deduct.return_value = MagicMock()
             _cvsvc.unlock_variant(db, user, ul, "compact")
 
@@ -167,8 +155,7 @@ class TestUnlockVariantAutoApply:
         user = _make_user()
         ul = _make_license()
 
-        with _with_available("showcase"), \
-             patch("app.services.card_variant_service.CreditService") as MockCS:
+        with patch("app.services.card_variant_service.CreditService") as MockCS:
             MockCS.return_value.deduct.return_value = MagicMock()
             _cvsvc.unlock_variant(db, user, ul, "showcase")
 
@@ -188,8 +175,7 @@ class TestUnlockVariantAutoApply:
 
         db.commit.side_effect = check_at_commit
 
-        with _with_available("compact"), \
-             patch("app.services.card_variant_service.CreditService") as MockCS:
+        with patch("app.services.card_variant_service.CreditService") as MockCS:
             MockCS.return_value.deduct.return_value = MagicMock()
             _cvsvc.unlock_variant(db, user, ul, "compact")
 
@@ -211,8 +197,7 @@ class TestUnlockVariantAutoApply:
         user = _make_user()
         ul = _make_license(unlocked_variants=["compact"])
 
-        with _with_available("compact"), \
-             patch("app.services.card_variant_service.CreditService") as MockCS:
+        with patch("app.services.card_variant_service.CreditService") as MockCS:
             _cvsvc.unlock_variant(db, user, ul, "compact")
             MockCS.return_value.deduct.assert_not_called()
 
@@ -222,21 +207,6 @@ class TestUnlockVariantAutoApply:
         db = _mock_db()
         with pytest.raises(ValueError, match="Unknown variant"):
             _cvsvc.unlock_variant(db, _make_user(), _make_license(), "nonexistent")
-
-    def test_unavailable_variant_blocks_unlock(self):
-        """compact/showcase/compact_bg/showcase_bg are available=False — unlock must raise."""
-        db = _mock_db()
-        for vid in ["compact", "showcase", "compact_bg", "showcase_bg"]:
-            with pytest.raises(ValueError, match="not yet available"):
-                _cvsvc.unlock_variant(db, _make_user(), _make_license(), vid)
-
-    def test_unavailable_variant_blocks_apply(self):
-        """apply_variant must also reject unavailable variants."""
-        db = _mock_db()
-        ul = _make_license(unlocked_variants=["compact", "showcase", "compact_bg", "showcase_bg"])
-        for vid in ["compact", "showcase", "compact_bg", "showcase_bg"]:
-            with pytest.raises(ValueError, match="not yet available"):
-                _cvsvc.apply_variant(db, ul, vid)
 
 
 # ── apply_theme / apply_variant: standalone ────────────────────────────────────
@@ -268,14 +238,12 @@ class TestApplyStandalone:
     def test_apply_variant_when_unlocked(self):
         db = _mock_db()
         ul = _make_license(unlocked_variants=["showcase"])
-        with _with_available("showcase"):
-            _cvsvc.apply_variant(db, ul, "showcase")
+        _cvsvc.apply_variant(db, ul, "showcase")
         assert ul.card_variant == "showcase"
         db.commit.assert_called_once()
 
     def test_apply_variant_locked_raises(self):
         db = _mock_db()
         ul = _make_license()
-        with _with_available("compact"):
-            with pytest.raises(ValueError, match="locked"):
-                _cvsvc.apply_variant(db, ul, "compact")
+        with pytest.raises(ValueError, match="locked"):
+            _cvsvc.apply_variant(db, ul, "compact")


### PR DESCRIPTION
## Root cause

Templates were never absent from git — they existed in commit `45ace0a` on branch `fix/e2e-ops-seed-1024` but were 159 commits behind main and never merged.

Previous hotfix (PR #108) incorrectly set `available=False` on these variants instead of restoring the working templates. This was a regression.

## Changes

**Restored from commit `45ace0a`:**
- `app/templates/public/player_card_compact.html` (299 lines)
- `app/templates/public/player_card_showcase.html` (303 lines)
- `app/templates/public/player_card_compact_bg.html` (302 lines)
- `app/templates/public/player_card_showcase_bg.html` (305 lines)

**`card_variant_service.py`** — reverted `available=False` → all 5 variants `available=True`

**Tests** — updated to assert all 5 templates exist and all 5 variants are available

## Result

All 5 variants render from explicit templates — no silent fallback, no disabled states.

## Test plan
- [x] 40/40 card tests pass locally
- [x] All 5 variants: `available=True`, `template_exists=True`, renders `explicit`
- [ ] Test Baseline Check green on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)