### PR TITLE
feat(seed): promotion event Phase 2 seed script + SC-04 hard validation

### DIFF
--- a/app/services/tournament/session_generation/formats/group_knockout_generator.py
+++ b/app/services/tournament/session_generation/formats/group_knockout_generator.py
@@ -89,6 +89,17 @@ class GroupKnockoutGenerator(BaseFormatGenerator):
             qualifiers_per_group = distribution['qualifiers_per_group']
             group_rounds = distribution['group_rounds']
 
+        # ── Qualification policy override ────────────────────────────────────
+        # Policy is scoped per player-count inside group_configuration[N_players].
+        # Reading from top-level config would affect ALL sizes sharing the same
+        # TournamentType (e.g. 16p would break if 9p policy were at top level).
+        _q_policy = (group_config or {}).get('qualification_policy', 'fixed_per_group')
+        _best_runner_up_count = int((group_config or {}).get('best_runner_up_count', 0))
+        if _q_policy == 'winners_plus_best_runner_up' and _best_runner_up_count > 0:
+            qualifiers_per_group = 1   # only group winners qualify automatically
+        else:
+            _best_runner_up_count = 0  # policy inactive — zero out to prevent drift
+
         # ✅ NEW: Assign players to groups with variable sizes
         group_assignments = {}  # {group_name: [user_id1, user_id2, ...]}
         player_index = 0
@@ -320,7 +331,7 @@ class GroupKnockoutGenerator(BaseFormatGenerator):
         # ============================================================================
         # PHASE 2: KNOCKOUT STAGE (TOP QUALIFIERS ONLY) - WITH BYE LOGIC
         # ============================================================================
-        knockout_players = groups_count * qualifiers_per_group
+        knockout_players = groups_count * qualifiers_per_group + _best_runner_up_count
         round_names = tournament_type.config.get('round_names', {})
 
         # ✅ NEW: Calculate knockout structure (byes, play-in, bronze)
@@ -400,29 +411,44 @@ class GroupKnockoutGenerator(BaseFormatGenerator):
                 session_start = current_time
                 session_end = session_start + timedelta(minutes=session_duration)
 
-                # ✅ Calculate seeding placeholders for first knockout round
+                # ── Seeding / qualification source metadata ──────────────────
+                # Round 1: slot labels written at generation time; resolved to
+                #   concrete participant_user_ids at ranking-calculation time
+                #   by assign_semifinal_participants() in the qualification service.
+                # Round > 1: source-label only; participants assigned when
+                #   the preceding round's results are entered (out of scope v1).
                 seeding_info = {}
                 if round_num == 1:
-                    # First round uses group qualifiers
-                    # Standard bracket seeding: 1 vs last, 2 vs second-to-last, etc.
-                    # For 4 qualifiers (2 groups): A1 vs B2, B1 vs A2
-                    # For 8 qualifiers (4 groups): A1 vs D2, B1 vs C2, C1 vs B2, D1 vs A2
-
-                    if knockout_players == 4:  # 2 groups
+                    if knockout_players == 4 and _best_runner_up_count > 0:
+                        # 3 groups of 3: 3 winners + 1 best runner-up
+                        if match_in_round == 1:
+                            seeding_info = {
+                                'matchup': 'Group A winner vs Best runner-up',
+                                'seed_1': 'A1', 'seed_2': 'BR',
+                            }
+                        elif match_in_round == 2:
+                            seeding_info = {
+                                'matchup': 'Group B winner vs Group C winner',
+                                'seed_1': 'B1', 'seed_2': 'C1',
+                            }
+                    elif knockout_players == 4:
+                        # Standard 2-group case: A1 vs B2, B1 vs A2
                         if match_in_round == 1:
                             seeding_info = {'matchup': 'A1 vs B2', 'seed_1': 'A1', 'seed_2': 'B2'}
                         elif match_in_round == 2:
                             seeding_info = {'matchup': 'B1 vs A2', 'seed_1': 'B1', 'seed_2': 'A2'}
-                    elif knockout_players == 8:  # 4 groups
+                    elif knockout_players == 8:
+                        # 4-group case
                         matchups = [
                             ('A1', 'D2'), ('B1', 'C2'), ('C1', 'B2'), ('D1', 'A2')
                         ]
                         if match_in_round <= len(matchups):
                             seed_1, seed_2 = matchups[match_in_round - 1]
                             seeding_info = {'matchup': f'{seed_1} vs {seed_2}', 'seed_1': seed_1, 'seed_2': seed_2}
+                elif round_num == knockout_rounds:
+                    seeding_info = {'matchup': 'SF1 winner vs SF2 winner'}
                 else:
