### PR TITLE
feat(sponsors): P2-B/C/D+P6+P7 — CSV audience import, promote-to-user, baseline onboarding, credit/unlock flow

### DIFF
--- a/alembic/versions/2026_05_03_1600_p6_p7_campaign_credit.py
+++ b/alembic/versions/2026_05_03_1600_p6_p7_campaign_credit.py
@@ -1,0 +1,87 @@
+"""P6+P7: Campaign specialization + credit ledger columns
+
+Revision ID: 2026_05_03_1600
+Revises: 2026_05_03_1500
+Create Date: 2026-05-03 16:00:00.000000
+
+P6 — sponsor_campaigns gains specialization_type so each campaign targets one license type.
+P7 — sponsor_campaigns gains credit config (grant_amount, unlock_cost) for the sponsor-funded
+     unlock flow.  credit_transactions gains sponsor_id + campaign_id for settlement tracing.
+
+Changes:
+  sponsor_campaigns  — ADD specialization_type VARCHAR(50) NOT NULL DEFAULT 'LFA_FOOTBALL_PLAYER'
+  sponsor_campaigns  — ADD credit_grant_amount  INTEGER     NOT NULL DEFAULT 100
+  sponsor_campaigns  — ADD unlock_cost          INTEGER     NOT NULL DEFAULT 100
+  sponsor_campaigns  — ADD CONSTRAINT chk_campaign_min_grant    (credit_grant_amount >= 100)
+  sponsor_campaigns  — ADD CONSTRAINT chk_campaign_unlock_lte   (unlock_cost <= credit_grant_amount)
+  credit_transactions — ADD sponsor_id   INTEGER NULL FK → sponsors.id   ON DELETE SET NULL
+  credit_transactions — ADD campaign_id  INTEGER NULL FK → sponsor_campaigns.id ON DELETE SET NULL
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '2026_05_03_1600'
+down_revision = '2026_05_03_1500'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # ── sponsor_campaigns: P6 specialization + P7 credit config ──────────────
+    op.add_column(
+        'sponsor_campaigns',
+        sa.Column('specialization_type', sa.String(50), nullable=False,
+                  server_default='LFA_FOOTBALL_PLAYER'),
+    )
+    op.add_column(
+        'sponsor_campaigns',
+        sa.Column('credit_grant_amount', sa.Integer, nullable=False, server_default='100'),
+    )
+    op.add_column(
+        'sponsor_campaigns',
+        sa.Column('unlock_cost', sa.Integer, nullable=False, server_default='100'),
+    )
+    op.create_check_constraint(
+        'chk_campaign_min_grant',
+        'sponsor_campaigns',
+        'credit_grant_amount >= 100',
+    )
+    op.create_check_constraint(
+        'chk_campaign_unlock_lte',
+        'sponsor_campaigns',
+        'unlock_cost <= credit_grant_amount',
+    )
+
+    # ── credit_transactions: P7 settlement columns ────────────────────────────
+    op.add_column(
+        'credit_transactions',
+        sa.Column(
+            'sponsor_id',
+            sa.Integer,
+            sa.ForeignKey('sponsors.id', ondelete='SET NULL'),
+            nullable=True,
+            index=True,
+        ),
+    )
+    op.add_column(
+        'credit_transactions',
+        sa.Column(
+            'campaign_id',
+            sa.Integer,
+            sa.ForeignKey('sponsor_campaigns.id', ondelete='SET NULL'),
+            nullable=True,
+            index=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('credit_transactions', 'campaign_id')
+    op.drop_column('credit_transactions', 'sponsor_id')
+
+    op.drop_constraint('chk_campaign_unlock_lte', 'sponsor_campaigns', type_='check')
+    op.drop_constraint('chk_campaign_min_grant', 'sponsor_campaigns', type_='check')
+    op.drop_column('sponsor_campaigns', 'unlock_cost')
+    op.drop_column('sponsor_campaigns', 'credit_grant_amount')
+    op.drop_column('sponsor_campaigns', 'specialization_type')

--- a/app/api/web_routes/admin/game_presets.py
+++ b/app/api/web_routes/admin/game_presets.py
@@ -44,6 +44,9 @@ async def admin_game_presets_page(
     )
 
 
+_VALID_FOOT_CONTEXTS = frozenset({"right", "left", "neutral"})
+
+
 @router.post("/admin/game-presets")
 async def admin_create_game_preset(
     request: Request,
@@ -54,6 +57,7 @@ async def admin_create_game_preset(
     difficulty: str = Form(""),
     min_players: int = Form(4),
     skill_impact: str = Form(""),
+    foot_context: str = Form("neutral"),
     db: Session = Depends(get_db),
     user: User = Depends(get_current_user_web)
 ):
@@ -75,6 +79,7 @@ async def admin_create_game_preset(
 
     total = sum(weights.get(s, 1) for s in skills) or 1
     skill_weights = {s: round(weights.get(s, 1) / total, 4) for s in skills}
+    resolved_foot_context = foot_context if foot_context in _VALID_FOOT_CONTEXTS else "neutral"
 
     game_config = {
         "version": "1.0",
@@ -83,6 +88,7 @@ async def admin_create_game_preset(
             "skills_tested": skills,
             "skill_weights": skill_weights,
             "skill_impact_on_matches": bool(skill_impact),
+            "foot_context": resolved_foot_context,
         },
         "simulation_config": {},
         "metadata": {
@@ -142,6 +148,7 @@ async def admin_edit_game_preset_submit(
     difficulty: str = Form(""),
     min_players: int = Form(4),
     skill_impact: str = Form(""),
+    foot_context: str = Form("neutral"),
     db: Session = Depends(get_db),
     user: User = Depends(get_current_user_web)
 ):
@@ -163,6 +170,7 @@ async def admin_edit_game_preset_submit(
 
     total = sum(weights.get(s, 1) for s in skills) or 1
     skill_weights = {s: round(weights.get(s, 1) / total, 4) for s in skills}
+    resolved_foot_context = foot_context if foot_context in _VALID_FOOT_CONTEXTS else "neutral"
 
     existing_config = preset.game_config or {}
     new_config = {
@@ -171,6 +179,7 @@ async def admin_edit_game_preset_submit(
             "skills_tested": skills,
             "skill_weights": skill_weights,
             "skill_impact_on_matches": bool(skill_impact),
+            "foot_context": resolved_foot_context,
         },
         "metadata": {
             "game_category": category or None,

--- a/app/api/web_routes/admin/sponsors.py
+++ b/app/api/web_routes/admin/sponsors.py
@@ -421,6 +421,9 @@ async def admin_sponsor_campaigns_create(
     campaign_type: str = Form("IMPORT"),
     event_date: Optional[str] = Form(None),
     notes: Optional[str] = Form(None),
+    specialization_type: str = Form("LFA_FOOTBALL_PLAYER"),
+    credit_grant_amount: int = Form(100),
+    unlock_cost: int = Form(100),
     db: Session = Depends(get_db),
     user: User = Depends(get_current_user_web),
 ):
@@ -432,6 +435,17 @@ async def admin_sponsor_campaigns_create(
     if not sponsor.is_active:
         return RedirectResponse(
             f"/admin/sponsors/{sponsor_id}?error=Inactive+partner+cannot+create+campaign",
+            status_code=303,
+        )
+    if credit_grant_amount < 100:
+        return RedirectResponse(
+            f"/admin/sponsors/{sponsor_id}?error=Credit+grant+must+be+at+least+100",
+            status_code=303,
+        )
+    if unlock_cost > credit_grant_amount:
+        return RedirectResponse(
+            f"/admin/sponsors/{sponsor_id}"
+            "?error=Unlock+cost+cannot+exceed+credit+grant+amount",
             status_code=303,
         )
     parsed_date: Optional[date] = None
@@ -448,6 +462,9 @@ async def admin_sponsor_campaigns_create(
         status="ACTIVE",
         notes=notes or None,
         created_by=user.id,
+        specialization_type=specialization_type.strip() or "LFA_FOOTBALL_PLAYER",
+        credit_grant_amount=credit_grant_amount,
+        unlock_cost=unlock_cost,
     )
     db.add(campaign)
     db.commit()

--- a/app/api/web_routes/admin/sponsors.py
+++ b/app/api/web_routes/admin/sponsors.py
@@ -518,6 +518,109 @@ async def admin_sponsor_campaign_detail(
     )
 
 
+@router.post("/admin/sponsors/{sponsor_id}/campaigns/{campaign_id}/close")
+async def admin_sponsor_campaign_close(
+    sponsor_id: int,
+    campaign_id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user_web),
+):
+    """Close a campaign — prevents further imports and audience promotions."""
+    _admin_guard(user)
+    sponsor = db.query(Sponsor).filter(Sponsor.id == sponsor_id).first()
+    if not sponsor:
+        raise HTTPException(status_code=404, detail="Partner not found")
+    campaign = (
+        db.query(SponsorCampaign)
+        .filter(SponsorCampaign.id == campaign_id, SponsorCampaign.sponsor_id == sponsor_id)
+        .first()
+    )
+    if not campaign:
+        raise HTTPException(status_code=404, detail="Campaign not found")
+    campaign.status = "CLOSED"
+    db.commit()
+    return RedirectResponse(
+        f"/admin/sponsors/{sponsor_id}/campaigns/{campaign_id}?flash=Campaign+closed",
+        status_code=303,
+    )
+
+
+@router.post("/admin/sponsors/{sponsor_id}/campaigns/{campaign_id}/edit")
+async def admin_sponsor_campaign_edit(
+    sponsor_id: int,
+    campaign_id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user_web),
+):
+    """Edit campaign name, credit fields, and event date."""
+    _admin_guard(user)
+    sponsor = db.query(Sponsor).filter(Sponsor.id == sponsor_id).first()
+    if not sponsor:
+        raise HTTPException(status_code=404, detail="Partner not found")
+    campaign = (
+        db.query(SponsorCampaign)
+        .filter(SponsorCampaign.id == campaign_id, SponsorCampaign.sponsor_id == sponsor_id)
+        .first()
+    )
+    if not campaign:
+        raise HTTPException(status_code=404, detail="Campaign not found")
+
+    base = f"/admin/sponsors/{sponsor_id}/campaigns/{campaign_id}"
+    form = await request.form()
+
+    name = (form.get("name") or "").strip()
+    if not name:
+        return RedirectResponse(f"{base}?error=Campaign+name+is+required", status_code=303)
+
+    try:
+        credit_grant_amount = int(form.get("credit_grant_amount", 0))
+    except (ValueError, TypeError):
+        return RedirectResponse(f"{base}?error=Invalid+credit+grant+amount", status_code=303)
+
+    if credit_grant_amount < 100:
+        return RedirectResponse(
+            f"{base}?error=Credit+grant+must+be+at+least+100", status_code=303
+        )
+
+    try:
+        unlock_cost = int(form.get("unlock_cost", 0))
+    except (ValueError, TypeError):
+        return RedirectResponse(f"{base}?error=Invalid+unlock+cost", status_code=303)
+
+    if unlock_cost > credit_grant_amount:
+        return RedirectResponse(
+            f"{base}?error=Unlock+cost+cannot+exceed+credit+grant", status_code=303
+        )
+
+    if campaign.status == "CLOSED":
+        if (
+            credit_grant_amount != campaign.credit_grant_amount
+            or unlock_cost != campaign.unlock_cost
+        ):
+            return RedirectResponse(
+                f"{base}?error=Credit+fields+are+locked+for+closed+campaigns",
+                status_code=303,
+            )
+
+    event_date_str = (form.get("event_date") or "").strip()
+    event_date_val: date | None = None
+    if event_date_str:
+        try:
+            event_date_val = date.fromisoformat(event_date_str)
+        except ValueError:
+            return RedirectResponse(f"{base}?error=Invalid+event+date", status_code=303)
+
+    campaign.name = name
+    campaign.credit_grant_amount = credit_grant_amount
+    campaign.unlock_cost = unlock_cost
+    campaign.event_date = event_date_val
+    db.commit()
+
+    return RedirectResponse(f"{base}?flash=Campaign+updated", status_code=303)
+
+
 # ── P3: Campaign-scoped audience list ────────────────────────────────────────
 
 def _build_audience_context(
@@ -623,6 +726,19 @@ async def admin_sponsor_campaign_audience_promote(
     if not sponsor.is_active:
         return RedirectResponse(
             f"/admin/sponsors/{sponsor_id}/campaigns/{campaign_id}?error=Inactive+partner",
+            status_code=303,
+        )
+    campaign = (
+        db.query(SponsorCampaign)
+        .filter(SponsorCampaign.id == campaign_id, SponsorCampaign.sponsor_id == sponsor_id)
+        .first()
+    )
+    if not campaign:
+        raise HTTPException(status_code=404, detail="Campaign not found")
+    if campaign.status == "CLOSED":
+        return RedirectResponse(
+            f"/admin/sponsors/{sponsor_id}/campaigns/{campaign_id}/audience"
+            "?error=Campaign+is+closed+-+promote+not+allowed",
             status_code=303,
         )
 
@@ -779,6 +895,12 @@ async def admin_sponsor_campaign_import_preview(
             "?error=Inactive+partner+cannot+import+audience",
             status_code=303,
         )
+    if campaign.status == "CLOSED":
+        return RedirectResponse(
+            f"/admin/sponsors/{sponsor_id}/campaigns/{campaign_id}"
+            "?error=Campaign+is+closed+-+import+not+allowed",
+            status_code=303,
+        )
 
     content = await file.read()
     base_url = f"/admin/sponsors/{sponsor_id}/campaigns/{campaign_id}/import"
@@ -829,6 +951,12 @@ async def admin_sponsor_campaign_import_apply(
         return RedirectResponse(
             f"/admin/sponsors/{sponsor_id}/campaigns/{campaign_id}"
             "?error=Inactive+partner+cannot+import+audience",
+            status_code=303,
+        )
+    if campaign.status == "CLOSED":
+        return RedirectResponse(
+            f"/admin/sponsors/{sponsor_id}/campaigns/{campaign_id}"
+            "?error=Campaign+is+closed+-+import+not+allowed",
             status_code=303,
         )
 

--- a/app/api/web_routes/admin/sponsors.py
+++ b/app/api/web_routes/admin/sponsors.py
@@ -343,6 +343,8 @@ async def admin_sponsor_promotion_create(
             status_code=303,
         )
 
+    created_semester_id: int | None = None
+
     for ag in age_groups:
         suffix = datetime.now().strftime("%H%M%S%f")[:9]
         code = f"PROMO-{date.fromisoformat(start_date).strftime('%Y%m%d')}-{ag.upper()[:6]}-{suffix}"
@@ -355,6 +357,7 @@ async def admin_sponsor_promotion_create(
             status=SemesterStatus.DRAFT,
             tournament_status="DRAFT",
             semester_category=SemesterCategory.PROMOTION_EVENT,
+            specialization_type="LFA_FOOTBALL_PLAYER",
             age_group=ag,                        # PRE / YOUTH / AMATEUR / PRO — already canonical
             enrollment_cost=0,
             campus_id=int(campus_id) if campus_id.strip() else None,
@@ -364,6 +367,7 @@ async def admin_sponsor_promotion_create(
         )
         db.add(t)
         db.flush()
+        created_semester_id = t.id
 
         # Derive location from campus
         if t.campus_id:
@@ -375,6 +379,7 @@ async def admin_sponsor_promotion_create(
             semester_id=t.id,
             tournament_type_id=int(tournament_type_id) if tournament_type_id.strip() else None,
             participant_type="INDIVIDUAL",       # sponsor events are always INDIVIDUAL
+            assignment_type="OPEN_ASSIGNMENT",
             number_of_rounds=1,
         ))
         # No TournamentTeamEnrollment — sponsor events have no teams
@@ -384,6 +389,12 @@ async def admin_sponsor_promotion_create(
         "sponsor_promotion_created sponsor=%s campaign=%s age_groups=%s by admin=%s",
         sponsor.name, campaign.id, age_groups, user.email,
     )
+
+    if len(age_groups) == 1 and created_semester_id:
+        return RedirectResponse(
+            url=f"/admin/tournaments/{created_semester_id}/edit?flash=Promotion+event+created",
+            status_code=303,
+        )
     return RedirectResponse(
         url=f"/admin/sponsors/{sponsor_id}?flash=Promotion+event+created",
         status_code=303,

--- a/app/models/credit_transaction.py
+++ b/app/models/credit_transaction.py
@@ -52,6 +52,10 @@ class CreditTransaction(Base):
     semester_id = Column(Integer, ForeignKey("semesters.id", ondelete="SET NULL"), nullable=True)
     enrollment_id = Column(Integer, ForeignKey("semester_enrollments.id", ondelete="SET NULL"), nullable=True)
 
+    # P7: sponsor settlement tracing — set on SPONSOR_CREDIT_GRANT and SPECIALIZATION_UNLOCK
+    sponsor_id  = Column(Integer, ForeignKey("sponsors.id",          ondelete="SET NULL"), nullable=True, index=True)
+    campaign_id = Column(Integer, ForeignKey("sponsor_campaigns.id", ondelete="SET NULL"), nullable=True, index=True)
+
     # Admin audit: which admin performed this adjustment (NULL for system/user actions)
     performed_by_user_id = Column(
         Integer,
@@ -77,6 +81,8 @@ class CreditTransaction(Base):
     semester = relationship("Semester")
     enrollment = relationship("SemesterEnrollment")
     performed_by = relationship("User", foreign_keys=[performed_by_user_id])
+    sponsor  = relationship("Sponsor",         foreign_keys=[sponsor_id])
+    campaign = relationship("SponsorCampaign", foreign_keys=[campaign_id])
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary for API responses"""

--- a/app/models/sponsor.py
+++ b/app/models/sponsor.py
@@ -54,6 +54,15 @@ class SponsorCampaign(Base):
     created_at    = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     created_by    = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
 
+    # P6: target specialization for this campaign's audience
+    specialization_type = Column(String(50), nullable=False, default="LFA_FOOTBALL_PLAYER")
+
+    # P7: sponsor-funded credit flow — grant is what the user receives,
+    #     unlock_cost is the specialization activation fee (deducted from the grant)
+    #     DB CHECKs: chk_campaign_min_grant (>=100), chk_campaign_unlock_lte (<=grant)
+    credit_grant_amount = Column(Integer, nullable=False, default=100)
+    unlock_cost         = Column(Integer, nullable=False, default=100)
+
     sponsor   = relationship("Sponsor", back_populates="campaigns")
     entries   = relationship("SponsorAudienceEntry", back_populates="campaign",
                              cascade="all, delete-orphan")

--- a/app/services/adaptive_learning.py
+++ b/app/services/adaptive_learning.py
@@ -2,8 +2,11 @@ from sqlalchemy.orm import Session
 from sqlalchemy import and_
 from datetime import datetime, timezone, timedelta
 from typing import List, Dict, Optional
+import logging
 import random
 import math
