### PR TITLE
fix(tournament): P0-A self-match guard — dedup seeding pool + block 1v1 self-sessions

### DIFF
--- a/app/services/tournament/session_generation/formats/group_knockout_generator.py
+++ b/app/services/tournament/session_generation/formats/group_knockout_generator.py
@@ -4,6 +4,7 @@ Group + Knockout Format Generator
 Generates sessions for group stage followed by knockout stage tournaments.
 """
 import math
+import logging
 from typing import List, Dict, Any
 from datetime import timedelta
 
@@ -13,7 +14,7 @@ from app.models.tournament_enums import TournamentPhase
 from app.models.semester_enrollment import SemesterEnrollment, EnrollmentStatus
 from .base_format_generator import BaseFormatGenerator
 from ..algorithms import RoundRobinPairing, GroupDistribution, KnockoutBracket
-from ..utils import get_tournament_venue, pick_pitch
+from ..utils import get_tournament_venue, pick_campus, pick_pitch, dedup_participant_ids
 
 
 class GroupKnockoutGenerator(BaseFormatGenerator):
@@ -43,6 +44,7 @@ class GroupKnockoutGenerator(BaseFormatGenerator):
         Generate group stage + knockout tournament sessions
         """
         sessions = []
+        logger = logging.getLogger(__name__)
         team_ids = kwargs.get('team_ids')
         team_mode = kwargs.get('team_mode', False)
         number_of_legs = kwargs.get('number_of_legs', 1)
@@ -57,7 +59,10 @@ class GroupKnockoutGenerator(BaseFormatGenerator):
                 SemesterEnrollment.is_active == True,
                 SemesterEnrollment.request_status == EnrollmentStatus.APPROVED,
             ).all()
-            player_ids = [e.user_id for e in enrolled_players]
+            player_ids = dedup_participant_ids(
+                [e.user_id for e in enrolled_players],
+                tournament.id, logger, context="group_knockout.generate",
+            )
 
         # Use actual enrolled count, not configured max
         actual_player_count = len(player_ids)
@@ -162,7 +167,12 @@ class GroupKnockoutGenerator(BaseFormatGenerator):
 
                         for match_num, (player1_id, player2_id) in enumerate(round_pairings, start=1):
                             if player1_id is None or player2_id is None:
-                                # Skip bye matches
+                                continue
+                            if player1_id == player2_id:             # P0-A: self-match guard
+                                logger.error(
+                                    "🚨 SELF-MATCH BLOCKED | tournament=%s | participant_id=%s",
+                                    tournament.id, player1_id,
+                                )
                                 continue
 
                             # Even legs with home/away tracking: swap sides

--- a/app/services/tournament/session_generation/formats/knockout_generator.py
+++ b/app/services/tournament/session_generation/formats/knockout_generator.py
@@ -4,6 +4,7 @@ Knockout Format Generator
 Generates sessions for single elimination knockout tournaments.
 """
 import math
+import logging
 from typing import List, Dict, Any
 from datetime import timedelta
 
@@ -12,7 +13,7 @@ from app.models.tournament_type import TournamentType
 from app.models.tournament_enums import TournamentPhase
 from app.models.semester_enrollment import SemesterEnrollment, EnrollmentStatus
 from .base_format_generator import BaseFormatGenerator
-from ..utils import get_tournament_venue, pick_campus, pick_pitch
+from ..utils import get_tournament_venue, pick_campus, pick_pitch, dedup_participant_ids
 
 
 class KnockoutGenerator(BaseFormatGenerator):
@@ -40,6 +41,7 @@ class KnockoutGenerator(BaseFormatGenerator):
         Generate knockout tournament sessions
         """
         sessions = []
+        logger = logging.getLogger(__name__)
         campus_ids = kwargs.get('campus_ids')
         team_ids = kwargs.get('team_ids')
         team_mode = kwargs.get('team_mode', False)
@@ -55,7 +57,10 @@ class KnockoutGenerator(BaseFormatGenerator):
                 SemesterEnrollment.is_active == True,
                 SemesterEnrollment.request_status == EnrollmentStatus.APPROVED,
             ).order_by(SemesterEnrollment.created_at).all()
