### PR TITLE
feat(promotion-event): PR2 — read-only Campaign Audience view

### DIFF
--- a/app/api/web_routes/tournaments/edit.py
+++ b/app/api/web_routes/tournaments/edit.py
@@ -13,6 +13,7 @@ from ....models.location import Location
 from ....models.semester import Semester, SemesterCategory
 from ....services.tournament import get_allowed_age_groups
 from ....models.semester_enrollment import SemesterEnrollment
+from ....models.sponsor import Sponsor, SponsorCampaign, SponsorAudienceEntry
 from ....models.session import Session as SessionModel, EventCategory
 from ....models.team import Team, TournamentTeamEnrollment
 from ....models.tournament_ranking import TournamentRanking
@@ -229,6 +230,30 @@ async def admin_tournament_edit_page(
         if s.game_results or (s.rounds_data and s.rounds_data.get("round_results"))
     )
 
+    # Campaign audience — only queried for PROMOTION_EVENT to avoid unnecessary work
+    _is_promo = t.semester_category == SemesterCategory.PROMOTION_EVENT
+    campaign_audience: list = []
+    organizer_sponsor = None
+    organizer_campaign = None
+    if _is_promo:
+        if t.organizer_sponsor_id:
+            organizer_sponsor = (
+                db.query(Sponsor).filter(Sponsor.id == t.organizer_sponsor_id).first()
+            )
+        if t.organizer_campaign_id:
+            organizer_campaign = (
+                db.query(SponsorCampaign)
+                .filter(SponsorCampaign.id == t.organizer_campaign_id)
+                .first()
+            )
+            if organizer_campaign:
+                campaign_audience = (
+                    db.query(SponsorAudienceEntry)
+                    .filter(SponsorAudienceEntry.campaign_id == t.organizer_campaign_id)
+                    .order_by(SponsorAudienceEntry.last_name, SponsorAudienceEntry.first_name)
+                    .all()
+                )
+
     return templates.TemplateResponse(
         "admin/tournament_edit.html",
         {
@@ -262,8 +287,11 @@ async def admin_tournament_edit_page(
             "eligible_instructors": eligible_instructors,
             "pitches_for_roster": pitches_for_roster,
             "has_absent_field": has_absent_field,
-            "is_promotion_event": t.semester_category == SemesterCategory.PROMOTION_EVENT,
+            "is_promotion_event": _is_promo,
             "promotion_age_groups": get_allowed_age_groups(t),
+            "campaign_audience": campaign_audience,
+            "organizer_sponsor": organizer_sponsor,
+            "organizer_campaign": organizer_campaign,
             "flash": request.query_params.get("flash"),
             "error": request.query_params.get("error"),
         },

--- a/app/templates/admin/tournament_edit.html
+++ b/app/templates/admin/tournament_edit.html
@@ -1137,6 +1137,70 @@ ID {{ t.id }} · {{ t.code }} · <strong>{{ t.tournament_status or t.status.valu
   </div>{# /wiz-step-body #}
 </div>{# /wiz-step-7 #}
 
+{# ── SECTION: Campaign Audience (PROMOTION_EVENT only) ──────────────────────── #}
+{% if is_promotion_event %}
+<div class="card" id="section-campaign-audience" style="margin-top:1.5rem;">
+    <div class="section-header">
+        <span class="section-icon">📋</span>
+        <h2>Campaign Audience</h2>
+        {% if campaign_audience %}
+        <span style="background:#e2e8f0;color:#4a5568;border-radius:.4rem;padding:.2rem .6rem;font-size:.8rem;font-weight:600;margin-left:.75rem;">{{ campaign_audience|length }}</span>
+        {% endif %}
+    </div>
+
+    {% if organizer_sponsor or organizer_campaign %}
+    <div style="margin-bottom:.75rem;font-size:.875rem;color:#718096;" id="campaign-audience-backlink">
+        {% if organizer_sponsor %}
+        Sponsor: <a href="/admin/sponsors/{{ organizer_sponsor.id }}" style="color:#667eea;">{{ organizer_sponsor.name }}</a>
+        {% endif %}
+        {% if organizer_sponsor and organizer_campaign %}&nbsp;·&nbsp;{% endif %}
+        {% if organizer_campaign %}
+        Campaign: <a href="/admin/sponsors/{{ organizer_sponsor.id if organizer_sponsor else t.organizer_sponsor_id }}/campaigns/{{ organizer_campaign.id }}/audience" style="color:#667eea;">{{ organizer_campaign.name }}</a>
+        {% endif %}
+    </div>
+    {% else %}
+    <p style="color:#a0aec0;font-style:italic;" id="campaign-audience-no-link">
+        No sponsor campaign is linked to this event. Audience data is unavailable until a campaign is assigned.
+    </p>
+    {% endif %}
+
+    {% if campaign_audience %}
+    <div style="overflow-x:auto;">
+    <table style="width:100%;border-collapse:collapse;font-size:.85rem;">
+        <thead>
+            <tr style="border-bottom:2px solid #e2e8f0;text-align:left;">
+                <th style="padding:.5rem .75rem;color:#718096;font-weight:600;">Name</th>
+                <th style="padding:.5rem .75rem;color:#718096;font-weight:600;">Email</th>
+                <th style="padding:.5rem .75rem;color:#718096;font-weight:600;">Status</th>
+                <th style="padding:.5rem .75rem;color:#718096;font-weight:600;">Promoted At</th>
+                <th style="padding:.5rem .75rem;color:#718096;font-weight:600;">Linked User</th>
+            </tr>
+        </thead>
+        <tbody>
+        {% for entry in campaign_audience %}
+        <tr style="border-bottom:1px solid #f0f4f8;">
+            <td style="padding:.5rem .75rem;">{{ entry.first_name }} {{ entry.last_name }}</td>
+            <td style="padding:.5rem .75rem;">{{ entry.email }}</td>
+            <td style="padding:.5rem .75rem;">
+                <span style="background:{% if entry.status == 'ACTIVE' %}#c6f6d5{% elif entry.status == 'SUPPRESSED' %}#fed7d7{% else %}#e2e8f0{% endif %};color:{% if entry.status == 'ACTIVE' %}#276749{% elif entry.status == 'SUPPRESSED' %}#742a2a{% else %}#4a5568{% endif %};border-radius:.3rem;padding:.15rem .5rem;font-size:.78rem;font-weight:600;">
+                    {{ entry.status }}
+                </span>
+            </td>
+            <td style="padding:.5rem .75rem;color:#718096;">{{ entry.promoted_at.strftime('%Y-%m-%d') if entry.promoted_at else '—' }}</td>
+            <td style="padding:.5rem .75rem;">
+                {% if entry.user %}<a href="/admin/users/{{ entry.user.id }}" style="color:#667eea;">{{ entry.user.name }}</a>{% else %}—{% endif %}
+            </td>
+        </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+    </div>
+    {% elif organizer_campaign %}
+    <p style="color:#a0aec0;font-style:italic;margin-top:.5rem;">No audience entries found for this campaign.</p>
+    {% endif %}
+</div>
+{% endif %}
+
 {# ── Result Entry Modal ────────────────────────────────────────────────────── #}
 <div id="result-modal-overlay"
      onclick="if(event.target===this)closeResultModal()"

--- a/tests/integration/web_flows/test_tournament_edit_ui.py
+++ b/tests/integration/web_flows/test_tournament_edit_ui.py
@@ -10,6 +10,11 @@ Integration tests — tournament edit page field rendering.
               enrolled-players section absent
   EDIT-UI-07  Non-promotion event → standard enrolled-players section shown,
               campaign audience placeholder absent
+  EDIT-UI-08  PROMOTION_EVENT with linked campaign → id="section-campaign-audience"
+              present, id="campaign-audience-backlink" present
+  EDIT-UI-09  PROMOTION_EVENT without campaign link → id="section-campaign-audience"
+              present, id="campaign-audience-no-link" shown (fallback)
+  EDIT-UI-10  Non-promotion event → id="section-campaign-audience" absent
 
 DONE = pytest tests/integration/web_flows/test_tournament_edit_ui.py -v
 """
@@ -25,6 +30,8 @@ from app.database import get_db
 from app.dependencies import get_current_user_web
 from app.models.user import User, UserRole
 from app.models.semester import Semester, SemesterStatus, SemesterCategory
+from app.models.sponsor import Sponsor, SponsorCampaign, SponsorAudienceEntry
+from app.models.club import CsvImportLog
 from app.core.security import get_password_hash
 
 
@@ -191,5 +198,141 @@ class TestNonPromotionEventEnrolledPlayersSection:
             html = resp.text
             assert 'id="section-checkin"' in html
             assert 'id="section-campaign-audience-placeholder"' not in html
+        finally:
+            app.dependency_overrides.clear()
+
+
+# ── Helpers for EDIT-UI-08/09/10 ─────────────────────────────────────────────
+
+def _make_sponsor(db: Session) -> Sponsor:
+    s = Sponsor(
+        name=f"Test Sponsor {uuid.uuid4().hex[:6]}",
+        code=f"TSP-{uuid.uuid4().hex[:6]}",
+        is_active=True,
+    )
+    db.add(s)
+    db.flush()
+    return s
+
+
+def _make_campaign(db: Session, sponsor: Sponsor) -> SponsorCampaign:
+    c = SponsorCampaign(
+        sponsor_id=sponsor.id,
+        name=f"Test Campaign {uuid.uuid4().hex[:6]}",
+        campaign_type="IMPORT",
+        status="ACTIVE",
+    )
+    db.add(c)
+    db.flush()
+    return c
+
+
+def _make_audience_entry(db: Session, sponsor: Sponsor, campaign: SponsorCampaign) -> SponsorAudienceEntry:
+    log = CsvImportLog(sponsor_id=sponsor.id, campaign_id=campaign.id)
+    db.add(log)
+    db.flush()
+    entry = SponsorAudienceEntry(
+        sponsor_id=sponsor.id,
+        campaign_id=campaign.id,
+        import_log_id=log.id,
+        first_name="Test",
+        last_name="Player",
+        email=f"audience+{uuid.uuid4().hex[:8]}@lfa.com",
+        status="ACTIVE",
+    )
+    db.add(entry)
+    db.flush()
+    return entry
+
+
+def _make_promotion_semester_with_campaign(
+    db: Session, sponsor: Sponsor, campaign: SponsorCampaign
+) -> Semester:
+    sem = Semester(
+        code=f"PROMO-CA-{uuid.uuid4().hex[:6]}",
+        name="UI Test Promo With Campaign",
+        start_date=date(2026, 9, 1),
+        end_date=date(2026, 9, 2),
+        status=SemesterStatus.DRAFT,
+        tournament_status="DRAFT",
+        semester_category=SemesterCategory.PROMOTION_EVENT,
+        age_group=None,
+        age_groups=["PRE", "YOUTH"],
+        enrollment_cost=0,
+        organizer_sponsor_id=sponsor.id,
+        organizer_campaign_id=campaign.id,
+    )
+    db.add(sem)
+    db.flush()
+    return sem
+
+
+# ── EDIT-UI-08 ────────────────────────────────────────────────────────────────
+
+class TestCampaignAudienceSectionWithLink:
+    """EDIT-UI-08: PROMOTION_EVENT with linked campaign → audience section and
+    backlink rendered."""
+
+    def test_edit_ui_08_section_and_backlink_present(self, test_db: Session):
+        admin = _make_admin(test_db)
+        sponsor = _make_sponsor(test_db)
+        campaign = _make_campaign(test_db, sponsor)
+        _make_audience_entry(test_db, sponsor, campaign)
+        sem = _make_promotion_semester_with_campaign(test_db, sponsor, campaign)
+        test_db.commit()
+
+        client = _client(test_db, admin)
+        try:
+            resp = client.get(f"/admin/tournaments/{sem.id}/edit")
+            assert resp.status_code == 200
+
+            html = resp.text
+            assert 'id="section-campaign-audience"' in html
+            assert 'id="campaign-audience-backlink"' in html
+            assert 'id="campaign-audience-no-link"' not in html
+        finally:
+            app.dependency_overrides.clear()
+
+
+# ── EDIT-UI-09 ────────────────────────────────────────────────────────────────
+
+class TestCampaignAudienceSectionFallback:
+    """EDIT-UI-09: PROMOTION_EVENT without campaign link → audience section shows
+    fallback message."""
+
+    def test_edit_ui_09_section_present_fallback_shown(self, test_db: Session):
+        admin = _make_admin(test_db)
+        sem = _make_promotion_semester(test_db, age_groups=["PRE"])
+        test_db.commit()
+
+        client = _client(test_db, admin)
+        try:
+            resp = client.get(f"/admin/tournaments/{sem.id}/edit")
+            assert resp.status_code == 200
+
+            html = resp.text
+            assert 'id="section-campaign-audience"' in html
+            assert 'id="campaign-audience-no-link"' in html
+            assert 'id="campaign-audience-backlink"' not in html
+        finally:
+            app.dependency_overrides.clear()
+
+
+# ── EDIT-UI-10 ────────────────────────────────────────────────────────────────
+
+class TestNonPromotionEventNoCampaignAudienceSection:
+    """EDIT-UI-10: non-promotion event → campaign audience section absent."""
+
+    def test_edit_ui_10_section_absent(self, test_db: Session):
+        admin = _make_admin(test_db)
+        sem = _make_mini_season_semester(test_db)
+        test_db.commit()
+
+        client = _client(test_db, admin)
+        try:
+            resp = client.get(f"/admin/tournaments/{sem.id}/edit")
+            assert resp.status_code == 200
+
+            assert 'id="section-campaign-audience"' not in resp.text
         finally:
             app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary

- `edit.py`: loads `Sponsor`, `SponsorCampaign`, `SponsorAudienceEntry` into template context **only for PROMOTION_EVENT** — zero extra queries for all other tournament types
- `tournament_edit.html`: adds `id="section-campaign-audience"` section (below wizard steps 1–7); shows sponsor/campaign backlinks when `organizer_sponsor_id` / `organizer_campaign_id` are set, fallback message otherwise; table columns: name, email, status, promoted_at, linked user
- Three new UI tests: EDIT-UI-08 (with campaign → section + backlink), EDIT-UI-09 (no campaign → section + fallback), EDIT-UI-10 (non-promotion → section absent)

## Test results

```
8 passed in 1.15s  (all 8 EDIT-UI tests green)
```

## Scope boundary

- No migration, no new model, no new route
- No session generation, no check-in, no bulk enroll (→ PR3)
- Audience table is read-only; zero mutation surface

## Test plan

- [ ] CI green on this branch
- [ ] Visit `/admin/tournaments/{id}/edit` for a PROMOTION_EVENT with a linked campaign → section renders with sponsor/campaign backlinks and audience table
- [ ] Same page for PROMOTION_EVENT without campaign link → fallback message shown
- [ ] Same page for non-PROMOTION_EVENT tournament → `id="section-campaign-audience"` absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)