### PR TITLE
feat(admin): restore compact preset table + two-column edit UI + logo-slot alignment

### DIFF
--- a/app/api/web_routes/admin/game_presets.py
+++ b/app/api/web_routes/admin/game_presets.py
@@ -82,6 +82,8 @@ async def admin_create_game_preset(
             if sk in skills and val in _VALID_FOOT_CONTEXTS:
                 skill_foot_contexts[sk] = val
 
+    foot_context = form_data.get("foot_context", "")
+
     total = sum(weights.get(s, 1) for s in skills) or 1
     skill_weights = {s: round(weights.get(s, 1) / total, 4) for s in skills}
 
@@ -92,6 +94,7 @@ async def admin_create_game_preset(
             "skills_tested": skills,
             "skill_weights": skill_weights,
             "skill_impact_on_matches": bool(skill_impact),
+            **({"foot_context": foot_context} if foot_context in _VALID_FOOT_CONTEXTS else {}),
             **({"skill_foot_contexts": skill_foot_contexts} if skill_foot_contexts else {}),
         },
         "simulation_config": {},
@@ -179,6 +182,8 @@ async def admin_edit_game_preset_submit(
             if sk in skills and val in _VALID_FOOT_CONTEXTS:
                 skill_foot_contexts[sk] = val
 
+    foot_context = form_data.get("foot_context", "")
+
     total = sum(weights.get(s, 1) for s in skills) or 1
     skill_weights = {s: round(weights.get(s, 1) / total, 4) for s in skills}
 
@@ -189,6 +194,7 @@ async def admin_edit_game_preset_submit(
             "skills_tested": skills,
             "skill_weights": skill_weights,
             "skill_impact_on_matches": bool(skill_impact),
+            **({"foot_context": foot_context} if foot_context in _VALID_FOOT_CONTEXTS else {}),
             **({"skill_foot_contexts": skill_foot_contexts} if skill_foot_contexts else {}),
         },
         "metadata": {

--- a/app/templates/admin/game_preset_edit.html
+++ b/app/templates/admin/game_preset_edit.html
@@ -6,49 +6,154 @@
 
 {% block extra_styles %}
 <style>
-    .edit-card {
+    /* ── Two-column layout ───────────────────────────────────────────────── */
+    .edit-layout {
+        display: grid;
+        grid-template-columns: 1fr 290px;
+        gap: 1.5rem;
+        align-items: start;
+    }
+    .edit-form-col {
         background: white;
         border-radius: 12px;
         padding: 2rem;
         box-shadow: 0 2px 8px rgba(0,0,0,0.06);
-        max-width: 900px;
+        min-width: 0;
     }
-    .edit-card h2 { margin-bottom: 1.5rem; color: #2d3748; }
+    .edit-form-col h2 { margin: 0 0 1.5rem; color: #2d3748; font-size: 1.15rem; }
+
+    .edit-chart-col { position: sticky; top: 1.5rem; }
+    .chart-panel {
+        background: white;
+        border-radius: 12px;
+        padding: 1.5rem;
+        box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+        text-align: center;
+    }
+    .chart-panel-title {
+        font-size: 0.72rem; font-weight: 700; color: #718096;
+        text-transform: uppercase; letter-spacing: 0.07em; margin-bottom: 1rem;
+    }
+
+    /* ── Form fields ─────────────────────────────────────────────────────── */
     .form-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 1rem; margin-bottom: 1rem; }
     .form-group label { display: block; font-size: 0.85rem; font-weight: 600; color: #4a5568; margin-bottom: 0.4rem; }
-    .form-group input, .form-group select, .form-group textarea { width: 100%; padding: 0.6rem 0.9rem; border: 1px solid #e2e8f0; border-radius: 8px; font-size: 0.9rem; }
+    .form-group input, .form-group select, .form-group textarea {
+        width: 100%; padding: 0.6rem 0.9rem; border: 1px solid #e2e8f0;
+        border-radius: 8px; font-size: 0.9rem; box-sizing: border-box; font-family: inherit;
+    }
     .form-group input:disabled { background: #f0f0f0; color: #718096; }
     .form-group.full { grid-column: 1 / -1; }
+
+    /* ── Skills section ──────────────────────────────────────────────────── */
     .skills-section { background: #f8f9fa; border-radius: 8px; padding: 1rem; margin-bottom: 1rem; }
-    .skills-section h4 { font-size: 0.9rem; color: #2d3748; margin-bottom: 0.75rem; }
-    .skill-group-label { font-size: 0.8rem; color: #718096; font-weight: 600; margin-bottom: 0.4rem; margin-top: 0.75rem; }
-    .skill-row { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 0.5rem; }
-    .skill-item { display: flex; align-items: center; gap: 0.4rem; background: white; border: 1px solid #e2e8f0; border-radius: 6px; padding: 0.3rem 0.6rem; }
+    .skills-section h4 { font-size: 0.85rem; color: #2d3748; margin-bottom: 0.6rem; }
+    .skill-group-label {
+        font-size: 0.7rem; color: #a0aec0; font-weight: 700;
+        text-transform: uppercase; letter-spacing: 0.05em;
+        margin-top: 0.65rem; margin-bottom: 0.3rem;
+    }
+    .skill-row { display: flex; flex-wrap: wrap; gap: 0.3rem; margin-bottom: 0.2rem; }
+    .skill-item {
+        display: flex; align-items: center; gap: 0.35rem;
+        background: white; border: 1px solid #e2e8f0; border-radius: 5px; padding: 0.2rem 0.5rem;
+        transition: border-color 0.12s, background 0.12s;
+    }
+    .skill-item:has(input:checked) { border-color: #667eea; background: #f0f4ff; }
     .skill-item input[type="checkbox"] { cursor: pointer; }
-    .skill-item label { font-size: 0.8rem; color: #4a5568; cursor: pointer; white-space: nowrap; }
+    .skill-item label { font-size: 0.77rem; color: #4a5568; cursor: pointer; white-space: nowrap; }
+
+    /* ── Weights section ─────────────────────────────────────────────────── */
     .weights-section { background: #ebf8ff; border-radius: 8px; padding: 1rem; margin-bottom: 1rem; }
-    .weights-section h4 { font-size: 0.9rem; color: #2c5282; margin-bottom: 0.75rem; }
-    .weight-row { display: grid; grid-template-columns: repeat(4, 1fr); gap: 0.75rem; }
-    .weight-item label { display: block; font-size: 0.8rem; color: #4a5568; margin-bottom: 0.3rem; }
-    .weight-item input { width: 100%; padding: 0.4rem 0.6rem; border: 1px solid #bee3f8; border-radius: 6px; font-size: 0.9rem; }
-    .sum-indicator { margin-top: 0.75rem; padding: 0.5rem 0.75rem; border-radius: 6px; font-size: 0.85rem; font-weight: 600; }
-    .sum-ok { background: #c6f6d5; color: #276749; }
+    .weights-section h4 { font-size: 0.85rem; color: #2c5282; margin-bottom: 0.75rem; }
+    .weight-row { display: grid; grid-template-columns: repeat(3, 1fr); gap: 0.55rem; }
+    .weight-item label {
+        display: block; font-size: 0.74rem; color: #4a5568; margin-bottom: 0.2rem;
+        white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    }
+    .weight-item input {
+        width: 100%; padding: 0.35rem 0.5rem; border: 1px solid #bee3f8;
+        border-radius: 6px; font-size: 0.85rem; box-sizing: border-box;
+    }
+    .weight-item input:focus { outline: none; border-color: #4299e1; box-shadow: 0 0 0 2px rgba(66,153,225,0.15); }
+    .sum-indicator { margin-top: 0.75rem; padding: 0.45rem 0.75rem; border-radius: 6px; font-size: 0.83rem; font-weight: 600; }
+    .sum-ok  { background: #c6f6d5; color: #276749; }
     .sum-err { background: #fed7d7; color: #9b2335; }
-    .form-actions { display: flex; gap: 0.75rem; margin-top: 1.5rem; }
+    /* B3: per-skill foot context select in each weight item */
     .skill-fc-select { width: 100%; padding: 0.3rem 0.4rem; border: 1px solid #e2e8f0; border-radius: 6px; font-size: 0.76rem; color: #4a5568; margin-top: 0.25rem; background: white; cursor: pointer; }
-    @media (max-width: 600px) { .weight-row { grid-template-columns: repeat(2, 1fr); } }
+
+    /* ── Form actions ────────────────────────────────────────────────────── */
+    .form-actions { display: flex; gap: 0.75rem; margin-top: 1.5rem; align-items: center; }
+    #submitBtn:disabled { opacity: 0.45; cursor: not-allowed; }
+
+    /* ── Chart internals ─────────────────────────────────────────────────── */
+    #presetChart { display: block; margin: 0 auto; overflow: visible; }
+
+    .chart-empty {
+        width: 180px; height: 180px; margin: 0 auto;
+        display: flex; align-items: center; justify-content: center;
+        border: 2px dashed #e2e8f0; border-radius: 50%;
+        color: #a0aec0; font-size: 0.8rem;
+    }
+
+    .chart-legend { margin-top: 0.9rem; text-align: left; }
+    .legend-item { display: flex; align-items: center; gap: 0.45rem; padding: 0.18rem 0; font-size: 0.77rem; color: #4a5568; }
+    .legend-dot { width: 9px; height: 9px; border-radius: 50%; flex-shrink: 0; }
+    .legend-name { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .legend-pct { font-weight: 700; color: #2d3748; min-width: 34px; text-align: right; font-size: 0.78rem; }
+
+    .chart-sum-badge {
+        display: inline-block; margin-top: 0.75rem;
+        padding: 0.25rem 0.65rem; border-radius: 999px;
+        font-size: 0.78rem; font-weight: 700;
+    }
+    .chart-sum-ok  { background: #c6f6d5; color: #276749; }
+    .chart-sum-err { background: #fed7d7; color: #9b2335; }
+
+    /* ── foot_context badge in chart panel ───────────────────────────────── */
+    .fc-info {
+        margin-top: 1rem; padding: 0.45rem 0.75rem;
+        border-radius: 8px; font-size: 0.78rem; text-align: left;
+    }
+    .fc-info-label {
+        font-size: 0.65rem; font-weight: 700; color: #a0aec0;
+        text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 0.2rem;
+    }
+    .fc-info-right   { background: #f0fff4; border: 1px solid #9ae6b4; color: #276749; }
+    .fc-info-left    { background: #ebf8ff; border: 1px solid #90cdf4; color: #2b6cb0; }
+    .fc-info-neutral { background: #f7fafc; border: 1px solid #e2e8f0; color: #718096; }
+    .fc-info-default { background: #f7fafc; border: 1px dashed #cbd5e0; color: #a0aec0; font-style: italic; }
+
+    /* ── Responsive ──────────────────────────────────────────────────────── */
+    @media (max-width: 820px) {
+        .edit-layout { grid-template-columns: 1fr; }
+        .edit-chart-col { position: static; order: -1; }
+        .chart-panel { margin-bottom: 1.5rem; }
+        .chart-empty { width: 160px; height: 160px; }
+        #presetChart { width: 160px; height: 160px; }
+        .weight-row { grid-template-columns: repeat(2, 1fr); }
+    }
 </style>
 {% endblock %}
 
 {% block admin_content %}
 
-    <div style="margin-bottom: 1rem;">
-        <a href="/admin/game-presets" class="btn btn-secondary">← Back to Game Presets</a>
-    </div>
+<div style="margin-bottom: 1rem;">
+    <a href="/admin/game-presets" class="btn btn-secondary">← Back to Game Presets</a>
+</div>
 
-    <div class="edit-card">
+{# foot_context detection — raw vs property fallback #}
+{% set sc_info = preset.game_config.get('skill_config', {}) if preset.game_config else {} %}
+{% set foot_ctx_raw = sc_info.get('foot_context') %}
+{% set foot_ctx = foot_ctx_raw if foot_ctx_raw else preset.foot_context %}
+
+<div class="edit-layout">
+
+    <!-- ── Left column: form ──────────────────────────────────────────────── -->
+    <div class="edit-form-col">
         <h2>✏️ Edit: {{ preset.name }}</h2>
-        <form method="post" action="/admin/game-presets/{{ preset.id }}/edit">
+        <form method="post" action="/admin/game-presets/{{ preset.id }}/edit" id="editForm">
+
             <div class="form-grid">
                 <div class="form-group">
                     <label>Name *</label>
@@ -82,6 +187,14 @@
                 </div>
                 {% set sc = preset.game_config.get('skill_config', {}) if preset.game_config else {} %}
                 <div class="form-group">
+                    <label>Foot Context</label>
+                    <select name="foot_context" id="footContextSelect" onchange="syncFcBadge(this.value)">
+                        <option value="neutral" {% if foot_ctx == 'neutral' %}selected{% endif %}>neutral — both feet / default</option>
+                        <option value="right"   {% if foot_ctx == 'right'   %}selected{% endif %}>right — right foot</option>
+                        <option value="left"    {% if foot_ctx == 'left'    %}selected{% endif %}>left — left foot</option>
+                    </select>
+                </div>
+                <div class="form-group">
                     <label>
                         <input type="checkbox" name="skill_impact" value="1"
                                {% if sc.get('skill_impact_on_matches', True) %}checked{% endif %}>
@@ -92,7 +205,7 @@
 
             <!-- Skills selection -->
             <div class="skills-section">
-                <h4>Skills tested — check each skill to include:</h4>
+                <h4>Skills tested — check to include:</h4>
                 {% for group in skill_groups %}
                 <div class="skill-group-label">{{ group.label }}</div>
                 <div class="skill-row">
@@ -111,14 +224,15 @@
 
             <!-- Skill weights -->
             <div class="weights-section" id="weightsSection">
-                <h4>Skill weights (%) — assign a percentage to each skill; must sum to <strong>100%</strong></h4>
+                <h4>Skill weights (%) — must sum to <strong>100%</strong></h4>
                 <div class="weight-row" id="weightInputs">
                     {% for skill_key in current_skills %}
                     {% set pct = weight_pcts.get(skill_key, 10) %}
                     {% set fc_val = skill_foot_contexts.get(skill_key, '') %}
                     <div class="weight-item">
                         <label>{{ skill_key.replace('_', ' ').title() }} %</label>
-                        <input type="number" name="skill_w_{{ skill_key }}" value="{{ pct }}" min="1" max="100" oninput="updateSum()">
+                        <input type="number" name="skill_w_{{ skill_key }}" value="{{ pct }}"
+                               min="1" max="100" oninput="onWeightInput()">
                         <select name="skill_fc_{{ skill_key }}" class="skill-fc-select">
                             <option value=""       {% if fc_val == ''        %}selected{% endif %}>— preset default —</option>
                             <option value="neutral"{% if fc_val == 'neutral' %}selected{% endif %}>neutral — both feet</option>
@@ -132,21 +246,206 @@
             </div>
 
             <div class="form-actions">
-                <button type="submit" class="btn btn-success">💾 Save Changes</button>
+                <button type="submit" class="btn btn-success" id="submitBtn">💾 Save Changes</button>
                 <a href="/admin/game-presets" class="btn btn-secondary">Cancel</a>
+                <span id="saveHint" style="font-size:0.78rem;color:#9b2335;display:none;">Fix weight sum first</span>
             </div>
+
         </form>
     </div>
+
+    <!-- ── Right column: chart panel ─────────────────────────────────────── -->
+    <div class="edit-chart-col">
+        <div class="chart-panel">
+            <div class="chart-panel-title">Skill Distribution</div>
+
+            <!-- SVG donut (built by JS) / empty state -->
+            <div id="chartSvgWrap">
+                <svg id="presetChart" width="180" height="180" viewBox="0 0 180 180"></svg>
+            </div>
+            <div id="chartEmpty" class="chart-empty" style="display:none;">No skills<br>selected</div>
+
+            <!-- Legend -->
+            <div class="chart-legend" id="chartLegend"></div>
+
+            <!-- Sum badge in chart panel -->
+            <div id="chartSumBadge" class="chart-sum-badge" style="display:none;"></div>
+
+            <!-- foot_context badge — synced with select via syncFcBadge() -->
+            <div class="fc-info fc-info-{{ foot_ctx }}" id="fcBadge">
+                <div class="fc-info-label">Foot Context</div>
+                <span id="fcBadgeText">{{ foot_ctx }}</span>
+            </div>
+
+        </div>
+    </div>
+
+</div>
 
 {% endblock %}
 
 {% block scripts %}
 <script>
-function updateWeights() {
+// ── Foot context badge sync ───────────────────────────────────────────────
+function syncFcBadge(val) {
+    const badge = document.getElementById('fcBadge');
+    const text  = document.getElementById('fcBadgeText');
+    if (!badge || !text) return;
+    badge.className = 'fc-info fc-info-' + (val || 'neutral');
+    text.textContent = val || 'neutral';
+}
+
+// ── Palette (12 colours, cycles for >12 skills) ───────────────────────────
+const CHART_COLORS = [
+    '#667eea','#48bb78','#ed8936','#4299e1',
+    '#ed64a6','#9f7aea','#38b2ac','#f6ad55',
+    '#fc8181','#4fd1c5','#fbd38d','#9ae6b4'
+];
+
+// ── SVG helpers ───────────────────────────────────────────────────────────
+function _polar(cx, cy, r, deg) {
+    const rad = (deg - 90) * Math.PI / 180;
+    return { x: cx + r * Math.cos(rad), y: cy + r * Math.sin(rad) };
+}
+
+function _arcPath(cx, cy, R, r, startDeg, endDeg) {
+    const s1 = _polar(cx, cy, R, startDeg), e1 = _polar(cx, cy, R, endDeg);
+    const s2 = _polar(cx, cy, r, endDeg),   e2 = _polar(cx, cy, r, startDeg);
+    const lg = (endDeg - startDeg > 180) ? 1 : 0;
+    const f = v => v.toFixed(3);
+    return `M${f(s1.x)} ${f(s1.y)} A${R} ${R} 0 ${lg} 1 ${f(e1.x)} ${f(e1.y)} `
+         + `L${f(s2.x)} ${f(s2.y)} A${r} ${r} 0 ${lg} 0 ${f(e2.x)} ${f(e2.y)} Z`;
+}
+
+function _svgEl(tag, attrs) {
+    const el = document.createElementNS('http://www.w3.org/2000/svg', tag);
+    Object.entries(attrs).forEach(([k, v]) => el.setAttribute(k, v));
+    return el;
+}
+
+// ── Chart builder ─────────────────────────────────────────────────────────
+function buildChart() {
+    const svg    = document.getElementById('presetChart');
+    const wrap   = document.getElementById('chartSvgWrap');
+    const empty  = document.getElementById('chartEmpty');
+    const legend = document.getElementById('chartLegend');
+    const badge  = document.getElementById('chartSumBadge');
+
     const checked = Array.from(document.querySelectorAll('[name^="skill_cb_"]:checked'));
+    const keys    = checked.map(cb => cb.name.replace('skill_cb_', ''));
+    const rawVals = keys.map(k => {
+        const inp = document.querySelector(`[name="skill_w_${k}"]`);
+        return Math.max(1, parseInt(inp ? inp.value : 0) || 1);
+    });
+    const inputSum = rawVals.reduce((a, b) => a + b, 0);
+
+    if (keys.length === 0) {
+        wrap.style.display = 'none';
+        empty.style.display = 'flex';
+        legend.innerHTML = '';
+        badge.style.display = 'none';
+        return;
+    }
+    wrap.style.display = 'block';
+    empty.style.display = 'none';
+
+    const pcts = rawVals.map(v => v / inputSum * 100);
+    const labels = checked.map(cb => {
+        const lbl = cb.closest('.skill-item')?.querySelector('label');
+        return lbl ? lbl.textContent.trim()
+                   : cb.name.replace('skill_cb_', '').replace(/_/g, ' ');
+    });
+
+    const cx = 90, cy = 90, R = 80, ri = 44;
+    svg.innerHTML = '';
+
+    if (keys.length === 1) {
+        svg.appendChild(_svgEl('circle', { cx, cy, r: R, fill: CHART_COLORS[0] }));
+        svg.appendChild(_svgEl('circle', { cx, cy, r: ri, fill: 'white' }));
+    } else {
+        let deg = 0;
+        keys.forEach((k, i) => {
+            const sweep  = pcts[i] / 100 * 360;
+            const endDeg = deg + sweep;
+            svg.appendChild(_svgEl('path', {
+                d: _arcPath(cx, cy, R, ri, deg, endDeg),
+                fill: CHART_COLORS[i % CHART_COLORS.length],
+                stroke: 'white',
+                'stroke-width': '2'
+            }));
+            deg = endDeg;
+        });
+    }
+
+    const txt = _svgEl('text', {
+        x: cx, y: cy - 7,
+        'text-anchor': 'middle', 'dominant-baseline': 'central',
+        'font-size': '20', 'font-weight': '700', fill: '#2d3748', 'font-family': 'inherit'
+    });
+    txt.textContent = keys.length;
+    const sub = _svgEl('text', {
+        x: cx, y: cy + 14,
+        'text-anchor': 'middle', 'dominant-baseline': 'central',
+        'font-size': '10', fill: '#a0aec0', 'font-family': 'inherit'
+    });
+    sub.textContent = keys.length === 1 ? 'skill' : 'skills';
+    svg.appendChild(txt);
+    svg.appendChild(sub);
+
+    legend.innerHTML = keys.map((k, i) => {
+        return `<div class="legend-item">
+            <span class="legend-dot" style="background:${CHART_COLORS[i % CHART_COLORS.length]}"></span>
+            <span class="legend-name">${labels[i]}</span>
+            <span class="legend-pct">${Math.round(pcts[i])}%</span>
+        </div>`;
+    }).join('');
+
+    badge.style.display = 'inline-block';
+    if (inputSum === 100) {
+        badge.textContent = '✅ 100%';
+        badge.className = 'chart-sum-badge chart-sum-ok';
+    } else {
+        const diff = inputSum - 100;
+        badge.textContent = `⚠️ ${inputSum}% (${diff > 0 ? '+' : ''}${diff})`;
+        badge.className = 'chart-sum-badge chart-sum-err';
+    }
+}
+
+// ── Form sum indicator + Save gating ─────────────────────────────────────
+function updateSum() {
+    const inputs = document.querySelectorAll('#weightInputs input[type="number"]');
+    let sum = 0;
+    inputs.forEach(inp => { sum += parseInt(inp.value) || 0; });
+
+    const indicator = document.getElementById('sumIndicator');
+    const btn       = document.getElementById('submitBtn');
+    const hint      = document.getElementById('saveHint');
+
+    if (sum === 100) {
+        indicator.className = 'sum-indicator sum-ok';
+        indicator.textContent = '✅ Sum: 100% — ready to save';
+        btn.disabled = false;
+        hint.style.display = 'none';
+    } else {
+        const diff = sum - 100;
+        indicator.className = 'sum-indicator sum-err';
+        indicator.textContent = `❌ Sum: ${sum}% (${diff > 0 ? '+' : ''}${diff}) — must be exactly 100%`;
+        btn.disabled = true;
+        hint.style.display = 'inline';
+    }
+
+    buildChart();
+}
+
+function onWeightInput() { updateSum(); }
+
+// ── Rebuild weight inputs when checkboxes change ──────────────────────────
+function updateWeights() {
+    const checked   = Array.from(document.querySelectorAll('[name^="skill_cb_"]:checked'));
     const container = document.getElementById('weightInputs');
-    const section = document.getElementById('weightsSection');
-    // Preserve existing weight and foot context values
+    const section   = document.getElementById('weightsSection');
+
+    // Preserve existing weight AND foot context values on checkbox toggle
     const existing = {};
     container.querySelectorAll('input[type="number"]').forEach(inp => {
         existing[inp.name] = inp.value;
@@ -155,43 +454,35 @@ function updateWeights() {
         existing[sel.name] = sel.value;
     });
     container.innerHTML = '';
+
     checked.forEach(cb => {
-        const key = cb.name.replace('skill_cb_', '');
-        const label = cb.parentElement.querySelector('label').textContent;
-        const div = document.createElement('div');
-        div.className = 'weight-item';
-        const val = existing['skill_w_' + key] || 10;
+        const key   = cb.name.replace('skill_cb_', '');
+        const label = cb.closest('.skill-item')?.querySelector('label')?.textContent.trim()
+                      || key.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+        const val   = existing['skill_w_' + key] || 10;
         const fcVal = existing['skill_fc_' + key] || '';
-        div.innerHTML = `<label>${label} %</label>
-            <input type="number" name="skill_w_${key}" value="${val}" min="1" max="100" oninput="updateSum()">
-            <select name="skill_fc_${key}" class="skill-fc-select">
-                <option value=""${fcVal==='' ? ' selected' : ''}>— preset default —</option>
-                <option value="neutral"${fcVal==='neutral' ? ' selected' : ''}>neutral — both feet</option>
-                <option value="right"${fcVal==='right' ? ' selected' : ''}>right — right foot</option>
-                <option value="left"${fcVal==='left' ? ' selected' : ''}>left — left foot</option>
-            </select>`;
+        const div   = document.createElement('div');
+        div.className = 'weight-item';
+        div.innerHTML = `<label>${label} %</label>`
+            + `<input type="number" name="skill_w_${key}" value="${val}" min="1" max="100" oninput="onWeightInput()">`
+            + `<select name="skill_fc_${key}" class="skill-fc-select">`
+            + `<option value=""${fcVal==='' ? ' selected' : ''}>— preset default —</option>`
+            + `<option value="neutral"${fcVal==='neutral' ? ' selected' : ''}>neutral — both feet</option>`
+            + `<option value="right"${fcVal==='right' ? ' selected' : ''}>right — right foot</option>`
+            + `<option value="left"${fcVal==='left' ? ' selected' : ''}>left — left foot</option>`
+            + `</select>`;
         container.appendChild(div);
     });
+
     section.style.display = checked.length === 0 ? 'none' : 'block';
     updateSum();
 }
 
-function updateSum() {
-    const inputs = document.querySelectorAll('#weightInputs input[type="number"]');
-    let sum = 0;
-    inputs.forEach(inp => { sum += parseInt(inp.value) || 0; });
-    const indicator = document.getElementById('sumIndicator');
-    if (sum === 100) {
-        indicator.className = 'sum-indicator sum-ok';
-        indicator.textContent = '✅ Sum: ' + sum + '% — ready to save';
-    } else {
-        const diff = sum - 100;
-        indicator.className = 'sum-indicator sum-err';
-        indicator.textContent = '❌ Sum: ' + sum + '% (' + (diff > 0 ? '+' : '') + diff + '%) — must be exactly 100%';
-    }
-}
-
-// Initial sum calculation
-document.addEventListener('DOMContentLoaded', updateSum);
+// ── Initialise on load ────────────────────────────────────────────────────
+document.addEventListener('DOMContentLoaded', function () {
+    const hasSkills = document.querySelectorAll('[name^="skill_cb_"]:checked').length > 0;
+    document.getElementById('weightsSection').style.display = hasSkills ? 'block' : 'none';
+    updateSum();
+});
 </script>
 {% endblock %}

--- a/app/templates/admin/game_preset_edit.html
+++ b/app/templates/admin/game_preset_edit.html
@@ -124,6 +124,17 @@
     .fc-info-neutral { background: #f7fafc; border: 1px solid #e2e8f0; color: #718096; }
     .fc-info-default { background: #f7fafc; border: 1px dashed #cbd5e0; color: #a0aec0; font-style: italic; }
 
+    /* ── Per-skill fc chip in legend ────────────────────────────────────── */
+    .legend-fc {
+        font-size: 0.67rem; font-weight: 600;
+        padding: 0.1rem 0.38rem; border-radius: 999px;
+        white-space: nowrap; flex-shrink: 0;
+    }
+    .legend-fc-right   { background: #f0fff4; color: #276749; border: 1px solid #9ae6b4; }
+    .legend-fc-left    { background: #ebf8ff; color: #2b6cb0; border: 1px solid #90cdf4; }
+    .legend-fc-neutral { background: #f7fafc; color: #718096; border: 1px solid #e2e8f0; }
+    .legend-fc-default { background: #f7fafc; color: #a0aec0; border: 1px dashed #cbd5e0; font-style: italic; }
+
     /* ── Responsive ──────────────────────────────────────────────────────── */
     @media (max-width: 820px) {
         .edit-layout { grid-template-columns: 1fr; }
@@ -293,6 +304,7 @@ function syncFcBadge(val) {
     if (!badge || !text) return;
     badge.className = 'fc-info fc-info-' + (val || 'neutral');
     text.textContent = val || 'neutral';
+    buildChart();
 }
 
 // ── Palette (12 colours, cycles for >12 skills) ───────────────────────────
@@ -355,6 +367,11 @@ function buildChart() {
         return lbl ? lbl.textContent.trim()
                    : cb.name.replace('skill_cb_', '').replace(/_/g, ' ');
     });
+    const presetFc = document.getElementById('footContextSelect')?.value || 'neutral';
+    const fcVals = keys.map(k => {
+        const sel = document.querySelector(`[name="skill_fc_${k}"]`);
+        return sel ? sel.value : '';
+    });
 
     const cx = 90, cy = 90, R = 80, ri = 44;
     svg.innerHTML = '';
@@ -393,10 +410,15 @@ function buildChart() {
     svg.appendChild(sub);
 
     legend.innerHTML = keys.map((k, i) => {
+        const rawFc   = fcVals[i];
+        const fcClass = rawFc || 'default';
+        const fcText  = rawFc || 'default';
+        const fcTitle = rawFc ? `${rawFc} foot` : `inherits preset: ${presetFc}`;
         return `<div class="legend-item">
             <span class="legend-dot" style="background:${CHART_COLORS[i % CHART_COLORS.length]}"></span>
             <span class="legend-name">${labels[i]}</span>
             <span class="legend-pct">${Math.round(pcts[i])}%</span>
+            <span class="legend-fc legend-fc-${fcClass}" title="${fcTitle}">${fcText}</span>
         </div>`;
     }).join('');
 
@@ -483,6 +505,11 @@ document.addEventListener('DOMContentLoaded', function () {
     const hasSkills = document.querySelectorAll('[name^="skill_cb_"]:checked').length > 0;
     document.getElementById('weightsSection').style.display = hasSkills ? 'block' : 'none';
     updateSum();
+
+    // Re-render legend whenever any per-skill fc select changes
+    document.getElementById('weightInputs').addEventListener('change', function (e) {
+        if (e.target.classList.contains('skill-fc-select')) buildChart();
+    });
 });
 </script>
 {% endblock %}

--- a/app/templates/admin/game_presets.html
+++ b/app/templates/admin/game_presets.html
@@ -8,18 +8,6 @@
 <style>
     .section-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1.5rem; }
     .section-header h2 { font-size: 1.5rem; color: #2d3748; }
-    .card { background: white; border-radius: 12px; box-shadow: 0 2px 8px rgba(0,0,0,0.06); margin-bottom: 1rem; overflow: hidden; }
-    .card-header { padding: 1rem 1.5rem; background: #f8f9fa; display: flex; justify-content: space-between; align-items: center; border-bottom: 1px solid #e2e8f0; cursor: pointer; }
-    .card-header h3 { font-size: 1.05rem; color: #2d3748; display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; }
-    .card-body { padding: 1.5rem; display: none; }
-    .card-body.open { display: block; }
-    .badge-active { background: #c6f6d5; color: #276749; }
-    .badge-inactive { background: #fed7d7; color: #9b2335; }
-    .badge-recommended { background: #fef3c7; color: #92400e; }
-    .info-row { margin-bottom: 0.75rem; }
-    .info-row label { font-size: 0.8rem; color: #718096; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; display: block; margin-bottom: 0.2rem; }
-    .skills-str { font-size: 0.9rem; color: #2d3748; }
-    .action-row { display: flex; gap: 0.75rem; margin-top: 1rem; flex-wrap: wrap; }
     .create-form { background: white; border-radius: 12px; box-shadow: 0 2px 8px rgba(0,0,0,0.06); padding: 2rem; margin-top: 1.5rem; }
     .create-form h3 { margin-bottom: 1.5rem; color: #2d3748; }
     .form-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 1rem; margin-bottom: 1rem; }
@@ -43,8 +31,46 @@
     .sum-err { background: #fed7d7; color: #9b2335; }
     .no-data { text-align: center; padding: 3rem; color: #718096; }
     .btn-sm { padding: 0.35rem 0.75rem; font-size: 0.8rem; }
+    /* B3: per-skill foot context select in weight items */
     .skill-fc-select { width: 100%; padding: 0.3rem 0.4rem; border: 1px solid #e2e8f0; border-radius: 6px; font-size: 0.76rem; color: #4a5568; margin-top: 0.25rem; background: white; cursor: pointer; }
-    @media (max-width: 600px) { .weight-row { grid-template-columns: repeat(2, 1fr); } }
+
+    /* ─── Preset table ──────────────────────────────────────────────────────── */
+    .preset-table { width: 100%; border-collapse: collapse; font-size: 0.875rem; }
+    .preset-table thead th { background: #f7fafc; color: #718096; font-size: 0.72rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; padding: 0.55rem 0.75rem; border-bottom: 2px solid #e2e8f0; white-space: nowrap; }
+    .preset-table tbody tr { border-bottom: 1px solid #f0f0f0; transition: background 0.1s; }
+    .preset-table tbody tr:last-child { border-bottom: none; }
+    .preset-table tbody tr:hover { background: #fafbff; }
+    .preset-table td { padding: 0.5rem 0.75rem; vertical-align: middle; }
+    .preset-code { font-family: monospace; font-size: 0.78rem; background: #f0f0f0; padding: 0.1rem 0.4rem; border-radius: 4px; color: #4a5568; }
+    .skill-pill { display: inline-block; background: #e9d8fd; color: #553c9a; border-radius: 4px; padding: 0.1rem 0.35rem; font-size: 0.72rem; margin-right: 0.2rem; white-space: nowrap; }
+    .skill-more { font-size: 0.72rem; color: #718096; }
+    .btn-tbl { padding: 0.2rem 0.55rem; font-size: 0.75rem; border-radius: 4px; font-weight: 600; cursor: pointer; text-decoration: none; display: inline-block; white-space: nowrap; }
+    .btn-tbl-primary { background: #5a4a9a; color: white; border: none; }
+    .btn-tbl-primary:hover { background: #4a3a8a; color: white; }
+    .btn-tbl-warning { background: white; color: #c05621; border: 1px solid #fbd38d; }
+    .btn-tbl-warning:hover { background: #fffbf0; }
+    .btn-tbl-danger { background: white; color: #c53030; border: 1px solid #fed7d7; }
+    .btn-tbl-danger:hover { background: #fff5f5; }
+    /* Laterality left-border indicators */
+    .lat-right   { border-left: 3px solid #48bb78; }
+    .lat-left    { border-left: 3px solid #4299e1; }
+    .lat-neutral { border-left: 3px solid #a0aec0; }
+    /* Foot context inline badges */
+    .fc-badge { display: inline-block; padding: 0.1rem 0.45rem; border-radius: 4px; font-size: 0.72rem; font-weight: 700; white-space: nowrap; }
+    .fc-right   { background: #f0fff4; color: #276749; border: 1px solid #9ae6b4; }
+    .fc-left    { background: #ebf8ff; color: #2b6cb0; border: 1px solid #90cdf4; }
+    .fc-neutral { background: #f7fafc; color: #718096; border: 1px solid #e2e8f0; }
+    .fc-default { background: #f7fafc; color: #a0aec0; border: 1px dashed #cbd5e0; font-style: italic; font-weight: 400; }
+    /* Mobile: stack table rows as cards */
+    @media (max-width: 768px) {
+        .preset-table thead { display: none; }
+        .preset-table, .preset-table tbody, .preset-table tr, .preset-table td { display: block; }
+        .preset-table tbody tr { border: 1px solid #e2e8f0; border-radius: 8px; margin-bottom: 0.75rem; padding: 0.25rem 0.75rem; background: white; border-left-width: 3px; }
+        .preset-table td { padding: 0.3rem 0; border: none; font-size: 0.85rem; }
+        .preset-table td::before { content: attr(data-label); font-weight: 700; font-size: 0.7rem; color: #a0aec0; text-transform: uppercase; letter-spacing: 0.04em; display: inline-block; width: 90px; }
+        .preset-table td[data-label=""]::before { display: none; }
+        .weight-row { grid-template-columns: repeat(2, 1fr); }
+    }
 </style>
 {% endblock %}
 
@@ -74,73 +100,76 @@
     </div>
 
     {% if presets %}
-        {% for p in presets %}
-        {% set sc = p.game_config.get('skill_config', {}) if p.game_config else {} %}
-        {% set meta = p.game_config.get('metadata', {}) if p.game_config else {} %}
-        {% set skills = sc.get('skills_tested', []) %}
-        {% set weights = sc.get('skill_weights', {}) %}
-        <div class="card">
-            <div class="card-header" onclick="toggleCard('preset-{{ p.id }}')">
-                <h3>
-                    {% if p.is_active %}🟢{% else %}⚫{% endif %}
-                    {% if p.is_recommended %}⭐ {% endif %}
-                    <strong>{{ p.name }}</strong>
-                    <code style="background: #f0f0f0; padding: 0.1rem 0.4rem; border-radius: 4px; font-size: 0.8rem">{{ p.code }}</code>
-                    · {{ skills | length }} skills
-                    <span class="badge {% if p.is_active %}badge-active{% else %}badge-inactive{% endif %}">{{ 'Active' if p.is_active else 'Inactive' }}</span>
-                    {% if p.is_recommended %}<span class="badge badge-recommended">⭐ Recommended</span>{% endif %}
-                </h3>
-                <span style="color: #718096; font-size: 0.85rem">id={{ p.id }} ▼</span>
-            </div>
-            <div class="card-body" id="preset-{{ p.id }}">
-                {% if p.description %}
-                <div class="info-row">
-                    <label>Description</label>
-                    <p class="skills-str">{{ p.description }}</p>
-                </div>
-                {% endif %}
-                <div class="info-row">
-                    <label>Skills</label>
-                    <p class="skills-str">
-                        {% if weights %}
-                            {% set total_w = weights.values() | sum %}
-                            {% for s in skills %}
-                                {% if s in weights %}
-                                    {{ s.replace('_', ' ').title() }} {{ (weights[s] / total_w * 100) | round | int }}%{% if not loop.last %}  ·  {% endif %}
-                                {% endif %}
-                            {% endfor %}
-                        {% else %}
-                            {{ skills | join(', ') or '—' }}
-                        {% endif %}
-                    </p>
-                </div>
-                <div class="info-row" style="display: flex; gap: 2rem">
-                    {% if meta.get('game_category') %}<span>🎮 {{ meta.game_category }}</span>{% endif %}
-                    {% if meta.get('difficulty_level') %}<span>📶 {{ meta.difficulty_level }}</span>{% endif %}
-                    {% if meta.get('min_players') %}<span>👥 min {{ meta.min_players }} players</span>{% endif %}
-                    <span style="color: #718096; font-size: 0.85rem">id={{ p.id }} · code={{ p.code }}</span>
-                </div>
-                <div class="action-row">
-                    {% if not p.is_locked %}
-                    <a href="/admin/game-presets/{{ p.id }}/edit" class="btn btn-sm btn-primary">✏️ Edit</a>
-                    {% endif %}
-                    <form method="post" action="/admin/game-presets/{{ p.id }}/toggle" style="display:inline">
-                        <button type="submit" class="btn btn-sm btn-warning">
-                            {{ '⚫ Deactivate' if p.is_active else '🟢 Activate' }}
-                        </button>
-                    </form>
-                    {% if not p.is_locked %}
-                    <form method="post" action="/admin/game-presets/{{ p.id }}/delete" style="display:inline"
-                          onsubmit="return confirm('Delete preset {{ p.name }}? This cannot be undone.')">
-                        <button type="submit" class="btn btn-sm btn-danger">🗑️ Delete</button>
-                    </form>
+    <div style="background: white; border-radius: 12px; box-shadow: 0 2px 8px rgba(0,0,0,0.06); overflow: hidden; margin-bottom: 1.5rem;">
+    <table class="preset-table">
+        <thead>
+            <tr>
+                <th></th>
+                <th>Name</th>
+                <th>Code</th>
+                <th>Foot Context</th>
+                <th>Skills</th>
+                <th>Rec.</th>
+                <th>ID</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for p in presets %}
+            {% set sc = p.game_config.get('skill_config', {}) if p.game_config else {} %}
+            {% set skills = sc.get('skills_tested', []) %}
+            {% set foot_ctx_raw = sc.get('foot_context') %}
+            {% set foot_ctx = foot_ctx_raw or p.foot_context %}
+            <tr class="{% if foot_ctx_raw == 'right' %}lat-right{% elif foot_ctx_raw == 'left' %}lat-left{% elif foot_ctx_raw == 'neutral' %}lat-neutral{% endif %}">
+                <td data-label="">
+                    {% if p.is_active %}
+                    <span title="Active" style="color: #276749; font-size: 0.9rem;">●</span>
                     {% else %}
-                    <span style="color: #718096; font-size: 0.8rem">🔒 Locked — cannot edit or delete</span>
+                    <span title="Inactive" style="color: #cbd5e0; font-size: 0.9rem;">●</span>
                     {% endif %}
-                </div>
-            </div>
-        </div>
-        {% endfor %}
+                </td>
+                <td data-label="Name">
+                    <strong>{{ p.name }}</strong>
+                    {% if not p.is_active %}<span style="font-size: 0.72rem; color: #a0aec0; margin-left: 0.3rem;">(inactive)</span>{% endif %}
+                </td>
+                <td data-label="Code"><code class="preset-code">{{ p.code }}</code></td>
+                <td data-label="Foot Context">
+                    {% if foot_ctx_raw %}
+                    <span class="fc-badge fc-{{ foot_ctx }}">{{ foot_ctx }}</span>
+                    {% else %}
+                    <span class="fc-badge fc-default" title="No explicit foot_context stored — defaults to neutral at runtime">{{ foot_ctx }}/default</span>
+                    {% endif %}
+                </td>
+                <td data-label="Skills">
+                    {% for s in skills[:3] %}<span class="skill-pill">{{ s.replace('_', ' ') }}</span>{% endfor %}
+                    {% if skills | length > 3 %}<span class="skill-more">+{{ skills | length - 3 }}</span>{% endif %}
+                    {% if not skills %}<span style="color: #cbd5e0; font-size: 0.8rem;">—</span>{% endif %}
+                </td>
+                <td data-label="Rec.">{% if p.is_recommended %}⭐{% else %}<span style="color: #e2e8f0;">—</span>{% endif %}</td>
+                <td data-label="ID" style="color: #a0aec0; font-size: 0.8rem; white-space: nowrap;">{{ p.id }}</td>
+                <td data-label="Actions">
+                    <div style="display: flex; gap: 0.3rem; flex-wrap: wrap; align-items: center;">
+                        {% if not p.is_locked %}
+                        <a href="/admin/game-presets/{{ p.id }}/edit" class="btn-tbl btn-tbl-primary">✏️ Edit</a>
+                        {% endif %}
+                        <form method="post" action="/admin/game-presets/{{ p.id }}/toggle" style="display:inline">
+                            <button type="submit" class="btn-tbl btn-tbl-warning">{{ '⚫ Off' if p.is_active else '🟢 On' }}</button>
+                        </form>
+                        {% if not p.is_locked %}
+                        <form method="post" action="/admin/game-presets/{{ p.id }}/delete" style="display:inline"
+                              onsubmit="return confirm('Delete preset {{ p.name }}? This cannot be undone.')">
+                            <button type="submit" class="btn-tbl btn-tbl-danger">🗑️</button>
+                        </form>
+                        {% else %}
+                        <span style="color: #a0aec0; font-size: 0.72rem;" title="Locked — cannot edit or delete">🔒</span>
+                        {% endif %}
+                    </div>
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    </div>
     {% else %}
         <div class="no-data">
             <p style="font-size: 1.5rem">🎮</p>
@@ -190,6 +219,14 @@
                     <input type="number" name="min_players" value="4" min="2" max="1024">
                 </div>
                 <div class="form-group">
+                    <label>Foot Context</label>
+                    <select name="foot_context">
+                        <option value="neutral" selected>neutral — both feet / default</option>
+                        <option value="right">right — right foot</option>
+                        <option value="left">left — left foot</option>
+                    </select>
+                </div>
+                <div class="form-group">
                     <label>
                         <input type="checkbox" name="skill_impact" value="1" checked>
                         Skill impact on matches
@@ -230,11 +267,6 @@
 
 {% block scripts %}
 <script>
-function toggleCard(id) {
-    const body = document.getElementById(id);
-    body.classList.toggle('open');
-}
-
 let codeManuallyEdited = false;
 document.getElementById('codeField').addEventListener('input', () => { codeManuallyEdited = true; });
 
@@ -258,7 +290,7 @@ function updateWeights() {
         return;
     }
     section.style.display = 'block';
-    // Preserve existing weight and foot context values
+    // Preserve existing weight AND foot context values on checkbox toggle
     const existing = {};
     container.querySelectorAll('input[type="number"]').forEach(inp => {
         existing[inp.name] = inp.value;
@@ -269,7 +301,8 @@ function updateWeights() {
     container.innerHTML = '';
     checked.forEach((cb) => {
         const key = cb.name.replace('skill_cb_', '');
-        const label = cb.parentElement.querySelector('label').textContent;
+        const label = cb.closest('.skill-item')?.querySelector('label')?.textContent.trim()
+                      || key.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
         const div = document.createElement('div');
         div.className = 'weight-item';
         const defaultVal = existing['skill_w_' + key] || 10;

--- a/app/templates/public/export/square/fifa.html
+++ b/app/templates/public/export/square/fifa.html
@@ -343,10 +343,17 @@ html, body {
     overflow: hidden;
 }
 
-/* Set Pieces (left col bottom): flex:1 fills remaining column height so its bottom edge
- * aligns with Physical Fitness even though it has only 3 skill rows. */
-.ex-cat--col-filler {
+/* Set Pieces (left col bottom): flex:1 fills remaining column height; logo-slot occupies
+ * the freed dark area at the bottom as a static visual placeholder. */
+.ex-cat--logo-host {
     flex: 1;
+}
+
+.ex-logo-slot {
+    flex-shrink: 0;
+    height: 96px;
+    border-top: 1px solid rgba(255,255,255,0.06);
+    margin-top: 0;
 }
 
 /* Category cell */
@@ -637,7 +644,7 @@ html, body {
             <!-- Left column: Outfield + Set Pieces -->
             <div class="ex-skill-col">
                 {% for cat in [skill_categories[0], skill_categories[1]] %}
-                <div class="ex-cat{% if loop.last %} ex-cat--col-filler{% endif %}">
+                <div class="ex-cat{% if loop.last %} ex-cat--logo-host{% endif %}">
                     <div class="ex-cat-name">{{ cat.emoji }} {{ cat.name_en }}</div>
                     <div class="ex-skill-rows">
                         {% for skill in cat.skills %}
@@ -671,6 +678,7 @@ html, body {
                         </div>
                         {% endfor %}
                     </div>
+                    {% if loop.last %}<div class="ex-logo-slot"></div>{% endif %}
                 </div>
                 {% endfor %}
             </div>

--- a/tests/unit/services/test_game_preset_edit_template_smoke.py
+++ b/tests/unit/services/test_game_preset_edit_template_smoke.py
@@ -126,3 +126,55 @@ class TestFcTmpl01EditPageRendersSkillFcSelects:
         assert '— preset default —' in resp.text, (
             "Default option text must appear in rendered select"
         )
+
+
+class TestAdminPresetsListTable:
+    """UI-PRESETS-01: GET /admin/game-presets renders compact <table>, not card/accordion."""
+
+    def test_list_uses_table_not_accordion(self, admin_client):
+        resp = admin_client.get("/admin/game-presets")
+        assert resp.status_code == 200
+        assert "preset-table" in resp.text, (
+            "preset-table class must be present — compact table UI expected"
+        )
+        assert "card-header" not in resp.text, (
+            "card-header must be absent — old accordion layout must not be rendered"
+        )
+
+
+class TestAdminPresetEditChartPanel:
+    """UI-PRESETS-02: GET /admin/game-presets/{id}/edit renders SVG chart panel."""
+
+    def test_chart_panel_and_canvas_rendered(self, admin_client, test_db):
+        gp = GamePreset(
+            code=f"cht_{uuid.uuid4().hex[:6]}",
+            name="Chart Panel Test",
+            is_active=True,
+            game_config={
+                "version": "1.0",
+                "format_config": {},
+                "simulation_config": {},
+                "skill_config": {
+                    "skills_tested": ["crossing"],
+                    "skill_weights": {"crossing": 1.0},
+                    "skill_impact_on_matches": True,
+                },
+                "metadata": {
+                    "game_category": "FOOTBALL",
+                    "difficulty_level": None,
+                    "min_players": 2,
+                },
+            },
+        )
+        test_db.add(gp)
+        test_db.commit()
+        test_db.refresh(gp)
+
+        resp = admin_client.get(f"/admin/game-presets/{gp.id}/edit")
+        assert resp.status_code == 200
+        assert 'id="presetChart"' in resp.text, (
+            "SVG element #presetChart must be present in edit page"
+        )
+        assert "chart-panel" in resp.text, (
+            "chart-panel container must be present — two-column layout expected"
+        )

--- a/tests/unit/services/test_game_preset_foot_context_edit.py
+++ b/tests/unit/services/test_game_preset_foot_context_edit.py
@@ -1,0 +1,247 @@
+"""
+Game Preset admin web route — foot_context edit/create tests.
+
+FC-EDIT-01  Edit lat_passing_right preset → Save → foot_context remains 'right'
+FC-EDIT-02  Edit lat_passing_left  preset → Save → foot_context remains 'left'
+FC-EDIT-03  Edit legacy preset (no explicit foot_context) → Save → 'neutral' written
+FC-EDIT-04  Create new preset with foot_context='right' → DB stores 'right'
+FC-EDIT-05  POST edit with invalid foot_context value → key absent → model property 'neutral'
+
+Route uses form_data.get() pattern (no OpenAPI drift):
+  valid value   → written to skill_config
+  invalid/empty → key omitted → GamePreset.foot_context property returns 'neutral' default
+
+Auth:  get_current_user_web dependency overridden → admin injected
+CSRF:  Authorization: Bearer header bypasses CSRFProtectionMiddleware
+DB:    SAVEPOINT-isolated (test_db fixture from unit/conftest.py)
+"""
+
+import uuid
+import pytest
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.main import app
+from app.database import get_db
+from app.dependencies import get_current_user_web
+from app.models.user import User, UserRole
+from app.models.game_preset import GamePreset
+from app.core.security import get_password_hash
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture(scope="function")
+def admin_user(test_db: Session) -> User:
+    u = User(
+        email=f"fcedit-admin+{uuid.uuid4().hex[:8]}@lfa.com",
+        name="FC Edit Admin",
+        password_hash=get_password_hash("Admin123!"),
+        role=UserRole.ADMIN,
+        is_active=True,
+    )
+    test_db.add(u)
+    test_db.commit()
+    test_db.refresh(u)
+    return u
+
+
+@pytest.fixture(scope="function")
+def admin_client(test_db: Session, admin_user: User) -> TestClient:
+    def override_get_db():
+        yield test_db
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user_web] = lambda: admin_user
+
+    with TestClient(app, headers={"Authorization": "Bearer test-csrf-bypass"}) as c:
+        yield c
+
+    app.dependency_overrides.clear()
+
+
+def _make_preset(test_db: Session, *, code: str, name: str, foot_context: str | None) -> GamePreset:
+    """Create a GamePreset with or without explicit foot_context in skill_config."""
+    sc: dict = {
+        "skills_tested": ["passing"],
+        "skill_weights": {"passing": 1.0},
+        "skill_impact_on_matches": True,
+    }
+    if foot_context is not None:
+        sc["foot_context"] = foot_context
+
+    gp = GamePreset(
+        code=code,
+        name=name,
+        is_active=True,
+        game_config={
+            "version": "1.0",
+            "format_config": {},
+            "skill_config": sc,
+            "simulation_config": {},
+            "metadata": {"game_category": "FOOTBALL", "difficulty_level": None, "min_players": 2},
+        },
+    )
+    test_db.add(gp)
+    test_db.commit()
+    test_db.refresh(gp)
+    return gp
+
+
+def _edit_form(*, name: str, foot_context: str, skill: str = "passing", weight: int = 100) -> dict:
+    """Build the minimal POST form data for the edit route."""
+    return {
+        "name": name,
+        "description": "",
+        "category": "FOOTBALL",
+        "difficulty": "",
+        "min_players": "2",
+        "foot_context": foot_context,
+        f"skill_cb_{skill}": skill,
+        f"skill_w_{skill}": str(weight),
+    }
+
+
+def _sc(test_db: Session, preset_id: int) -> dict:
+    """Re-read skill_config from DB (expire cache first)."""
+    test_db.expire_all()
+    gp = test_db.query(GamePreset).filter(GamePreset.id == preset_id).first()
+    return (gp.game_config or {}).get("skill_config", {})
+
+
+def _gp(test_db: Session, preset_id: int) -> GamePreset:
+    test_db.expire_all()
+    return test_db.query(GamePreset).filter(GamePreset.id == preset_id).first()
+
+
+# ── FC-EDIT-01 ────────────────────────────────────────────────────────────────
+
+class TestFcEdit01RightPreservedOnSave:
+    """FC-EDIT-01: Edit lat_passing_right → Save → foot_context stays 'right'."""
+
+    def test_fc_edit_01(self, admin_client, test_db):
+        preset = _make_preset(
+            test_db,
+            code=f"lat_passing_right_{uuid.uuid4().hex[:6]}",
+            name="Lat Passing Right",
+            foot_context="right",
+        )
+        resp = admin_client.post(
+            f"/admin/game-presets/{preset.id}/edit",
+            data=_edit_form(name="Lat Passing Right", foot_context="right"),
+            follow_redirects=False,
+        )
+        assert resp.status_code == 303, f"Expected 303, got {resp.status_code}: {resp.text}"
+        assert _sc(test_db, preset.id).get("foot_context") == "right"
+
+
+# ── FC-EDIT-02 ────────────────────────────────────────────────────────────────
+
+class TestFcEdit02LeftPreservedOnSave:
+    """FC-EDIT-02: Edit lat_passing_left → Save → foot_context stays 'left'."""
+
+    def test_fc_edit_02(self, admin_client, test_db):
+        preset = _make_preset(
+            test_db,
+            code=f"lat_passing_left_{uuid.uuid4().hex[:6]}",
+            name="Lat Passing Left",
+            foot_context="left",
+        )
+        resp = admin_client.post(
+            f"/admin/game-presets/{preset.id}/edit",
+            data=_edit_form(name="Lat Passing Left", foot_context="left"),
+            follow_redirects=False,
+        )
+        assert resp.status_code == 303
+        assert _sc(test_db, preset.id).get("foot_context") == "left"
+
+
+# ── FC-EDIT-03 ────────────────────────────────────────────────────────────────
+
+class TestFcEdit03LegacyGetsNeutralOnSave:
+    """FC-EDIT-03: Edit legacy preset (no foot_context key) → Save with neutral → 'neutral' written."""
+
+    def test_fc_edit_03(self, admin_client, test_db):
+        preset = _make_preset(
+            test_db,
+            code=f"legacy_preset_{uuid.uuid4().hex[:6]}",
+            name="Legacy Preset",
+            foot_context=None,
+        )
+        assert "foot_context" not in _sc(test_db, preset.id)
+
+        resp = admin_client.post(
+            f"/admin/game-presets/{preset.id}/edit",
+            data=_edit_form(name="Legacy Preset", foot_context="neutral"),
+            follow_redirects=False,
+        )
+        assert resp.status_code == 303
+        assert _sc(test_db, preset.id).get("foot_context") == "neutral"
+
+
+# ── FC-EDIT-04 ────────────────────────────────────────────────────────────────
+
+class TestFcEdit04CreateWithRightContext:
+    """FC-EDIT-04: Create new preset with foot_context='right' → DB stores 'right'."""
+
+    def test_fc_edit_04(self, admin_client, test_db):
+        code = f"new_right_{uuid.uuid4().hex[:6]}"
+        name = f"New Right Preset {uuid.uuid4().hex[:4]}"
+        resp = admin_client.post(
+            "/admin/game-presets",
+            data={
+                "name": name,
+                "code": code,
+                "description": "",
+                "category": "FOOTBALL",
+                "difficulty": "",
+                "min_players": "2",
+                "foot_context": "right",
+                "skill_cb_passing": "passing",
+                "skill_w_passing": "100",
+            },
+            follow_redirects=False,
+        )
+        assert resp.status_code == 303
+
+        test_db.expire_all()
+        gp = test_db.query(GamePreset).filter(GamePreset.code == code).first()
+        assert gp is not None, f"Preset with code={code!r} not found after create"
+        sc = (gp.game_config or {}).get("skill_config", {})
+        assert sc.get("foot_context") == "right", (
+            f"Expected foot_context='right', got {sc.get('foot_context')!r}"
+        )
+
+
+# ── FC-EDIT-05 ────────────────────────────────────────────────────────────────
+
+class TestFcEdit05InvalidValueFallsBackToNeutral:
+    """FC-EDIT-05: POST edit with invalid foot_context → key absent → model property returns 'neutral'.
+
+    Route writes foot_context only for valid values (right/left/neutral).
+    Invalid submission → key omitted from skill_config → GamePreset.foot_context
+    property defaults to 'neutral'.  No invalid string ever reaches the DB.
+    """
+
+    def test_fc_edit_05(self, admin_client, test_db):
+        preset = _make_preset(
+            test_db,
+            code=f"invalid_fc_{uuid.uuid4().hex[:6]}",
+            name="Invalid FC Preset",
+            foot_context="right",
+        )
+        resp = admin_client.post(
+            f"/admin/game-presets/{preset.id}/edit",
+            data=_edit_form(name="Invalid FC Preset", foot_context="BOTH_FEET"),
+            follow_redirects=False,
+        )
+        assert resp.status_code == 303
+        gp = _gp(test_db, preset.id)
+        sc = (gp.game_config or {}).get("skill_config", {})
+        assert "foot_context" not in sc or sc["foot_context"] in {"right", "left", "neutral"}, (
+            "Invalid foot_context must not be stored in DB"
+        )
+        assert gp.foot_context == "neutral", (
+            "GamePreset.foot_context property must return 'neutral' default when key is absent"
+        )

--- a/tests/unit/test_platform_export_layout.py
+++ b/tests/unit/test_platform_export_layout.py
@@ -1161,7 +1161,7 @@ class TestFifaSquareAllSkills:
     EX-29  All 11 Outfield skill names present in rendered Square export HTML
     EX-30  square/fifa.html template source contains no skill slicing (cat.skills[:)
     EX-31  Square export uses 2-column flex layout (v4 proportional columns)
-    EX-31b Square export uses col-filler to bottom-align Set Pieces with Physical Fitness
+    EX-31b Square export uses logo-host to bottom-align Set Pieces with Physical Fitness + logo-slot placeholder
     """
 
     def _get_fifa_export_html(self, client, platform: str = "instagram_square") -> str:
@@ -1226,18 +1226,22 @@ class TestFifaSquareAllSkills:
         )
 
     def test_ex31b_square_proportional_row_heights(self, client):
-        """Square export uses .ex-cat--col-filler to bottom-align Set Pieces with Physical Fitness.
+        """Square export uses .ex-cat--logo-host to bottom-align Set Pieces with Physical Fitness.
 
         v4 flex-column layout: Set Pieces (3 rows, left col bottom) has flex:1 so its cell
         expands to fill remaining left-column height, aligning its bottom edge with Physical
-        Fitness. The 24px fixed skill row height (.ex-row { flex: none; min-height: 24px })
-        is preserved unchanged.
+        Fitness. A static .ex-logo-slot placeholder fills the freed dark area at the bottom.
+        The 24px fixed skill row height (.ex-row { flex: none; min-height: 24px }) is unchanged.
         """
         html = self._get_fifa_export_html(client, "instagram_square")
         assert html, "Export returned empty response for instagram_square"
-        assert "ex-cat--col-filler" in html, (
-            "ex-cat--col-filler not found in Square export HTML — "
+        assert "ex-cat--logo-host" in html, (
+            "ex-cat--logo-host not found in Square export HTML — "
             "Set Pieces cell must carry this class so it expands to match Physical Fitness height"
+        )
+        assert "ex-logo-slot" in html, (
+            "ex-logo-slot not found in Square export HTML — "
+            "static placeholder must be rendered inside the Set Pieces cell"
         )
 
     def test_ex31c_sponsor_logo_slot_present_without_logo(self, client):


### PR DESCRIPTION
## Summary

- **Admin game-presets list** restored as compact table (was lost when sponsors-p4 never merged after B3): status badge, foot-context badge, skill chips, record count, ID column, inline Actions
- **Admin preset edit** restored to two-column layout with pure-SVG inline donut chart (no CDN dependency): left = full form, right = 290px chart panel with live weight visualization, fc-info badge, weight sum indicator
- **Silent data loss bug fixed**: `foot_context` was dropped from `skill_config` on every save — POST create + edit handlers now persist it when value ∈ `_VALID_FOOT_CONTEXTS`; invalid values are silently dropped (no OpenAPI drift vs. `Form()` approach)
- **B3 `skill_fc_*` selects preserved** throughout both templates and `updateWeights()` JS — per-skill foot context overrides survive all edits
- **FIFA square logo-slot**: `.ex-cat--col-filler` → `.ex-cat--logo-host` + static `.ex-logo-slot` (96px, border-top) eliminates 104px gap between Set Pieces and Physical Fitness panel bottoms

## Modified files

| File | Change |
|---|---|
| `app/api/web_routes/admin/game_presets.py` | +`foot_context` persist in POST create + POST edit (+6 lines) |
| `app/templates/admin/game_presets.html` | Compact table layout (restored + B3 merged) |
| `app/templates/admin/game_preset_edit.html` | Two-column + SVG donut chart (restored + B3 merged) |
| `app/templates/public/export/square/fifa.html` | logo-host/logo-slot CSS + HTML |
| `tests/unit/services/test_game_preset_foot_context_edit.py` | **NEW** FC-EDIT-01..05 (foot_context persist round-trip) |
| `tests/unit/services/test_game_preset_edit_template_smoke.py` | +UI-PRESETS-01 (table not accordion), +UI-PRESETS-02 (chart panel) |
| `tests/unit/test_platform_export_layout.py` | EX-31b updated for logo-host/logo-slot |

## Test plan

- [x] FC-EDIT-01: `foot_context="right"` on edit → stored as `"right"`
- [x] FC-EDIT-02: `foot_context="left"` on edit → stored as `"left"`
- [x] FC-EDIT-03: legacy preset (no fc key) + submit `"neutral"` → stored as `"neutral"`
- [x] FC-EDIT-04: create with `foot_context="right"` → stored as `"right"`
- [x] FC-EDIT-05: invalid `foot_context="BOTH_FEET"` → key absent, property returns `"neutral"`
- [x] FC-TMPL-01a: edit page renders `skill_fc_crossing` select with `value="right"` selected
- [x] FC-TMPL-01b: edit page with no override renders `— preset default —` option
- [x] UI-PRESETS-01: list page uses `preset-table`, no `card-header`
- [x] UI-PRESETS-02: edit page renders `id="presetChart"` + `chart-panel`
- [x] EX-31b: FIFA square has `ex-cat--logo-host` + `ex-logo-slot`
- [x] Full unit suite: **110 passed, 1 skipped** (pre-existing Playwright skip), 0 failures
- [ ] No model / migration / OpenAPI changes
- [ ] Route change limited to foot_context persistence in existing GamePreset create/edit POST handlers

🤖 Generated with [Claude Code](https://claude.com/claude-code)