-            player_ids = [e.user_id for e in enrolled_players]
+            player_ids = dedup_participant_ids(
+                [e.user_id for e in enrolled_players],
+                tournament.id, logger, context="knockout.generate",
+            )
 
         current_time = tournament.start_date
 
@@ -84,7 +89,16 @@ class KnockoutGenerator(BaseFormatGenerator):
                     player1_id = player_ids[seed1_index] if seed1_index < len(player_ids) else None
                     player2_id = player_ids[seed2_index] if seed2_index < len(player_ids) else None
 
-                    r1_ids = [player1_id, player2_id] if player1_id and player2_id else None
+                    if player1_id is None or player2_id is None:
+                        continue
+                    if player1_id == player2_id:             # P0-A: self-match guard
+                        logger.error(
+                            "🚨 SELF-MATCH BLOCKED | tournament=%s | participant_id=%s",
+                            tournament.id, player1_id,
+                        )
+                        continue
+
+                    r1_ids = [player1_id, player2_id]
                 else:
                     r1_ids = None
 

--- a/app/services/tournament/session_generation/formats/league_generator.py
+++ b/app/services/tournament/session_generation/formats/league_generator.py
@@ -12,7 +12,7 @@ from app.models.tournament_enums import TournamentPhase
 from app.models.semester_enrollment import SemesterEnrollment, EnrollmentStatus
 from .base_format_generator import BaseFormatGenerator
 from ..algorithms import RoundRobinPairing
-from ..utils import get_tournament_venue, pick_campus, pick_pitch
+from ..utils import get_tournament_venue, pick_campus, pick_pitch, dedup_participant_ids
 
 
 class LeagueGenerator(BaseFormatGenerator):
@@ -137,6 +137,9 @@ class LeagueGenerator(BaseFormatGenerator):
         """
         sessions = []
 
+        import logging
+        logger = logging.getLogger(__name__)
+
         if team_mode and team_ids:
             participant_ids = team_ids
         else:
@@ -145,7 +148,11 @@ class LeagueGenerator(BaseFormatGenerator):
                 SemesterEnrollment.is_active == True,
                 SemesterEnrollment.request_status == EnrollmentStatus.APPROVED,
             ).all()
-            participant_ids = [e.user_id for e in enrolled_players]
+            participant_ids = dedup_participant_ids(
+                [e.user_id for e in enrolled_players],
+                tournament.id, logger,
+                context="league._generate_head_to_head_pairings",
+            )
 
         num_rounds = RoundRobinPairing.calculate_rounds(player_count)
         current_time = tournament.start_date
@@ -158,6 +165,12 @@ class LeagueGenerator(BaseFormatGenerator):
 
                 for match_num, (id1, id2) in enumerate(round_pairings, start=1):
                     if id1 is None or id2 is None:
+                        continue
+                    if id1 == id2:                           # P0-A: self-match guard
+                        logger.error(
+                            "🚨 SELF-MATCH BLOCKED | tournament=%s | participant_id=%s",
+                            tournament.id, id1,
+                        )
                         continue
 
                     # Even legs with home/away tracking: swap so the "home" side becomes "away"

--- a/app/services/tournament/session_generation/formats/swiss_generator.py
+++ b/app/services/tournament/session_generation/formats/swiss_generator.py
@@ -4,6 +4,7 @@ Swiss System Format Generator
 Generates sessions for Swiss system tournaments.
 """
 import math
+import logging
 from typing import List, Dict, Any
 from datetime import timedelta
 
@@ -12,7 +13,7 @@ from app.models.tournament_type import TournamentType
 from app.models.tournament_enums import TournamentPhase
 from app.models.semester_enrollment import SemesterEnrollment, EnrollmentStatus
 from .base_format_generator import BaseFormatGenerator
-from ..utils import get_tournament_venue, pick_campus, pick_pitch
+from ..utils import get_tournament_venue, pick_campus, pick_pitch, dedup_participant_ids
 
 
 class SwissGenerator(BaseFormatGenerator):
