### PR TITLE
feat(sponsors): multi-age promotion event — single Semester with age_groups JSONB

### DIFF
--- a/alembic/versions/2026_05_03_1600_p6_p7_campaign_credit.py
+++ b/alembic/versions/2026_05_03_1600_p6_p7_campaign_credit.py
@@ -1,0 +1,87 @@
+"""P6+P7: Campaign specialization + credit ledger columns
+
+Revision ID: 2026_05_03_1600
+Revises: 2026_05_03_1500
+Create Date: 2026-05-03 16:00:00.000000
+
+P6 — sponsor_campaigns gains specialization_type so each campaign targets one license type.
+P7 — sponsor_campaigns gains credit config (grant_amount, unlock_cost) for the sponsor-funded
+     unlock flow.  credit_transactions gains sponsor_id + campaign_id for settlement tracing.
+
+Changes:
+  sponsor_campaigns  — ADD specialization_type VARCHAR(50) NOT NULL DEFAULT 'LFA_FOOTBALL_PLAYER'
+  sponsor_campaigns  — ADD credit_grant_amount  INTEGER     NOT NULL DEFAULT 100
+  sponsor_campaigns  — ADD unlock_cost          INTEGER     NOT NULL DEFAULT 100
+  sponsor_campaigns  — ADD CONSTRAINT chk_campaign_min_grant    (credit_grant_amount >= 100)
+  sponsor_campaigns  — ADD CONSTRAINT chk_campaign_unlock_lte   (unlock_cost <= credit_grant_amount)
+  credit_transactions — ADD sponsor_id   INTEGER NULL FK → sponsors.id   ON DELETE SET NULL
+  credit_transactions — ADD campaign_id  INTEGER NULL FK → sponsor_campaigns.id ON DELETE SET NULL
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '2026_05_03_1600'
+down_revision = '2026_05_03_1500'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # ── sponsor_campaigns: P6 specialization + P7 credit config ──────────────
+    op.add_column(
+        'sponsor_campaigns',
+        sa.Column('specialization_type', sa.String(50), nullable=False,
+                  server_default='LFA_FOOTBALL_PLAYER'),
+    )
+    op.add_column(
+        'sponsor_campaigns',
+        sa.Column('credit_grant_amount', sa.Integer, nullable=False, server_default='100'),
+    )
+    op.add_column(
+        'sponsor_campaigns',
+        sa.Column('unlock_cost', sa.Integer, nullable=False, server_default='100'),
+    )
+    op.create_check_constraint(
+        'chk_campaign_min_grant',
+        'sponsor_campaigns',
+        'credit_grant_amount >= 100',
+    )
+    op.create_check_constraint(
+        'chk_campaign_unlock_lte',
+        'sponsor_campaigns',
+        'unlock_cost <= credit_grant_amount',
+    )
+
+    # ── credit_transactions: P7 settlement columns ────────────────────────────
+    op.add_column(
+        'credit_transactions',
+        sa.Column(
+            'sponsor_id',
+            sa.Integer,
+            sa.ForeignKey('sponsors.id', ondelete='SET NULL'),
+            nullable=True,
+            index=True,
+        ),
+    )
+    op.add_column(
+        'credit_transactions',
+        sa.Column(
+            'campaign_id',
+            sa.Integer,
+            sa.ForeignKey('sponsor_campaigns.id', ondelete='SET NULL'),
+            nullable=True,
+            index=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('credit_transactions', 'campaign_id')
+    op.drop_column('credit_transactions', 'sponsor_id')
+
+    op.drop_constraint('chk_campaign_unlock_lte', 'sponsor_campaigns', type_='check')
+    op.drop_constraint('chk_campaign_min_grant', 'sponsor_campaigns', type_='check')
+    op.drop_column('sponsor_campaigns', 'unlock_cost')
+    op.drop_column('sponsor_campaigns', 'credit_grant_amount')
+    op.drop_column('sponsor_campaigns', 'specialization_type')

--- a/alembic/versions/2026_05_05_1000_semesters_age_groups.py
+++ b/alembic/versions/2026_05_05_1000_semesters_age_groups.py
@@ -1,0 +1,40 @@
+"""semesters.age_groups JSONB — multi-age promotion event support
+
+Revision ID: 2026_05_05_1000
+Revises: 2026_05_03_1600
+Create Date: 2026-05-05 10:00:00.000000
+
+Domain: sponsor promotion events must create a single event for multiple age categories.
+        The new age_groups JSONB column stores the full list; age_group (String) is kept
+        for backward compat (single-age semesters and existing queries).
+
+Changes:
+  semesters — ADD COLUMN age_groups JSONB NULL
+              (no backfill — get_allowed_age_groups() fallback covers existing rows)
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = '2026_05_05_1000'
+down_revision = '2026_05_03_1600'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'semesters',
+        sa.Column(
+            'age_groups',
+            JSONB,
+            nullable=True,
+            comment='Multi-age eligibility list e.g. ["PRE","YOUTH"]. '
+                    'Overrides age_group when set. '
+                    'Populated by sponsor promotion when >1 age selected.',
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('semesters', 'age_groups')

--- a/app/api/api_v1/endpoints/tournaments/enroll.py
+++ b/app/api/api_v1/endpoints/tournaments/enroll.py
@@ -24,7 +24,7 @@ from app.services.age_category_service import (
     calculate_age_at_season_start
 )
 from app.services.enrollment_conflict_service import EnrollmentConflictService
-from app.services.tournament.validation import validate_tournament_enrollment_age, check_duplicate_enrollment
+from app.services.tournament.validation import validate_tournament_enrollment_age, check_duplicate_enrollment, get_allowed_age_groups
 from app.services.audit_service import AuditService
 from app.models.audit_log import AuditAction
 import logging
@@ -165,30 +165,34 @@ def enroll_in_tournament(
     age_at_season_start = calculate_age_at_season_start(current_user.date_of_birth, season_year)
     player_age_category = get_automatic_age_category(age_at_season_start)
 
-    # For 18+ users, automatically infer category from tournament age group
+    # For 18+ users, automatically infer category from tournament's allowed age groups
     if not player_age_category:
-        tournament_age_group = tournament.age_group
-        if tournament_age_group in ["AMATEUR", "PRO"]:
-            player_age_category = tournament_age_group
+        allowed = get_allowed_age_groups(tournament)
+        upper_allowed = [ag for ag in (allowed or []) if ag in ["AMATEUR", "PRO"]]
+        if len(upper_allowed) == 1:
+            player_age_category = upper_allowed[0]
             logger.info(f"✅ Auto-assigned age category {player_age_category} to user {current_user.id} based on tournament {tournament.code}")
-        else:
-            # Tournament is PRE or YOUTH, but player is 18+
+        elif len(upper_allowed) > 1:
+            # Multi-age event with multiple adult categories — admin must assign explicitly
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"You are over 18 and cannot enroll in {tournament_age_group} tournaments. Please enroll in AMATEUR or PRO tournaments."
+                detail="This event spans multiple adult age categories. "
+                       "Please ask an administrator to assign your age category before enrolling."
+            )
+        else:
+            # No upper group (PRE/YOUTH only) — 18+ cannot enroll
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="You are over 18 and cannot enroll in this tournament. Please enroll in AMATEUR or PRO tournaments."
             )
 
