### PR TITLE
feat(tournament): guard PROMOTION_EVENT age group from configure-wizard override

### DIFF
--- a/app/api/api_v1/endpoints/tournaments/lifecycle_updates.py
+++ b/app/api/api_v1/endpoints/tournaments/lifecycle_updates.py
@@ -17,7 +17,7 @@ from pydantic import BaseModel, Field
 from app.database import get_db
 from app.dependencies import get_current_admin_user_hybrid
 from app.models.user import User, UserRole
-from app.models.semester import Semester
+from app.models.semester import Semester, SemesterCategory
 from app.models.specialization import SpecializationType
 from app.api.api_v1.endpoints.tournaments.lifecycle import record_status_change
 
@@ -137,6 +137,11 @@ def update_tournament(
 
     # Update age_group
     if request.age_group is not None:
+        if tournament.semester_category == SemesterCategory.PROMOTION_EVENT:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Age group cannot be changed for promotion events.",
+            )
         updates["age_group"] = {"old": tournament.age_group, "new": request.age_group}
         tournament.age_group = request.age_group
 

--- a/app/api/web_routes/tournaments/edit.py
+++ b/app/api/web_routes/tournaments/edit.py
@@ -10,7 +10,8 @@ from ....dependencies import get_current_user_web
 from ....models.campus import Campus
 from ....models.game_preset import GamePreset
 from ....models.location import Location
-from ....models.semester import Semester
+from ....models.semester import Semester, SemesterCategory
+from ....services.tournament import get_allowed_age_groups
 from ....models.semester_enrollment import SemesterEnrollment
 from ....models.session import Session as SessionModel, EventCategory
 from ....models.team import Team, TournamentTeamEnrollment
@@ -261,6 +262,8 @@ async def admin_tournament_edit_page(
             "eligible_instructors": eligible_instructors,
             "pitches_for_roster": pitches_for_roster,
             "has_absent_field": has_absent_field,
+            "is_promotion_event": t.semester_category == SemesterCategory.PROMOTION_EVENT,
+            "promotion_age_groups": get_allowed_age_groups(t),
             "flash": request.query_params.get("flash"),
             "error": request.query_params.get("error"),
         },