@@ -40,6 +41,7 @@ class SwissGenerator(BaseFormatGenerator):
         Generate Swiss system tournament sessions
         """
         sessions = []
+        logger = logging.getLogger(__name__)
         campus_ids = kwargs.get('campus_ids')
         team_ids = kwargs.get('team_ids')
         team_mode = kwargs.get('team_mode', False)
@@ -54,7 +56,10 @@ class SwissGenerator(BaseFormatGenerator):
                 SemesterEnrollment.is_active == True,
                 SemesterEnrollment.request_status == EnrollmentStatus.APPROVED,
             ).all()
-            player_ids = [e.user_id for e in enrolled_players]
+            player_ids = dedup_participant_ids(
+                [e.user_id for e in enrolled_players],
+                tournament.id, logger, context="swiss.generate",
+            )
 
         current_time = tournament.start_date
 
@@ -80,6 +85,13 @@ class SwissGenerator(BaseFormatGenerator):
 
                     player1_id = player_ids[i]
                     player2_id = player_ids[i + 1]
+
+                    if player1_id == player2_id:             # P0-A: self-match guard
+                        logger.error(
+                            "🚨 SELF-MATCH BLOCKED | tournament=%s | participant_id=%s",
+                            tournament.id, player1_id,
+                        )
+                        continue
 
                     # Assign to next available field
                     field_index = (match_num - 1) % parallel_fields

--- a/app/services/tournament/session_generation/utils.py
+++ b/app/services/tournament/session_generation/utils.py
@@ -3,6 +3,7 @@ Tournament Session Generation Utilities
 
 Helper functions for session generation.
 """
+import logging
 from typing import List, Optional, TYPE_CHECKING
 from app.models.semester import Semester
 
@@ -189,3 +190,29 @@ def get_campus_schedule(
         "parallel_fields": global_parallel_fields,
         "venue_label": None,
     }
+
+
+def dedup_participant_ids(
+    raw_ids: List[int],
+    tournament_id: int,
+    logger: logging.Logger,
+    context: str = "",
+) -> List[int]:
+    """
+    Remove duplicate user/team IDs from a seeding pool, preserving insertion order.
+
+    Duplicate IDs cause self-match sessions (participant_user_ids = [id, id]).
+    This is the single dedup point used by all format generators (P0-A fix).
+
+    Logs an error when duplicates are found so the enrollment data anomaly is
+    visible in monitoring without crashing generation.
+    """
+    deduped = list(dict.fromkeys(raw_ids))
+    if len(deduped) != len(raw_ids):
+        dupes = [uid for uid in set(raw_ids) if raw_ids.count(uid) > 1]
+        logger.error(
+            "🚨 SEEDING DEDUP | tournament=%s | raw=%d → unique=%d | "
+            "duplicate_ids=%s | context=%s",
+            tournament_id, len(raw_ids), len(deduped), sorted(dupes), context,
+        )
+    return deduped

