### PR TITLE
feat(semester): add PROMOTION_EVENT to SemesterCategory (Phase 1)

### DIFF
--- a/alembic/versions/2026_05_02_1000_add_promotion_event_semester_category.py
+++ b/alembic/versions/2026_05_02_1000_add_promotion_event_semester_category.py
@@ -1,0 +1,70 @@
+"""add PROMOTION_EVENT value to semester_category_type enum
+
+Revision ID: 2026_05_02_1000
+Revises: 2026_05_01_1200
+Create Date: 2026-05-02 10:00:00.000000
+
+Adds PROMOTION_EVENT to the semester_category_type PostgreSQL ENUM.
+
+PROMOTION_EVENT semesters reuse the full Tournament/Semester pipeline
+(tournament_status, TournamentConfiguration, reward and ranking pipeline).
+The new value enables clean filtering in admin lists and the events hub
+without touching any backend business logic.
+
+Deployment order:
+  1. Run this migration (ALTER TYPE ADD VALUE)
+  2. Deploy application code (which now recognises PROMOTION_EVENT)
+  3. Run scripts/migrate_promo_events_category.py --dry-run
+  4. Run scripts/migrate_promo_events_category.py --apply
+
+Downgrade:
+  PostgreSQL does not support ALTER TYPE DROP VALUE.
+  The downgrade script reverts data then rebuilds the enum type from scratch.
+  Only run downgrade if no rows have semester_category = 'PROMOTION_EVENT'.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '2026_05_02_1000'
+down_revision = '2026_05_01_1200'
+branch_labels = None
+depends_on = None
+
+_ENUM_NAME = 'semester_category_type'
+_ENUM_VALUES_OLD = ('ACADEMY_SEASON', 'MINI_SEASON', 'TOURNAMENT', 'CAMP')
+_ENUM_VALUES_NEW = ('ACADEMY_SEASON', 'MINI_SEASON', 'TOURNAMENT', 'CAMP', 'PROMOTION_EVENT')
+
+
+def upgrade() -> None:
+    # ALTER TYPE ... ADD VALUE is transactional on PostgreSQL 12+.
+    # IF NOT EXISTS makes it safe to re-run (idempotent).
+    op.execute(
+        "ALTER TYPE semester_category_type ADD VALUE IF NOT EXISTS 'PROMOTION_EVENT'"
+    )
+
+
+def downgrade() -> None:
+    # PostgreSQL has no DROP VALUE — must rebuild the enum type.
+    # Step 1: revert any PROMOTION_EVENT rows to TOURNAMENT before removing the value.
+    op.execute(
+        "UPDATE semesters SET semester_category = 'TOURNAMENT' "
+        "WHERE semester_category = 'PROMOTION_EVENT'"
+    )
+    # Step 2: detach column from the enum type.
+    op.execute(
+        "ALTER TABLE semesters "
+        "ALTER COLUMN semester_category TYPE TEXT"
+    )
+    # Step 3: drop old enum type (now has no dependents).
+    op.execute("DROP TYPE semester_category_type")
+    # Step 4: recreate without PROMOTION_EVENT.
+    op.execute(
+        "CREATE TYPE semester_category_type AS ENUM "
+        "('ACADEMY_SEASON', 'MINI_SEASON', 'TOURNAMENT', 'CAMP')"
+    )
+    # Step 5: restore column to enum type.
+    op.execute(
+        "ALTER TABLE semesters "
+        "ALTER COLUMN semester_category TYPE semester_category_type "
+        "USING semester_category::semester_category_type"
+    )

--- a/app/api/web_routes/admin/analytics.py
+++ b/app/api/web_routes/admin/analytics.py
@@ -335,7 +335,10 @@ async def admin_events_hub_page(
         or_(
             Semester.code.like("TOURN-%"),
             Semester.code.like("OPS-%"),
-            Semester.semester_category == SemesterCategory.TOURNAMENT,
+            Semester.semester_category.in_([
+                SemesterCategory.TOURNAMENT,
+                SemesterCategory.PROMOTION_EVENT,
+            ]),
         ),
         Semester.status != SemesterStatus.CANCELLED,
     ).scalar() or 0
@@ -361,7 +364,11 @@ async def admin_events_hub_page(
 
     upcoming_events = db.query(Semester).filter(
         or_(
-            Semester.semester_category.in_([SemesterCategory.TOURNAMENT, SemesterCategory.CAMP]),
+            Semester.semester_category.in_([
+                SemesterCategory.TOURNAMENT,
+                SemesterCategory.CAMP,
+                SemesterCategory.PROMOTION_EVENT,
+            ]),
             Semester.code.like("TOURN-%"),
             Semester.code.like("OPS-%"),
         ),

--- a/app/api/web_routes/admin/clubs.py
+++ b/app/api/web_routes/admin/clubs.py
@@ -421,10 +421,10 @@ async def admin_club_promotion(
         extra={"admin": user.email, "club": club.name, "age_groups": age_groups, "tournament_ids": created_ids},
     )
 
-    # Redirect to tournaments list; flash is shown via query param
+    # Redirect to promotion events list; flash is shown via query param
     names_enc = "+".join(ag.replace(" ", "_") for ag in age_groups)
     return RedirectResponse(
-        url=f"/admin/tournaments?flash=Promotion+tournaments+created+for+{names_enc}",
+        url=f"/admin/promotion-events?flash=Promotion+tournaments+created+for+{names_enc}",
         status_code=303,
     )
 

--- a/app/api/web_routes/admin/clubs.py
+++ b/app/api/web_routes/admin/clubs.py
@@ -366,7 +366,7 @@ async def admin_club_promotion(
             end_date=date.fromisoformat(end_date),
             status=SemesterStatus.DRAFT,
             tournament_status="DRAFT",
-            semester_category=SemesterCategory.TOURNAMENT,
+            semester_category=SemesterCategory.PROMOTION_EVENT,
             specialization_type="LFA_FOOTBALL_PLAYER",
             age_group=_normalize_club_age_group(ag),  # U15 → YOUTH, U12 → PRE, etc.
             enrollment_cost=0,
@@ -475,9 +475,9 @@ async def admin_teams_page(
     """Admin: global teams list, filterable by tournament."""
     _admin_guard(user)
 
-    # All tournaments for filter dropdown (TEAM participant type)
+    # All tournaments + promotion events for filter dropdown (TEAM participant type)
     tournaments = db.query(Semester).filter(
-        Semester.semester_category == SemesterCategory.TOURNAMENT,
+        Semester.semester_category.in_([SemesterCategory.TOURNAMENT, SemesterCategory.PROMOTION_EVENT]),
     ).order_by(Semester.start_date.desc()).all()
 
     if tournament_filter:

--- a/app/api/web_routes/admin/locations.py
+++ b/app/api/web_routes/admin/locations.py
@@ -386,12 +386,15 @@ async def admin_location_events_page(
     campus_ids = [c.id for c in campuses]
     campus_map = {c.id: c for c in campuses}
 
-    # Tournaments (TOURNAMENT category OR legacy TOURN-/OPS- codes) at this location
+    # Tournaments and promotion events at this location.
     tournaments = (
         db.query(Semester)
         .filter(
             or_(
-                Semester.semester_category == SemesterCategory.TOURNAMENT,
+                Semester.semester_category.in_([
+                    SemesterCategory.TOURNAMENT,
+                    SemesterCategory.PROMOTION_EVENT,
+                ]),
                 Semester.code.like("TOURN-%"),
                 Semester.code.like("OPS-%"),
             ),

--- a/app/api/web_routes/admin/semesters.py
+++ b/app/api/web_routes/admin/semesters.py
@@ -216,7 +216,7 @@ async def admin_semester_edit_dispatch(
     if not sem:
         raise HTTPException(status_code=404, detail="Semester not found")
     is_tournament = (
-        sem.semester_category == SemesterCategory.TOURNAMENT
+        sem.semester_category in (SemesterCategory.TOURNAMENT, SemesterCategory.PROMOTION_EVENT)
         or (sem.code or "").startswith("TOURN-")
         or (sem.code or "").startswith("OPS-")
     )

--- a/app/api/web_routes/dashboard.py
+++ b/app/api/web_routes/dashboard.py
@@ -261,7 +261,10 @@ async def dashboard(
         quick_stats = {
             "active_semesters": db.query(Semester).filter(
                 Semester.status == SemesterStatus.ONGOING,
-                Semester.semester_category != SemesterCategory.TOURNAMENT
+                Semester.semester_category.notin_([
+                    SemesterCategory.TOURNAMENT,
+                    SemesterCategory.PROMOTION_EVENT,
+                ])
             ).count(),
             "enrolled_students": db.query(SemesterEnrollment).filter(
                 SemesterEnrollment.request_status == EnrollmentStatus.APPROVED

--- a/app/api/web_routes/events.py
+++ b/app/api/web_routes/events.py
@@ -52,6 +52,13 @@ async def events_hub(
         Semester.end_date >= today,
     ).count()
 
+    promos_open = db.query(Semester).filter(
+        Semester.semester_category == SemesterCategory.PROMOTION_EVENT,
+        Semester.tournament_status.in_(["ENROLLMENT_OPEN", "IN_PROGRESS"]),
+        Semester.status != SemesterStatus.CANCELLED,
+        Semester.end_date >= today,
+    ).count()
+
     spec_value = user.specialization.value if user.specialization else None
 
     academy_available = 0
@@ -84,6 +91,7 @@ async def events_hub(
             **_spec_ctx(user, db),
             "camps_open": camps_open,
             "tournaments_open": tournaments_open,
+            "promos_open": promos_open,
             "academy_available": academy_available,
             "mini_available": mini_available,
             "my_active_enrollments": my_active,

--- a/app/api/web_routes/tournaments/lifecycle.py
+++ b/app/api/web_routes/tournaments/lifecycle.py
@@ -31,17 +31,15 @@ async def admin_promotion_events_list(
     db: Session = Depends(get_db),
     user: User = Depends(get_current_user_web),
 ):
-    """Admin: list all promotion tournaments (TEAM and INDIVIDUAL)."""
+    """Admin: list all promotion events (PROMOTION_EVENT category)."""
     _admin_only(user)
 
-    # All TOURNAMENT-category semesters — both TEAM and INDIVIDUAL participant types.
+    # All semesters in the dedicated PROMOTION_EVENT category.
+    # participant_type filter no longer needed — the category is the discriminator.
     promotions = (
         db.query(Semester)
-        .join(TournamentConfiguration,
-              TournamentConfiguration.semester_id == Semester.id)
         .filter(
-            Semester.semester_category == SemesterCategory.TOURNAMENT,
-            TournamentConfiguration.participant_type.in_(["TEAM", "INDIVIDUAL"]),
+            Semester.semester_category == SemesterCategory.PROMOTION_EVENT,
         )
         .order_by(Semester.start_date.desc(), Semester.name.asc(), Semester.id.asc())
         .all()

--- a/app/models/semester.py
+++ b/app/models/semester.py
@@ -20,10 +20,11 @@ class SemesterStatus(str, enum.Enum):
 
 class SemesterCategory(str, enum.Enum):
     """Top-level category for a semester, drives access control and reporting."""
-    ACADEMY_SEASON = "ACADEMY_SEASON"  # Jul-Jun multi-month program
-    MINI_SEASON = "MINI_SEASON"        # Short academy season (4-8 weeks)
-    TOURNAMENT = "TOURNAMENT"          # Competitive tournament
-    CAMP = "CAMP"                      # Short-term intensive camp (e.g. summer/winter camp)
+    ACADEMY_SEASON  = "ACADEMY_SEASON"   # Jul-Jun multi-month program
+    MINI_SEASON     = "MINI_SEASON"      # Short academy season (4-8 weeks)
+    TOURNAMENT      = "TOURNAMENT"       # Competitive tournament
+    CAMP            = "CAMP"             # Short-term intensive camp (e.g. summer/winter camp)
+    PROMOTION_EVENT = "PROMOTION_EVENT"  # Scouting / showcase event (uses tournament pipeline, separate UI)
 
 
 # Many-to-many association table for additional instructors
@@ -75,7 +76,7 @@ class Semester(Base):
         Enum(SemesterCategory, name='semester_category_type'),
         nullable=True,
         index=True,
-        comment="Program category: ACADEMY_SEASON | MINI_SEASON | TOURNAMENT | CAMP"
+        comment="Program category: ACADEMY_SEASON | MINI_SEASON | TOURNAMENT | CAMP | PROMOTION_EVENT"
     )
     parent_semester_id = Column(
         Integer,

--- a/app/templates/events_hub.html
+++ b/app/templates/events_hub.html
@@ -164,6 +164,20 @@
             </div>
         </a>
 
+        {# ── Promotion Events ─────────────────────────────────────────────── #}
+        <a href="/events/promotions" class="event-cat-card" style="--cat-color: #e74c3c;">
+            <div class="cat-icon">🎯</div>
+            <div class="cat-title">Promotion Events</div>
+            <div class="cat-desc">Scouting and showcase events — get seen by coaches and clubs.</div>
+            <div class="cat-counter {% if promos_open == 0 %}none{% endif %}">
+                {% if promos_open > 0 %}
+                    {{ promos_open }} event{{ 's' if promos_open != 1 }} open
+                {% else %}
+                    No events open right now
+                {% endif %}
+            </div>
+        </a>
+
         {# ── Academy Season ───────────────────────────────────────────────── #}
         <a href="/semesters/enroll?category=ACADEMY_SEASON" class="event-cat-card" style="--cat-color: #3498db;">
             <div class="cat-icon">🎓</div>

--- a/scripts/e2e_lifecycle_visibility_test.py
+++ b/scripts/e2e_lifecycle_visibility_test.py
@@ -423,7 +423,7 @@ def _promotion_wizard(club_id, campus_id, tt_id, age_group, name_prefix):
             "age_groups": [age_group],
         },
     )
-    _assert_redirect_ok(resp, "/admin/tournaments", f"Promotion wizard ({age_group})")
+    _assert_redirect_ok(resp, "/admin/promotion-events", f"Promotion wizard ({age_group})")
     t = _get_tournament(name_prefix)
     info(
         f"Tournament: id={t.id}  name={t.name!r}  "

--- a/scripts/e2e_matrix_test.py
+++ b/scripts/e2e_matrix_test.py
@@ -302,7 +302,7 @@ def _create_team_tournament(club_id, campus_id, tt_id, age_group, label, name_pr
             "age_groups": [age_group],
         },
     )
-    _assert_redirect(resp, "/admin/tournaments", f"Promotion wizard ({label})")
+    _assert_redirect(resp, "/admin/promotion-events", f"Promotion wizard ({label})")
     t = _get_tournament_after_promotion(name_prefix)
     info(f"Tournament: id={t.id}  name={t.name!r}  status={t.tournament_status}")
     return t.id

--- a/scripts/e2e_promo_flow_test.py
+++ b/scripts/e2e_promo_flow_test.py
@@ -228,7 +228,7 @@ def run() -> None:
                 "age_groups": ["U12", "U15"],
             },
         )
-        assert_redirect(resp, "/admin/tournaments", "Promotion wizard")
+        assert_redirect(resp, "/admin/promotion-events", "Promotion wizard")
 
         _db.expire_all()
         tournaments = _db.query(Semester).filter(

--- a/scripts/migrate_promo_events_category.py
+++ b/scripts/migrate_promo_events_category.py
@@ -1,0 +1,190 @@
+"""
+Data migration: reclassify Promotion Event semesters.
+
+Updates all Semester records where:
+  - code LIKE 'PROMO-%'  (the promo event code prefix set by clubs admin)
+  - semester_category = 'TOURNAMENT'  (old classification)
+
+to:
+  - semester_category = 'PROMOTION_EVENT'  (new dedicated category)
+
+No other records are touched. TournamentConfiguration, SemesterEnrollment,
+reward/ranking pipeline, and tournament_status are all unchanged.
+
+Modes
+-----
+  --dry-run   (default) — list affected records, make no changes
+  --apply     — execute UPDATE and commit
+  --rollback  — revert: set PROMOTION_EVENT → TOURNAMENT for emergency rollback
+
+Usage
+-----
+  DATABASE_URL="..." python scripts/migrate_promo_events_category.py           # dry-run
+  DATABASE_URL="..." python scripts/migrate_promo_events_category.py --apply
+  DATABASE_URL="..." python scripts/migrate_promo_events_category.py --rollback
+
+Deployment order
+----------------
+  1. alembic upgrade head        (adds PROMOTION_EVENT enum value)
+  2. deploy application code     (code recognises PROMOTION_EVENT)
+  3. python ... --dry-run        (verify which records will move)
+  4. python ... --apply          (execute the migration)
+"""
+import sys
+import os
+import argparse
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from sqlalchemy.orm import Session
+
+from app.database import SessionLocal
+from app.models.semester import Semester, SemesterCategory
+
+
+# ── Criteria ──────────────────────────────────────────────────────────────────
+
+def _promo_candidates(db: Session):
+    """Records matching the migration criteria (not yet reclassified)."""
+    return (
+        db.query(Semester)
+        .filter(
+            Semester.code.like("PROMO-%"),
+            Semester.semester_category == SemesterCategory.TOURNAMENT,
+        )
+        .order_by(Semester.start_date.desc(), Semester.id.asc())
+        .all()
+    )
+
+
+def _already_reclassified(db: Session):
+    """Records already in PROMOTION_EVENT category."""
+    return (
+        db.query(Semester)
+        .filter(Semester.semester_category == SemesterCategory.PROMOTION_EVENT)
+        .order_by(Semester.start_date.desc(), Semester.id.asc())
+        .all()
+    )
+
+
+def _tournament_non_promo(db: Session):
+    """TOURNAMENT records whose code does NOT start with PROMO- (shown for audit, never touched)."""
+    return (
+        db.query(Semester)
+        .filter(
+            Semester.semester_category == SemesterCategory.TOURNAMENT,
+            ~Semester.code.like("PROMO-%"),
+        )
+        .count()
+    )
+
+
+# ── Dry-run ───────────────────────────────────────────────────────────────────
+
+def _dry_run(db: Session) -> None:
+    candidates = _promo_candidates(db)
+    already    = _already_reclassified(db)
+    non_promo  = _tournament_non_promo(db)
+
+    print("=" * 70)
+    print("DRY RUN — Promotion Event category migration")
+    print("Criteria: code LIKE 'PROMO-%' AND semester_category = 'TOURNAMENT'")
+    print("=" * 70)
+
+    if candidates:
+        print(f"\n[{len(candidates)}] records will be reclassified → PROMOTION_EVENT:\n")
+        for s in candidates:
+            print(f"  [{s.id:>5}]  {s.code:<45}  status={s.tournament_status or s.status.value!r:<20}  \"{s.name}\"")
+    else:
+        print("\n  No records match the criteria — nothing to migrate.")
+
+    if already:
+        print(f"\n[{len(already)}] records already have semester_category = PROMOTION_EVENT (skipped):\n")
+        for s in already:
+            print(f"  [{s.id:>5}]  {s.code}")
+
+    print(f"\n[audit]  TOURNAMENT records with non-PROMO- codes (will NOT be touched): {non_promo}")
+    print()
+    if candidates:
+        print("To apply:    python scripts/migrate_promo_events_category.py --apply")
+    print("To rollback: python scripts/migrate_promo_events_category.py --rollback")
+
+
+# ── Apply ─────────────────────────────────────────────────────────────────────
+
+def _apply(db: Session) -> None:
+    candidates = _promo_candidates(db)
+
+    if not candidates:
+        print("No records match the migration criteria. Nothing to do.")
+        return
+
+    print(f"Reclassifying {len(candidates)} record(s) → PROMOTION_EVENT …")
+    for s in candidates:
+        print(f"  [{s.id:>5}]  {s.code}  \"{s.name}\"")
+        s.semester_category = SemesterCategory.PROMOTION_EVENT
+
+    db.commit()
+
+    # Verify
+    remaining = _promo_candidates(db)
+    reclassified = _already_reclassified(db)
+    print(f"\n✅  Done.")
+    print(f"    Reclassified: {len(candidates)}")
+    print(f"    PROMOTION_EVENT total now: {len(reclassified)}")
+    print(f"    PROMO- records still as TOURNAMENT: {len(remaining)}  (should be 0)")
+
+
+# ── Rollback ──────────────────────────────────────────────────────────────────
+
+def _rollback(db: Session) -> None:
+    targets = _already_reclassified(db)
+
+    if not targets:
+        print("No PROMOTION_EVENT records found. Nothing to roll back.")
+        return
+
+    print(f"ROLLBACK: reverting {len(targets)} record(s) PROMOTION_EVENT → TOURNAMENT …")
+    for s in targets:
+        print(f"  [{s.id:>5}]  {s.code}  \"{s.name}\"")
+        s.semester_category = SemesterCategory.TOURNAMENT
+
+    db.commit()
+    print(f"\n✅  Rollback complete. {len(targets)} records restored to TOURNAMENT.")
+
+
+# ── Entry point ───────────────────────────────────────────────────────────────
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Reclassify PROMO-* semesters to PROMOTION_EVENT category."
+    )
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--dry-run",  dest="mode", action="store_const", const="dry",
+                       help="List affected records without making changes (default)")
+    group.add_argument("--apply",    dest="mode", action="store_const", const="apply",
+                       help="Execute the UPDATE and commit")
+    group.add_argument("--rollback", dest="mode", action="store_const", const="rollback",
+                       help="Revert PROMOTION_EVENT records back to TOURNAMENT")
+    parser.set_defaults(mode="dry")
+    args = parser.parse_args()
+
+    db: Session = SessionLocal()
+    try:
+        if args.mode == "dry":
+            _dry_run(db)
+        elif args.mode == "apply":
+            _apply(db)
+        elif args.mode == "rollback":
+            _rollback(db)
+    except Exception:
+        db.rollback()
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/e2e/admin_ui/test_promotion_flow_e2e.py
+++ b/tests/e2e/admin_ui/test_promotion_flow_e2e.py
@@ -5,7 +5,7 @@ Playwright E2E — Club & Promotion Flow (PROMO-01..05)
   PROMO-01  Admin creates a club via UI modal → club appears in list
   PROMO-02  Admin uploads CSV → import result panel shows correct created/updated counts
   PROMO-03  CSV with an invalid row → error count visible, valid rows processed
-  PROMO-04  Promotion wizard: 2 age groups → 2 Semester(TOURNAMENT) rows in DB
+  PROMO-04  Promotion wizard: 2 age groups → 2 Semester(PROMOTION_EVENT) rows in DB
   PROMO-05  Created tournaments each have teams enrolled (TournamentTeamEnrollment)
 
 Run (CI / headless, with video):
@@ -416,9 +416,9 @@ class TestPromo04And05PromotionWizard:
 
             # Submit the promotion wizard
             page.click("#promotion-modal button[type=submit]")
-            # Wait for redirect to /admin/tournaments
+            # Wait for redirect to /admin/promotion-events
             page.wait_for_url(
-                lambda url: "/admin/tournaments" in url,
+                lambda url: "/admin/promotion-events" in url,
                 timeout=20_000,
             )
             page.wait_for_load_state("networkidle")
@@ -427,18 +427,18 @@ class TestPromo04And05PromotionWizard:
             content = page.content()
             assert "Internal Server Error" not in content
 
-            # ── PROMO-04: verify 2 tournaments in DB ──────────────────────────
+            # ── PROMO-04: verify 2 promotion events in DB ─────────────────────
             db_session.expire_all()
             tournaments = (
                 db_session.query(Semester)
                 .filter(
-                    Semester.semester_category == SemesterCategory.TOURNAMENT,
+                    Semester.semester_category == SemesterCategory.PROMOTION_EVENT,
                     Semester.name.like(f"{club.name}%"),
                 )
                 .all()
             )
             assert len(tournaments) == 2, (
-                f"Expected 2 promotion tournaments, found {len(tournaments)}"
+                f"Expected 2 promotion events, found {len(tournaments)}"
             )
             age_labels = {t.age_group for t in tournaments}
             # U12 → PRE, U15 → YOUTH via _normalize_club_age_group()
@@ -617,26 +617,26 @@ class TestPromo00GoldenPath:
                 u15_cb.first.check()
 
             page.click("#promotion-modal button[type=submit]")
-            page.wait_for_url(lambda url: "/admin/tournaments" in url, timeout=20_000)
+            page.wait_for_url(lambda url: "/admin/promotion-events" in url, timeout=20_000)
             page.wait_for_load_state("networkidle")
-            _ss(page, "00g_tournaments_page")
+            _ss(page, "00g_promotion_events_page")
 
             content = page.content()
             assert "Internal Server Error" not in content
             assert tourn_name in content or "Promotion tournaments created" in content, \
-                "Expected tournament name or success banner on /admin/tournaments"
+                "Expected tournament name or success banner on /admin/promotion-events"
 
             # ── 8. DB assertions ──────────────────────────────────────────────
             db_session.expire_all()
             tournaments = (
                 db_session.query(Semester)
                 .filter(
-                    Semester.semester_category == SemesterCategory.TOURNAMENT,
+                    Semester.semester_category == SemesterCategory.PROMOTION_EVENT,
                     Semester.name.like(f"{club_name}%"),
                 )
                 .all()
             )
-            assert len(tournaments) == 1, f"Expected 1 tournament, found {len(tournaments)}"
+            assert len(tournaments) == 1, f"Expected 1 promotion event, found {len(tournaments)}"
             # U15 → mapped to YOUTH by _normalize_club_age_group()
             assert tournaments[0].age_group == "YOUTH", (
                 f"Expected Semester.age_group='YOUTH' (U15 normalized), got '{tournaments[0].age_group}'"

--- a/tests/integration/web_flows/test_club_csv_import.py
+++ b/tests/integration/web_flows/test_club_csv_import.py
@@ -8,7 +8,7 @@ Club CSV Import Integration Tests — CLUB-01 through CLUB-08
   CLUB-05  CSV duplicate email → user name/position UPDATE (no duplicate user)
   CLUB-06  initial_credits > 0 → CreditTransaction created
   CLUB-07  initial_credits idempotency → second import does NOT create duplicate tx
-  CLUB-08  Promotion wizard → N tournaments created, teams enrolled per age_group
+  CLUB-08  Promotion wizard → N promotion events created (PROMOTION_EVENT), teams enrolled per age_group
 
 DONE = pytest tests/integration/web_flows/test_club_csv_import.py -v
 """
