### PR TITLE
fix(tournament-edit): session ordering, KO pending label, seed URL

### DIFF
--- a/app/api/web_routes/tournaments/edit.py
+++ b/app/api/web_routes/tournaments/edit.py
@@ -23,6 +23,61 @@ from . import templates, _admin_only
 
 router = APIRouter()
 
+# ── Session ordering helpers ────────────────────────────────────────────────────
+
+# Canonical KO game-type order — guards against inconsistent tournament_round values.
+_KO_GAME_TYPE_ORDER: dict[str, int] = {
+    "Semi-finals": 0,
+    "Final": 1,
+    "3rd Place Match": 2,
+}
+
+
+def _session_sort_key(s) -> tuple:
+    """Sort key: GROUP_STAGE first (A→B→C, R1→R2→R3), then KNOCKOUT (SF→F→B).
+
+    For KO sessions ko_type_order (derived from game_type) is placed before
+    tournament_round so that correct KO ordering is preserved even when round
+    numbers are inconsistent.  For GROUP sessions ko_type_order is pinned to 0
+    so it has no effect and tournament_round drives the within-group order.
+    """
+    phase_str = s.tournament_phase.value if hasattr(s.tournament_phase, "value") else str(s.tournament_phase or "")
+    is_group = "GROUP" in phase_str
+    ko_type_order = 0 if is_group else _KO_GAME_TYPE_ORDER.get(s.game_type or "", 99)
+    return (
+        0 if is_group else 1,            # GROUP_STAGE before KNOCKOUT
+        s.group_identifier or "Z",       # A < B < C; KO has no group → sorts last
+        ko_type_order,                   # SF(0) < Final(1) < Bronze(2); 0 for GROUP (no-op)
+        s.tournament_round or 99,        # R1 < R2 < R3 within group; secondary for KO
+        s.tournament_match_number or 99, # M1 < M2 within same round
+    )
+
+
+def _matchup_label(s, teams_dict: dict, users_dict: dict) -> str | None:
+    """Return a human-readable matchup label for a session.
+
+    Priority:
+      1. Concrete team names (TEAM tournaments)
+      2. Concrete player names (HEAD_TO_HEAD with participants assigned)
+      3. ⏳ pending label from structure_config["matchup"] (bracket not yet resolved)
+      4. None
+    """
+    if s.participant_team_ids:
+        names = [teams_dict.get(tid, f"Team #{tid}") for tid in s.participant_team_ids[:2]]
+        return " vs ".join(names) if len(names) >= 2 else names[0]
+    if s.participant_user_ids:
+        if s.match_format == "HEAD_TO_HEAD" and len(s.participant_user_ids) >= 2:
+            u1 = users_dict.get(s.participant_user_ids[0])
+            u2 = users_dict.get(s.participant_user_ids[1])
+            n1 = u1.name if u1 else f"Player #{s.participant_user_ids[0]}"
+            n2 = u2.name if u2 else f"Player #{s.participant_user_ids[1]}"
+            return f"{n1} vs {n2}"
+        return f"{len(s.participant_user_ids)} participants"
+    matchup = (s.structure_config or {}).get("matchup")
+    if matchup:
+        return f"⏳ {matchup}"
+    return None
+
 
 # ── Tournament Edit Page ────────────────────────────────────────────────────────
 
@@ -110,24 +165,9 @@ async def admin_tournament_edit_page(
             SessionModel.semester_id == tournament_id,
             SessionModel.event_category == EventCategory.MATCH,
         )
-        .order_by(SessionModel.date_start)
         .all()
     )