--- a/app/templates/admin/tournament_edit.html
+++ b/app/templates/admin/tournament_edit.html
@@ -292,11 +292,17 @@ ID {{ t.id }} · {{ t.code }} · <strong>{{ t.tournament_status or t.status.valu
     <div class="form-row">
         <div class="form-group">
             <label>Age Group</label>
+            {% if is_promotion_event %}
+            <div id="basic-age-group-readonly" class="form-control-plaintext">
+                {{ promotion_age_groups | join(", ") if promotion_age_groups else "—" }}
+            </div>
+            {% else %}
             <select id="basic-age-group">
                 {% for ag in ['PRE', 'YOUTH', 'AMATEUR', 'PRO'] %}
                 <option value="{{ ag }}" {% if t.age_group == ag %}selected{% endif %}>{{ ag }}</option>
                 {% endfor %}
             </select>
+            {% endif %}
         </div>
         <div class="form-group">
             <label>Max Players</label>
@@ -1279,7 +1285,7 @@ async function saveBasicInfo() {
         start_date:      document.getElementById('basic-start-date').value || undefined,
         end_date:        document.getElementById('basic-end-date').value || undefined,
         enrollment_cost: parseInt(document.getElementById('basic-enrollment-cost').value) || 0,
-        age_group:       document.getElementById('basic-age-group').value || undefined,
+        age_group:       document.getElementById('basic-age-group')?.value || undefined,
         campus_id:       parseInt(document.getElementById('basic-campus-id').value) || undefined,
         location_id:     parseInt(document.getElementById('basic-location-id').value) || undefined,
     };

--- a/tests/integration/web_flows/test_tournament_edit_ui.py
+++ b/tests/integration/web_flows/test_tournament_edit_ui.py
@@ -1,0 +1,145 @@
+"""
+Integration tests — tournament edit page age group field rendering.
+
+  EDIT-UI-01  PROMOTION_EVENT (multi-age) → id="basic-age-group-readonly" present,
+              id="basic-age-group" absent
+  EDIT-UI-02  PROMOTION_EVENT (single-age) → id="basic-age-group-readonly" present,
+              id="basic-age-group" absent
+  EDIT-UI-03  Non-promotion event → id="basic-age-group" present
+
+DONE = pytest tests/integration/web_flows/test_tournament_edit_ui.py -v
+"""
+import uuid
+from datetime import date
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.main import app
+from app.database import get_db
+from app.dependencies import get_current_user_web
+from app.models.user import User, UserRole
+from app.models.semester import Semester, SemesterStatus, SemesterCategory
+from app.core.security import get_password_hash
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _make_admin(db: Session) -> User:
+    u = User(
+        email=f"edit-ui-admin+{uuid.uuid4().hex[:8]}@lfa.com",
+        name="Edit UI Admin",
+        password_hash=get_password_hash("Admin1234!"),
+        role=UserRole.ADMIN,
+        is_active=True,
+    )
+    db.add(u)
+    db.flush()
+    return u
+
+
+def _make_promotion_semester(db: Session, age_groups: list) -> Semester:
+    sem = Semester(
+        code=f"PROMO-UI-{uuid.uuid4().hex[:6]}",
+        name="UI Test Promo Event",
+        start_date=date(2026, 9, 1),
+        end_date=date(2026, 9, 2),
+        status=SemesterStatus.DRAFT,
+        tournament_status="DRAFT",
+        semester_category=SemesterCategory.PROMOTION_EVENT,
+        age_group=age_groups[0] if len(age_groups) == 1 else None,
+        age_groups=age_groups,
+        enrollment_cost=0,
+    )
+    db.add(sem)
+    db.flush()
+    return sem
+
+
+def _make_mini_season_semester(db: Session) -> Semester:
+    sem = Semester(
+        code=f"MINI-UI-{uuid.uuid4().hex[:6]}",
+        name="UI Test Mini Season",
+        start_date=date(2026, 9, 1),
+        end_date=date(2026, 9, 2),
+        status=SemesterStatus.DRAFT,
+        tournament_status="DRAFT",
+        semester_category=SemesterCategory.MINI_SEASON,
+        age_group="AMATEUR",
+        enrollment_cost=0,
+    )
+    db.add(sem)
+    db.flush()
+    return sem
+
+
+def _client(db: Session, admin: User) -> TestClient:
+    app.dependency_overrides[get_db] = lambda: db
+    app.dependency_overrides[get_current_user_web] = lambda: admin
+    return TestClient(app, headers={"Authorization": "Bearer test-csrf-bypass"})
+
+
+# ── EDIT-UI-01 ────────────────────────────────────────────────────────────────
+
+class TestPromotionEventMultiAge:
+    """EDIT-UI-01: multi-age PROMOTION_EVENT → readonly div, no select."""
+
+    def test_edit_ui_01_readonly_present_select_absent(self, test_db: Session):
+        admin = _make_admin(test_db)
+        sem = _make_promotion_semester(test_db, age_groups=["PRE", "YOUTH"])
+        test_db.commit()
+
+        client = _client(test_db, admin)
+        try:
+            resp = client.get(f"/admin/tournaments/{sem.id}/edit")
+            assert resp.status_code == 200
+
+            html = resp.text
+            assert 'id="basic-age-group-readonly"' in html
+            assert 'id="basic-age-group"' not in html
+        finally:
+            app.dependency_overrides.clear()
+
+
+# ── EDIT-UI-02 ────────────────────────────────────────────────────────────────
+
+class TestPromotionEventSingleAge:
+    """EDIT-UI-02: single-age PROMOTION_EVENT → readonly div, no select."""
+
+    def test_edit_ui_02_readonly_present_select_absent(self, test_db: Session):
+        admin = _make_admin(test_db)
+        sem = _make_promotion_semester(test_db, age_groups=["PRE"])
+        test_db.commit()
+
+        client = _client(test_db, admin)
+        try:
+            resp = client.get(f"/admin/tournaments/{sem.id}/edit")
+            assert resp.status_code == 200
+
+            html = resp.text
+            assert 'id="basic-age-group-readonly"' in html
+            assert 'id="basic-age-group"' not in html
+        finally:
+            app.dependency_overrides.clear()
+
+
+# ── EDIT-UI-03 ────────────────────────────────────────────────────────────────
+
+class TestNonPromotionEventSelect:
+    """EDIT-UI-03: non-promotion event → age group <select> rendered normally."""
+
+    def test_edit_ui_03_select_present(self, test_db: Session):
+        admin = _make_admin(test_db)
+        sem = _make_mini_season_semester(test_db)
+        test_db.commit()
+
+        client = _client(test_db, admin)
+        try:
+            resp = client.get(f"/admin/tournaments/{sem.id}/edit")
+            assert resp.status_code == 200
+
+            assert 'id="basic-age-group"' in resp.text
+            assert 'id="basic-age-group-readonly"' not in resp.text
+        finally:
+            app.dependency_overrides.clear()

--- a/tests/unit/test_lifecycle_updates.py
+++ b/tests/unit/test_lifecycle_updates.py
@@ -35,6 +35,7 @@ from app.api.api_v1.endpoints.tournaments.lifecycle_updates import (
     TournamentUpdateRequest,
 )
 from app.models.user import UserRole
+from app.models.semester import SemesterCategory
 
 _VALID = "app.services.tournament.status_validator.VALID_TRANSITIONS"
 _TSG   = "app.services.tournament_session_generator.TournamentSessionGenerator"
@@ -85,6 +86,8 @@ def _tournament(**overrides):
     t.name = "Old Name"
     t.enrollment_cost = 100
     t.age_group = "AMATEUR"
+    t.age_groups = None          # explicit None — prevents MagicMock auto-attr trap
+    t.semester_category = None   # explicit None — enum comparison safe
     t.focus_description = "Old Desc"
     t.start_date = date(2026, 4, 1)
     t.end_date = date(2026, 5, 1)
@@ -185,6 +188,20 @@ class TestUpdateTournamentSimpleFields:
         t = _tournament()
         result = update_tournament(1, TournamentUpdateRequest(age_group="YOUTH"), db=_db(t), current_user=_admin())
         assert t.age_group == "YOUTH"
+
+    def test_age_group_blocked_for_promotion_event(self):
+        """PROMOTION_EVENT guard: 400 raised; age_group and age_groups unchanged."""
+        t = _tournament(
+            age_group="PRE",
+            age_groups=["PRE", "YOUTH"],
+            semester_category=SemesterCategory.PROMOTION_EVENT,
+        )
+        with pytest.raises(HTTPException) as exc:
+            update_tournament(1, TournamentUpdateRequest(age_group="AMATEUR"), db=_db(t), current_user=_admin())
+        assert exc.value.status_code == 400
+        assert "promotion" in exc.value.detail.lower()
+        assert t.age_group == "PRE"
+        assert t.age_groups == ["PRE", "YOUTH"]
 
     def test_update_description(self):
         t = _tournament()


### PR DESCRIPTION
## Summary

- **Backend guard** (`lifecycle_updates.py`): `PATCH /{id}` raises 400 when `semester_category == PROMOTION_EVENT` and `age_group` is submitted — `age_group` and `age_groups` stay unchanged
- **UI** (`tournament_edit.html`): age group field renders as read-only plaintext (`id="basic-age-group-readonly"`) for promotion events; editable `<select id="basic-age-group">` suppressed; JS uses `?.value` (optional chaining) to avoid null-deref when select absent
- **Route** (`edit.py`): GET handler injects `is_promotion_event` + `promotion_age_groups` into template context

## Tests

| Suite | Tests | Result |
|---|---|---|
| `test_lifecycle_updates.py` | 44 (1 new guard test + `_tournament()` helper fix) | ✅ |
| `test_tournament_edit_ui.py` (new) | 3 (EDIT-UI-01/02/03) | ✅ |

**Guard test** asserts 400 + `age_group` unchanged + `age_groups` unchanged after PROMOTION_EVENT block fires.

**UI tests** use stable `id`-based assertions — no brittle text-content matching.

## Test plan

- [ ] `pytest tests/unit/test_lifecycle_updates.py -v` — 44/44 green
- [ ] `pytest tests/integration/web_flows/test_tournament_edit_ui.py -v` — 3/3 green
- [ ] Manual: open `/admin/tournaments/{promo_id}/edit` — age group field shows read-only text, no select
- [ ] Manual: open `/admin/tournaments/{mini_id}/edit` — age group select renders normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)