@@ -438,15 +438,15 @@ class TestPromotionWizard:
                 follow_redirects=False,
             )
             assert resp.status_code == 303
-            assert "/admin/tournaments" in resp.headers.get("location", "")
+            assert "/admin/promotion-events" in resp.headers.get("location", "")
         finally:
             app.dependency_overrides.clear()
 
-        # 2 tournaments created
+        # 2 promotion events created
         tournaments = (
             test_db.query(Semester)
             .filter(
-                Semester.semester_category == SemesterCategory.TOURNAMENT,
+                Semester.semester_category == SemesterCategory.PROMOTION_EVENT,
                 Semester.name.like("Vasas Cup 2026%"),
             )
             .all()

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -25581,7 +25581,7 @@
     },
     "/admin/promotion-events": {
       "get": {
-        "description": "Admin: list all promotion tournaments (TEAM and INDIVIDUAL).",
+        "description": "Admin: list all promotion events (PROMOTION_EVENT category).",
         "operationId": "admin_promotion_events_list_admin_promotion_events_get",
         "responses": {
           "200": {


### PR DESCRIPTION
## Summary

Introduces `SemesterCategory.PROMOTION_EVENT` as a stable classification for scouting and showcase events. No new backend domain — promotion events continue to use the full Tournament/Semester pipeline. The difference is now expressed at the category, admin listing, and discovery layer only.

## Why not a new backend domain

Promotion events share the entire existing infrastructure:
- `Semester` + `TournamentConfiguration` + `TournamentRewardConfig`
- `tournament_status` lifecycle + `status_validator`
- `Session`, `TournamentRanking`, `TournamentParticipation`
- `calculate_and_store_rankings()` + `distribute_rewards_for_tournament()`

A separate `SemesterCategory.PROMOTION_EVENT` value is the minimal stable discriminator that allows clean filtering at every layer (admin lists, user discovery, counters) without duplicating any business logic.

## Modified files (10)

| File | Change |
|---|---|
| `app/models/semester.py` | `PROMOTION_EVENT` added to `SemesterCategory` enum |
| `alembic/versions/2026_05_02_1000_...py` | `ALTER TYPE semester_category_type ADD VALUE IF NOT EXISTS 'PROMOTION_EVENT'` |
| `scripts/migrate_promo_events_category.py` | Data migration: `PROMO-*` records `TOURNAMENT → PROMOTION_EVENT`; default dry-run |
| `app/api/web_routes/tournaments/lifecycle.py` | `/admin/promotion-events` filter: `== PROMOTION_EVENT` (replaces `TOURNAMENT + participant_type IN`) |
| `app/api/web_routes/admin/semesters.py` | Edit dispatch: `PROMOTION_EVENT` included in `is_tournament` (→ tournament wizard for Phase 1) |
| `app/api/web_routes/dashboard.py` | `active_semesters`: `!= TOURNAMENT` → `notin_([TOURNAMENT, PROMOTION_EVENT])` |
| `app/api/web_routes/admin/analytics.py` | `tournament_count` + `upcoming_events`: include `PROMOTION_EVENT` |
| `app/api/web_routes/admin/locations.py` | Location tournaments list: include `PROMOTION_EVENT` |
| `app/api/web_routes/events.py` | `promos_open` counter added |
| `app/templates/events_hub.html` | "Promotion Events" hub card added |

**Zero changes:** reward pipeline, ranking pipeline, `status_validator`, `TournamentConfiguration`, `TournamentRewardConfig`, `GameConfiguration`, `TournamentRanking`, `TournamentParticipation`, `Session`.

## Migration

```bash
# upgrade (idempotent — IF NOT EXISTS):
alembic upgrade head
# → ALTER TYPE semester_category_type ADD VALUE IF NOT EXISTS 'PROMOTION_EVENT'
```

**Downgrade:** PostgreSQL does not support `DROP VALUE`. The downgrade script rebuilds the enum type (data-safe only if no `PROMOTION_EVENT` rows exist). Documented as an emergency procedure, not a normal rollback path.

## Data migration script

```bash
# Review what will be reclassified (default, no writes):
python scripts/migrate_promo_events_category.py --dry-run

# Execute only after dry-run output is reviewed and approved:
python scripts/migrate_promo_events_category.py --apply

# Emergency rollback: revert PROMOTION_EVENT → TOURNAMENT:
python scripts/migrate_promo_events_category.py --rollback
```

**Criteria:** `code LIKE 'PROMO-%' AND semester_category = 'TOURNAMENT'`
**Safety:** no `TOURN-*` or `OPS-*` record can match. The dry-run shows the full audit before any write.

## Deployment order

```
1. alembic upgrade head           → DB enum type includes PROMOTION_EVENT
2. deploy this code               → app recognises PROMOTION_EVENT; promo list filters by it
3. dry-run on production data     → review output, confirm N records and their codes
4. --apply (after review)         → reclassify PROMO-* records
5. smoke validation               → checklist below
```

> Between steps 1 and 4, `/admin/promotion-events` will appear empty. This is intentional — the data migration has not run yet. `/admin/tournaments` remains unaffected.

## Acceptance checklist

- [ ] `/admin/promotion-events` loads 200, lists only `PROMOTION_EVENT` records
- [ ] `/admin/tournaments` loads 200, contains no `PROMOTION_EVENT` records
- [ ] `/events` hub shows "Promotion Events" card with `promos_open` counter
- [ ] Admin dashboard `active_semesters` counter excludes promotion events
- [ ] Status transition on a promo event works (existing `tournament_status` pipeline)
- [ ] Location detail: promotion events appear in the tournaments section
- [ ] Analytics upcoming events: promotion events appear
- [ ] Reward pipeline: no regression (existing promo event with reward distributes correctly)
- [ ] `pytest tests/integration/web_flows/test_admin_smoke.py` → 157/157 passed

## Known pre-existing failures (unrelated to this PR)

These fail on `main` before this branch and are not caused by these changes:

| Test | Status |
|---|---|
| `test_migration_rollback.py::TestMigration1400PartialUniqueIndex` | Pre-existing |
| `test_reward_distribution_idempotency.py::test_business_invariant_*` | Pre-existing |
| `test_adaptive_learning_smoke.py::test_submit_answer_negative_time_spent_*` | Pre-existing |
| `test_critical_e2e.py::test_admin_toggle_user_status_deactivates_active_user` | Pre-existing (test ordering / DB state) |

## Out of scope (Phase 2)

- Simplified promo admin wizard (`/admin/promotion-events/new`, `/admin/promotion-events/{id}/edit`)
- Public promo browse page (`/events/promotions`)
- Sport director promo workflow
- Promo-friendly lifecycle copy mapping (`ENROLLMENT_OPEN → "Registration Open"` etc.)
- Analytics/counter separation (tournament KPI vs. promo KPI)

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)