+
+logger = logging.getLogger(__name__)
 
 from ..models.quiz import (
     Quiz, QuizQuestion, UserQuestionPerformance, AdaptiveLearningSession,
@@ -84,11 +87,16 @@ class AdaptiveLearningService:
         if not selected_question:
             return {"session_complete": True, "reason": "pool_exhausted"}
         
+        # Shuffle answer options so the correct answer position is random.
+        # Grading is ID-based (selected_option_id), so shuffle does not affect correctness check.
+        shuffled_options = list(selected_question.answer_options)
+        random.shuffle(shuffled_options)
+
         # Return question with session info
         return {
             "id": selected_question.id,
             "text": selected_question.question_text,
-            "options": [{"id": opt.id, "text": opt.option_text} for opt in selected_question.answer_options],
+            "options": [{"id": opt.id, "text": opt.option_text} for opt in shuffled_options],
             "type": selected_question.question_type.value if selected_question.question_type else "multiple_choice",
             "difficulty": self._get_question_difficulty(selected_question.id),
             "session_time_remaining": self._get_session_time_remaining(session)
@@ -249,8 +257,9 @@ class AdaptiveLearningService:
         return {
             "weak_concepts": [p for p in performances if p.mastery_level < 0.6],
             "strong_concepts": [p for p in performances if p.mastery_level > 0.8],
-            "due_for_review": [p for p in performances if p.next_review_at and 
-                             p.next_review_at <= datetime.now(timezone.utc)]
+            "due_for_review": [p for p in performances if p.next_review_at and
+                               p.next_review_at <= datetime.now(timezone.utc)],
+            "attempted_ids": {p.question_id for p in performances},
         }
     
     def _get_candidate_questions(
@@ -288,6 +297,12 @@ class AdaptiveLearningService:
 
         # Fall back to all questions matching base filters (no metadata required)
         if not questions:
+            logger.warning(
+                "al_difficulty_fallback category=%s target=%.2f range=±0.2 module=%r → full pool",
+                category.value if hasattr(category, "value") else category,
+                target_difficulty,
+                module_prefix,
+            )
             questions = (
                 self.db.query(QuizQuestion)
                 .join(Quiz)
@@ -297,25 +312,29 @@ class AdaptiveLearningService:
 
         return questions
     
-    def _select_adaptive_question(self, candidate_questions: List[QuizQuestion], 
-                                performance_data: Dict, session: AdaptiveLearningSession) -> QuizQuestion:
+    def _select_adaptive_question(self, candidate_questions: List[QuizQuestion],
+                                  performance_data: Dict, session: AdaptiveLearningSession) -> QuizQuestion:
         """Adaptív kérdésválasztó algoritmus"""
-        
-        # Prioritize questions due for review
-        due_questions = [q for q in candidate_questions 
-                        if any(p.question_id == q.id for p in performance_data["due_for_review"])]
-        
+        attempted_ids = performance_data.get("attempted_ids", set())
+
+        # Priority 0: questions the user has never attempted — maximises pool coverage
+        never_seen = [q for q in candidate_questions if q.id not in attempted_ids]
+        if never_seen:
+            return random.choice(never_seen)
+
+        # Priority 1: questions due for spaced-repetition review
+        due_questions = [q for q in candidate_questions
+                         if any(p.question_id == q.id for p in performance_data["due_for_review"])]
         if due_questions:
             return random.choice(due_questions)
-            
-        # Focus on weak concepts
-        weak_concept_questions = [q for q in candidate_questions 
-                                if any(p.question_id == q.id for p in performance_data["weak_concepts"])]
-        
-        if weak_concept_questions and random.random() < 0.7:  # 70% chance to focus on weak areas
+
+        # Priority 2: weak concepts (mastery < 0.6) — 70 % chance
+        weak_concept_questions = [q for q in candidate_questions
+                                   if any(p.question_id == q.id for p in performance_data["weak_concepts"])]
+        if weak_concept_questions and random.random() < 0.7:
             return random.choice(weak_concept_questions)
-        
-        # Otherwise, random selection from candidates
+
+        # Fallback: random from all candidates
         return random.choice(candidate_questions)
     
     def _calculate_performance_trend(self, session: AdaptiveLearningSession) -> float:

--- a/app/services/credit_service.py
+++ b/app/services/credit_service.py
@@ -43,7 +43,9 @@ class CreditService:
         description: str,
         idempotency_key: str,
         semester_id: Optional[int] = None,
-        enrollment_id: Optional[int] = None
+        enrollment_id: Optional[int] = None,
+        sponsor_id: Optional[int] = None,
+        campaign_id: Optional[int] = None,
     ) -> tuple[CreditTransaction, bool]:
         """
         Create a credit transaction with idempotency protection.
@@ -98,6 +100,8 @@ class CreditService:
             idempotency_key=idempotency_key,
             semester_id=semester_id,
             enrollment_id=enrollment_id,
+            sponsor_id=sponsor_id,
+            campaign_id=campaign_id,
             created_at=datetime.utcnow()
         )
 
@@ -149,6 +153,8 @@ class CreditService:
         transaction_type: str,
         description: str,
         idempotency_key: str,
+        sponsor_id: Optional[int] = None,
+        campaign_id: Optional[int] = None,
     ) -> CreditTransaction:
         """
         Atomically deduct credits from a user's balance.
@@ -181,8 +187,123 @@ class CreditService:
                 balance_after=new_balance,
                 description=description,
                 idempotency_key=idempotency_key,
+                sponsor_id=sponsor_id,
+                campaign_id=campaign_id,
             )
 
+        user.credit_balance = new_balance
+        logger.info(
+            f"💳 Deducted {amount} credits from user {user.id}: "
+            f"balance {new_balance + amount} → {new_balance} ({transaction_type})"
+        )
+        return transaction
+
+    def award(
+        self,
+        user: User,
+        amount: int,
+        transaction_type: str,
+        description: str,
+        idempotency_key: str,
+        sponsor_id: Optional[int] = None,
+        campaign_id: Optional[int] = None,
+    ) -> tuple[CreditTransaction, bool]:
+        """
+        Award (add) credits to a user's balance within the caller's transaction.
+
+        Checks idempotency BEFORE the SQL UPDATE to avoid phantom balance changes
+        on retry.  No internal SAVEPOINT — caller owns the outer transaction and
+        must call db.commit() (or db.rollback()) when appropriate.
+
+        Returns:
+            (transaction, created) — created=False means idempotent no-op.
+        """
+        # Idempotency-first: do NOT run SQL UPDATE if transaction already exists.
+        existing = self.db.query(CreditTransaction).filter(
+            CreditTransaction.idempotency_key == idempotency_key
+        ).first()
+        if existing:
+            logger.info(
+                f"🔒 IDEMPOTENT AWARD: key='{idempotency_key}' already exists "
+                f"(id={existing.id}). Skipping."
+            )
+            return (existing, False)
+
+        result = self.db.execute(
+            text(
+                "UPDATE users SET credit_balance = credit_balance + :amount "
+                "WHERE id = :uid RETURNING credit_balance"
+            ),
+            {"amount": amount, "uid": user.id},
+        ).fetchone()
+
+        new_balance = result[0]
+        transaction = CreditTransaction(
+            user_id=user.id,
+            user_license_id=None,
+            transaction_type=transaction_type,
+            amount=+amount,
+            balance_after=new_balance,
+            description=description,
+            idempotency_key=idempotency_key,
+            sponsor_id=sponsor_id,
+            campaign_id=campaign_id,
+            created_at=datetime.utcnow(),
+        )
+        self.db.add(transaction)
+        self.db.flush()
+
+        user.credit_balance = new_balance
+        logger.info(
+            f"🎁 Awarded {amount} credits to user {user.id}: "
+            f"balance {new_balance - amount} → {new_balance} ({transaction_type})"
+        )
+        return (transaction, True)
+
+    def deduct_batch(
+        self,
+        user: User,
+        amount: int,
+        transaction_type: str,
+        description: str,
+        idempotency_key: str,
+        sponsor_id: Optional[int] = None,
+        campaign_id: Optional[int] = None,
+    ) -> CreditTransaction:
+        """
+        Deduct credits within the caller's transaction (no internal SAVEPOINT).
+
+        For use in batch operations where the caller manages the outer transaction
+        and an InsufficientCreditsError must roll back the whole batch.
+
+        Raises:
+            InsufficientCreditsError: if user has fewer credits than amount.
+        """
+        result = self.db.execute(
+            text(
+                "UPDATE users SET credit_balance = credit_balance - :amount "
+                "WHERE id = :uid AND credit_balance >= :amount "
+                "RETURNING credit_balance"
+            ),
+            {"amount": amount, "uid": user.id},
+        ).fetchone()
+
+        if result is None:
+            self.db.refresh(user)
+            raise InsufficientCreditsError(required=amount, available=user.credit_balance)
+
+        new_balance = result[0]
+        transaction, _ = self.create_transaction(
+            user_id=user.id,
+            user_license_id=None,
+            transaction_type=transaction_type,
+            amount=-amount,
+            balance_after=new_balance,
+            description=description,
+            idempotency_key=idempotency_key,
+            sponsor_id=sponsor_id,
+            campaign_id=campaign_id,
+        )
         user.credit_balance = new_balance
         logger.info(
             f"💳 Deducted {amount} credits from user {user.id}: "

--- a/app/services/sponsor_promote_service.py
+++ b/app/services/sponsor_promote_service.py
@@ -7,19 +7,25 @@ Business rules:
     promoted_at / promoted_by are never overwritten.
   - Email matches existing User → user_id linked only. User profile NOT modified.
     DOB is NOT overwritten on existing Users.
-  - No existing User → User + UserLicense created (role=STUDENT, random password).
-    date_of_birth copied from entry (may be None).
-  - Baseline onboarding (P2-D): written after promote IF all 4 conditions met:
-      1. entry.status == ACTIVE  (already checked by promote gate)
+  - No existing User → User created (role=STUDENT, random password).
+  - License: _ensure_license() returns the existing active license for
+    campaign.specialization_type, or creates a new one — for BOTH new and
+    existing users.  Existing licenses of other types are never touched.
+  - Credit flow (per promoted entry, atomic with the batch commit):
+      1. SPONSOR_CREDIT_GRANT  +campaign.credit_grant_amount  (idempotent)
+      2. SPECIALIZATION_UNLOCK -campaign.unlock_cost           (idempotent)
+      Grant and unlock are ALWAYS issued as a pair; neither can exist without
+      the other within a successful promote run.
+  - Baseline onboarding (P2-D): written after credits IF all 4 conditions met:
+      1. entry.status == ACTIVE  (already checked)
       2. entry.consent_given     (already checked)
       3. entry.date_of_birth IS NOT NULL
       4. entry.position in {STRIKER, MIDFIELDER, DEFENDER, GOALKEEPER}
     AND license.onboarding_completed is False AND license.football_skills is None.
-  - Existing User: baseline only if their LFA_FOOTBALL_PLAYER license has no onboarding at all.
-    No license → baseline skipped (no new license created for existing users).
   - foot_dominance default (50) applied only when baseline is actually written.
   - No SemesterEnrollment is ever created here.
   - Single db.commit() at the end of the batch (atomic).
+  - If campaign_id is None the credit flow is skipped (legacy/test path only).
 """
 from __future__ import annotations
 
@@ -32,8 +38,9 @@ from sqlalchemy.orm import Session
 
 from app.core.security import get_password_hash
 from app.models.license import UserLicense
-from app.models.sponsor import SponsorAudienceEntry
+from app.models.sponsor import SponsorAudienceEntry, SponsorCampaign
 from app.models.user import User, UserRole
+from app.services.credit_service import CreditService
 from app.services.skill_progression import SYSTEM_BASELINE
 from app.skills_config import get_all_skill_keys
 
@@ -54,6 +61,8 @@ class PromoteResult:
     skipped: int = 0               # status != ACTIVE or consent_given == False
     promoted_with_onboarding: int = 0    # subset of promoted where baseline was written
     promoted_without_onboarding: int = 0  # subset of promoted where baseline was skipped
+    credits_granted: int = 0       # total SPONSOR_CREDIT_GRANT amount across the batch
+    unlock_deductions: int = 0     # total SPECIALIZATION_UNLOCK amount across the batch
     errors: list[str] = field(default_factory=list)
 
     @property
@@ -109,6 +118,68 @@ def _write_baseline(entry: SponsorAudienceEntry, license: UserLicense, now: date
     flag_modified(license, "football_skills")
 
 
+def _ensure_license(
+    user: User,
+    specialization_type: str,
+    now: datetime,
+    db: Session,
+) -> UserLicense:
+    """Return the user's active license for specialization_type, creating one if absent."""
+    license = (
+        db.query(UserLicense)
+        .filter(
+            UserLicense.user_id == user.id,
+            UserLicense.specialization_type == specialization_type,
+            UserLicense.is_active == True,
+        )
+        .first()
+    )
+    if license is None:
+        license = UserLicense(
+            user_id=user.id,
+            specialization_type=specialization_type,
+            current_level=1,
+            max_achieved_level=1,
+            started_at=now,
+            is_active=True,
+        )
+        db.add(license)
+        db.flush()
+    return license
+
+
+def _apply_credits(
+    user: User,
+    campaign: SponsorCampaign,
+    credit_svc: CreditService,
+) -> tuple[int, int]:
+    """Issue grant + unlock as an invariant pair. Returns (granted, deducted)."""
+    grant_key  = f"sponsor_grant:{campaign.id}:{user.id}"
+    unlock_key = f"spec_unlock:{campaign.id}:{user.id}:{campaign.specialization_type}"
+
+    credit_svc.award(
+        user=user,
+        amount=campaign.credit_grant_amount,
+        transaction_type="SPONSOR_CREDIT_GRANT",
+        description=f"Sponsor credit grant — {campaign.name}",
+        idempotency_key=grant_key,
+        sponsor_id=campaign.sponsor_id,
+        campaign_id=campaign.id,
+    )
+    credit_svc.deduct_batch(
+        user=user,
+        amount=campaign.unlock_cost,
+        transaction_type="SPECIALIZATION_UNLOCK",
+        description=(
+            f"Specialization unlock — {campaign.specialization_type} via {campaign.name}"
+        ),
+        idempotency_key=unlock_key,
+        sponsor_id=campaign.sponsor_id,
+        campaign_id=campaign.id,
+    )
+    return campaign.credit_grant_amount, campaign.unlock_cost
+
+
 def promote_entries(
     entry_ids: list[int],
     sponsor_id: int,
@@ -116,20 +187,49 @@ def promote_entries(
     admin_user: User,
     campaign_id: int | None = None,
 ) -> PromoteResult:
-    """Promote selected SponsorAudienceEntry rows to Users with optional baseline onboarding.
+    """Promote selected SponsorAudienceEntry rows to Users.
+
+    Per-entry steps (in order):
+      1. Idempotence: entry.user_id already set → already_linked, skip
+      2. Status + consent guard → skipped
+      3. User link-or-create
+      4. License ensure (create if absent for campaign.specialization_type)
+      5. Credit grant (+campaign.credit_grant_amount) — idempotent
+      6. Specialization unlock (-campaign.unlock_cost) — idempotent, always paired with grant
+      7. Baseline onboarding (optional, condition-gated)
+      8. Audit fields
 
     Atomically processes the batch; single db.commit() at end.
-    Any unhandled exception propagates and rolls back everything.
+    Any unhandled exception propagates and rolls back everything — no partial commits.
 
     campaign_id: when provided, only entries belonging to that campaign are promoted.
-    Entries from other campaigns in the same sponsor are silently excluded and reported
-    as errors — prevents cross-campaign promote via crafted POST bodies.
+    Also loads the SponsorCampaign for credit config + specialization_type.
+    When None, credit flow is skipped (legacy path).
     """
     result = PromoteResult()
     if not entry_ids:
         return result
 
     now = datetime.now(timezone.utc)
+
+    # Load campaign for credit config (required for P7 flow)
+    campaign: SponsorCampaign | None = None
+    if campaign_id is not None:
+        campaign = (
+            db.query(SponsorCampaign)
+            .filter(
+                SponsorCampaign.id == campaign_id,
+                SponsorCampaign.sponsor_id == sponsor_id,
+            )
+            .first()
+        )
+        if campaign is None:
+            result.errors.append(
+                f"Campaign {campaign_id} not found for sponsor {sponsor_id}"
+            )
+            return result
+
+    credit_svc = CreditService(db)
 
     # Load all requested entries scoped to this sponsor+campaign in one query
     q = (
@@ -162,40 +262,24 @@ def promote_entries(
             existing_users[u.email] = u
 
     for entry in entries:
-        # ── Idempotence: already promoted ─────────────────────────────────────
+        # ── [1] Idempotence: already promoted ─────────────────────────────────
         if entry.user_id is not None:
             result.already_linked += 1
             continue
 
-        # ── Status guard ──────────────────────────────────────────────────────
+        # ── [2] Status + consent guard ─────────────────────────────────────────
         if entry.status != "ACTIVE":
             result.skipped += 1
             continue
-
-        # ── Explicit consent guard (belt-and-suspenders) ──────────────────────
         if not entry.consent_given:
             result.skipped += 1
             continue
 
-        # ── Link or create User ───────────────────────────────────────────────
-        license: UserLicense | None = None
-
+        # ── [3] User link-or-create ────────────────────────────────────────────
         if entry.email in existing_users:
-            # Email matches existing User — link only, no profile modification (DOB not touched)
-            existing_user = existing_users[entry.email]
-            entry.user_id = existing_user.id
-            # Find existing LFA_FOOTBALL_PLAYER license (no new license created)
-            license = (
-                db.query(UserLicense)
-                .filter(
-                    UserLicense.user_id == existing_user.id,
-                    UserLicense.specialization_type == "LFA_FOOTBALL_PLAYER",
-                    UserLicense.is_active == True,
-                )
-                .first()
-            )
+            user = existing_users[entry.email]
         else:
-            new_user = User(
+            user = User(
                 email=entry.email,
                 name=f"{entry.first_name} {entry.last_name}",
                 first_name=entry.first_name,
@@ -208,28 +292,33 @@ def promote_entries(
                 payment_verified=False,
                 created_by=admin_user.id,
             )
-            db.add(new_user)
+            db.add(user)
             db.flush()
-            license = UserLicense(
-                user_id=new_user.id,
-                specialization_type="LFA_FOOTBALL_PLAYER",
-                current_level=1,
-                max_achieved_level=1,
-                started_at=now,
-                is_active=True,
-            )
-            db.add(license)
-            db.flush()
-            entry.user_id = new_user.id
 
-        # ── Baseline onboarding (P2-D) ────────────────────────────────────────
-        if license is not None and _should_write_baseline(entry, license):
+        entry.user_id = user.id
+
+        # ── [4] License ensure ─────────────────────────────────────────────────
+        spec_type = (
+            campaign.specialization_type
+            if campaign is not None
+            else "LFA_FOOTBALL_PLAYER"
+        )
+        license = _ensure_license(user, spec_type, now, db)
+
+        # ── [5] + [6] Credit grant + unlock (always paired) ────────────────────
+        if campaign is not None:
+            granted, deducted = _apply_credits(user, campaign, credit_svc)
+            result.credits_granted    += granted
+            result.unlock_deductions  += deducted
+
+        # ── [7] Baseline onboarding ────────────────────────────────────────────
+        if _should_write_baseline(entry, license):
             _write_baseline(entry, license, now)
             result.promoted_with_onboarding += 1
         else:
             result.promoted_without_onboarding += 1
 
-        # ── Set audit fields (only on first promotion) ────────────────────────
+        # ── [8] Audit fields ───────────────────────────────────────────────────
         entry.promoted_at = now
         entry.promoted_by = admin_user.id
         result.promoted += 1
@@ -238,9 +327,12 @@ def promote_entries(
 
     logger.info(
         "sponsor_audience_promote_done sponsor_id=%s promoted=%s "
-        "(with_onboarding=%s without=%s) already_linked=%s skipped=%s errors=%s",
+        "(with_onboarding=%s without=%s) already_linked=%s skipped=%s "
+        "credits_granted=%s unlock_deductions=%s errors=%s",
         sponsor_id, result.promoted,
         result.promoted_with_onboarding, result.promoted_without_onboarding,
-        result.already_linked, result.skipped, len(result.errors),
+        result.already_linked, result.skipped,
+        result.credits_granted, result.unlock_deductions,
+        len(result.errors),
     )
     return result

--- a/app/templates/adaptive_learning_session.html
+++ b/app/templates/adaptive_learning_session.html
@@ -597,7 +597,7 @@
         </div>
         <div id="als-progress-label" class="als-progress-label">Question 0</div>
 
-        <div class="als-question-card">
+        <div id="als-question-card" class="als-question-card">
             <div id="als-question-num" class="als-question-num">Question 1</div>
             <p id="als-question-text" class="als-question-text"></p>
         </div>
@@ -1082,6 +1082,8 @@
         document.getElementById('als-feedback').style.display = 'none';
         document.getElementById('als-feedback').className = 'als-feedback';
         document.getElementById('als-next-btn-wrap').style.display = 'none';
+        document.getElementById('als-question-card').style.display = '';
+        document.getElementById('als-options').style.display = '';
         updateProgress();
         showPhase('question');
     }
@@ -1137,6 +1139,7 @@
             }
             fb.style.display = 'block';
 
+            _showAnsweredState();
             _showNextButton();
         }).catch(function () {
             showError('Network error while recording answer. Please check your connection.');
@@ -1148,6 +1151,13 @@
         var btn  = document.getElementById('als-next-btn');
         if (wrap) wrap.style.display = 'block';
         if (btn)  btn.disabled = false;
+    }
+
+    function _showAnsweredState() {
+        var card = document.getElementById('als-question-card');
+        var opts = document.getElementById('als-options');
+        if (card) card.style.display = 'none';
+        if (opts) opts.style.display = 'none';
     }
 
     /* ── Next question ─────────────────────────────────────────────────────── */

--- a/app/templates/adaptive_learning_session.html
+++ b/app/templates/adaptive_learning_session.html
@@ -251,6 +251,20 @@
     .als-next-cat-btn:hover:not(:disabled) { background: #4338ca; }
     .als-next-cat-btn:disabled { opacity: 0.45; cursor: not-allowed; }
 
+    .als-next-btn {
+        background: var(--app-primary, #4f46e5);
+        color: #fff;
+        border: none;
+        border-radius: 8px;
+        padding: 0.6rem 1.6rem;
+        font-size: 0.95rem;
+        font-weight: 600;
+        cursor: pointer;
+        transition: background 0.15s, opacity 0.15s;
+    }
+    .als-next-btn:hover:not(:disabled) { background: #4338ca; }
+    .als-next-btn:disabled { opacity: 0.45; cursor: not-allowed; }
+
     /* ── Question card ───────────────────────────────────────────────────────── */
     .als-question-card {
         background: var(--app-card);
@@ -590,8 +604,8 @@
 
         <div id="als-options" class="als-options"></div>
         <div id="als-feedback" class="als-feedback"></div>
-        <div id="als-auto-advance" style="display:none; text-align:center; font-size:0.82rem; color:var(--app-text-muted); margin-top:0.5rem;">
-            Next question in 1.5s…
+        <div id="als-next-btn-wrap" style="display:none; text-align:center; margin-top:1rem;">
+            <button id="als-next-btn" class="als-next-btn" onclick="alsNext()">Next question →</button>
         </div>
     </div>
 
@@ -1067,7 +1081,7 @@
 
         document.getElementById('als-feedback').style.display = 'none';
         document.getElementById('als-feedback').className = 'als-feedback';
-        document.getElementById('als-auto-advance').style.display = 'none';
+        document.getElementById('als-next-btn-wrap').style.display = 'none';
         updateProgress();
         showPhase('question');
     }
@@ -1123,30 +1137,29 @@
             }
             fb.style.display = 'block';
 
-            var advanceDelay = d.correct ? 1500 : 3000;
-            _scheduleNextAction(advanceDelay);
+            _showNextButton();
         }).catch(function () {
             showError('Network error while recording answer. Please check your connection.');
         });
     }
 
-    function _scheduleNextAction(delayMs) {
-        var adv = document.getElementById('als-auto-advance');
-        if (adv) {
-            adv.textContent = delayMs >= 3000 ? 'Next question in 3s…' : 'Next question in 1.5s…';
-            adv.style.display = 'block';
-        }
-        setTimeout(function () {
-            if (adv) adv.style.display = 'none';
-            alsNext();
-        }, delayMs);
+    function _showNextButton() {
+        var wrap = document.getElementById('als-next-btn-wrap');
+        var btn  = document.getElementById('als-next-btn');
+        if (wrap) wrap.style.display = 'block';
+        if (btn)  btn.disabled = false;
     }
 
     /* ── Next question ─────────────────────────────────────────────────────── */
     window.alsNext = function () {
+        var btn  = document.getElementById('als-next-btn');
+        var wrap = document.getElementById('als-next-btn-wrap');
+        if (btn) btn.disabled = true;  // double-click guard
+
         var excludeParam = state.recentIds.join(',');
         get('/adaptive-learning/session/' + state.sessionId + '/next-question?exclude_ids=' + excludeParam)
             .then(function (res) {
+                if (wrap) wrap.style.display = 'none';
                 if (!res) return;
                 var d = res.data;
                 if (d.session_complete) {
@@ -1160,6 +1173,7 @@
                 if (!d.id) { alsComplete(); return; }
                 renderQuestion(d);
             }).catch(function () {
+                if (btn)  btn.disabled = false;  // re-enable on network error
                 showError('Could not load the next question. Please try again.');
             });
     };

--- a/app/templates/admin/game_preset_edit.html
+++ b/app/templates/admin/game_preset_edit.html
@@ -108,7 +108,7 @@
     .chart-sum-ok  { background: #c6f6d5; color: #276749; }
     .chart-sum-err { background: #fed7d7; color: #9b2335; }
 
-    /* ── foot_context read-only info ─────────────────────────────────────── */
+    /* ── foot_context badge in chart panel ───────────────────────────────── */
     .fc-info {
         margin-top: 1rem; padding: 0.45rem 0.75rem;
         border-radius: 8px; font-size: 0.78rem; text-align: left;
@@ -185,6 +185,14 @@
                 </div>
                 {% set sc = preset.game_config.get('skill_config', {}) if preset.game_config else {} %}
                 <div class="form-group">
+                    <label>Foot Context</label>
+                    <select name="foot_context" id="footContextSelect" onchange="syncFcBadge(this.value)">
+                        <option value="neutral" {% if foot_ctx == 'neutral' %}selected{% endif %}>neutral — mindkét lábas / default</option>
+                        <option value="right"   {% if foot_ctx == 'right'   %}selected{% endif %}>right — jobb lábas</option>
+                        <option value="left"    {% if foot_ctx == 'left'    %}selected{% endif %}>left — bal lábas</option>
+                    </select>
+                </div>
+                <div class="form-group">
                     <label>
                         <input type="checkbox" name="skill_impact" value="1"
                                {% if sc.get('skill_impact_on_matches', True) %}checked{% endif %}>
@@ -254,10 +262,10 @@
             <!-- Sum badge in chart panel -->
             <div id="chartSumBadge" class="chart-sum-badge" style="display:none;"></div>
 
-            <!-- foot_context read-only info -->
-            <div class="fc-info {% if foot_ctx_explicit %}fc-info-{{ foot_ctx }}{% else %}fc-info-default{% endif %}">
+            <!-- foot_context badge — synced with select via syncFcBadge() -->
+            <div class="fc-info fc-info-{{ foot_ctx }}" id="fcBadge">
                 <div class="fc-info-label">Foot Context</div>
-                {% if foot_ctx_explicit %}{{ foot_ctx }}{% else %}{{ foot_ctx }}/default{% endif %}
+                <span id="fcBadgeText">{{ foot_ctx }}</span>
             </div>
 
         </div>
@@ -269,6 +277,15 @@
 
 {% block scripts %}
 <script>
+// ── Foot context badge sync ───────────────────────────────────────────────
+function syncFcBadge(val) {
+    const badge = document.getElementById('fcBadge');
+    const text  = document.getElementById('fcBadgeText');
+    if (!badge || !text) return;
+    badge.className = 'fc-info fc-info-' + (val || 'neutral');
+    text.textContent = val || 'neutral';
+}
+
 // ── Palette (12 colours, cycles for >12 skills) ───────────────────────────
 const CHART_COLORS = [
     '#667eea','#48bb78','#ed8936','#4299e1',

--- a/app/templates/admin/game_preset_edit.html
+++ b/app/templates/admin/game_preset_edit.html
@@ -6,47 +6,152 @@
 
 {% block extra_styles %}
 <style>
-    .edit-card {
+    /* ── Two-column layout ───────────────────────────────────────────────── */
+    .edit-layout {
+        display: grid;
+        grid-template-columns: 1fr 290px;
+        gap: 1.5rem;
+        align-items: start;
+    }
+    .edit-form-col {
         background: white;
         border-radius: 12px;
         padding: 2rem;
         box-shadow: 0 2px 8px rgba(0,0,0,0.06);
-        max-width: 900px;
+        min-width: 0;
     }
-    .edit-card h2 { margin-bottom: 1.5rem; color: #2d3748; }
+    .edit-form-col h2 { margin: 0 0 1.5rem; color: #2d3748; font-size: 1.15rem; }
+
+    .edit-chart-col { position: sticky; top: 1.5rem; }
+    .chart-panel {
+        background: white;
+        border-radius: 12px;
+        padding: 1.5rem;
+        box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+        text-align: center;
+    }
+    .chart-panel-title {
+        font-size: 0.72rem; font-weight: 700; color: #718096;
+        text-transform: uppercase; letter-spacing: 0.07em; margin-bottom: 1rem;
+    }
+
+    /* ── Form fields ─────────────────────────────────────────────────────── */
     .form-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 1rem; margin-bottom: 1rem; }
     .form-group label { display: block; font-size: 0.85rem; font-weight: 600; color: #4a5568; margin-bottom: 0.4rem; }
-    .form-group input, .form-group select, .form-group textarea { width: 100%; padding: 0.6rem 0.9rem; border: 1px solid #e2e8f0; border-radius: 8px; font-size: 0.9rem; }
+    .form-group input, .form-group select, .form-group textarea {
+        width: 100%; padding: 0.6rem 0.9rem; border: 1px solid #e2e8f0;
+        border-radius: 8px; font-size: 0.9rem; box-sizing: border-box; font-family: inherit;
+    }
     .form-group input:disabled { background: #f0f0f0; color: #718096; }
     .form-group.full { grid-column: 1 / -1; }
+
+    /* ── Skills section ──────────────────────────────────────────────────── */
     .skills-section { background: #f8f9fa; border-radius: 8px; padding: 1rem; margin-bottom: 1rem; }
-    .skills-section h4 { font-size: 0.9rem; color: #2d3748; margin-bottom: 0.75rem; }
-    .skill-group-label { font-size: 0.8rem; color: #718096; font-weight: 600; margin-bottom: 0.4rem; margin-top: 0.75rem; }
-    .skill-row { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 0.5rem; }
-    .skill-item { display: flex; align-items: center; gap: 0.4rem; background: white; border: 1px solid #e2e8f0; border-radius: 6px; padding: 0.3rem 0.6rem; }
+    .skills-section h4 { font-size: 0.85rem; color: #2d3748; margin-bottom: 0.6rem; }
+    .skill-group-label {
+        font-size: 0.7rem; color: #a0aec0; font-weight: 700;
+        text-transform: uppercase; letter-spacing: 0.05em;
+        margin-top: 0.65rem; margin-bottom: 0.3rem;
+    }
+    .skill-row { display: flex; flex-wrap: wrap; gap: 0.3rem; margin-bottom: 0.2rem; }
+    .skill-item {
+        display: flex; align-items: center; gap: 0.35rem;
+        background: white; border: 1px solid #e2e8f0; border-radius: 5px; padding: 0.2rem 0.5rem;
+        transition: border-color 0.12s, background 0.12s;
+    }
+    .skill-item:has(input:checked) { border-color: #667eea; background: #f0f4ff; }
     .skill-item input[type="checkbox"] { cursor: pointer; }
-    .skill-item label { font-size: 0.8rem; color: #4a5568; cursor: pointer; white-space: nowrap; }
+    .skill-item label { font-size: 0.77rem; color: #4a5568; cursor: pointer; white-space: nowrap; }
+
+    /* ── Weights section ─────────────────────────────────────────────────── */
     .weights-section { background: #ebf8ff; border-radius: 8px; padding: 1rem; margin-bottom: 1rem; }
-    .weights-section h4 { font-size: 0.9rem; color: #2c5282; margin-bottom: 0.75rem; }
-    .weight-row { display: grid; grid-template-columns: repeat(4, 1fr); gap: 0.75rem; }
-    .weight-item label { display: block; font-size: 0.8rem; color: #4a5568; margin-bottom: 0.3rem; }
-    .weight-item input { width: 100%; padding: 0.4rem 0.6rem; border: 1px solid #bee3f8; border-radius: 6px; font-size: 0.9rem; }
-    .sum-indicator { margin-top: 0.75rem; padding: 0.5rem 0.75rem; border-radius: 6px; font-size: 0.85rem; font-weight: 600; }
-    .sum-ok { background: #c6f6d5; color: #276749; }
+    .weights-section h4 { font-size: 0.85rem; color: #2c5282; margin-bottom: 0.75rem; }
+    .weight-row { display: grid; grid-template-columns: repeat(3, 1fr); gap: 0.55rem; }
+    .weight-item label {
+        display: block; font-size: 0.74rem; color: #4a5568; margin-bottom: 0.2rem;
+        white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    }
+    .weight-item input {
+        width: 100%; padding: 0.35rem 0.5rem; border: 1px solid #bee3f8;
+        border-radius: 6px; font-size: 0.85rem; box-sizing: border-box;
+    }
+    .weight-item input:focus { outline: none; border-color: #4299e1; box-shadow: 0 0 0 2px rgba(66,153,225,0.15); }
+    .sum-indicator { margin-top: 0.75rem; padding: 0.45rem 0.75rem; border-radius: 6px; font-size: 0.83rem; font-weight: 600; }
+    .sum-ok  { background: #c6f6d5; color: #276749; }
     .sum-err { background: #fed7d7; color: #9b2335; }
-    .form-actions { display: flex; gap: 0.75rem; margin-top: 1.5rem; }
+
+    /* ── Form actions ────────────────────────────────────────────────────── */
+    .form-actions { display: flex; gap: 0.75rem; margin-top: 1.5rem; align-items: center; }
+    #submitBtn:disabled { opacity: 0.45; cursor: not-allowed; }
+
+    /* ── Chart internals ─────────────────────────────────────────────────── */
+    #presetChart { display: block; margin: 0 auto; overflow: visible; }
+
+    .chart-empty {
+        width: 180px; height: 180px; margin: 0 auto;
+        display: flex; align-items: center; justify-content: center;
+        border: 2px dashed #e2e8f0; border-radius: 50%;
+        color: #a0aec0; font-size: 0.8rem;
+    }
+
+    .chart-legend { margin-top: 0.9rem; text-align: left; }
+    .legend-item { display: flex; align-items: center; gap: 0.45rem; padding: 0.18rem 0; font-size: 0.77rem; color: #4a5568; }
+    .legend-dot { width: 9px; height: 9px; border-radius: 50%; flex-shrink: 0; }
+    .legend-name { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .legend-pct { font-weight: 700; color: #2d3748; min-width: 34px; text-align: right; font-size: 0.78rem; }
+
+    .chart-sum-badge {
+        display: inline-block; margin-top: 0.75rem;
+        padding: 0.25rem 0.65rem; border-radius: 999px;
+        font-size: 0.78rem; font-weight: 700;
+    }
+    .chart-sum-ok  { background: #c6f6d5; color: #276749; }
+    .chart-sum-err { background: #fed7d7; color: #9b2335; }
+
+    /* ── foot_context read-only info ─────────────────────────────────────── */
+    .fc-info {
+        margin-top: 1rem; padding: 0.45rem 0.75rem;
+        border-radius: 8px; font-size: 0.78rem; text-align: left;
+    }
+    .fc-info-label {
+        font-size: 0.65rem; font-weight: 700; color: #a0aec0;
+        text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 0.2rem;
+    }
+    .fc-info-right   { background: #f0fff4; border: 1px solid #9ae6b4; color: #276749; }
+    .fc-info-left    { background: #ebf8ff; border: 1px solid #90cdf4; color: #2b6cb0; }
+    .fc-info-neutral { background: #f7fafc; border: 1px solid #e2e8f0; color: #718096; }
+    .fc-info-default { background: #f7fafc; border: 1px dashed #cbd5e0; color: #a0aec0; font-style: italic; }
+
+    /* ── Responsive ──────────────────────────────────────────────────────── */
+    @media (max-width: 820px) {
+        .edit-layout { grid-template-columns: 1fr; }
+        .edit-chart-col { position: static; order: -1; }
+        .chart-panel { margin-bottom: 1.5rem; }
+        .chart-empty { width: 160px; height: 160px; }
+        #presetChart { width: 160px; height: 160px; }
+    }
 </style>
 {% endblock %}
 
 {% block admin_content %}
 
-    <div style="margin-bottom: 1rem;">
-        <a href="/admin/game-presets" class="btn btn-secondary">← Back to Game Presets</a>
-    </div>
+<div style="margin-bottom: 1rem;">
+    <a href="/admin/game-presets" class="btn btn-secondary">← Back to Game Presets</a>
+</div>
 
-    <div class="edit-card">
+{# foot_context detection — raw vs property fallback #}
+{% set sc_info = preset.game_config.get('skill_config', {}) if preset.game_config else {} %}
+{% set foot_ctx_raw = sc_info.get('foot_context') %}
+{% set foot_ctx = foot_ctx_raw if foot_ctx_raw else preset.foot_context %}
+{% set foot_ctx_explicit = foot_ctx_raw is not none and foot_ctx_raw != '' %}
+
+<div class="edit-layout">
+
+    <!-- ── Left column: form ──────────────────────────────────────────────── -->
+    <div class="edit-form-col">
         <h2>✏️ Edit: {{ preset.name }}</h2>
-        <form method="post" action="/admin/game-presets/{{ preset.id }}/edit">
+        <form method="post" action="/admin/game-presets/{{ preset.id }}/edit" id="editForm">
+
             <div class="form-grid">
                 <div class="form-group">
                     <label>Name *</label>
@@ -90,7 +195,7 @@
 
             <!-- Skills selection -->
             <div class="skills-section">
-                <h4>Skills tested — check each skill to include:</h4>
+                <h4>Skills tested — check to include:</h4>
                 {% for group in skill_groups %}
                 <div class="skill-group-label">{{ group.label }}</div>
                 <div class="skill-row">
@@ -109,13 +214,14 @@
 
             <!-- Skill weights -->
             <div class="weights-section" id="weightsSection">
-                <h4>Skill weights (%) — assign a percentage to each skill; must sum to <strong>100%</strong></h4>
+                <h4>Skill weights (%) — must sum to <strong>100%</strong></h4>
                 <div class="weight-row" id="weightInputs">
                     {% for skill_key in current_skills %}
                     {% set pct = weight_pcts.get(skill_key, 10) %}
                     <div class="weight-item">
                         <label>{{ skill_key.replace('_', ' ').title() }} %</label>
-                        <input type="number" name="skill_w_{{ skill_key }}" value="{{ pct }}" min="1" max="100" oninput="updateSum()">
+                        <input type="number" name="skill_w_{{ skill_key }}" value="{{ pct }}"
+                               min="1" max="100" oninput="onWeightInput()">
                     </div>
                     {% endfor %}
                 </div>
@@ -123,55 +229,236 @@
             </div>
 
             <div class="form-actions">
-                <button type="submit" class="btn btn-success">💾 Save Changes</button>
+                <button type="submit" class="btn btn-success" id="submitBtn">💾 Save Changes</button>
                 <a href="/admin/game-presets" class="btn btn-secondary">Cancel</a>
+                <span id="saveHint" style="font-size:0.78rem;color:#9b2335;display:none;">Fix weight sum first</span>
             </div>
+
         </form>
     </div>
+
+    <!-- ── Right column: chart panel ─────────────────────────────────────── -->
+    <div class="edit-chart-col">
+        <div class="chart-panel">
+            <div class="chart-panel-title">Skill Distribution</div>
+
+            <!-- SVG donut (built by JS) / empty state -->
+            <div id="chartSvgWrap">
+                <svg id="presetChart" width="180" height="180" viewBox="0 0 180 180"></svg>
+            </div>
+            <div id="chartEmpty" class="chart-empty" style="display:none;">No skills<br>selected</div>
+
+            <!-- Legend -->
+            <div class="chart-legend" id="chartLegend"></div>
+
+            <!-- Sum badge in chart panel -->
+            <div id="chartSumBadge" class="chart-sum-badge" style="display:none;"></div>
+
+            <!-- foot_context read-only info -->
+            <div class="fc-info {% if foot_ctx_explicit %}fc-info-{{ foot_ctx }}{% else %}fc-info-default{% endif %}">
+                <div class="fc-info-label">Foot Context</div>
+                {% if foot_ctx_explicit %}{{ foot_ctx }}{% else %}{{ foot_ctx }}/default{% endif %}
+            </div>
+
+        </div>
+    </div>
+
+</div>
 
 {% endblock %}
 
 {% block scripts %}
 <script>
-function updateWeights() {
+// ── Palette (12 colours, cycles for >12 skills) ───────────────────────────
+const CHART_COLORS = [
+    '#667eea','#48bb78','#ed8936','#4299e1',
+    '#ed64a6','#9f7aea','#38b2ac','#f6ad55',
+    '#fc8181','#4fd1c5','#fbd38d','#9ae6b4'
+];
+
+// ── SVG helpers ───────────────────────────────────────────────────────────
+function _polar(cx, cy, r, deg) {
+    const rad = (deg - 90) * Math.PI / 180;
+    return { x: cx + r * Math.cos(rad), y: cy + r * Math.sin(rad) };
+}
+
+function _arcPath(cx, cy, R, r, startDeg, endDeg) {
+    const s1 = _polar(cx, cy, R, startDeg), e1 = _polar(cx, cy, R, endDeg);
+    const s2 = _polar(cx, cy, r, endDeg),   e2 = _polar(cx, cy, r, startDeg);
+    const lg = (endDeg - startDeg > 180) ? 1 : 0;
+    const f = v => v.toFixed(3);
+    return `M${f(s1.x)} ${f(s1.y)} A${R} ${R} 0 ${lg} 1 ${f(e1.x)} ${f(e1.y)} `
+         + `L${f(s2.x)} ${f(s2.y)} A${r} ${r} 0 ${lg} 0 ${f(e2.x)} ${f(e2.y)} Z`;
+}
+
+function _svgEl(tag, attrs) {
+    const el = document.createElementNS('http://www.w3.org/2000/svg', tag);
+    Object.entries(attrs).forEach(([k, v]) => el.setAttribute(k, v));
+    return el;
+}
+
+// ── Chart builder ─────────────────────────────────────────────────────────
+function buildChart() {
+    const svg    = document.getElementById('presetChart');
+    const wrap   = document.getElementById('chartSvgWrap');
+    const empty  = document.getElementById('chartEmpty');
+    const legend = document.getElementById('chartLegend');
+    const badge  = document.getElementById('chartSumBadge');
+
+    // Collect checked skills + their typed weight values
     const checked = Array.from(document.querySelectorAll('[name^="skill_cb_"]:checked'));
+    const keys    = checked.map(cb => cb.name.replace('skill_cb_', ''));
+    const rawVals = keys.map(k => {
+        const inp = document.querySelector(`[name="skill_w_${k}"]`);
+        return Math.max(1, parseInt(inp ? inp.value : 0) || 1);
+    });
+    const inputSum = rawVals.reduce((a, b) => a + b, 0);
+
+    // Empty state
+    if (keys.length === 0) {
+        wrap.style.display = 'none';
+        empty.style.display = 'flex';
+        legend.innerHTML = '';
+        badge.style.display = 'none';
+        return;
+    }
+    wrap.style.display = 'block';
+    empty.style.display = 'none';
+
+    // Proportional percentages for slice sizes (always sum to 100 visually)
+    const pcts = rawVals.map(v => v / inputSum * 100);
+
+    // Friendly labels from DOM
+    const labels = checked.map(cb => {
+        const lbl = cb.closest('.skill-item')?.querySelector('label');
+        return lbl ? lbl.textContent.trim()
+                   : cb.name.replace('skill_cb_', '').replace(/_/g, ' ');
+    });
+
+    // Draw SVG
+    const cx = 90, cy = 90, R = 80, ri = 44;
+    svg.innerHTML = '';
+
+    if (keys.length === 1) {
+        // Full donut — two concentric circles
+        svg.appendChild(_svgEl('circle', { cx, cy, r: R, fill: CHART_COLORS[0] }));
+        svg.appendChild(_svgEl('circle', { cx, cy, r: ri, fill: 'white' }));
+    } else {
+        let deg = 0;
+        keys.forEach((k, i) => {
+            const sweep  = pcts[i] / 100 * 360;
+            const endDeg = deg + sweep;
+            svg.appendChild(_svgEl('path', {
+                d: _arcPath(cx, cy, R, ri, deg, endDeg),
+                fill: CHART_COLORS[i % CHART_COLORS.length],
+                stroke: 'white',
+                'stroke-width': '2'
+            }));
+            deg = endDeg;
+        });
+    }
+
+    // Centre label: skill count
+    const txt = _svgEl('text', {
+        x: cx, y: cy - 7,
+        'text-anchor': 'middle', 'dominant-baseline': 'central',
+        'font-size': '20', 'font-weight': '700', fill: '#2d3748',
+        'font-family': 'inherit'
+    });
+    txt.textContent = keys.length;
+    const sub = _svgEl('text', {
+        x: cx, y: cy + 14,
+        'text-anchor': 'middle', 'dominant-baseline': 'central',
+        'font-size': '10', fill: '#a0aec0', 'font-family': 'inherit'
+    });
+    sub.textContent = keys.length === 1 ? 'skill' : 'skills';
+    svg.appendChild(txt);
+    svg.appendChild(sub);
+
+    // Legend
+    legend.innerHTML = keys.map((k, i) => {
+        const dispPct = Math.round(pcts[i]);
+        return `<div class="legend-item">
+            <span class="legend-dot" style="background:${CHART_COLORS[i % CHART_COLORS.length]}"></span>
+            <span class="legend-name">${labels[i]}</span>
+            <span class="legend-pct">${dispPct}%</span>
+        </div>`;
+    }).join('');
+
+    // Sum badge in chart panel
+    badge.style.display = 'inline-block';
+    if (inputSum === 100) {
+        badge.textContent = '✅ 100%';
+        badge.className = 'chart-sum-badge chart-sum-ok';
+    } else {
+        const diff = inputSum - 100;
+        badge.textContent = `⚠️ ${inputSum}% (${diff > 0 ? '+' : ''}${diff})`;
+        badge.className = 'chart-sum-badge chart-sum-err';
+    }
+}
+
+// ── Form sum indicator + Save gating ─────────────────────────────────────
+function updateSum() {
+    const inputs = document.querySelectorAll('#weightInputs input[type="number"]');
+    let sum = 0;
+    inputs.forEach(inp => { sum += parseInt(inp.value) || 0; });
+
+    const indicator = document.getElementById('sumIndicator');
+    const btn       = document.getElementById('submitBtn');
+    const hint      = document.getElementById('saveHint');
+
+    if (sum === 100) {
+        indicator.className = 'sum-indicator sum-ok';
+        indicator.textContent = '✅ Sum: 100% — ready to save';
+        btn.disabled = false;
+        hint.style.display = 'none';
+    } else {
+        const diff = sum - 100;
+        indicator.className = 'sum-indicator sum-err';
+        indicator.textContent = `❌ Sum: ${sum}% (${diff > 0 ? '+' : ''}${diff}) — must be exactly 100%`;
+        btn.disabled = true;
+        hint.style.display = 'inline';
+    }
+
+    buildChart();
+}
+
+function onWeightInput() { updateSum(); }
+
+// ── Rebuild weight inputs when checkboxes change ──────────────────────────
+function updateWeights() {
+    const checked   = Array.from(document.querySelectorAll('[name^="skill_cb_"]:checked'));
     const container = document.getElementById('weightInputs');
-    const section = document.getElementById('weightsSection');
-    // Preserve existing values
+    const section   = document.getElementById('weightsSection');
+
+    // Preserve current values before clearing
     const existing = {};
     container.querySelectorAll('input[type="number"]').forEach(inp => {
         existing[inp.name] = inp.value;
     });
     container.innerHTML = '';
+
     checked.forEach(cb => {
-        const key = cb.name.replace('skill_cb_', '');
-        const label = cb.parentElement.querySelector('label').textContent;
-        const div = document.createElement('div');
+        const key   = cb.name.replace('skill_cb_', '');
+        const label = cb.closest('.skill-item')?.querySelector('label')?.textContent.trim()
+                      || key.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+        const val   = existing['skill_w_' + key] || 10;
+        const div   = document.createElement('div');
         div.className = 'weight-item';
-        const val = existing['skill_w_' + key] || 10;
-        div.innerHTML = `<label>${label} %</label><input type="number" name="skill_w_${key}" value="${val}" min="1" max="100" oninput="updateSum()">`;
+        div.innerHTML = `<label>${label} %</label>`
+            + `<input type="number" name="skill_w_${key}" value="${val}" min="1" max="100" oninput="onWeightInput()">`;
         container.appendChild(div);
     });
+
     section.style.display = checked.length === 0 ? 'none' : 'block';
     updateSum();
 }
 
-function updateSum() {
-    const inputs = document.querySelectorAll('#weightInputs input[type="number"]');
-    let sum = 0;
-    inputs.forEach(inp => { sum += parseInt(inp.value) || 0; });
-    const indicator = document.getElementById('sumIndicator');
-    if (sum === 100) {
-        indicator.className = 'sum-indicator sum-ok';
-        indicator.textContent = '✅ Sum: ' + sum + '% — ready to save';
-    } else {
-        const diff = sum - 100;
-        indicator.className = 'sum-indicator sum-err';
-        indicator.textContent = '❌ Sum: ' + sum + '% (' + (diff > 0 ? '+' : '') + diff + '%) — must be exactly 100%';
-    }
-}
-
-// Initial sum calculation
-document.addEventListener('DOMContentLoaded', updateSum);
+// ── Initialise on load ────────────────────────────────────────────────────
+document.addEventListener('DOMContentLoaded', function () {
+    const hasSkills = document.querySelectorAll('[name^="skill_cb_"]:checked').length > 0;
+    document.getElementById('weightsSection').style.display = hasSkills ? 'block' : 'none';
+    updateSum(); // draws chart + sets button state
+});
 </script>
 {% endblock %}

--- a/app/templates/admin/game_preset_edit.html
+++ b/app/templates/admin/game_preset_edit.html
@@ -187,9 +187,9 @@
                 <div class="form-group">
                     <label>Foot Context</label>
                     <select name="foot_context" id="footContextSelect" onchange="syncFcBadge(this.value)">
-                        <option value="neutral" {% if foot_ctx == 'neutral' %}selected{% endif %}>neutral — mindkét lábas / default</option>
-                        <option value="right"   {% if foot_ctx == 'right'   %}selected{% endif %}>right — jobb lábas</option>
-                        <option value="left"    {% if foot_ctx == 'left'    %}selected{% endif %}>left — bal lábas</option>
+                        <option value="neutral" {% if foot_ctx == 'neutral' %}selected{% endif %}>neutral — both feet / default</option>
+                        <option value="right"   {% if foot_ctx == 'right'   %}selected{% endif %}>right — right foot</option>
+                        <option value="left"    {% if foot_ctx == 'left'    %}selected{% endif %}>left — left foot</option>
                     </select>
                 </div>
                 <div class="form-group">

--- a/app/templates/admin/game_presets.html
+++ b/app/templates/admin/game_presets.html
@@ -8,18 +8,6 @@
 <style>
     .section-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1.5rem; }
     .section-header h2 { font-size: 1.5rem; color: #2d3748; }
-    .card { background: white; border-radius: 12px; box-shadow: 0 2px 8px rgba(0,0,0,0.06); margin-bottom: 1rem; overflow: hidden; }
-    .card-header { padding: 1rem 1.5rem; background: #f8f9fa; display: flex; justify-content: space-between; align-items: center; border-bottom: 1px solid #e2e8f0; cursor: pointer; }
-    .card-header h3 { font-size: 1.05rem; color: #2d3748; display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; }
-    .card-body { padding: 1.5rem; display: none; }
-    .card-body.open { display: block; }
-    .badge-active { background: #c6f6d5; color: #276749; }
-    .badge-inactive { background: #fed7d7; color: #9b2335; }
-    .badge-recommended { background: #fef3c7; color: #92400e; }
-    .info-row { margin-bottom: 0.75rem; }
-    .info-row label { font-size: 0.8rem; color: #718096; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; display: block; margin-bottom: 0.2rem; }
-    .skills-str { font-size: 0.9rem; color: #2d3748; }
-    .action-row { display: flex; gap: 0.75rem; margin-top: 1rem; flex-wrap: wrap; }
     .create-form { background: white; border-radius: 12px; box-shadow: 0 2px 8px rgba(0,0,0,0.06); padding: 2rem; margin-top: 1.5rem; }
     .create-form h3 { margin-bottom: 1.5rem; color: #2d3748; }
     .form-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 1rem; margin-bottom: 1rem; }
@@ -43,6 +31,45 @@
     .sum-err { background: #fed7d7; color: #9b2335; }
     .no-data { text-align: center; padding: 3rem; color: #718096; }
     .btn-sm { padding: 0.35rem 0.75rem; font-size: 0.8rem; }
+
+    /* ─── Preset table ──────────────────────────────────────────────────────── */
+    .preset-table { width: 100%; border-collapse: collapse; font-size: 0.875rem; }
+    .preset-table thead th { background: #f7fafc; color: #718096; font-size: 0.72rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; padding: 0.55rem 0.75rem; border-bottom: 2px solid #e2e8f0; white-space: nowrap; }
+    .preset-table tbody tr { border-bottom: 1px solid #f0f0f0; transition: background 0.1s; }
+    .preset-table tbody tr:last-child { border-bottom: none; }
+    .preset-table tbody tr:hover { background: #fafbff; }
+    .preset-table td { padding: 0.5rem 0.75rem; vertical-align: middle; }
+    .preset-code { font-family: monospace; font-size: 0.78rem; background: #f0f0f0; padding: 0.1rem 0.4rem; border-radius: 4px; color: #4a5568; }
+    .skill-pill { display: inline-block; background: #e9d8fd; color: #553c9a; border-radius: 4px; padding: 0.1rem 0.35rem; font-size: 0.72rem; margin-right: 0.2rem; white-space: nowrap; }
+    .skill-more { font-size: 0.72rem; color: #718096; }
+    .btn-tbl { padding: 0.2rem 0.55rem; font-size: 0.75rem; border-radius: 4px; font-weight: 600; cursor: pointer; text-decoration: none; display: inline-block; white-space: nowrap; }
+    .btn-tbl-primary { background: #5a4a9a; color: white; border: none; }
+    .btn-tbl-primary:hover { background: #4a3a8a; color: white; }
+    .btn-tbl-warning { background: white; color: #c05621; border: 1px solid #fbd38d; }
+    .btn-tbl-warning:hover { background: #fffbf0; }
+    .btn-tbl-danger { background: white; color: #c53030; border: 1px solid #fed7d7; }
+    .btn-tbl-danger:hover { background: #fff5f5; }
+
+    /* Laterality left-border indicators */
+    .lat-right   { border-left: 3px solid #48bb78; }
+    .lat-left    { border-left: 3px solid #4299e1; }
+    .lat-neutral { border-left: 3px solid #a0aec0; }
+
+    /* Foot context inline badges */
+    .fc-badge { display: inline-block; padding: 0.1rem 0.45rem; border-radius: 4px; font-size: 0.72rem; font-weight: 700; white-space: nowrap; }
+    .fc-right   { background: #f0fff4; color: #276749; border: 1px solid #9ae6b4; }
+    .fc-left    { background: #ebf8ff; color: #2b6cb0; border: 1px solid #90cdf4; }
+    .fc-neutral { background: #f7fafc; color: #718096; border: 1px solid #e2e8f0; }
+
+    /* Mobile: stack table rows as cards */
+    @media (max-width: 768px) {
+        .preset-table thead { display: none; }
+        .preset-table, .preset-table tbody, .preset-table tr, .preset-table td { display: block; }
+        .preset-table tbody tr { border: 1px solid #e2e8f0; border-radius: 8px; margin-bottom: 0.75rem; padding: 0.25rem 0.75rem; background: white; border-left-width: 3px; }
+        .preset-table td { padding: 0.3rem 0; border: none; font-size: 0.85rem; }
+        .preset-table td::before { content: attr(data-label); font-weight: 700; font-size: 0.7rem; color: #a0aec0; text-transform: uppercase; letter-spacing: 0.04em; display: inline-block; width: 90px; }
+        .preset-table td[data-label=""]::before { display: none; }
+    }
 </style>
 {% endblock %}
 
@@ -72,73 +99,75 @@
     </div>
 
     {% if presets %}
-        {% for p in presets %}
-        {% set sc = p.game_config.get('skill_config', {}) if p.game_config else {} %}
-        {% set meta = p.game_config.get('metadata', {}) if p.game_config else {} %}
-        {% set skills = sc.get('skills_tested', []) %}
-        {% set weights = sc.get('skill_weights', {}) %}
-        <div class="card">
-            <div class="card-header" onclick="toggleCard('preset-{{ p.id }}')">
-                <h3>
-                    {% if p.is_active %}🟢{% else %}⚫{% endif %}
-                    {% if p.is_recommended %}⭐ {% endif %}
-                    <strong>{{ p.name }}</strong>
-                    <code style="background: #f0f0f0; padding: 0.1rem 0.4rem; border-radius: 4px; font-size: 0.8rem">{{ p.code }}</code>
-                    · {{ skills | length }} skills
-                    <span class="badge {% if p.is_active %}badge-active{% else %}badge-inactive{% endif %}">{{ 'Active' if p.is_active else 'Inactive' }}</span>
-                    {% if p.is_recommended %}<span class="badge badge-recommended">⭐ Recommended</span>{% endif %}
-                </h3>
-                <span style="color: #718096; font-size: 0.85rem">id={{ p.id }} ▼</span>
-            </div>
-            <div class="card-body" id="preset-{{ p.id }}">
-                {% if p.description %}
-                <div class="info-row">
-                    <label>Description</label>
-                    <p class="skills-str">{{ p.description }}</p>
-                </div>
-                {% endif %}
-                <div class="info-row">
-                    <label>Skills</label>
-                    <p class="skills-str">
-                        {% if weights %}
-                            {% set total_w = weights.values() | sum %}
-                            {% for s in skills %}
-                                {% if s in weights %}
-                                    {{ s.replace('_', ' ').title() }} {{ (weights[s] / total_w * 100) | round | int }}%{% if not loop.last %}  ·  {% endif %}
-                                {% endif %}
-                            {% endfor %}
-                        {% else %}
-                            {{ skills | join(', ') or '—' }}
-                        {% endif %}
-                    </p>
-                </div>
-                <div class="info-row" style="display: flex; gap: 2rem">
-                    {% if meta.get('game_category') %}<span>🎮 {{ meta.game_category }}</span>{% endif %}
-                    {% if meta.get('difficulty_level') %}<span>📶 {{ meta.difficulty_level }}</span>{% endif %}
-                    {% if meta.get('min_players') %}<span>👥 min {{ meta.min_players }} players</span>{% endif %}
-                    <span style="color: #718096; font-size: 0.85rem">id={{ p.id }} · code={{ p.code }}</span>
-                </div>
-                <div class="action-row">
-                    {% if not p.is_locked %}
-                    <a href="/admin/game-presets/{{ p.id }}/edit" class="btn btn-sm btn-primary">✏️ Edit</a>
-                    {% endif %}
-                    <form method="post" action="/admin/game-presets/{{ p.id }}/toggle" style="display:inline">
-                        <button type="submit" class="btn btn-sm btn-warning">
-                            {{ '⚫ Deactivate' if p.is_active else '🟢 Activate' }}
-                        </button>
-                    </form>
-                    {% if not p.is_locked %}
-                    <form method="post" action="/admin/game-presets/{{ p.id }}/delete" style="display:inline"
-                          onsubmit="return confirm('Delete preset {{ p.name }}? This cannot be undone.')">
-                        <button type="submit" class="btn btn-sm btn-danger">🗑️ Delete</button>
-                    </form>
+    <div style="background: white; border-radius: 12px; box-shadow: 0 2px 8px rgba(0,0,0,0.06); overflow: hidden; margin-bottom: 1.5rem;">
+    <table class="preset-table">
+        <thead>
+            <tr>
+                <th></th>
+                <th>Name</th>
+                <th>Code</th>
+                <th>Foot Context</th>
+                <th>Skills</th>
+                <th>Rec.</th>
+                <th>ID</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for p in presets %}
+            {% set sc = p.game_config.get('skill_config', {}) if p.game_config else {} %}
+            {% set skills = sc.get('skills_tested', []) %}
+            {% set foot_ctx = sc.get('foot_context', '') %}
+            <tr class="{% if foot_ctx == 'right' %}lat-right{% elif foot_ctx == 'left' %}lat-left{% elif foot_ctx == 'neutral' %}lat-neutral{% endif %}">
+                <td data-label="">
+                    {% if p.is_active %}
+                    <span title="Active" style="color: #276749; font-size: 0.9rem;">●</span>
                     {% else %}
-                    <span style="color: #718096; font-size: 0.8rem">🔒 Locked — cannot edit or delete</span>
+                    <span title="Inactive" style="color: #cbd5e0; font-size: 0.9rem;">●</span>
                     {% endif %}
-                </div>
-            </div>
-        </div>
-        {% endfor %}
+                </td>
+                <td data-label="Name">
+                    <strong>{{ p.name }}</strong>
+                    {% if not p.is_active %}<span style="font-size: 0.72rem; color: #a0aec0; margin-left: 0.3rem;">(inactive)</span>{% endif %}
+                </td>
+                <td data-label="Code"><code class="preset-code">{{ p.code }}</code></td>
+                <td data-label="Foot Context">
+                    {% if foot_ctx %}
+                    <span class="fc-badge fc-{{ foot_ctx }}">{{ foot_ctx }}</span>
+                    {% else %}
+                    <span style="color: #cbd5e0; font-size: 0.8rem;">—</span>
+                    {% endif %}
+                </td>
+                <td data-label="Skills">
+                    {% for s in skills[:3] %}<span class="skill-pill">{{ s.replace('_', ' ') }}</span>{% endfor %}
+                    {% if skills | length > 3 %}<span class="skill-more">+{{ skills | length - 3 }}</span>{% endif %}
+                    {% if not skills %}<span style="color: #cbd5e0; font-size: 0.8rem;">—</span>{% endif %}
+                </td>
+                <td data-label="Rec.">{% if p.is_recommended %}⭐{% else %}<span style="color: #e2e8f0;">—</span>{% endif %}</td>
+                <td data-label="ID" style="color: #a0aec0; font-size: 0.8rem; white-space: nowrap;">{{ p.id }}</td>
+                <td data-label="Actions">
+                    <div style="display: flex; gap: 0.3rem; flex-wrap: wrap; align-items: center;">
+                        {% if not p.is_locked %}
+                        <a href="/admin/game-presets/{{ p.id }}/edit" class="btn-tbl btn-tbl-primary">✏️ Edit</a>
+                        {% endif %}
+                        <form method="post" action="/admin/game-presets/{{ p.id }}/toggle" style="display:inline">
+                            <button type="submit" class="btn-tbl btn-tbl-warning">{{ '⚫ Off' if p.is_active else '🟢 On' }}</button>
+                        </form>
+                        {% if not p.is_locked %}
+                        <form method="post" action="/admin/game-presets/{{ p.id }}/delete" style="display:inline"
+                              onsubmit="return confirm('Delete preset {{ p.name }}? This cannot be undone.')">
+                            <button type="submit" class="btn-tbl btn-tbl-danger">🗑️</button>
+                        </form>
+                        {% else %}
+                        <span style="color: #a0aec0; font-size: 0.72rem;" title="Locked — cannot edit or delete">🔒</span>
+                        {% endif %}
+                    </div>
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    </div>
     {% else %}
         <div class="no-data">
             <p style="font-size: 1.5rem">🎮</p>
@@ -228,11 +257,6 @@
 
 {% block scripts %}
 <script>
-function toggleCard(id) {
-    const body = document.getElementById(id);
-    body.classList.toggle('open');
-}
-
 let codeManuallyEdited = false;
 document.getElementById('codeField').addEventListener('input', () => { codeManuallyEdited = true; });
 

--- a/app/templates/admin/game_presets.html
+++ b/app/templates/admin/game_presets.html
@@ -60,6 +60,7 @@
     .fc-right   { background: #f0fff4; color: #276749; border: 1px solid #9ae6b4; }
     .fc-left    { background: #ebf8ff; color: #2b6cb0; border: 1px solid #90cdf4; }
     .fc-neutral { background: #f7fafc; color: #718096; border: 1px solid #e2e8f0; }
+    .fc-default { background: #f7fafc; color: #a0aec0; border: 1px dashed #cbd5e0; font-style: italic; font-weight: 400; }
 
     /* Mobile: stack table rows as cards */
     @media (max-width: 768px) {
@@ -117,8 +118,9 @@
             {% for p in presets %}
             {% set sc = p.game_config.get('skill_config', {}) if p.game_config else {} %}
             {% set skills = sc.get('skills_tested', []) %}
-            {% set foot_ctx = sc.get('foot_context', '') %}
-            <tr class="{% if foot_ctx == 'right' %}lat-right{% elif foot_ctx == 'left' %}lat-left{% elif foot_ctx == 'neutral' %}lat-neutral{% endif %}">
+            {% set foot_ctx_raw = sc.get('foot_context') %}
+            {% set foot_ctx = foot_ctx_raw or p.foot_context %}
+            <tr class="{% if foot_ctx_raw == 'right' %}lat-right{% elif foot_ctx_raw == 'left' %}lat-left{% elif foot_ctx_raw == 'neutral' %}lat-neutral{% endif %}">
                 <td data-label="">
                     {% if p.is_active %}
                     <span title="Active" style="color: #276749; font-size: 0.9rem;">●</span>
@@ -132,10 +134,10 @@
                 </td>
                 <td data-label="Code"><code class="preset-code">{{ p.code }}</code></td>
                 <td data-label="Foot Context">
-                    {% if foot_ctx %}
+                    {% if foot_ctx_raw %}
                     <span class="fc-badge fc-{{ foot_ctx }}">{{ foot_ctx }}</span>
                     {% else %}
-                    <span style="color: #cbd5e0; font-size: 0.8rem;">—</span>
+                    <span class="fc-badge fc-default" title="No explicit foot_context stored — defaults to neutral at runtime">{{ foot_ctx }}/default</span>
                     {% endif %}
                 </td>
                 <td data-label="Skills">

--- a/app/templates/admin/game_presets.html
+++ b/app/templates/admin/game_presets.html
@@ -219,6 +219,14 @@
                     <input type="number" name="min_players" value="4" min="2" max="1024">
                 </div>
                 <div class="form-group">
+                    <label>Foot Context</label>
+                    <select name="foot_context">
+                        <option value="neutral" selected>neutral — mindkét lábas / default</option>
+                        <option value="right">right — jobb lábas</option>
+                        <option value="left">left — bal lábas</option>
+                    </select>
+                </div>
+                <div class="form-group">
                     <label>
                         <input type="checkbox" name="skill_impact" value="1" checked>
                         Skill impact on matches

--- a/app/templates/admin/game_presets.html
+++ b/app/templates/admin/game_presets.html
@@ -221,9 +221,9 @@
                 <div class="form-group">
                     <label>Foot Context</label>
                     <select name="foot_context">
-                        <option value="neutral" selected>neutral — mindkét lábas / default</option>
-                        <option value="right">right — jobb lábas</option>
-                        <option value="left">left — bal lábas</option>
+                        <option value="neutral" selected>neutral — both feet / default</option>
+                        <option value="right">right — right foot</option>
+                        <option value="left">left — left foot</option>
                     </select>
                 </div>
                 <div class="form-group">

--- a/app/templates/admin/sponsor_campaign_detail.html
+++ b/app/templates/admin/sponsor_campaign_detail.html
@@ -34,6 +34,28 @@
     .alert-bar { padding: 0.75rem 1rem; border-radius: 8px; margin-bottom: 1rem; font-size: 0.9rem; }
     .alert-success { background: #f0fff4; border: 1px solid #9ae6b4; color: #276749; }
     .alert-error   { background: #fff5f5; border: 1px solid #feb2b2; color: #9b2c2c; }
+
+    .status-badge { display: inline-block; padding: 0.15rem 0.6rem; border-radius: 999px; font-size: 0.78rem; font-weight: 700; }
+    .status-badge--active { background: #f0fff4; color: #276749; border: 1px solid #9ae6b4; }
+    .status-badge--closed { background: #f7fafc; color: #718096; border: 1px solid #cbd5e0; }
+
+    .btn-danger { padding: 0.4rem 1rem; border-radius: 6px; font-size: 0.83rem; font-weight: 600; border: 1px solid #fc8181; background: white; color: #c53030; cursor: pointer; }
+    .btn-danger:hover { background: #fff5f5; }
+
+    .modal-overlay { display: none; position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 1000; align-items: center; justify-content: center; }
+    .modal-box { background: white; border-radius: 12px; padding: 2rem; width: 100%; max-width: 560px; max-height: 90vh; overflow-y: auto; box-shadow: 0 20px 60px rgba(0,0,0,0.3); }
+    .modal-box h3 { margin: 0 0 1.5rem; font-size: 1.1rem; color: #2d3748; }
+    .m-form-group { margin-bottom: 1rem; }
+    .m-form-group label { display: block; font-size: 0.8rem; font-weight: 600; color: #718096; margin-bottom: 0.3rem; text-transform: uppercase; letter-spacing: 0.04em; }
+    .m-form-group input, .m-form-group select { width: 100%; padding: 0.5rem 0.75rem; border: 1px solid #e2e8f0; border-radius: 6px; font-size: 0.9rem; box-sizing: border-box; font-family: inherit; }
+    .m-form-group input:focus { outline: none; border-color: #667eea; box-shadow: 0 0 0 3px rgba(102,126,234,0.15); }
+    .m-form-group input[readonly] { background: #f7fafc; color: #718096; cursor: not-allowed; }
+    .form-row { display: flex; gap: 1rem; }
+    .form-row .m-form-group { flex: 1; }
+    .field-hint { font-size: 0.75rem; color: #a0aec0; margin-top: 0.2rem; }
+    .modal-actions { display: flex; gap: 0.75rem; justify-content: flex-end; margin-top: 1.5rem; }
+    .btn-modal-primary { background: #5a4a9a; color: white; border: none; padding: 0.5rem 1.25rem; border-radius: 6px; font-weight: 600; cursor: pointer; font-size: 0.9rem; }
+    .btn-modal-secondary { background: white; color: #718096; border: 1px solid #e2e8f0; padding: 0.5rem 1.25rem; border-radius: 6px; cursor: pointer; font-size: 0.9rem; }
 </style>
 {% endblock %}
 
@@ -58,15 +80,26 @@
 <div class="section-card">
     <div class="section-header">
         <h3>📊 Campaign Overview</h3>
-        <div style="display:flex;gap:0.5rem;">
+        <div style="display:flex;gap:0.5rem;align-items:center;">
             {% if active_entries %}
             <a href="/admin/sponsors/{{ sponsor.id }}/campaigns/{{ campaign.id }}/audience"
                class="btn-action">👥 View Audience →</a>
             {% endif %}
-            {% if sponsor.is_active %}
+            {% if sponsor.is_active and campaign.status == 'ACTIVE' %}
             <a href="/admin/sponsors/{{ sponsor.id }}/campaigns/{{ campaign.id }}/import"
                class="btn-cta">↑ Upload CSV</a>
+            <form method="POST"
+                  action="/admin/sponsors/{{ sponsor.id }}/campaigns/{{ campaign.id }}/close"
+                  style="margin:0;"
+                  onsubmit="return confirm('Close this campaign?\n\nNo further imports or promotions will be allowed.')">
+                <input type="hidden" name="csrf_token" class="csrf-field">
+                <button type="submit" class="btn-danger">✕ Close Campaign</button>
+            </form>
             {% endif %}
+            <button class="btn-action"
+                    onclick="document.getElementById('edit-campaign-modal').style.display='flex'">
+                ✏️ Edit
+            </button>
         </div>
     </div>
     <div class="section-body">
@@ -89,7 +122,21 @@
             </div>
             <div class="meta-item">
                 <div class="meta-label">Status</div>
-                <div class="meta-value" style="font-size:0.85rem;">{{ campaign.status }}</div>
+                <div class="meta-value" style="font-size:0.85rem;">
+                    <span class="status-badge status-badge--{{ campaign.status | lower }}">{{ campaign.status }}</span>
+                </div>
+            </div>
+            <div class="meta-item">
+                <div class="meta-label">Specialization</div>
+                <div class="meta-value" style="font-size:0.85rem;">{{ campaign.specialization_type }}</div>
+            </div>
+            <div class="meta-item">
+                <div class="meta-label">Credit Grant</div>
+                <div class="meta-value" style="color:#38a169;">{{ campaign.credit_grant_amount }}</div>
+            </div>
+            <div class="meta-item">
+                <div class="meta-label">Unlock Cost</div>
+                <div class="meta-value" style="color:#553c9a;">{{ campaign.unlock_cost }}</div>
             </div>
             {% if campaign.event_date %}
             <div class="meta-item">
@@ -136,12 +183,59 @@
         {% else %}
         <p style="color:#a0aec0;font-size:0.85rem;margin:0;">
             No imports yet.
-            {% if sponsor.is_active %}
+            {% if sponsor.is_active and campaign.status == 'ACTIVE' %}
             <a href="/admin/sponsors/{{ sponsor.id }}/campaigns/{{ campaign.id }}/import"
                style="color:#667eea;">Upload a CSV to this campaign.</a>
             {% endif %}
         </p>
         {% endif %}
+    </div>
+</div>
+
+<!-- ── Edit Campaign Modal ─────────────────────────────────────────────────── -->
+<div id="edit-campaign-modal" class="modal-overlay">
+    <div class="modal-box">
+        <h3>✏️ Edit Campaign</h3>
+        <form method="POST"
+              action="/admin/sponsors/{{ sponsor.id }}/campaigns/{{ campaign.id }}/edit">
+            <input type="hidden" name="csrf_token" class="csrf-field">
+            <div class="m-form-group">
+                <label>Campaign Name *</label>
+                <input name="name" type="text" required value="{{ campaign.name }}">
+            </div>
+            <div class="m-form-group">
+                <label>Event Date</label>
+                <input name="event_date" type="date"
+                       value="{{ campaign.event_date.strftime('%Y-%m-%d') if campaign.event_date else '' }}">
+            </div>
+            <div class="form-row">
+                <div class="m-form-group">
+                    <label>Credit Grant (min 100) *</label>
+                    <input name="credit_grant_amount" type="number" min="100" required
+                           value="{{ campaign.credit_grant_amount }}"
+                           {% if campaign.status == 'CLOSED' %}readonly{% endif %}>
+                    <div class="field-hint">
+                        {% if campaign.status == 'CLOSED' %}Locked — campaign is closed.{% else %}Credits awarded to each promoted participant.{% endif %}
+                    </div>
+                </div>
+                <div class="m-form-group">
+                    <label>Unlock Cost *</label>
+                    <input name="unlock_cost" type="number" min="0" required
+                           value="{{ campaign.unlock_cost }}"
+                           {% if campaign.status == 'CLOSED' %}readonly{% endif %}>
+                    <div class="field-hint">
+                        {% if campaign.status == 'CLOSED' %}Locked — campaign is closed.{% else %}Deducted for specialization activation (≤ grant).{% endif %}
+                    </div>
+                </div>
+            </div>
+            <div class="modal-actions">
+                <button type="button" class="btn-modal-secondary"
+                        onclick="document.getElementById('edit-campaign-modal').style.display='none'">
+                    Cancel
+                </button>
+                <button type="submit" class="btn-modal-primary">Save Changes</button>
+            </div>
+        </form>
     </div>
 </div>
 

--- a/app/templates/admin/sponsor_detail.html
+++ b/app/templates/admin/sponsor_detail.html
@@ -397,6 +397,25 @@
                 </div>
             </div>
             <div class="m-form-group">
+                <label>Specialization *</label>
+                <select name="specialization_type">
+                    <option value="LFA_FOOTBALL_PLAYER" selected>LFA Football Player</option>
+                </select>
+                <div class="field-hint">License type granted to promoted participants.</div>
+            </div>
+            <div class="form-row">
+                <div class="m-form-group">
+                    <label>Credit Grant (min 100) *</label>
+                    <input name="credit_grant_amount" type="number" min="100" value="100" required>
+                    <div class="field-hint">Credits awarded to each promoted participant.</div>
+                </div>
+                <div class="m-form-group">
+                    <label>Unlock Cost *</label>
+                    <input name="unlock_cost" type="number" min="0" value="100" required>
+                    <div class="field-hint">Deducted for specialization activation (≤ grant).</div>
+                </div>
+            </div>
+            <div class="m-form-group">
                 <label>Notes</label>
                 <textarea name="notes" rows="2" placeholder="Optional context…"></textarea>
             </div>

--- a/scripts/seed_laterality_test_fixtures.py
+++ b/scripts/seed_laterality_test_fixtures.py
@@ -1,7 +1,10 @@
 """
 Seed laterality test fixtures.
 
-Creates 6 GamePresets (shooting × right/left/neutral  +  crossing × right/left/neutral)
+Creates 9 GamePresets:
+  shooting × right/left/neutral
+  crossing × right/left/neutral
+  passing  × right/left/neutral  ← added for sponsor foot_dominance bridge tests
 and 4 control users with LFA licenses for laterality-aware skill routing tests.
 
 Idempotent: code-based for presets, email-based for users.
@@ -68,6 +71,25 @@ _LAT_PRESETS = [
         "name": "Laterality Test: Crossing (neutral)",
         "foot_context": "neutral",
         "skills": ["crossing"],
+    },
+    # ── Passing presets (foot_dominance bridge test) ──────────────────────────
+    {
+        "code": "lat_passing_right",
+        "name": "Laterality Test: Passing (right foot)",
+        "foot_context": "right",
+        "skills": ["passing"],
+    },
+    {
+        "code": "lat_passing_left",
+        "name": "Laterality Test: Passing (left foot)",
+        "foot_context": "left",
+        "skills": ["passing"],
+    },
+    {
+        "code": "lat_passing_neutral",
+        "name": "Laterality Test: Passing (neutral)",
+        "foot_context": "neutral",
+        "skills": ["passing"],
     },
 ]
 

--- a/tests/fixtures/lat_test_8users.csv
+++ b/tests/fixtures/lat_test_8users.csv
@@ -1,0 +1,10 @@
+# foot_dominance scale: 0 = left-dominant, 100 = right-dominant, 50 = balanced
+email,first_name,last_name,date_of_birth,position,foot_dominance,consent_given
+lat_right_strong@lat.test,Strong,Right,2000-01-15,STRIKER,85,true
+lat_right_mod@lat.test,Moderate,Right,1999-03-20,MIDFIELDER,70,true
+lat_balanced@lat.test,Balanced,Player,1998-06-10,DEFENDER,50,true
+lat_left_mod@lat.test,Moderate,Left,2001-09-05,MIDFIELDER,30,true
+lat_left_strong@lat.test,Strong,Left,1997-12-01,GOALKEEPER,15,true
+lat_no_dob@lat.test,NoDob,Edge,,STRIKER,70,true
+lat_no_consent@lat.test,NoConsent,Edge,2000-05-05,MIDFIELDER,70,false
+lat_bad_pos@lat.test,BadPos,Edge,2000-07-07,COACH,70,true

--- a/tests/integration/web_flows/test_promotion_events_organizer.py
+++ b/tests/integration/web_flows/test_promotion_events_organizer.py
@@ -20,12 +20,13 @@ from app.database import get_db
 from app.dependencies import get_current_user_web, get_current_admin_user_hybrid
 from app.models.user import User, UserRole
 from app.models.club import Club
-from app.models.sponsor import Sponsor
+from app.models.sponsor import Sponsor, SponsorCampaign
 from app.models.semester import Semester, SemesterCategory
 from app.models.campus import Campus
 from app.models.location import Location
 from app.models.team import Team, TeamMember
 from app.models.tournament_type import TournamentType as TournamentTypeModel
+from app.models.tournament_configuration import TournamentConfiguration
 from app.core.security import get_password_hash
 from app.services.club_service import create_club
 
@@ -278,5 +279,218 @@ class TestStandaloneOrganizerCell:
                 "Expected '— standalone —' label for standalone event in /admin/promotion-events, "
                 "but 'standalone' not found in page HTML"
             )
+        finally:
+            app.dependency_overrides.clear()
+
+
+# ── SPON-PROMO-01..05: Sponsor Promotion Create — Block A + B ─────────────────
+
+
+def _make_campaign(db: Session, sponsor: Sponsor, admin: User) -> SponsorCampaign:
+    c = SponsorCampaign(
+        sponsor_id=sponsor.id,
+        name=f"Test Campaign {uuid.uuid4().hex[:6]}",
+        status="ACTIVE",
+        credit_grant_amount=200,
+        unlock_cost=100,
+        created_by=admin.id,
+    )
+    db.add(c)
+    db.flush()
+    return c
+
+
+def _post_promotion(
+    client: TestClient,
+    sponsor_id: int,
+    campaign_id: int,
+    age_groups: list[str],
+) -> object:
+    return client.post(
+        f"/admin/sponsors/{sponsor_id}/promotion",
+        data={
+            "tournament_name": f"Test Promo {uuid.uuid4().hex[:6]}",
+            "start_date": "2026-09-01",
+            "end_date": "2026-09-03",
+            "campaign_id": str(campaign_id),
+            "campus_id": "",
+            "tournament_type_id": "",
+            "age_groups": age_groups,
+        },
+        follow_redirects=False,
+    )
+
+
+class TestSponsorPromotionBlockA:
+    """SPON-PROMO-01/02: Block A — specialization_type + assignment_type set on new records."""
+
+    def test_spon_promo_01_specialization_type(self, test_db: Session):
+        """SPON-PROMO-01: created Semester has specialization_type='LFA_FOOTBALL_PLAYER'."""
+        admin = _make_admin(test_db)
+        sponsor = _make_sponsor(test_db, admin)
+        campaign = _make_campaign(test_db, sponsor, admin)
+        test_db.commit()
+
+        client = _admin_client(test_db, admin)
+        try:
+            resp = _post_promotion(client, sponsor.id, campaign.id, ["AMATEUR"])
+            assert resp.status_code in (302, 303), f"Expected redirect, got {resp.status_code}"
+
+            test_db.expire_all()
+            event = (
+                test_db.query(Semester)
+                .filter(
+                    Semester.semester_category == SemesterCategory.PROMOTION_EVENT,
+                    Semester.organizer_sponsor_id == sponsor.id,
+                    Semester.organizer_campaign_id == campaign.id,
+                )
+                .first()
+            )
+            assert event is not None, "No promotion event found after POST"
+            assert event.specialization_type == "LFA_FOOTBALL_PLAYER", (
+                f"Expected 'LFA_FOOTBALL_PLAYER', got '{event.specialization_type}'"
+            )
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_spon_promo_02_assignment_type(self, test_db: Session):
+        """SPON-PROMO-02: created TournamentConfiguration has assignment_type='OPEN_ASSIGNMENT'."""
+        admin = _make_admin(test_db)
+        sponsor = _make_sponsor(test_db, admin)
+        campaign = _make_campaign(test_db, sponsor, admin)
+        test_db.commit()
+
+        client = _admin_client(test_db, admin)
+        try:
+            resp = _post_promotion(client, sponsor.id, campaign.id, ["YOUTH"])
+            assert resp.status_code in (302, 303), f"Expected redirect, got {resp.status_code}"
+
+            test_db.expire_all()
+            event = (
+                test_db.query(Semester)
+                .filter(
+                    Semester.semester_category == SemesterCategory.PROMOTION_EVENT,
+                    Semester.organizer_sponsor_id == sponsor.id,
+                )
+                .first()
+            )
+            assert event is not None, "No promotion event found after POST"
+            cfg = (
+                test_db.query(TournamentConfiguration)
+                .filter(TournamentConfiguration.semester_id == event.id)
+                .first()
+            )
+            assert cfg is not None, "No TournamentConfiguration found"
+            assert cfg.assignment_type == "OPEN_ASSIGNMENT", (
+                f"Expected 'OPEN_ASSIGNMENT', got '{cfg.assignment_type}'"
+            )
+        finally:
+            app.dependency_overrides.clear()
+
+
+class TestSponsorPromotionBlockBRedirect:
+    """SPON-PROMO-03/04: Block B — single age_group → edit page; multi → sponsor detail."""
+
+    def test_spon_promo_03_single_age_group_redirects_to_edit(self, test_db: Session):
+        """SPON-PROMO-03: single age_group → redirect to /admin/tournaments/{id}/edit."""
+        admin = _make_admin(test_db)
+        sponsor = _make_sponsor(test_db, admin)
+        campaign = _make_campaign(test_db, sponsor, admin)
+        test_db.commit()
+
+        client = _admin_client(test_db, admin)
+        try:
+            resp = _post_promotion(client, sponsor.id, campaign.id, ["AMATEUR"])
+            assert resp.status_code in (302, 303), f"Expected redirect, got {resp.status_code}"
+
+            location = resp.headers.get("location", "")
+            assert "/admin/tournaments/" in location and "/edit" in location, (
+                f"Expected redirect to /admin/tournaments/{{id}}/edit, got: '{location}'"
+            )
+            assert f"/admin/sponsors/{sponsor.id}" not in location, (
+                f"Single-group create should NOT redirect to sponsor page, got: '{location}'"
+            )
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_spon_promo_04_multi_age_group_redirects_to_sponsor(self, test_db: Session):
+        """SPON-PROMO-04: multiple age_groups → redirect to /admin/sponsors/{id}."""
+        admin = _make_admin(test_db)
+        sponsor = _make_sponsor(test_db, admin)
+        campaign = _make_campaign(test_db, sponsor, admin)
+        test_db.commit()
+
+        client = _admin_client(test_db, admin)
+        try:
+            resp = _post_promotion(client, sponsor.id, campaign.id, ["AMATEUR", "YOUTH"])
+            assert resp.status_code in (302, 303), f"Expected redirect, got {resp.status_code}"
+
+            location = resp.headers.get("location", "")
+            assert f"/admin/sponsors/{sponsor.id}" in location, (
+                f"Multi-group create should redirect to sponsor page, got: '{location}'"
+            )
+            assert "/edit" not in location, (
+                f"Multi-group create should NOT redirect to edit page, got: '{location}'"
+            )
+
+            test_db.expire_all()
+            events = (
+                test_db.query(Semester)
+                .filter(
+                    Semester.semester_category == SemesterCategory.PROMOTION_EVENT,
+                    Semester.organizer_sponsor_id == sponsor.id,
+                    Semester.organizer_campaign_id == campaign.id,
+                )
+                .all()
+            )
+            assert len(events) == 2, f"Expected 2 events, got {len(events)}"
+        finally:
+            app.dependency_overrides.clear()
+
+
+class TestSponsorPromotionOrganizerIntegrity:
+    """SPON-PROMO-05: organizer FK fields intact on both single and multi age_group creates."""
+
+    def test_spon_promo_05_organizer_ids_set_on_all_records(self, test_db: Session):
+        """SPON-PROMO-05: organizer_sponsor_id + organizer_campaign_id set on every created record."""
+        admin = _make_admin(test_db)
+        sponsor = _make_sponsor(test_db, admin)
+        campaign = _make_campaign(test_db, sponsor, admin)
+        test_db.commit()
+
+        client = _admin_client(test_db, admin)
+        try:
+            resp = _post_promotion(client, sponsor.id, campaign.id, ["PRE", "AMATEUR"])
+            assert resp.status_code in (302, 303)
+
+            test_db.expire_all()
+            events = (
+                test_db.query(Semester)
+                .filter(
+                    Semester.semester_category == SemesterCategory.PROMOTION_EVENT,
+                    Semester.organizer_sponsor_id == sponsor.id,
+                )
+                .order_by(Semester.id)
+                .all()
+            )
+            assert len(events) == 2, f"Expected 2 events, got {len(events)}"
+            for ev in events:
+                assert ev.organizer_sponsor_id == sponsor.id, (
+                    f"organizer_sponsor_id: expected {sponsor.id}, got {ev.organizer_sponsor_id}"
+                )
+                assert ev.organizer_campaign_id == campaign.id, (
+                    f"organizer_campaign_id: expected {campaign.id}, got {ev.organizer_campaign_id}"
+                )
+                assert ev.organizer_club_id is None, (
+                    f"organizer_club_id should be None, got {ev.organizer_club_id}"
+                )
+                assert ev.specialization_type == "LFA_FOOTBALL_PLAYER"
+                cfg = (
+                    test_db.query(TournamentConfiguration)
+                    .filter(TournamentConfiguration.semester_id == ev.id)
+                    .first()
+                )
+                assert cfg is not None
+                assert cfg.assignment_type == "OPEN_ASSIGNMENT"
         finally:
             app.dependency_overrides.clear()

--- a/tests/integration/web_flows/test_sponsor_campaign.py
+++ b/tests/integration/web_flows/test_sponsor_campaign.py
@@ -1,5 +1,5 @@
 """
-P3 SponsorCampaign — isolation + guard tests (SPON-CAM-01 through SPON-CAM-07)
+P3 SponsorCampaign — isolation + guard tests (SPON-CAM-01 through SPON-CAM-20)
 
   SPON-CAM-01  Same email in 2 campaigns → 2 separate entries, both ACTIVE
   SPON-CAM-02  rollback_import(log1) → only campaign1 entries DELETED; campaign2 untouched
@@ -8,6 +8,19 @@ P3 SponsorCampaign — isolation + guard tests (SPON-CAM-01 through SPON-CAM-07)
   SPON-CAM-05  Migration backfill integrity: no NULL campaign_id after _make_* helpers
   SPON-CAM-06  apply_import without campaign_id → explicit ValueError (not silent fail)
   SPON-CAM-07  Legacy GET /audience → 303 redirect (HTTP-level test)
+  SPON-CAM-08  Campaign detail shows specialization_type, credit_grant_amount, unlock_cost
+  SPON-CAM-09  Close campaign → status becomes CLOSED
+  SPON-CAM-10  Close campaign idempotent (already CLOSED → no error, stays CLOSED)
+  SPON-CAM-11  CLOSED campaign: import/apply returns 303 with closed error message
+  SPON-CAM-12  CLOSED campaign: import/preview returns 303 with closed error message
+  SPON-CAM-13  CLOSED campaign: audience/promote returns 303 with closed error message
+  SPON-CAM-14  Edit campaign name → name updated
+  SPON-CAM-15  Edit campaign credit fields → grant/unlock updated (ACTIVE only)
+  SPON-CAM-16  Edit validation: empty name rejected
+  SPON-CAM-17  Edit validation: credit_grant < 100 rejected
+  SPON-CAM-18  Edit validation: unlock_cost > credit_grant rejected
+  SPON-CAM-19  CLOSED campaign edit: credit fields locked (values unchanged)
+  SPON-CAM-20  CLOSED campaign edit: name field is still editable
 
 DONE = pytest tests/integration/web_flows/test_sponsor_campaign.py -v
 """
@@ -291,6 +304,375 @@ class TestLegacyAudienceRedirect:
             resp = client.get(f"/admin/sponsors/{sponsor.id}/audience")
             assert resp.status_code == 303
             assert f"/admin/sponsors/{sponsor.id}" in resp.headers["location"]
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+            app.dependency_overrides.pop(get_current_user_web, None)
+
+
+# ── SPON-CAM-08 ───────────────────────────────────────────────────────────────
+
+class TestCampaignDetailP7Fields:
+    """SPON-CAM-08: Campaign detail page renders specialization_type, credit_grant_amount,
+    and unlock_cost as read-only meta-items."""
+
+    def _client_and_campaign(self, test_db: Session):
+        from fastapi.testclient import TestClient
+        from app.main import app
+        from app.database import get_db
+        from app.dependencies import get_current_user_web
+
+        admin = _make_admin(test_db)
+        sponsor = _make_sponsor(test_db, admin)
+        campaign = SponsorCampaign(
+            sponsor_id=sponsor.id,
+            name=f"P7 Test {uuid.uuid4().hex[:4]}",
+            campaign_type="IMPORT",
+            status="ACTIVE",
+            specialization_type="LFA_FOOTBALL_PLAYER",
+            credit_grant_amount=200,
+            unlock_cost=150,
+            created_by=admin.id,
+        )
+        test_db.add(campaign)
+        test_db.commit()
+
+        def _override_db():
+            yield test_db
+
+        app.dependency_overrides[get_db] = _override_db
+        app.dependency_overrides[get_current_user_web] = lambda: admin
+
+        client = TestClient(app, follow_redirects=False)
+        return client, sponsor, campaign, app
+
+    def test_spon_cam_08a_specialization_type_displayed(self, test_db: Session):
+        client, sponsor, campaign, app = self._client_and_campaign(test_db)
+        from app.database import get_db
+        from app.dependencies import get_current_user_web
+        try:
+            resp = client.get(f"/admin/sponsors/{sponsor.id}/campaigns/{campaign.id}")
+            assert resp.status_code == 200
+            assert "LFA_FOOTBALL_PLAYER" in resp.text
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+            app.dependency_overrides.pop(get_current_user_web, None)
+
+    def test_spon_cam_08b_credit_grant_amount_displayed(self, test_db: Session):
+        client, sponsor, campaign, app = self._client_and_campaign(test_db)
+        from app.database import get_db
+        from app.dependencies import get_current_user_web
+        try:
+            resp = client.get(f"/admin/sponsors/{sponsor.id}/campaigns/{campaign.id}")
+            assert resp.status_code == 200
+            assert "200" in resp.text
+            assert "Credit Grant" in resp.text
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+            app.dependency_overrides.pop(get_current_user_web, None)
+
+    def test_spon_cam_08c_unlock_cost_displayed(self, test_db: Session):
+        client, sponsor, campaign, app = self._client_and_campaign(test_db)
+        from app.database import get_db
+        from app.dependencies import get_current_user_web
+        try:
+            resp = client.get(f"/admin/sponsors/{sponsor.id}/campaigns/{campaign.id}")
+            assert resp.status_code == 200
+            assert "150" in resp.text
+            assert "Unlock Cost" in resp.text
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+            app.dependency_overrides.pop(get_current_user_web, None)
+
+
+# ── SPON-CAM-09 / SPON-CAM-10 ────────────────────────────────────────────────
+
+class TestCampaignClose:
+    """SPON-CAM-09/10: POST .../close sets status=CLOSED; idempotent second call."""
+
+    def _setup(self, test_db: Session):
+        from fastapi.testclient import TestClient
+        from app.main import app
+        from app.database import get_db
+        from app.dependencies import get_current_user_web
+
+        admin = _make_admin(test_db)
+        sponsor = _make_sponsor(test_db, admin)
+        campaign = _make_campaign(test_db, sponsor, admin)
+        test_db.commit()
+
+        def _override_db():
+            yield test_db
+
+        app.dependency_overrides[get_db] = _override_db
+        app.dependency_overrides[get_current_user_web] = lambda: admin
+        client = TestClient(
+            app,
+            headers={"Authorization": "Bearer test-csrf-bypass"},
+            follow_redirects=False,
+        )
+        return client, sponsor, campaign, app
+
+    def test_spon_cam_09_close_sets_closed_status(self, test_db: Session):
+        from app.database import get_db
+        from app.dependencies import get_current_user_web
+        client, sponsor, campaign, app = self._setup(test_db)
+        try:
+            resp = client.post(
+                f"/admin/sponsors/{sponsor.id}/campaigns/{campaign.id}/close",
+                data={"csrf_token": "test"},
+            )
+            assert resp.status_code == 303
+            assert "flash=Campaign+closed" in resp.headers["location"]
+            test_db.expire(campaign)
+            assert campaign.status == "CLOSED"
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+            app.dependency_overrides.pop(get_current_user_web, None)
+
+    def test_spon_cam_10_close_idempotent(self, test_db: Session):
+        from app.database import get_db
+        from app.dependencies import get_current_user_web
+        client, sponsor, campaign, app = self._setup(test_db)
+        try:
+            campaign.status = "CLOSED"
+            test_db.commit()
+            resp = client.post(
+                f"/admin/sponsors/{sponsor.id}/campaigns/{campaign.id}/close",
+                data={"csrf_token": "test"},
+            )
+            assert resp.status_code == 303
+            test_db.expire(campaign)
+            assert campaign.status == "CLOSED"
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+            app.dependency_overrides.pop(get_current_user_web, None)
+
+
+# ── SPON-CAM-11 / SPON-CAM-12 / SPON-CAM-13 ─────────────────────────────────
+
+class TestClosedCampaignGuards:
+    """SPON-CAM-11/12/13: CLOSED campaign blocks import apply, import preview, and promote."""
+
+    def _setup(self, test_db: Session):
+        from fastapi.testclient import TestClient
+        from app.main import app
+        from app.database import get_db
+        from app.dependencies import get_current_user_web
+
+        admin = _make_admin(test_db)
+        sponsor = _make_sponsor(test_db, admin)
+        campaign = _make_campaign(test_db, sponsor, admin)
+        campaign.status = "CLOSED"
+        test_db.commit()
+
+        def _override_db():
+            yield test_db
+
+        app.dependency_overrides[get_db] = _override_db
+        app.dependency_overrides[get_current_user_web] = lambda: admin
+        client = TestClient(
+            app,
+            headers={"Authorization": "Bearer test-csrf-bypass"},
+            follow_redirects=False,
+        )
+        return client, sponsor, campaign, app
+
+    def test_spon_cam_11_closed_campaign_import_apply_blocked(self, test_db: Session):
+        import base64
+        from app.database import get_db
+        from app.dependencies import get_current_user_web
+        client, sponsor, campaign, app = self._setup(test_db)
+        try:
+            csv_b64 = base64.b64encode(b"first_name,last_name,email,consent_given\n").decode()
+            resp = client.post(
+                f"/admin/sponsors/{sponsor.id}/campaigns/{campaign.id}/import/apply",
+                data={"csrf_token": "test", "csv_data": csv_b64, "filename": "test.csv"},
+            )
+            assert resp.status_code == 303
+            assert "closed" in resp.headers["location"].lower()
+            assert "import" in resp.headers["location"].lower()
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+            app.dependency_overrides.pop(get_current_user_web, None)
+
+    def test_spon_cam_12_closed_campaign_import_preview_blocked(self, test_db: Session):
+        from io import BytesIO
+        from app.database import get_db
+        from app.dependencies import get_current_user_web
+        client, sponsor, campaign, app = self._setup(test_db)
+        try:
+            csv_bytes = b"first_name,last_name,email,consent_given\nTest,Player,t@t.com,1\n"
+            resp = client.post(
+                f"/admin/sponsors/{sponsor.id}/campaigns/{campaign.id}/import/preview",
+                files={"file": ("test.csv", BytesIO(csv_bytes), "text/csv")},
+            )
+            assert resp.status_code == 303
+            assert "closed" in resp.headers["location"].lower()
+            assert "import" in resp.headers["location"].lower()
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+            app.dependency_overrides.pop(get_current_user_web, None)
+
+    def test_spon_cam_13_closed_campaign_promote_blocked(self, test_db: Session):
+        from app.database import get_db
+        from app.dependencies import get_current_user_web
+        client, sponsor, campaign, app = self._setup(test_db)
+        try:
+            # CLOSED guard fires before processing entry IDs — dummy ID is fine
+            resp = client.post(
+                f"/admin/sponsors/{sponsor.id}/campaigns/{campaign.id}/audience/promote",
+                data={"csrf_token": "test", "entry_ids": "9999"},
+            )
+            assert resp.status_code == 303
+            assert "closed" in resp.headers["location"].lower()
+            assert "promote" in resp.headers["location"].lower()
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+            app.dependency_overrides.pop(get_current_user_web, None)
+
+
+# ── SPON-CAM-14 through SPON-CAM-20 ──────────────────────────────────────────
+
+class TestCampaignEdit:
+    """SPON-CAM-14..20: Campaign EDIT route — happy path, validation, CLOSED lock."""
+
+    def _setup(self, test_db: Session, *, closed: bool = False):
+        from fastapi.testclient import TestClient
+        from app.main import app
+        from app.database import get_db
+        from app.dependencies import get_current_user_web
+
+        admin = _make_admin(test_db)
+        sponsor = _make_sponsor(test_db, admin)
+        campaign = SponsorCampaign(
+            sponsor_id=sponsor.id,
+            name=f"Edit Test {uuid.uuid4().hex[:4]}",
+            campaign_type="IMPORT",
+            status="CLOSED" if closed else "ACTIVE",
+            specialization_type="LFA_FOOTBALL_PLAYER",
+            credit_grant_amount=200,
+            unlock_cost=100,
+            created_by=admin.id,
+        )
+        test_db.add(campaign)
+        test_db.commit()
+
+        def _override_db():
+            yield test_db
+
+        app.dependency_overrides[get_db] = _override_db
+        app.dependency_overrides[get_current_user_web] = lambda: admin
+        client = TestClient(
+            app,
+            headers={"Authorization": "Bearer test-csrf-bypass"},
+            follow_redirects=False,
+        )
+        return client, sponsor, campaign, app
+
+    def _post_edit(self, client, sponsor, campaign, *, name=None, credit_grant=None, unlock=None):
+        return client.post(
+            f"/admin/sponsors/{sponsor.id}/campaigns/{campaign.id}/edit",
+            data={
+                "csrf_token": "test",
+                "name": name if name is not None else campaign.name,
+                "credit_grant_amount": str(credit_grant if credit_grant is not None else campaign.credit_grant_amount),
+                "unlock_cost": str(unlock if unlock is not None else campaign.unlock_cost),
+            },
+        )
+
+    def test_spon_cam_14_edit_name_updated(self, test_db: Session):
+        from app.database import get_db
+        from app.dependencies import get_current_user_web
+        client, sponsor, campaign, app = self._setup(test_db)
+        try:
+            resp = self._post_edit(client, sponsor, campaign, name="New Name")
+            assert resp.status_code == 303
+            assert "flash=Campaign+updated" in resp.headers["location"]
+            test_db.expire(campaign)
+            assert campaign.name == "New Name"
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+            app.dependency_overrides.pop(get_current_user_web, None)
+
+    def test_spon_cam_15_edit_credit_fields_updated(self, test_db: Session):
+        from app.database import get_db
+        from app.dependencies import get_current_user_web
+        client, sponsor, campaign, app = self._setup(test_db)
+        try:
+            resp = self._post_edit(client, sponsor, campaign, credit_grant=300, unlock=150)
+            assert resp.status_code == 303
+            assert "flash=Campaign+updated" in resp.headers["location"]
+            test_db.expire(campaign)
+            assert campaign.credit_grant_amount == 300
+            assert campaign.unlock_cost == 150
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+            app.dependency_overrides.pop(get_current_user_web, None)
+
+    def test_spon_cam_16_edit_empty_name_rejected(self, test_db: Session):
+        from app.database import get_db
+        from app.dependencies import get_current_user_web
+        client, sponsor, campaign, app = self._setup(test_db)
+        try:
+            resp = self._post_edit(client, sponsor, campaign, name="")
+            assert resp.status_code == 303
+            assert "error=" in resp.headers["location"]
+            assert "name" in resp.headers["location"].lower()
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+            app.dependency_overrides.pop(get_current_user_web, None)
+
+    def test_spon_cam_17_edit_credit_grant_below_100_rejected(self, test_db: Session):
+        from app.database import get_db
+        from app.dependencies import get_current_user_web
+        client, sponsor, campaign, app = self._setup(test_db)
+        try:
+            resp = self._post_edit(client, sponsor, campaign, credit_grant=50, unlock=50)
+            assert resp.status_code == 303
+            assert "error=" in resp.headers["location"]
+            assert "100" in resp.headers["location"] or "grant" in resp.headers["location"].lower()
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+            app.dependency_overrides.pop(get_current_user_web, None)
+
+    def test_spon_cam_18_edit_unlock_exceeds_grant_rejected(self, test_db: Session):
+        from app.database import get_db
+        from app.dependencies import get_current_user_web
+        client, sponsor, campaign, app = self._setup(test_db)
+        try:
+            resp = self._post_edit(client, sponsor, campaign, credit_grant=200, unlock=250)
+            assert resp.status_code == 303
+            assert "error=" in resp.headers["location"]
+            assert "exceed" in resp.headers["location"].lower() or "unlock" in resp.headers["location"].lower()
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+            app.dependency_overrides.pop(get_current_user_web, None)
+
+    def test_spon_cam_19_closed_campaign_credit_change_rejected(self, test_db: Session):
+        from app.database import get_db
+        from app.dependencies import get_current_user_web
+        client, sponsor, campaign, app = self._setup(test_db, closed=True)
+        try:
+            resp = self._post_edit(client, sponsor, campaign, credit_grant=500, unlock=100)
+            assert resp.status_code == 303
+            assert "error=" in resp.headers["location"]
+            assert "locked" in resp.headers["location"].lower() or "closed" in resp.headers["location"].lower()
+            test_db.expire(campaign)
+            assert campaign.credit_grant_amount == 200
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+            app.dependency_overrides.pop(get_current_user_web, None)
+
+    def test_spon_cam_20_closed_campaign_name_editable(self, test_db: Session):
+        from app.database import get_db
+        from app.dependencies import get_current_user_web
+        client, sponsor, campaign, app = self._setup(test_db, closed=True)
+        try:
+            resp = self._post_edit(client, sponsor, campaign, name="Renamed Closed")
+            assert resp.status_code == 303
+            assert "flash=Campaign+updated" in resp.headers["location"]
+            test_db.expire(campaign)
+            assert campaign.name == "Renamed Closed"
         finally:
             app.dependency_overrides.pop(get_db, None)
             app.dependency_overrides.pop(get_current_user_web, None)

--- a/tests/integration/web_flows/test_sponsor_promote_credits.py
+++ b/tests/integration/web_flows/test_sponsor_promote_credits.py
@@ -1,0 +1,502 @@
+"""
+Sponsor Promote Credit Flow Tests — SPON-CREDIT-01 through SPON-CREDIT-10
+
+  SPON-CREDIT-01  Grant + unlock always issued as a pair after successful promote
+  SPON-CREDIT-02  Retry (double-promote call) → credit_balance unchanged, no new CreditTransactions
+  SPON-CREDIT-03  Existing user without campaign's license → new UserLicense created, credits issued
+  SPON-CREDIT-04  Existing user with existing license → already_linked, no credit duplication
+  SPON-CREDIT-05  unlock_cost > credit_grant_amount → campaign create route 303+error
+  SPON-CREDIT-06  credit_grant_amount < 100 → campaign create route 303+error
+  SPON-CREDIT-07  Balance invariant: SUM(ct.amount) WHERE user_id == user.credit_balance
+  SPON-CREDIT-08  3-entry batch → 3 SPONSOR_CREDIT_GRANT + 3 SPECIALIZATION_UNLOCK rows
+  SPON-CREDIT-09  All settlement rows have sponsor_id + campaign_id
+  SPON-CREDIT-10  Partial-failure rollback: grant would succeed but unlock raises →
+                  nothing committed (via InsufficientCreditsError simulation)
+
+DONE = pytest tests/integration/web_flows/test_sponsor_promote_credits.py -v
+"""
+import uuid
+from datetime import date, datetime
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.dependencies import get_current_user_web
+from app.main import app
+from app.models.credit_transaction import CreditTransaction
+from app.models.license import UserLicense
+from app.models.sponsor import Sponsor, SponsorAudienceEntry, SponsorCampaign
+from app.models.user import User, UserRole
+from app.core.security import get_password_hash
+from app.services.credit_service import InsufficientCreditsError
+from app.services.sponsor_promote_service import promote_entries
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _make_admin(db: Session) -> User:
+    u = User(
+        email=f"admin-cred+{uuid.uuid4().hex[:8]}@lfa.com",
+        name="Credit Admin",
+        password_hash=get_password_hash("Admin1234!"),
+        role=UserRole.ADMIN,
+        is_active=True,
+    )
+    db.add(u)
+    db.flush()
+    return u
+
+
+def _make_sponsor(db: Session, admin: User) -> Sponsor:
+    s = Sponsor(
+        name=f"CreditSponsor {uuid.uuid4().hex[:6]}",
+        code=f"CRED-{uuid.uuid4().hex[:5].upper()}",
+        is_active=True,
+        created_by=admin.id,
+    )
+    db.add(s)
+    db.flush()
+    return s
+
+
+def _make_campaign(
+    db: Session,
+    sponsor: Sponsor,
+    admin: User,
+    *,
+    credit_grant_amount: int = 100,
+    unlock_cost: int = 100,
+    specialization_type: str = "LFA_FOOTBALL_PLAYER",
+) -> SponsorCampaign:
+    c = SponsorCampaign(
+        sponsor_id=sponsor.id,
+        name=f"CreditCampaign {uuid.uuid4().hex[:4]}",
+        campaign_type="IMPORT",
+        status="ACTIVE",
+        created_by=admin.id,
+        specialization_type=specialization_type,
+        credit_grant_amount=credit_grant_amount,
+        unlock_cost=unlock_cost,
+    )
+    db.add(c)
+    db.flush()
+    return c
+
+
+def _make_import_log(db: Session, sponsor: Sponsor, campaign: SponsorCampaign, admin: User):
+    from app.models.club import CsvImportLog
+    log = CsvImportLog(
+        sponsor_id=sponsor.id,
+        campaign_id=campaign.id,
+        filename="test.csv",
+        total_rows=1,
+        uploaded_by=admin.id,
+        status="DONE",
+    )
+    db.add(log)
+    db.flush()
+    return log
+
+
+def _make_entry(
+    db: Session,
+    sponsor: Sponsor,
+    campaign: SponsorCampaign,
+    log,
+    admin: User,
+    *,
+    email: str | None = None,
+    status: str = "ACTIVE",
+    consent_given: bool = True,
+    position: str | None = "STRIKER",
+    dob: date | None = date(2005, 3, 15),
+) -> SponsorAudienceEntry:
+    e = SponsorAudienceEntry(
+        sponsor_id=sponsor.id,
+        campaign_id=campaign.id,
+        import_log_id=log.id,
+        email=email or f"cred+{uuid.uuid4().hex[:8]}@test.com",
+        first_name="Credit",
+        last_name="User",
+        status=status,
+        consent_given=consent_given,
+        position=position,
+        date_of_birth=dob,
+        imported_by=admin.id,
+    )
+    db.add(e)
+    db.flush()
+    return e
+
+
+def _client(db: Session, admin: User) -> TestClient:
+    app.dependency_overrides[get_db] = lambda: db
+    app.dependency_overrides[get_current_user_web] = lambda: admin
+    return TestClient(app, headers={"Authorization": "Bearer test-csrf-bypass"})
+
+
+def _credit_rows(db: Session, user: User, tx_type: str) -> list[CreditTransaction]:
+    return (
+        db.query(CreditTransaction)
+        .filter(
+            CreditTransaction.user_id == user.id,
+            CreditTransaction.transaction_type == tx_type,
+        )
+        .all()
+    )
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+class TestSponsorPromoteCredits:
+
+    def test_spon_credit_01_grant_and_unlock_always_paired(self, test_db: Session):
+        """After a successful promote, exactly 1 GRANT + 1 UNLOCK per promoted user."""
+        admin    = _make_admin(test_db)
+        sponsor  = _make_sponsor(test_db, admin)
+        campaign = _make_campaign(test_db, sponsor, admin)
+        log      = _make_import_log(test_db, sponsor, campaign, admin)
+        entry    = _make_entry(test_db, sponsor, campaign, log, admin)
+
+        result = promote_entries([entry.id], sponsor.id, test_db, admin,
+                                 campaign_id=campaign.id)
+
+        assert result.promoted == 1
+        assert result.credits_granted == 100
+        assert result.unlock_deductions == 100
+
+        test_db.expire_all()
+        promoted_user = test_db.query(User).filter(User.id == entry.user_id).first()
+
+        grants  = _credit_rows(test_db, promoted_user, "SPONSOR_CREDIT_GRANT")
+        unlocks = _credit_rows(test_db, promoted_user, "SPECIALIZATION_UNLOCK")
+        assert len(grants)  == 1
+        assert len(unlocks) == 1
+        assert grants[0].amount  == +100
+        assert unlocks[0].amount == -100
+
+    def test_spon_credit_02_retry_no_duplicate_credit(self, test_db: Session):
+        """Calling promote_entries twice on the same entry doesn't duplicate credit rows
+        and leaves credit_balance unchanged on the second call."""
+        admin    = _make_admin(test_db)
+        sponsor  = _make_sponsor(test_db, admin)
+        campaign = _make_campaign(test_db, sponsor, admin)
+        log      = _make_import_log(test_db, sponsor, campaign, admin)
+        entry    = _make_entry(test_db, sponsor, campaign, log, admin)
+
+        # First promote
+        r1 = promote_entries([entry.id], sponsor.id, test_db, admin,
+                             campaign_id=campaign.id)
+        assert r1.promoted == 1
+        test_db.expire_all()
+
+        user = test_db.query(User).filter(User.id == entry.user_id).first()
+        balance_after_first = user.credit_balance
+
+        # Second promote (same entry_ids)
+        r2 = promote_entries([entry.id], sponsor.id, test_db, admin,
+                             campaign_id=campaign.id)
+        assert r2.promoted == 0
+        assert r2.already_linked == 1
+        test_db.expire_all()
+
+        user = test_db.query(User).filter(User.id == entry.user_id).first()
+        assert user.credit_balance == balance_after_first
+
+        grants  = _credit_rows(test_db, user, "SPONSOR_CREDIT_GRANT")
+        unlocks = _credit_rows(test_db, user, "SPECIALIZATION_UNLOCK")
+        assert len(grants)  == 1, "No duplicate grant on retry"
+        assert len(unlocks) == 1, "No duplicate unlock on retry"
+
+    def test_spon_credit_03_existing_user_no_license_gets_new_license_and_credits(
+        self, test_db: Session
+    ):
+        """Existing user without the campaign's specialization license receives a new
+        UserLicense AND full credit grant+unlock."""
+        admin    = _make_admin(test_db)
+        sponsor  = _make_sponsor(test_db, admin)
+        campaign = _make_campaign(test_db, sponsor, admin,
+                                  specialization_type="LFA_FOOTBALL_PLAYER")
+        log      = _make_import_log(test_db, sponsor, campaign, admin)
+
+        # Pre-create a User with a DIFFERENT specialization license
+        existing_email = f"existing+{uuid.uuid4().hex[:8]}@test.com"
+        existing_user  = User(
+            email=existing_email,
+            name="Existing User",
+            password_hash=get_password_hash(uuid.uuid4().hex),
+            role=UserRole.STUDENT,
+            is_active=True,
+        )
+        test_db.add(existing_user)
+        test_db.flush()
+        # No LFA_FOOTBALL_PLAYER license — user has none at all
+
+        entry = _make_entry(test_db, sponsor, campaign, log, admin,
+                            email=existing_email)
+
+        result = promote_entries([entry.id], sponsor.id, test_db, admin,
+                                 campaign_id=campaign.id)
+
+        assert result.promoted == 1
+        test_db.expire_all()
+
+        # New license created for this user
+        license = (
+            test_db.query(UserLicense)
+            .filter(
+                UserLicense.user_id == existing_user.id,
+                UserLicense.specialization_type == "LFA_FOOTBALL_PLAYER",
+                UserLicense.is_active == True,
+            )
+            .first()
+        )
+        assert license is not None, "UserLicense must be created for existing user"
+
+        # Credits issued
+        grants = _credit_rows(test_db, existing_user, "SPONSOR_CREDIT_GRANT")
+        assert len(grants) == 1
+
+    def test_spon_credit_04_existing_user_with_license_already_linked(self, test_db: Session):
+        """Existing user that was already promoted → already_linked, zero new credit rows."""
+        admin    = _make_admin(test_db)
+        sponsor  = _make_sponsor(test_db, admin)
+        campaign = _make_campaign(test_db, sponsor, admin)
+        log      = _make_import_log(test_db, sponsor, campaign, admin)
+        entry    = _make_entry(test_db, sponsor, campaign, log, admin)
+
+        # First promote — creates User, license, credits
+        r1 = promote_entries([entry.id], sponsor.id, test_db, admin,
+                             campaign_id=campaign.id)
+        assert r1.promoted == 1
+        test_db.expire_all()
+
+        user = test_db.query(User).filter(User.id == entry.user_id).first()
+        grants_before = len(_credit_rows(test_db, user, "SPONSOR_CREDIT_GRANT"))
+
+        # Second promote — already_linked path
+        r2 = promote_entries([entry.id], sponsor.id, test_db, admin,
+                             campaign_id=campaign.id)
+        assert r2.already_linked == 1
+        assert r2.promoted == 0
+        test_db.expire_all()
+
+        grants_after = len(_credit_rows(test_db, user, "SPONSOR_CREDIT_GRANT"))
+        assert grants_after == grants_before, "No extra credit rows for already-linked entry"
+
+    def test_spon_credit_05_unlock_exceeds_grant_route_rejects(self, test_db: Session):
+        """Campaign create POST with unlock_cost > credit_grant_amount → 303 + error."""
+        admin   = _make_admin(test_db)
+        sponsor = _make_sponsor(test_db, admin)
+        client  = _client(test_db, admin)
+
+        try:
+            resp = client.post(
+                f"/admin/sponsors/{sponsor.id}/campaigns",
+                data={
+                    "csrf_token": "",
+                    "name": "Bad Campaign",
+                    "campaign_type": "IMPORT",
+                    "specialization_type": "LFA_FOOTBALL_PLAYER",
+                    "credit_grant_amount": "100",
+                    "unlock_cost": "150",   # exceeds grant
+                },
+                follow_redirects=False,
+            )
+            assert resp.status_code == 303
+            assert "error" in resp.headers["location"]
+        finally:
+            app.dependency_overrides.clear()
+
+        # No campaign created
+        count = (
+            test_db.query(SponsorCampaign)
+            .filter(
+                SponsorCampaign.sponsor_id == sponsor.id,
+                SponsorCampaign.name == "Bad Campaign",
+            )
+            .count()
+        )
+        assert count == 0
+
+    def test_spon_credit_06_grant_below_100_route_rejects(self, test_db: Session):
+        """Campaign create POST with credit_grant_amount < 100 → 303 + error."""
+        admin   = _make_admin(test_db)
+        sponsor = _make_sponsor(test_db, admin)
+        client  = _client(test_db, admin)
+
+        try:
+            resp = client.post(
+                f"/admin/sponsors/{sponsor.id}/campaigns",
+                data={
+                    "csrf_token": "",
+                    "name": "Cheap Campaign",
+                    "campaign_type": "IMPORT",
+                    "specialization_type": "LFA_FOOTBALL_PLAYER",
+                    "credit_grant_amount": "50",   # below minimum
+                    "unlock_cost": "50",
+                },
+                follow_redirects=False,
+            )
+            assert resp.status_code == 303
+            assert "error" in resp.headers["location"]
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_spon_credit_07_balance_invariant_sum_equals_balance(self, test_db: Session):
+        """After promote: SUM(credit_transactions.amount) WHERE user_id == user.credit_balance."""
+        admin    = _make_admin(test_db)
+        sponsor  = _make_sponsor(test_db, admin)
+        campaign = _make_campaign(test_db, sponsor, admin,
+                                  credit_grant_amount=100, unlock_cost=100)
+        log   = _make_import_log(test_db, sponsor, campaign, admin)
+        entry = _make_entry(test_db, sponsor, campaign, log, admin)
+
+        promote_entries([entry.id], sponsor.id, test_db, admin,
+                        campaign_id=campaign.id)
+        test_db.expire_all()
+
+        user = test_db.query(User).filter(User.id == entry.user_id).first()
+        tx_sum = (
+            test_db.query(func.sum(CreditTransaction.amount))
+            .filter(CreditTransaction.user_id == user.id)
+            .scalar()
+            or 0
+        )
+        assert tx_sum == user.credit_balance, (
+            f"Ledger invariant broken: SUM={tx_sum}, credit_balance={user.credit_balance}"
+        )
+
+    def test_spon_credit_08_batch_three_entries_correct_row_count(self, test_db: Session):
+        """3-entry batch → exactly 3 SPONSOR_CREDIT_GRANT + 3 SPECIALIZATION_UNLOCK rows."""
+        admin    = _make_admin(test_db)
+        sponsor  = _make_sponsor(test_db, admin)
+        campaign = _make_campaign(test_db, sponsor, admin)
+        log      = _make_import_log(test_db, sponsor, campaign, admin)
+
+        entries = [
+            _make_entry(test_db, sponsor, campaign, log, admin)
+            for _ in range(3)
+        ]
+        entry_ids = [e.id for e in entries]
+
+        result = promote_entries(entry_ids, sponsor.id, test_db, admin,
+                                 campaign_id=campaign.id)
+        assert result.promoted == 3
+
+        grants = (
+            test_db.query(CreditTransaction)
+            .filter(
+                CreditTransaction.campaign_id == campaign.id,
+                CreditTransaction.transaction_type == "SPONSOR_CREDIT_GRANT",
+            )
+            .count()
+        )
+        unlocks = (
+            test_db.query(CreditTransaction)
+            .filter(
+                CreditTransaction.campaign_id == campaign.id,
+                CreditTransaction.transaction_type == "SPECIALIZATION_UNLOCK",
+            )
+            .count()
+        )
+        assert grants == 3
+        assert unlocks == 3
+
+    def test_spon_credit_09_settlement_columns_populated(self, test_db: Session):
+        """Every SPONSOR_CREDIT_GRANT / SPECIALIZATION_UNLOCK row carries sponsor_id
+        and campaign_id — required for settlement queries."""
+        admin    = _make_admin(test_db)
+        sponsor  = _make_sponsor(test_db, admin)
+        campaign = _make_campaign(test_db, sponsor, admin)
+        log      = _make_import_log(test_db, sponsor, campaign, admin)
+        entry    = _make_entry(test_db, sponsor, campaign, log, admin)
+
+        promote_entries([entry.id], sponsor.id, test_db, admin,
+                        campaign_id=campaign.id)
+
+        rows = (
+            test_db.query(CreditTransaction)
+            .filter(
+                CreditTransaction.campaign_id == campaign.id,
+                CreditTransaction.transaction_type.in_(
+                    ["SPONSOR_CREDIT_GRANT", "SPECIALIZATION_UNLOCK"]
+                ),
+            )
+            .all()
+        )
+        assert len(rows) == 2
+        for row in rows:
+            assert row.sponsor_id == sponsor.id, "sponsor_id must be set for settlement"
+            assert row.campaign_id == campaign.id, "campaign_id must be set for settlement"
+
+    def test_spon_credit_10_partial_failure_rolls_back_atomically(self, test_db: Session):
+        """If the unlock deduction fails (e.g. InsufficientCreditsError), the grant
+        must not be committed either — the entire batch rolls back.
+
+        Setup data is committed to the SAVEPOINT so it survives the rollback of
+        the failed promote attempt.  The promote changes (user_id, grant TX) are
+        flushed but never committed; after an explicit rollback they are undone.
+        """
+        admin    = _make_admin(test_db)
+        sponsor  = _make_sponsor(test_db, admin)
+        campaign = _make_campaign(test_db, sponsor, admin)
+        log      = _make_import_log(test_db, sponsor, campaign, admin)
+        entry    = _make_entry(test_db, sponsor, campaign, log, admin)
+
+        # Commit test data to the SAVEPOINT so it survives a subsequent rollback.
+        test_db.commit()
+        entry_id   = entry.id
+        sponsor_id = sponsor.id
+        campaign_id = campaign.id
+
+        from app.services import sponsor_promote_service as svc_module
+
+        def _failing_apply(user, campaign, credit_svc):
+            # Award the grant (flushes SQL UPDATE + CreditTransaction)
+            credit_svc.award(
+                user=user,
+                amount=campaign.credit_grant_amount,
+                transaction_type="SPONSOR_CREDIT_GRANT",
+                description="test grant",
+                idempotency_key=f"sponsor_grant:{campaign.id}:{user.id}",
+                sponsor_id=campaign.sponsor_id,
+                campaign_id=campaign.id,
+            )
+            # Then simulate unlock failure
+            raise InsufficientCreditsError(required=campaign.unlock_cost, available=0)
+
+        with patch.object(svc_module, "_apply_credits", side_effect=_failing_apply):
+            with pytest.raises(InsufficientCreditsError):
+                promote_entries([entry_id], sponsor_id, test_db, admin,
+                                campaign_id=campaign_id)
+
+        # promote_entries raised without committing; caller must rollback.
+        # This mirrors production: FastAPI exception handler closes/rolls back the session.
+        test_db.rollback()
+        test_db.expire_all()
+
+        # entry.user_id must remain NULL — promote was not committed
+        fresh_entry = (
+            test_db.query(SponsorAudienceEntry)
+            .filter(SponsorAudienceEntry.id == entry_id)
+            .first()
+        )
+        assert fresh_entry is not None, "Entry must exist (committed in setup)"
+        assert fresh_entry.user_id is None, (
+            "entry.user_id must be NULL after partial-failure rollback"
+        )
+
+        # No credit rows for this campaign
+        credit_count = (
+            test_db.query(CreditTransaction)
+            .filter(CreditTransaction.campaign_id == campaign_id)
+            .count()
+        )
+        assert credit_count == 0, (
+            "No CreditTransaction rows must persist after partial-failure rollback"
+        )

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -2271,6 +2271,11 @@
             "title": "Difficulty",
             "type": "string"
           },
+          "foot_context": {
+            "default": "neutral",
+            "title": "Foot Context",
+            "type": "string"
+          },
           "min_players": {
             "default": 4,
             "title": "Min Players",
@@ -2536,6 +2541,11 @@
           "difficulty": {
             "default": "",
             "title": "Difficulty",
+            "type": "string"
+          },
+          "foot_context": {
+            "default": "neutral",
+            "title": "Foot Context",
             "type": "string"
           },
           "min_players": {

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -27048,6 +27048,106 @@
         ]
       }
     },