-                    # Later rounds use previous match winners
-                    seeding_info = {'matchup': f'Winner of previous matches', 'round': round_num}
+                    seeding_info = {'matchup': f'Round {round_num - 1} winners'}
 
                 sessions.append({
                     'title': f'{tournament.name} - {round_name} - Match {match_in_round}',

--- a/scripts/seed_promotion_events.py
+++ b/scripts/seed_promotion_events.py
@@ -1,0 +1,796 @@
+"""
+Promotion Event Seed Script — Phase 2
+======================================
+Creates PROMOTION_EVENT lifecycle scenarios for manual QA and CI smoke testing.
+
+Lifecycle used by this script (compatible with main branch state-machine):
+  DRAFT → ENROLLMENT_OPEN → ENROLLMENT_CLOSED
+  → bulk-enroll-campaign  (POST /api/v1/tournaments/{id}/bulk-enroll-campaign)
+  → CHECK_IN_OPEN         (session generation triggered here)
+  → IN_PROGRESS           (requires master_instructor_id)
+  → COMPLETED
+
+Note: once PR2.5 (PROMOTION_EVENT fast-path) is merged to main, the
+ENROLLMENT_OPEN hop can be dropped and DRAFT → ENROLLMENT_CLOSED used directly.
+
+Scenarios:
+  SC-01  DRAFT             — tournament created, no audience enrolled
+  SC-02  ENROLLMENT_CLOSED — audience locked, 9 players bulk-enrolled
+  SC-03  CHECK_IN_OPEN     — 13 sessions generated (9 GS + 2 SF + 1 F + 1 B)
+  SC-04  VALIDATION        — hard failure if session structure or SF labels are wrong
+
+Reset scope (ALLOW_SEED_RESET=true required):
+  - Only Semester rows whose name starts with PROMO-SEED-
+  - Only the SEED-SPONSOR sponsor row (cascades to its campaigns and entries)
+  - No manual data is ever touched
+
+Usage:
+  PYTHONPATH=. python scripts/seed_promotion_events.py
+  PYTHONPATH=. python scripts/seed_promotion_events.py --dry-run
+  PYTHONPATH=. python scripts/seed_promotion_events.py --scenarios SC-01,SC-04
+  ALLOW_SEED_RESET=true PYTHONPATH=. python scripts/seed_promotion_events.py --reset
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+import uuid
+import datetime
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+os.environ.setdefault("DATABASE_URL", "postgresql://postgres:postgres@localhost:5432/lfa_intern_system")
+os.environ.setdefault("SECRET_KEY", "e2e-test-secret-key-minimum-32-chars-needed")
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session as DBSession
+
+from app.main import app
+from app.database import SessionLocal
+from app.models.club import CsvImportLog
+from app.models.license import UserLicense
+from app.models.semester import Semester, SemesterCategory, SemesterStatus
+from app.models.semester_enrollment import SemesterEnrollment
+from app.models.session import Session as SessionModel
+from app.models.sponsor import Sponsor, SponsorAudienceEntry, SponsorCampaign
+from app.models.tournament_configuration import TournamentConfiguration
+from app.models.tournament_enums import TournamentPhase
+from app.models.tournament_type import TournamentType
+from app.models.user import User, UserRole
+from app.core.security import get_password_hash
+from app.dependencies import (
+    get_current_admin_or_instructor_user_hybrid,
+    get_current_admin_user_hybrid,
+    get_current_user_web,
+)
+
+logger = logging.getLogger(__name__)
+
+_SPONSOR_NAME = "SEED-SPONSOR"
+_CAMPAIGN_NAME = "SEED-CAMPAIGN"
+_TOURNAMENT_PREFIX = "PROMO-SEED-"
+_GROUP_KNOCKOUT_CODE = "group_knockout"
+_NINE_PLAYER_KEY = "9_players"
+
+_EXPECTED_SESSIONS = 13
+_EXPECTED_GROUP_STAGE = 9
+_EXPECTED_PLAY_IN = 0
+_EXPECTED_SEMI_FINALS = 2
+_EXPECTED_FINAL = 1
+_EXPECTED_BRONZE = 1
+_EXPECTED_SF_MATCHUPS = frozenset({
+    "Group A winner vs Best runner-up",
+    "Group B winner vs Group C winner",
+})
+
+# ─── Production guard ─────────────────────────────────────────────────────────
+
+_BLOCKED_URL_FRAGMENTS = ("lfa.com", "production", "staging", "prod")
+
+
+def _assert_not_production() -> None:
+    db_url = os.environ.get("DATABASE_URL", "")
+    for fragment in _BLOCKED_URL_FRAGMENTS:
+        if fragment in db_url.lower():
+            sys.exit(
+                f"BLOCKED: Seed script cannot run against production/staging URL.\n"
+                f"  DATABASE_URL contains '{fragment}': {db_url}"
+            )
+
+
+# ─── Preflight: group_knockout 9_players policy ───────────────────────────────
+
+def _preflight_group_knockout_9p(db: DBSession) -> TournamentType:
+    """Verify the DB config has the 9_players policy required for SC-04.
+
+    Exits immediately with a clear message if anything is wrong, so SC-04
+    never silently produces the wrong session structure.
+    """
+    tt = db.query(TournamentType).filter(TournamentType.code == _GROUP_KNOCKOUT_CODE).first()
+    if not tt:
+        sys.exit(
+            f"PREFLIGHT FAIL: TournamentType code='{_GROUP_KNOCKOUT_CODE}' not found in DB.\n"
+            f"  Run tournament type seed/migration to create it."
+        )
+
+    cfg = tt.config.get("group_configuration", {})
+    nine = cfg.get(_NINE_PLAYER_KEY)
+    if not nine:
+        sys.exit(
+            f"PREFLIGHT FAIL: group_configuration['{_NINE_PLAYER_KEY}'] missing from\n"
+            f"  TournamentType '{_GROUP_KNOCKOUT_CODE}' (DB id={tt.id}).\n"
+            f"  Add it to app/tournament_types/group_knockout.json and re-seed the tournament types."
+        )
+
+    policy = nine.get("qualification_policy")
+    if policy != "winners_plus_best_runner_up":
+        sys.exit(
+            f"PREFLIGHT FAIL: group_configuration['{_NINE_PLAYER_KEY}'].qualification_policy\n"
+            f"  must be 'winners_plus_best_runner_up', got '{policy}'.\n"
+            f"  Fix app/tournament_types/group_knockout.json and re-seed."
+        )
+
+    brc = nine.get("best_runner_up_count")
+    if int(brc or 0) != 1:
+        sys.exit(
+            f"PREFLIGHT FAIL: group_configuration['{_NINE_PLAYER_KEY}'].best_runner_up_count\n"
+            f"  must be 1, got '{brc}'.\n"
+            f"  Fix app/tournament_types/group_knockout.json and re-seed."
+        )
+
+    return tt
+
+
+# ─── Reset ────────────────────────────────────────────────────────────────────
+
+def run_reset(db: DBSession) -> None:
+    """Delete all PROMO-SEED-* tournament rows and the SEED-SPONSOR.
+
+    Requires ALLOW_SEED_RESET=true. Never touches manually created data.
+    """
+    if os.environ.get("ALLOW_SEED_RESET") != "true":
+        sys.exit("Reset requires ALLOW_SEED_RESET=true env var.")
+
+    _assert_not_production()
+
+    promo_ids = [
+        row.id
+        for row in db.query(Semester.id)
+        .filter(Semester.name.like(f"{_TOURNAMENT_PREFIX}%"))
+        .all()
+    ]
+    if promo_ids:
+        db.query(SessionModel).filter(
+            SessionModel.semester_id.in_(promo_ids)
+        ).delete(synchronize_session=False)
+        db.query(SemesterEnrollment).filter(
+            SemesterEnrollment.semester_id.in_(promo_ids)
+        ).delete(synchronize_session=False)
+        db.query(TournamentConfiguration).filter(
+            TournamentConfiguration.semester_id.in_(promo_ids)
+        ).delete(synchronize_session=False)
+        db.query(Semester).filter(
+            Semester.id.in_(promo_ids)
+        ).delete(synchronize_session=False)
+        print(f"  Deleted {len(promo_ids)} PROMO-SEED tournament(s) with their sessions/enrollments")
+
+    sponsor = db.query(Sponsor).filter(Sponsor.name == _SPONSOR_NAME).first()
+    if sponsor:
+        db.delete(sponsor)
+        print(f"  Deleted {_SPONSOR_NAME} (id={sponsor.id}) — cascades campaigns/entries")
+
+    db.commit()
+    print("Reset complete")
+
+
+# ─── Sponsor / Campaign / Audience setup ─────────────────────────────────────
+
+def _get_or_create_sponsor(db: DBSession, dry_run: bool) -> Sponsor | None:
+    sponsor = db.query(Sponsor).filter(Sponsor.name == _SPONSOR_NAME).first()
+    if sponsor:
+        return sponsor
+    if dry_run:
+        print("  [dry-run] Would create SEED-SPONSOR")
+        return None
+    sponsor = Sponsor(name=_SPONSOR_NAME, code="SEED-SPNSR", is_active=True)
+    db.add(sponsor)
+    db.flush()
+    return sponsor
+
+
+def _get_or_create_campaign(
+    db: DBSession, sponsor: Sponsor, dry_run: bool
+) -> SponsorCampaign | None:
+    camp = (
+        db.query(SponsorCampaign)
+        .filter(
+            SponsorCampaign.sponsor_id == sponsor.id,
+            SponsorCampaign.name == _CAMPAIGN_NAME,
+        )
+        .first()
+    )
+    if camp:
+        return camp
+    if dry_run:
+        print("  [dry-run] Would create SEED-CAMPAIGN")
+        return None
+    camp = SponsorCampaign(
+        sponsor_id=sponsor.id,
+        name=_CAMPAIGN_NAME,
+        status="ACTIVE",
+    )
+    db.add(camp)
+    db.flush()
+    return camp
+
+
+def _ensure_9_audience_entries(
+    db: DBSession,
+    sponsor: Sponsor,
+    campaign: SponsorCampaign,
+    admin: User,
+) -> list[int]:
+    """Ensure 9 seed players exist with promoted user + active LFA_FOOTBALL_PLAYER license.
+
+    Idempotent: safe to call multiple times.
+    Returns list of user_ids.
+    """
+    import_log = (
+        db.query(CsvImportLog)
+        .filter(
+            CsvImportLog.sponsor_id == sponsor.id,
+            CsvImportLog.campaign_id == campaign.id,
+        )
+        .first()
+    )
+    if not import_log:
+        import_log = CsvImportLog(
+            sponsor_id=sponsor.id,
+            campaign_id=campaign.id,
+            uploaded_by=admin.id,
+            filename="seed_9_players.csv",
+            total_rows=9,
+            rows_created=9,
+            status="DONE",
+        )
+        db.add(import_log)
+        db.flush()
+
+    user_ids: list[int] = []
+    for i in range(1, 10):
+        email = f"seed.player.{i}@promo-seed.test"
+
+        user = db.query(User).filter(User.email == email).first()
+        if not user:
+            user = User(
+                email=email,
+                name=f"Seed{i} PromoPlayer",
+                first_name=f"Seed{i}",
+                last_name="PromoPlayer",
+                password_hash=get_password_hash(uuid.uuid4().hex),
+                role=UserRole.STUDENT,
+                is_active=True,
+                credit_balance=0,
+            )
+            db.add(user)
+            db.flush()
+
+        lic = (
+            db.query(UserLicense)
+            .filter(
+                UserLicense.user_id == user.id,
+                UserLicense.specialization_type == "LFA_FOOTBALL_PLAYER",
+            )
+            .first()
+        )
+        if not lic:
+            now = datetime.datetime.now(datetime.timezone.utc)
+            lic = UserLicense(
+                user_id=user.id,
+                specialization_type="LFA_FOOTBALL_PLAYER",
+                is_active=True,
+                started_at=now,
+            )
+            db.add(lic)
+            db.flush()
+        else:
+            lic.is_active = True
+
+        entry = (
+            db.query(SponsorAudienceEntry)
+            .filter(
+                SponsorAudienceEntry.campaign_id == campaign.id,
+                SponsorAudienceEntry.email == email,
+            )
+            .first()
+        )
+        if not entry:
+            entry = SponsorAudienceEntry(
+                sponsor_id=sponsor.id,
+                campaign_id=campaign.id,
+                import_log_id=import_log.id,
+                first_name=f"Seed{i}",
+                last_name="PromoPlayer",
+                email=email,
+                consent_given=True,
+                status="ACTIVE",
+                user_id=user.id,
+            )
+            db.add(entry)
+            db.flush()
+        else:
+            entry.status = "ACTIVE"
+            entry.consent_given = True
+            entry.user_id = user.id
+
+        user_ids.append(user.id)
+
+    db.flush()
+    return user_ids
+
+
+# ─── Tournament creation (direct ORM) ────────────────────────────────────────
+
+def _create_tournament(
+    db: DBSession,
+    name: str,
+    sponsor: Sponsor,
+    campaign: SponsorCampaign,
+    tt: TournamentType,
+    campus_id: int,
+    dry_run: bool,
+) -> Semester | None:
+    if dry_run:
+        print(f"  [dry-run] Would create tournament '{name}'")
+        return None
+
+    from app.models.campus import Campus
+
+    suffix = uuid.uuid4().hex[:8]
+    code = f"{_TOURNAMENT_PREFIX}{suffix}"
+    today = datetime.date.today()
+
+    t = Semester(
+        code=code,
+        name=name,
+        start_date=today,
+        end_date=today + datetime.timedelta(days=1),
+        status=SemesterStatus.DRAFT,
+        tournament_status="DRAFT",
+        semester_category=SemesterCategory.PROMOTION_EVENT,
+        specialization_type="LFA_FOOTBALL_PLAYER",
+        enrollment_cost=0,
+        campus_id=campus_id,
+        organizer_sponsor_id=sponsor.id,
+        organizer_campaign_id=campaign.id,
+        organizer_club_id=None,
+    )
+    db.add(t)
+    db.flush()
+
+    campus_obj = db.query(Campus).filter(Campus.id == campus_id).first()
+    if campus_obj and campus_obj.location_id:
+        t.location_id = campus_obj.location_id
+
+    db.add(
+        TournamentConfiguration(
+            semester_id=t.id,
+            tournament_type_id=tt.id,
+            participant_type="INDIVIDUAL",
+            number_of_rounds=1,
+            assignment_type="OPEN_ASSIGNMENT",
+        )
+    )
+    db.commit()
+    db.refresh(t)
+    return t
+
+
+# ─── API helpers ─────────────────────────────────────────────────────────────
+
+def _transition(client: TestClient, tid: int, new_status: str) -> bool:
+    r = client.patch(
+        f"/api/v1/tournaments/{tid}/status",
+        json={"new_status": new_status, "reason": "seed"},
+    )
+    if r.status_code != 200:
+        print(f"  FAIL transition {tid} -> {new_status}: {r.status_code} {r.text[:200]}")
+        return False
+    return True
+
+
+def _lock_enrollment(client: TestClient, tid: int) -> bool:
+    """DRAFT → ENROLLMENT_OPEN → ENROLLMENT_CLOSED.
+
+    Main branch requires the ENROLLMENT_OPEN intermediate hop.
+    Once PR2.5 (PROMOTION_EVENT fast-path) is merged, this can be replaced
+    with a single DRAFT → ENROLLMENT_CLOSED transition.
+    """
+    if not _transition(client, tid, "ENROLLMENT_OPEN"):
+        return False
+    return _transition(client, tid, "ENROLLMENT_CLOSED")
+
+
+def _bulk_enroll_direct(db: DBSession, tid: int, campaign_id: int, sponsor_id: int) -> dict:
+    """Enroll all eligible campaign audience entries as SemesterEnrollments.
+
+    Mirrors the logic of campaign_enrollment_service.bulk_enroll_from_campaign
+    which lives on the PR2 branch (not yet merged to main).  When PR2 is merged,
+    this function can be replaced with a call to that API endpoint.
+
+    Eligibility (per entry):
+      - status == "ACTIVE" and consent_given == True
+      - user_id IS NOT NULL  (entry has been promoted)
+      - User.is_active == True
+      - Active LFA_FOOTBALL_PLAYER UserLicense exists
+      - No existing active SemesterEnrollment for this tournament
+    """
+    from app.models.semester_enrollment import SemesterEnrollment, EnrollmentStatus
+
+    entries = (
+        db.query(SponsorAudienceEntry)
+        .filter(
+            SponsorAudienceEntry.sponsor_id == sponsor_id,
+            SponsorAudienceEntry.campaign_id == campaign_id,
+            SponsorAudienceEntry.status == "ACTIVE",
+            SponsorAudienceEntry.consent_given == True,
+            SponsorAudienceEntry.user_id.isnot(None),
+        )
+        .all()
+    )
+
+    enrolled: list[int] = []
+    skipped: list[dict] = []
+
+    for entry in entries:
+        user_id = entry.user_id
+
+        user = db.query(User).filter(User.id == user_id, User.is_active == True).first()
+        if not user:
+            skipped.append({"user_id": user_id, "reason": "inactive or not found"})
+            continue
+
+        lic = (
+            db.query(UserLicense)
+            .filter(
+                UserLicense.user_id == user_id,
+                UserLicense.specialization_type == "LFA_FOOTBALL_PLAYER",
+                UserLicense.is_active == True,
+            )
+            .first()
+        )
+        if not lic:
+            skipped.append({"user_id": user_id, "reason": "no active LFA_FOOTBALL_PLAYER license"})
+            continue
+
+        active = (
+            db.query(SemesterEnrollment)
+            .filter(
+                SemesterEnrollment.semester_id == tid,
+                SemesterEnrollment.user_id == user_id,
+                SemesterEnrollment.is_active == True,
+            )
+            .first()
+        )
+        if active:
+            skipped.append({"user_id": user_id, "reason": "already enrolled"})
+            continue
+
+        inactive = (
+            db.query(SemesterEnrollment)
+            .filter(
+                SemesterEnrollment.semester_id == tid,
+                SemesterEnrollment.user_id == user_id,
+                SemesterEnrollment.user_license_id == lic.id,
+                SemesterEnrollment.is_active == False,
+            )
+            .first()
+        )
+        if inactive:
+            inactive.is_active = True
+            inactive.request_status = EnrollmentStatus.APPROVED
+        else:
+            db.add(
+                SemesterEnrollment(
+                    semester_id=tid,
+                    user_id=user_id,
+                    user_license_id=lic.id,
+                    is_active=True,
+                    request_status=EnrollmentStatus.APPROVED,
+                )
+            )
+        enrolled.append(user_id)
+
+    db.flush()
+    return {
+        "enrolled_count": len(enrolled),
+        "skipped_count": len(skipped),
+        "enrolled": enrolled,
+        "skipped": skipped,
+    }
+
+
+# ─── SC-04 hard validation ────────────────────────────────────────────────────
+
+def _validate_sc04(db: DBSession, tid: int, tournament_name: str) -> None:
+    """Hard-fail if the session structure does not match the expected 9-player group_knockout.
+
+    Expected:
+      - 13 sessions total
+      - 9 Group Stage  (game_type like "Group X - Round N")
+      - 0 Play-in      (game_type == "Play-in Round")
+      - 2 Semi-finals  (game_type == "Semi-finals")
+      - 1 Final        (game_type == "Final")
+      - 1 Bronze       (game_type == "3rd Place Match")
+      - SF matchup labels: "Group A winner vs Best runner-up" and
+                           "Group B winner vs Group C winner"
+    """
+    db.expire_all()
+    sessions = db.query(SessionModel).filter(SessionModel.semester_id == tid).all()
+    total = len(sessions)
+
+    group_stage = 0
+    play_in = 0
+    semi_finals = 0
+    final = 0
+    bronze = 0
+    sf_matchups: list[str] = []
+
+    for s in sessions:
+        phase = s.tournament_phase
+        gt = s.game_type or ""
+
+        if phase == TournamentPhase.GROUP_STAGE or phase == TournamentPhase.GROUP_STAGE.value:
+            group_stage += 1
+        elif gt == "Play-in Round":
+            play_in += 1
+        elif gt == "Semi-finals":
+            semi_finals += 1
+            sc = s.structure_config or {}
+            matchup = sc.get("matchup", "")
+            if matchup:
+                sf_matchups.append(matchup)
+        elif gt == "Final":
+            final += 1
+        elif gt == "3rd Place Match":
+            bronze += 1
+
+    errors: list[str] = []
+
+    if total != _EXPECTED_SESSIONS:
+        errors.append(f"sessions: expected {_EXPECTED_SESSIONS}, got {total}")
+    if group_stage != _EXPECTED_GROUP_STAGE:
+        errors.append(f"Group Stage: expected {_EXPECTED_GROUP_STAGE}, got {group_stage}")
+    if play_in != _EXPECTED_PLAY_IN:
+        errors.append(f"Play-in: expected {_EXPECTED_PLAY_IN}, got {play_in}")
+    if semi_finals != _EXPECTED_SEMI_FINALS:
+        errors.append(f"Semi-finals: expected {_EXPECTED_SEMI_FINALS}, got {semi_finals}")
+    if final != _EXPECTED_FINAL:
+        errors.append(f"Final: expected {_EXPECTED_FINAL}, got {final}")
+    if bronze != _EXPECTED_BRONZE:
+        errors.append(f"Bronze: expected {_EXPECTED_BRONZE}, got {bronze}")
+
+    actual_sf_matchups = frozenset(sf_matchups)
+    if actual_sf_matchups != _EXPECTED_SF_MATCHUPS:
+        errors.append(
+            f"SF matchup labels mismatch.\n"
+            f"    expected: {sorted(_EXPECTED_SF_MATCHUPS)}\n"
+            f"    got:      {sorted(actual_sf_matchups)}"
+        )
+
+    if errors:
+        print(f"\n  SC-04 VALIDATION FAILED for '{tournament_name}':")
+        for e in errors:
+            print(f"    * {e}")
+        sys.exit(1)
+
+    print(
+        f"  SC-04 OK: {total} sessions"
+        f" ({group_stage} GS + {semi_finals} SF + {final} F + {bronze} B),"
+        f" SF labels correct"
+    )
+
+
+# ─── Main entry point ─────────────────────────────────────────────────────────
+
+def run_scenarios(
+    db: DBSession,
+    client: TestClient,
+    *,
+    scenario_ids: list[str] | None = None,
+    dry_run: bool = False,
+    campus_id: int = 1,
+) -> dict[str, int | None]:
+    """Run promotion event seed scenarios.
+
+    Always runs the group_knockout preflight before any scenario so that
+    SC-04 structural failures are caught early with a clear message.
+
+    Args:
+        db:           Committed SQLAlchemy session (caller owns lifecycle).
+        client:       TestClient with admin auth overrides already applied.
+        scenario_ids: Subset to run, e.g. ["SC-01", "SC-04"]. None = all.
+        dry_run:      If True, print intent but write nothing.
+        campus_id:    Campus to associate with the tournament (default=1).
+
+    Returns:
+        Dict mapping scenario_id -> created tournament id (or None in dry-run).
+    """
+    _assert_not_production()
+
+    tt = _preflight_group_knockout_9p(db)
+
+    all_scenarios = ["SC-01", "SC-02", "SC-03", "SC-04"]
+    to_run = [s for s in all_scenarios if s in (scenario_ids or all_scenarios)]
+
+    admin = db.query(User).filter(User.email == "admin@lfa.com").first()
+    if not admin:
+        sys.exit("admin@lfa.com not found — run bootstrap first")
+
+    instructor = db.query(User).filter(User.email == "instructor@lfa.com").first()
+
+    sponsor = _get_or_create_sponsor(db, dry_run)
+    campaign = _get_or_create_campaign(db, sponsor, dry_run) if sponsor else None
+
+    if not dry_run and sponsor and campaign:
+        _ensure_9_audience_entries(db, sponsor, campaign, admin)
+        db.commit()
+
+    results: dict[str, int | None] = {}
+
+    # ── SC-01: DRAFT ──────────────────────────────────────────────────────────
+    if "SC-01" in to_run:
+        print("\n[SC-01] DRAFT")
+        t = _create_tournament(
+            db, f"{_TOURNAMENT_PREFIX}SC-01 Draft", sponsor, campaign, tt, campus_id, dry_run
+        )
+        if t:
+            print(f"  id={t.id}  status=DRAFT")
+        results["SC-01"] = t.id if t else None
+
+    # ── SC-02: ENROLLMENT_CLOSED + bulk-enroll ────────────────────────────────
+    if "SC-02" in to_run:
+        print("\n[SC-02] ENROLLMENT_CLOSED + bulk-enroll")
+        t = _create_tournament(
+            db, f"{_TOURNAMENT_PREFIX}SC-02 Locked", sponsor, campaign, tt, campus_id, dry_run
+        )
+        if t:
+            result = _bulk_enroll_direct(db, t.id, campaign.id, sponsor.id)
+            db.commit()
+            if _lock_enrollment(client, t.id):
+                db.expire_all()
+                print(
+                    f"  id={t.id}  status=ENROLLMENT_CLOSED"
+                    f"  enrolled={result.get('enrolled_count', 0)}"
+                    f"  skipped={result.get('skipped_count', 0)}"
+                )
+        results["SC-02"] = t.id if t else None
+
+    # ── SC-03: CHECK_IN_OPEN → 13 sessions ────────────────────────────────────
+    if "SC-03" in to_run:
+        print("\n[SC-03] CHECK_IN_OPEN (13 sessions expected)")
+        t = _create_tournament(
+            db, f"{_TOURNAMENT_PREFIX}SC-03 CheckIn", sponsor, campaign, tt, campus_id, dry_run
+        )
+        if t:
+            _bulk_enroll_direct(db, t.id, campaign.id, sponsor.id)
+            db.commit()
+            _lock_enrollment(client, t.id)
+            if _transition(client, t.id, "CHECK_IN_OPEN"):
+                db.expire_all()
+                count = (
+                    db.query(SessionModel)
+                    .filter(SessionModel.semester_id == t.id)
+                    .count()
+                )
+                if count != _EXPECTED_SESSIONS:
+                    sys.exit(
+                        f"SC-03: expected {_EXPECTED_SESSIONS} sessions after CHECK_IN_OPEN,"
+                        f" got {count}. Verify group_knockout 9_players config."
+                    )
+                print(f"  id={t.id}  status=CHECK_IN_OPEN  sessions={count}")
+        results["SC-03"] = t.id if t else None
+
+    # ── SC-04: full session structure validation ───────────────────────────────
+    if "SC-04" in to_run:
+        print("\n[SC-04] Full session structure validation (hard failure)")
+        t = _create_tournament(
+            db, f"{_TOURNAMENT_PREFIX}SC-04 Validate", sponsor, campaign, tt, campus_id, dry_run
+        )
+        if t:
+            _bulk_enroll_direct(db, t.id, campaign.id, sponsor.id)
+            db.commit()
+            _lock_enrollment(client, t.id)
+            _transition(client, t.id, "CHECK_IN_OPEN")
+            db.expire_all()
+
+            _validate_sc04(db, t.id, t.name)
+
+            if instructor:
+                t_db = db.query(Semester).filter(Semester.id == t.id).first()
+                t_db.master_instructor_id = instructor.id
+                db.commit()
+                db.expire_all()
+                if _transition(client, t.id, "IN_PROGRESS"):
+                    db.expire_all()
+                    print(f"  id={t.id}  status=IN_PROGRESS")
+            else:
+                print(f"  id={t.id}  status=CHECK_IN_OPEN  (no instructor@lfa.com, skipping IN_PROGRESS)")
+        results["SC-04"] = t.id if t else None
+
+    return results
+
+
+# ─── CLI entry point ─────────────────────────────────────────────────────────
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Seed promotion event scenarios")
+    parser.add_argument("--dry-run", action="store_true", help="Print intent only, write nothing")
+    parser.add_argument(
+        "--reset",
+        action="store_true",
+        help="Delete all PROMO-SEED-* data (requires ALLOW_SEED_RESET=true)",
+    )
+    parser.add_argument(
+        "--scenarios",
+        help="Comma-separated scenario IDs to run, e.g. SC-01,SC-04. Default: all.",
+    )
+    parser.add_argument("--campus-id", type=int, default=1, metavar="ID")
+    args = parser.parse_args()
+
+    _assert_not_production()
+
+    logging.basicConfig(level=logging.WARNING)
+
+    db = SessionLocal()
+    try:
+        if args.reset:
+            run_reset(db)
+            return
+
+        scenario_ids = (
+            [s.strip() for s in args.scenarios.split(",")] if args.scenarios else None
+        )
+
+        admin = db.query(User).filter(User.email == "admin@lfa.com").first()
+        if not admin:
+            sys.exit("admin@lfa.com not found — run bootstrap first")
+
+        app.dependency_overrides[get_current_user_web] = lambda: admin
+        app.dependency_overrides[get_current_admin_user_hybrid] = lambda: admin
+        app.dependency_overrides[get_current_admin_or_instructor_user_hybrid] = lambda: admin
+
+        client = TestClient(app, follow_redirects=False)
+
+        print("\n" + "=" * 60)
+        print("  PROMOTION EVENT SEED — Phase 2")
+        if args.dry_run:
+            print("  MODE: dry-run (no writes)")
+        print("=" * 60)
+
+        results = run_scenarios(
+            db,
+            client,
+            scenario_ids=scenario_ids,
+            dry_run=args.dry_run,
+            campus_id=args.campus_id,
+        )
+
+        print("\n" + "=" * 60)
+        print("  DONE")
+        for sc, tid in results.items():
+            if tid and not args.dry_run:
+                print(f"  {sc}: http://localhost:8000/admin/promotion-events/{tid}")
+            else:
+                print(f"  {sc}: (dry-run or skipped)")
+        print("=" * 60)
+
+    finally:
+        db.close()
+        app.dependency_overrides.clear()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/test_promotion_seed_smoke.py
+++ b/tests/integration/test_promotion_seed_smoke.py
@@ -1,0 +1,266 @@
+"""
+Smoke tests for scripts/seed_promotion_events.py
+
+Calls the script's importable entry point `run_scenarios(db, client, ...)`
+directly — no inline logic copied from the script.
+
+What is tested:
+  1. Preflight detects a missing/broken 9_players config and exits early.
+  2. Dry-run returns None for all scenario IDs (no DB writes).
+  3. SC-01 creates a DRAFT tournament with the PROMO-SEED- prefix.
+  4. SC-04 completes without sys.exit: session structure validates (13 sessions,
+     correct phase breakdown, correct SF matchup labels).
+
+Each test uses a real DB session with SAVEPOINT isolation — all writes are
+rolled back at teardown so no cleanup step is needed.
+"""
+
+from __future__ import annotations
+
+import os
+import importlib.util
+import pathlib
+import sys
+import types
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.main import app
+from app.database import get_db
+from app.dependencies import (
+    get_current_admin_or_instructor_user_hybrid,
+    get_current_admin_user_hybrid,
+    get_current_user_web,
+)
+from app.models.tournament_enums import TournamentPhase
+from app.models.tournament_type import TournamentType
+from app.models.semester import Semester, SemesterCategory
+from app.models.session import Session as SessionModel
+from app.models.user import User, UserRole
+from app.core.security import get_password_hash
+
+# ─── Load the script module at collection time ───────────────────────────────
+
+_SCRIPT_PATH = pathlib.Path(__file__).parents[2] / "scripts" / "seed_promotion_events.py"
+
+def _load_seed_module() -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location("seed_promotion_events", _SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_seed = _load_seed_module()
+run_scenarios = _seed.run_scenarios
+run_reset = _seed.run_reset
+_preflight_group_knockout_9p = _seed._preflight_group_knockout_9p
+_validate_sc04 = _seed._validate_sc04
+
+
+# ─── Fixtures ────────────────────────────────────────────────────────────────
+
+@pytest.fixture()
+def admin_user(test_db: Session) -> User:
+    user = test_db.query(User).filter(User.email == "admin@lfa.com").first()
+    if not user:
+        pytest.skip("admin@lfa.com not found — run bootstrap first")
+    return user
+
+
+@pytest.fixture()
+def seed_client(test_db: Session, admin_user: User) -> TestClient:
+    """TestClient with get_db and auth overrides wired to the SAVEPOINT session."""
+
+    def _override_db():
+        yield test_db
+
+    app.dependency_overrides[get_db] = _override_db
+    app.dependency_overrides[get_current_user_web] = lambda: admin_user
+    app.dependency_overrides[get_current_admin_user_hybrid] = lambda: admin_user
+    app.dependency_overrides[get_current_admin_or_instructor_user_hybrid] = lambda: admin_user
+
+    client = TestClient(app, follow_redirects=False)
+    yield client
+
+    app.dependency_overrides.pop(get_db, None)
+    app.dependency_overrides.pop(get_current_user_web, None)
+    app.dependency_overrides.pop(get_current_admin_user_hybrid, None)
+    app.dependency_overrides.pop(get_current_admin_or_instructor_user_hybrid, None)
+
+
+# ─── Tests ───────────────────────────────────────────────────────────────────
+
+class TestPreflight:
+    def test_preflight_passes_with_valid_db(self, test_db: Session) -> None:
+        """Preflight should succeed when DB has the 9_players policy."""
+        tt = _preflight_group_knockout_9p(test_db)
+        nine = tt.config["group_configuration"]["9_players"]
+        assert nine["qualification_policy"] == "winners_plus_best_runner_up"
+        assert int(nine["best_runner_up_count"]) == 1
+
+    def test_preflight_fails_if_9_players_missing(
+        self, test_db: Session, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Preflight must sys.exit when 9_players config is absent."""
+        tt = test_db.query(TournamentType).filter(
+            TournamentType.code == "group_knockout"
+        ).first()
+        if not tt:
+            pytest.skip("group_knockout TournamentType not in DB")
+
+        original_config = tt.config
+
+        def _patched_query(*args, **kwargs):
+            class _FakeTT:
+                id = tt.id
+                config = {
+                    "group_configuration": {
+                        # 9_players deliberately absent
+                        "8_players": {"groups": 2, "qualifiers": 2},
+                    },
+                    "round_names": original_config.get("round_names", {}),
+                }
+
+            class _FakeQuery:
+                def filter(self, *a, **kw):
+                    return self
+
+                def first(self):
+                    return _FakeTT()
+
+            return _FakeQuery()
+
+        monkeypatch.setattr(test_db, "query", _patched_query)
+
+        with pytest.raises(SystemExit):
+            _preflight_group_knockout_9p(test_db)
+
+
+class TestDryRun:
+    def test_dry_run_writes_nothing(
+        self, test_db: Session, seed_client: TestClient
+    ) -> None:
+        """Dry-run must return None for every scenario and create no DB rows."""
+        from app.models.sponsor import Sponsor
+
+        sponsor_before = (
+            test_db.query(Sponsor)
+            .filter(Sponsor.name == "SEED-SPONSOR")
+            .count()
+        )
+
+        results = run_scenarios(
+            test_db,
+            seed_client,
+            scenario_ids=["SC-01"],
+            dry_run=True,
+        )
+
+        sponsor_after = (
+            test_db.query(Sponsor)
+            .filter(Sponsor.name == "SEED-SPONSOR")
+            .count()
+        )
+
+        assert results["SC-01"] is None
+        assert sponsor_after == sponsor_before
+
+
+class TestSC01:
+    def test_sc01_creates_draft_tournament(
+        self, test_db: Session, seed_client: TestClient
+    ) -> None:
+        """SC-01: creates one PROMO-SEED-* tournament in DRAFT status."""
+        results = run_scenarios(
+            test_db,
+            seed_client,
+            scenario_ids=["SC-01"],
+            dry_run=False,
+        )
+
+        tid = results.get("SC-01")
+        assert tid is not None, "SC-01 must return a tournament id"
+
+        test_db.expire_all()
+        t = test_db.query(Semester).filter(Semester.id == tid).first()
+        assert t is not None
+        assert t.tournament_status == "DRAFT"
+        assert t.semester_category == SemesterCategory.PROMOTION_EVENT
+        assert t.name.startswith("PROMO-SEED-")
+        assert t.organizer_sponsor_id is not None
+        assert t.organizer_campaign_id is not None
+
+
+class TestSC04:
+    def test_sc04_session_structure_valid(
+        self, test_db: Session, seed_client: TestClient
+    ) -> None:
+        """SC-04: 13 sessions with correct phase breakdown and SF matchup labels.
+
+        This is the hard-failure gate: _validate_sc04 exits with sys.exit(1) if
+        anything is wrong, so any failure here is a real structural regression.
+        """
+        results = run_scenarios(
+            test_db,
+            seed_client,
+            scenario_ids=["SC-04"],
+            dry_run=False,
+        )
+
+        tid = results.get("SC-04")
+        assert tid is not None, "SC-04 must return a tournament id"
+
+        test_db.expire_all()
+        sessions = (
+            test_db.query(SessionModel)
+            .filter(SessionModel.semester_id == tid)
+            .all()
+        )
+
+        # Re-run the hard validation via the script's own function
+        # (redundant but makes failures immediately actionable in pytest output)
+        _validate_sc04(test_db, tid, "smoke-test")
+
+        total = len(sessions)
+        assert total == 13, f"expected 13 sessions, got {total}"
+
+        by_phase_and_type = {
+            "group_stage": 0,
+            "play_in": 0,
+            "semi_finals": 0,
+            "final": 0,
+            "bronze": 0,
+        }
+        sf_matchups: list[str] = []
+
+        for s in sessions:
+            phase = s.tournament_phase
+            gt = s.game_type or ""
+            if phase in (TournamentPhase.GROUP_STAGE, TournamentPhase.GROUP_STAGE.value):
+                by_phase_and_type["group_stage"] += 1
+            elif gt == "Play-in Round":
+                by_phase_and_type["play_in"] += 1
+            elif gt == "Semi-finals":
+                by_phase_and_type["semi_finals"] += 1
+                sc = s.structure_config or {}
+                matchup = sc.get("matchup", "")
+                if matchup:
+                    sf_matchups.append(matchup)
+            elif gt == "Final":
+                by_phase_and_type["final"] += 1
+            elif gt == "3rd Place Match":
+                by_phase_and_type["bronze"] += 1
+
+        assert by_phase_and_type["group_stage"] == 9, by_phase_and_type
+        assert by_phase_and_type["play_in"] == 0, by_phase_and_type
+        assert by_phase_and_type["semi_finals"] == 2, by_phase_and_type
+        assert by_phase_and_type["final"] == 1, by_phase_and_type
+        assert by_phase_and_type["bronze"] == 1, by_phase_and_type
+
+        assert frozenset(sf_matchups) == frozenset({
+            "Group A winner vs Best runner-up",
+            "Group B winner vs Group C winner",
+        }), f"SF matchup labels wrong: {sf_matchups}"


### PR DESCRIPTION
## Summary

- **`scripts/seed_promotion_events.py`** — importálható `run_scenarios(db, client)` entry point; 4 lifecycle scenario (SC-01 DRAFT → SC-04 teljes validáció); hard-exit ha SC-04 struktúra hibás; `ALLOW_SEED_RESET=true` gate; production URL block; dry-run mód; group_knockout 9_players preflight
- **`tests/integration/test_promotion_seed_smoke.py`** — 5 smoke test, mind `run_scenarios(...)` belépési pontot hívja (nem inline logika); SAVEPOINT-izolált; 4 class: Preflight / DryRun / SC01 / SC04
- **`group_knockout_generator.py` (bug fix, backport)** — `knockout_players` számítás nem tartalmazta `_best_runner_up_count`-ot → 9 players esetén 3 qualifiert (nem 4) számolt → play-in + no bronze. Javítás: `+ _best_runner_up_count` hozzáadása + helyes SF matchup labelek. E nélkül SC-04 nem zöldíthető.

## SC-04 live futtatási report

```
[SC-04] Full session structure validation (hard failure)
📸 ENROLLMENT SNAPSHOT saved at CHECK_IN_OPEN for tournament 22854: 9 players
✅ Auto-generated 13 sessions at CHECK_IN_OPEN for tournament 22854
  SC-04 OK: 13 sessions (9 GS + 2 SF + 1 F + 1 B), SF labels correct
  id=22854  status=IN_PROGRESS
  Admin URL: http://localhost:8000/admin/promotion-events/22854
```

SF matchup labelek:
- Match 1: `Group A winner vs Best runner-up`
- Match 2: `Group B winner vs Group C winner`

## Smoke test eredmény

```
5 passed in 0.69s
```

## Megjegyzések

- **`csak 3 fájl változott`** (nem 2): a generator fix kötelező volt — nélküle SC-04 sosem zöld main-en
- `ENROLLMENT_OPEN` közbülső lépés szükséges main-en (PR2.5 fast-path nincs még merge-elve)
- `_bulk_enroll_direct()` saját maga végzi az enrollment ORM-hívást mert `campaign_enrollment_service.py` és a `bulk-enroll-campaign` endpoint sem létezik main-en (PR2 hozta)
- Reset: `ALLOW_SEED_RESET=true PYTHONPATH=. python scripts/seed_promotion_events.py --reset`

## Test plan

- [x] SC-04 live futtatás zöld (id=22854, IN_PROGRESS)
- [x] `--dry-run` futtatás: 0 DB sor
- [x] `5/5 smoke test` zöld
- [ ] CI green on HEAD SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)