### PR TITLE
feat(laterality): laterality-aware skill aggregation — foot dominance × tournament foot context

### DIFF
--- a/alembic/versions/2026_05_01_1100_add_foot_context_to_tournament_participations.py
+++ b/alembic/versions/2026_05_01_1100_add_foot_context_to_tournament_participations.py
@@ -1,0 +1,63 @@
+"""Add foot_context column to tournament_participations.
+
+Laterality-aware skill aggregation — Phase F2.
+Stores which foot-laterality context the tournament preset targets
+so that per-tournament EMA deltas can be routed to the correct
+lateral_components bucket in UserLicense.football_skills.
+
+Revision ID: 2026_05_01_1100
+Revises: 2026_05_01_1000
+Depends on: 2026_05_01_1000 (add_sponsor_logo_url)
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import inspect
+
+revision = "2026_05_01_1100"
+down_revision = "2026_05_01_1000"
+branch_labels = None
+depends_on = None
+
+_TABLE = "tournament_participations"
+_COL   = "foot_context"
+_CK    = "ck_tournament_participations_foot_context"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    existing_cols = {c["name"] for c in inspect(bind).get_columns(_TABLE)}
+    if _COL not in existing_cols:
+        op.add_column(
+            _TABLE,
+            sa.Column(
+                _COL,
+                sa.String(10),
+                nullable=False,
+                server_default="neutral",
+            ),
+        )
+    # CHECK constraint — idempotent guard via raw SQL
+    existing_constraints = {
+        c["name"]
+        for c in inspect(bind).get_check_constraints(_TABLE)
+    }
+    if _CK not in existing_constraints:
+        op.create_check_constraint(
+            _CK,
+            _TABLE,
+            f"{_COL} IN ('right', 'left', 'neutral')",
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    existing_constraints = {
+        c["name"]
+        for c in inspect(bind).get_check_constraints(_TABLE)
+    }
+    if _CK in existing_constraints:
+        op.drop_constraint(_CK, _TABLE, type_="check")
+
+    existing_cols = {c["name"] for c in inspect(bind).get_columns(_TABLE)}
+    if _COL in existing_cols:
+        op.drop_column(_TABLE, _COL)

--- a/alembic/versions/2026_05_01_1200_add_foot_score_check_constraints.py
+++ b/alembic/versions/2026_05_01_1200_add_foot_score_check_constraints.py
@@ -1,0 +1,50 @@
+"""Add CHECK constraints for right_foot_score / left_foot_score on user_licenses.
+
+Laterality-aware skill aggregation — Phase F2b.
+Enforces that foot scores, when present, stay within the valid 0–100 range.
+Both columns remain nullable (NULL = not yet assessed).
+
+Revision ID: 2026_05_01_1200
+Revises: 2026_05_01_1100
+Depends on: 2026_05_01_1100 (add_foot_context_to_tournament_participations)
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import inspect
+
+revision = "2026_05_01_1200"
+down_revision = "2026_05_01_1100"
+branch_labels = None
+depends_on = None
+
+_TABLE  = "user_licenses"
+_CK_R   = "ck_user_licenses_right_foot_range"
+_CK_L   = "ck_user_licenses_left_foot_range"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    existing = {c["name"] for c in inspect(bind).get_check_constraints(_TABLE)}
+
+    if _CK_R not in existing:
+        op.create_check_constraint(
+            _CK_R,
+            _TABLE,
+            "right_foot_score IS NULL OR (right_foot_score >= 0 AND right_foot_score <= 100)",
+        )
+    if _CK_L not in existing:
+        op.create_check_constraint(
+            _CK_L,
+            _TABLE,
+            "left_foot_score IS NULL OR (left_foot_score >= 0 AND left_foot_score <= 100)",
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    existing = {c["name"] for c in inspect(bind).get_check_constraints(_TABLE)}
+
+    if _CK_R in existing:
+        op.drop_constraint(_CK_R, _TABLE, type_="check")
+    if _CK_L in existing:
+        op.drop_constraint(_CK_L, _TABLE, type_="check")

--- a/app/api/web_routes/onboarding.py
+++ b/app/api/web_routes/onboarding.py
@@ -223,10 +223,12 @@ async def lfa_player_onboarding_web_submit(
     try:
         body = await request.json()
 
-        position   = body.get("position", "")
-        goals      = body.get("goals", "")
-        motivation = body.get("motivation", "")
-        skills     = body.get("skills", {})
+        position      = body.get("position", "")
+        goals         = body.get("goals", "")
+        motivation    = body.get("motivation", "")
+        skills        = body.get("skills", {})
+        # foot_dominance: 0 = fully left, 50 = balanced, 100 = fully right. Default: 50.
+        foot_dominance = body.get("foot_dominance", 50)
 
         logger.info("onboarding_submit_received", extra={"user": user.email, "skill_count": len(skills)})
 
@@ -234,6 +236,14 @@ async def lfa_player_onboarding_web_submit(
         valid_positions = ["STRIKER", "MIDFIELDER", "DEFENDER", "GOALKEEPER"]
         if position not in valid_positions:
             return JSONResponse(status_code=400, content={"error": f"Invalid position: {position}"})
+
+        # Validate foot_dominance
+        try:
+            foot_dominance = float(foot_dominance)
+        except (TypeError, ValueError):
+            return JSONResponse(status_code=400, content={"error": "foot_dominance must be a number 0–100"})
+        if not (0.0 <= foot_dominance <= 100.0):
+            return JSONResponse(status_code=400, content={"error": "foot_dominance out of range (0–100)"})
 
         # Validate all 29 skills present
         expected_skills = set(get_all_skill_keys())
@@ -277,6 +287,10 @@ async def lfa_player_onboarding_web_submit(
         average_skill = sum(float(v) for v in skills.values()) / len(skills)
 
         license.football_skills      = football_skills
+        # Dominant foot: canonical storage in UserLicense columns (not motivation_scores).
+        # right_foot_score = slider value; left_foot_score = complement.
+        license.right_foot_score     = foot_dominance
+        license.left_foot_score      = 100.0 - foot_dominance
         license.motivation_scores    = {
             "position":              position,
             "goals":                 goals,
@@ -300,7 +314,7 @@ async def lfa_player_onboarding_web_submit(
         db.refresh(user)
         db.refresh(license)
 
-        logger.info("onboarding_complete", extra={"user": user.email, "position": position, "skill_count": len(skills), "avg_skill": round(average_skill, 1)})
+        logger.info("onboarding_complete", extra={"user": user.email, "position": position, "skill_count": len(skills), "avg_skill": round(average_skill, 1), "foot_dominance": foot_dominance})
 
         return {"success": True, "redirect": "/dashboard/lfa-football-player"}
 
@@ -373,10 +387,12 @@ async def lfa_player_onboarding_submit(
         body = await request.json()
 
         # Get form data
-        position = body.get("position")
-        goals = body.get("goals", "")
-        motivation = body.get("motivation", "")
-        skills = body.get("skills", {})  # NEW: All 36 skills, 0-100 scale
+        position      = body.get("position")
+        goals         = body.get("goals", "")
+        motivation    = body.get("motivation", "")
+        skills        = body.get("skills", {})  # NEW: All 36 skills, 0-100 scale
+        # foot_dominance: 0 = fully left, 50 = balanced, 100 = fully right. Default: 50.
+        foot_dominance = body.get("foot_dominance", 50)
 
         logger.info("onboarding_full_submit_received", extra={"user": user.email, "skill_count": len(skills)})
 
@@ -384,6 +400,14 @@ async def lfa_player_onboarding_submit(
         valid_positions = ["STRIKER", "MIDFIELDER", "DEFENDER", "GOALKEEPER"]
         if position not in valid_positions:
             raise ValueError(f"Invalid position: {position}")
+
+        # Validate foot_dominance
+        try:
+            foot_dominance = float(foot_dominance)
+        except (TypeError, ValueError):
+            raise ValueError("foot_dominance must be a number 0–100")
+        if not (0.0 <= foot_dominance <= 100.0):
+            raise ValueError(f"foot_dominance out of range: {foot_dominance} (must be 0–100)")
 
         # Validate skills (must have all 36 skills)
         from app.skills_config import get_all_skill_keys
@@ -424,6 +448,9 @@ async def lfa_player_onboarding_submit(
             }
 
         license.football_skills = football_skills
+        # Dominant foot: canonical storage in UserLicense columns (not motivation_scores).
+        license.right_foot_score = foot_dominance
+        license.left_foot_score  = 100.0 - foot_dominance
 
         # Store metadata in motivation_scores for backward compatibility
         average_skill = sum(skills.values()) / len(skills) if skills else SYSTEM_BASELINE

--- a/app/models/game_preset.py
+++ b/app/models/game_preset.py
@@ -152,3 +152,18 @@ class GamePreset(Base):
     def recommended_player_count(self):
         """Extract recommended player count range from metadata"""
         return self.game_config.get("metadata", {}).get("recommended_player_count", {})
+
+    # Valid foot context values — kept as a frozenset for O(1) lookup and immutability.
+    _VALID_FOOT_CONTEXTS = frozenset({"right", "left", "neutral"})
+
+    @property
+    def foot_context(self) -> str:
+        """Return the foot-laterality context for this preset.
+
+        Stored in game_config.skill_config.foot_context.
+        Valid values: "right" | "left" | "neutral".
+        Any missing or invalid stored value silently falls back to "neutral"
+        so callers never receive an unexpected value.
+        """
+        raw = (self.game_config or {}).get("skill_config", {}).get("foot_context", "neutral")
+        return raw if raw in self._VALID_FOOT_CONTEXTS else "neutral"

--- a/app/models/tournament_achievement.py
+++ b/app/models/tournament_achievement.py
@@ -61,6 +61,15 @@ class TournamentParticipation(Base):
     xp_awarded = Column(Integer, nullable=False, default=0)
     credits_awarded = Column(Integer, nullable=False, default=0)
     achieved_at = Column(DateTime(timezone=True), server_default=func.now())
+    # Laterality context: which foot the tournament preset targets.
+    # Values: "right" | "left" | "neutral". Populated from GamePreset.foot_context
+    # at participation-record creation time. CHECK constraint enforces valid values.
+    foot_context = Column(
+        String(10),
+        nullable=False,
+        server_default="neutral",
+        comment="Foot-laterality context of the tournament preset: right | left | neutral",
+    )
 
     # Relationships
     user = relationship("User", back_populates="tournament_participations")

--- a/app/services/skill_progression/__init__.py
+++ b/app/services/skill_progression/__init__.py
@@ -1,11 +1,12 @@
 """
-skill_progression sub-package — Layers 1 + 2 + 3 + 4 + 5.
+skill_progression sub-package — Layers 1 + 2 + 3 + 4 + 5 + Lateral.
 
 Layer 1 (_formulas):    pure math, constants
 Layer 2 (_config):      skill key enumeration, baseline lookup, tournament mapping
 Layer 3 (_db_helpers):  DB-backed opponent factor + match performance modifier
 Layer 4 (_ema_engine):  sequential EMA history-replay loops (ctsc + cstsd)
 Layer 5 (_views):       per-user skill profile, timeline, audit, and checkpoint views
+Lateral (_lateral):     laterality-aware skill aggregation (foot-context routing)
 
 The canonical import surface remains app.services.skill_progression_service (thin shim).
 """
@@ -37,6 +38,10 @@ from ._views import (
     get_skill_audit,
     get_avg_skill_level_checkpoints,
 )
+from ._lateral import (
+    aggregate_lateral_components,
+    update_lateral_component,
+)
 
 __all__ = [
     "MIN_SKILL_VALUE",
@@ -57,4 +62,6 @@ __all__ = [
     "get_skill_timeline",
     "get_skill_audit",
     "get_avg_skill_level_checkpoints",
+    "aggregate_lateral_components",
+    "update_lateral_component",
 ]

--- a/app/services/skill_progression/_lateral.py
+++ b/app/services/skill_progression/_lateral.py
@@ -1,0 +1,180 @@
+"""
+Laterality-Aware Skill Aggregation
+====================================
+Layer 2 — gameplay aggregation only.
+
+This module is intentionally isolated:
+  - Does NOT import from _ema_engine  (Layer 3)
+  - Does NOT import from dominant_foot (Layer 1 / display)
+  - Called exclusively from the tournament reward orchestrator
+
+Public API
+----------
+aggregate_lateral_components(skill_entry, right_foot_score, left_foot_score) -> float
+update_lateral_component(skill_entry, foot_context, delta) -> dict
+
+Aggregation formula (MVP — neutral_weight = 1.0)
+-------------------------------------------------
+R  = right_foot_score / (right_foot_score + left_foot_score)
+L  = 1 - R
+(If both scores are 0 or None → R = L = 0.5, balanced fallback)
+
+weights:
+  "right"   → R   (only if component exists)
+  "left"    → L   (only if component exists)
+  "neutral" → 1.0 (fixed; see NOTE below)
+
+NOTE: neutral_weight is hard-coded at 1.0 for MVP.
+If per-preset configurability is needed in the future, promote
+neutral_weight to a parameter and wire it from GamePreset.foot_context.
+
+final = Σ(weight_k * level_k) / Σ(weight_k)
+        clamped to [MIN_SKILL_VALUE, MAX_SKILL_CAP]
+
+If no lateral_components key exists → no-op, returns existing current_level.
+If lateral_components is empty      → no-op, returns existing current_level.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+# Reuse the same cap/floor as the EMA engine so aggregated values
+# never leave the system-wide valid range.
+from app.services.skill_progression._formulas import MIN_SKILL_VALUE, MAX_SKILL_CAP
+
+# MVP constant — see module docstring for upgrade path.
+_NEUTRAL_WEIGHT: float = 1.0
+
+_VALID_CONTEXTS = frozenset({"right", "left", "neutral"})
+
+
+# ---------------------------------------------------------------------------
+# Public helpers
+# ---------------------------------------------------------------------------
+
+def update_lateral_component(
+    skill_entry: dict,
+    foot_context: str,
+    delta: float,
+) -> dict:
+    """Apply an EMA delta to the appropriate lateral component.
+
+    Creates the component bucket on first contact, initialising
+    ``level`` from the existing global ``current_level`` so that players
+    who accumulated history before this feature was introduced start
+    from their actual current level rather than the system baseline.
+
+    Args:
+        skill_entry:  One entry from UserLicense.football_skills, e.g.
+                      {"current_level": 65.3, "baseline": 60.0, ...}
+        foot_context: "right" | "left" | "neutral"
+        delta:        EMA delta from compute_single_tournament_skill_delta
+
+    Returns:
+        A copy of skill_entry with lateral_components updated.
+        The caller is responsible for writing this back to the JSONB
+        and for re-running aggregate_lateral_components to refresh
+        current_level.
+    """
+    if foot_context not in _VALID_CONTEXTS:
+        foot_context = "neutral"
+
+    entry = dict(skill_entry)
+    components: dict = dict(entry.get("lateral_components") or {})
+
+    current_global = float(entry.get("current_level", 60.0))
+
+    if foot_context not in components:
+        # First tournament in this context — seed from current global level.
+        new_level = _clamp(current_global + delta)
+        components[foot_context] = {
+            "level":           new_level,
+            "total_delta":     delta,
+            "tournament_count": 1,
+            "last_delta":      delta,
+        }
+    else:
+        bucket = dict(components[foot_context])
+        new_level = _clamp(float(bucket["level"]) + delta)
+        bucket["level"]            = new_level
+        bucket["total_delta"]      = round(float(bucket.get("total_delta", 0.0)) + delta, 4)
+        bucket["tournament_count"] = int(bucket.get("tournament_count", 0)) + 1
+        bucket["last_delta"]       = delta
+        components[foot_context]   = bucket
+
+    entry["lateral_components"] = components
+    return entry
+
+
+def aggregate_lateral_components(
+    skill_entry: dict,
+    right_foot_score: Optional[float],
+    left_foot_score: Optional[float],
+) -> float:
+    """Compute the aggregated current_level from lateral components.
+
+    Handles all partial-availability cases:
+      - Only neutral           → neutral.level
+      - Only right             → right.level
+      - Only left              → left.level
+      - right + neutral        → (R * right + 1.0 * neutral) / (R + 1.0)
+      - left  + neutral        → (L * left  + 1.0 * neutral) / (L + 1.0)
+      - right + left           → (R * right + L * left) / (R + L)
+      - All three              → full formula
+      - No / empty components  → existing current_level unchanged
+
+    Args:
+        skill_entry:      One entry from UserLicense.football_skills
+        right_foot_score: UserLicense.right_foot_score (may be None)
+        left_foot_score:  UserLicense.left_foot_score  (may be None)
+
+    Returns:
+        Aggregated level, clamped to [MIN_SKILL_VALUE, MAX_SKILL_CAP].
+        Returns the existing current_level if no components are present.
+    """
+    components = skill_entry.get("lateral_components") or {}
+    if not components:
+        return float(skill_entry.get("current_level", 60.0))
+
+    R, L = _foot_ratios(right_foot_score, left_foot_score)
+
+    weights: dict[str, float] = {}
+    if "right"   in components: weights["right"]   = R
+    if "left"    in components: weights["left"]    = L
+    if "neutral" in components: weights["neutral"] = _NEUTRAL_WEIGHT
+
+    denominator = sum(weights.values())
+    if denominator == 0.0:
+        return float(skill_entry.get("current_level", 60.0))
+
+    numerator = sum(
+        weights[ctx] * float(components[ctx]["level"])
+        for ctx in weights
+    )
+    return _clamp(numerator / denominator)
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+def _foot_ratios(
+    right: Optional[float],
+    left: Optional[float],
+) -> tuple[float, float]:
+    """Return (R, L) dominance ratios in [0, 1], summing to 1.0.
+
+    Falls back to (0.5, 0.5) when both scores are absent or zero.
+    """
+    r = max(float(right or 0.0), 0.0)
+    l = max(float(left  or 0.0), 0.0)
+    total = r + l
+    if total == 0.0:
+        return 0.5, 0.5
+    return r / total, l / total
+
+
+def _clamp(value: float) -> float:
+    """Clamp to [MIN_SKILL_VALUE, MAX_SKILL_CAP] and round to 1 decimal."""
+    return round(max(MIN_SKILL_VALUE, min(MAX_SKILL_CAP, value)), 1)

--- a/app/services/tournament/tournament_participation_service.py
+++ b/app/services/tournament/tournament_participation_service.py
@@ -384,6 +384,7 @@ def record_tournament_participation(
     credits: int,
     assessed_by_id: Optional[int] = None,
     team_id: Optional[int] = None,
+    foot_context: str = "neutral",
 ) -> TournamentParticipation:
     """
     Record tournament participation and update player skill assessments.
@@ -415,12 +416,9 @@ def record_tournament_participation(
         TournamentParticipation.semester_id == tournament_id
     ).first()
 
-    # Resolve foot_context from the tournament's game preset (F4a — laterality).
-    # Semester.game_preset uses a backward-compatible property (P3 path).
-    # Falls back to "neutral" when no preset is attached or the JSONB key is absent.
-    _semester = db.query(Semester).filter(Semester.id == tournament_id).first()
-    _preset   = getattr(_semester, "game_preset", None) if _semester else None
-    _foot_ctx = getattr(_preset, "foot_context", "neutral") if _preset is not None else "neutral"
+    # foot_context is resolved by the caller from the tournament's game preset (F4a).
+    # Default "neutral" covers callers that don't supply laterality context.
+    _foot_ctx = foot_context if foot_context in ("right", "left", "neutral") else "neutral"
 
     if existing_participation:
         existing_participation.placement = placement

--- a/app/services/tournament/tournament_participation_service.py
+++ b/app/services/tournament/tournament_participation_service.py
@@ -415,11 +415,19 @@ def record_tournament_participation(
         TournamentParticipation.semester_id == tournament_id
     ).first()
 
+    # Resolve foot_context from the tournament's game preset (F4a — laterality).
+    # Semester.game_preset uses a backward-compatible property (P3 path).
+    # Falls back to "neutral" when no preset is attached or the JSONB key is absent.
+    _semester = db.query(Semester).filter(Semester.id == tournament_id).first()
+    _preset   = getattr(_semester, "game_preset", None) if _semester else None
+    _foot_ctx = getattr(_preset, "foot_context", "neutral") if _preset is not None else "neutral"
+
     if existing_participation:
         existing_participation.placement = placement
         existing_participation.skill_points_awarded = skill_points if skill_points else None
         existing_participation.xp_awarded = total_xp
         existing_participation.credits_awarded = credits
+        existing_participation.foot_context = _foot_ctx
         participation = existing_participation
     else:
         participation = TournamentParticipation(
@@ -429,7 +437,8 @@ def record_tournament_participation(
             placement=placement,
             skill_points_awarded=skill_points if skill_points else None,
             xp_awarded=total_xp,
-            credits_awarded=credits
+            credits_awarded=credits,
+            foot_context=_foot_ctx,
         )
         db.add(participation)
 

--- a/app/services/tournament/tournament_reward_orchestrator.py
+++ b/app/services/tournament/tournament_reward_orchestrator.py
@@ -298,10 +298,15 @@ def distribute_rewards_for_user(
     bonus_xp = participation_service.convert_skill_points_to_xp(db, skill_points)
     total_xp = base_xp + bonus_xp
 
+    # Resolve foot_context from the already-loaded tournament preset (F4a — laterality).
+    _preset    = getattr(tournament, "game_preset", None) if tournament else None
+    _foot_ctx  = getattr(_preset, "foot_context", "neutral") if _preset is not None else "neutral"
+
     # Record participation
     participation_record = participation_service.record_tournament_participation(
         db, user_id, tournament_id, placement, skill_points, base_xp, credits, distributed_by,
         team_id=team_id,
+        foot_context=_foot_ctx,
     )
 
     # ── Monitoring: log dominant/minor delta ratio (sampled: podium placements only) ──

--- a/app/services/tournament/tournament_reward_orchestrator.py
+++ b/app/services/tournament/tournament_reward_orchestrator.py
@@ -336,6 +336,10 @@ def distribute_rewards_for_user(
             from app.models.license import UserLicense
             from sqlalchemy.orm.attributes import flag_modified
             from datetime import timezone
+            from app.services.skill_progression import (
+                update_lateral_component,
+                aggregate_lateral_components,
+            )
 
             # R04: Lock UserLicense row before reading football_skills JSONB.
             # Prevents two concurrent distributions from both reading stale skills,
@@ -363,6 +367,12 @@ def distribute_rewards_for_user(
                         for sk in list(updated_skills.keys()):
                             updated_skills[sk] = _normalise_skill_entry(updated_skills[sk])
 
+                        # F4b — laterality write-back context
+                        _foot_ctx   = getattr(participation_record, "foot_context", "neutral") or "neutral"
+                        _raw_deltas = participation_record.skill_rating_delta or {}
+                        _right_ft   = active_license.right_foot_score
+                        _left_ft    = active_license.left_foot_score
+
                         changed = 0
                         for skill_key, sdata in computed.items():
                             if skill_key not in updated_skills:
@@ -371,8 +381,22 @@ def distribute_rewards_for_user(
                             if not isinstance(entry, dict):
                                 # Should not happen after normalisation — defensive guard
                                 continue
-                            # Only update delta-related fields; preserve baseline & assessment fields
-                            entry["current_level"]    = sdata["current_level"]
+
+                            # ── Lateral component update (F4b) ────────────────────────
+                            # Apply this tournament's EMA delta to the foot-context bucket.
+                            # update_lateral_component initialises the bucket from the
+                            # pre-tournament current_level on first contact so that
+                            # existing skill history is preserved.
+                            _skill_delta = float(_raw_deltas.get(skill_key, 0.0))
+                            entry = update_lateral_component(entry, _foot_ctx, _skill_delta)
+
+                            # Re-aggregate current_level from all lateral components.
+                            # Falls back to the EMA-derived sdata["current_level"] when
+                            # no lateral_components exist (backward-compatible old records).
+                            _agg = aggregate_lateral_components(entry, _right_ft, _left_ft)
+                            entry["current_level"] = _agg
+
+                            # ── Global tracking fields (unchanged semantics) ──────────
                             entry["tournament_delta"] = sdata["tournament_delta"]
                             entry["total_delta"]      = sdata["total_delta"]
                             entry["tournament_count"] = sdata["tournament_count"]
@@ -387,7 +411,8 @@ def distribute_rewards_for_user(
                         logger.info(
                             f"✅ Persisted skill deltas for user {user_id} "
                             f"(license {active_license.id}): {changed} skills updated, "
-                            f"placement={participation_record.placement}"
+                            f"placement={participation_record.placement}, "
+                            f"foot_context={_foot_ctx}"
                         )
                 else:
                     logger.warning(

--- a/app/templates/lfa_player_onboarding.html
+++ b/app/templates/lfa_player_onboarding.html
@@ -498,6 +498,8 @@
         status.textContent = '⏳ Saving onboarding data...';
 
         try {
+            // foot_dominance: 0=fully left, 50=balanced, 100=fully right
+            const footDominance = parseInt(document.getElementById('foot-dominance-slider').value, 10);
             const response = await fetch('/specialization/lfa-player/onboarding-web', {
                 method: 'POST',
                 headers: {
@@ -506,8 +508,6 @@
                 },
                 credentials: 'include',
                 // motivation: "" — Streamlit parity: goals dropdown only, no free text
-                // foot_dominance: 0=fully left, 50=balanced, 100=fully right
-                const footDominance = parseInt(document.getElementById('foot-dominance-slider').value, 10);
                 body: JSON.stringify({ position: selectedPosition, goals, motivation: '', skills, foot_dominance: footDominance }),
             });
 

--- a/app/templates/lfa_player_onboarding.html
+++ b/app/templates/lfa_player_onboarding.html
@@ -103,6 +103,29 @@
         .position-name { font-weight: 700; font-size: 0.9rem; }
         .position-desc { font-size: 0.75rem; opacity: 0.7; margin-top: 0.2rem; }
 
+        /* ── Foot dominance slider (Step 6) ── */
+        .foot-slider-wrap {
+            border: 1px solid #e8eaf6;
+            border-radius: 12px;
+            padding: 1.2rem 1.2rem 1rem;
+            background: #f7f8ff;
+            margin-bottom: 1.2rem;
+        }
+        .foot-slider-title {
+            font-weight: 700; font-size: 0.95rem; color: #2c3e50; margin-bottom: 0.3rem;
+        }
+        .foot-slider-subtitle {
+            font-size: 0.8rem; color: #7f8c8d; margin-bottom: 1rem;
+        }
+        .foot-labels {
+            display: flex; justify-content: space-between;
+            font-size: 0.78rem; font-weight: 600; color: #667eea; margin-top: 0.4rem;
+        }
+        .foot-value-display {
+            text-align: center; font-size: 0.9rem; font-weight: 700;
+            color: #667eea; margin-top: 0.5rem; min-height: 1.4em;
+        }
+
         /* ── Skill sliders (Steps 2-5) ── */
         .skill-item {
             border: 1px solid #f0f0f0;
@@ -318,6 +341,20 @@
         <!-- Skill profile summary — populated by JS when navigating to step 6 -->
         <div class="skill-summary" id="skill-summary"></div>
 
+        <!-- Foot dominance slider — saved to right_foot_score / left_foot_score -->
+        <div class="foot-slider-wrap">
+            <div class="foot-slider-title">⚽ Dominant Foot</div>
+            <div class="foot-slider-subtitle">Move the slider to indicate your stronger foot. This helps personalise your skill analysis.</div>
+            <input type="range" id="foot-dominance-slider" min="0" max="100" value="50" step="1"
+                   oninput="updateFootLabel(this.value)">
+            <div class="foot-labels">
+                <span>Left</span>
+                <span>Balanced</span>
+                <span>Right</span>
+            </div>
+            <div class="foot-value-display" id="foot-value-label">Balanced (50 / 50)</div>
+        </div>
+
         <div class="form-group">
             <label for="goals">What is your primary goal?</label>
             <select id="goals" name="goals" required>
@@ -379,6 +416,16 @@
         card.classList.add('selected');
         selectedPosition = card.dataset.position;
         document.getElementById('btn-step1-next').disabled = false;
+    }
+
+    // ── Foot dominance slider ────────────────────────────────────────────────
+    function updateFootLabel(value) {
+        const v = parseInt(value, 10);
+        let label;
+        if (v < 35)       label = `Left foot  (L ${100 - v} / R ${v})`;
+        else if (v > 65)  label = `Right foot  (R ${v} / L ${100 - v})`;
+        else              label = `Balanced  (R ${v} / L ${100 - v})`;
+        document.getElementById('foot-value-label').textContent = label;
     }
 
     // ── Skill sliders ────────────────────────────────────────────────────────
@@ -459,7 +506,9 @@
                 },
                 credentials: 'include',
                 // motivation: "" — Streamlit parity: goals dropdown only, no free text
-                body: JSON.stringify({ position: selectedPosition, goals, motivation: '', skills }),
+                // foot_dominance: 0=fully left, 50=balanced, 100=fully right
+                const footDominance = parseInt(document.getElementById('foot-dominance-slider').value, 10);
+                body: JSON.stringify({ position: selectedPosition, goals, motivation: '', skills, foot_dominance: footDominance }),
             });
 
             const data = await response.json();

--- a/tests/unit/services/test_foot_context_constraints.py
+++ b/tests/unit/services/test_foot_context_constraints.py
@@ -1,0 +1,217 @@
+"""
+Constraint and model tests for foot-laterality feature.
+
+Tests: FC-01 through FC-07
+Covers:
+  - TournamentParticipation.foot_context DB constraint
+  - GamePreset.foot_context property (pure Python)
+  - UserLicense right/left foot score CHECK constraints
+"""
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from app.models.game_preset import GamePreset
+
+
+# ---------------------------------------------------------------------------
+# FC-04: GamePreset.foot_context property — pure Python, no DB needed
+# ---------------------------------------------------------------------------
+
+class TestGamePresetFootContextProperty:
+    """
+    GamePreset.foot_context is a pure-Python @property — test it without a DB.
+
+    We can't use GamePreset.__new__ directly because the SQLAlchemy mapper
+    is not initialised on a bare instance, so attribute access raises
+    AttributeError.  Instead we call the property's fget via a minimal stub
+    class that owns game_config as a plain Python attribute.
+    """
+
+    class _Stub:
+        """Minimal stand-in that owns game_config as a plain attribute."""
+        _VALID_FOOT_CONTEXTS = frozenset({"right", "left", "neutral"})
+        foot_context = GamePreset.foot_context  # copy the property descriptor
+
+        def __init__(self, game_config):
+            self.game_config = game_config
+
+    def _preset(self, skill_config: dict) -> "_Stub":
+        return self._Stub(game_config={"skill_config": skill_config})
+
+    def test_fc04_valid_right_returned(self):
+        """FC-04a: foot_context='right' stored correctly → property returns 'right'."""
+        assert self._preset({"foot_context": "right"}).foot_context == "right"
+
+    def test_fc04_valid_left_returned(self):
+        """FC-04b: foot_context='left' stored correctly → property returns 'left'."""
+        assert self._preset({"foot_context": "left"}).foot_context == "left"
+
+    def test_fc04_valid_neutral_returned(self):
+        """FC-04c: foot_context='neutral' stored correctly → property returns 'neutral'."""
+        assert self._preset({"foot_context": "neutral"}).foot_context == "neutral"
+
+    def test_fc04_invalid_value_falls_back_to_neutral(self):
+        """FC-04d: invalid stored value → property silently returns 'neutral'."""
+        assert self._preset({"foot_context": "BOTH"}).foot_context == "neutral"
+
+    def test_fc04_missing_key_falls_back_to_neutral(self):
+        """FC-04e: foot_context key absent → property returns 'neutral'."""
+        assert self._preset({}).foot_context == "neutral"
+
+    def test_fc04_none_game_config_falls_back_to_neutral(self):
+        """FC-04f: game_config is None → property returns 'neutral' without crash."""
+        p = self._Stub(game_config=None)
+        assert p.foot_context == "neutral"
+
+
+# ---------------------------------------------------------------------------
+# FC-01..03: TournamentParticipation.foot_context DB constraint
+# ---------------------------------------------------------------------------
+
+class TestTournamentParticipationFootContextConstraint:
+    """
+    These tests insert raw SQL into tournament_participations to verify
+    the CHECK constraint at the DB level.  The test_db fixture wraps
+    everything in a SAVEPOINT that is rolled back after each test.
+    """
+
+    def _insert_participation(self, db, foot_context_value: str, user_id: int, semester_id: int):
+        from sqlalchemy import text
+        db.execute(text(
+            "INSERT INTO tournament_participations "
+            "(user_id, semester_id, placement, xp_awarded, credits_awarded, foot_context) "
+            "VALUES (:uid, :sid, 1, 0, 0, :fc)"
+        ), {"uid": user_id, "sid": semester_id, "fc": foot_context_value})
+        db.flush()
+
+    def _make_minimal_user_and_semester(self, db):
+        """Create the minimum records needed for a participation FK."""
+        from sqlalchemy import text
+        import uuid
+        email = f"fc-test-{uuid.uuid4().hex[:8]}@test.com"
+        db.execute(text(
+            "INSERT INTO users "
+            "(email, name, password_hash, role, is_active, "
+            "payment_verified, credit_balance, credit_purchased, "
+            "xp_balance, nda_accepted, parental_consent) "
+            "VALUES (:e, 'FC Test', 'x', 'STUDENT', true, "
+            "false, 0, 0, 0, false, false)"
+        ), {"e": email})
+        user_id = db.execute(text(
+            "SELECT id FROM users WHERE email = :e"
+        ), {"e": email}).scalar()
+
+        code = f"FC-SEM-{uuid.uuid4().hex[:8]}"
+        db.execute(text(
+            "INSERT INTO semesters (code, name, semester_category, status, "
+            "specialization_type, start_date, end_date, enrollment_cost) "
+            "VALUES (:c, 'FC Sem', 'MINI_SEASON', 'ONGOING', "
+            "'LFA_FOOTBALL_PLAYER', '2026-01-01', '2026-12-31', 0)"
+        ), {"c": code})
+        semester_id = db.execute(text(
+            "SELECT id FROM semesters WHERE code = :c"
+        ), {"c": code}).scalar()
+
+        db.flush()
+        return user_id, semester_id
+
+    def test_fc01_default_neutral_when_omitted(self, test_db):
+        """FC-01: INSERT without foot_context → DB DEFAULT 'neutral' applied."""
+        from sqlalchemy import text
+        uid, sid = self._make_minimal_user_and_semester(test_db)
+        test_db.execute(text(
+            "INSERT INTO tournament_participations "
+            "(user_id, semester_id, placement, xp_awarded, credits_awarded) "
+            "VALUES (:uid, :sid, 1, 0, 0)"
+        ), {"uid": uid, "sid": sid})
+        test_db.flush()
+        row = test_db.execute(text(
+            "SELECT foot_context FROM tournament_participations "
+            "WHERE user_id = :uid AND semester_id = :sid"
+        ), {"uid": uid, "sid": sid}).fetchone()
+        assert row[0] == "neutral"
+
+    def test_fc02_invalid_foot_context_rejected(self, test_db):
+        """FC-02: INSERT foot_context='invalid' → IntegrityError from CHECK constraint."""
+        uid, sid = self._make_minimal_user_and_semester(test_db)
+        with pytest.raises(IntegrityError):
+            self._insert_participation(test_db, "invalid", uid, sid)
+
+    def test_fc03_valid_values_accepted(self, test_db):
+        """FC-03: 'right', 'left', 'neutral' all accepted without error."""
+        import uuid
+        from sqlalchemy import text
+        for ctx in ("right", "left", "neutral"):
+            uid, sid = self._make_minimal_user_and_semester(test_db)
+            self._insert_participation(test_db, ctx, uid, sid)
+            row = test_db.execute(text(
+                "SELECT foot_context FROM tournament_participations "
+                "WHERE user_id = :uid AND semester_id = :sid"
+            ), {"uid": uid, "sid": sid}).fetchone()
+            assert row[0] == ctx
+
+
+# ---------------------------------------------------------------------------
+# FC-05..07: UserLicense right/left foot score CHECK constraints
+# ---------------------------------------------------------------------------
+
+class TestFootScoreCheckConstraints:
+
+    def _make_minimal_user(self, db):
+        from sqlalchemy import text
+        import uuid
+        email = f"fs-test-{uuid.uuid4().hex[:8]}@test.com"
+        db.execute(text(
+            "INSERT INTO users "
+            "(email, name, password_hash, role, is_active, "
+            "payment_verified, credit_balance, credit_purchased, "
+            "xp_balance, nda_accepted, parental_consent) "
+            "VALUES (:e, 'FS Test', 'x', 'STUDENT', true, "
+            "false, 0, 0, 0, false, false)"
+        ), {"e": email})
+        uid = db.execute(text(
+            "SELECT id FROM users WHERE email = :e"
+        ), {"e": email}).scalar()
+        db.flush()
+        return uid
+
+    def _insert_license(self, db, uid, right_score, left_score):
+        from sqlalchemy import text
+        db.execute(text(
+            "INSERT INTO user_licenses "
+            "(user_id, specialization_type, is_active, onboarding_completed, "
+            "payment_verified, credit_balance, credit_purchased, "
+            "current_level, max_achieved_level, renewal_cost, "
+            "started_at, right_foot_score, left_foot_score) "
+            "VALUES (:uid, 'LFA_FOOTBALL_PLAYER', true, false, false, 0, 0, "
+            "1, 1, 0, now(), :r, :l)"
+        ), {"uid": uid, "r": right_score, "l": left_score})
+        db.flush()
+
+    def test_fc05_null_foot_scores_allowed(self, test_db):
+        """FC-05: NULL right/left foot scores pass constraint (not assessed yet)."""
+        uid = self._make_minimal_user(test_db)
+        self._insert_license(test_db, uid, None, None)  # must not raise
+
+    def test_fc05b_valid_range_accepted(self, test_db):
+        """FC-05b: scores within 0–100 accepted."""
+        uid = self._make_minimal_user(test_db)
+        self._insert_license(test_db, uid, 68.0, 32.0)  # must not raise
+
+    def test_fc05c_boundary_0_100_accepted(self, test_db):
+        """FC-05c: boundary values 0 and 100 accepted."""
+        uid = self._make_minimal_user(test_db)
+        self._insert_license(test_db, uid, 0.0, 100.0)
+
+    def test_fc06_right_foot_over_100_rejected(self, test_db):
+        """FC-06: right_foot_score=101.0 → IntegrityError (CHECK constraint)."""
+        uid = self._make_minimal_user(test_db)
+        with pytest.raises(IntegrityError):
+            self._insert_license(test_db, uid, 101.0, 50.0)
+
+    def test_fc07_left_foot_negative_rejected(self, test_db):
+        """FC-07: left_foot_score=-1.0 → IntegrityError (CHECK constraint)."""
+        uid = self._make_minimal_user(test_db)
+        with pytest.raises(IntegrityError):
+            self._insert_license(test_db, uid, 50.0, -1.0)

--- a/tests/unit/services/test_lateral_aggregation.py
+++ b/tests/unit/services/test_lateral_aggregation.py
@@ -1,0 +1,212 @@
+"""
+Unit tests for laterality-aware skill aggregation (_lateral.py).
+
+Tests: LA-01 through LA-13
+Layer: L2 — gameplay aggregation only (no DB, no EMA, no badge logic)
+"""
+
+import pytest
+from app.services.skill_progression._lateral import (
+    aggregate_lateral_components,
+    update_lateral_component,
+)
+from app.services.skill_progression._formulas import MIN_SKILL_VALUE, MAX_SKILL_CAP
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _entry(current_level=65.0, components=None):
+    """Minimal football_skills entry dict."""
+    e = {"baseline": 60.0, "current_level": current_level, "total_delta": 5.0}
+    if components is not None:
+        e["lateral_components"] = components
+    return e
+
+
+def _lc(level, count=1, total_delta=1.0, last_delta=1.0):
+    """Build a lateral component bucket."""
+    return {"level": level, "tournament_count": count,
+            "total_delta": total_delta, "last_delta": last_delta}
+
+
+# ---------------------------------------------------------------------------
+# aggregate_lateral_components — all partial-availability cases
+# ---------------------------------------------------------------------------
+
+class TestAggregateOnlyOneComponent:
+
+    def test_la01_only_neutral_returns_neutral_level(self):
+        """LA-01: only neutral component → result equals neutral.level."""
+        entry = _entry(components={"neutral": _lc(64.0)})
+        result = aggregate_lateral_components(entry, right_foot_score=50.0, left_foot_score=50.0)
+        assert result == 64.0
+
+    def test_la02_only_right_returns_right_level(self):
+        """LA-02: only right component → result equals right.level (R weight normalised to 1)."""
+        entry = _entry(components={"right": _lc(67.0)})
+        result = aggregate_lateral_components(entry, right_foot_score=68.0, left_foot_score=32.0)
+        assert result == 67.0
+
+    def test_la03_only_left_returns_left_level(self):
+        """LA-03: only left component → result equals left.level."""
+        entry = _entry(components={"left": _lc(61.5)})
+        result = aggregate_lateral_components(entry, right_foot_score=32.0, left_foot_score=68.0)
+        assert result == 61.5
+
+
+class TestAggregateTwoComponents:
+
+    def test_la04_right_and_neutral_R068(self):
+        """LA-04: right + neutral, R=0.68 → (0.68*70 + 1.0*64) / 1.68 ≈ 66.6."""
+        entry = _entry(components={"right": _lc(70.0), "neutral": _lc(64.0)})
+        result = aggregate_lateral_components(entry, right_foot_score=68.0, left_foot_score=32.0)
+        expected = round((0.68 * 70.0 + 1.0 * 64.0) / 1.68, 1)
+        assert result == expected
+
+    def test_la05_left_and_neutral_R032(self):
+        """LA-05: left + neutral, R=0.32 → (0.32 weight on left? No — L=0.68).
+        L = 1 - R = 0.68.  (0.68*68 + 1.0*62) / 1.68 ≈ 64.2"""
+        entry = _entry(components={"left": _lc(68.0), "neutral": _lc(62.0)})
+        result = aggregate_lateral_components(entry, right_foot_score=32.0, left_foot_score=68.0)
+        L = 68.0 / (32.0 + 68.0)          # 0.68
+        expected = round((L * 68.0 + 1.0 * 62.0) / (L + 1.0), 1)
+        assert result == expected
+
+    def test_la06_right_and_left_only(self):
+        """LA-06: right + left (no neutral), balanced player R=0.5 → average of two."""
+        entry = _entry(components={"right": _lc(70.0), "left": _lc(60.0)})
+        result = aggregate_lateral_components(entry, right_foot_score=50.0, left_foot_score=50.0)
+        # R=L=0.5 → (0.5*70 + 0.5*60) / 1.0 = 65.0
+        assert result == 65.0
+
+
+class TestAggregateAllThree:
+
+    def test_la07_all_three_R07(self):
+        """LA-07: all three components, R=0.7 → full formula."""
+        entry = _entry(components={
+            "right":   _lc(70.0),
+            "left":    _lc(62.0),
+            "neutral": _lc(65.0),
+        })
+        result = aggregate_lateral_components(entry, right_foot_score=70.0, left_foot_score=30.0)
+        R, L = 0.7, 0.3
+        expected = round((R * 70.0 + L * 62.0 + 1.0 * 65.0) / (R + L + 1.0), 1)
+        assert result == expected
+
+    def test_la08_balanced_player_R05_symmetry(self):
+        """LA-08: balanced player (R=L=0.5) with symmetric right/left levels
+        → current_level lies between right and left, pulled toward neutral."""
+        entry = _entry(components={
+            "right":   _lc(70.0),
+            "left":    _lc(70.0),
+            "neutral": _lc(65.0),
+        })
+        result = aggregate_lateral_components(entry, right_foot_score=50.0, left_foot_score=50.0)
+        # (0.5*70 + 0.5*70 + 1.0*65) / 2.0 = 67.5
+        assert result == round((0.5 * 70.0 + 0.5 * 70.0 + 1.0 * 65.0) / 2.0, 1)
+
+
+class TestAggregateEdgeCases:
+
+    def test_la09_no_lateral_components_key_returns_current_level(self):
+        """LA-09: no lateral_components key (old record) → current_level unchanged."""
+        entry = _entry(current_level=67.3)  # no 'lateral_components' key at all
+        result = aggregate_lateral_components(entry, right_foot_score=68.0, left_foot_score=32.0)
+        assert result == 67.3
+
+    def test_la10_empty_lateral_components_returns_current_level(self):
+        """LA-10: lateral_components={} (explicitly empty) → current_level unchanged."""
+        entry = _entry(current_level=65.0, components={})
+        result = aggregate_lateral_components(entry, right_foot_score=68.0, left_foot_score=32.0)
+        assert result == 65.0
+
+    def test_la11_both_foot_scores_none_defaults_to_balanced(self):
+        """LA-11: both foot scores None → R=L=0.5 fallback."""
+        entry = _entry(components={"right": _lc(70.0), "left": _lc(60.0)})
+        result = aggregate_lateral_components(entry, right_foot_score=None, left_foot_score=None)
+        # R=L=0.5 → (0.5*70 + 0.5*60) / 1.0 = 65.0
+        assert result == 65.0
+
+    def test_la12_zero_right_score_right_component_excluded(self):
+        """LA-12: right_foot_score=0.0 → R=0 → right component weight=0 → excluded."""
+        entry = _entry(components={"right": _lc(90.0), "neutral": _lc(64.0)})
+        result = aggregate_lateral_components(entry, right_foot_score=0.0, left_foot_score=80.0)
+        # R=0 → w_right=0; only neutral has weight (1.0) → result == neutral.level
+        assert result == 64.0
+
+    def test_la13_output_capped_at_max_skill_cap(self):
+        """LA-13: formula result > 99.0 → clamped to MAX_SKILL_CAP (99.0)."""
+        entry = _entry(components={"neutral": _lc(100.0)})
+        result = aggregate_lateral_components(entry, right_foot_score=None, left_foot_score=None)
+        assert result == MAX_SKILL_CAP
+
+    def test_la14_output_floored_at_min_skill_value(self):
+        """LA-14: formula result < 40.0 → clamped to MIN_SKILL_VALUE (40.0)."""
+        entry = _entry(components={"neutral": _lc(20.0)})
+        result = aggregate_lateral_components(entry, right_foot_score=None, left_foot_score=None)
+        assert result == MIN_SKILL_VALUE
+
+
+# ---------------------------------------------------------------------------
+# update_lateral_component
+# ---------------------------------------------------------------------------
+
+class TestUpdateLateralComponent:
+
+    def test_new_component_initialised_from_current_level(self):
+        """First tournament in a context seeds the component from current_level + delta."""
+        entry = _entry(current_level=65.0)  # no lateral_components
+        updated = update_lateral_component(entry, "right", delta=0.8)
+        assert "lateral_components" in updated
+        comp = updated["lateral_components"]["right"]
+        assert comp["level"] == round(65.0 + 0.8, 1)
+        assert comp["tournament_count"] == 1
+        assert comp["last_delta"] == 0.8
+
+    def test_existing_component_accumulated(self):
+        """Subsequent tournament in same context accumulates the delta."""
+        entry = _entry(current_level=67.8, components={"right": _lc(67.8, count=1)})
+        updated = update_lateral_component(entry, "right", delta=0.5)
+        comp = updated["lateral_components"]["right"]
+        assert comp["level"] == round(67.8 + 0.5, 1)
+        assert comp["tournament_count"] == 2
+
+    def test_negative_delta_decreases_component_level(self):
+        """Negative EMA delta decreases the component level (bad tournament result)."""
+        entry = _entry(current_level=65.0, components={"neutral": _lc(65.0, count=2)})
+        updated = update_lateral_component(entry, "neutral", delta=-1.2)
+        comp = updated["lateral_components"]["neutral"]
+        assert comp["level"] == round(65.0 - 1.2, 1)
+
+    def test_invalid_foot_context_falls_back_to_neutral(self):
+        """An unrecognised foot_context string is coerced to 'neutral'."""
+        entry = _entry(current_level=65.0)
+        updated = update_lateral_component(entry, "invalid_ctx", delta=1.0)
+        assert "neutral" in updated["lateral_components"]
+        assert "invalid_ctx" not in updated["lateral_components"]
+
+    def test_component_level_capped_by_clamp(self):
+        """Component level cannot exceed MAX_SKILL_CAP after delta application."""
+        entry = _entry(current_level=98.5, components={"right": _lc(98.5)})
+        updated = update_lateral_component(entry, "right", delta=2.0)
+        assert updated["lateral_components"]["right"]["level"] == MAX_SKILL_CAP
+
+    def test_component_level_floored_by_clamp(self):
+        """Component level cannot go below MIN_SKILL_VALUE after delta application."""
+        entry = _entry(current_level=41.0, components={"left": _lc(41.0)})
+        updated = update_lateral_component(entry, "left", delta=-5.0)
+        assert updated["lateral_components"]["left"]["level"] == MIN_SKILL_VALUE
+
+    def test_other_components_untouched(self):
+        """Updating 'right' must not modify 'neutral' or 'left' components."""
+        entry = _entry(current_level=65.0, components={
+            "neutral": _lc(64.0, count=3),
+            "left":    _lc(61.0, count=1),
+        })
+        updated = update_lateral_component(entry, "right", delta=0.9)
+        assert updated["lateral_components"]["neutral"]["level"] == 64.0
+        assert updated["lateral_components"]["neutral"]["tournament_count"] == 3
+        assert updated["lateral_components"]["left"]["level"] == 61.0

--- a/tests/unit/services/test_onboarding_foot_dominance.py
+++ b/tests/unit/services/test_onboarding_foot_dominance.py
@@ -1,0 +1,224 @@
+"""
+Onboarding foot_dominance field validation tests.
+
+Tests: OB-01 through OB-06
+Covers both POST handlers:
+  - /specialization/lfa-player/onboarding-web  (cookie auth, browser)
+  - /specialization/lfa-player/onboarding-submit (JWT auth, API)
+
+Uses the same MagicMock-DB pattern as test_onboarding_web.py.
+"""
+
+import asyncio
+import pytest
+from unittest.mock import MagicMock, AsyncMock, patch
+
+from app.api.web_routes.onboarding import (
+    lfa_player_onboarding_web_submit,
+    lfa_player_onboarding_submit,
+)
+from app.models.user import UserRole
+
+_BASE = "app.api.web_routes.onboarding"
+# complete_lfa_player_onboarding and flag_modified are imported inside the
+# handler function body, so they must be patched at their source modules.
+_PATCH_COMPLETE = "app.services.onboarding_service.complete_lfa_player_onboarding"
+_PATCH_FLAG     = "sqlalchemy.orm.attributes.flag_modified"
+
+
+# ---------------------------------------------------------------------------
+# Helpers (mirror test_onboarding_web.py)
+# ---------------------------------------------------------------------------
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _user(uid=42):
+    u = MagicMock()
+    u.id = uid
+    u.role = UserRole.STUDENT
+    u.email = "foot@test.com"
+    return u
+
+
+def _mock_db(license_mock=None):
+    """Return a minimal DB mock that returns `license_mock` for .first()."""
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = (
+        license_mock if license_mock is not None else MagicMock()
+    )
+    return db
+
+
+def _valid_skills():
+    from app.services.skill_progression._config import get_all_skill_keys
+    return {k: 50 for k in get_all_skill_keys()}
+
+
+# ---------------------------------------------------------------------------
+# Web handler (/onboarding-web)
+# ---------------------------------------------------------------------------
+
+class TestOnboardingWebFootDominance:
+
+    def _req(self, body: dict):
+        r = MagicMock()
+        r.json = AsyncMock(return_value=body)
+        return r
+
+    def _valid_body(self, foot_dominance=50):
+        body = {
+            "position":      "MIDFIELDER",
+            "goals":         "improve_skills",
+            "motivation":    "",
+            "skills":        _valid_skills(),
+        }
+        if foot_dominance is not None:
+            body["foot_dominance"] = foot_dominance
+        return body
+
+    def test_ob01_foot_dominance_70_saves_right70_left30(self):
+        """OB-01: foot_dominance=70 → right_foot_score=70, left_foot_score=30."""
+        license_mock = MagicMock()
+        db = _mock_db(license_mock)
+        body = self._valid_body(foot_dominance=70)
+
+        with patch(_PATCH_COMPLETE), \
+             patch(_PATCH_FLAG):
+            result = _run(lfa_player_onboarding_web_submit(
+                request=self._req(body), db=db, user=_user()
+            ))
+
+        assert result.get("success") is True
+        assert license_mock.right_foot_score == 70.0
+        assert license_mock.left_foot_score  == 30.0
+
+    def test_ob02_foot_dominance_boundary_0(self):
+        """OB-02: foot_dominance=0 → right=0.0, left=100.0."""
+        license_mock = MagicMock()
+        db = _mock_db(license_mock)
+        body = self._valid_body(foot_dominance=0)
+
+        with patch(_PATCH_COMPLETE), \
+             patch(_PATCH_FLAG):
+            _run(lfa_player_onboarding_web_submit(
+                request=self._req(body), db=db, user=_user()
+            ))
+
+        assert license_mock.right_foot_score == 0.0
+        assert license_mock.left_foot_score  == 100.0
+
+    def test_ob03_foot_dominance_boundary_100(self):
+        """OB-03: foot_dominance=100 → right=100.0, left=0.0."""
+        license_mock = MagicMock()
+        db = _mock_db(license_mock)
+        body = self._valid_body(foot_dominance=100)
+
+        with patch(_PATCH_COMPLETE), \
+             patch(_PATCH_FLAG):
+            _run(lfa_player_onboarding_web_submit(
+                request=self._req(body), db=db, user=_user()
+            ))
+
+        assert license_mock.right_foot_score == 100.0
+        assert license_mock.left_foot_score  == 0.0
+
+    def test_ob04_missing_foot_dominance_defaults_to_50(self):
+        """OB-04: foot_dominance absent → defaults to 50 → right=50.0, left=50.0."""
+        license_mock = MagicMock()
+        db = _mock_db(license_mock)
+        body = self._valid_body(foot_dominance=None)  # key omitted
+        body.pop("foot_dominance", None)
+
+        with patch(_PATCH_COMPLETE), \
+             patch(_PATCH_FLAG):
+            result = _run(lfa_player_onboarding_web_submit(
+                request=self._req(body), db=db, user=_user()
+            ))
+
+        assert result.get("success") is True
+        assert license_mock.right_foot_score == 50.0
+        assert license_mock.left_foot_score  == 50.0
+
+    def test_ob05_foot_dominance_out_of_range_returns_400(self):
+        """OB-05: foot_dominance=101 → 400 JSON error response."""
+        from starlette.responses import JSONResponse
+        db = _mock_db()
+        body = self._valid_body(foot_dominance=101)
+
+        result = _run(lfa_player_onboarding_web_submit(
+            request=self._req(body), db=db, user=_user()
+        ))
+
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == 400
+
+    def test_ob06_foot_dominance_negative_returns_400(self):
+        """OB-06: foot_dominance=-1 → 400 JSON error response."""
+        from starlette.responses import JSONResponse
+        db = _mock_db()
+        body = self._valid_body(foot_dominance=-1)
+
+        result = _run(lfa_player_onboarding_web_submit(
+            request=self._req(body), db=db, user=_user()
+        ))
+
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# JWT handler (/onboarding-submit) — same validation, raises ValueError
+# ---------------------------------------------------------------------------
+
+class TestOnboardingSubmitFootDominance:
+
+    def _req(self, body: dict):
+        r = MagicMock()
+        r.json = AsyncMock(return_value=body)
+        return r
+
+    def _valid_body(self, foot_dominance=50):
+        body = {
+            "position":   "MIDFIELDER",
+            "goals":      "improve_skills",
+            "motivation": "",
+            "skills":     _valid_skills(),
+        }
+        if foot_dominance is not None:
+            body["foot_dominance"] = foot_dominance
+        return body
+
+    def test_jwt_foot_dominance_70_saves_correctly(self):
+        """JWT handler: foot_dominance=70 → right=70.0, left=30.0."""
+        from fastapi import HTTPException
+        license_mock = MagicMock()
+        db = _mock_db(license_mock)
+        body = self._valid_body(foot_dominance=70)
+
+        with patch("app.skills_config.get_all_skill_keys",
+                   return_value=list(body["skills"].keys())), \
+             patch(_PATCH_COMPLETE), \
+             patch(_PATCH_FLAG):
+            result = _run(lfa_player_onboarding_submit(
+                request=self._req(body), db=db, user=_user()
+            ))
+
+        assert result.get("success") is True
+        assert license_mock.right_foot_score == 70.0
+        assert license_mock.left_foot_score  == 30.0
+
+    def test_jwt_foot_dominance_out_of_range_raises_500(self):
+        """JWT handler: foot_dominance=105 → wrapped in 500 HTTPException."""
+        from fastapi import HTTPException
+        db = _mock_db()
+        body = self._valid_body(foot_dominance=105)
+
+        with patch("app.skills_config.get_all_skill_keys",
+                   return_value=list(body["skills"].keys())):
+            with pytest.raises(HTTPException) as exc:
+                _run(lfa_player_onboarding_submit(
+                    request=self._req(body), db=db, user=_user()
+                ))
+        assert exc.value.status_code == 500

--- a/tests/unit/services/test_tournament_lateral_writeback.py
+++ b/tests/unit/services/test_tournament_lateral_writeback.py
@@ -1,0 +1,238 @@
+"""
+Tournament lateral write-back integration tests.
+
+Tests: TW-01 through TW-04, BC-01 through BC-03
+
+Layer: L2 integration — exercises the update_lateral_component +
+aggregate_lateral_components pipeline exactly as the reward orchestrator
+calls it, but without the full ORM/DB stack.
+
+BC tests verify that Layer-1 (badge display) and the standard skill-entry
+interface are unaffected by the lateral write-back.
+"""
+
+import pytest
+from app.services.skill_progression._lateral import (
+    aggregate_lateral_components,
+    update_lateral_component,
+)
+from app.services.skill_progression._formulas import MIN_SKILL_VALUE, MAX_SKILL_CAP
+from app.utils.dominant_foot import calculate_dominant_badge
+
+
+# ---------------------------------------------------------------------------
+# Helpers — replicate the orchestrator's per-skill loop
+# ---------------------------------------------------------------------------
+
+def _entry(current_level=65.0, baseline=60.0):
+    """Minimal skill entry without lateral_components (old-format record)."""
+    return {
+        "baseline":        baseline,
+        "current_level":   current_level,
+        "total_delta":     5.0,
+        "tournament_delta": 0.5,
+        "tournament_count": 3,
+    }
+
+
+def _apply_tournament(entry: dict, foot_ctx: str, delta: float,
+                      right_ft: float | None, left_ft: float | None) -> dict:
+    """Single-pass of the orchestrator's per-skill logic."""
+    entry = update_lateral_component(entry, foot_ctx, delta)
+    agg   = aggregate_lateral_components(entry, right_ft, left_ft)
+    entry["current_level"] = agg
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# TW-01..04 — write-back integration
+# ---------------------------------------------------------------------------
+
+class TestTournamentLateralWriteback:
+
+    def test_tw01_right_foot_tournament_increments_right_count(self):
+        """TW-01: right-foot tournament → lateral_components['right'].tournament_count += 1."""
+        entry = _entry(current_level=65.0)
+        # Seed the right bucket (first contact)
+        entry = _apply_tournament(entry, "right", delta=0.8,
+                                  right_ft=70.0, left_ft=30.0)
+        assert entry["lateral_components"]["right"]["tournament_count"] == 1
+
+        # Second right-foot tournament
+        entry = _apply_tournament(entry, "right", delta=0.5,
+                                  right_ft=70.0, left_ft=30.0)
+        assert entry["lateral_components"]["right"]["tournament_count"] == 2
+
+    def test_tw02_neutral_tournament_first_contact_creates_bucket(self):
+        """TW-02: neutral tournament on a new skill entry → lateral_components['neutral'] created."""
+        entry = _entry(current_level=65.0)
+        entry = _apply_tournament(entry, "neutral", delta=0.6,
+                                  right_ft=50.0, left_ft=50.0)
+
+        assert "lateral_components" in entry
+        assert "neutral" in entry["lateral_components"]
+        comp = entry["lateral_components"]["neutral"]
+        assert comp["tournament_count"] == 1
+        assert comp["level"] == round(65.0 + 0.6, 1)
+        assert comp["last_delta"] == 0.6
+
+    def test_tw03_aggregated_current_level_matches_formula_after_right_and_neutral(self):
+        """TW-03: after right + neutral tournaments, current_level == weighted formula result."""
+        entry = _entry(current_level=65.0)
+        right_ft, left_ft = 70.0, 30.0
+        R = right_ft / (right_ft + left_ft)   # 0.7
+
+        # First: right-foot tournament
+        entry = _apply_tournament(entry, "right", delta=1.0,
+                                  right_ft=right_ft, left_ft=left_ft)
+        right_level = entry["lateral_components"]["right"]["level"]   # 66.0
+
+        # Second: neutral tournament
+        entry = _apply_tournament(entry, "neutral", delta=0.5,
+                                  right_ft=right_ft, left_ft=left_ft)
+        neutral_level = entry["lateral_components"]["neutral"]["level"]  # seeded from post-right current_level + 0.5
+
+        # Expected aggregation: (R * right + 1.0 * neutral) / (R + 1.0)
+        expected = round((R * right_level + 1.0 * neutral_level) / (R + 1.0), 1)
+        assert entry["current_level"] == expected
+
+    def test_tw04_old_record_neutral_tournament_current_level_shifts_by_delta(self):
+        """TW-04: old record (no lateral_components) + neutral tournament →
+        current_level changes by exactly the delta on first contact."""
+        delta = 0.8
+        start_level = 65.0
+        entry = _entry(current_level=start_level)
+
+        entry = _apply_tournament(entry, "neutral", delta=delta,
+                                  right_ft=50.0, left_ft=50.0)
+
+        # With balanced scores (R=L=0.5) and only neutral component:
+        # current_level = neutral.level = clamp(start + delta)
+        expected = round(start_level + delta, 1)
+        assert entry["current_level"] == expected
+
+    def test_tw04b_old_record_gains_lateral_components_on_first_tournament(self):
+        """TW-04b: old record gets lateral_components key after first tournament."""
+        entry = _entry(current_level=65.0)
+        assert "lateral_components" not in entry
+
+        entry = _apply_tournament(entry, "right", delta=0.4,
+                                  right_ft=68.0, left_ft=32.0)
+
+        assert "lateral_components" in entry
+
+    def test_tw05_negative_delta_decreases_component_and_current_level(self):
+        """TW-05: bad tournament result (negative delta) decreases both bucket and aggregated level."""
+        entry = _entry(current_level=65.0)
+        # Seed with one good neutral tournament first
+        entry = _apply_tournament(entry, "neutral", delta=1.0,
+                                  right_ft=50.0, left_ft=50.0)
+        level_after_good = entry["current_level"]
+
+        # Now a bad neutral tournament
+        entry = _apply_tournament(entry, "neutral", delta=-2.0,
+                                  right_ft=50.0, left_ft=50.0)
+        assert entry["current_level"] < level_after_good
+
+    def test_tw06_right_dominant_player_weights_right_component_more(self):
+        """TW-06: right-dominant player (R=0.8) with separate right and left tournaments →
+        current_level is closer to right_level than to left_level."""
+        entry = _entry(current_level=65.0)
+        right_ft, left_ft = 80.0, 20.0
+
+        # One right-foot tournament (good result)
+        entry = _apply_tournament(entry, "right", delta=2.0,
+                                  right_ft=right_ft, left_ft=left_ft)
+        right_level = entry["lateral_components"]["right"]["level"]  # 67.0
+
+        # One left-foot tournament (poor result — level seeded from current_level at that point)
+        pre_left = entry["current_level"]
+        entry = _apply_tournament(entry, "left", delta=-1.5,
+                                  right_ft=right_ft, left_ft=left_ft)
+        left_level = entry["lateral_components"]["left"]["level"]
+
+        # R=0.8 → current_level must be closer to right_level
+        dist_to_right = abs(entry["current_level"] - right_level)
+        dist_to_left  = abs(entry["current_level"] - left_level)
+        assert dist_to_right < dist_to_left
+
+
+# ---------------------------------------------------------------------------
+# BC-01..03 — backward compatibility
+# ---------------------------------------------------------------------------
+
+class TestBackwardCompatibility:
+
+    def test_bc01_dominant_badge_right_footed(self):
+        """BC-01a: right-footed player (70/30) → badge 'Rl'."""
+        assert calculate_dominant_badge(70.0, 30.0) == "Rl"
+
+    def test_bc01_dominant_badge_left_footed(self):
+        """BC-01b: left-footed player (25/75) → badge 'rL'."""
+        assert calculate_dominant_badge(25.0, 75.0) == "rL"
+
+    def test_bc01_dominant_badge_balanced(self):
+        """BC-01c: balanced player (50/50) → badge 'RL'."""
+        assert calculate_dominant_badge(50.0, 50.0) == "RL"
+
+    def test_bc01_dominant_badge_unassessed(self):
+        """BC-01d: no scores (None/None) → badge 'rl'."""
+        assert calculate_dominant_badge(None, None) == "rl"
+
+    def test_bc02_update_lateral_component_preserves_standard_entry_keys(self):
+        """BC-02: update_lateral_component does not delete standard skill-entry keys
+        that get_skill_profile / the dashboard expect."""
+        entry = {
+            "baseline":         60.0,
+            "current_level":    65.0,
+            "total_delta":      5.0,
+            "tournament_delta": 0.5,
+            "tournament_count": 3,
+        }
+        updated = update_lateral_component(entry, "neutral", delta=0.7)
+
+        for key in ("baseline", "current_level", "total_delta", "tournament_delta", "tournament_count"):
+            assert key in updated, f"Expected key '{key}' preserved after update_lateral_component"
+
+    def test_bc02_aggregate_does_not_mutate_entry(self):
+        """BC-02b: aggregate_lateral_components is a pure read — it must not mutate the entry dict."""
+        entry = _entry(current_level=65.0)
+        entry_with = dict(entry)
+        entry_with["lateral_components"] = {"neutral": {"level": 65.0, "tournament_count": 1,
+                                                         "total_delta": 0.5, "last_delta": 0.5}}
+        original_keys = set(entry_with.keys())
+
+        _ = aggregate_lateral_components(entry_with, 50.0, 50.0)
+
+        assert set(entry_with.keys()) == original_keys
+
+    def test_bc03_neutral_preset_old_record_monotone_with_delta(self):
+        """BC-03: neutral preset on an old record (no lateral_components) —
+        current_level changes monotonically with the EMA delta direction."""
+        positive_delta = 0.9
+        negative_delta = -0.9
+        base = 65.0
+
+        entry_up = _apply_tournament(_entry(base), "neutral", positive_delta, 50.0, 50.0)
+        entry_dn = _apply_tournament(_entry(base), "neutral", negative_delta, 50.0, 50.0)
+
+        assert entry_up["current_level"] > base
+        assert entry_dn["current_level"] < base
+
+    def test_bc03b_zero_delta_does_not_change_current_level(self):
+        """BC-03b: delta=0.0 on a fresh record → current_level unchanged at start_level."""
+        start_level = 65.0
+        entry = _apply_tournament(_entry(start_level), "neutral", 0.0, 50.0, 50.0)
+        assert entry["current_level"] == start_level
+
+    def test_bc04_lateral_functions_do_not_import_from_ema_or_badge(self):
+        """BC-04: _lateral.py must not depend on _ema_engine or dominant_foot
+        — enforced by checking the module's import graph at import time."""
+        import sys
+        # If the module imported cleanly (it's already in sys.modules at this point)
+        # without pulling in _ema_engine, the layer boundary holds.
+        assert "app.services.skill_progression._ema_engine" not in (
+            getattr(sys.modules.get("app.services.skill_progression._lateral"), "__dict__", {})
+        ), "Layer 2 must not import Layer 3 (_ema_engine)"
+        # Verify the module itself is loaded
+        assert "app.services.skill_progression._lateral" in sys.modules


### PR DESCRIPTION
## Summary

- **New module `_lateral.py`** (Layer 2): `update_lateral_component` routes EMA deltas into foot-context buckets (`right`/`left`/`neutral`) per skill; `aggregate_lateral_components` recomputes `current_level` as a weighted blend `(R·right + L·left + 1.0·neutral) / (R+L+1.0)`, clamped to [40.0, 99.0]. Falls back to existing `current_level` for old records (zero regression risk on existing data).
- **Onboarding**: both handlers (`/onboarding-web`, `/onboarding-submit`) accept `foot_dominance` slider (0–100). Default 50/50. Out-of-range returns HTTP 400 / ValueError→500. Slider UI injected into step 6 of `lfa_player_onboarding.html`.
- **Migrations**: `2026_05_01_1100` adds `tournament_participations.foot_context` (VARCHAR 10, NOT NULL, DEFAULT 'neutral', CHECK IN); `2026_05_01_1200` adds range CHECK constraints on `user_licenses.right_foot_score` / `left_foot_score`. Both idempotent and fully reversible.

## Changed files

| File | Change |
|------|--------|
| `app/services/skill_progression/_lateral.py` | **NEW** — L2 aggregation module |
| `app/services/skill_progression/__init__.py` | exports `update_lateral_component`, `aggregate_lateral_components` |
| `app/models/game_preset.py` | `foot_context` @property |
| `app/models/tournament_achievement.py` | `TournamentParticipation.foot_context` column |
| `app/services/tournament/tournament_participation_service.py` | resolves foot_context from game preset at participation create/update |
| `app/services/tournament/tournament_reward_orchestrator.py` | routes EMA delta through lateral write-back loop |
| `app/api/web_routes/onboarding.py` | foot_dominance validation + right/left score assignment |
| `app/templates/lfa_player_onboarding.html` | foot-dominance slider (step 6) |
| `alembic/versions/2026_05_01_1100_*` | migration: foot_context column |
| `alembic/versions/2026_05_01_1200_*` | migration: foot score CHECK constraints |

## Tests

65 new unit tests, **4 204 passed / 0 failed** on local run:

| File | Tests | Scope |
|------|-------|-------|
| `test_lateral_aggregation.py` | 21 | LA-01..14 + update fn — pure Python, no DB |
| `test_foot_context_constraints.py` | 14 | FC-01..07 — DB CHECK constraints |
| `test_onboarding_foot_dominance.py` | 8 | OB-01..06 — both onboarding handlers |
| `test_tournament_lateral_writeback.py` | 22 | TW-01..06 integration + BC-01..04 backward compat |

## Test plan

- [ ] `api-smoke-tests` — all 1 737 smoke endpoints green
- [ ] `skill-weight-regression` — EMA delta / placement formula unchanged
- [ ] `test-baseline-check` — no existing skill baseline regression
- [ ] `tournament-type-matrix` — all tournament types still resolve correctly
- [ ] `team-enrollment-integration` — lateral foot_context column doesn't break team flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)