### PR TITLE
feat(promotion-event): PR1 — enrollment guards + campaign audience placeholder

### DIFF
--- a/app/api/api_v1/endpoints/tournaments/enroll.py
+++ b/app/api/api_v1/endpoints/tournaments/enroll.py
@@ -11,7 +11,7 @@ from datetime import datetime, timedelta
 from app.database import get_db
 from app.api.deps import get_current_user
 from app.models.user import User, UserRole
-from app.models.semester import Semester
+from app.models.semester import Semester, SemesterCategory
 from app.models.semester_enrollment import SemesterEnrollment, EnrollmentStatus
 from app.models.license import UserLicense
 from app.models.session import Session as SessionModel
@@ -81,7 +81,14 @@ def enroll_in_tournament(
             detail="Tournament not found"
         )
 
-    # 2. Verify tournament status (check tournament_status field, NOT the old status field)
+    # 2. Block self-enrollment for PROMOTION_EVENT — participants come from sponsor campaign audience
+    if tournament.semester_category == SemesterCategory.PROMOTION_EVENT:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="This event accepts participants by invitation only.",
+        )
+
+    # 3. Verify tournament status (check tournament_status field, NOT the old status field)
     # Only ENROLLMENT_OPEN and IN_PROGRESS allow enrollment
     # ENROLLMENT_CLOSED does NOT allow new enrollments (enrollment period ended)
     if tournament.tournament_status not in ["ENROLLMENT_OPEN", "IN_PROGRESS"]:

--- a/app/api/web_routes/tournaments/players.py
+++ b/app/api/web_routes/tournaments/players.py
@@ -11,7 +11,7 @@ from ....database import get_db
 from ....dependencies import get_current_user_web, get_current_admin_or_instructor_user_hybrid
 from ....models.club import Club
 from ....models.license import UserLicense
-from ....models.semester import Semester
+from ....models.semester import Semester, SemesterCategory
 from ....models.semester_enrollment import SemesterEnrollment
 from ....models.team import Team, TeamMember
 from ....models.user import User
@@ -19,6 +19,20 @@ import app.services.tournament.enrollment_service as _enroll_service
 from . import templates, _admin_only
 
 router = APIRouter()
+
+_PROMO_GUARD_MSG = "Standard enrollment management is not available for promotion events."
+
+
+def _fetch_tournament_or_404(db: Session, tournament_id: int) -> Semester:
+    t = db.query(Semester).filter(Semester.id == tournament_id).first()
+    if not t:
+        raise HTTPException(status_code=404, detail="Tournament not found")
+    return t
+
+
+def _raise_if_promotion_event(t: Semester) -> None:
+    if t.semester_category == SemesterCategory.PROMOTION_EVENT:
+        raise HTTPException(status_code=400, detail=_PROMO_GUARD_MSG)
 
 
 @router.get("/admin/tournaments/{tournament_id}/players", response_class=HTMLResponse)