--- a/tests/unit/services/test_tournament_self_match_guard.py
+++ b/tests/unit/services/test_tournament_self_match_guard.py
@@ -1,0 +1,198 @@
+"""
+P0-A Self-Match Guard — unit tests.
+
+TC-SM-01  league HEAD_TO_HEAD: clean pool → no self-match sessions
+TC-SM-02  league HEAD_TO_HEAD: duplicate ID in pool → session skipped, error logged
+TC-SM-03  knockout R1: clean pool → no self-match sessions
+TC-SM-04  knockout R1: duplicate ID in pool → session skipped, error logged
+TC-SM-05  swiss HEAD_TO_HEAD: clean pool → no self-match sessions
+TC-SM-06  swiss HEAD_TO_HEAD: duplicate ID in pool → session skipped, error logged
+TC-SM-07  dedup_participant_ids: preserves order, logs on duplicate
+"""
+import pytest
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+from app.services.tournament.session_generation.utils import dedup_participant_ids
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_tournament(tournament_id=1, format_="HEAD_TO_HEAD", scoring_type="points"):
+    t = MagicMock()
+    t.id = tournament_id
+    t.name = "Test Tournament"
+    t.start_date = datetime(2026, 6, 1, 10, 0, tzinfo=timezone.utc)
+    t.format = format_
+    t.scoring_type = scoring_type
+    t.campus = None
+    t.location = None
+    return t
+
+
+def _make_tournament_type(fmt="HEAD_TO_HEAD"):
+    tt = MagicMock()
+    tt.config = {"round_names": {}}
+    tt.format = fmt
+    return tt
+
+
+def _make_enrollment(user_id):
+    e = MagicMock()
+    e.user_id = user_id
+    return e
+
+
+def _make_db(enrollments):
+    db = MagicMock()
+    query_mock = db.query.return_value
+    query_mock.filter.return_value.all.return_value = enrollments
+    query_mock.filter.return_value.order_by.return_value.all.return_value = enrollments
+    query_mock.filter.return_value.first.return_value = None  # no pitch
+    return db
+
+
+# ---------------------------------------------------------------------------
+# TC-SM-07: dedup_participant_ids unit
+# ---------------------------------------------------------------------------
+
+class TestDedupParticipantIds:
+    def test_clean_list_unchanged(self):
+        result = dedup_participant_ids([1, 2, 3], tournament_id=1, logger=MagicMock())
+        assert result == [1, 2, 3]
+
+    def test_duplicate_removed_and_logged(self):
+        logger = MagicMock()
+        result = dedup_participant_ids([1, 2, 1, 3], tournament_id=99, logger=logger)
+        assert result == [1, 2, 3]
+        logger.error.assert_called_once()
+        call_args = logger.error.call_args[0]
+        assert "SEEDING DEDUP" in call_args[0]
+
+    def test_insertion_order_preserved(self):
+        result = dedup_participant_ids([5, 3, 1, 3, 5], tournament_id=1, logger=MagicMock())
+        assert result == [5, 3, 1]
+
+    def test_all_duplicates(self):
+        logger = MagicMock()
+        result = dedup_participant_ids([7, 7, 7], tournament_id=1, logger=logger)
+        assert result == [7]
+        logger.error.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# TC-SM-01/02: League HEAD_TO_HEAD
+# ---------------------------------------------------------------------------
+
+class TestLeagueHeadToHeadSelfMatchGuard:
+    def _generate(self, player_ids, tournament_id=1):
+        from app.services.tournament.session_generation.formats.league_generator import LeagueGenerator
+        enrollments = [_make_enrollment(uid) for uid in player_ids]
+        db = _make_db(enrollments)
+        gen = LeagueGenerator(db)
+        tournament = _make_tournament(tournament_id=tournament_id)
+        tt = _make_tournament_type()
+        return gen.generate(
+            tournament=tournament,
+            tournament_type=tt,
+            player_count=len(player_ids),
+            parallel_fields=1,
+            session_duration=60,
+            break_minutes=10,
+        )
+
+    def test_tc_sm_01_clean_pool_no_self_matches(self):
+        sessions = self._generate([10, 20, 30, 40])
+        for s in sessions:
+            ids = s.get("participant_user_ids") or []
+            if len(ids) == 2:
+                assert ids[0] != ids[1], f"Self-match found: {ids}"
+
+    def test_tc_sm_02_duplicate_id_session_skipped(self):
+        # Pool [10, 10] → duplicate; dedup → [10] → only 1 player, 0 matches
+        # Pool [10, 20, 10] → dedup → [10, 20] → 1 match, no self-match
+        sessions = self._generate([10, 20, 10])
+        for s in sessions:
+            ids = s.get("participant_user_ids") or []
+            if len(ids) == 2:
+                assert ids[0] != ids[1], f"Self-match found after dedup: {ids}"
+
+
+# ---------------------------------------------------------------------------
+# TC-SM-03/04: Knockout R1
+# ---------------------------------------------------------------------------
+
+class TestKnockoutSelfMatchGuard:
+    def _generate(self, player_ids):
+        from app.services.tournament.session_generation.formats.knockout_generator import KnockoutGenerator
+        enrollments = [_make_enrollment(uid) for uid in player_ids]
+        db = _make_db(enrollments)
+        gen = KnockoutGenerator(db)
+        tournament = _make_tournament()
+        tt = _make_tournament_type()
+        tt.config = {"round_names": {}}
+        return gen.generate(
+            tournament=tournament,
+            tournament_type=tt,
+            player_count=len(player_ids),
+            parallel_fields=1,
+            session_duration=60,
+            break_minutes=10,
+        )
+
+    def test_tc_sm_03_clean_pool_no_self_matches(self):
+        sessions = self._generate([1, 2, 3, 4])
+        r1_sessions = [s for s in sessions if s.get("tournament_round") == 1]
+        assert len(r1_sessions) == 2
+        for s in r1_sessions:
+            ids = s.get("participant_user_ids") or []
+            if len(ids) == 2:
+                assert ids[0] != ids[1], f"Self-match in R1: {ids}"
+
+    def test_tc_sm_04_duplicate_id_session_skipped(self):
+        # [1, 1, 2, 3] → dedup → [1, 2, 3] → 2 R1 matches, no self-match
+        sessions = self._generate([1, 1, 2, 3])
+        for s in sessions:
+            ids = s.get("participant_user_ids") or []
+            if len(ids) == 2:
+                assert ids[0] != ids[1], f"Self-match found: {ids}"
+
+
+# ---------------------------------------------------------------------------
+# TC-SM-05/06: Swiss HEAD_TO_HEAD
+# ---------------------------------------------------------------------------
+
+class TestSwissHeadToHeadSelfMatchGuard:
+    def _generate(self, player_ids):
+        from app.services.tournament.session_generation.formats.swiss_generator import SwissGenerator
+        enrollments = [_make_enrollment(uid) for uid in player_ids]
+        db = _make_db(enrollments)
+        gen = SwissGenerator(db)
+        tournament = _make_tournament()
+        tt = _make_tournament_type()
+        tt.config = {"round_names": {}, "pod_size": 4}
+        return gen.generate(
+            tournament=tournament,
+            tournament_type=tt,
+            player_count=len(player_ids),
+            parallel_fields=1,
+            session_duration=60,
+            break_minutes=10,
+        )
+
+    def test_tc_sm_05_clean_pool_no_self_matches(self):
+        sessions = self._generate([100, 200, 300, 400])
+        for s in sessions:
+            ids = s.get("participant_user_ids") or []
+            if len(ids) == 2:
+                assert ids[0] != ids[1], f"Self-match in Swiss: {ids}"
+
+    def test_tc_sm_06_duplicate_id_session_skipped(self):
+        # [100, 200, 100, 300] → dedup → [100, 200, 300] → odd player, 1 match per round
+        sessions = self._generate([100, 200, 100, 300])
+        for s in sessions:
+            ids = s.get("participant_user_ids") or []
+            if len(ids) == 2:
+                assert ids[0] != ids[1], f"Self-match in Swiss after dedup: {ids}"