-
-    def _matchup_label(s, teams_dict: dict, users_dict: dict):
-        """Return 'Team A vs Team B' / 'Player X vs Player Y' / 'N participants' / None."""
-        if s.participant_team_ids:
-            names = [teams_dict.get(tid, f"Team #{tid}") for tid in s.participant_team_ids[:2]]
-            return " vs ".join(names) if len(names) >= 2 else names[0]
-        if s.participant_user_ids:
-            if s.match_format == "HEAD_TO_HEAD" and len(s.participant_user_ids) >= 2:
-                u1 = users_dict.get(s.participant_user_ids[0])
-                u2 = users_dict.get(s.participant_user_ids[1])
-                n1 = u1.name if u1 else f"Player #{s.participant_user_ids[0]}"
-                n2 = u2.name if u2 else f"Player #{s.participant_user_ids[1]}"
-                return f"{n1} vs {n2}"
-            return f"{len(s.participant_user_ids)} participants"
-        return None
+    all_match_sessions.sort(key=_session_sort_key)
 
     # Team name map for TEAM tournaments (team_id → name) — built first for matchup_label
     enrolled_teams: dict = {}

--- a/app/tournament_types/group_knockout.json
+++ b/app/tournament_types/group_knockout.json
@@ -31,6 +31,13 @@
       "players_per_group": 4,
       "qualifiers": 2
     },
+    "9_players": {
+      "groups": 3,
+      "players_per_group": 3,
+      "qualifiers": 1,
+      "qualification_policy": "winners_plus_best_runner_up",
+      "best_runner_up_count": 1
+    },
     "12_players": {
       "groups": 3,
       "players_per_group": 4,
@@ -61,6 +68,14 @@
       "players_per_group": 4,
       "qualifiers": 2
     }