@@ -35,6 +49,11 @@ async def admin_tournament_players_page(
     if not t:
         return RedirectResponse(url="/admin/tournaments?error=Tournament+not+found", status_code=303)
 
+    if t.semester_category == SemesterCategory.PROMOTION_EVENT:
+        return RedirectResponse(
+            url=f"/admin/tournaments/{tournament_id}/edit?error=Player+management+is+not+available+for+promotion+events",
+            status_code=303,
+        )
     cfg = t.tournament_config_obj
     if cfg is None:
         return RedirectResponse(
@@ -122,6 +141,7 @@ async def admin_tournament_players_enroll(
     """Enroll a single player into an INDIVIDUAL tournament (admin bypass)."""
     _admin_only(user)
     try:
+        _raise_if_promotion_event(_fetch_tournament_or_404(db, tournament_id))
         _enroll_service.enroll_player_admin(db, tournament_id, user_id, user.id)
         db.commit()
         return RedirectResponse(
@@ -146,6 +166,7 @@ async def admin_tournament_players_remove(
     """Remove a player's active enrollment from an INDIVIDUAL tournament."""
     _admin_only(user)
     try:
+        _raise_if_promotion_event(_fetch_tournament_or_404(db, tournament_id))
         _enroll_service.unenroll_player_admin(db, tournament_id, player_user_id)
         db.commit()
         return RedirectResponse(
@@ -173,6 +194,11 @@ async def admin_tournament_players_enroll_from_team(
     t = db.query(Semester).filter(Semester.id == tournament_id).first()
     if not t:
         return RedirectResponse(url="/admin/tournaments?error=Tournament+not+found", status_code=303)
+    if t.semester_category == SemesterCategory.PROMOTION_EVENT:
+        return RedirectResponse(
+            url=f"/admin/tournaments/{tournament_id}/edit?error=Player+management+is+not+available+for+promotion+events",
+            status_code=303,
+        )
     if t.tournament_status != "ENROLLMENT_OPEN":
         return RedirectResponse(
             url=f"/admin/tournaments/{tournament_id}/players?error=Enrollment+is+not+open",
@@ -356,6 +382,7 @@ async def admin_enroll_player(
     user: User = Depends(get_current_admin_or_instructor_user_hybrid),
 ):
     """Bulk-enroll one or more players (admin bypass — no credit deduction)."""
+    _raise_if_promotion_event(_fetch_tournament_or_404(db, tournament_id))
     body = await request.json()
     user_ids = body.get("user_ids", [])
 
@@ -382,6 +409,7 @@ async def admin_unenroll_player(
     user: User = Depends(get_current_admin_or_instructor_user_hybrid),
 ):
     """Remove a player's active enrollment (admin action)."""
+    _raise_if_promotion_event(_fetch_tournament_or_404(db, tournament_id))
     body = await request.json()
     uid = body.get("user_id")
     if not uid:

--- a/app/templates/admin/tournament_edit.html
+++ b/app/templates/admin/tournament_edit.html
@@ -591,7 +591,19 @@ ID {{ t.id }} · {{ t.code }} · <strong>{{ t.tournament_status or t.status.valu
   <div class="wiz-step-body">
 
 {# ── SECTION 4: Enrolled Players / Teams ─────────────────────────────────── #}
-{% if cfg and cfg.participant_type == 'TEAM' %}
+{% if is_promotion_event %}
+<div class="card" id="section-campaign-audience-placeholder">
+    <div class="section-header">
+        <span class="section-icon">📋</span>
+        <h2>Campaign Audience</h2>
+    </div>
+    <p style="color:#a0aec0;margin:0 0 .75rem;">
+        Participants for this event come from the sponsor campaign audience, not from standard enrollment.
+        Standard player add/remove actions are disabled for promotion events.
+    </p>
+    <a href="#section-campaign-audience" class="btn btn-outline" style="display:inline-block;">View Campaign Audience ↓</a>
+</div>
+{% elif cfg and cfg.participant_type == 'TEAM' %}
 <div class="card" id="section-checkin">
     <div class="section-header">
         <span class="section-icon">👥</span>

--- a/tests/integration/web_flows/test_tournament_edit_ui.py
+++ b/tests/integration/web_flows/test_tournament_edit_ui.py
@@ -1,11 +1,15 @@
 """
-Integration tests — tournament edit page age group field rendering.
+Integration tests — tournament edit page field rendering.
 
   EDIT-UI-01  PROMOTION_EVENT (multi-age) → id="basic-age-group-readonly" present,
               id="basic-age-group" absent
   EDIT-UI-02  PROMOTION_EVENT (single-age) → id="basic-age-group-readonly" present,
               id="basic-age-group" absent
   EDIT-UI-03  Non-promotion event → id="basic-age-group" present
+  EDIT-UI-06  PROMOTION_EVENT → campaign audience placeholder shown, standard
+              enrolled-players section absent
+  EDIT-UI-07  Non-promotion event → standard enrolled-players section shown,
+              campaign audience placeholder absent
 
 DONE = pytest tests/integration/web_flows/test_tournament_edit_ui.py -v
 """
@@ -141,5 +145,51 @@ class TestNonPromotionEventSelect:
 
             assert 'id="basic-age-group"' in resp.text
             assert 'id="basic-age-group-readonly"' not in resp.text
+        finally:
+            app.dependency_overrides.clear()
+
+
+# ── EDIT-UI-06 ────────────────────────────────────────────────────────────────
+
+class TestPromotionEventEnrolledPlayersSection:
+    """EDIT-UI-06: PROMOTION_EVENT → campaign audience placeholder shown; standard
+    enrolled-players section absent."""
+
+    def test_edit_ui_06_campaign_placeholder_present_enrolled_absent(self, test_db: Session):
+        admin = _make_admin(test_db)
+        sem = _make_promotion_semester(test_db, age_groups=["PRE", "YOUTH"])
+        test_db.commit()
+
+        client = _client(test_db, admin)
+        try:
+            resp = client.get(f"/admin/tournaments/{sem.id}/edit")
+            assert resp.status_code == 200
+
+            html = resp.text
+            assert 'id="section-campaign-audience-placeholder"' in html
+            assert 'id="section-checkin"' not in html
+        finally:
+            app.dependency_overrides.clear()
+
+
+# ── EDIT-UI-07 ────────────────────────────────────────────────────────────────
+
+class TestNonPromotionEventEnrolledPlayersSection:
+    """EDIT-UI-07: non-promotion event → standard enrolled-players section shown;
+    campaign audience placeholder absent."""
+
+    def test_edit_ui_07_enrolled_section_present_placeholder_absent(self, test_db: Session):
+        admin = _make_admin(test_db)
+        sem = _make_mini_season_semester(test_db)
+        test_db.commit()
+
+        client = _client(test_db, admin)
+        try:
+            resp = client.get(f"/admin/tournaments/{sem.id}/edit")
+            assert resp.status_code == 200
+
+            html = resp.text
+            assert 'id="section-checkin"' in html
+            assert 'id="section-campaign-audience-placeholder"' not in html
         finally:
             app.dependency_overrides.clear()

--- a/tests/unit/services/test_tournament_enroll.py
+++ b/tests/unit/services/test_tournament_enroll.py
@@ -42,6 +42,7 @@ from app.api.api_v1.endpoints.tournaments.enroll import (
     unenroll_from_tournament,
 )
 from app.models.user import UserRole
+from app.models.semester import SemesterCategory
 
 _BASE = "app.api.api_v1.endpoints.tournaments.enroll"
 
@@ -78,14 +79,15 @@ def _seq_db(*qs):
 
 
 def _tournament(*, status="ENROLLMENT_OPEN", age_group="PRE", cost=500, max_players=32,
-                age_groups=None):
+                age_groups=None, semester_category=None):
     t = MagicMock()
     t.id = 1
     t.tournament_status = status
     t.name = "LFA Tournament"
     t.code = "LFA-T-001"
     t.age_group = age_group
-    t.age_groups = age_groups  # None for single-age legacy; explicit list for multi-age
+    t.age_groups = age_groups          # explicit None — MagicMock auto-attr trap prevention
+    t.semester_category = semester_category  # explicit None — enum comparison safe
     t.enrollment_cost = cost
     t.max_players = max_players
     t.start_date.isoformat.return_value = "2024-07-01"
@@ -155,6 +157,18 @@ class TestEnrollInTournament:
         with pytest.raises(Exception) as exc:
             enroll_in_tournament(self.TID, db=db, current_user=_student())
         assert exc.value.status_code == 404
+
+    def test_400_promotion_event_blocks_self_enroll(self):
+        """PROMOTION_EVENT guard fires before status check — 400, invitation only."""
+        t = _tournament(
+            status="ENROLLMENT_OPEN",
+            semester_category=SemesterCategory.PROMOTION_EVENT,
+        )
+        db = _seq_db(_q(first=t))
+        with pytest.raises(Exception) as exc:
+            enroll_in_tournament(self.TID, db=db, current_user=_student())
+        assert exc.value.status_code == 400
+        assert "invitation" in exc.value.detail.lower()
 
     def test_400_wrong_tournament_status_triggers_audit(self):
         t = _tournament(status="COMPLETED")


### PR DESCRIPTION
## Summary

Closes all P0 enrollment paths for PROMOTION_EVENT tournaments. Participants must come exclusively from the sponsor campaign audience — standard self-enrollment and admin force-enrollment are now blocked.

### Guards added

| Endpoint | Type | Guard |
|---|---|---|
| `POST /{id}/enroll` (enroll.py) | Student self-enroll | 400 "invitation only" |
| `GET /admin/tournaments/{id}/players` | Admin players page | Redirect to edit page |
| `POST /admin/tournaments/{id}/players/enroll` | Admin force-enroll | 400 |
| `POST /admin/tournaments/{id}/players/{uid}/remove` | Admin remove | 400 |
| `POST /admin/tournaments/{id}/players/enroll-from-team` | Bulk team enroll | Redirect |
| `POST /admin/tournaments/{id}/enroll-player` (JSON) | Admin bulk enroll | 400 |
| `POST /admin/tournaments/{id}/unenroll-player` (JSON) | Admin unenroll | 400 |

### UI change

PROMOTION_EVENT: "Enrolled Players" section replaced by `id="section-campaign-audience-placeholder"` card with info text + anchor to future PR2 audience section. Non-PROMOTION_EVENT unchanged.

### Implementation pattern

`players.py`: two shared helpers `_fetch_tournament_or_404()` + `_raise_if_promotion_event()` used consistently across all 5 mutation endpoints. Redirect-based endpoints redirect; JSON endpoints raise HTTPException.

## Tests

| Suite | Tests | Result |
|---|---|---|
| `test_tournament_enroll.py` | +1 guard test (`_tournament()` helper fixed) | ✅ |
| `test_tournament_edit_ui.py` | +2 (EDIT-UI-06 + EDIT-UI-07) | ✅ |
| Combined | **33 passed** | ✅ |

## Test plan

- [ ] `pytest tests/unit/services/test_tournament_enroll.py tests/integration/web_flows/test_tournament_edit_ui.py` — 33/33
- [ ] Manual: student tries to enroll in PROMOTION_EVENT → 400 "invitation only"
- [ ] Manual: admin `/admin/tournaments/{promo_id}/players` → redirected to edit page
- [ ] Manual: PROMOTION_EVENT edit page → "Campaign Audience" card shown, no "Manage Players" button
- [ ] Manual: MINI_SEASON edit page → "Enrolled Players" section unchanged

## Scope boundary

No session generation, check-in, lifecycle, migration, or TEAM support changes.
PR2 will add the read-only Campaign Audience view + backlink. PR3 will add bulk enroll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)