### PR TITLE
feat(tournament): guard PROMOTION_EVENT participant_type from configure-wizard override

### DIFF
--- a/app/api/api_v1/endpoints/tournaments/lifecycle_updates.py
+++ b/app/api/api_v1/endpoints/tournaments/lifecycle_updates.py
@@ -195,6 +195,11 @@ def update_tournament(
 
     # Update participant_type (lives in TournamentConfiguration)
     if request.participant_type is not None:
+        if tournament.semester_category == SemesterCategory.PROMOTION_EVENT:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Participant type cannot be changed for promotion events.",
+            )
         valid_types = ["INDIVIDUAL", "TEAM", "MIXED"]
         if request.participant_type not in valid_types:
             raise HTTPException(

--- a/app/templates/admin/tournament_edit.html
+++ b/app/templates/admin/tournament_edit.html
@@ -363,6 +363,9 @@ ID {{ t.id }} · {{ t.code }} · <strong>{{ t.tournament_status or t.status.valu
         </div>
         <div class="form-group">
             <label>Participant Type</label>
+            {% if is_promotion_event %}
+            <div id="basic-participant-type-readonly" class="form-control-plaintext">👤 Individual</div>
+            {% else %}
             <select id="basic-participant-type-h2h">
                 <option value="INDIVIDUAL" {% if not cfg or cfg.participant_type == 'INDIVIDUAL' %}selected{% endif %}>👤 Individual</option>
                 <option value="TEAM" {% if cfg and cfg.participant_type == 'TEAM' %}selected{% endif %}>👥 Team</option>
@@ -370,6 +373,7 @@ ID {{ t.id }} · {{ t.code }} · <strong>{{ t.tournament_status or t.status.valu
             </select>
             {% if cfg and cfg.participant_type == 'TEAM' %}
             <a href="/admin/tournaments/{{ t.id }}/teams" class="btn btn-sm btn-outline" style="margin-top:6px">👥 Manage Teams →</a>
+            {% endif %}
             {% endif %}
         </div>
         <div class="form-group">
@@ -410,10 +414,14 @@ ID {{ t.id }} · {{ t.code }} · <strong>{{ t.tournament_status or t.status.valu
         </div>
         <div class="form-group">
             <label>Participant Type</label>
+            {% if is_promotion_event %}
+            <div id="basic-participant-type-readonly" class="form-control-plaintext">👤 Individual</div>
+            {% else %}
             <select id="basic-participant-type-ir">
                 <option value="INDIVIDUAL" {% if not cfg or cfg.participant_type == 'INDIVIDUAL' %}selected{% endif %}>👤 Individual</option>
                 <option value="TEAM" {% if cfg and cfg.participant_type == 'TEAM' %}selected{% endif %}>👥 Team</option>
             </select>
+            {% endif %}
         </div>
         <div class="form-group">
             <label>Number of Rounds</label>
@@ -1295,7 +1303,7 @@ async function saveBasicInfo() {
     if (_currentFormat === 'HEAD_TO_HEAD') {
         const ttId = document.getElementById('basic-tournament-type').value;
         if (ttId) body.tournament_type_id = parseInt(ttId);
-        const ptVal = document.getElementById('basic-participant-type-h2h').value;
+        const ptVal = document.getElementById('basic-participant-type-h2h')?.value;
         if (ptVal) body.participant_type = ptVal;
         const gpVal = document.getElementById('basic-game-preset-id-h2h').value;
         if (gpVal) body.game_preset_id = parseInt(gpVal);
@@ -1306,7 +1314,7 @@ async function saveBasicInfo() {
         body.ranking_direction = document.getElementById('basic-ranking-direction').value;
         const muEl = document.getElementById('basic-measurement-unit');
         if (muEl && muEl.value.trim()) body.measurement_unit = muEl.value.trim();
-        const ptVal = document.getElementById('basic-participant-type-ir').value;
+        const ptVal = document.getElementById('basic-participant-type-ir')?.value;
         if (ptVal) body.participant_type = ptVal;
         const roundsVal = document.getElementById('basic-rounds').value;
         if (roundsVal) body.number_of_rounds = parseInt(roundsVal);

--- a/tests/integration/web_flows/test_tournament_edit_ui.py
+++ b/tests/integration/web_flows/test_tournament_edit_ui.py
@@ -1,11 +1,14 @@
 """
-Integration tests — tournament edit page age group field rendering.
+Integration tests — tournament edit page age group + participant type field rendering.
 
   EDIT-UI-01  PROMOTION_EVENT (multi-age) → id="basic-age-group-readonly" present,
               id="basic-age-group" absent
   EDIT-UI-02  PROMOTION_EVENT (single-age) → id="basic-age-group-readonly" present,
               id="basic-age-group" absent
   EDIT-UI-03  Non-promotion event → id="basic-age-group" present
+  EDIT-UI-04  PROMOTION_EVENT → id="basic-participant-type-readonly" present,
+              id="basic-participant-type-h2h" and id="basic-participant-type-ir" absent
+  EDIT-UI-05  Non-promotion event (H2H format) → id="basic-participant-type-h2h" present
 
 DONE = pytest tests/integration/web_flows/test_tournament_edit_ui.py -v
 """
@@ -141,5 +144,53 @@ class TestNonPromotionEventSelect:
 
             assert 'id="basic-age-group"' in resp.text
             assert 'id="basic-age-group-readonly"' not in resp.text
+        finally:
+            app.dependency_overrides.clear()
+
+
+# ── EDIT-UI-04 ────────────────────────────────────────────────────────────────
+
+class TestPromotionEventParticipantTypeReadOnly:
+    """EDIT-UI-04: PROMOTION_EVENT → participant_type readonly div, no selects."""
+
+    def test_edit_ui_04_readonly_present_selects_absent(self, test_db: Session):
+        admin = _make_admin(test_db)
+        sem = _make_promotion_semester(test_db, age_groups=["PRE", "YOUTH"])
+        test_db.commit()
+
+        client = _client(test_db, admin)
+        try:
+            resp = client.get(f"/admin/tournaments/{sem.id}/edit")
+            assert resp.status_code == 200
+
+            html = resp.text
+            assert 'id="basic-participant-type-readonly"' in html
+            assert 'id="basic-participant-type-h2h"' not in html
+            assert 'id="basic-participant-type-ir"' not in html
+        finally:
+            app.dependency_overrides.clear()
+
+
+# ── EDIT-UI-05 ────────────────────────────────────────────────────────────────
+
+class TestNonPromotionEventParticipantTypeSelect:
+    """EDIT-UI-05: non-promotion event → participant_type select rendered normally."""
+
+    def test_edit_ui_05_select_present(self, test_db: Session):
+        admin = _make_admin(test_db)
+        sem = _make_mini_season_semester(test_db)
+        test_db.commit()
+
+        client = _client(test_db, admin)
+        try:
+            resp = client.get(f"/admin/tournaments/{sem.id}/edit")
+            assert resp.status_code == 200
+
+            html = resp.text
+            assert 'id="basic-participant-type-readonly"' not in html
+            assert (
+                'id="basic-participant-type-h2h"' in html
+                or 'id="basic-participant-type-ir"' in html
+            )
         finally:
             app.dependency_overrides.clear()

--- a/tests/unit/test_lifecycle_updates.py
+++ b/tests/unit/test_lifecycle_updates.py
@@ -203,6 +203,16 @@ class TestUpdateTournamentSimpleFields:
         assert t.age_group == "PRE"
         assert t.age_groups == ["PRE", "YOUTH"]
 
+    def test_participant_type_blocked_for_promotion_event(self):
+        """PROMOTION_EVENT guard: participant_type PATCH → 400; cfg.participant_type unchanged."""
+        t = _tournament(semester_category=SemesterCategory.PROMOTION_EVENT)
+        t.tournament_config_obj.participant_type = "INDIVIDUAL"
+        with pytest.raises(HTTPException) as exc:
+            update_tournament(1, TournamentUpdateRequest(participant_type="TEAM"), db=_db(t), current_user=_admin())
+        assert exc.value.status_code == 400
+        assert "promotion" in exc.value.detail.lower()
+        assert t.tournament_config_obj.participant_type == "INDIVIDUAL"
+
     def test_update_description(self):
         t = _tournament()
         result = update_tournament(1, TournamentUpdateRequest(description="New desc"), db=_db(t), current_user=_admin())


### PR DESCRIPTION
## Summary

- **Backend guard** (`lifecycle_updates.py`): `PATCH /{id}` raises 400 when `semester_category == PROMOTION_EVENT` and `participant_type` is submitted — mirrors the `age_group` guard from #132
- **UI** (`tournament_edit.html`): both `basic-participant-type-h2h` and `basic-participant-type-ir` selects suppressed for PROMOTION_EVENT; replaced with read-only plaintext `id="basic-participant-type-readonly"`; JS uses `?.value` optional chaining on both selects
- No changes to `enroll.py`, `promote_entries()`, session generation, lifecycle, or migrations

## Tests

| Suite | Tests | Result |
|---|---|---|
| `test_lifecycle_updates.py` | 45 (1 new guard test) | ✅ |
| `test_tournament_edit_ui.py` | 5 (2 new: EDIT-UI-04/05) | ✅ |
| Combined | **50 passed** | ✅ |

**Guard test**: asserts 400 + `cfg.participant_type` unchanged after PROMOTION_EVENT block fires.

**UI tests**: stable `id`-based assertions — readonly div present/absent, selects present/absent per category.

## Test plan

- [ ] `pytest tests/unit/test_lifecycle_updates.py tests/integration/web_flows/test_tournament_edit_ui.py` — 50/50 green
- [ ] Manual: `/admin/tournaments/{promo_id}/edit` → participant type shows "👤 Individual" read-only, no select
- [ ] Manual: `/admin/tournaments/{normal_id}/edit` → participant type select visible and editable

🤖 Generated with [Claude Code](https://claude.com/claude-code)