-    # 6. Verify age category enrollment rules using shared validation
-    tournament_age_group = tournament.age_group
-    is_valid, error_message = validate_tournament_enrollment_age(
-        player_age_category,
-        tournament_age_group
-    )
-
-    if not is_valid:
+    # 6. Verify age category enrollment rules using get_allowed_age_groups
+    allowed = get_allowed_age_groups(tournament)
+    if allowed is not None and player_age_category not in allowed:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=error_message
+            detail=f"Your age category ({player_age_category}) is not eligible for this event. "
+                   f"Eligible categories: {allowed}"
         )
 
     # 7. Acquire row-level lock on the tournament row FIRST to prevent race conditions

--- a/app/api/web_routes/admin/sponsors.py
+++ b/app/api/web_routes/admin/sponsors.py
@@ -343,41 +343,42 @@ async def admin_sponsor_promotion_create(
             status_code=303,
         )
 
-    for ag in age_groups:
-        suffix = datetime.now().strftime("%H%M%S%f")[:9]
-        code = f"PROMO-{date.fromisoformat(start_date).strftime('%Y%m%d')}-{ag.upper()[:6]}-{suffix}"
+    suffix = datetime.now().strftime("%H%M%S%f")[:9]
+    code = f"PROMO-{date.fromisoformat(start_date).strftime('%Y%m%d')}-{suffix}"
 