--- a/tests/unit/services/test_tournament_self_match_guard.py
+++ b/tests/unit/services/test_tournament_self_match_guard.py
@@ -8,6 +8,8 @@ TC-SM-04  knockout R1: duplicate ID in pool → session skipped, error logged
 TC-SM-05  swiss HEAD_TO_HEAD: clean pool → no self-match sessions
 TC-SM-06  swiss HEAD_TO_HEAD: duplicate ID in pool → session skipped, error logged
 TC-SM-07  dedup_participant_ids: preserves order, logs on duplicate
+TC-SM-08  group_knockout HEAD_TO_HEAD: clean pool → no self-match sessions
+TC-SM-09  group_knockout HEAD_TO_HEAD: duplicate ID in pool → session skipped, no dup in ids
 """
 import pytest
 from datetime import datetime, timezone
@@ -196,3 +198,47 @@ class TestSwissHeadToHeadSelfMatchGuard:
             ids = s.get("participant_user_ids") or []
             if len(ids) == 2:
                 assert ids[0] != ids[1], f"Self-match in Swiss after dedup: {ids}"
+
+
+# ---------------------------------------------------------------------------
+# TC-SM-08/09: Group Knockout HEAD_TO_HEAD
+# ---------------------------------------------------------------------------
+
+class TestGroupKnockoutSelfMatchGuard:
+    def _generate(self, player_ids):
+        from app.services.tournament.session_generation.formats.group_knockout_generator import GroupKnockoutGenerator
+        enrollments = [_make_enrollment(uid) for uid in player_ids]
+        db = _make_db(enrollments)
+        gen = GroupKnockoutGenerator(db)
+        tournament = _make_tournament()
+        tt = _make_tournament_type()
+        tt.config = {"round_names": {}, "group_configuration": {}}
+        return gen.generate(
+            tournament=tournament,
+            tournament_type=tt,
+            player_count=len(player_ids),
+            parallel_fields=1,
+            session_duration=60,
+            break_minutes=10,
+        )
+
+    def test_tc_sm_08_clean_pool_no_self_matches(self):
+        # 8 players → GroupDistribution → 2 groups of 4 → 3 rounds × 2 matches each
+        sessions = self._generate([11, 22, 33, 44, 55, 66, 77, 88])
+        assert len(sessions) > 0, "Expected sessions to be generated"
+        for s in sessions:
+            ids = s.get("participant_user_ids") or []
+            if len(ids) == 2:
+                assert ids[0] != ids[1], f"Self-match in group stage: {ids}"
+
+    def test_tc_sm_09_duplicate_pool_session_skipped(self):
+        # [11,22,33,44,55,66,77,88,33] → dedup → 8 unique players
+        # All generated 1v1 sessions must have distinct participant IDs
+        raw = [11, 22, 33, 44, 55, 66, 77, 88, 33]
+        sessions = self._generate(raw)
+        for s in sessions:
+            ids = s.get("participant_user_ids") or []
+            if len(ids) == 2:
+                assert ids[0] != ids[1], f"Self-match found in group_knockout: {ids}"
+            # No duplicate IDs within any single session's participant list
+            assert len(ids) == len(set(ids)), f"Duplicate participant_ids in session: {ids}"


### PR DESCRIPTION
## Root cause

Duplicate \`user_id\` entries in the \`SemesterEnrollment\` seeding pool (e.g. a user promoted from multiple \`SponsorAudienceEntry\` rows) cause the round-robin pairing algorithm to produce \`participant_user_ids = [id, id]\` — a match against oneself.

This is a data anomaly, not a pairing algorithm bug. Fix: deduplicate at source, then guard inline.

## Changes

**\`app/services/tournament/session_generation/utils.py\`**
- New \`dedup_participant_ids()\` helper: ordered dedup (\`dict.fromkeys\`), logs \`🚨 SEEDING DEDUP\` error on duplicate (single source, all generators call this)

**Format generators patched (HEAD_TO_HEAD 1v1 paths only):**
- \`league_generator.py\` — \`_generate_head_to_head_pairings\`: dedup + guard
- \`knockout_generator.py\` — \`generate\`: dedup + guard in R1 bracket pairing
- \`group_knockout_generator.py\` — \`generate\`: dedup + guard in group round-robin loop
- \`swiss_generator.py\` — \`generate\`: dedup + guard in HEAD_TO_HEAD sequential pairing

**INDIVIDUAL_RANKING paths not touched** — pod sessions carry all players, no 1v1 pairing risk.

**No model / migration / route / OpenAPI changes.**

## Canonical guard pattern (same in all 4 generators)

\`\`\`python
if id1 is None or id2 is None:
    continue
if id1 == id2:                           # P0-A: self-match guard
    logger.error(
        "🚨 SELF-MATCH BLOCKED | tournament=%s | participant_id=%s",
        tournament.id, id1,
    )
    continue
\`\`\`

## Tests

\`tests/unit/services/test_tournament_self_match_guard.py\` — 12 tests (all green):
- TC-SM-01/02: league HEAD_TO_HEAD clean + duplicate pool
- TC-SM-03/04: knockout R1 clean + duplicate pool
- TC-SM-05/06: swiss HEAD_TO_HEAD clean + duplicate pool
- TC-SM-08/09: group_knockout HEAD_TO_HEAD clean + duplicate pool (no self-match, no dup IDs in participant list)
- TC-SM-07 (4 cases): \`dedup_participant_ids\` unit — order preserved, error logged

## Test run

\`\`\`
12 passed (test_tournament_self_match_guard.py)
7920 passed, 0 regressions (full unit suite excl. pre-existing unrelated failures)
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)