+    "/admin/sponsors/{sponsor_id}/campaigns/{campaign_id}/close": {
+      "post": {
+        "description": "Close a campaign \u2014 prevents further imports and audience promotions.",
+        "operationId": "admin_sponsor_campaign_close_admin_sponsors__sponsor_id__campaigns__campaign_id__close_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "sponsor_id",
+            "required": true,
+            "schema": {
+              "title": "Sponsor Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "campaign_id",
+            "required": true,
+            "schema": {
+              "title": "Campaign Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Admin Sponsor Campaign Close",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/admin/sponsors/{sponsor_id}/campaigns/{campaign_id}/edit": {
+      "post": {
+        "description": "Edit campaign name, credit fields, and event date.",
+        "operationId": "admin_sponsor_campaign_edit_admin_sponsors__sponsor_id__campaigns__campaign_id__edit_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "sponsor_id",
+            "required": true,
+            "schema": {
+              "title": "Sponsor Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "campaign_id",
+            "required": true,
+            "schema": {
+              "title": "Campaign Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Admin Sponsor Campaign Edit",
+        "tags": [
+          "web"
+        ]
+      }
+    },
     "/admin/sponsors/{sponsor_id}/campaigns/{campaign_id}/import": {
       "get": {
         "description": "Render CSV upload form scoped to a campaign.",

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -2797,6 +2797,11 @@
             "title": "Campaign Type",
             "type": "string"
           },
+          "credit_grant_amount": {
+            "default": 100,
+            "title": "Credit Grant Amount",
+            "type": "integer"
+          },
           "event_date": {
             "anyOf": [
               {
@@ -2822,6 +2827,16 @@
               }
             ],
             "title": "Notes"
+          },
+          "specialization_type": {
+            "default": "LFA_FOOTBALL_PLAYER",
+            "title": "Specialization Type",
+            "type": "string"
+          },
+          "unlock_cost": {
+            "default": 100,
+            "title": "Unlock Cost",
+            "type": "integer"
           }
         },
         "required": [

--- a/tests/unit/services/test_adaptive_learning_service.py
+++ b/tests/unit/services/test_adaptive_learning_service.py
@@ -1086,7 +1086,7 @@ class TestAnswerOptionShuffle:
              patch.object(svc, "_get_candidate_questions", return_value=[question]), \
              patch.object(svc, "_get_session_time_remaining", return_value=120), \
              patch.object(svc, "_get_question_difficulty", return_value=0.4):
-            return svc.get_next_question(user_id=1, session_id=1)
+            return svc.get_next_question(user_id=42, session_id=99)
 
     def test_shuffle_applied_to_options(self):
         """AL-SHUFFLE-01: options in response differ from original insertion order."""

--- a/tests/unit/services/test_adaptive_learning_service.py
+++ b/tests/unit/services/test_adaptive_learning_service.py
@@ -713,10 +713,13 @@ class TestSelectAdaptiveQuestion:
       L286: weak_concept OR random >= 0.7 → fallback random.choice
     """
 
-    def _perf_data(self, due_ids=None, weak_ids=None):
+    def _perf_data(self, due_ids=None, weak_ids=None, attempted_ids=None):
+        # attempted_ids defaults to all candidate IDs so the never-seen path
+        # is bypassed and the original due/weak paths can be exercised.
         return {
             "due_for_review": [MagicMock(question_id=i) for i in (due_ids or [])],
             "weak_concepts": [MagicMock(question_id=i) for i in (weak_ids or [])],
+            "attempted_ids": set(attempted_ids) if attempted_ids is not None else {10, 20, 30},
         }
 
     def test_due_question_returned_preferentially(self):
@@ -1039,3 +1042,230 @@ class TestGetNextQuestionDedup:
         assert result is not None
         assert not result.get("session_complete"), "Should return Q5 as fallback"
         assert result.get("id") == 5
+
+
+# ===========================================================================
+# Answer-option shuffle — Fix #1
+# ===========================================================================
+
+@pytest.mark.unit
+class TestAnswerOptionShuffle:
+    """
+    Correct answer position must be random.
+    Grading is ID-based, so shuffle must not affect correctness evaluation.
+
+    AL-SHUFFLE-01: options returned by get_next_question are shuffled
+    AL-SHUFFLE-02: shuffled options contain every original option id (no drop/dup)
+    AL-SHUFFLE-03: with a reversed-shuffle, correct option id still survives (grading safe)
+    AL-SHUFFLE-04: uniform position distribution over many calls (chi-squared sanity)
+    """
+
+    def _make_option(self, oid, text, is_correct=False):
+        opt = MagicMock()
+        opt.id = oid
+        opt.option_text = text
+        opt.is_correct = is_correct
+        return opt
+
+    def _make_question(self, qid, options):
+        q = MagicMock()
+        q.id = qid
+        q.question_text = "Q?"
+        q.question_type = MagicMock(value="multiple_choice")
+        q.answer_options = options
+        return q
+
+    def _get_result(self, svc, db, question):
+        """Wire up DB mock and call get_next_question, return the result dict."""
+        _q(db, first=MagicMock())
+        with patch.object(svc, "_is_session_time_expired", return_value=False), \
+             patch.object(svc, "_get_user_performance_data", return_value={
+                 "weak_concepts": [], "strong_concepts": [], "due_for_review": [],
+                 "attempted_ids": set(),
+             }), \
+             patch.object(svc, "_get_candidate_questions", return_value=[question]), \
+             patch.object(svc, "_get_session_time_remaining", return_value=120), \
+             patch.object(svc, "_get_question_difficulty", return_value=0.4):
+            return svc.get_next_question(user_id=1, session_id=1)
+
+    def test_shuffle_applied_to_options(self):
+        """AL-SHUFFLE-01: options in response differ from original insertion order."""
+        svc, db = _svc()
+        opts = [self._make_option(i, f"opt{i}") for i in range(1, 5)]
+        question = self._make_question(99, opts)
+        orders_seen = set()
+        for _ in range(40):
+            result = self._get_result(svc, db, question)
+            assert result is not None and "options" in result
+            orders_seen.add(tuple(o["id"] for o in result["options"]))
+        # At least 2 distinct orderings must appear across 40 draws
+        assert len(orders_seen) >= 2, "options always in same order — shuffle not working"
+
+    def test_shuffle_preserves_all_option_ids(self):
+        """AL-SHUFFLE-02: shuffled list has same IDs as original (no drop/duplication)."""
+        svc, db = _svc()
+        opts = [self._make_option(i, f"opt{i}") for i in [10, 20, 30, 40]]
+        question = self._make_question(99, opts)
+        result = self._get_result(svc, db, question)
+        returned_ids = {o["id"] for o in result["options"]}
+        assert returned_ids == {10, 20, 30, 40}
+
+    def test_grading_not_broken_by_shuffle(self):
+        """AL-SHUFFLE-03: correct option id is present regardless of shuffle order."""
+        svc, db = _svc()
+        correct_id = 3
+        opts = [
+            self._make_option(1, "wrong A"),
+            self._make_option(2, "wrong B"),
+            self._make_option(correct_id, "CORRECT", is_correct=True),
+            self._make_option(4, "wrong D"),
+        ]
+        question = self._make_question(99, opts)
+        for _ in range(20):
+            result = self._get_result(svc, db, question)
+            ids = [o["id"] for o in result["options"]]
+            assert correct_id in ids, "Correct option id dropped from shuffled list"
+
+    def test_correct_position_not_always_first(self):
+        """AL-SHUFFLE-04: correct option id not always at index 0."""
+        svc, db = _svc()
+        correct_id = 99
+        opts = [self._make_option(correct_id, "CORRECT", is_correct=True)] + \
+               [self._make_option(i, f"wrong{i}") for i in range(1, 4)]
+        question = self._make_question(7, opts)
+        positions = []
+        for _ in range(60):
+            result = self._get_result(svc, db, question)
+            ids = [o["id"] for o in result["options"]]
+            positions.append(ids.index(correct_id))
+        # Must appear at more than one position
+        assert len(set(positions)) >= 2, "Correct answer always at same position after shuffle"
+        # Must not be exclusively at index 0
+        assert any(p != 0 for p in positions), "Correct answer never left index 0"
+
+
+# ===========================================================================
+# Never-seen question priority — Fix #2
+# ===========================================================================
+
+@pytest.mark.unit
+class TestNeverSeenPriority:
+    """
+    Questions never attempted by the user are served before review/weak queues.
+
+    AL-COVERAGE-01: never-seen candidate returned over due-for-review candidate
+    AL-COVERAGE-02: never-seen candidate returned over weak-concept candidate
+    AL-COVERAGE-03: once all candidates seen, falls through to due/weak/random
+    AL-COVERAGE-04: full pool covered before repetition in a single session
+    """
+
+    def _perf(self, attempted_ids=None, due_ids=None, weak_ids=None):
+        return {
+            "attempted_ids": set(attempted_ids or []),
+            "due_for_review": [MagicMock(question_id=i) for i in (due_ids or [])],
+            "weak_concepts": [MagicMock(question_id=i) for i in (weak_ids or [])],
+        }
+
+    def _q(self, qid):
+        q = MagicMock()
+        q.id = qid
+        return q
+
+    def test_never_seen_beats_due_for_review(self):
+        """AL-COVERAGE-01: unseen candidate wins over due-review candidate."""
+        svc, _ = _svc()
+        q_unseen = self._q(1)
+        q_due = self._q(2)
+        perf = self._perf(attempted_ids=[2], due_ids=[2])  # q2 due, q1 never seen
+        with patch("random.choice", side_effect=lambda lst: lst[0]):
+            result = svc._select_adaptive_question([q_unseen, q_due], perf, MagicMock())
+        assert result is q_unseen
+
+    def test_never_seen_beats_weak_concept(self):
+        """AL-COVERAGE-02: unseen candidate wins over weak-concept candidate."""
+        svc, _ = _svc()
+        q_unseen = self._q(5)
+        q_weak = self._q(6)
+        perf = self._perf(attempted_ids=[6], weak_ids=[6])  # q6 weak, q5 never seen
+        with patch("random.choice", side_effect=lambda lst: lst[0]):
+            result = svc._select_adaptive_question([q_unseen, q_weak], perf, MagicMock())
+        assert result is q_unseen
+
+    def test_all_seen_falls_through_to_due(self):
+        """AL-COVERAGE-03: when all candidates attempted, due-for-review path fires."""
+        svc, _ = _svc()
+        q_due = self._q(10)
+        q_other = self._q(11)
+        perf = self._perf(attempted_ids=[10, 11], due_ids=[10])
+        with patch("random.choice", return_value=q_due):
+            result = svc._select_adaptive_question([q_due, q_other], perf, MagicMock())
+        assert result is q_due
+
+    def test_full_pool_covered_before_repetition(self):
+        """AL-COVERAGE-04: 5-question pool fully covered before any repeat."""
+        svc, _ = _svc()
+        pool = [self._q(i) for i in range(5)]
+        seen_ids = set()
+        attempted_ids: set = set()
+
+        for _ in range(5):
+            available = [q for q in pool if q.id not in seen_ids]
+            perf = self._perf(attempted_ids=attempted_ids)
+            chosen = svc._select_adaptive_question(available, perf, MagicMock())
+            assert chosen.id not in seen_ids, f"Question {chosen.id} repeated before pool exhausted"
+            seen_ids.add(chosen.id)
+            attempted_ids.add(chosen.id)
+
+        assert seen_ids == {0, 1, 2, 3, 4}
+
+
+# ===========================================================================
+# Difficulty fallback logging — Fix #3
+# ===========================================================================
+
+@pytest.mark.unit
+class TestDifficultyFallbackLogging:
+    """
+    When the difficulty-window query returns empty, the fallback must log a warning.
+
+    AL-FALLBACK-01: warning emitted when difficulty query returns empty
+    AL-FALLBACK-02: no warning when difficulty query succeeds
+    """
+
+    def _make_db_with_two_calls(self, first_returns, second_returns):
+        """DB mock where first .all() returns first_returns, second returns second_returns."""
+        db = MagicMock()
+        calls = {"n": 0}
+        base_q = MagicMock()
+        base_q.filter.return_value = base_q
+        base_q.join.return_value = base_q
+        base_q.outerjoin.return_value = base_q
+
+        def _all():
+            n = calls["n"]
+            calls["n"] += 1
+            return first_returns if n == 0 else second_returns
+
+        base_q.all.side_effect = _all
+        db.query.return_value = base_q
+        return db
+
+    def test_warning_logged_on_fallback(self):
+        """AL-FALLBACK-01: logger.warning fired when difficulty window is empty."""
+        db = self._make_db_with_two_calls(first_returns=[], second_returns=[MagicMock()])
+        svc = AdaptiveLearningService(db)
+        with patch("app.services.adaptive_learning.logger") as mock_log:
+            result = svc._get_candidate_questions(QuizCategory.GENERAL, target_difficulty=0.9)
+        mock_log.warning.assert_called_once()
+        call_args = mock_log.warning.call_args[0]
+        assert "al_difficulty_fallback" in call_args[0]
+
+    def test_no_warning_when_questions_found(self):
+        """AL-FALLBACK-02: logger.warning not called when difficulty query succeeds."""
+        db = self._make_db_with_two_calls(
+            first_returns=[MagicMock()], second_returns=[]
+        )
+        svc = AdaptiveLearningService(db)
+        with patch("app.services.adaptive_learning.logger") as mock_log:
+            svc._get_candidate_questions(QuizCategory.GENERAL, target_difficulty=0.5)
+        mock_log.warning.assert_not_called()

--- a/tests/unit/services/test_game_preset_foot_context_edit.py
+++ b/tests/unit/services/test_game_preset_foot_context_edit.py
@@ -1,0 +1,229 @@
+"""
+Game Preset admin web route — foot_context edit/create tests.
+
+FC-EDIT-01  Edit lat_passing_right preset → Save → foot_context remains 'right'
+FC-EDIT-02  Edit lat_passing_left  preset → Save → foot_context remains 'left'
+FC-EDIT-03  Edit legacy preset (no explicit foot_context) → Save → foot_context='neutral'
+FC-EDIT-04  Create new preset with foot_context='right' → DB stores 'right'
+FC-EDIT-05  POST edit with invalid foot_context value → fallback to 'neutral'
+
+Auth:  get_current_user_web dependency overridden → admin injected
+CSRF:  Authorization: Bearer header bypasses CSRFProtectionMiddleware
+DB:    SAVEPOINT-isolated (test_db fixture from unit/conftest.py)
+"""
+
+import uuid
+import pytest
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.main import app
+from app.database import get_db
+from app.dependencies import get_current_user_web
+from app.models.user import User, UserRole
+from app.models.game_preset import GamePreset
+from app.core.security import get_password_hash
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture(scope="function")
+def admin_user(test_db: Session) -> User:
+    u = User(
+        email=f"fcedit-admin+{uuid.uuid4().hex[:8]}@lfa.com",
+        name="FC Edit Admin",
+        password_hash=get_password_hash("Admin123!"),
+        role=UserRole.ADMIN,
+        is_active=True,
+    )
+    test_db.add(u)
+    test_db.commit()
+    test_db.refresh(u)
+    return u
+
+
+@pytest.fixture(scope="function")
+def admin_client(test_db: Session, admin_user: User) -> TestClient:
+    def override_get_db():
+        yield test_db
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user_web] = lambda: admin_user
+
+    with TestClient(app, headers={"Authorization": "Bearer test-csrf-bypass"}) as c:
+        yield c
+
+    app.dependency_overrides.clear()
+
+
+def _make_preset(test_db: Session, *, code: str, name: str, foot_context: str | None) -> GamePreset:
+    """Create a GamePreset with or without explicit foot_context in skill_config."""
+    sc: dict = {
+        "skills_tested": ["passing"],
+        "skill_weights": {"passing": 1.0},
+        "skill_impact_on_matches": True,
+    }
+    if foot_context is not None:
+        sc["foot_context"] = foot_context
+
+    gp = GamePreset(
+        code=code,
+        name=name,
+        is_active=True,
+        game_config={
+            "version": "1.0",
+            "format_config": {},
+            "skill_config": sc,
+            "simulation_config": {},
+            "metadata": {"game_category": "FOOTBALL", "difficulty_level": None, "min_players": 2},
+        },
+    )
+    test_db.add(gp)
+    test_db.commit()
+    test_db.refresh(gp)
+    return gp
+
+
+def _edit_form(*, name: str, foot_context: str, skill: str = "passing", weight: int = 100) -> dict:
+    """Build the minimal POST form data for the edit route."""
+    return {
+        "name": name,
+        "description": "",
+        "category": "FOOTBALL",
+        "difficulty": "",
+        "min_players": "2",
+        "foot_context": foot_context,
+        f"skill_cb_{skill}": skill,
+        f"skill_w_{skill}": str(weight),
+    }
+
+
+def _sc(test_db: Session, preset_id: int) -> dict:
+    """Re-read skill_config from DB (expire cache first)."""
+    test_db.expire_all()
+    gp = test_db.query(GamePreset).filter(GamePreset.id == preset_id).first()
+    return (gp.game_config or {}).get("skill_config", {})
+
+
+# ── FC-EDIT-01 ────────────────────────────────────────────────────────────────
+
+class TestFcEdit01RightPreservedOnSave:
+    """FC-EDIT-01: Edit lat_passing_right → Save → foot_context stays 'right'."""
+
+    def test_fc_edit_01(self, admin_client, test_db):
+        preset = _make_preset(
+            test_db,
+            code=f"lat_passing_right_{uuid.uuid4().hex[:6]}",
+            name="Lat Passing Right",
+            foot_context="right",
+        )
+        resp = admin_client.post(
+            f"/admin/game-presets/{preset.id}/edit",
+            data=_edit_form(name="Lat Passing Right", foot_context="right"),
+            follow_redirects=False,
+        )
+        assert resp.status_code == 303, f"Expected 303, got {resp.status_code}: {resp.text}"
+        assert _sc(test_db, preset.id).get("foot_context") == "right"
+
+
+# ── FC-EDIT-02 ────────────────────────────────────────────────────────────────
+
+class TestFcEdit02LeftPreservedOnSave:
+    """FC-EDIT-02: Edit lat_passing_left → Save → foot_context stays 'left'."""
+
+    def test_fc_edit_02(self, admin_client, test_db):
+        preset = _make_preset(
+            test_db,
+            code=f"lat_passing_left_{uuid.uuid4().hex[:6]}",
+            name="Lat Passing Left",
+            foot_context="left",
+        )
+        resp = admin_client.post(
+            f"/admin/game-presets/{preset.id}/edit",
+            data=_edit_form(name="Lat Passing Left", foot_context="left"),
+            follow_redirects=False,
+        )
+        assert resp.status_code == 303
+        assert _sc(test_db, preset.id).get("foot_context") == "left"
+
+
+# ── FC-EDIT-03 ────────────────────────────────────────────────────────────────
+
+class TestFcEdit03LegacyGetsNeutralOnSave:
+    """FC-EDIT-03: Edit legacy preset (no foot_context key) → Save → 'neutral' written."""
+
+    def test_fc_edit_03(self, admin_client, test_db):
+        preset = _make_preset(
+            test_db,
+            code=f"legacy_preset_{uuid.uuid4().hex[:6]}",
+            name="Legacy Preset",
+            foot_context=None,   # no explicit foot_context
+        )
+        # Confirm precondition: no foot_context key in DB
+        assert "foot_context" not in _sc(test_db, preset.id)
+
+        resp = admin_client.post(
+            f"/admin/game-presets/{preset.id}/edit",
+            data=_edit_form(name="Legacy Preset", foot_context="neutral"),
+            follow_redirects=False,
+        )
+        assert resp.status_code == 303
+        assert _sc(test_db, preset.id).get("foot_context") == "neutral"
+
+
+# ── FC-EDIT-04 ────────────────────────────────────────────────────────────────
+
+class TestFcEdit04CreateWithRightContext:
+    """FC-EDIT-04: Create new preset with foot_context='right' → DB stores 'right'."""
+
+    def test_fc_edit_04(self, admin_client, test_db):
+        code = f"new_right_{uuid.uuid4().hex[:6]}"
+        name = f"New Right Preset {uuid.uuid4().hex[:4]}"
+        resp = admin_client.post(
+            "/admin/game-presets",
+            data={
+                "name": name,
+                "code": code,
+                "description": "",
+                "category": "FOOTBALL",
+                "difficulty": "",
+                "min_players": "2",
+                "foot_context": "right",
+                "skill_cb_passing": "passing",
+                "skill_w_passing": "100",
+            },
+            follow_redirects=False,
+        )
+        assert resp.status_code == 303
+
+        test_db.expire_all()
+        gp = test_db.query(GamePreset).filter(GamePreset.code == code).first()
+        assert gp is not None, f"Preset with code={code!r} not found after create"
+        sc = (gp.game_config or {}).get("skill_config", {})
+        assert sc.get("foot_context") == "right", (
+            f"Expected foot_context='right', got {sc.get('foot_context')!r}"
+        )
+
+
+# ── FC-EDIT-05 ────────────────────────────────────────────────────────────────
+
+class TestFcEdit05InvalidValueFallsBackToNeutral:
+    """FC-EDIT-05: POST edit with invalid foot_context → stored as 'neutral'."""
+
+    def test_fc_edit_05(self, admin_client, test_db):
+        preset = _make_preset(
+            test_db,
+            code=f"invalid_fc_{uuid.uuid4().hex[:6]}",
+            name="Invalid FC Preset",
+            foot_context="right",
+        )
+        resp = admin_client.post(
+            f"/admin/game-presets/{preset.id}/edit",
+            data=_edit_form(name="Invalid FC Preset", foot_context="BOTH_FEET"),
+            follow_redirects=False,
+        )
+        assert resp.status_code == 303
+        assert _sc(test_db, preset.id).get("foot_context") == "neutral", (
+            "Invalid foot_context value must fall back to 'neutral'"
+        )

--- a/tests/unit/services/test_sponsor_laterality_pipeline.py
+++ b/tests/unit/services/test_sponsor_laterality_pipeline.py
@@ -1,0 +1,496 @@
+"""
+Sponsor Promote → Foot Score → Laterality Bridge Pipeline Tests.
+
+Tests: LAT-SPON-01 through LAT-SPON-10
+
+Scope:
+  - foot_dominance (SponsorAudienceEntry) correctly maps to
+    UserLicense.right_foot_score / left_foot_score via promote_entries()
+  - Baseline write conditions (dob, position, consent guard)
+  - right_foot_score / left_foot_score correctly weights lateral_components
+    after a tournament with a foot-specific passing preset
+  - Idempotence and email-dedup of promote_entries()
+
+foot_dominance scale: 0 = left-dominant, 100 = right-dominant, 50 = balanced.
+
+All tests use test_db (function-scoped SAVEPOINT) — each test creates its own
+sponsor / campaign / entries / presets inline; no session-scoped seeds needed.
+"""
+import uuid
+from datetime import date, timedelta
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.models.club import CsvImportLog
+from app.models.game_configuration import GameConfiguration
+from app.models.game_preset import GamePreset
+from app.models.license import UserLicense
+from app.models.semester import Semester, SemesterStatus, SemesterCategory
+from app.models.sponsor import Sponsor, SponsorCampaign, SponsorAudienceEntry
+from app.models.tournament_achievement import TournamentSkillMapping
+from app.models.user import User, UserRole
+from app.core.security import get_password_hash
+from app.services.sponsor_promote_service import promote_entries
+from app.services.tournament.tournament_reward_orchestrator import distribute_rewards_for_user
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _uid() -> str:
+    return uuid.uuid4().hex[:8]
+
+
+def _make_admin(db: Session) -> User:
+    admin = User(
+        email=f"spon-admin-{_uid()}@lat.test",
+        name="Sponsor Admin",
+        password_hash=get_password_hash("Admin123!"),
+        role=UserRole.ADMIN,
+        is_active=True,
+    )
+    db.add(admin)
+    db.flush()
+    return admin
+
+
+def _make_import_log(db: Session, sponsor: Sponsor, campaign: SponsorCampaign) -> CsvImportLog:
+    """Create a minimal CsvImportLog required by sponsor_audience_entries.import_log_id NOT NULL."""
+    log = CsvImportLog(
+        sponsor_id=sponsor.id,
+        campaign_id=campaign.id,
+        filename="lat_test.csv",
+        total_rows=1,
+        rows_created=1,
+        rows_updated=0,
+        rows_skipped=0,
+        rows_failed=0,
+        errors=[],
+        status="DONE",
+    )
+    db.add(log)
+    db.flush()
+    return log
+
+
+def _make_sponsor_campaign(db: Session, admin: User) -> tuple:
+    """Create Sponsor + SponsorCampaign + CsvImportLog. Returns (sponsor, campaign, import_log)."""
+    sponsor = Sponsor(
+        name=f"LatTest Sponsor {_uid()}",
+        code=f"LAT-{_uid()}",
+        is_active=True,
+        created_by=admin.id,
+    )
+    db.add(sponsor)
+    db.flush()
+
+    campaign = SponsorCampaign(
+        sponsor_id=sponsor.id,
+        name=f"LatTest Campaign {_uid()}",
+        status="ACTIVE",
+        specialization_type="LFA_FOOTBALL_PLAYER",
+        credit_grant_amount=200,
+        unlock_cost=100,
+        created_by=admin.id,
+    )
+    db.add(campaign)
+    db.flush()
+
+    import_log = _make_import_log(db, sponsor, campaign)
+    return sponsor, campaign, import_log
+
+
+def _make_entry(
+    db: Session,
+    sponsor: Sponsor,
+    campaign: SponsorCampaign,
+    import_log: CsvImportLog,
+    *,
+    email: str | None = None,
+    foot_dominance: int | None = 50,
+    position: str = "STRIKER",
+    date_of_birth: date | None = date(2000, 1, 1),
+    consent_given: bool = True,
+    status: str = "ACTIVE",
+) -> SponsorAudienceEntry:
+    entry = SponsorAudienceEntry(
+        sponsor_id=sponsor.id,
+        campaign_id=campaign.id,
+        import_log_id=import_log.id,
+        email=email or f"lat-{_uid()}@lat.test",
+        first_name="Test",
+        last_name="User",
+        date_of_birth=date_of_birth,
+        position=position,
+        foot_dominance=foot_dominance,
+        consent_given=consent_given,
+        status=status,
+    )
+    db.add(entry)
+    db.flush()
+    return entry
+
+
+def _load_license(db: Session, user_id: int) -> UserLicense:
+    lic = db.query(UserLicense).filter(
+        UserLicense.user_id == user_id,
+        UserLicense.specialization_type == "LFA_FOOTBALL_PLAYER",
+        UserLicense.is_active == True,
+    ).first()
+    assert lic is not None, f"Active LFA license not found for user_id={user_id}"
+    return lic
+
+
+def _make_passing_preset(db: Session, foot_context: str) -> GamePreset:
+    """Create a test-local passing preset with the given foot_context."""
+    preset = GamePreset(
+        code=f"lat-pass-{foot_context}-{_uid()}",
+        name=f"Inline Passing ({foot_context})",
+        description=f"Test-local passing preset foot_context={foot_context}",
+        game_config={
+            "version": "1.0",
+            "metadata": {
+                "game_category": "FOOTBALL",
+                "difficulty_level": "intermediate",
+                "min_players": 2,
+                "recommended_player_count": {"min": 2, "max": 16},
+            },
+            "skill_config": {
+                "foot_context": foot_context,
+                "skills_tested": ["passing"],
+                "skill_weights": {"passing": 1.5},
+            },
+            "format_config": {},
+            "simulation_config": {},
+        },
+        is_active=True,
+        is_recommended=False,
+        is_locked=False,
+    )
+    db.add(preset)
+    db.flush()
+    return preset
+
+
+def _make_tournament(db: Session, preset_id: int, skills: list) -> Semester:
+    sem = Semester(
+        code=f"LAT-SPON-{_uid()}",
+        name="LatSpon Passing Trial",
+        start_date=date.today(),
+        end_date=date.today() + timedelta(days=30),
+        status=SemesterStatus.ONGOING,
+        semester_category=SemesterCategory.TOURNAMENT,
+        enrollment_cost=0,
+    )
+    db.add(sem)
+    db.flush()
+
+    for skill in skills:
+        db.add(TournamentSkillMapping(
+            semester_id=sem.id,
+            skill_name=skill,
+            skill_category="football_skill",
+            weight=1.0,
+        ))
+
+    db.add(GameConfiguration(semester_id=sem.id, game_preset_id=preset_id))
+    db.flush()
+    db.refresh(sem)
+    return sem
+
+
+# ── LAT-SPON-01..05 — Baseline foot score writing ────────────────────────────
+
+class TestSponsorBaselineFootScore:
+
+    def test_lat_spon_01_foot_dominance_85_right_dominant(self, test_db: Session):
+        """LAT-SPON-01: foot_dominance=85 → right_foot_score=85.0, left_foot_score=15.0."""
+        admin = _make_admin(test_db)
+        sponsor, campaign, import_log = _make_sponsor_campaign(test_db, admin)
+        entry = _make_entry(test_db, sponsor, campaign, import_log, foot_dominance=85)
+
+        result = promote_entries(
+            [entry.id], sponsor.id, test_db, admin, campaign_id=campaign.id
+        )
+
+        assert result.promoted == 1
+        assert result.promoted_with_onboarding == 1
+
+        test_db.refresh(entry)
+        lic = _load_license(test_db, entry.user_id)
+        assert lic.right_foot_score == 85.0
+        assert lic.left_foot_score == 15.0
+
+    def test_lat_spon_02_foot_dominance_15_left_dominant(self, test_db: Session):
+        """LAT-SPON-02: foot_dominance=15 → right_foot_score=15.0, left_foot_score=85.0."""
+        admin = _make_admin(test_db)
+        sponsor, campaign, import_log = _make_sponsor_campaign(test_db, admin)
+        entry = _make_entry(test_db, sponsor, campaign, import_log, foot_dominance=15)
+
+        promote_entries([entry.id], sponsor.id, test_db, admin, campaign_id=campaign.id)
+
+        test_db.refresh(entry)
+        lic = _load_license(test_db, entry.user_id)
+        assert lic.right_foot_score == 15.0
+        assert lic.left_foot_score == 85.0
+
+    def test_lat_spon_03_foot_dominance_none_defaults_to_50_50(self, test_db: Session):
+        """LAT-SPON-03: foot_dominance=None → default 50.0 / 50.0 (balanced fallback)."""
+        admin = _make_admin(test_db)
+        sponsor, campaign, import_log = _make_sponsor_campaign(test_db, admin)
+        entry = _make_entry(test_db, sponsor, campaign, import_log, foot_dominance=None)
+
+        promote_entries([entry.id], sponsor.id, test_db, admin, campaign_id=campaign.id)
+
+        test_db.refresh(entry)
+        lic = _load_license(test_db, entry.user_id)
+        assert lic.right_foot_score == 50.0
+        assert lic.left_foot_score == 50.0
+
+    def test_lat_spon_04_no_dob_baseline_not_written(self, test_db: Session):
+        """LAT-SPON-04: date_of_birth=None → baseline NOT written.
+        right_foot_score / left_foot_score remain None; football_skills remain None."""
+        admin = _make_admin(test_db)
+        sponsor, campaign, import_log = _make_sponsor_campaign(test_db, admin)
+        entry = _make_entry(
+            test_db, sponsor, campaign, import_log,
+            foot_dominance=70,
+            date_of_birth=None,
+        )
+
+        result = promote_entries(
+            [entry.id], sponsor.id, test_db, admin, campaign_id=campaign.id
+        )
+
+        assert result.promoted == 1
+        assert result.promoted_with_onboarding == 0
+        assert result.promoted_without_onboarding == 1
+
+        test_db.refresh(entry)
+        lic = _load_license(test_db, entry.user_id)
+        assert lic.right_foot_score is None
+        assert lic.left_foot_score is None
+        assert lic.football_skills is None
+
+    def test_lat_spon_05_invalid_position_baseline_not_written_user_created(
+        self, test_db: Session
+    ):
+        """LAT-SPON-05: position=COACH (not in VALID_POSITIONS) → baseline NOT written.
+        User and license are still created; credits are still issued."""
+        admin = _make_admin(test_db)
+        sponsor, campaign, import_log = _make_sponsor_campaign(test_db, admin)
+        entry = _make_entry(
+            test_db, sponsor, campaign, import_log,
+            foot_dominance=70,
+            position="COACH",
+        )
+
+        result = promote_entries(
+            [entry.id], sponsor.id, test_db, admin, campaign_id=campaign.id
+        )
+
+        assert result.promoted == 1
+        assert result.promoted_with_onboarding == 0
+        assert result.promoted_without_onboarding == 1
+
+        test_db.refresh(entry)
+        assert entry.user_id is not None
+
+        lic = _load_license(test_db, entry.user_id)
+        assert lic is not None
+        assert lic.football_skills is None
+        assert lic.right_foot_score is None
+
+
+# ── LAT-SPON-06..08 — Foot score → lateral aggregation bridge ────────────────
+
+class TestSponsorLateralityBridge:
+    """Full pipeline: sponsor promote sets foot scores → tournament with
+    foot-specific passing preset → lateral_components weighted by those scores."""
+
+    def _promote_and_load(
+        self,
+        db: Session,
+        foot_dominance: int,
+        position: str = "MIDFIELDER",
+    ) -> tuple:
+        """Promote one entry and return (user, license)."""
+        admin = _make_admin(db)
+        sponsor, campaign, import_log = _make_sponsor_campaign(db, admin)
+        entry = _make_entry(
+            db, sponsor, campaign, import_log,
+            foot_dominance=foot_dominance,
+            position=position,
+        )
+        promote_entries([entry.id], sponsor.id, db, admin, campaign_id=campaign.id)
+        db.refresh(entry)
+        user = db.query(User).filter(User.id == entry.user_id).first()
+        lic = _load_license(db, user.id)
+        return user, lic
+
+    def test_lat_spon_06_strong_right_right_preset_updates_right_bucket(
+        self, test_db: Session
+    ):
+        """LAT-SPON-06: foot_dominance=85 + right-foot passing preset
+        → passing.lateral_components['right'] bucket created."""
+        user, lic = self._promote_and_load(test_db, foot_dominance=85)
+        assert lic.right_foot_score == 85.0
+
+        preset = _make_passing_preset(test_db, "right")
+        tournament = _make_tournament(test_db, preset.id, ["passing"])
+
+        distribute_rewards_for_user(
+            db=test_db,
+            user_id=user.id,
+            tournament_id=tournament.id,
+            placement=1,
+            total_participants=4,
+        )
+
+        test_db.refresh(lic)
+        passing_entry = lic.football_skills.get("passing", {})
+        assert isinstance(passing_entry, dict), \
+            "passing skill must be a dict after write-back"
+        lateral = passing_entry.get("lateral_components", {})
+        assert "right" in lateral, f"'right' bucket missing; lateral={lateral}"
+        assert lateral["right"]["tournament_count"] == 1
+
+    def test_lat_spon_07_strong_left_left_preset_updates_left_bucket(
+        self, test_db: Session
+    ):
+        """LAT-SPON-07: foot_dominance=15 + left-foot passing preset
+        → passing.lateral_components['left'] bucket created."""
+        user, lic = self._promote_and_load(test_db, foot_dominance=15)
+        assert lic.left_foot_score == 85.0
+
+        preset = _make_passing_preset(test_db, "left")
+        tournament = _make_tournament(test_db, preset.id, ["passing"])
+
+        distribute_rewards_for_user(
+            db=test_db,
+            user_id=user.id,
+            tournament_id=tournament.id,
+            placement=1,
+            total_participants=4,
+        )
+
+        test_db.refresh(lic)
+        passing_entry = lic.football_skills.get("passing", {})
+        lateral = passing_entry.get("lateral_components", {})
+        assert "left" in lateral, f"'left' bucket missing; lateral={lateral}"
+        assert lateral["left"]["tournament_count"] == 1
+
+    def test_lat_spon_08_balanced_right_then_left_symmetric_aggregate(
+        self, test_db: Session
+    ):
+        """LAT-SPON-08: foot_dominance=50 + right preset then left preset
+        → R=L=0.5 weights → current_level = (0.5*right + 0.5*left) / 1.0."""
+        user, lic = self._promote_and_load(test_db, foot_dominance=50)
+        assert lic.right_foot_score == 50.0
+        assert lic.left_foot_score == 50.0
+
+        # Right tournament first
+        preset_r = _make_passing_preset(test_db, "right")
+        t_r = _make_tournament(test_db, preset_r.id, ["passing"])
+        distribute_rewards_for_user(
+            db=test_db, user_id=user.id, tournament_id=t_r.id,
+            placement=1, total_participants=4,
+        )
+
+        # Left tournament second
+        preset_l = _make_passing_preset(test_db, "left")
+        t_l = _make_tournament(test_db, preset_l.id, ["passing"])
+        distribute_rewards_for_user(
+            db=test_db, user_id=user.id, tournament_id=t_l.id,
+            placement=1, total_participants=4,
+        )
+
+        test_db.refresh(lic)
+        entry = lic.football_skills.get("passing", {})
+        lateral = entry.get("lateral_components", {})
+        assert "right" in lateral and "left" in lateral, (
+            f"Both right and left buckets expected; got: {list(lateral.keys())}"
+        )
+
+        r_level = lateral["right"]["level"]
+        l_level = lateral["left"]["level"]
+        expected_agg = (0.5 * r_level + 0.5 * l_level) / 1.0
+
+        assert entry["current_level"] == pytest.approx(expected_agg, abs=0.2), (
+            f"current_level={entry['current_level']} != symmetric avg={expected_agg} "
+            f"(right={r_level}, left={l_level})"
+        )
+
+
+# ── LAT-SPON-09..10 — Idempotence + email dedup ──────────────────────────────
+
+class TestSponsorPromoteEdgeCases:
+
+    def test_lat_spon_09_already_promoted_entry_idempotent(self, test_db: Session):
+        """LAT-SPON-09: Second promote call on already-promoted entry → already_linked.
+        foot_scores are NOT overwritten."""
+        admin = _make_admin(test_db)
+        sponsor, campaign, import_log = _make_sponsor_campaign(test_db, admin)
+        entry = _make_entry(test_db, sponsor, campaign, import_log, foot_dominance=80)
+
+        r1 = promote_entries([entry.id], sponsor.id, test_db, admin, campaign_id=campaign.id)
+        assert r1.promoted == 1
+
+        test_db.refresh(entry)
+        lic = _load_license(test_db, entry.user_id)
+        assert lic.right_foot_score == 80.0
+
+        # Second promote must be a full no-op
+        r2 = promote_entries([entry.id], sponsor.id, test_db, admin, campaign_id=campaign.id)
+        assert r2.promoted == 0
+        assert r2.already_linked == 1
+
+        test_db.refresh(lic)
+        assert lic.right_foot_score == 80.0
+
+    def test_lat_spon_10_existing_user_email_no_duplicate_license_correct(
+        self, test_db: Session
+    ):
+        """LAT-SPON-10: Entry email matches pre-existing User → user not duplicated.
+        A new LFA license is created for the existing user with foot scores set."""
+        admin = _make_admin(test_db)
+
+        existing_email = f"existing-{_uid()}@lat.test"
+        existing_user = User(
+            email=existing_email,
+            name="Pre-Existing User",
+            password_hash=get_password_hash("Test123!"),
+            role=UserRole.STUDENT,
+            is_active=True,
+        )
+        test_db.add(existing_user)
+        test_db.flush()
+        existing_id = existing_user.id
+
+        sponsor, campaign, import_log = _make_sponsor_campaign(test_db, admin)
+        entry = _make_entry(
+            test_db, sponsor, campaign, import_log,
+            email=existing_email,
+            foot_dominance=65,
+        )
+
+        result = promote_entries(
+            [entry.id], sponsor.id, test_db, admin, campaign_id=campaign.id
+        )
+
+        assert result.promoted == 1
+
+        # The pre-existing user must be reused — no duplicate
+        user_count = (
+            test_db.query(User).filter(User.email == existing_email).count()
+        )
+        assert user_count == 1, (
+            f"Expected 1 user with email {existing_email!r}, got {user_count}"
+        )
+
+        test_db.refresh(entry)
+        assert entry.user_id == existing_id
+
+        lic = _load_license(test_db, existing_id)
+        assert lic.right_foot_score == 65.0
+        assert lic.left_foot_score == 35.0

--- a/tests/unit/test_adaptive_learning_template.py
+++ b/tests/unit/test_adaptive_learning_template.py
@@ -478,3 +478,82 @@ class TestLanguageSwitcherJsGuard:
         assert '&language=en' in html or "session_language" in html, (
             "alsInit URL must embed the session language"
         )
+
+
+class TestAnsweredStateHide:
+    """After submitting an answer, question card and options must be hidden.
+    Only feedback + Next button remain visible until the user advances."""
+
+    def test_question_card_has_id(self):
+        """als-question-card must carry an id= so JS can target it."""
+        html = _render_session_page()
+        assert 'id="als-question-card"' in html, \
+            'als-question-card div missing id="als-question-card"'
+
+    def test_show_answered_state_helper_present(self):
+        """_showAnsweredState() helper must exist in the template JS."""
+        html = _render_session_page()
+        assert "_showAnsweredState" in html, \
+            "_showAnsweredState helper function missing from template"
+
+    def test_show_answered_state_called_after_answer(self):
+        """_showAnsweredState() must be called in the alsAnswer success path."""
+        html = _render_session_page()
+        # Locate alsAnswer function body
+        start = html.index("function alsAnswer(")
+        end = html.index("\n    }", start)
+        body = html[start:end]
+        assert "_showAnsweredState()" in body, \
+            "_showAnsweredState() not called inside alsAnswer success path"
+
+    def test_show_answered_state_hides_question_card(self):
+        """_showAnsweredState must set display:none on als-question-card."""
+        html = _render_session_page()
+        fn_start = html.index("function _showAnsweredState(")
+        fn_end = html.index("}", fn_start)
+        fn_body = html[fn_start:fn_end]
+        assert "als-question-card" in fn_body, \
+            "_showAnsweredState does not reference als-question-card"
+        assert "display" in fn_body and "none" in fn_body, \
+            "_showAnsweredState does not set display:none on question card"
+
+    def test_show_answered_state_hides_options(self):
+        """_showAnsweredState must set display:none on als-options."""
+        html = _render_session_page()
+        fn_start = html.index("function _showAnsweredState(")
+        fn_end = html.index("}", fn_start)
+        fn_body = html[fn_start:fn_end]
+        assert "als-options" in fn_body, \
+            "_showAnsweredState does not reference als-options"
+
+    def test_render_question_restores_question_card(self):
+        """renderQuestion must restore als-question-card visibility (display='')."""
+        html = _render_session_page()
+        fn_start = html.index("function renderQuestion(")
+        fn_end = html.index("\n    }", fn_start)
+        fn_body = html[fn_start:fn_end]
+        assert "als-question-card" in fn_body, \
+            "renderQuestion does not restore als-question-card"
+
+    def test_render_question_restores_options(self):
+        """renderQuestion must restore als-options visibility (display='')."""
+        html = _render_session_page()
+        fn_start = html.index("function renderQuestion(")
+        fn_end = html.index("\n    }", fn_start)
+        fn_body = html[fn_start:fn_end]
+        assert "als-options" in fn_body and "display" in fn_body, \
+            "renderQuestion does not restore als-options display"
+
+    def test_error_path_does_not_hide_question(self):
+        """On POST /answer failure (!res.ok), _showAnsweredState must NOT be called
+        so the question remains visible for retry."""
+        html = _render_session_page()
+        fn_start = html.index("function alsAnswer(")
+        fn_end = html.index("\n    }", fn_start)
+        fn_body = html[fn_start:fn_end]
+        # Find the !res.ok error branch
+        err_start = fn_body.index("if (!res.ok)")
+        err_end = fn_body.index("return;", err_start) + len("return;")
+        err_branch = fn_body[err_start:err_end]
+        assert "_showAnsweredState" not in err_branch, \
+            "_showAnsweredState must NOT be called in the !res.ok error branch"

--- a/tests/unit/test_adaptive_learning_template.py
+++ b/tests/unit/test_adaptive_learning_template.py
@@ -270,41 +270,49 @@ class TestNoFixedQuestionCount:
 
 
 class TestFeedbackTiming:
-    """Auto-advance delays must differ for correct vs wrong answers."""
+    """Auto-advance removed: feedback + explanation stay until user clicks Next."""
 
-    def test_correct_answer_uses_1500ms(self):
-        """Correct answer advance delay must be 1500ms."""
+    def test_no_auto_advance(self):
+        """_scheduleNextAction must be gone — no setTimeout auto-advance."""
         html = _render_session_page()
-        assert "1500" in html, "1500ms delay missing"
+        assert "_scheduleNextAction" not in html, \
+            "_scheduleNextAction still present — auto-advance not fully removed"
 
-    def test_wrong_answer_uses_3000ms(self):
-        """Wrong answer advance delay must be 3000ms."""
+    def test_show_next_button_called_after_answer(self):
+        """_showNextButton() must be called in the answer handler (replaces auto-advance)."""
         html = _render_session_page()
-        assert "3000" in html, "3000ms delay missing"
+        assert "_showNextButton()" in html, \
+            "_showNextButton() not called in answer handler"
 
-    def test_delay_is_outcome_dependent(self):
-        """advanceDelay must branch on d.correct — correct path and wrong path must differ."""
+    def test_next_button_element_present(self):
+        """als-next-btn-wrap and als-next-btn must exist in the question phase HTML."""
         html = _render_session_page()
-        # The delay logic must be conditional on d.correct
-        assert "d.correct" in html, "d.correct not referenced in delay logic"
-        assert "advanceDelay" in html, "advanceDelay variable missing"
+        assert 'id="als-next-btn-wrap"' in html, "als-next-btn-wrap element missing"
+        assert 'id="als-next-btn"' in html, "als-next-btn element missing"
 
-    def test_schedule_next_action_accepts_delay_param(self):
-        """_scheduleNextAction must accept a delay parameter, not hardcode 1000ms."""
+    def test_next_button_hidden_by_default(self):
+        """als-next-btn-wrap must start hidden (display:none)."""
         html = _render_session_page()
-        assert "_scheduleNextAction(advanceDelay)" in html, \
-            "_scheduleNextAction must be called with advanceDelay argument"
-        # Old hardcoded 1-second call must be gone
-        assert "_scheduleNextAction();" not in html, \
-            "_scheduleNextAction() called without delay — hardcoded timing still present"
+        assert 'id="als-next-btn-wrap" style="display:none' in html, \
+            "als-next-btn-wrap is not hidden by default"
 
-    def test_auto_advance_label_shows_correct_duration(self):
-        """Auto-advance label must show '1.5s' or '3s', not the old '1s'."""
+    def test_next_button_disable_guard(self):
+        """alsNext must disable the button immediately to prevent double submission."""
         html = _render_session_page()
-        assert "1.5s" in html, "'1.5s' label missing from auto-advance"
-        assert "3s" in html, "'3s' label missing from auto-advance"
-        # Old 1-second label must be gone
-        assert "in 1s" not in html, "old 'in 1s' label still present"
+        assert "btn.disabled = true" in html, \
+            "double-click guard (btn.disabled = true) missing from alsNext"
+
+    def test_next_button_reenabled_on_error(self):
+        """alsNext must re-enable the button in the catch block (slow network recovery)."""
+        html = _render_session_page()
+        assert "btn.disabled = false" in html, \
+            "error recovery (btn.disabled = false) missing from alsNext catch block"
+
+    def test_no_old_auto_advance_element(self):
+        """als-auto-advance element must be gone."""
+        html = _render_session_page()
+        assert "als-auto-advance" not in html, \
+            "als-auto-advance element still present in template"
 
 
 class TestCategoryPickerThreshold:


### PR DESCRIPTION
## Summary

### Sponsors P2-B / P2-C / P2-D / P6 / P7

- **P2-B**: `SponsorAudienceEntry` CSV import — upsert, consent normalization, age/position parsing; `CsvImportLog` tracking
- **P2-C**: Promote-to-user flow — link-or-create `User` (role=STUDENT), atomic batch, idempotent; admin web UI + modal
- **P2-D**: Baseline onboarding on promote — writes `football_skills` (29 keys, SYSTEM_BASELINE) + foot dominance when DOB + position are present
- **P6**: `SponsorCampaign.specialization_type` — per-campaign audience target; migration `2026_05_03_1500`
- **P7**: Sponsor-funded credit/unlock pair — `credit_grant_amount` + `unlock_cost` on campaign; every promote issues `SPONSOR_CREDIT_GRANT` + `SPECIALIZATION_UNLOCK` atomically; `CreditTransaction` carries `sponsor_id` + `campaign_id` for settlement tracing; migration `2026_05_03_1600`

### Sponsor Campaign Admin — P0 lifecycle (campaign detail + close + edit)

- **P6/P7 fields visible**: `sponsor_campaign_detail.html` now shows `specialization_type`, `credit_grant_amount`, `unlock_cost` as read-only meta-items in the Campaign Overview card; `event_date` conditional block unchanged
- **Campaign close**: `POST .../campaigns/{id}/close` sets `status=CLOSED` (idempotent); Close Campaign button visible for ACTIVE campaigns only; status shown as styled badge (green=ACTIVE, grey=CLOSED)
- **CLOSED guards**: `import/preview`, `import/apply`, `audience/promote` all return 303 with ASCII-safe error message when campaign is CLOSED; Upload CSV button hidden in template
- **Campaign edit**: `POST .../campaigns/{id}/edit` — validates name (required), `credit_grant_amount` (≥ 100), `unlock_cost` (≤ grant), CLOSED credit lock (credit fields immutable once closed); `event_date` optional; Edit button always visible regardless of status
- **CLOSED edit form**: credit fields rendered with `readonly` attribute; backend independently rejects any changed value — double-layered guard
- **OpenAPI snapshot**: updated for the 2 new admin POST routes (715 → 717 routes)
- **Tests**: SPON-CAM-08..22 added (22/22 pass) covering P7 field display, close, idempotency, 3 CLOSED guards, edit happy path, 4 validation cases, CLOSED credit lock, CLOSED name edit

### Sponsor Promotion Event — tournament flow alignment (Block A + B)

- New `PROMOTION_EVENT` records now receive `Semester.specialization_type="LFA_FOOTBALL_PLAYER"` (previously NULL — inconsistent with all other individual tournament-type semesters)
- `TournamentConfiguration.assignment_type="OPEN_ASSIGNMENT"` now set on creation (previously NULL — caused instructor assignment guards to silently pass as APPLICATION_BASED)
- Single-age-group sponsor promotion creation redirects to `/admin/tournaments/{id}/edit` so the admin can immediately configure scoring/format; multi-age-group creation retains existing redirect to `/admin/sponsors/{id}`
- No migration, no GameConfiguration, no template change, no OpenAPI snapshot change
- Tests: SPON-PROMO-01..05 added (5/5 pass)

### Sponsor Laterality Pipeline Tests

- 8-user laterality test CSV fixture added (`tests/fixtures/lat_test_8users.csv`)
- `foot_dominance` scale documented: 0 = left-dominant, 100 = right-dominant, 50 = balanced
- 3 new passing presets added to `seed_laterality_test_fixtures.py`: `lat_passing_right`, `lat_passing_left`, `lat_passing_neutral`; existing shooting/crossing presets untouched; total: 9 presets
- LAT-SPON-01..10 tests added (`tests/unit/services/test_sponsor_laterality_pipeline.py`): covers sponsor promote → `foot_dominance` → `right_foot_score`/`left_foot_score` → `lateral_components` aggregation bridge
- No migration, no model change, no route/schema/OpenAPI snapshot change

### Admin Game Presets UI

- Expandable card list replaced with compact dense table/list
- Columns: Status, Name, Code, Foot Context, Skills, Recommended, ID, Actions
- Laterality presets get right/left/neutral visual indicators (green/blue/grey left border + inline badge)
- Mobile fallback handled via CSS-only stacked rows (`data-label` + `display: block` transform, no HTML duplication)
- Routes, models, seed scripts, OpenAPI snapshot unchanged

### Admin Game Preset Edit UI

- Edit page redesigned into two-column layout (form left, live chart panel right)
- Live SVG donut chart for selected skill weight distribution — pure inline JS, no external library
- Chart updates in real-time on checkbox toggle and weight input change
- Centre label shows selected skill count; legend shows each skill with proportional %
- Sum status shown visually in both form and chart panel; Save disabled when sum ≠ 100%
- `foot_context` shown as read-only info on chart panel: explicit badge for `lat_*` presets, `neutral/default` (dashed) for legacy presets
- Mobile ≤820px: single-column layout, chart panel above form
- Route, backend, model, seed, migration and OpenAPI snapshot unchanged

### Admin Game Preset — foot_context editing + UI

- `foot_context` is now editable on the Game Preset edit form (`<select name="foot_context">`) and on the create form
- Valid values: `neutral`, `right`, `left`; invalid form values fall back to `neutral`
- Edit save no longer drops existing `foot_context` from `skill_config` (BUG-1 fix)
- Chart panel badge syncs live with the select via `syncFcBadge()` JS helper
- **Foot context select labels are in English**: "neutral — both feet / default", "right — right foot", "left — left foot" (form values unchanged)
- Tests FC-EDIT-01..05: preservation on right/left edit, legacy preset neutral write, create with right, invalid value fallback
- **No per-skill laterality in this PR** — preset-level `foot_context` only. Per-skill override model (`skill_foot_contexts` JSONB dict + orchestrator per-skill resolve) is a separate design task documented in `docs/design/FOOT_CONTEXT_PER_SKILL_HYBRID.md`; no model/orchestrator/migration change here

### Adaptive Learning — integrity + UX fixes

- **Answer shuffle**: `get_next_question` now calls `random.shuffle()` on the loaded `answer_options` list before serialising. Grading remains ID-based so shuffle is safe. Fixes 99.1% A/B bias across 375 questions in 31 JSON files.
- **Never-seen priority (P0)**: `_select_adaptive_question` adds a new priority-0 branch — questions the user has never attempted (cross-session via `UserQuestionPerformance`) are always preferred over due-for-review or weak-concept questions. Zero additional DB queries: uses the existing `attempted_ids` set derived from the `UserQuestionPerformance` load.
- **Difficulty fallback logging**: when the difficulty-window query returns zero results and falls back to the full pool, a `WARNING` is emitted (`al_difficulty_fallback category=… target=… range=±0.2 module=… → full pool`).
- **Auto-advance removed**: the 1.5 s / 3.0 s `setTimeout → alsNext` chain (`_scheduleNextAction`) is gone. After answering, feedback + explanation stay visible indefinitely.
- **Answered-state UX**: after submitting an answer `#als-question-card` and `#als-options` are hidden via `_showAnsweredState()`. Only the feedback block and the explicit **Next question →** button remain visible. `renderQuestion()` restores both elements before rendering the next question. Error path (`!res.ok`) intentionally skipped — question stays for retry.

## Key invariants (sponsors)

- Grant + unlock always issued as a pair (never one without the other)
- `_ensure_license()` creates a new `UserLicense` for `campaign.specialization_type` if none exists — never skips
- Idempotency keys: `sponsor_grant:{cid}:{uid}` / `spec_unlock:{cid}:{uid}:{spec}` — re-runs are safe
- `award()` and `deduct_batch()` are SAVEPOINT-free — caller's outer transaction provides atomicity
- Single `db.commit()` at end of `promote_entries()` — partial failure = nothing committed
- CLOSED campaign: credit fields locked at both template (readonly) and backend (validation) level

## Test plan

- [ ] `tests/integration/web_flows/test_sponsor_promote_credits.py` — 10 tests (SPON-CREDIT-01..10): new user, existing user, idempotent re-run, existing license kept, new license created, credit balance delta, settlement FK columns, partial failure rollback, grant + unlock always paired
- [ ] `tests/integration/web_flows/test_sponsor_promote.py` — existing 23 tests still green
- [ ] `tests/integration/web_flows/test_sponsor_campaign.py` — 22 tests (SPON-CAM-01..22): isolation, close, CLOSED guards, edit, validation
- [ ] `tests/integration/web_flows/test_promotion_events_organizer.py` — 9 tests (ORG-01..04 + SPON-PROMO-01..05): organizer FK integrity, Block A/B defaults + redirects
- [ ] `tests/unit/services/test_sponsor_laterality_pipeline.py` — 10 tests (LAT-SPON-01..10): foot_dominance → foot scores, baseline skip conditions, lateral_components routing, symmetric aggregation, idempotence, email dedup
- [ ] `tests/unit/services/test_game_preset_foot_context_edit.py` — 5 tests (FC-EDIT-01..05): preservation on right/left, legacy neutral write, create with right, invalid fallback
- [ ] `tests/unit/services/test_adaptive_learning_service.py` — 82 tests: all pass
- [ ] `tests/unit/test_adaptive_learning_template.py` — 64 tests: all pass
- [ ] `tests/unit/services/test_game_presets_crud.py` + `tests/integration/api_smoke/test_game_presets_smoke.py` — 33 tests: all pass (template-only change, no route/model impact)
- [ ] Migration: `alembic upgrade head` / `alembic downgrade -1` round-trip
- [ ] CI: all GitHub Actions checks pass on head SHA `42da4ca`

## Manual QA (Playwright, in-browser)

| Scenario | Result |
|---|---|
| Answer after → `#als-question-card` + `#als-options` hidden, feedback + Next visible | ✅ |
| Next → question card + options restored, Next hidden, new question rendered | ✅ |
| POST /answer 503 → question NOT hidden, "try again" feedback shown, retry possible | ✅ |
| Game Presets `/admin/game-presets` → compact table visible, 15 rows × ~40px | ✅ |
| `lat_*` rows → right=green border, left=blue border, neutral=grey border | ✅ |
| Foot Context column → fc-badge pill correct colour per context | ✅ |
| Skills > 3 → first 3 pills + `+N` overflow indicator | ✅ |
| Toggle / Edit / Delete actions → all functional, forms POST correctly | ✅ |
| Game Preset edit → Foot Context select pre-filled with current value | ✅ |
| Edit `lat_passing_right` → chart panel badge syncs to right on select change | ✅ |
| Save → foot_context preserved in DB | ✅ |
| Create form → Foot Context select visible, default neutral | ✅ |
| Foot Context select labels → English only ("both feet / default", "right foot", "left foot") | ✅ |

## Pre-existing failures (not caused by this PR)

- `test_migration_rollback.py` — pre-existing, unrelated to sponsor work
- `test_business_invariant_ranking_count_equals_player_count` — pre-existing, confirmed by stash+run
- `test_admin_toggle_user_status_deactivates_active_user` — pre-existing, confirmed by stash+run

🤖 Generated with [Claude Code](https://claude.com/claude-code)