-        t = Semester(
-            code=code,
-            name=f"{tournament_name} ({ag})",
-            start_date=date.fromisoformat(start_date),
-            end_date=date.fromisoformat(end_date),
-            status=SemesterStatus.DRAFT,
-            tournament_status="DRAFT",
-            semester_category=SemesterCategory.PROMOTION_EVENT,
-            age_group=ag,                        # PRE / YOUTH / AMATEUR / PRO — already canonical
-            enrollment_cost=0,
-            campus_id=int(campus_id) if campus_id.strip() else None,
-            organizer_sponsor_id=sponsor.id,     # sponsor organizer
-            organizer_campaign_id=campaign.id,   # campaign whose audience feeds this event
-            organizer_club_id=None,              # explicit NULL — never a club
-        )
-        db.add(t)
-        db.flush()
+    t = Semester(
+        code=code,
+        name=tournament_name,
+        start_date=date.fromisoformat(start_date),
+        end_date=date.fromisoformat(end_date),
+        status=SemesterStatus.DRAFT,
+        tournament_status="DRAFT",
+        semester_category=SemesterCategory.PROMOTION_EVENT,
+        specialization_type="LFA_FOOTBALL_PLAYER",
+        age_group=age_groups[0] if len(age_groups) == 1 else None,
+        age_groups=age_groups,
+        enrollment_cost=0,
+        campus_id=int(campus_id) if campus_id.strip() else None,
+        organizer_sponsor_id=sponsor.id,
+        organizer_campaign_id=campaign.id,
+        organizer_club_id=None,
+    )
+    db.add(t)
+    db.flush()
 
-        # Derive location from campus
-        if t.campus_id:
-            campus_obj = db.query(Campus).filter(Campus.id == t.campus_id).first()
-            if campus_obj and campus_obj.location_id:
-                t.location_id = campus_obj.location_id
+    # Derive location from campus
+    if t.campus_id:
+        campus_obj = db.query(Campus).filter(Campus.id == t.campus_id).first()
+        if campus_obj and campus_obj.location_id:
+            t.location_id = campus_obj.location_id
 
-        db.add(TournamentConfiguration(
-            semester_id=t.id,
-            tournament_type_id=int(tournament_type_id) if tournament_type_id.strip() else None,
-            participant_type="INDIVIDUAL",       # sponsor events are always INDIVIDUAL
-            number_of_rounds=1,
-        ))
-        # No TournamentTeamEnrollment — sponsor events have no teams
+    db.add(TournamentConfiguration(
+        semester_id=t.id,
+        tournament_type_id=int(tournament_type_id) if tournament_type_id.strip() else None,
+        participant_type="INDIVIDUAL",
+        number_of_rounds=1,
+        assignment_type="OPEN_ASSIGNMENT",
+    ))
 
     db.commit()
     logger.info(

--- a/app/models/semester.py
+++ b/app/models/semester.py
@@ -96,6 +96,10 @@ class Semester(Base):
                                  comment="Specialization type (SEASON types: LFA_PLAYER_PRE/YOUTH/AMATEUR/PRO, GANCUJU_PLAYER, LFA_COACH, INTERNSHIP, OR user license for tournaments: LFA_FOOTBALL_PLAYER)")
     age_group = Column(String(20), nullable=True, index=True,
                       comment="Age group (PRE, YOUTH, AMATEUR, PRO)")