+  },
+  "round_names": {
+    "64": "Round of 64",
+    "32": "Round of 32",
+    "16": "Round of 16",
+    "8": "Quarter-finals",
+    "4": "Semi-finals",
+    "2": "Final"
   },
   "placement_rules": {
     "group_stage": {

--- a/scripts/seed_promotion_events.py
+++ b/scripts/seed_promotion_events.py
@@ -85,6 +85,14 @@ _EXPECTED_SF_MATCHUPS = frozenset({
     "Group B winner vs Group C winner",
 })
 
+# ─── URL helpers ──────────────────────────────────────────────────────────────
+
+
+def _admin_tournament_url(tid: int) -> str:
+    """Return the canonical admin edit URL for a tournament."""
+    return f"/admin/tournaments/{tid}/edit"
+
+
 # ─── Production guard ─────────────────────────────────────────────────────────
 
 _BLOCKED_URL_FRAGMENTS = ("lfa.com", "production", "staging", "prod")
@@ -782,7 +790,7 @@ def main() -> None:
         print("  DONE")
         for sc, tid in results.items():
             if tid and not args.dry_run:
-                print(f"  {sc}: http://localhost:8000/admin/promotion-events/{tid}")
+                print(f"  {sc}: http://localhost:8000{_admin_tournament_url(tid)}")
             else:
                 print(f"  {sc}: (dry-run or skipped)")
         print("=" * 60)

--- a/tests/e2e/test_knockout_matrix.py
+++ b/tests/e2e/test_knockout_matrix.py
@@ -324,7 +324,7 @@ def test_knockout_seeding_matrix(
     ]
     # More precise: sessions that were in initially_unseeded AND are now the deepest KO round
     # Use: sessions with title containing the deepest "Round of N" phrase
-    expected_round_name = {8: "Round of 4", 16: "Round of 8", 32: "Round of 16"}
+    expected_round_name = {8: "Semi-finals", 16: "Quarter-finals", 32: "Round of 16"}
     r1_title_keyword = expected_round_name[player_count]
     round1_sessions = [
         s for s in refreshed
@@ -440,8 +440,10 @@ def test_seeding_api_only(player_count: int, num_groups: int, expected_r1: int):
 
     refreshed = _get_sessions(token, tid)
 
-    # Identify first-round knockout sessions by the deepest "Round of N" title
-    r1_keyword = {8: "Round of 4", 16: "Round of 8", 32: "Round of 16"}[player_count]
+    # Identify first-round knockout sessions by title keyword.
+    # Keywords come from group_knockout.json round_names (4→Semi-finals, 8→Quarter-finals,
+    # 16→Round of 16). 8p KO has 4 players (2g×2q), 16p has 8 (4g×2q), 32p has 16 (8g×2q).
+    r1_keyword = {8: "Semi-finals", 16: "Quarter-finals", 32: "Round of 16"}[player_count]
     round1 = [s for s in refreshed if r1_keyword in (s.get("title") or "")]
 
     assert len(round1) == expected_r1, (

--- a/tests/unit/test_tournament_edit_helpers.py
+++ b/tests/unit/test_tournament_edit_helpers.py
@@ -1,0 +1,218 @@
+"""Unit tests for tournament edit page helper functions.
+
+Tests:
+  - _session_sort_key: ordering GROUP before KNOCKOUT, group-alphabetical,
+    round-within-group, KO game-type priority (SF → Final → Bronze)
+  - _matchup_label: concrete participants take priority, ⏳ fallback from
+    structure_config["matchup"] when no participants assigned
+  - _admin_tournament_url: correct URL format (seed script helper)
+"""
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import types
+
+import pytest
+
+from app.api.web_routes.tournaments.edit import _session_sort_key, _matchup_label
+
+# ── Seed script import ────────────────────────────────────────────────────────
+
+_SCRIPT_PATH = pathlib.Path(__file__).parents[2] / "scripts" / "seed_promotion_events.py"
+
+
+def _load_seed_module() -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location("seed_promotion_events", _SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_seed = _load_seed_module()
+_admin_tournament_url = _seed._admin_tournament_url
+
+
+# ── Session mock factory ──────────────────────────────────────────────────────
+
+def _sess(
+    *,
+    tournament_phase=None,
+    group_identifier=None,
+    tournament_round=None,
+    tournament_match_number=None,
+    game_type=None,
+    participant_team_ids=None,
+    participant_user_ids=None,
+    match_format=None,
+    structure_config=None,
+):
+    """Build a lightweight session-like namespace for helper unit tests."""
+    return types.SimpleNamespace(
+        tournament_phase=tournament_phase,
+        group_identifier=group_identifier,
+        tournament_round=tournament_round,
+        tournament_match_number=tournament_match_number,
+        game_type=game_type,
+        participant_team_ids=participant_team_ids,
+        participant_user_ids=participant_user_ids,
+        match_format=match_format,
+        structure_config=structure_config,
+    )
+
+
+# ── _session_sort_key ─────────────────────────────────────────────────────────
+
+class TestSessionSortKey:
+    def test_group_stage_before_knockout(self):
+        gs = _sess(tournament_phase="GROUP_STAGE", group_identifier="A", tournament_round=1)
+        ko = _sess(tournament_phase="KNOCKOUT", game_type="Semi-finals", tournament_round=1)
+        assert _session_sort_key(gs) < _session_sort_key(ko)
+
+    def test_group_phase_enum_value_accepted(self):
+        """tournament_phase may be an enum with .value attribute."""
+        class _FakeEnum:
+            value = "GROUP_STAGE"
+        gs = _sess(tournament_phase=_FakeEnum(), group_identifier="A", tournament_round=1)
+        ko = _sess(tournament_phase="KNOCKOUT", game_type="Final")
+        assert _session_sort_key(gs) < _session_sort_key(ko)
+
+    def test_group_alphabetical_A_before_B_before_C(self):
+        a = _sess(tournament_phase="GROUP_STAGE", group_identifier="A", tournament_round=1, tournament_match_number=1)
+        b = _sess(tournament_phase="GROUP_STAGE", group_identifier="B", tournament_round=1, tournament_match_number=1)
+        c = _sess(tournament_phase="GROUP_STAGE", group_identifier="C", tournament_round=1, tournament_match_number=1)
+        assert _session_sort_key(a) < _session_sort_key(b) < _session_sort_key(c)
+
+    def test_round_order_within_group(self):
+        r1 = _sess(tournament_phase="GROUP_STAGE", group_identifier="A", tournament_round=1, tournament_match_number=1)
+        r2 = _sess(tournament_phase="GROUP_STAGE", group_identifier="A", tournament_round=2, tournament_match_number=1)
+        r3 = _sess(tournament_phase="GROUP_STAGE", group_identifier="A", tournament_round=3, tournament_match_number=1)
+        assert _session_sort_key(r1) < _session_sort_key(r2) < _session_sort_key(r3)
+
+    def test_match_number_order_within_round(self):
+        m1 = _sess(tournament_phase="GROUP_STAGE", group_identifier="B", tournament_round=1, tournament_match_number=1)
+        m2 = _sess(tournament_phase="GROUP_STAGE", group_identifier="B", tournament_round=1, tournament_match_number=2)
+        assert _session_sort_key(m1) < _session_sort_key(m2)
+
+    def test_ko_semi_before_final_before_bronze(self):
+        sf = _sess(tournament_phase="KNOCKOUT", game_type="Semi-finals", tournament_round=1, tournament_match_number=1)
+        fi = _sess(tournament_phase="KNOCKOUT", game_type="Final", tournament_round=2, tournament_match_number=1)
+        br = _sess(tournament_phase="KNOCKOUT", game_type="3rd Place Match", tournament_round=3, tournament_match_number=1)
+        assert _session_sort_key(sf) < _session_sort_key(fi) < _session_sort_key(br)
+
+    def test_ko_game_type_priority_over_round(self):
+        """If round numbers are wrong, game_type still produces the correct order."""
+        # Bronze has tournament_round=1 (wrong), but game_type=3rd Place Match → sorts last
+        sf = _sess(tournament_phase="KNOCKOUT", game_type="Semi-finals", tournament_round=2)
+        br = _sess(tournament_phase="KNOCKOUT", game_type="3rd Place Match", tournament_round=1)
+        fi = _sess(tournament_phase="KNOCKOUT", game_type="Final", tournament_round=3)
+        ordered = sorted([br, fi, sf], key=_session_sort_key)
+        assert [s.game_type for s in ordered] == ["Semi-finals", "Final", "3rd Place Match"]
+
+    def test_full_sc04_order(self):
+        """Simulate the 13-session SC-04 tournament and verify end-to-end sort."""
+        sessions = [
+            # Group sessions (interleaved as date_start would give them)
+            _sess(tournament_phase="GROUP_STAGE", group_identifier="A", tournament_round=1, tournament_match_number=2, game_type="Group A - Round 1"),
+            _sess(tournament_phase="GROUP_STAGE", group_identifier="B", tournament_round=1, tournament_match_number=2, game_type="Group B - Round 1"),
+            _sess(tournament_phase="GROUP_STAGE", group_identifier="C", tournament_round=1, tournament_match_number=2, game_type="Group C - Round 1"),
+            _sess(tournament_phase="GROUP_STAGE", group_identifier="A", tournament_round=2, tournament_match_number=1, game_type="Group A - Round 2"),
+            _sess(tournament_phase="GROUP_STAGE", group_identifier="B", tournament_round=2, tournament_match_number=1, game_type="Group B - Round 2"),
+            _sess(tournament_phase="GROUP_STAGE", group_identifier="C", tournament_round=2, tournament_match_number=1, game_type="Group C - Round 2"),
+            _sess(tournament_phase="GROUP_STAGE", group_identifier="A", tournament_round=3, tournament_match_number=1, game_type="Group A - Round 3"),
+            _sess(tournament_phase="GROUP_STAGE", group_identifier="B", tournament_round=3, tournament_match_number=1, game_type="Group B - Round 3"),
+            _sess(tournament_phase="GROUP_STAGE", group_identifier="C", tournament_round=3, tournament_match_number=1, game_type="Group C - Round 3"),
+            # Knockout
+            _sess(tournament_phase="KNOCKOUT", game_type="Semi-finals", tournament_round=1, tournament_match_number=1),
+            _sess(tournament_phase="KNOCKOUT", game_type="Semi-finals", tournament_round=1, tournament_match_number=2),
+            _sess(tournament_phase="KNOCKOUT", game_type="Final", tournament_round=2, tournament_match_number=1),
+            _sess(tournament_phase="KNOCKOUT", game_type="3rd Place Match", tournament_round=3, tournament_match_number=1),
+        ]
+        import random
+        random.shuffle(sessions)
+        ordered = sorted(sessions, key=_session_sort_key)
+
+        expected = [
+            "Group A - Round 1", "Group A - Round 2", "Group A - Round 3",
+            "Group B - Round 1", "Group B - Round 2", "Group B - Round 3",
+            "Group C - Round 1", "Group C - Round 2", "Group C - Round 3",
+            "Semi-finals", "Semi-finals",
+            "Final",
+            "3rd Place Match",
+        ]
+        assert [s.game_type for s in ordered] == expected
+
+
+# ── _matchup_label ────────────────────────────────────────────────────────────
+
+class TestMatchupLabel:
+    def test_concrete_team_participants_priority(self):
+        s = _sess(participant_team_ids=[10, 20])
+        result = _matchup_label(s, {10: "Red FC", 20: "Blue FC"}, {})
+        assert result == "Red FC vs Blue FC"
+
+    def test_concrete_user_head_to_head_priority(self):
+        u1 = types.SimpleNamespace(name="Alice")
+        u2 = types.SimpleNamespace(name="Bob")
+        s = _sess(participant_user_ids=[1, 2], match_format="HEAD_TO_HEAD")
+        result = _matchup_label(s, {}, {1: u1, 2: u2})
+        assert result == "Alice vs Bob"
+
+    def test_concrete_participants_override_structure_config(self):
+        """If participant_user_ids is populated, structure_config matchup is ignored."""
+        u1 = types.SimpleNamespace(name="Alice")
+        u2 = types.SimpleNamespace(name="Bob")
+        s = _sess(
+            participant_user_ids=[1, 2],
+            match_format="HEAD_TO_HEAD",
+            structure_config={"matchup": "Group A winner vs Best runner-up"},
+        )
+        result = _matchup_label(s, {}, {1: u1, 2: u2})
+        assert result == "Alice vs Bob"
+        assert "Group A winner" not in result
+
+    def test_pending_fallback_from_structure_config(self):
+        """No participants assigned → ⏳ prefix + structure_config matchup label."""
+        s = _sess(
+            participant_user_ids=None,
+            participant_team_ids=None,
+            structure_config={"matchup": "Group A winner vs Best runner-up"},
+        )
+        result = _matchup_label(s, {}, {})
+        assert result == "⏳ Group A winner vs Best runner-up"
+
+    def test_pending_fallback_sf2(self):
+        s = _sess(structure_config={"matchup": "Group B winner vs Group C winner"})
+        assert _matchup_label(s, {}, {}) == "⏳ Group B winner vs Group C winner"
+
+    def test_pending_fallback_final(self):
+        s = _sess(structure_config={"matchup": "SF1 winner vs SF2 winner"})
+        assert _matchup_label(s, {}, {}) == "⏳ SF1 winner vs SF2 winner"
+
+    def test_no_fallback_when_no_matchup_in_structure_config(self):
+        """structure_config exists but has no 'matchup' key → None."""
+        s = _sess(structure_config={"round_name": "3rd Place Match"})
+        assert _matchup_label(s, {}, {}) is None
+
+    def test_returns_none_when_nothing_available(self):
+        s = _sess()
+        assert _matchup_label(s, {}, {}) is None
+
+
+# ── _admin_tournament_url ─────────────────────────────────────────────────────
+
+class TestAdminTournamentUrl:
+    def test_format_is_edit_page(self):
+        assert _admin_tournament_url(22857) == "/admin/tournaments/22857/edit"
+
+    def test_no_promotion_events_path(self):
+        url = _admin_tournament_url(1)
+        assert "/admin/promotion-events/" not in url
+        assert url.startswith("/admin/tournaments/")
+        assert url.endswith("/edit")
+
+    def test_various_ids(self):
+        for tid in [1, 100, 99999]:
+            url = _admin_tournament_url(tid)
+            assert str(tid) in url
+            assert url == f"/admin/tournaments/{tid}/edit"


### PR DESCRIPTION
## Summary

- **Fix A** — \`_session_sort_key\`: GROUP_STAGE sessions first (A→B→C, R1→R2→R3 within each group), then KNOCKOUT (SF→Final→Bronze). KO \`game_type\` placed before \`tournament_round\` in sort tuple — correct order is preserved even if round numbers are inconsistent.
- **Fix C** — \`_matchup_label\`: when \`participant_user_ids\`/\`participant_team_ids\` are empty, shows \`⏳ <structure_config["matchup"]>\` (bracket-pending label). Concrete participants always take priority. Both helpers extracted to module level for testability.
- **Fix E** — \`_admin_tournament_url(tid)\` helper in seed script; fixes the printed URL from \`/admin/promotion-events/{id}\` (404) to \`/admin/tournaments/{id}/edit\`.

## Changed files (5)

- \`app/api/web_routes/tournaments/edit.py\` — Fix A + Fix C: \`_session_sort_key\`, \`_matchup_label\` extracted to module level; \`_KO_GAME_TYPE_ORDER\` constant; \`all_match_sessions\` sorted via Python-level sort
- \`app/tournament_types/group_knockout.json\` — added \`9_players\` group config + \`round_names\` section (required for clean-DB bootstrap of SC-04 promotion events)
- \`scripts/seed_promotion_events.py\` — Fix E: \`_admin_tournament_url(tid)\` helper + corrected DONE-block print URL
- \`tests/unit/test_tournament_edit_helpers.py\` — 19 new unit tests (new file)
- \`tests/e2e/test_knockout_matrix.py\` — updated \`r1_keyword\` mapping to use semantic names (\`"Semi-finals"\`, \`"Quarter-finals"\`) instead of generic \`"Round of 4"\`/\`"Round of 8"\` after \`round_names\` was added to JSON

## NOT in this PR

Live group standings, instructor.py refactor, resolve-bracket endpoint, Resolve Bracket button, TournamentRanking workflow.

## Validated on SC-04 tournament #22857

Session Results panel order (13 sessions):
\`\`\`
 1  GROUP_STAGE  A  R1  Group A - Round 1    Player #91367 vs Player #91368
 2  GROUP_STAGE  A  R2  Group A - Round 2    Player #91366 vs Player #91367
 3  GROUP_STAGE  A  R3  Group A - Round 3    Player #91366 vs Player #91368
 4  GROUP_STAGE  B  R1  Group B - Round 1    Player #91370 vs Player #91371
 5  GROUP_STAGE  B  R2  Group B - Round 2    Player #91369 vs Player #91370
 6  GROUP_STAGE  B  R3  Group B - Round 3    Player #91369 vs Player #91371
 7  GROUP_STAGE  C  R1  Group C - Round 1    Player #91373 vs Player #91374
 8  GROUP_STAGE  C  R2  Group C - Round 2    Player #91372 vs Player #91373
 9  GROUP_STAGE  C  R3  Group C - Round 3    Player #91372 vs Player #91374
10  KNOCKOUT     -  SF  Semi-finals          ⏳ Group A winner vs Best runner-up
11  KNOCKOUT     -  SF  Semi-finals          ⏳ Group B winner vs Group C winner
12  KNOCKOUT     -  F   Final                ⏳ SF1 winner vs SF2 winner
13  KNOCKOUT     -  B   3rd Place Match      (title fallback — no matchup in structure_config)
\`\`\`

## Test plan

- [x] 19/19 unit tests green (\`tests/unit/test_tournament_edit_helpers.py\`)
- [x] 5/5 smoke tests green (\`tests/integration/test_promotion_seed_smoke.py\`)
- [x] CI 46/46 PASS + 1 SKIP (informational) on head SHA \`f28e8fc\`
- [ ] Manual UI validation: \`http://localhost:8000/admin/tournaments/22857/edit\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)