+    age_groups = Column(JSONB, nullable=True,
+                       comment='Multi-age eligibility list e.g. ["PRE","YOUTH"]. '
+                               'Overrides age_group when set. '
+                               'Populated by sponsor promotion when >1 age selected.')
     theme = Column(String(200), nullable=True,
                   comment="Marketing theme (e.g., 'New Year Challenge', 'Q1', 'Fall')")
     focus_description = Column(String(500), nullable=True,

--- a/app/services/tournament/__init__.py
+++ b/app/services/tournament/__init__.py
@@ -20,6 +20,7 @@ from .validation import (
     check_duplicate_enrollment,
     validate_tournament_session_type,
     validate_tournament_attendance_status,
+    get_allowed_age_groups,
 )
 
 from .core import (
@@ -48,6 +49,7 @@ __all__ = [
     "check_duplicate_enrollment",
     "validate_tournament_session_type",
     "validate_tournament_attendance_status",
+    "get_allowed_age_groups",
     # Core CRUD functions
     "create_tournament_semester",
     "create_tournament_sessions",

--- a/app/services/tournament/validation.py
+++ b/app/services/tournament/validation.py
@@ -104,6 +104,22 @@ def validate_tournament_enrollment_age(
     return True, None
 
 
+def get_allowed_age_groups(semester) -> list:
+    """
+    Single source of truth for age eligibility on a Semester.
+
+    Precedence:
+      1. semester.age_groups  (JSONB list — multi-age events)
+      2. semester.age_group   (String — legacy single-age, backward compat)
+      3. None                 (no age restriction)
+    """
+    if semester.age_groups:
+        return list(semester.age_groups)
+    if semester.age_group:
+        return [semester.age_group]
+    return None
+
+
 def validate_tournament_ready_for_enrollment(
     tournament: Semester
 ) -> Tuple[bool, Optional[str]]:

--- a/app/templates/admin/sponsor_promotion_wizard.html
+++ b/app/templates/admin/sponsor_promotion_wizard.html
@@ -146,8 +146,8 @@
                 </div>
             </div>
 
-            <!-- ── Location & Format ───────────────────────────────── -->
-            <h3>Location &amp; Format</h3>
+            <!-- ── Location ───────────────────────────────────────── -->
+            <h3>Location</h3>
 
             <div class="form-group">
                 <label>Location / Campus <span style="font-weight:400;font-size:0.78rem;text-transform:none;letter-spacing:0;color:#a0aec0;">— optional</span></label>
@@ -157,17 +157,6 @@
                     <option value="{{ c.id }}">{{ c.name }}</option>
                     {% endfor %}
                 </select>
-            </div>
-
-            <div class="form-group">
-                <label>Event Format <span style="font-weight:400;font-size:0.78rem;text-transform:none;letter-spacing:0;color:#a0aec0;">— optional</span></label>
-                <select name="tournament_type_id">
-                    <option value="">— select format —</option>
-                    {% for tt in tournament_types %}
-                    <option value="{{ tt.id }}">{{ tt.display_name }}</option>
-                    {% endfor %}
-                </select>
-                <div class="field-hint">Defines scoring and activity structure. Can be set later.</div>
             </div>
 
             <!-- ── Age Category ────────────────────────────────────── -->
@@ -204,7 +193,7 @@
                 </label>
             </div>
             <p class="field-hint" style="margin-top: 0.6rem; margin-bottom: 0;">
-                One promotion event will be created per selected age category.
+                One promotion event will be created for all selected age categories.
             </p>
 
             <!-- ── CTA ───────────────────────────────────────────────── -->

--- a/tests/integration/web_flows/test_sponsor_campaign_promotion.py
+++ b/tests/integration/web_flows/test_sponsor_campaign_promotion.py
@@ -6,7 +6,7 @@ Sponsor Campaign → Promotion Event — P4 integration tests (SPON-CAM-08..13)
   SPON-CAM-09  Wizard POST with valid campaign_id → Semester.organizer_campaign_id == campaign.id
   SPON-CAM-10  Wizard GET with 0 ACTIVE campaigns → 303 redirect with error
   SPON-CAM-11  Wizard POST without campaign_id → 303 + error (no Semester created)
-  SPON-CAM-12  Multi-age-group (PRE+YOUTH) → 2 Semesters, both organizer_campaign_id == campaign.id
+  SPON-CAM-12  Multi-age-group (PRE+YOUTH) → 1 Semester, age_groups=["PRE","YOUTH"], age_group=None
   SPON-CAM-13  Club event (club wizard) → organizer_campaign_id IS NULL
 
 DONE = pytest tests/integration/web_flows/test_sponsor_campaign_promotion.py -v
@@ -24,6 +24,7 @@ from app.dependencies import get_current_user_web
 from app.models.user import User, UserRole
 from app.models.sponsor import Sponsor, SponsorAudienceEntry, SponsorCampaign
 from app.models.semester import Semester
+from app.models.tournament_configuration import TournamentConfiguration
 from app.models.club import CsvImportLog
 from app.core.security import get_password_hash
 from app.services.sponsor_promote_service import promote_entries
@@ -262,9 +263,9 @@ class TestWizardPostNoCampaignRejected:
 # ── SPON-CAM-12 ───────────────────────────────────────────────────────────────
 
 class TestWizardMultiAgeGroup:
-    """SPON-CAM-12: PRE+YOUTH → 2 Semesters, both organizer_campaign_id == campaign.id."""
+    """SPON-CAM-12: PRE+YOUTH → 1 Semester, age_groups=["PRE","YOUTH"], age_group=None."""
 
-    def test_spon_cam_12_two_age_groups_both_linked_to_campaign(self, test_db: Session):
+    def test_spon_cam_12_two_age_groups_single_semester(self, test_db: Session):
         admin = _make_admin(test_db)
         sponsor = _make_sponsor(test_db, admin)
         campaign = _make_campaign(test_db, sponsor, admin)
@@ -290,12 +291,32 @@ class TestWizardMultiAgeGroup:
                 .filter(Semester.organizer_sponsor_id == sponsor.id)
                 .all()
             )
-            assert len(new_sems) == 2
-            for sem in new_sems:
-                assert sem.organizer_campaign_id == campaign.id
-                assert sem.organizer_club_id is None
-            age_groups = {sem.age_group for sem in new_sems}
-            assert age_groups == {"PRE", "YOUTH"}
+            # Single event for all selected age groups
+            assert len(new_sems) == 1
+            s = new_sems[0]
+
+            # Organizer linkage
+            assert s.organizer_campaign_id == campaign.id
+            assert s.organizer_club_id is None
+
+            # Multi-age: age_groups JSONB set, scalar age_group null
+            assert set(s.age_groups) == {"PRE", "YOUTH"}
+            assert s.age_group is None
+
+            # Name has no age-category suffix
+            assert "(PRE)" not in s.name
+            assert "(YOUTH)" not in s.name
+            assert s.name == "CAM-12 Multi Event"
+
+            # Domain defaults
+            assert s.specialization_type == "LFA_FOOTBALL_PLAYER"
+
+            # TournamentConfiguration wired correctly
+            tc = test_db.query(TournamentConfiguration).filter(
+                TournamentConfiguration.semester_id == s.id
+            ).first()
+            assert tc is not None
+            assert tc.assignment_type == "OPEN_ASSIGNMENT"
         finally:
             app.dependency_overrides.clear()
 

--- a/tests/unit/services/test_sponsor_promotion_multi_age.py
+++ b/tests/unit/services/test_sponsor_promotion_multi_age.py
@@ -1,0 +1,154 @@
+"""
+Unit tests for sponsor promotion multi-age redesign (Option B).
+
+Tests verified:
+  MA-01  Single age_groups=[PRE] → age_group='PRE', age_groups=['PRE']
+  MA-02  Multi age_groups=[PRE,YOUTH] → age_group=None, age_groups=['PRE','YOUTH']
+  MA-03  Single age: name carries no age-category suffix
+  MA-04  Multi age: name carries no age-category suffix
+  MA-05  Organizer fields (sponsor_id, campaign_id, club_id) set correctly
+  MA-06  specialization_type == "LFA_FOOTBALL_PLAYER"
+  MA-07  get_allowed_age_groups: multi-age JSONB takes precedence over scalar
+  MA-08  get_allowed_age_groups: scalar age_group backward-compat fallback
+
+DONE = pytest tests/unit/services/test_sponsor_promotion_multi_age.py -v
+"""
+from types import SimpleNamespace
+
+import pytest
+
+from app.models.semester import Semester, SemesterStatus, SemesterCategory
+from app.models.tournament_configuration import TournamentConfiguration
+from app.services.tournament.validation import get_allowed_age_groups
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _make_semester(age_groups: list, tournament_name: str = "Test Event",
+                   sponsor_id: int = 1, campaign_id: int = 10) -> Semester:
+    """Build a Semester the same way the wizard route does — no DB flush needed."""
+    from datetime import date
+    return Semester(
+        code="PROMO-TEST-001",
+        name=tournament_name,
+        start_date=date(2026, 9, 1),
+        end_date=date(2026, 9, 2),
+        status=SemesterStatus.DRAFT,
+        tournament_status="DRAFT",
+        semester_category=SemesterCategory.PROMOTION_EVENT,
+        specialization_type="LFA_FOOTBALL_PLAYER",
+        age_group=age_groups[0] if len(age_groups) == 1 else None,
+        age_groups=age_groups,
+        enrollment_cost=0,
+        organizer_sponsor_id=sponsor_id,
+        organizer_campaign_id=campaign_id,
+        organizer_club_id=None,
+    )
+
+
+def _make_tc(semester_id=None) -> TournamentConfiguration:
+    return TournamentConfiguration(
+        semester_id=semester_id,
+        participant_type="INDIVIDUAL",
+        number_of_rounds=1,
+        assignment_type="OPEN_ASSIGNMENT",
+    )
+
+
+# ── MA-01 / MA-02: age_group vs age_groups semantics ─────────────────────────
+
+class TestAgeGroupFieldSemantics:
+
+    def test_ma_01_single_age_sets_scalar_and_list(self):
+        """Single PRE → age_group='PRE', age_groups=['PRE']."""
+        s = _make_semester(["PRE"])
+        assert s.age_group == "PRE"
+        assert s.age_groups == ["PRE"]
+
+    def test_ma_02_multi_age_nulls_scalar(self):
+        """PRE+YOUTH → age_group=None, age_groups=['PRE','YOUTH']."""
+        s = _make_semester(["PRE", "YOUTH"])
+        assert s.age_group is None
+        assert set(s.age_groups) == {"PRE", "YOUTH"}
+
+    def test_ma_02_four_age_groups(self):
+        """All four groups → age_group=None, age_groups contains all four."""
+        s = _make_semester(["PRE", "YOUTH", "AMATEUR", "PRO"])
+        assert s.age_group is None
+        assert set(s.age_groups) == {"PRE", "YOUTH", "AMATEUR", "PRO"}
+
+
+# ── MA-03 / MA-04: no name suffix ────────────────────────────────────────────
+
+class TestNoNameSuffix:
+    _AGE_SUFFIXES = ("(PRE)", "(YOUTH)", "(AMATEUR)", "(PRO)")
+
+    def test_ma_03_no_suffix_single(self):
+        """Single-age event name must not have any age-category suffix."""
+        s = _make_semester(["PRE"], tournament_name="Spring Cup 2026")
+        assert s.name == "Spring Cup 2026"
+        for suffix in self._AGE_SUFFIXES:
+            assert suffix not in s.name
+
+    def test_ma_04_no_suffix_multi(self):
+        """Multi-age event name must not have any age-category suffix."""
+        s = _make_semester(["PRE", "YOUTH"], tournament_name="Open Challenge")
+        assert s.name == "Open Challenge"
+        for suffix in self._AGE_SUFFIXES:
+            assert suffix not in s.name
+
+
+# ── MA-05 / MA-06: organizer fields + domain defaults ────────────────────────
+
+class TestOrganizerFieldsAndDefaults:
+
+    def test_ma_05_organizer_fields(self):
+        """organizer_sponsor_id + campaign_id set; club_id=None."""
+        s = _make_semester(["YOUTH"], sponsor_id=7, campaign_id=42)
+        assert s.organizer_sponsor_id == 7
+        assert s.organizer_campaign_id == 42
+        assert s.organizer_club_id is None
+
+    def test_ma_06_specialization_type(self):
+        """specialization_type must always be LFA_FOOTBALL_PLAYER."""
+        s = _make_semester(["AMATEUR"])
+        assert s.specialization_type == "LFA_FOOTBALL_PLAYER"
+
+    def test_ma_06_tc_assignment_type(self):
+        """TournamentConfiguration.assignment_type == 'OPEN_ASSIGNMENT'."""
+        tc = _make_tc(semester_id=99)
+        assert tc.assignment_type == "OPEN_ASSIGNMENT"
+        assert tc.participant_type == "INDIVIDUAL"
+
+
+# ── MA-07 / MA-08: get_allowed_age_groups ────────────────────────────────────
+
+class TestGetAllowedAgeGroups:
+
+    def test_ma_07_jsonb_takes_precedence(self):
+        """age_groups JSONB overrides scalar age_group."""
+        sem = SimpleNamespace(age_groups=["PRE", "YOUTH"], age_group="PRE")
+        assert get_allowed_age_groups(sem) == ["PRE", "YOUTH"]
+
+    def test_ma_07_returns_copy(self):
+        """Returns a new list (not a reference to the stored JSONB)."""
+        stored = ["PRE", "YOUTH"]
+        sem = SimpleNamespace(age_groups=stored, age_group=None)
+        result = get_allowed_age_groups(sem)
+        assert result == stored
+        assert result is not stored
+
+    def test_ma_08_scalar_fallback(self):
+        """Falls back to [age_group] when age_groups is None."""
+        sem = SimpleNamespace(age_groups=None, age_group="YOUTH")
+        assert get_allowed_age_groups(sem) == ["YOUTH"]
+
+    def test_ma_08_empty_list_fallback(self):
+        """Empty list is falsy → falls back to scalar."""
+        sem = SimpleNamespace(age_groups=[], age_group="AMATEUR")
+        assert get_allowed_age_groups(sem) == ["AMATEUR"]
+
+    def test_ma_both_none_returns_none(self):
+        """No restriction when both fields are None."""
+        sem = SimpleNamespace(age_groups=None, age_group=None)
+        assert get_allowed_age_groups(sem) is None

--- a/tests/unit/services/test_tournament_enroll.py
+++ b/tests/unit/services/test_tournament_enroll.py
@@ -77,13 +77,15 @@ def _seq_db(*qs):
     return db
 
 
-def _tournament(*, status="ENROLLMENT_OPEN", age_group="PRE", cost=500, max_players=32):
+def _tournament(*, status="ENROLLMENT_OPEN", age_group="PRE", cost=500, max_players=32,
+                age_groups=None):
     t = MagicMock()
     t.id = 1
     t.tournament_status = status
     t.name = "LFA Tournament"
     t.code = "LFA-T-001"
     t.age_group = age_group
+    t.age_groups = age_groups  # None for single-age legacy; explicit list for multi-age
     t.enrollment_cost = cost
     t.max_players = max_players
     t.start_date.isoformat.return_value = "2024-07-01"
@@ -239,17 +241,19 @@ class TestEnrollInTournament:
                 assert "cannot enroll" not in str(exc)
 
     def test_400_age_category_validation_fails(self):
+        """PRE player in PRO-only tournament → 400, detail names both categories."""
         t = _tournament(age_group="PRO")
         lic = _license()
         db = _seq_db(_q(first=t), _q(first=None), _q(first=lic))
         with patch(f"{_BASE}.get_current_season_year", return_value=2024), \
              patch(f"{_BASE}.calculate_age_at_season_start", return_value=10), \
-             patch(f"{_BASE}.get_automatic_age_category", return_value="PRE"), \
-             patch(f"{_BASE}.validate_tournament_enrollment_age", return_value=(False, "PRE cannot enroll in PRO")):
+             patch(f"{_BASE}.get_automatic_age_category", return_value="PRE"):
             with pytest.raises(Exception) as exc:
                 enroll_in_tournament(self.TID, db=db, current_user=_student())
         assert exc.value.status_code == 400
-        assert "PRE cannot enroll in PRO" in exc.value.detail
+        # New message: "Your age category (PRE) is not eligible...Eligible: ['PRO']"
+        assert "PRE" in exc.value.detail
+        assert "PRO" in exc.value.detail
 
     def test_400_tournament_full(self):
         t = _tournament(max_players=16)


### PR DESCRIPTION
## Summary

- **Root cause**: promotion wizard looped \`for ag in age_groups\` creating one \`Semester\` per age category, fragmenting what is logically a single event into N database records
- **Fix**: single \`Semester\` per wizard POST; new \`age_groups JSONB\` column stores the full selected list; scalar \`age_group\` kept populated for single-age events (backward compat)
- **Bonus fixes**: \`specialization_type\` and \`assignment_type\` were silently left NULL on all promotion events — both now set explicitly

## Migrations

| File | Type | Detail |
|---|---|---|
| \`2026_05_03_1600_p6_p7_campaign_credit.py\` | **Restored** | File existed in git history (commit fc3e2d6) but was missing from working tree; DB already had this revision applied — restoring it unblocks \`alembic upgrade head\` |
| \`2026_05_05_1000_semesters_age_groups.py\` | **New** | \`semesters.age_groups JSONB NULL\` — ADD COLUMN only, **no backfill**; \`get_allowed_age_groups()\` fallback chain handles all existing rows |

Chain: \`…2026_05_03_1500 → 2026_05_03_1600 → 2026_05_05_1000 (head)\`
Downgrade/upgrade round-trip: verified clean.

## Application changes

| Layer | Change |
|---|---|
| \`Semester\` model | \`age_groups JSONB\` column |
| \`validation.py\` | \`get_allowed_age_groups(sem)\` — precedence: \`age_groups\` > \`age_group\` > \`None\` |
| \`tournament/__init__.py\` | exports \`get_allowed_age_groups\` |
| \`sponsors.py\` route | per-age loop → single Semester; \`age_group=scalar\|None\`; explicit \`specialization_type="LFA_FOOTBALL_PLAYER"\` and \`assignment_type="OPEN_ASSIGNMENT"\` |
| Wizard template | Event Format select removed; header "Location & Format" → "Location"; hint updated |
| \`enroll.py\` | 18+ inference uses \`get_allowed_age_groups()\`; multi-adult ambiguity raises explicit 400 |

## Test changes

| File | Change |
|---|---|
| \`test_sponsor_campaign_promotion.py\` (SPON-CAM-12) | Updated: 1 Semester assertion + \`age_groups\`, \`age_group\`, name, \`specialization_type\`, \`assignment_type\` checks |
| \`test_sponsor_promotion_multi_age.py\` | New: 13 unit tests (MA-01..08) — pure model + \`get_allowed_age_groups\` coverage |
| \`test_tournament_enroll.py\` | \`_tournament()\` mock gets explicit \`age_groups=None\`; \`test_400_age_category_validation_fails\` assertion updated to new error format |

## Test plan

- [ ] 32/32 local: SPON-CAM integration + MA unit + P0-A self-match
- [ ] 27/27 \`test_tournament_enroll.py\` (including the two fixed tests)
- [ ] CI green on HEAD SHA \`d23bd4a\`
- [ ] Migration chain: \`alembic heads\` = single head, downgrade/upgrade clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)