### PR TITLE
feat(eligibility): enforce LFA_COACH license + level at all instructor assignment points

### DIFF
--- a/app/api/api_v1/endpoints/teams.py
+++ b/app/api/api_v1/endpoints/teams.py
@@ -3,20 +3,74 @@ Teams REST API
 
 Endpoints for team management in team-based tournaments.
 Student-facing: create teams, invite members, respond to invites.
-Admin: user search for invite flow.
+Admin: user search for invite flow, admin team creation, direct member add.
 """
 from typing import List, Optional
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel
 from sqlalchemy.orm import Session
 from sqlalchemy import or_, and_
 
 from ....database import get_db
-from ....dependencies import get_current_user, get_current_active_user
+from ....dependencies import get_current_user, get_current_active_user, get_current_admin_user_hybrid
 from ....models.user import User, UserRole
 from ....models.team import Team, TeamMember, TeamInvite, TeamInviteStatus
 from ....services.tournament import team_service
 
 router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# Admin: team creation with explicit captain (automation / framework path)
+# ---------------------------------------------------------------------------
+
+class AdminCreateTeamRequest(BaseModel):
+    name: str
+    captain_user_id: int
+    specialization_type: Optional[str] = None
+    code: Optional[str] = None
+
+
+@router.post("/teams", status_code=status.HTTP_201_CREATED)
+def admin_create_team(
+    body: AdminCreateTeamRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_admin_user_hybrid),
+):
+    """Admin-only: create a team with an explicit captain. Bearer-token auth."""
+    if current_user.role != UserRole.ADMIN:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin only")
+    team = team_service.create_team(
+        db,
+        name=body.name,
+        captain_user_id=body.captain_user_id,
+        specialization_type=body.specialization_type or "",
+        code=body.code,
+    )
+    return {"id": team.id, "name": team.name, "code": team.code, "captain_user_id": team.captain_user_id}
+
+
+# ---------------------------------------------------------------------------
+# Admin: direct member add (no invite flow)
+# ---------------------------------------------------------------------------
+
+class AdminAddMemberRequest(BaseModel):
+    user_id: int
+    role: Optional[str] = "PLAYER"
+
+
+@router.post("/teams/{team_id}/members", status_code=status.HTTP_201_CREATED)
+def admin_add_team_member(
+    team_id: int,
+    body: AdminAddMemberRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_admin_user_hybrid),
+):
+    """Admin-only: add a user directly to a team without the invite flow. Bearer-token auth."""
+    if current_user.role != UserRole.ADMIN:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin only")
+    member = team_service.add_team_member(db, team_id=team_id, user_id=body.user_id, role=body.role or "PLAYER")
+    return {"id": member.id, "team_id": member.team_id, "user_id": member.user_id, "role": member.role}
 
 
 # ---------------------------------------------------------------------------

--- a/app/api/api_v1/endpoints/tournaments/__init__.py
+++ b/app/api/api_v1/endpoints/tournaments/__init__.py
@@ -23,6 +23,7 @@ from .checkin import router as checkin_router  # ✅ Pre-tournament check-in (re
 from .ops_scenario import router as ops_scenario_router  # ✅ OPS scenario endpoint (split from generator.py)
 from .lifecycle_instructor import router as lifecycle_instructor_router  # ✅ Cycle 2 instructor assignment (split from lifecycle.py)
 from .lifecycle_updates import router as lifecycle_updates_router        # ✅ Admin tournament update (split from lifecycle.py)
+from .team_enrollment import router as team_enrollment_router            # ✅ Admin team enrollment (automation path)
 
 # Combine all tournament routers
 router = APIRouter()
@@ -47,5 +48,6 @@ router.include_router(generate_sessions_router)  # ✅ Session generation with a
 router.include_router(ops_scenario_router)  # ✅ OPS scenario endpoint (admin-only)
 router.include_router(lifecycle_instructor_router)  # ✅ Cycle 2: assign-instructor, instructor/accept, instructor/decline
 router.include_router(lifecycle_updates_router)     # ✅ Admin PATCH /{id}: tournament field updates
+router.include_router(team_enrollment_router)        # ✅ Admin team enrollment (automation path)
 
 __all__ = ["router"]

--- a/app/api/api_v1/endpoints/tournaments/instructor_assignment.py
+++ b/app/api/api_v1/endpoints/tournaments/instructor_assignment.py
@@ -137,34 +137,12 @@ def accept_instructor_assignment(
     # REFACTORED: Use shared services
     require_instructor(current_user)
 
-    # Eligibility check — license, expiry, AND level vs tournament age group.
-    # LicenseValidator.get_coach_license() now also filters is_active + expires_at,
-    # but we use the full eligibility service here so the authority is consistent
-    # with all other assignment flows.
-    from app.services.tournament.instructor_eligibility_service import (
-        is_eligible_master_instructor,
-        resolve_tournament_age_groups,
-    )
-    from app.repositories.tournament_repository import TournamentRepository as _TR
-    _t = _TR(db).get_optional(tournament_id)
-    if _t:
-        _age_groups = resolve_tournament_age_groups(_t)
-        _eligible, _reason = is_eligible_master_instructor(db, current_user.id, _age_groups)
-        if not _eligible:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail={
-                    "error": "instructor_not_eligible",
-                    "message": f"Instructor not eligible for this tournament: {_reason}",
-                    "user_id": current_user.id,
-                },
-            )
-
     tournament_repo = TournamentRepository(db)
     tournament = tournament_repo.get_or_404(tournament_id)
 
     # ============================================================================
     # VALIDATION 4: Tournament status allows instructor acceptance
+    # (checked before eligibility so wrong-status returns 400, not 403)
     # ============================================================================
     # Two scenarios:
     # 1. SEEKING_INSTRUCTOR: Instructor volunteers for APPLICATION_BASED tournaments
@@ -182,6 +160,24 @@ def accept_instructor_assignment(
                 "tournament_id": tournament_id,
                 "tournament_name": tournament.name
             }
+        )
+
+    # Eligibility check — license, expiry, AND level vs tournament age group.
+    # Runs after status check so wrong-status always returns 400 before this.
+    from app.services.tournament.instructor_eligibility_service import (
+        is_eligible_master_instructor,
+        resolve_tournament_age_groups,
+    )
+    _age_groups = resolve_tournament_age_groups(tournament)
+    _eligible, _reason = is_eligible_master_instructor(db, current_user.id, _age_groups)
+    if not _eligible:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "error": "instructor_not_eligible",
+                "message": f"Instructor not eligible for this tournament: {_reason}",
+                "user_id": current_user.id,
+            },
         )
 
     # ============================================================================

--- a/app/api/api_v1/endpoints/tournaments/instructor_assignment.py
+++ b/app/api/api_v1/endpoints/tournaments/instructor_assignment.py
@@ -136,7 +136,29 @@ def accept_instructor_assignment(
     """
     # REFACTORED: Use shared services
     require_instructor(current_user)
-    LicenseValidator.get_coach_license(db, current_user.id, raise_if_missing=True)
+
+    # Eligibility check — license, expiry, AND level vs tournament age group.
+    # LicenseValidator.get_coach_license() now also filters is_active + expires_at,
+    # but we use the full eligibility service here so the authority is consistent
+    # with all other assignment flows.
+    from app.services.tournament.instructor_eligibility_service import (
+        is_eligible_master_instructor,
+        resolve_tournament_age_groups,
+    )
+    from app.repositories.tournament_repository import TournamentRepository as _TR
+    _t = _TR(db).get_optional(tournament_id)
+    if _t:
+        _age_groups = resolve_tournament_age_groups(_t)
+        _eligible, _reason = is_eligible_master_instructor(db, current_user.id, _age_groups)
+        if not _eligible:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={
+                    "error": "instructor_not_eligible",
+                    "message": f"Instructor not eligible for this tournament: {_reason}",
+                    "user_id": current_user.id,
+                },
+            )
 
     tournament_repo = TournamentRepository(db)
     tournament = tournament_repo.get_or_404(tournament_id)

--- a/app/api/api_v1/endpoints/tournaments/lifecycle.py
+++ b/app/api/api_v1/endpoints/tournaments/lifecycle.py
@@ -281,12 +281,13 @@ def transition_tournament_status(
     # Record old status for response and history
     old_status = tournament.tournament_status
 
-    # ── Pre-check: instructor prerequisite (before status flush) ──────────────
-    # GenerationValidator also checks this, but that check runs AFTER the flush.
-    # In SAVEPOINT-isolated tests the flushed status change would remain visible
-    # even after an HTTPException, making the status assertion fail.  Checking
-    # here (before any mutation) keeps the status unchanged on failure.
+    # ── Pre-checks (before status flush) ─────────────────────────────────────
+    # All pre-checks must run before the status flush so a 400 leaves
+    # tournament_status unchanged (important for SAVEPOINT-isolated tests).
+
     if request.new_status == "CHECK_IN_OPEN":
+        # Instructor eligibility — GenerationValidator repeats this, but that runs
+        # after the flush; checking here keeps status unchanged on failure.
         from app.services.tournament.instructor_eligibility_service import (
             check_tournament_master_instructor_eligible,
         )
@@ -295,6 +296,29 @@ def transition_tournament_status(
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=f"Cannot advance to CHECK_IN_OPEN: {reason}",
+            )
+
+        # Schedule configuration — NULL fields are NOT silently defaulted;
+        # the admin must explicitly set match/break/parallel before closing enrollment.
+        from app.services.tournament.readiness_validator import check_pre_check_in_open
+        sched = check_pre_check_in_open(db, tournament)
+        if not sched.ok:
+            _codes = f" [{', '.join(sched.requirement_codes)}]" if sched.requirement_codes else ""
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Cannot advance to CHECK_IN_OPEN: {'; '.join(sched.blocking_errors)}{_codes}",
+            )
+
+    if request.new_status == "IN_PROGRESS":
+        # Reward configuration — a tournament without reward config enters IN_PROGRESS
+        # but never distributes XP; block here so the admin is forced to configure it.
+        from app.services.tournament.readiness_validator import check_pre_in_progress
+        rwd = check_pre_in_progress(db, tournament)
+        if not rwd.ok:
+            _codes = f" [{', '.join(rwd.requirement_codes)}]" if rwd.requirement_codes else ""
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Cannot advance to IN_PROGRESS: {'; '.join(rwd.blocking_errors)}{_codes}",
             )
 
     # Update tournament status
@@ -544,9 +568,15 @@ def transition_tournament_status(
                 if success:
                     print(f"✅ Auto-regenerated {len(sessions_created)} sessions at IN_PROGRESS for tournament {tournament_id}")
                 else:
-                    print(f"⚠️ Failed to regenerate sessions at IN_PROGRESS: {message}")
+                    raise HTTPException(
+                        status_code=400,
+                        detail=f"Session regeneration failed at IN_PROGRESS: {message}",
+                    )
             else:
-                print(f"⚠️ Cannot regenerate sessions at IN_PROGRESS: {reason}")
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Cannot regenerate sessions at IN_PROGRESS: {reason}",
+                )
 
     # Record status history
     record_status_change(

--- a/app/api/api_v1/endpoints/tournaments/lifecycle.py
+++ b/app/api/api_v1/endpoints/tournaments/lifecycle.py
@@ -287,14 +287,14 @@ def transition_tournament_status(
     # even after an HTTPException, making the status assertion fail.  Checking
     # here (before any mutation) keeps the status unchanged on failure.
     if request.new_status == "CHECK_IN_OPEN":
-        from app.services.tournament.instructor_service import has_master_instructor_assignment
-        if not has_master_instructor_assignment(db, tournament_id):
+        from app.services.tournament.instructor_eligibility_service import (
+            check_tournament_master_instructor_eligible,
+        )
+        eligible, reason = check_tournament_master_instructor_eligible(db, tournament_id)
+        if not eligible:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail=(
-                    "Cannot generate sessions: No instructor assigned. "
-                    "Assign a master instructor before generating sessions."
-                ),
+                detail=f"Cannot advance to CHECK_IN_OPEN: {reason}",
             )
 
     # Update tournament status

--- a/app/api/api_v1/endpoints/tournaments/lifecycle.py
+++ b/app/api/api_v1/endpoints/tournaments/lifecycle.py
@@ -321,6 +321,26 @@ def transition_tournament_status(
                 detail=f"Cannot advance to IN_PROGRESS: {'; '.join(rwd.blocking_errors)}{_codes}",
             )
 
+    if request.new_status == "COMPLETED":
+        from app.services.tournament.readiness_validator import check_pre_completed
+        comp = check_pre_completed(db, tournament)
+        if not comp.ok:
+            _codes = f" [{', '.join(comp.requirement_codes)}]" if comp.requirement_codes else ""
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Cannot advance to COMPLETED: {'; '.join(comp.blocking_errors)}{_codes}",
+            )
+
+    if request.new_status == "REWARDS_DISTRIBUTED":
+        from app.services.tournament.readiness_validator import check_pre_rewards_distributed
+        rdist = check_pre_rewards_distributed(db, tournament)
+        if not rdist.ok:
+            _codes = f" [{', '.join(rdist.requirement_codes)}]" if rdist.requirement_codes else ""
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Cannot advance to REWARDS_DISTRIBUTED: {'; '.join(rdist.blocking_errors)}{_codes}",
+            )
+
     # Update tournament status
     tournament.tournament_status = request.new_status
     db.flush()

--- a/app/api/api_v1/endpoints/tournaments/ops_scenario/__init__.py
+++ b/app/api/api_v1/endpoints/tournaments/ops_scenario/__init__.py
@@ -886,7 +886,7 @@ def run_ops_scenario(
         t_cfg = _TCfg(
             semester_id=tournament.id,
             tournament_type_id=tt.id,
-            participant_type="INDIVIDUAL",
+            participant_type=request.participant_type,
             is_multi_day=False,
             max_players=request.max_players or _effective_count,  # Use override if provided
             parallel_fields=1,
@@ -899,7 +899,7 @@ def run_ops_scenario(
         t_cfg = _TCfg(
             semester_id=tournament.id,
             tournament_type_id=None,
-            participant_type="INDIVIDUAL",
+            participant_type=request.participant_type,
             is_multi_day=False,
             max_players=request.max_players or _effective_count,  # Use override if provided
             parallel_fields=1,

--- a/app/api/api_v1/endpoints/tournaments/ops_scenario/schemas.py
+++ b/app/api/api_v1/endpoints/tournaments/ops_scenario/schemas.py
@@ -126,6 +126,14 @@ class OpsScenarioRequest(BaseModel):
             "False: Skip session generation (manual mode for instructor assignment tests)."
         ),
     )
+    participant_type: str = Field(
+        "INDIVIDUAL",
+        description=(
+            "Participant type for the tournament: 'INDIVIDUAL' or 'TEAM'. "
+            "Default: 'INDIVIDUAL' (all existing callers are unaffected). "
+            "Set to 'TEAM' to create a team-based tournament (TeamLeagueScenario prerequisite)."
+        ),
+    )
 
 
 class OpsScenarioResponse(BaseModel):

--- a/app/api/api_v1/endpoints/tournaments/ops_scenario/schemas.py
+++ b/app/api/api_v1/endpoints/tournaments/ops_scenario/schemas.py
@@ -126,12 +126,13 @@ class OpsScenarioRequest(BaseModel):
             "False: Skip session generation (manual mode for instructor assignment tests)."
         ),
     )
-    participant_type: str = Field(
+    participant_type: Literal["INDIVIDUAL", "TEAM"] = Field(
         "INDIVIDUAL",
         description=(
             "Participant type for the tournament: 'INDIVIDUAL' or 'TEAM'. "
             "Default: 'INDIVIDUAL' (all existing callers are unaffected). "
-            "Set to 'TEAM' to create a team-based tournament (TeamLeagueScenario prerequisite)."
+            "Set to 'TEAM' to create a team-based tournament (TeamLeagueScenario prerequisite). "
+            "MIXED is not accepted — no implemented flow behind it."
         ),
     )
 

--- a/app/api/api_v1/endpoints/tournaments/team_enrollment.py
+++ b/app/api/api_v1/endpoints/tournaments/team_enrollment.py
@@ -1,0 +1,50 @@
+"""Admin team-enrollment endpoint — POST /{tournament_id}/enroll-team."""
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.dependencies import get_current_admin_user_hybrid
+from app.models.user import User, UserRole
+from app.services.tournament import team_service
+
+router = APIRouter()
+
+
+class TeamEnrollRequest(BaseModel):
+    team_id: int
+
+
+@router.post("/{tournament_id}/enroll-team", status_code=status.HTTP_200_OK)
+def admin_enroll_team(
+    tournament_id: int,
+    body: TeamEnrollRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_admin_user_hybrid),
+):
+    """
+    Admin-only: enroll an existing team into a TEAM tournament.
+
+    Guards (enforced by service):
+    - tournament exists, participant_type == TEAM, status == ENROLLMENT_OPEN
+    - team exists and is active
+    - no duplicate enrollment (idempotent: returns existing enrollment on repeat call)
+    - if team_enrollment_cost > 0: deducts from captain's credit balance
+
+    Returns 200 whether the enrollment is new or pre-existing (idempotent).
+    """
+    if current_user.role != UserRole.ADMIN:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin only")
+
+    enrollment = team_service.admin_enroll_team_in_tournament(
+        db,
+        team_id=body.team_id,
+        tournament_id=tournament_id,
+    )
+    return {
+        "enrolled": True,
+        "enrollment_id": enrollment.id,
+        "team_id": enrollment.team_id,
+        "tournament_id": enrollment.semester_id,
+        "payment_verified": enrollment.payment_verified,
+    }

--- a/app/api/web_routes/admin/sponsors.py
+++ b/app/api/web_routes/admin/sponsors.py
@@ -18,6 +18,11 @@ from ....models.tournament_configuration import TournamentConfiguration
 from ....models.tournament_type import TournamentType as TournamentTypeModel
 from ....models.license import UserLicense
 from ....models.user import User, UserRole
+from ....services.tournament.instructor_eligibility_service import (
+    get_eligible_master_instructors,
+    get_instructor_license_levels,
+    is_eligible_master_instructor,
+)
 from ....services.sponsor_csv_import_service import (
     MAX_CSV_BYTES,
     apply_import,
@@ -275,11 +280,10 @@ async def admin_sponsor_promotion_form(
 
     campuses = db.query(Campus).filter(Campus.is_active == True).order_by(Campus.name).all()  # noqa: E712
     tournament_types = db.query(TournamentTypeModel).order_by(TournamentTypeModel.display_name).all()
-    instructors = (
-        db.query(User)
-        .filter(User.role == UserRole.INSTRUCTOR, User.is_active == True)  # noqa: E712
-        .order_by(User.name)
-        .all()
+    # age_groups unknown at GET time — filter by license+role, level validated at POST
+    instructors = get_eligible_master_instructors(db, age_groups=None)
+    instructor_license_levels = get_instructor_license_levels(
+        db, [instr.id for instr in instructors]
     )
 
     return templates.TemplateResponse(
@@ -292,6 +296,7 @@ async def admin_sponsor_promotion_form(
             "campuses": campuses,
             "tournament_types": tournament_types,
             "instructors": instructors,
+            "instructor_license_levels": instructor_license_levels,
         },
     )
 
@@ -360,14 +365,11 @@ async def admin_sponsor_promotion_create(
                 url=f"/admin/sponsors/{sponsor_id}/promotion?error=Invalid+instructor+selection",
                 status_code=303,
             )
-        instructor = (
-            db.query(User)
-            .filter(User.id == iid, User.role == UserRole.INSTRUCTOR, User.is_active == True)  # noqa: E712
-            .first()
-        )
-        if not instructor:
+        eligible, reason = is_eligible_master_instructor(db, iid, age_groups)
+        if not eligible:
+            error_msg = reason.replace(" ", "+")
             return RedirectResponse(
-                url=f"/admin/sponsors/{sponsor_id}/promotion?error=Selected+instructor+not+found+or+inactive",
+                url=f"/admin/sponsors/{sponsor_id}/promotion?error={error_msg}",
                 status_code=303,
             )
         resolved_instructor_id = iid

--- a/app/services/shared/license_validator.py
+++ b/app/services/shared/license_validator.py
@@ -16,7 +16,10 @@ Usage:
     license = LicenseValidator.get_coach_license(db, user_id)
 """
 
+from datetime import datetime, timezone
+
 from fastapi import HTTPException, status
+from sqlalchemy import or_
 from sqlalchemy.orm import Session
 from typing import Optional
 
@@ -63,9 +66,12 @@ class LicenseValidator:
         Raises:
             HTTPException(403): If no coach license found and raise_if_missing=True
         """
+        now = datetime.now(timezone.utc)
         coach_license = db.query(UserLicense).filter(
             UserLicense.user_id == user_id,
-            UserLicense.specialization_type == "LFA_COACH"
+            UserLicense.specialization_type == "LFA_COACH",
+            UserLicense.is_active == True,  # noqa: E712
+            or_(UserLicense.expires_at.is_(None), UserLicense.expires_at > now),
         ).order_by(UserLicense.current_level.desc()).first()
 
         if not coach_license and raise_if_missing:

--- a/app/services/tournament/instructor_eligibility_service.py
+++ b/app/services/tournament/instructor_eligibility_service.py
@@ -1,0 +1,308 @@
+"""
+Instructor Eligibility Service
+
+Rögzített domain policy (2026-05-07):
+
+  Master Instructor:
+    - User.role == INSTRUCTOR
+    - User.is_active == True
+    - UserLicense(specialization_type="LFA_COACH", is_active=True) létezik
+    - expires_at IS NULL OR expires_at > now()   [timezone-safe]
+    - current_level >= _required_level(age_groups)
+    - payment_verified: OUT-OF-SCOPE (nem enforcelve)
+
+  Field / Assistant Instructor:
+    - Ugyanaz mint Master
+    - Minimum level: max(1, _required_level(age_groups) - 1)
+
+  Revoked / suspended:
+    - is_active=False lefedi; nincs külön revoked/suspended mező ebben a PR-ban.
+
+  Multi-age Promotion Event:
+    - A legmagasabb (legszigorúbb) age_group minimumát kell teljesíteni.
+
+Age group → minimum coach level (LFA scale 1–8):
+    PRE    → 1   (COACH_LFA_PRE_ASSISTANT)
+    YOUTH  → 3   (COACH_LFA_YOUTH_ASSISTANT)
+    AMATEUR → 5  (COACH_LFA_AMATEUR_ASSISTANT)
+    PRO    → 7   (COACH_LFA_PRO_ASSISTANT)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+from sqlalchemy import and_, or_
+from sqlalchemy.orm import Session
+
+from app.models.license import UserLicense
+from app.models.user import User, UserRole
+
+if TYPE_CHECKING:
+    from app.models.semester import Semester
+
+# ── Age group → minimum coach level ──────────────────────────────────────────
+
+_LEVEL_FOR_AGE_GROUP: dict[str, int] = {
+    "PRE": 1,
+    "YOUTH": 3,
+    "AMATEUR": 5,
+    "PRO": 7,
+}
+
+
+# ── Timezone-safe comparison ──────────────────────────────────────────────────
+
+def _to_utc_aware(dt: datetime) -> datetime:
+    """Normalize a datetime to UTC-aware.
+
+    Treats naive datetimes as UTC (the convention used throughout this project).
+    Safe to call on aware datetimes too — they are returned unchanged if already
+    UTC, otherwise converted.
+    """
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+# ── Internal helpers ──────────────────────────────────────────────────────────
+
+def _required_level(age_groups: list[str]) -> int:
+    """Return the highest minimum coach level required across all age groups.
+
+    Empty list → 1 (most permissive fallback).
+    Unknown age group string → treated as 1 (backward-compat).
+    """
+    return max((_LEVEL_FOR_AGE_GROUP.get(ag, 1) for ag in age_groups), default=1)
+
+
+def _active_coach_license(db: Session, user_id: int) -> UserLicense | None:
+    """Return the highest-level active, non-expired LFA_COACH license, or None.
+
+    SQLAlchemy filter handles timezone comparison at DB level (PostgreSQL TIMESTAMPTZ).
+    The Python-side _to_utc_aware() call ensures we pass a timezone-aware datetime
+    regardless of the local system clock configuration.
+    """
+    now = _to_utc_aware(datetime.now(timezone.utc))
+    return (
+        db.query(UserLicense)
+        .filter(
+            UserLicense.user_id == user_id,
+            UserLicense.specialization_type == "LFA_COACH",
+            UserLicense.is_active == True,  # noqa: E712
+            or_(UserLicense.expires_at.is_(None), UserLicense.expires_at > now),
+        )
+        .order_by(UserLicense.current_level.desc())
+        .first()
+    )
+
+
+def _get_master_instructor_id(db: Session, tournament_id: int) -> int | None:
+    """Resolve the master instructor user-id for a tournament.
+
+    Checks (in order):
+    1. Semester.master_instructor_id  (legacy / wizard-assigned field)
+    2. TournamentInstructorSlot with role=MASTER and status != ABSENT
+
+    Returns None if no master assignment found — callers must handle this as
+    "No master instructor assigned" (not "User not found").
+    """
+    from app.models.semester import Semester
+    from app.models.tournament_instructor_slot import (
+        TournamentInstructorSlot,
+        SlotRole,
+        SlotStatus,
+    )
+
+    t = db.query(Semester).filter(Semester.id == tournament_id).first()
+    if not t:
+        return None
+
+    if t.master_instructor_id:
+        return t.master_instructor_id
+
+    slot = (
+        db.query(TournamentInstructorSlot)
+        .filter(
+            TournamentInstructorSlot.semester_id == tournament_id,
+            TournamentInstructorSlot.role == SlotRole.MASTER.value,
+            TournamentInstructorSlot.status != SlotStatus.ABSENT.value,
+        )
+        .first()
+    )
+    return slot.instructor_id if slot else None
+
+
+# ── Public API ────────────────────────────────────────────────────────────────
+
+def resolve_tournament_age_groups(tournament: "Semester") -> list[str]:
+    """Canonical age group resolution for any Semester/tournament object.
+
+    Priority:
+      1. age_groups  — JSONB list (multi-age Promotion Events)
+      2. age_group   — scalar string (single-age tournaments)
+      3. []          — neither set; callers use _required_level([]) → 1
+
+    Shared by lifecycle.py, generation_validator.py, sponsors.py, and
+    instructor_planning_service.py — do NOT duplicate this logic inline.
+    """
+    if tournament.age_groups:
+        return list(tournament.age_groups)
+    if tournament.age_group:
+        return [tournament.age_group]
+    return []
+
+
+def is_eligible_master_instructor(
+    db: Session,
+    user_id: int,
+    age_groups: list[str],
+) -> tuple[bool, str]:
+    """Check master instructor eligibility against the rögzített domain policy.
+
+    Returns:
+        (True, "")               — eligible
+        (False, human_reason)    — not eligible; reason is English, suitable for
+                                   HTTP error detail or redirect query param.
+    """
+    user = db.query(User).filter(User.id == user_id).first()
+    if not user:
+        return False, f"User {user_id} not found"
+    if user.role != UserRole.INSTRUCTOR:
+        return False, f"User role is '{user.role.value}', expected 'instructor'"
+    if not user.is_active:
+        return False, "User account is inactive"
+
+    lic = _active_coach_license(db, user_id)
+    if not lic:
+        return False, "No active, valid LFA_COACH license found (license may be missing, inactive, or expired)"
+
+    req = _required_level(age_groups)
+    if lic.current_level < req:
+        return False, (
+            f"Coach level {lic.current_level} is insufficient for age groups "
+            f"{age_groups} (minimum required: {req})"
+        )
+
+    return True, ""
+
+
+def is_eligible_field_instructor(
+    db: Session,
+    user_id: int,
+    age_groups: list[str],
+) -> tuple[bool, str]:
+    """Check field / assistant instructor eligibility.
+
+    Same as master but minimum level is max(1, _required_level(age_groups) - 1).
+    """
+    user = db.query(User).filter(User.id == user_id).first()
+    if not user:
+        return False, f"User {user_id} not found"
+    if user.role != UserRole.INSTRUCTOR:
+        return False, f"User role is '{user.role.value}', expected 'instructor'"
+    if not user.is_active:
+        return False, "User account is inactive"
+
+    lic = _active_coach_license(db, user_id)
+    if not lic:
+        return False, "No active, valid LFA_COACH license found (license may be missing, inactive, or expired)"
+
+    req = max(1, _required_level(age_groups) - 1)
+    if lic.current_level < req:
+        return False, (
+            f"Coach level {lic.current_level} is insufficient for field role in "
+            f"age groups {age_groups} (minimum required: {req})"
+        )
+
+    return True, ""
+
+
+def check_tournament_master_instructor_eligible(
+    db: Session,
+    tournament_id: int,
+) -> tuple[bool, str]:
+    """Check that the tournament's assigned master instructor is eligible.
+
+    Used by lifecycle.py (CHECK_IN_OPEN) and GenerationValidator.
+
+    Returns:
+        (True, "")                        — eligible
+        (False, "No master instructor assigned")      — no assignment at all
+        (False, human_reason_from_policy) — assigned but not eligible
+    """
+    from app.models.semester import Semester
+
+    t = db.query(Semester).filter(Semester.id == tournament_id).first()
+    if not t:
+        return False, "Tournament not found"
+
+    master_id = _get_master_instructor_id(db, tournament_id)
+    if master_id is None:
+        return False, "No master instructor assigned"
+
+    age_groups = resolve_tournament_age_groups(t)
+    return is_eligible_master_instructor(db, master_id, age_groups)
+
+
+def get_eligible_master_instructors(
+    db: Session,
+    age_groups: list[str] | None = None,
+) -> list[User]:
+    """Return all Users eligible as master instructor.
+
+    age_groups=None → license + role filter only (level NOT filtered).
+                      Used for wizard GET where age_groups are not yet known.
+    age_groups set  → full level filter applied.
+
+    Uses JOIN (not subquery) to avoid SQLAlchemy in_() subquery warnings.
+    """
+    now = _to_utc_aware(datetime.now(timezone.utc))
+
+    license_conditions = and_(
+        UserLicense.specialization_type == "LFA_COACH",
+        UserLicense.is_active == True,  # noqa: E712
+        or_(UserLicense.expires_at.is_(None), UserLicense.expires_at > now),
+    )
+    if age_groups:
+        req = _required_level(age_groups)
+        license_conditions = and_(license_conditions, UserLicense.current_level >= req)
+
+    return (
+        db.query(User)
+        .join(UserLicense, and_(UserLicense.user_id == User.id, license_conditions))
+        .filter(
+            User.role == UserRole.INSTRUCTOR,
+            User.is_active == True,  # noqa: E712
+        )
+        .order_by(User.name)
+        .all()
+    )
+
+
+def get_instructor_license_levels(
+    db: Session,
+    user_ids: list[int],
+) -> dict[int, int]:
+    """Return {user_id: current_level} for the given instructor user IDs.
+
+    Only returns entries where an active, non-expired LFA_COACH license exists.
+    Used to populate the `instructor_license_levels` dict in template context
+    without attaching dynamic attributes to ORM objects.
+    """
+    if not user_ids:
+        return {}
+
+    now = _to_utc_aware(datetime.now(timezone.utc))
+    rows = (
+        db.query(UserLicense.user_id, UserLicense.current_level)
+        .filter(
+            UserLicense.user_id.in_(user_ids),
+            UserLicense.specialization_type == "LFA_COACH",
+            UserLicense.is_active == True,  # noqa: E712
+            or_(UserLicense.expires_at.is_(None), UserLicense.expires_at > now),
+        )
+        .all()
+    )
+    return {row.user_id: row.current_level for row in rows}

--- a/app/services/tournament/instructor_planning_service.py
+++ b/app/services/tournament/instructor_planning_service.py
@@ -87,12 +87,35 @@ def add_slot(
     notes: Optional[str] = None,
 ) -> TournamentInstructorSlot:
     """Add an instructor to the tournament roster."""
+    from app.services.tournament.instructor_eligibility_service import (
+        is_eligible_master_instructor,
+        is_eligible_field_instructor,
+        resolve_tournament_age_groups,
+    )
+
     tournament = _get_tournament_or_404(db, semester_id)
 
     # Validate instructor exists
     instructor = db.query(User).filter(User.id == instructor_id).first()
     if not instructor:
         raise HTTPException(status_code=404, detail=f"User {instructor_id} not found")
+
+    # Eligibility check — must happen before role business rules
+    age_groups = resolve_tournament_age_groups(tournament)
+    if role == SlotRole.MASTER.value:
+        eligible, reason = is_eligible_master_instructor(db, instructor_id, age_groups)
+        if not eligible:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Instructor not eligible as master: {reason}",
+            )
+    elif role == SlotRole.FIELD.value:
+        eligible, reason = is_eligible_field_instructor(db, instructor_id, age_groups)
+        if not eligible:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Instructor not eligible as field instructor: {reason}",
+            )
 
     # Role business rules
     if role == SlotRole.MASTER.value:

--- a/app/services/tournament/readiness_validator.py
+++ b/app/services/tournament/readiness_validator.py
@@ -1,0 +1,113 @@
+"""
+Tournament Readiness Validator
+
+Pre-transition content checks for CHECK_IN_OPEN and IN_PROGRESS.
+These complement the status-graph and enrollment-count checks in
+status_validator.py with content-level policy enforcement:
+    - status_validator.py: valid transitions + instructor presence + enrollment count
+    - readiness_validator.py (this file): schedule config + reward config presence
+
+Called from lifecycle.py before the status flush so any 400 leaves
+tournament_status unchanged.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+    from app.models.semester import Semester
+
+
+@dataclass
+class ReadinessResult:
+    ok: bool
+    blocking_errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    requirement_codes: list[str] = field(default_factory=list)
+
+
+def check_pre_check_in_open(db: "Session", tournament: "Semester") -> ReadinessResult:
+    """
+    Validate content readiness before transitioning to CHECK_IN_OPEN.
+
+    Policy:
+    - match_duration_minutes, break_duration_minutes, parallel_fields must all
+      be explicitly configured in TournamentConfiguration.  NULL values are NOT
+      silently defaulted to 90 / 15 / 1 — the admin must make an explicit choice.
+    - Valid ranges: match_duration > 0, break_duration >= 0, parallel_fields >= 1.
+    """
+    errors: list[str] = []
+    codes: list[str] = []
+
+    cfg = tournament.tournament_config_obj
+    missing: list[str] = []
+
+    if cfg is None or cfg.match_duration_minutes is None:
+        missing.append("match_duration_minutes")
+    if cfg is None or cfg.break_duration_minutes is None:
+        missing.append("break_duration_minutes")
+    if cfg is None or cfg.parallel_fields is None:
+        missing.append("parallel_fields")
+
+    if missing:
+        errors.append(
+            f"Schedule Configuration must be set before CHECK_IN_OPEN. "
+            f"Missing: {', '.join(missing)}. "
+            f"Configure via the Schedule Configuration section."
+        )
+        codes.append("SCHEDULE_CONFIG_MISSING")
+    else:
+        range_errs: list[str] = []
+        if cfg.match_duration_minutes <= 0:
+            range_errs.append("match_duration_minutes must be > 0")
+        if cfg.break_duration_minutes < 0:
+            range_errs.append("break_duration_minutes cannot be negative")
+        if cfg.parallel_fields < 1:
+            range_errs.append("parallel_fields must be >= 1")
+        if range_errs:
+            errors.extend(range_errs)
+            codes.append("SCHEDULE_CONFIG_INVALID")
+
+    return ReadinessResult(
+        ok=not errors,
+        blocking_errors=errors,
+        warnings=[],
+        requirement_codes=codes,
+    )
+
+
+def check_pre_in_progress(db: "Session", tournament: "Semester") -> ReadinessResult:
+    """
+    Validate content readiness before transitioning to IN_PROGRESS.
+
+    Policy:
+    - Reward configuration must be present (non-empty reward_config JSONB).
+      A tournament entering IN_PROGRESS without reward config will never
+      distribute XP or badges to participants.
+
+    TODO (GAP-4 tech debt): Re-validate master instructor LFA_COACH eligibility.
+    status_validator.py:168-186 checks instructor *presence* only; a license may
+    expire between CHECK_IN_OPEN and IN_PROGRESS.  When addressed, call
+    check_tournament_master_instructor_eligible(db, tournament.id) here and surface
+    as a INSTRUCTOR_ELIGIBILITY_STALE blocking error with code "INSTRUCTOR_LICENSE_EXPIRED".
+    """
+    errors: list[str] = []
+    codes: list[str] = []
+
+    # tournament.reward_config property returns {} when reward_config_obj is None
+    # or when reward_config_obj.reward_config is None/empty — both are falsy.
+    if not tournament.reward_config:
+        errors.append(
+            "Reward Configuration is required before starting the tournament (IN_PROGRESS). "
+            "Set a reward policy via the Reward Configuration section."
+        )
+        codes.append("REWARD_CONFIG_MISSING")
+
+    return ReadinessResult(
+        ok=not errors,
+        blocking_errors=errors,
+        warnings=[],
+        requirement_codes=codes,
+    )

--- a/app/services/tournament/readiness_validator.py
+++ b/app/services/tournament/readiness_validator.py
@@ -1,11 +1,13 @@
 """
 Tournament Readiness Validator
 
-Pre-transition content checks for CHECK_IN_OPEN and IN_PROGRESS.
-These complement the status-graph and enrollment-count checks in
-status_validator.py with content-level policy enforcement:
+Pre-transition content checks for CHECK_IN_OPEN, IN_PROGRESS, COMPLETED,
+and REWARDS_DISTRIBUTED.  These complement the status-graph and
+enrollment-count checks in status_validator.py with content-level policy
+enforcement:
     - status_validator.py: valid transitions + instructor presence + enrollment count
-    - readiness_validator.py (this file): schedule config + reward config presence
+    - readiness_validator.py (this file): schedule config + reward config + session
+      completion + ranking coverage + participation records
 
 Called from lifecycle.py before the status flush so any 400 leaves
 tournament_status unchanged.
@@ -37,6 +39,9 @@ def check_pre_check_in_open(db: "Session", tournament: "Semester") -> ReadinessR
       be explicitly configured in TournamentConfiguration.  NULL values are NOT
       silently defaulted to 90 / 15 / 1 — the admin must make an explicit choice.
     - Valid ranges: match_duration > 0, break_duration >= 0, parallel_fields >= 1.
+    - PROMOTION_EVENT: organizer_sponsor_id must be set and the sponsor must be active.
+      organizer_campaign_id is optional at this stage (follow-up: campaign status /
+      audience import / budget mapping require a separate policy decision).
     """
     errors: list[str] = []
     codes: list[str] = []
@@ -69,6 +74,30 @@ def check_pre_check_in_open(db: "Session", tournament: "Semester") -> ReadinessR
         if range_errs:
             errors.extend(range_errs)
             codes.append("SCHEDULE_CONFIG_INVALID")
+
+    # PROMOTION_EVENT sponsor guard — organizer_sponsor_id is mandatory; the
+    # referenced Sponsor must be active.  organizer_campaign_id is optional here.
+    from app.models.semester import SemesterCategory
+    if tournament.semester_category == SemesterCategory.PROMOTION_EVENT:
+        if not tournament.organizer_sponsor_id:
+            errors.append(
+                "PROMOTION_EVENT tournaments require an organizer sponsor before CHECK_IN_OPEN. "
+                "Set organizer_sponsor_id via the Tournament Settings."
+            )
+            codes.append("PROMOTION_SPONSOR_MISSING")
+        else:
+            from app.models.sponsor import Sponsor
+            sponsor = (
+                db.query(Sponsor)
+                .filter(Sponsor.id == tournament.organizer_sponsor_id)
+                .first()
+            )
+            if sponsor is None or not sponsor.is_active:
+                errors.append(
+                    "The organizer sponsor is inactive or not found. "
+                    "Activate the sponsor record before transitioning to CHECK_IN_OPEN."
+                )
+                codes.append("PROMOTION_SPONSOR_INACTIVE")
 
     return ReadinessResult(
         ok=not errors,
@@ -104,6 +133,229 @@ def check_pre_in_progress(db: "Session", tournament: "Semester") -> ReadinessRes
             "Set a reward policy via the Reward Configuration section."
         )
         codes.append("REWARD_CONFIG_MISSING")
+
+    return ReadinessResult(
+        ok=not errors,
+        blocking_errors=errors,
+        warnings=[],
+        requirement_codes=codes,
+    )
+
+
+def check_pre_completed(db: "Session", tournament: "Semester") -> ReadinessResult:
+    """
+    Validate content readiness before transitioning to COMPLETED.
+
+    Policy:
+    - All auto-generated MATCH sessions must have session_status == 'completed'.
+      Manual or TRAINING sessions are excluded — only sessions where
+      auto_generated=True AND event_category=MATCH are checked.
+    - TournamentRanking count must equal enrolled participant count (INDIVIDUAL:
+      SemesterEnrollment approved+active; TEAM: TournamentTeamEnrollment active).
+      Rankings are calculated via POST /{id}/calculate-rankings.
+    """
+    errors: list[str] = []
+    codes: list[str] = []
+
+    from app.models.session import Session as SessionModel, EventCategory
+    from app.models.tournament_ranking import TournamentRanking
+
+    # Check 1: all auto-generated MATCH sessions must be session_status='completed'.
+    incomplete_count = (
+        db.query(SessionModel)
+        .filter(
+            SessionModel.semester_id == tournament.id,
+            SessionModel.auto_generated == True,  # noqa: E712
+            SessionModel.event_category == EventCategory.MATCH,
+            SessionModel.session_status != "completed",
+        )
+        .count()
+    )
+
+    if incomplete_count > 0:
+        errors.append(
+            f"{incomplete_count} match session(s) are not yet completed "
+            f"(session_status != 'completed'). "
+            "Mark all tournament matches as completed before closing the tournament."
+        )
+        codes.append("SESSIONS_INCOMPLETE")
+
+    # Check 2: ranking count must equal enrolled participant count.
+    cfg = tournament.tournament_config_obj
+    participant_type = cfg.participant_type if cfg else "INDIVIDUAL"
+
+    if participant_type == "TEAM":
+        from app.models.team import TournamentTeamEnrollment
+        enrolled_count = (
+            db.query(TournamentTeamEnrollment)
+            .filter(
+                TournamentTeamEnrollment.semester_id == tournament.id,
+                TournamentTeamEnrollment.is_active == True,  # noqa: E712
+            )
+            .count()
+        )
+        ranking_participant_type = "TEAM"
+    else:
+        from app.models.semester_enrollment import SemesterEnrollment, EnrollmentStatus
+        enrolled_count = (
+            db.query(SemesterEnrollment)
+            .filter(
+                SemesterEnrollment.semester_id == tournament.id,
+                SemesterEnrollment.is_active == True,  # noqa: E712
+                SemesterEnrollment.request_status == EnrollmentStatus.APPROVED,
+            )
+            .count()
+        )
+        ranking_participant_type = "INDIVIDUAL"
+
+    ranking_count = (
+        db.query(TournamentRanking)
+        .filter(
+            TournamentRanking.tournament_id == tournament.id,
+            TournamentRanking.participant_type == ranking_participant_type,
+        )
+        .count()
+    )
+
+    if enrolled_count > 0 and ranking_count != enrolled_count:
+        errors.append(
+            f"Rankings are incomplete: {ranking_count} of {enrolled_count} "
+            f"{ranking_participant_type.lower()} participant(s) ranked. "
+            "Call POST /{id}/calculate-rankings before completing the tournament."
+        )
+        codes.append("RANKINGS_INCOMPLETE")
+
+    return ReadinessResult(
+        ok=not errors,
+        blocking_errors=errors,
+        warnings=[],
+        requirement_codes=codes,
+    )
+
+
+def check_pre_rewards_distributed(db: "Session", tournament: "Semester") -> ReadinessResult:
+    """
+    Validate content readiness before transitioning to REWARDS_DISTRIBUTED.
+
+    Policy:
+    - reward_policy_snapshot must be non-null.  The snapshot is locked at
+      IN_PROGRESS entry (lifecycle.py).  If it is missing the reward policy
+      cannot be audited after distribution.
+    - TournamentRanking must cover all enrolled participants (ranking_count ==
+      enrolled_count).  Stale or partial rankings block distribution.
+    - TournamentParticipation records must cover all enrolled participants:
+        INDIVIDUAL: participation_count == enrolled_user_count
+        TEAM: every active enrolled team_id must appear in at least one
+              TournamentParticipation.team_id row.  This is a direct FK join —
+              TournamentParticipation.team_id references the same teams.id as
+              TournamentTeamEnrollment.team_id.
+    """
+    errors: list[str] = []
+    codes: list[str] = []
+
+    from app.models.tournament_ranking import TournamentRanking
+    from app.models.tournament_achievement import TournamentParticipation
+
+    # Check 1: reward_policy_snapshot must be locked.
+    if not tournament.reward_policy_snapshot:
+        errors.append(
+            "Reward policy snapshot is missing. The snapshot is locked at IN_PROGRESS "
+            "entry — ensure reward_config was set before the tournament was started."
+        )
+        codes.append("SNAPSHOT_MISSING")
+
+    # Resolve participant type and enrolled count (shared by checks 2 + 3).
+    cfg = tournament.tournament_config_obj
+    participant_type = cfg.participant_type if cfg else "INDIVIDUAL"
+
+    if participant_type == "TEAM":
+        from app.models.team import TournamentTeamEnrollment
+        enrolled_team_ids: set[int] = {
+            row[0]
+            for row in db.query(TournamentTeamEnrollment.team_id)
+            .filter(
+                TournamentTeamEnrollment.semester_id == tournament.id,
+                TournamentTeamEnrollment.is_active == True,  # noqa: E712
+            )
+            .all()
+        }
+        enrolled_count = len(enrolled_team_ids)
+        ranking_participant_type = "TEAM"
+    else:
+        from app.models.semester_enrollment import SemesterEnrollment, EnrollmentStatus
+        enrolled_count = (
+            db.query(SemesterEnrollment)
+            .filter(
+                SemesterEnrollment.semester_id == tournament.id,
+                SemesterEnrollment.is_active == True,  # noqa: E712
+                SemesterEnrollment.request_status == EnrollmentStatus.APPROVED,
+            )
+            .count()
+        )
+        enrolled_team_ids = set()
+        ranking_participant_type = "INDIVIDUAL"
+
+    # Check 2: rankings must be complete.
+    ranking_count = (
+        db.query(TournamentRanking)
+        .filter(
+            TournamentRanking.tournament_id == tournament.id,
+            TournamentRanking.participant_type == ranking_participant_type,
+        )
+        .count()
+    )
+
+    if enrolled_count > 0 and ranking_count != enrolled_count:
+        errors.append(
+            f"Rankings are incomplete: {ranking_count} of {enrolled_count} "
+            f"{ranking_participant_type.lower()} participant(s) ranked. "
+            "Recalculate rankings before distributing rewards."
+        )
+        codes.append("RANKINGS_INCOMPLETE")
+
+    # Check 3: TournamentParticipation coverage.
+    if participant_type == "TEAM" and enrolled_team_ids:
+        covered_team_ids: set[int] = {
+            row[0]
+            for row in db.query(TournamentParticipation.team_id)
+            .filter(
+                TournamentParticipation.semester_id == tournament.id,
+                TournamentParticipation.team_id.isnot(None),
+            )
+            .all()
+        }
+        uncovered = enrolled_team_ids - covered_team_ids
+        if uncovered:
+            any_covered = bool(covered_team_ids & enrolled_team_ids)
+            errors.append(
+                f"{len(uncovered)} enrolled team(s) have no reward distribution records "
+                f"(TournamentParticipation). "
+                "Call the distribute-rewards endpoint before marking REWARDS_DISTRIBUTED."
+            )
+            codes.append(
+                "PARTICIPATION_INCOMPLETE" if any_covered else "PARTICIPATION_RECORDS_MISSING"
+            )
+    else:
+        # INDIVIDUAL: one TournamentParticipation row per enrolled user expected.
+        participation_count = (
+            db.query(TournamentParticipation)
+            .filter(TournamentParticipation.semester_id == tournament.id)
+            .count()
+        )
+
+        if enrolled_count > 0 and participation_count == 0:
+            errors.append(
+                "No reward distribution records found (TournamentParticipation). "
+                "Call the distribute-rewards endpoint before marking REWARDS_DISTRIBUTED."
+            )
+            codes.append("PARTICIPATION_RECORDS_MISSING")
+        elif enrolled_count > 0 and participation_count < enrolled_count:
+            errors.append(
+                f"Reward distribution is incomplete: {participation_count} of "
+                f"{enrolled_count} participant(s) have distribution records. "
+                "Call the distribute-rewards endpoint."
+            )
+            codes.append("PARTICIPATION_INCOMPLETE")
 
     return ReadinessResult(
         ok=not errors,

--- a/app/services/tournament/readiness_validator.py
+++ b/app/services/tournament/readiness_validator.py
@@ -75,17 +75,21 @@ def check_pre_check_in_open(db: "Session", tournament: "Semester") -> ReadinessR
             errors.extend(range_errs)
             codes.append("SCHEDULE_CONFIG_INVALID")
 
-    # PROMOTION_EVENT sponsor guard — organizer_sponsor_id is mandatory; the
-    # referenced Sponsor must be active.  organizer_campaign_id is optional here.
+    # PROMOTION_EVENT organizer guard — the event must have at least one organizer
+    # (organizer_club_id OR organizer_sponsor_id).  The two fields are mutually
+    # exclusive (Semester._guard_single_organizer_fk ORM validator).
+    # Club-organized events (organizer_club_id set, organizer_sponsor_id NULL) are
+    # valid without further sponsor checks.  Sponsor-organized events must reference
+    # an active Sponsor.  organizer_campaign_id is optional at this stage.
     from app.models.semester import SemesterCategory
     if tournament.semester_category == SemesterCategory.PROMOTION_EVENT:
-        if not tournament.organizer_sponsor_id:
+        if not tournament.organizer_sponsor_id and not tournament.organizer_club_id:
             errors.append(
-                "PROMOTION_EVENT tournaments require an organizer sponsor before CHECK_IN_OPEN. "
-                "Set organizer_sponsor_id via the Tournament Settings."
+                "PROMOTION_EVENT tournaments require an organizer (club or sponsor) before CHECK_IN_OPEN. "
+                "Set organizer_sponsor_id or organizer_club_id via the Tournament Settings."
             )
             codes.append("PROMOTION_SPONSOR_MISSING")
-        else:
+        elif tournament.organizer_sponsor_id:
             from app.models.sponsor import Sponsor
             sponsor = (
                 db.query(Sponsor)
@@ -98,6 +102,7 @@ def check_pre_check_in_open(db: "Session", tournament: "Semester") -> ReadinessR
                     "Activate the sponsor record before transitioning to CHECK_IN_OPEN."
                 )
                 codes.append("PROMOTION_SPONSOR_INACTIVE")
+        # else: organizer_club_id is set — club-organized PROMOTION_EVENT, allowed.
 
     return ReadinessResult(
         ok=not errors,

--- a/app/services/tournament/session_generation/validators/generation_validator.py
+++ b/app/services/tournament/session_generation/validators/generation_validator.py
@@ -51,12 +51,13 @@ class GenerationValidator:
         # session_generator assigns instructor_id via: FIELD-slot per pitch OR master_instructor_id.
         # If neither is set, every generated session gets instructor_id=NULL — a domain invariant
         # violation.  Guard here (before enrollment count) so the error is attributable and clear.
-        from app.services.tournament.instructor_service import has_master_instructor_assignment
-        if not has_master_instructor_assignment(self.db, tournament_id):
-            return False, (
-                "Cannot generate sessions: No instructor assigned. "
-                "Assign a master instructor before generating sessions."
-            )
+        # Eligibility (license + level) is also checked — not just assignment presence.
+        from app.services.tournament.instructor_eligibility_service import (
+            check_tournament_master_instructor_eligible,
+        )
+        eligible, reason = check_tournament_master_instructor_eligible(self.db, tournament_id)
+        if not eligible:
+            return False, f"Cannot generate sessions: {reason}"
 
         # Check if enrollment is closed (tournament status must be CHECK_IN_OPEN or later)
         if tournament.tournament_status not in ["CHECK_IN_OPEN", "IN_PROGRESS", "COMPLETED"]:

--- a/app/services/tournament/team_service.py
+++ b/app/services/tournament/team_service.py
@@ -440,6 +440,98 @@ def cancel_invite(
     return True
 
 
+def admin_enroll_team_in_tournament(
+    db: Session,
+    team_id: int,
+    tournament_id: int,
+) -> TournamentTeamEnrollment:
+    """
+    Admin-only: enroll any active team into a TEAM tournament without requiring
+    caller to be the team captain.
+
+    Guards (same as enroll_existing_team_in_tournament minus captain check):
+    - team exists and is active
+    - tournament exists, participant_type == TEAM, status == ENROLLMENT_OPEN
+    - no active enrollment already exists (idempotent: returns existing if found)
+    - if cost > 0: deducts from captain's credit balance (SELECT FOR UPDATE)
+
+    Returns the existing enrollment record when called twice (idempotent).
+    """
+    from app.models.semester import Semester
+
+    team = get_team(db, team_id)
+    if not team or not team.is_active:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Team not found")
+
+    tournament = db.query(Semester).filter(Semester.id == tournament_id).first()
+    if not tournament:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Tournament not found")
+
+    cfg = db.query(TournamentConfiguration).filter(
+        TournamentConfiguration.semester_id == tournament_id
+    ).first()
+    if not cfg or cfg.participant_type != "TEAM":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="This tournament does not support team enrollment",
+        )
+
+    if tournament.tournament_status != "ENROLLMENT_OPEN":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Tournament enrollment is not open (current status: {tournament.tournament_status})",
+        )
+
+    existing = db.query(TournamentTeamEnrollment).filter(
+        and_(
+            TournamentTeamEnrollment.semester_id == tournament_id,
+            TournamentTeamEnrollment.team_id == team_id,
+            TournamentTeamEnrollment.is_active == True,
+        )
+    ).first()
+    if existing:
+        return existing
+
+    cost = cfg.team_enrollment_cost if cfg else 0
+
+    if cost > 0:
+        license = (
+            db.query(UserLicense)
+            .filter(
+                UserLicense.user_id == team.captain_user_id,
+                UserLicense.is_active == True,
+            )
+            .with_for_update()
+            .first()
+        )
+        if not license or license.credit_balance < cost:
+            available = license.credit_balance if license else 0
+            raise HTTPException(
+                status_code=status.HTTP_402_PAYMENT_REQUIRED,
+                detail=f"Insufficient credits. Required: {cost}, Available: {available}",
+            )
+        license.credit_balance -= cost
+        db.add(CreditTransaction(
+            user_license_id=license.id,
+            amount=-cost,
+            balance_after=license.credit_balance,
+            transaction_type=TransactionType.ENROLLMENT.value,
+            description=f"Team enrollment fee for tournament {tournament_id}",
+            idempotency_key=f"team-enroll-{team_id}-{tournament_id}",
+        ))
+
+    enrollment = TournamentTeamEnrollment(
+        semester_id=tournament_id,
+        team_id=team_id,
+        is_active=True,
+        payment_verified=(cost == 0),
+    )
+    db.add(enrollment)
+    db.commit()
+    db.refresh(enrollment)
+    return enrollment
+
+
 def get_pending_invites_for_user(db: Session, user_id: int) -> List[TeamInvite]:
     """Get all PENDING invites for a user"""
     return db.query(TeamInvite).filter(

--- a/app/templates/admin/sponsor_promotion_wizard.html
+++ b/app/templates/admin/sponsor_promotion_wizard.html
@@ -167,7 +167,10 @@
                 <select name="master_instructor_id">
                     <option value="">— assign later —</option>
                     {% for instr in instructors %}
-                    <option value="{{ instr.id }}">{{ instr.name }} ({{ instr.email }})</option>
+                    <option value="{{ instr.id }}">
+                        {{- instr.name }} ({{ instr.email }})
+                        {%- if instructor_license_levels.get(instr.id) %} — Level {{ instructor_license_levels[instr.id] }}{% endif %}
+                    </option>
                     {% endfor %}
                 </select>
                 <div class="field-hint">Required before advancing to CHECK_IN_OPEN. Assign now or set later on the tournament edit page.</div>

--- a/app/templates/admin/tournament_edit.html
+++ b/app/templates/admin/tournament_edit.html
@@ -544,7 +544,7 @@ ID {{ t.id }} · {{ t.code }} · <strong>{{ t.tournament_status or t.status.valu
                 ('third_place',  '🥉 3rd Place',   150, 1.2),
                 ('participation','🎽 Participation', 50, 1.0),
             ] %}
-            {% set tier_data = reward_cfg.get(tier, {}) if reward_cfg else {} %}
+            {% set tier_data = (reward_cfg.get(tier) or {}) if reward_cfg else {} %}
             <tr style="border-bottom:1px solid #f0f0f0;">
                 <td style="padding:0.4rem 0.5rem;">{{ icon }}</td>
                 <td style="padding:0.4rem 0.5rem;text-align:right;">

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,7 +5,7 @@ testpaths = tests
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
-norecursedirs = implementation .git .venv __pycache__ .pytest_cache scripts app/tests tests/manual tests/manual_integration tests/features tests/debug .archive archive tests/security/xss tests/security/fuzzing tests/security/scanning
+norecursedirs = implementation .git .venv __pycache__ .pytest_cache scripts app/tests tests/manual tests/manual_integration tests/features tests/debug .archive archive tests/security/xss tests/security/fuzzing tests/security/scanning tests/lifecycle_framework
 
 # Logging (from tests/e2e config)
 log_cli = true

--- a/scripts/bootstrap_clean.py
+++ b/scripts/bootstrap_clean.py
@@ -410,6 +410,25 @@ def _seed_users(db) -> tuple:
         db.flush()
         _ok(f"Instructor user created: instructor@lfa.com / instructor123 (id={instr.id})")
 
+    # Ensure instructor has an active LFA_COACH license (required by eligibility checks)
+    coach_lic = db.query(UserLicense).filter(
+        UserLicense.user_id == instr.id,
+        UserLicense.specialization_type == "LFA_COACH",
+    ).first()
+    if coach_lic:
+        _skip(f"LFA_COACH license for 'instructor@lfa.com' already exists")
+    else:
+        db.add(UserLicense(
+            user_id=instr.id,
+            specialization_type="LFA_COACH",
+            current_level=5,
+            max_achieved_level=5,
+            is_active=True,
+            started_at=datetime.now(),
+        ))
+        db.flush()
+        _ok(f"LFA_COACH license created for instructor@lfa.com (level=5)")
+
     return admin, instr
 
 

--- a/scripts/e2e_lifecycle_visibility_test.py
+++ b/scripts/e2e_lifecycle_visibility_test.py
@@ -67,6 +67,7 @@ from app.models.team import Team, TeamMember, TournamentTeamEnrollment  # noqa: 
 from app.models.tournament_achievement import TournamentParticipation  # noqa: E402
 from app.models.tournament_configuration import TournamentConfiguration  # noqa: E402
 from app.models.tournament_ranking import TournamentRanking  # noqa: E402
+from app.models.sponsor import Sponsor  # noqa: E402
 from app.models.tournament_type import TournamentType  # noqa: E402
 from app.models.user import User  # noqa: E402
 from app.dependencies import (  # noqa: E402
@@ -167,6 +168,59 @@ def _api_post(url, body):
     resp = _client.post(url, json=body)
     _refresh_csrf(resp)
     return resp
+
+
+def _set_schedule_config(tid):
+    resp = _api_patch(f"/api/v1/tournaments/{tid}/schedule-config", {
+        "match_duration_minutes": 90,
+        "break_duration_minutes": 15,
+        "parallel_fields": 1,
+    })
+    if resp.status_code not in (200, 201):
+        body = {}
+        try:
+            body = resp.json()
+        except Exception:
+            pass
+        detail = body.get("detail", "") if isinstance(body, dict) else resp.text[:150]
+        fail(f"schedule-config: HTTP {resp.status_code} — {detail}")
+    ok("schedule-config set")
+
+
+def _set_reward_config(tid):
+    resp = _api_post(f"/api/v1/tournaments/{tid}/reward-config", {
+        "skill_mappings": [
+            {"skill": "speed", "weight": 1.0, "category": "PHYSICAL", "enabled": True}
+        ],
+    })
+    if resp.status_code not in (200, 201):
+        body = {}
+        try:
+            body = resp.json()
+        except Exception:
+            pass
+        detail = body.get("detail", "") if isinstance(body, dict) else resp.text[:150]
+        fail(f"reward-config: HTTP {resp.status_code} — {detail}")
+    ok("reward-config set")
+
+
+def _prepare_for_check_in(tid, sponsor_id):
+    """Set schedule config, reward config, and organizer sponsor before CHECK_IN_OPEN.
+
+    All three are required by the readiness guards:
+    - SCHEDULE_CONFIG_MISSING: checked at CHECK_IN_OPEN
+    - PROMOTION_SPONSOR_MISSING: checked at CHECK_IN_OPEN for PROMOTION_EVENT
+    - REWARD_CONFIG_MISSING: checked at IN_PROGRESS
+    No official API endpoint exists for organizer_sponsor_id, so it is set directly.
+    """
+    _set_schedule_config(tid)
+    _set_reward_config(tid)
+    _db.expire_all()
+    t_obj = _db.query(Semester).filter(Semester.id == tid).first()
+    t_obj.organizer_sponsor_id = sponsor_id
+    _db.commit()
+    _db.expire_all()
+    ok(f"organizer_sponsor_id = {sponsor_id}")
 
 
 # ── Assertion helpers ─────────────────────────────────────────────────────────
@@ -562,7 +616,7 @@ def test_guard_c_instructor_required(club, campus, tt_id):
 # ══════════════════════════════════════════════════════════════════════════════
 # GUARD D — 0 rankings → COMPLETED rejected
 # ══════════════════════════════════════════════════════════════════════════════
-def test_guard_d_rankings_required(club, campus, tt_id, instructor):
+def test_guard_d_rankings_required(club, campus, tt_id, instructor, sponsor_id):
     """Advance to IN_PROGRESS without rankings; assert COMPLETED fails."""
     prefix = f"Guard-D-{uuid.uuid4().hex[:6]}"
     t = _promotion_wizard(club.id, campus.id, tt_id, "U15", prefix)
@@ -578,6 +632,9 @@ def test_guard_d_rankings_required(club, campus, tt_id, instructor):
     t_obj.master_instructor_id = instructor.id
     _db.commit()
     _db.expire_all()
+
+    # Set schedule config, reward config, and sponsor (PROMOTION_EVENT guard).
+    _prepare_for_check_in(t.id, sponsor_id)
 
     _status_transition(t.id, "CHECK_IN_OPEN")  # sessions generated here
 
@@ -603,7 +660,7 @@ def test_guard_d_rankings_required(club, campus, tt_id, instructor):
 # ══════════════════════════════════════════════════════════════════════════════
 # FULL LIFECYCLE + VISIBILITY + DB INVARIANTS
 # ══════════════════════════════════════════════════════════════════════════════
-def test_full_lifecycle_visibility(club, campus, tt_id, instructor):
+def test_full_lifecycle_visibility(club, campus, tt_id, instructor, sponsor_id):
     """
     Full lifecycle traversal for a U15+U18 TEAM+League tournament.
 
@@ -650,6 +707,9 @@ def test_full_lifecycle_visibility(club, campus, tt_id, instructor):
     _db.commit()
     _db.expire_all()
     ok(f"master_instructor_id = {instructor.id}")
+
+    # Set schedule config, reward config, and sponsor (PROMOTION_EVENT guard).
+    _prepare_for_check_in(t.id, sponsor_id)
 
     # ─── → CHECK_IN_OPEN ──────────────────────────────────────────────────────
     _status_transition(t.id, "CHECK_IN_OPEN")
@@ -763,7 +823,7 @@ def test_frontend_consistency(tid):
 # ══════════════════════════════════════════════════════════════════════════════
 # IDEMPOTENCY — calculate-rankings × 2, distribute-rewards-v2 × 2
 # ══════════════════════════════════════════════════════════════════════════════
-def test_idempotency(club, campus, tt_id, instructor):
+def test_idempotency(club, campus, tt_id, instructor, sponsor_id):
     """
     Prove operations that are expected to be idempotent truly are:
 
@@ -786,6 +846,8 @@ def test_idempotency(club, campus, tt_id, instructor):
     t_obj.master_instructor_id = instructor.id
     _db.commit()
     _db.expire_all()
+    # Set schedule config, reward config, and sponsor (PROMOTION_EVENT guard).
+    _prepare_for_check_in(t.id, sponsor_id)
     _status_transition(t.id, "CHECK_IN_OPEN")
     _status_transition(t.id, "IN_PROGRESS")
 
@@ -868,7 +930,7 @@ def test_idempotency(club, campus, tt_id, instructor):
 # ══════════════════════════════════════════════════════════════════════════════
 # PUBLIC API STRICT — HTML content matches DB state at each step
 # ══════════════════════════════════════════════════════════════════════════════
-def test_public_api_strict(club, campus, tt_id, instructor):
+def test_public_api_strict(club, campus, tt_id, instructor, sponsor_id):
     """
     At each visible status, GET /events/{id} HTML must contain:
       - The tournament name
@@ -932,6 +994,9 @@ def test_public_api_strict(club, campus, tt_id, instructor):
     t_obj.master_instructor_id = instructor.id
     _db.commit()
     _db.expire_all()
+
+    # Set schedule config, reward config, and sponsor (PROMOTION_EVENT guard).
+    _prepare_for_check_in(t.id, sponsor_id)
 
     # CHECK_IN_OPEN
     _status_transition(t.id, "CHECK_IN_OPEN")
@@ -1018,6 +1083,17 @@ def run():
         n = sum(1 for tm in teams if tm.age_group_label == ag)
         info(f"  {ag}: {n} teams")
 
+    # Tests create PROMOTION_EVENT tournaments — organizer_sponsor_id is required
+    # before CHECK_IN_OPEN. No API endpoint exists for this field, so we write
+    # it directly. Create a shared sponsor here and pass it to each test.
+    lc_sponsor = _db.query(Sponsor).filter(Sponsor.code == "LC-VIS-E2E").first()
+    if not lc_sponsor:
+        lc_sponsor = Sponsor(name="Lifecycle Visibility E2E Sponsor", code="LC-VIS-E2E", is_active=True)
+        _db.add(lc_sponsor)
+        _db.commit()
+        _db.refresh(lc_sponsor)
+    ok(f"Shared sponsor: id={lc_sponsor.id}  code={lc_sponsor.code!r}")
+
     # ── Run tests ──────────────────────────────────────────────────────────────
     _run_test(
         "GUARD-A: campus_id=NULL → ENROLLMENT_OPEN rejected (HTTP 400)",
@@ -1034,14 +1110,14 @@ def run():
     _run_test(
         "GUARD-D: 0 rankings → COMPLETED rejected (HTTP 400)",
         test_guard_d_rankings_required,
-        club, campus, tt_league.id, instructor,
+        club, campus, tt_league.id, instructor, lc_sponsor.id,
     )
 
     full_lc_tid = _run_test(
         "FULL-LC: DRAFT→…→REWARDS_DISTRIBUTED "
         "(visibility + DB-invariants + session-correctness + ranking-sanity at each step)",
         test_full_lifecycle_visibility,
-        club, campus, tt_league.id, instructor,
+        club, campus, tt_league.id, instructor, lc_sponsor.id,
     )
 
     _run_test(
@@ -1061,13 +1137,13 @@ def run():
         "IDEMPOTENCY: calculate-rankings × 2 → count unchanged; "
         "distribute-rewards-v2 × 2 → TournamentParticipation unchanged",
         test_idempotency,
-        club, campus, tt_league.id, instructor,
+        club, campus, tt_league.id, instructor, lc_sponsor.id,
     )
 
     _run_test(
         "PUB-STRICT: /events/{id} HTML contains name + status label + rankings at each step",
         test_public_api_strict,
-        club, campus, tt_league.id, instructor,
+        club, campus, tt_league.id, instructor, lc_sponsor.id,
     )
 
     # ── Summary ───────────────────────────────────────────────────────────────

--- a/scripts/e2e_lifecycle_visibility_test.py
+++ b/scripts/e2e_lifecycle_visibility_test.py
@@ -67,7 +67,6 @@ from app.models.team import Team, TeamMember, TournamentTeamEnrollment  # noqa: 
 from app.models.tournament_achievement import TournamentParticipation  # noqa: E402
 from app.models.tournament_configuration import TournamentConfiguration  # noqa: E402
 from app.models.tournament_ranking import TournamentRanking  # noqa: E402
-from app.models.sponsor import Sponsor  # noqa: E402
 from app.models.tournament_type import TournamentType  # noqa: E402
 from app.models.user import User  # noqa: E402
 from app.dependencies import (  # noqa: E402
@@ -204,23 +203,17 @@ def _set_reward_config(tid):
     ok("reward-config set")
 
 
-def _prepare_for_check_in(tid, sponsor_id):
-    """Set schedule config, reward config, and organizer sponsor before CHECK_IN_OPEN.
+def _prepare_for_check_in(tid):
+    """Set schedule config and reward config before CHECK_IN_OPEN / IN_PROGRESS.
 
-    All three are required by the readiness guards:
     - SCHEDULE_CONFIG_MISSING: checked at CHECK_IN_OPEN
-    - PROMOTION_SPONSOR_MISSING: checked at CHECK_IN_OPEN for PROMOTION_EVENT
     - REWARD_CONFIG_MISSING: checked at IN_PROGRESS
-    No official API endpoint exists for organizer_sponsor_id, so it is set directly.
+    PROMOTION_EVENT tournaments created via the promotion wizard have
+    organizer_club_id already set; the organizer guard allows this without
+    requiring organizer_sponsor_id (the two fields are mutually exclusive).
     """
     _set_schedule_config(tid)
     _set_reward_config(tid)
-    _db.expire_all()
-    t_obj = _db.query(Semester).filter(Semester.id == tid).first()
-    t_obj.organizer_sponsor_id = sponsor_id
-    _db.commit()
-    _db.expire_all()
-    ok(f"organizer_sponsor_id = {sponsor_id}")
 
 
 # ── Assertion helpers ─────────────────────────────────────────────────────────
@@ -616,7 +609,7 @@ def test_guard_c_instructor_required(club, campus, tt_id):
 # ══════════════════════════════════════════════════════════════════════════════
 # GUARD D — 0 rankings → COMPLETED rejected
 # ══════════════════════════════════════════════════════════════════════════════
-def test_guard_d_rankings_required(club, campus, tt_id, instructor, sponsor_id):
+def test_guard_d_rankings_required(club, campus, tt_id, instructor):
     """Advance to IN_PROGRESS without rankings; assert COMPLETED fails."""
     prefix = f"Guard-D-{uuid.uuid4().hex[:6]}"
     t = _promotion_wizard(club.id, campus.id, tt_id, "U15", prefix)
@@ -633,8 +626,8 @@ def test_guard_d_rankings_required(club, campus, tt_id, instructor, sponsor_id):
     _db.commit()
     _db.expire_all()
 
-    # Set schedule config, reward config, and sponsor (PROMOTION_EVENT guard).
-    _prepare_for_check_in(t.id, sponsor_id)
+    # Set schedule config and reward config before CHECK_IN_OPEN / IN_PROGRESS.
+    _prepare_for_check_in(t.id)
 
     _status_transition(t.id, "CHECK_IN_OPEN")  # sessions generated here
 
@@ -660,7 +653,7 @@ def test_guard_d_rankings_required(club, campus, tt_id, instructor, sponsor_id):
 # ══════════════════════════════════════════════════════════════════════════════
 # FULL LIFECYCLE + VISIBILITY + DB INVARIANTS
 # ══════════════════════════════════════════════════════════════════════════════
-def test_full_lifecycle_visibility(club, campus, tt_id, instructor, sponsor_id):
+def test_full_lifecycle_visibility(club, campus, tt_id, instructor):
     """
     Full lifecycle traversal for a U15+U18 TEAM+League tournament.
 
@@ -708,8 +701,8 @@ def test_full_lifecycle_visibility(club, campus, tt_id, instructor, sponsor_id):
     _db.expire_all()
     ok(f"master_instructor_id = {instructor.id}")
 
-    # Set schedule config, reward config, and sponsor (PROMOTION_EVENT guard).
-    _prepare_for_check_in(t.id, sponsor_id)
+    # Set schedule config and reward config before CHECK_IN_OPEN / IN_PROGRESS.
+    _prepare_for_check_in(t.id)
 
     # ─── → CHECK_IN_OPEN ──────────────────────────────────────────────────────
     _status_transition(t.id, "CHECK_IN_OPEN")
@@ -823,7 +816,7 @@ def test_frontend_consistency(tid):
 # ══════════════════════════════════════════════════════════════════════════════
 # IDEMPOTENCY — calculate-rankings × 2, distribute-rewards-v2 × 2
 # ══════════════════════════════════════════════════════════════════════════════
-def test_idempotency(club, campus, tt_id, instructor, sponsor_id):
+def test_idempotency(club, campus, tt_id, instructor):
     """
     Prove operations that are expected to be idempotent truly are:
 
@@ -846,8 +839,8 @@ def test_idempotency(club, campus, tt_id, instructor, sponsor_id):
     t_obj.master_instructor_id = instructor.id
     _db.commit()
     _db.expire_all()
-    # Set schedule config, reward config, and sponsor (PROMOTION_EVENT guard).
-    _prepare_for_check_in(t.id, sponsor_id)
+    # Set schedule config and reward config before CHECK_IN_OPEN / IN_PROGRESS.
+    _prepare_for_check_in(t.id)
     _status_transition(t.id, "CHECK_IN_OPEN")
     _status_transition(t.id, "IN_PROGRESS")
 
@@ -930,7 +923,7 @@ def test_idempotency(club, campus, tt_id, instructor, sponsor_id):
 # ══════════════════════════════════════════════════════════════════════════════
 # PUBLIC API STRICT — HTML content matches DB state at each step
 # ══════════════════════════════════════════════════════════════════════════════
-def test_public_api_strict(club, campus, tt_id, instructor, sponsor_id):
+def test_public_api_strict(club, campus, tt_id, instructor):
     """
     At each visible status, GET /events/{id} HTML must contain:
       - The tournament name
@@ -995,8 +988,8 @@ def test_public_api_strict(club, campus, tt_id, instructor, sponsor_id):
     _db.commit()
     _db.expire_all()
 
-    # Set schedule config, reward config, and sponsor (PROMOTION_EVENT guard).
-    _prepare_for_check_in(t.id, sponsor_id)
+    # Set schedule config and reward config before CHECK_IN_OPEN / IN_PROGRESS.
+    _prepare_for_check_in(t.id)
 
     # CHECK_IN_OPEN
     _status_transition(t.id, "CHECK_IN_OPEN")
@@ -1083,17 +1076,6 @@ def run():
         n = sum(1 for tm in teams if tm.age_group_label == ag)
         info(f"  {ag}: {n} teams")
 
-    # Tests create PROMOTION_EVENT tournaments — organizer_sponsor_id is required
-    # before CHECK_IN_OPEN. No API endpoint exists for this field, so we write
-    # it directly. Create a shared sponsor here and pass it to each test.
-    lc_sponsor = _db.query(Sponsor).filter(Sponsor.code == "LC-VIS-E2E").first()
-    if not lc_sponsor:
-        lc_sponsor = Sponsor(name="Lifecycle Visibility E2E Sponsor", code="LC-VIS-E2E", is_active=True)
-        _db.add(lc_sponsor)
-        _db.commit()
-        _db.refresh(lc_sponsor)
-    ok(f"Shared sponsor: id={lc_sponsor.id}  code={lc_sponsor.code!r}")
-
     # ── Run tests ──────────────────────────────────────────────────────────────
     _run_test(
         "GUARD-A: campus_id=NULL → ENROLLMENT_OPEN rejected (HTTP 400)",
@@ -1110,14 +1092,14 @@ def run():
     _run_test(
         "GUARD-D: 0 rankings → COMPLETED rejected (HTTP 400)",
         test_guard_d_rankings_required,
-        club, campus, tt_league.id, instructor, lc_sponsor.id,
+        club, campus, tt_league.id, instructor,
     )
 
     full_lc_tid = _run_test(
         "FULL-LC: DRAFT→…→REWARDS_DISTRIBUTED "
         "(visibility + DB-invariants + session-correctness + ranking-sanity at each step)",
         test_full_lifecycle_visibility,
-        club, campus, tt_league.id, instructor, lc_sponsor.id,
+        club, campus, tt_league.id, instructor,
     )
 
     _run_test(
@@ -1137,13 +1119,13 @@ def run():
         "IDEMPOTENCY: calculate-rankings × 2 → count unchanged; "
         "distribute-rewards-v2 × 2 → TournamentParticipation unchanged",
         test_idempotency,
-        club, campus, tt_league.id, instructor, lc_sponsor.id,
+        club, campus, tt_league.id, instructor,
     )
 
     _run_test(
         "PUB-STRICT: /events/{id} HTML contains name + status label + rankings at each step",
         test_public_api_strict,
-        club, campus, tt_league.id, instructor, lc_sponsor.id,
+        club, campus, tt_league.id, instructor,
     )
 
     # ── Summary ───────────────────────────────────────────────────────────────

--- a/scripts/e2e_matrix_test.py
+++ b/scripts/e2e_matrix_test.py
@@ -232,15 +232,18 @@ def _enroll_teams_direct(tid, teams):
 
 # ── Common lifecycle (after enrollment phase) ─────────────────────────────────
 def _common_lifecycle(tid, instructor_id, expected_min_sessions=1):
-    """ENROLLMENT_CLOSED → CHECK_IN_OPEN → (set instructor) → IN_PROGRESS → verify."""
+    """ENROLLMENT_CLOSED → (set instructor) → CHECK_IN_OPEN → IN_PROGRESS → verify."""
     _status_transition(tid, "ENROLLMENT_CLOSED")
-    _status_transition(tid, "CHECK_IN_OPEN")
 
-    # Set instructor directly (simulates wizard Basic Info save)
+    # Set instructor BEFORE CHECK_IN_OPEN — eligibility guard requires master_instructor_id
+    # to be set (or a MASTER slot to exist) before the transition is allowed.
     t = _db.query(Semester).filter(Semester.id == tid).first()
     t.master_instructor_id = instructor_id
     _db.commit()
     ok(f"master_instructor_id = {instructor_id}")
+
+    _db.expire_all()
+    _status_transition(tid, "CHECK_IN_OPEN")
 
     _db.expire_all()
     _status_transition(tid, "IN_PROGRESS")

--- a/scripts/e2e_matrix_test.py
+++ b/scripts/e2e_matrix_test.py
@@ -46,6 +46,7 @@ from app.models.semester import Semester  # noqa: E402
 from app.models.session import Session as SessionModel  # noqa: E402
 from app.models.team import Team, TeamMember, TournamentTeamEnrollment  # noqa: E402
 from app.models.tournament_configuration import TournamentConfiguration  # noqa: E402
+from app.models.sponsor import Sponsor  # noqa: E402
 from app.models.tournament_type import TournamentType  # noqa: E402
 from app.models.user import User, UserRole  # noqa: E402
 from app.dependencies import (  # noqa: E402
@@ -129,6 +130,34 @@ def _api_patch(url, body):
     resp = _client.patch(url, json=body)
     _refresh_csrf(resp)
     return resp
+
+
+def _api_post(url, body):
+    resp = _client.post(url, json=body)
+    _refresh_csrf(resp)
+    return resp
+
+
+def _set_schedule_config(tid):
+    _assert_api_ok(
+        _api_patch(f"/api/v1/tournaments/{tid}/schedule-config", {
+            "match_duration_minutes": 90,
+            "break_duration_minutes": 15,
+            "parallel_fields": 1,
+        }),
+        "schedule-config",
+    )
+
+
+def _set_reward_config(tid):
+    _assert_api_ok(
+        _api_post(f"/api/v1/tournaments/{tid}/reward-config", {
+            "skill_mappings": [
+                {"skill": "speed", "weight": 1.0, "category": "PHYSICAL", "enabled": True}
+            ],
+        }),
+        "reward-config",
+    )
 
 
 # ── Assertion helpers ─────────────────────────────────────────────────────────
@@ -231,16 +260,24 @@ def _enroll_teams_direct(tid, teams):
 
 
 # ── Common lifecycle (after enrollment phase) ─────────────────────────────────
-def _common_lifecycle(tid, instructor_id, expected_min_sessions=1):
-    """ENROLLMENT_CLOSED → (set instructor) → CHECK_IN_OPEN → IN_PROGRESS → verify."""
+def _common_lifecycle(tid, instructor_id, expected_min_sessions=1, *, organizer_sponsor_id=None):
+    """ENROLLMENT_CLOSED → (set instructor + config) → CHECK_IN_OPEN → IN_PROGRESS → verify."""
     _status_transition(tid, "ENROLLMENT_CLOSED")
 
-    # Set instructor BEFORE CHECK_IN_OPEN — eligibility guard requires master_instructor_id
-    # to be set (or a MASTER slot to exist) before the transition is allowed.
+    # Set instructor (and optional sponsor) directly — eligibility guard requires
+    # master_instructor_id before CHECK_IN_OPEN; no API endpoint exists for sponsor.
     t = _db.query(Semester).filter(Semester.id == tid).first()
     t.master_instructor_id = instructor_id
+    if organizer_sponsor_id is not None:
+        t.organizer_sponsor_id = organizer_sponsor_id
     _db.commit()
     ok(f"master_instructor_id = {instructor_id}")
+    if organizer_sponsor_id is not None:
+        ok(f"organizer_sponsor_id = {organizer_sponsor_id}")
+
+    # Schedule + reward config required before CHECK_IN_OPEN.
+    _set_schedule_config(tid)
+    _set_reward_config(tid)
 
     _db.expire_all()
     _status_transition(tid, "CHECK_IN_OPEN")
@@ -314,7 +351,7 @@ def _create_team_tournament(club_id, campus_id, tt_id, age_group, label, name_pr
 # ══════════════════════════════════════════════════════════════════════════════
 # S1: TEAM + League — 2 teams (U15 + U18)
 # ══════════════════════════════════════════════════════════════════════════════
-def s1_team_league(club, campus, tt_by_code, instructor, boot_teams):
+def s1_team_league(club, campus, tt_by_code, instructor, boot_teams, *, sponsor_id):
     prefix = f"S1-League-{uuid.uuid4().hex[:6]}"
     # Create via promotion wizard (enrolls LFA U15 automatically)
     tid = _create_team_tournament(club.id, campus.id, tt_by_code["league"].id, "U15", "league/U15", prefix)
@@ -325,7 +362,7 @@ def s1_team_league(club, campus, tt_by_code, instructor, boot_teams):
         fail_local(f"Need ≥2 teams, got {count}")
 
     _status_transition(tid, "ENROLLMENT_OPEN")
-    _common_lifecycle(tid, instructor.id, expected_min_sessions=1)
+    _common_lifecycle(tid, instructor.id, expected_min_sessions=1, organizer_sponsor_id=sponsor_id)
 
 
 # ══════════════════════════════════════════════════════════════════════════════
@@ -457,7 +494,7 @@ def s3_individual_group_knockout(club, campus, tt_by_code, instructor, boot_team
 # ══════════════════════════════════════════════════════════════════════════════
 # S4: TEAM + League 2-leg — 2 teams (U15 + U18), number_of_legs=2
 # ══════════════════════════════════════════════════════════════════════════════
-def s4_team_league_2leg(club, campus, tt_by_code, instructor, boot_teams):
+def s4_team_league_2leg(club, campus, tt_by_code, instructor, boot_teams, *, sponsor_id):
     prefix = f"S4-2Leg-{uuid.uuid4().hex[:6]}"
     tid = _create_team_tournament(club.id, campus.id, tt_by_code["league"].id, "U15", "2leg/U15", prefix)
 
@@ -478,7 +515,7 @@ def s4_team_league_2leg(club, campus, tt_by_code, instructor, boot_teams):
 
     _status_transition(tid, "ENROLLMENT_OPEN")
     # 2 teams × 2 legs = 2 matches
-    _common_lifecycle(tid, instructor.id, expected_min_sessions=2)
+    _common_lifecycle(tid, instructor.id, expected_min_sessions=2, organizer_sponsor_id=sponsor_id)
 
     # Verify exactly 2× matches (1 per leg)
     sess_count = _db.query(SessionModel).filter(SessionModel.semester_id == tid).count()
@@ -596,9 +633,21 @@ def run():
         sys.exit(1)
     info(f"  Bootstrap teams loaded: {[t.name for t in boot_teams.values()]}")
 
+    # S1/S4 create PROMOTION_EVENT tournaments — organizer_sponsor_id is required
+    # before CHECK_IN_OPEN. No API endpoint exists for this field, so we write
+    # it directly in _common_lifecycle via the DB. Create a shared sponsor here.
+    lc_sponsor = _db.query(Sponsor).filter(Sponsor.code == "MATRIX-E2E").first()
+    if not lc_sponsor:
+        lc_sponsor = Sponsor(name="Matrix E2E Sponsor", code="MATRIX-E2E", is_active=True)
+        _db.add(lc_sponsor)
+        _db.commit()
+        _db.refresh(lc_sponsor)
+    ok(f"Shared sponsor: id={lc_sponsor.id}  code={lc_sponsor.code!r}")
+
     # ── Run scenarios ─────────────────────────────────────────────────────────
     _run_scenario("S1: TEAM + League (U15+U18, 2 teams)",
-                  s1_team_league, club, campus, tt_by_code, instructor, boot_teams)
+                  s1_team_league, club, campus, tt_by_code, instructor, boot_teams,
+                  sponsor_id=lc_sponsor.id)
 
     _run_scenario("S2: INDIVIDUAL + Knockout (8 players from U15)",
                   s2_individual_knockout, club, campus, tt_by_code, instructor, boot_teams)
@@ -607,7 +656,8 @@ def run():
                   s3_individual_group_knockout, club, campus, tt_by_code, instructor, boot_teams)
 
     _run_scenario("S4: TEAM + League 2-leg (U15+U18, 2 teams)",
-                  s4_team_league_2leg, club, campus, tt_by_code, instructor, boot_teams)
+                  s4_team_league_2leg, club, campus, tt_by_code, instructor, boot_teams,
+                  sponsor_id=lc_sponsor.id)
 
     _run_scenario("S5: INDIVIDUAL + League (U15+U18 players individually)",
                   s5_individual_league, club, campus, tt_by_code, instructor, boot_teams)

--- a/scripts/e2e_matrix_test.py
+++ b/scripts/e2e_matrix_test.py
@@ -46,7 +46,6 @@ from app.models.semester import Semester  # noqa: E402
 from app.models.session import Session as SessionModel  # noqa: E402
 from app.models.team import Team, TeamMember, TournamentTeamEnrollment  # noqa: E402
 from app.models.tournament_configuration import TournamentConfiguration  # noqa: E402
-from app.models.sponsor import Sponsor  # noqa: E402
 from app.models.tournament_type import TournamentType  # noqa: E402
 from app.models.user import User, UserRole  # noqa: E402
 from app.dependencies import (  # noqa: E402
@@ -260,22 +259,18 @@ def _enroll_teams_direct(tid, teams):
 
 
 # ── Common lifecycle (after enrollment phase) ─────────────────────────────────
-def _common_lifecycle(tid, instructor_id, expected_min_sessions=1, *, organizer_sponsor_id=None):
+def _common_lifecycle(tid, instructor_id, expected_min_sessions=1):
     """ENROLLMENT_CLOSED → (set instructor + config) → CHECK_IN_OPEN → IN_PROGRESS → verify."""
     _status_transition(tid, "ENROLLMENT_CLOSED")
 
-    # Set instructor (and optional sponsor) directly — eligibility guard requires
-    # master_instructor_id before CHECK_IN_OPEN; no API endpoint exists for sponsor.
+    # Set instructor directly — eligibility guard requires master_instructor_id
+    # before CHECK_IN_OPEN; no API endpoint exists for this field.
     t = _db.query(Semester).filter(Semester.id == tid).first()
     t.master_instructor_id = instructor_id
-    if organizer_sponsor_id is not None:
-        t.organizer_sponsor_id = organizer_sponsor_id
     _db.commit()
     ok(f"master_instructor_id = {instructor_id}")
-    if organizer_sponsor_id is not None:
-        ok(f"organizer_sponsor_id = {organizer_sponsor_id}")
 
-    # Schedule + reward config required before CHECK_IN_OPEN.
+    # Schedule + reward config required before CHECK_IN_OPEN / IN_PROGRESS.
     _set_schedule_config(tid)
     _set_reward_config(tid)
 
@@ -351,7 +346,7 @@ def _create_team_tournament(club_id, campus_id, tt_id, age_group, label, name_pr
 # ══════════════════════════════════════════════════════════════════════════════
 # S1: TEAM + League — 2 teams (U15 + U18)
 # ══════════════════════════════════════════════════════════════════════════════
-def s1_team_league(club, campus, tt_by_code, instructor, boot_teams, *, sponsor_id):
+def s1_team_league(club, campus, tt_by_code, instructor, boot_teams):
     prefix = f"S1-League-{uuid.uuid4().hex[:6]}"
     # Create via promotion wizard (enrolls LFA U15 automatically)
     tid = _create_team_tournament(club.id, campus.id, tt_by_code["league"].id, "U15", "league/U15", prefix)
@@ -362,7 +357,7 @@ def s1_team_league(club, campus, tt_by_code, instructor, boot_teams, *, sponsor_
         fail_local(f"Need ≥2 teams, got {count}")
 
     _status_transition(tid, "ENROLLMENT_OPEN")
-    _common_lifecycle(tid, instructor.id, expected_min_sessions=1, organizer_sponsor_id=sponsor_id)
+    _common_lifecycle(tid, instructor.id, expected_min_sessions=1)
 
 
 # ══════════════════════════════════════════════════════════════════════════════
@@ -494,7 +489,7 @@ def s3_individual_group_knockout(club, campus, tt_by_code, instructor, boot_team
 # ══════════════════════════════════════════════════════════════════════════════
 # S4: TEAM + League 2-leg — 2 teams (U15 + U18), number_of_legs=2
 # ══════════════════════════════════════════════════════════════════════════════
-def s4_team_league_2leg(club, campus, tt_by_code, instructor, boot_teams, *, sponsor_id):
+def s4_team_league_2leg(club, campus, tt_by_code, instructor, boot_teams):
     prefix = f"S4-2Leg-{uuid.uuid4().hex[:6]}"
     tid = _create_team_tournament(club.id, campus.id, tt_by_code["league"].id, "U15", "2leg/U15", prefix)
 
@@ -515,7 +510,7 @@ def s4_team_league_2leg(club, campus, tt_by_code, instructor, boot_teams, *, spo
 
     _status_transition(tid, "ENROLLMENT_OPEN")
     # 2 teams × 2 legs = 2 matches
-    _common_lifecycle(tid, instructor.id, expected_min_sessions=2, organizer_sponsor_id=sponsor_id)
+    _common_lifecycle(tid, instructor.id, expected_min_sessions=2)
 
     # Verify exactly 2× matches (1 per leg)
     sess_count = _db.query(SessionModel).filter(SessionModel.semester_id == tid).count()
@@ -633,21 +628,9 @@ def run():
         sys.exit(1)
     info(f"  Bootstrap teams loaded: {[t.name for t in boot_teams.values()]}")
 
-    # S1/S4 create PROMOTION_EVENT tournaments — organizer_sponsor_id is required
-    # before CHECK_IN_OPEN. No API endpoint exists for this field, so we write
-    # it directly in _common_lifecycle via the DB. Create a shared sponsor here.
-    lc_sponsor = _db.query(Sponsor).filter(Sponsor.code == "MATRIX-E2E").first()
-    if not lc_sponsor:
-        lc_sponsor = Sponsor(name="Matrix E2E Sponsor", code="MATRIX-E2E", is_active=True)
-        _db.add(lc_sponsor)
-        _db.commit()
-        _db.refresh(lc_sponsor)
-    ok(f"Shared sponsor: id={lc_sponsor.id}  code={lc_sponsor.code!r}")
-
     # ── Run scenarios ─────────────────────────────────────────────────────────
     _run_scenario("S1: TEAM + League (U15+U18, 2 teams)",
-                  s1_team_league, club, campus, tt_by_code, instructor, boot_teams,
-                  sponsor_id=lc_sponsor.id)
+                  s1_team_league, club, campus, tt_by_code, instructor, boot_teams)
 
     _run_scenario("S2: INDIVIDUAL + Knockout (8 players from U15)",
                   s2_individual_knockout, club, campus, tt_by_code, instructor, boot_teams)
@@ -656,8 +639,7 @@ def run():
                   s3_individual_group_knockout, club, campus, tt_by_code, instructor, boot_teams)
 
     _run_scenario("S4: TEAM + League 2-leg (U15+U18, 2 teams)",
-                  s4_team_league_2leg, club, campus, tt_by_code, instructor, boot_teams,
-                  sponsor_id=lc_sponsor.id)
+                  s4_team_league_2leg, club, campus, tt_by_code, instructor, boot_teams)
 
     _run_scenario("S5: INDIVIDUAL + League (U15+U18 players individually)",
                   s5_individual_league, club, campus, tt_by_code, instructor, boot_teams)

--- a/scripts/reset_e2e_web_db.py
+++ b/scripts/reset_e2e_web_db.py
@@ -346,6 +346,13 @@ def scenario_baseline(db) -> list[str]:
         lines.append(f"  upserted user {spec['email']} ({spec['role'].value})")
     _upsert_user(db, _INACTIVE_STUDENT, credit_balance=0, is_active=False)
     lines.append(f"  upserted inactive user {_INACTIVE_STUDENT['email']}")
+
+    # grandmaster@lfa.com needs an active LFA_COACH license for tournament instructor eligibility
+    grandmaster = db.query(User).filter(User.email == "grandmaster@lfa.com").first()
+    if grandmaster:
+        _upsert_lfa_coach_license(db, grandmaster)
+        lines.append(f"  upserted LFA_COACH license for grandmaster@lfa.com (level=5)")
+
     _upsert_semester(db)
     lines.append(f"  upserted semester {_SEMESTER_CODE}")
     _upsert_e2e_invitation_code(db)
@@ -450,6 +457,30 @@ def _upsert_lfa_license(db, user: User) -> UserLicense:
             payment_verified_at=datetime.now(),
             onboarding_completed=True,
             onboarding_completed_at=datetime.now(),
+            is_active=True,
+        )
+        db.add(lic)
+        db.commit()
+        db.refresh(lic)
+    return lic
+
+
+def _upsert_lfa_coach_license(db, user: User) -> UserLicense:
+    """Ensure an instructor has an active LFA_COACH license (level 5, no expiry)."""
+    lic = db.query(UserLicense).filter(
+        UserLicense.user_id == user.id,
+        UserLicense.specialization_type == "LFA_COACH",
+    ).first()
+    if lic:
+        lic.is_active = True
+        db.commit()
+    else:
+        lic = UserLicense(
+            user_id=user.id,
+            specialization_type="LFA_COACH",
+            current_level=5,
+            max_achieved_level=5,
+            started_at=datetime.now(),
             is_active=True,
         )
         db.add(lic)

--- a/scripts/seed_rewards_distributed_poc.py
+++ b/scripts/seed_rewards_distributed_poc.py
@@ -1,0 +1,616 @@
+#!/usr/bin/env python3
+"""
+Seed PoC: REWARDS_DISTRIBUTED via pure API/service lifecycle flow.
+
+Diagnostics-first: every lifecycle transition is logged with status-before,
+target-status, HTTP code, and guard detail on failure.
+
+Credential policy (from scripts/bootstrap_clean.py):
+  admin@lfa.com          → admin123
+  instructor@lfa.com     → instructor123
+  lfa-adult-*.@lfa.com   → Bootstrap#123   (36 bootstrap players, 12 adult)
+
+distribute-rewards-v2 (rewards_v2.py:92): sets tournament_status = "REWARDS_DISTRIBUTED"
+directly inside the endpoint — no separate lifecycle PATCH needed.
+
+Hidden dependencies resolved before implementation:
+  1. Instructor LFA_COACH level=5 → age_group must be AMATEUR (requires 5, not PRO=7)
+  2. Session check-in requires session.instructor_id == current_user.id
+     → session generator sets instructor_id = master_instructor_id (fallback)
+  3. Session completion: PATCH /sessions/{sid}/head-to-head-results sets session_status="completed"
+     AND triggers KnockoutProgressionService for round advancement
+  4. Tournament sessions endpoint does not expose session_status; use result_submitted proxy
+
+Prerequisites: PYTHONPATH=. python scripts/bootstrap_clean.py
+Run:          PYTHONPATH=. python scripts/seed_rewards_distributed_poc.py
+"""
+import os
+import sys
+import logging
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, BASE_DIR)
+
+logging.basicConfig(level=logging.WARNING)  # suppress SQLAlchemy noise
+
+from fastapi.testclient import TestClient  # noqa: E402
+from sqlalchemy.orm import Session as OrmSession  # noqa: E402
+
+from app.main import app  # noqa: E402
+from app.database import SessionLocal  # noqa: E402
+
+# ── Credentials (authoritative source: bootstrap_clean.py) ───────────────────
+_ADMIN_EMAIL = "admin@lfa.com"
+_ADMIN_PASS  = "admin123"
+_INSTR_EMAIL = "instructor@lfa.com"
+_INSTR_PASS  = "instructor123"
+_PLAYER_PASS = "Bootstrap#123"
+
+# ── ANSI colours ─────────────────────────────────────────────────────────────
+_G = "\033[92m"   # green
+_R = "\033[91m"   # red
+_C = "\033[96m"   # cyan
+_Y = "\033[93m"   # yellow
+_GR = "\033[90m"  # grey
+_B = "\033[1m"    # bold
+_X = "\033[0m"    # reset
+
+
+def _ok(msg):    print(f"{_G}  ✅ {msg}{_X}")
+def _warn(msg):  print(f"{_Y}  ⚠  {msg}{_X}")
+def _info(msg):  print(f"{_C}  ℹ  {msg}{_X}")
+def _debug(msg): print(f"{_GR}     {msg}{_X}")
+
+
+def _fail(msg):
+    print(f"{_R}  ❌ {msg}{_X}")
+    sys.exit(1)
+
+
+# ── Auth ──────────────────────────────────────────────────────────────────────
+def _login(client: TestClient, email: str, password: str) -> str:
+    """POST /api/v1/auth/login with JSON body; returns JWT access_token."""
+    resp = client.post(
+        "/api/v1/auth/login",
+        json={"email": email, "password": password},
+    )
+    if resp.status_code != 200:
+        _fail(f"Login failed for {email} (HTTP {resp.status_code}): {resp.text}")
+    token = resp.json().get("access_token")
+    if not token:
+        _fail(f"No access_token in login response for {email}")
+    return token
+
+
+def _h(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ── Orchestration logging ─────────────────────────────────────────────────────
+def _log(step: str, from_s: str | None, to_s: str, code: int, detail: str | None = None):
+    ok = code in (200, 201)
+    icon = "✅" if ok else "❌"
+    colour = _G if ok else _R
+    arrow = f"{from_s} → {to_s}" if from_s else f"→ {to_s}"
+    print(f"{colour}  {icon} [{step}] {arrow}  HTTP {code}{_X}")
+    if detail:
+        print(f"{_GR}     GUARD: {detail}{_X}")
+
+
+def _assert(resp, step: str, expected=(200, 201)) -> dict:
+    if resp.status_code not in expected:
+        try:
+            detail = resp.json().get("detail", resp.text)
+        except Exception:
+            detail = resp.text
+        _log(step, None, "FAIL", resp.status_code, str(detail))
+        _fail(f"[{step}] Expected {expected}, got HTTP {resp.status_code}: {detail}")
+    return resp.json()
+
+
+# ── Fixture resolution ────────────────────────────────────────────────────────
+def _preflight_check() -> None:
+    """Verify bootstrap fixtures exist before making any API calls."""
+    from app.models.user import User as UserModel
+    from app.models.license import UserLicense
+
+    db = SessionLocal()
+    try:
+        instr = db.query(UserModel).filter(UserModel.email == _INSTR_EMAIL).first()
+        if not instr:
+            _fail(f"Instructor {_INSTR_EMAIL} not in DB — run: PYTHONPATH=. python scripts/bootstrap_clean.py")
+
+        coach_lic = (
+            db.query(UserLicense)
+            .filter(
+                UserLicense.user_id == instr.id,
+                UserLicense.specialization_type == "LFA_COACH",
+                UserLicense.is_active == True,  # noqa: E712
+            )
+            .first()
+        )
+        if not coach_lic:
+            _fail(
+                f"Instructor {_INSTR_EMAIL} has no active LFA_COACH license — "
+                "run: PYTHONPATH=. python scripts/bootstrap_clean.py"
+            )
+        _debug(f"Preflight: LFA_COACH level={coach_lic.current_level} ✓")
+    finally:
+        db.close()
+
+
+def _resolve_instructor(client: TestClient, admin_tok: str) -> int:
+    resp = client.get("/api/v1/users/?role=instructor&size=100", headers=_h(admin_tok))
+    data = _assert(resp, "resolve-instructor")
+    for u in data.get("users", []):
+        if u.get("email") == _INSTR_EMAIL:
+            return u["id"]
+    _fail(f"Instructor {_INSTR_EMAIL} not in DB — run bootstrap_clean.py")
+
+
+def _resolve_campus(client: TestClient, admin_tok: str) -> int:
+    resp = client.get("/api/v1/admin/campuses", headers=_h(admin_tok))
+    data = _assert(resp, "resolve-campus")
+    items = data if isinstance(data, list) else data.get("campuses", [])
+    active = [c for c in items if c.get("is_active", True)]
+    if not active:
+        _fail("No active campus — run bootstrap_clean.py")
+    return active[0]["id"]
+
+
+def _resolve_players(client: TestClient, count: int = 4) -> list[dict]:
+    """
+    Return `count` adult bootstrap players with id + fresh JWT token.
+
+    Uses direct DB query (not users API) because the users list endpoint raises
+    Pydantic validation errors on .test-TLD emails that other seed scripts created.
+    Player resolution is fixture setup, not lifecycle flow.
+    """
+    from app.models.user import User as UserModel, UserRole
+
+    db = SessionLocal()
+    try:
+        adults = (
+            db.query(UserModel)
+            .filter(
+                UserModel.role == UserRole.STUDENT,
+                UserModel.email.like("lfa-adult-%@lfa.com"),
+                UserModel.is_active == True,  # noqa: E712
+            )
+            .limit(count)
+            .all()
+        )
+    finally:
+        db.close()
+
+    if len(adults) < count:
+        _fail(
+            f"Need {count} adult seed players, found {len(adults)} — run bootstrap_clean.py"
+        )
+
+    result = []
+    for u in adults:
+        tok = _login(client, u.email, _PLAYER_PASS)
+        result.append({"id": u.id, "email": u.email, "token": tok})
+    return result
+
+
+# ── Lifecycle helpers ─────────────────────────────────────────────────────────
+def _transition(
+    client: TestClient, admin_tok: str, tid: int,
+    from_s: str, to_s: str, reason: str = "PoC lifecycle step",
+) -> dict:
+    resp = client.patch(
+        f"/api/v1/tournaments/{tid}/status",
+        headers=_h(admin_tok),
+        json={"new_status": to_s, "reason": reason},
+    )
+    detail = None
+    if resp.status_code not in (200, 201):
+        try:
+            detail = resp.json().get("detail")
+        except Exception:
+            detail = resp.text
+    _log(f"PATCH status → {to_s}", from_s, to_s, resp.status_code, detail)
+    if resp.status_code not in (200, 201):
+        _fail(f"Transition {from_s} → {to_s} failed: {detail}")
+    return resp.json()
+
+
+# ── Session management ────────────────────────────────────────────────────────
+def _get_tournament_sessions(client: TestClient, tok: str, tid: int) -> list[dict]:
+    """GET /api/v1/tournaments/{tid}/sessions — returns a plain list."""
+    resp = client.get(f"/api/v1/tournaments/{tid}/sessions", headers=_h(tok))
+    data = _assert(resp, f"GET /tournaments/{tid}/sessions")
+    return data if isinstance(data, list) else data.get("sessions", [])
+
+
+def _complete_session(
+    client: TestClient,
+    instr_tok: str,
+    tid: int,
+    session: dict,
+) -> bool:
+    """
+    Check-in + HEAD_TO_HEAD result submission for a single session.
+    Returns True if processed, False if participants not yet assigned (TBD round).
+    """
+    sid = session["id"]
+    participants = session.get("participant_user_ids") or []
+    if len(participants) < 2:
+        _debug(f"Session {sid}: participants TBD (knockout progression pending), skipping")
+        return False
+
+    # ── Check-in (scheduled → in_progress) ───────────────────────────────────
+    ci_resp = client.post(
+        f"/api/v1/sessions/{sid}/check-in",
+        headers=_h(instr_tok),
+        json={},
+    )
+    if ci_resp.status_code in (200, 201):
+        _debug(f"Session {sid}: checked in (→ in_progress)")
+    else:
+        # 400 = already in_progress (acceptable)
+        _debug(f"Session {sid}: check-in HTTP {ci_resp.status_code} (may be in_progress already)")
+
+    # ── Submit HEAD_TO_HEAD result (participants[0] wins 2–0) ─────────────────
+    result_resp = client.patch(
+        f"/api/v1/sessions/{sid}/head-to-head-results",
+        headers=_h(instr_tok),
+        json={
+            "results": [
+                {"user_id": participants[0], "score": 2},
+                {"user_id": participants[1], "score": 0},
+            ],
+            "notes": "PoC deterministic result: participant[0] wins 2-0",
+        },
+    )
+
+    detail = None
+    if result_resp.status_code not in (200, 201):
+        try:
+            detail = result_resp.json().get("detail")
+        except Exception:
+            detail = result_resp.text
+
+    _log(
+        f"Session {sid} HEAD_TO_HEAD result",
+        "in_progress", "completed",
+        result_resp.status_code,
+        detail,
+    )
+    if result_resp.status_code not in (200, 201):
+        _fail(f"Session {sid} result submission failed: {detail}")
+
+    progression = result_resp.json().get("knockout_progression")
+    if progression:
+        _debug(f"Session {sid}: knockout progression → {progression.get('message', progression)}")
+
+    return True
+
+
+def _complete_all_sessions(
+    client: TestClient,
+    instr_tok: str,
+    tid: int,
+) -> int:
+    """
+    Round-by-round session completion loop.
+    Re-queries after each round to pick up knockout progression (next-round participants).
+    Returns total sessions completed.
+    """
+    completed = 0
+    for round_num in range(1, 11):  # safety cap: 10 rounds max
+        sessions = _get_tournament_sessions(client, instr_tok, tid)
+        pending = [s for s in sessions if not s.get("result_submitted")]
+        if not pending:
+            _info(f"All sessions completed after {round_num - 1} round pass(es)")
+            break
+
+        _info(f"Round pass {round_num}: {len(pending)} pending session(s)")
+        made_progress = False
+        for sess in pending:
+            if _complete_session(client, instr_tok, tid, sess):
+                completed += 1
+                made_progress = True
+
+        if not made_progress:
+            _fail(
+                f"Round pass {round_num}: no progress — {len(pending)} pending sessions "
+                "all have empty participant_user_ids. Possible session generator issue."
+            )
+    return completed
+
+
+# ── Verification ──────────────────────────────────────────────────────────────
+def _verify_api(
+    client: TestClient,
+    admin_tok: str,
+    instr_tok: str,
+    tid: int,
+    enrolled_count: int,
+) -> None:
+    print(f"\n{_B}═══ API-LEVEL VERIFICATION ═══════════════════════════════{_X}")
+
+    # 1. Tournament detail
+    resp = client.get(f"/api/v1/tournaments/{tid}", headers=_h(admin_tok))
+    t = _assert(resp, "GET /tournaments/{tid}")
+    t_status = t.get("tournament_status") or t.get("status")
+    assert t_status == "REWARDS_DISTRIBUTED", \
+        f"Tournament status: expected REWARDS_DISTRIBUTED, got {t_status}"
+    _ok(f"GET /tournaments/{tid} → tournament_status = {t_status}")
+
+    # 2. Rankings
+    resp = client.get(f"/api/v1/tournaments/{tid}/rankings", headers=_h(admin_tok))
+    rankings_body = _assert(resp, "GET /tournaments/{tid}/rankings")
+    rank_list = rankings_body.get("rankings", [])
+    assert len(rank_list) >= enrolled_count, \
+        f"Rankings: expected ≥{enrolled_count}, got {len(rank_list)}"
+    _ok(f"GET /tournaments/{tid}/rankings → {len(rank_list)} entries")
+
+    # 3. Sessions — all completed
+    sessions = _get_tournament_sessions(client, instr_tok, tid)
+    match_sessions = [s for s in sessions if s.get("is_tournament_game")]
+    completed = sum(1 for s in match_sessions if s.get("result_submitted"))
+    assert completed == len(match_sessions) and len(match_sessions) > 0, \
+        f"Sessions: expected all {len(match_sessions)} completed, got {completed}"
+    _ok(f"GET /tournaments/{tid}/sessions → {completed}/{len(match_sessions)} MATCH sessions completed")
+
+    # 4. Reward summary for top-ranked player (best-effort, non-blocking)
+    if rank_list:
+        uid = rank_list[0].get("user_id")
+        if uid:
+            resp = client.get(
+                f"/api/v1/tournaments/{tid}/rewards/{uid}",
+                headers=_h(admin_tok),
+            )
+            if resp.status_code == 200:
+                _ok(f"GET /tournaments/{tid}/rewards/{uid} → reward summary OK")
+            else:
+                _warn(f"GET /tournaments/{tid}/rewards/{uid} → HTTP {resp.status_code} (non-blocking)")
+
+
+def _verify_db(db: OrmSession, tid: int, enrolled_count: int) -> None:
+    print(f"\n{_B}═══ DB-LEVEL VERIFICATION ════════════════════════════════{_X}")
+
+    from app.models.semester import Semester
+    from app.models.session import Session as SessionModel, EventCategory
+    from app.models.tournament_ranking import TournamentRanking
+
+    t = db.query(Semester).filter(Semester.id == tid).first()
+    if t is None:
+        _fail(f"Tournament {tid} not found in DB")
+
+    # Guard 1: tournament_status
+    assert t.tournament_status == "REWARDS_DISTRIBUTED", \
+        f"DB tournament_status: expected REWARDS_DISTRIBUTED, got {t.tournament_status}"
+    _ok(f"DB: tournament_status = {t.tournament_status}")
+
+    # Guard 2: reward_policy_snapshot not NULL (SNAPSHOT_MISSING guard passed)
+    assert t.reward_policy_snapshot is not None, \
+        "DB: reward_policy_snapshot is NULL — SNAPSHOT_MISSING guard would block"
+    _ok("DB: reward_policy_snapshot IS NOT NULL")
+
+    # Guard 3: no incomplete auto-generated MATCH sessions (SESSIONS_INCOMPLETE guard passed)
+    incomplete = (
+        db.query(SessionModel)
+        .filter(
+            SessionModel.semester_id == tid,
+            SessionModel.auto_generated == True,  # noqa: E712
+            SessionModel.event_category == EventCategory.MATCH,
+            SessionModel.session_status != "completed",
+        )
+        .count()
+    )
+    assert incomplete == 0, \
+        f"DB: {incomplete} auto-generated MATCH session(s) not completed — SESSIONS_INCOMPLETE"
+    _ok("DB: all auto-generated MATCH sessions have session_status='completed'")
+
+    # Guard 4: TournamentRanking coverage (RANKINGS_INCOMPLETE guard passed)
+    ranking_count = (
+        db.query(TournamentRanking)
+        .filter(TournamentRanking.tournament_id == tid)
+        .count()
+    )
+    assert ranking_count >= enrolled_count, \
+        f"DB: TournamentRanking count {ranking_count} < enrolled {enrolled_count}"
+    _ok(f"DB: TournamentRanking count = {ranking_count} (≥ enrolled {enrolled_count})")
+
+    # Guard 5: TournamentParticipation records (PARTICIPATION_RECORDS_MISSING guard passed)
+    try:
+        from app.models.tournament_achievement import TournamentParticipation
+        part_count = (
+            db.query(TournamentParticipation)
+            .filter(TournamentParticipation.semester_id == tid)
+            .count()
+        )
+        assert part_count > 0, \
+            f"DB: TournamentParticipation count = 0 — PARTICIPATION_RECORDS_MISSING"
+        _ok(f"DB: TournamentParticipation count = {part_count}")
+    except ImportError:
+        _warn("TournamentParticipation not importable — guard 5 skipped")
+
+
+# ── Main orchestration ────────────────────────────────────────────────────────
+def run() -> None:
+    print(f"\n{_B}{'═' * 60}")
+    print("  LFA — REWARDS_DISTRIBUTED Seed PoC")
+    print("  Credential policy: scripts/bootstrap_clean.py")
+    print(f"{'═' * 60}{_X}\n")
+
+    _preflight_check()
+    client = TestClient(app, raise_server_exceptions=True)
+
+    # ── [0] Auth ──────────────────────────────────────────────────────────────
+    print(f"{_B}[0] Authentication{_X}")
+    admin_tok = _login(client, _ADMIN_EMAIL, _ADMIN_PASS)
+    _ok(f"{_ADMIN_EMAIL}")
+    instr_tok = _login(client, _INSTR_EMAIL, _INSTR_PASS)
+    _ok(f"{_INSTR_EMAIL}")
+
+    # ── [1] Fixture resolution ────────────────────────────────────────────────
+    print(f"\n{_B}[1] Fixture Resolution{_X}")
+    instr_id  = _resolve_instructor(client, admin_tok)
+    _ok(f"instructor_id = {instr_id}")
+    campus_id = _resolve_campus(client, admin_tok)
+    _ok(f"campus_id = {campus_id}")
+    players   = _resolve_players(client, count=4)
+    _ok(f"players = {[p['email'] for p in players]}")
+
+    # ── [2] Create tournament ─────────────────────────────────────────────────
+    print(f"\n{_B}[2] Create Tournament — SEEKING_INSTRUCTOR{_X}")
+    resp = client.post(
+        "/api/v1/tournaments/ops/run-scenario",
+        headers=_h(admin_tok),
+        json={
+            "scenario": "smoke_test",
+            "player_count": 0,
+            "max_players": 16,
+            "tournament_format": "HEAD_TO_HEAD",
+            "tournament_type_code": "knockout",
+            "auto_generate_sessions": False,
+            "simulation_mode": "manual",
+            "age_group": "AMATEUR",       # AMATEUR requires level 5; bootstrap instructor = level 5
+            "enrollment_cost": 0,         # zero cost → no credit fixtures needed
+            "initial_tournament_status": "SEEKING_INSTRUCTOR",
+            "dry_run": False,
+            "confirmed": False,
+            "campus_ids": [campus_id],
+        },
+    )
+    data = _assert(resp, "ops/run-scenario")
+    tid = data["tournament_id"]
+    _log("ops/run-scenario", None, "SEEKING_INSTRUCTOR", resp.status_code)
+    _ok(f"Tournament ID = {tid}, status = SEEKING_INSTRUCTOR, sessions = {data.get('session_count', 0)}")
+
+    # ── [3] Assign + accept instructor ────────────────────────────────────────
+    print(f"\n{_B}[3] Instructor Assignment{_X}")
+    resp = client.post(
+        f"/api/v1/tournaments/{tid}/direct-assign-instructor",
+        headers=_h(admin_tok),
+        json={"instructor_id": instr_id, "assignment_message": "PoC assignment"},
+    )
+    assign_data = _assert(resp, "direct-assign-instructor")
+    _log("direct-assign-instructor", "SEEKING_INSTRUCTOR", "SEEKING_INSTRUCTOR", resp.status_code)
+    _ok(f"Assigned (assignment_id = {assign_data.get('assignment_id')})")
+
+    resp = client.post(
+        f"/api/v1/tournaments/{tid}/instructor-assignment/accept",
+        headers=_h(instr_tok),
+        json={},
+    )
+    accept_data = _assert(resp, "instructor-assignment/accept")
+    _log(
+        "instructor-assignment/accept",
+        "SEEKING_INSTRUCTOR", "INSTRUCTOR_CONFIRMED",
+        resp.status_code,
+    )
+    _ok(f"Instructor accepted (status = {accept_data.get('status')})")
+
+    # ── [4] Enrollment ────────────────────────────────────────────────────────
+    print(f"\n{_B}[4] Enrollment Phase{_X}")
+    _transition(client, admin_tok, tid, "INSTRUCTOR_CONFIRMED", "ENROLLMENT_OPEN")
+
+    for p in players:
+        resp = client.post(
+            f"/api/v1/tournaments/{tid}/enroll",
+            headers=_h(p["token"]),
+            json={},
+        )
+        enroll = _assert(resp, f"enroll {p['email']}")
+        _debug(f"Enrolled {p['email']} (status = {enroll.get('status', 'ok')})")
+    _ok(f"Enrolled {len(players)} players")
+
+    _transition(client, admin_tok, tid, "ENROLLMENT_OPEN", "ENROLLMENT_CLOSED")
+
+    # ── [5] Schedule config ───────────────────────────────────────────────────
+    print(f"\n{_B}[5] Schedule Config (guard: SCHEDULE_CONFIG_MISSING before CHECK_IN_OPEN){_X}")
+    resp = client.patch(
+        f"/api/v1/tournaments/{tid}/schedule-config",
+        headers=_h(admin_tok),
+        json={"match_duration_minutes": 90, "break_duration_minutes": 15, "parallel_fields": 1},
+    )
+    _assert(resp, "PATCH schedule-config")
+    _log("PATCH schedule-config", None, "configured", resp.status_code)
+    _ok("Schedule config set")
+
+    # ── [6] CHECK_IN_OPEN ─────────────────────────────────────────────────────
+    print(f"\n{_B}[6] CHECK_IN_OPEN (guard: SCHEDULE_CONFIG_MISSING){_X}")
+    _transition(client, admin_tok, tid, "ENROLLMENT_CLOSED", "CHECK_IN_OPEN")
+
+    # ── [7] Reward config ─────────────────────────────────────────────────────
+    print(f"\n{_B}[7] Reward Config (guard: REWARD_CONFIG_MISSING before IN_PROGRESS){_X}")
+    resp = client.post(
+        f"/api/v1/tournaments/{tid}/reward-config",
+        headers=_h(admin_tok),
+        json={
+            "skill_mappings": [
+                {"skill": "speed", "weight": 1.0, "category": "PHYSICAL", "enabled": True}
+            ]
+        },
+    )
+    _assert(resp, "POST reward-config")
+    _log("POST reward-config", None, "configured", resp.status_code)
+    _ok("Reward config set")
+
+    # ── [8] IN_PROGRESS — auto-generates sessions ─────────────────────────────
+    print(f"\n{_B}[8] IN_PROGRESS (guard: REWARD_CONFIG_MISSING → auto-generates sessions){_X}")
+    _transition(client, admin_tok, tid, "CHECK_IN_OPEN", "IN_PROGRESS")
+    sessions_preview = _get_tournament_sessions(client, instr_tok, tid)
+    _ok(f"Sessions auto-generated: {len(sessions_preview)} total")
+
+    # ── [9] Complete all sessions round-by-round ──────────────────────────────
+    print(f"\n{_B}[9] Session Completion (round-by-round, deterministic){_X}")
+    _info("participant[0] always wins 2-0; knockout progression auto-advances winners")
+    session_count = _complete_all_sessions(client, instr_tok, tid)
+    _ok(f"Completed {session_count} session(s)")
+
+    # ── [10] Calculate rankings ───────────────────────────────────────────────
+    print(f"\n{_B}[10] Calculate Rankings{_X}")
+    resp = client.post(
+        f"/api/v1/tournaments/{tid}/calculate-rankings",
+        headers=_h(instr_tok),
+        json={},
+    )
+    _assert(resp, "POST calculate-rankings")
+    _log("POST calculate-rankings", "IN_PROGRESS", "IN_PROGRESS", resp.status_code)
+    _ok("Rankings calculated")
+
+    # ── [11] COMPLETED ────────────────────────────────────────────────────────
+    print(f"\n{_B}[11] COMPLETED (guards: SESSIONS_INCOMPLETE, RANKINGS_INCOMPLETE){_X}")
+    _transition(client, admin_tok, tid, "IN_PROGRESS", "COMPLETED")
+
+    # ── [12] Distribute rewards → REWARDS_DISTRIBUTED (auto-transition) ───────
+    print(f"\n{_B}[12] Distribute Rewards (rewards_v2.py:92 → auto-transition){_X}")
+    resp = client.post(
+        f"/api/v1/tournaments/{tid}/distribute-rewards-v2",
+        headers=_h(admin_tok),
+        json={"tournament_id": tid, "force_redistribution": False},
+    )
+    dist = _assert(resp, "POST distribute-rewards-v2")
+    _log("POST distribute-rewards-v2", "COMPLETED", "REWARDS_DISTRIBUTED", resp.status_code)
+    _ok(
+        f"Rewards distributed: {dist.get('total_participants')} participants — "
+        f"{dist.get('message')}"
+    )
+
+    # ── Verification ──────────────────────────────────────────────────────────
+    _verify_api(client, admin_tok, instr_tok, tid, enrolled_count=len(players))
+
+    db = SessionLocal()
+    try:
+        _verify_db(db, tid, enrolled_count=len(players))
+    finally:
+        db.close()
+
+    # ── Summary ───────────────────────────────────────────────────────────────
+    print(f"\n{_B}{_G}{'═' * 60}")
+    print("  ✅  REWARDS_DISTRIBUTED SEED POC — PASS")
+    print(f"  Tournament ID : {tid}")
+    print(f"  Sessions      : {session_count} completed")
+    print(f"  Players       : {len(players)} enrolled")
+    print(f"{'═' * 60}{_X}\n")
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -375,6 +375,32 @@ def e2e_test_users():
                 }
                 print(f"   ✅ {user_spec['key']}: {user_spec['email']} (created, id={new_user.id})")
 
+        # Ensure grandmaster@lfa.com has an active LFA_COACH license (required by
+        # the session generation eligibility guard — PR #143).
+        from app.models.license import UserLicense
+        instructor_id = created_users.get("instructor", {}).get("id")
+        if instructor_id:
+            coach_lic = db.query(UserLicense).filter(
+                UserLicense.user_id == instructor_id,
+                UserLicense.specialization_type == "LFA_COACH",
+            ).first()
+            if coach_lic:
+                coach_lic.is_active = True
+                coach_lic.current_level = 7
+                coach_lic.expires_at = None
+                db.flush()
+            else:
+                db.add(UserLicense(
+                    user_id=instructor_id,
+                    specialization_type="LFA_COACH",
+                    current_level=7,
+                    max_achieved_level=7,
+                    is_active=True,
+                    started_at=datetime.now(timezone.utc),
+                    expires_at=None,
+                ))
+                db.flush()
+
         # Commit all changes
         db.commit()
         print(f"   📊 E2E test users ready: {len(created_users)} users available")

--- a/tests/e2e/integration_critical/test_instructor_lifecycle.py
+++ b/tests/e2e/integration_critical/test_instructor_lifecycle.py
@@ -220,6 +220,24 @@ def test_instructor_full_lifecycle(
     print(f"✅ Step 3.75: Enrollment closed (status=ENROLLMENT_CLOSED)")
 
     # ==================================================================
+    # STEP 3.8: Set schedule config (required before CHECK_IN_OPEN)
+    # ==================================================================
+
+    print(f"[Step 3.8] Setting schedule config for tournament {tournament_id}...")
+    sched_cfg_response = requests.patch(
+        f"{api_url}/api/v1/tournaments/{tournament_id}/schedule-config",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={
+            "match_duration_minutes": 90,
+            "break_duration_minutes": 15,
+            "parallel_fields": 1,
+        }
+    )
+    assert sched_cfg_response.status_code in [200, 201], \
+        f"Schedule config failed: {sched_cfg_response.text}"
+    print(f"✅ Step 3.8: Schedule config set")
+
+    # ==================================================================
     # STEP 3.9: Admin opens check-in (ENROLLMENT_CLOSED → CHECK_IN_OPEN)
     # ==================================================================
 
@@ -237,6 +255,24 @@ def test_instructor_full_lifecycle(
         f"Open check-in failed: {checkin_open_response.text}"
 
     print(f"✅ Step 3.9: Check-in opened (status=CHECK_IN_OPEN)")
+
+    # ==================================================================
+    # STEP 3.91: Set reward config (required before IN_PROGRESS)
+    # ==================================================================
+
+    print(f"[Step 3.91] Setting reward config for tournament {tournament_id}...")
+    reward_cfg_response = requests.post(
+        f"{api_url}/api/v1/tournaments/{tournament_id}/reward-config",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={
+            "skill_mappings": [
+                {"skill": "speed", "weight": 1.0, "category": "PHYSICAL", "enabled": True}
+            ],
+        }
+    )
+    assert reward_cfg_response.status_code in [200, 201], \
+        f"Reward config failed: {reward_cfg_response.text}"
+    print(f"✅ Step 3.91: Reward config set")
 
     # ==================================================================
     # STEP 3.95: Admin starts tournament (CHECK_IN_OPEN → IN_PROGRESS)

--- a/tests/integration/web_flows/test_admin_smoke.py
+++ b/tests/integration/web_flows/test_admin_smoke.py
@@ -2995,6 +2995,30 @@ class TestSmoke24SessionGenWizard:
 
     # ── Helpers ───────────────────────────────────────────────────────────────
 
+    def _make_eligible_instructor(self, test_db: Session) -> User:
+        """Create a fresh INSTRUCTOR user with active LFA_COACH license."""
+        from datetime import datetime, timezone
+        uid = uuid.uuid4().hex[:8]
+        instr = User(
+            name=f"S24 Instructor {uid}",
+            email=f"s24-instr-{uid}@smoke24.test",
+            role=UserRole.INSTRUCTOR,
+            password_hash="x",
+            is_active=True,
+        )
+        test_db.add(instr)
+        test_db.flush()
+        test_db.add(UserLicense(
+            user_id=instr.id,
+            specialization_type=SpecializationType.LFA_COACH.value,
+            current_level=7,
+            max_achieved_level=7,
+            is_active=True,
+            started_at=datetime.now(timezone.utc),
+        ))
+        test_db.flush()
+        return instr
+
     def _make_ir_tournament(
         self,
         test_db: Session,
@@ -3020,13 +3044,14 @@ class TestSmoke24SessionGenWizard:
         # Session generation requires ≥1 active pitch on the campus (domain invariant)
         test_db.add(Pitch(campus_id=camp.id, pitch_number=1, name="Pálya A", capacity=22, is_active=True))
         test_db.flush()
+        eligible_instructor = self._make_eligible_instructor(test_db)
         tourn = Semester(
             code=f"S24{suffix}-{uuid.uuid4().hex[:6]}",
             name=f"SMOKE-24{suffix} Wizard Test",
             start_date=today,
             end_date=today + timedelta(days=7),
             tournament_status=status,
-            master_instructor_id=admin_user.id,
+            master_instructor_id=eligible_instructor.id,
             campus_id=camp.id,
             tournament_config_obj=TournamentConfiguration(
                 participant_type="INDIVIDUAL",

--- a/tests/integration/web_flows/test_admin_smoke.py
+++ b/tests/integration/web_flows/test_admin_smoke.py
@@ -2522,6 +2522,30 @@ class TestSmoke22GamePresetPlayerCountGuard:
                by hardcoded >=2 guard (confirms preset guard is NOT the blocker)
     """
 
+    def _make_eligible_instructor(self, test_db):
+        """Create a fresh INSTRUCTOR user with active LFA_COACH license."""
+        from datetime import datetime, timezone
+        uid = uuid.uuid4().hex[:8]
+        instr = User(
+            name=f"S22 Instructor {uid}",
+            email=f"s22-instr-{uid}@smoke22.test",
+            role=UserRole.INSTRUCTOR,
+            password_hash="x",
+            is_active=True,
+        )
+        test_db.add(instr)
+        test_db.flush()
+        test_db.add(UserLicense(
+            user_id=instr.id,
+            specialization_type=SpecializationType.LFA_COACH.value,
+            current_level=7,
+            max_achieved_level=7,
+            is_active=True,
+            started_at=datetime.now(timezone.utc),
+        ))
+        test_db.flush()
+        return instr
+
     def _make_ir_tournament(self, test_db, admin_user, suffix=""):
         """Create an INDIVIDUAL_RANKING tournament in IN_PROGRESS status."""
         from datetime import date, timedelta
@@ -2542,13 +2566,14 @@ class TestSmoke22GamePresetPlayerCountGuard:
         # Session generation requires ≥1 active pitch on the campus (domain invariant)
         test_db.add(Pitch(campus_id=camp.id, pitch_number=1, name="Pálya A", capacity=22, is_active=True))
         test_db.flush()
+        eligible_instructor = self._make_eligible_instructor(test_db)
         tourn = Semester(
             code=f"S22{suffix}-{uuid.uuid4().hex[:6]}",
             name=f"SMOKE-22{suffix} Preset Guard Test",
             start_date=today,
             end_date=today + timedelta(days=7),
             tournament_status="IN_PROGRESS",
-            master_instructor_id=admin_user.id,
+            master_instructor_id=eligible_instructor.id,
             campus_id=camp.id,
             tournament_config_obj=TournamentConfiguration(
                 tournament_type_id=None,

--- a/tests/integration/web_flows/test_critical_e2e.py
+++ b/tests/integration/web_flows/test_critical_e2e.py
@@ -108,6 +108,21 @@ def _make_license(db: Session, user: User) -> UserLicense:
     return lic
 
 
+def _make_coach_license(db: Session, user: User) -> UserLicense:
+    lic = UserLicense(
+        user_id=user.id,
+        specialization_type="LFA_COACH",
+        current_level=7,
+        max_achieved_level=7,
+        is_active=True,
+        started_at=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        expires_at=None,
+    )
+    db.add(lic)
+    db.flush()
+    return lic
+
+
 def _make_tournament(db: Session, enrollment_cost: int = 0) -> Semester:
     sem = Semester(
         code=f"TOURN-{_uid()}",
@@ -906,6 +921,7 @@ def test_instructor_slot_duplicate_rejected(test_db: Session, client: TestClient
     """
     admin = _make_user(test_db, role=UserRole.ADMIN)
     instructor = _make_user(test_db, role=UserRole.INSTRUCTOR)
+    _make_coach_license(test_db, instructor)
     tourn = _make_tournament(test_db)
 
     app.dependency_overrides[get_current_user_web] = lambda: admin
@@ -4081,6 +4097,7 @@ def test_admin_instructor_slot_create_planned(test_db: Session, client: TestClie
     """
     admin = _make_user(test_db, role=UserRole.ADMIN)
     instructor = _make_user(test_db, role=UserRole.INSTRUCTOR)
+    _make_coach_license(test_db, instructor)
     uid = _uid()
 
     sem = Semester(

--- a/tests/integration/web_flows/test_instructor_planning.py
+++ b/tests/integration/web_flows/test_instructor_planning.py
@@ -24,6 +24,7 @@ from app.main import app
 from app.database import engine, get_db
 from app.dependencies import get_current_user_web
 from app.models.user import User, UserRole
+from app.models.license import UserLicense
 from app.models.campus import Campus
 from app.models.location import Location
 from app.models.pitch import Pitch
@@ -78,6 +79,17 @@ def _user(db: Session, role: UserRole = UserRole.INSTRUCTOR) -> User:
     )
     db.add(u)
     db.flush()
+    if role == UserRole.INSTRUCTOR:
+        db.add(UserLicense(
+            user_id=u.id,
+            specialization_type="LFA_COACH",
+            current_level=7,
+            max_achieved_level=7,
+            is_active=True,
+            started_at=datetime(2025, 1, 1, tzinfo=timezone.utc),
+            expires_at=None,
+        ))
+        db.flush()
     return u
 
 

--- a/tests/integration/web_flows/test_instructor_prereq_guard.py
+++ b/tests/integration/web_flows/test_instructor_prereq_guard.py
@@ -12,7 +12,7 @@ Tests:
 from __future__ import annotations
 
 import uuid
-from datetime import date, timedelta
+from datetime import date, timedelta, datetime, timezone
 
 import pytest
 from fastapi.testclient import TestClient
@@ -85,6 +85,16 @@ def _make_instructor(db: Session) -> User:
         is_active=True,
     )
     db.add(u)
+    db.flush()
+    db.add(UserLicense(
+        user_id=u.id,
+        specialization_type="LFA_COACH",
+        current_level=7,
+        max_achieved_level=7,
+        is_active=True,
+        started_at=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        expires_at=None,
+    ))
     db.flush()
     return u
 

--- a/tests/integration/web_flows/test_lifecycle_reward_matrix.py
+++ b/tests/integration/web_flows/test_lifecycle_reward_matrix.py
@@ -76,6 +76,7 @@ from app.models.team import Team, TeamMember, TournamentTeamEnrollment
 from app.models.location import Location
 from app.models.campus import Campus
 from app.models.pitch import Pitch
+from app.models.tournament_reward_config import TournamentRewardConfig
 from app.core.security import get_password_hash
 
 
@@ -197,10 +198,22 @@ def _tournament(
         number_of_rounds=1,
         parallel_fields=1,
         ranking_direction="DESC",
+        match_duration_minutes=60,   # required by readiness_validator (GAP-1 guard)
+        break_duration_minutes=10,
     ))
     db.add(GameConfiguration(
         semester_id=t.id,
         game_preset_id=preset.id,
+    ))
+    db.add(TournamentRewardConfig(
+        semester_id=t.id,
+        reward_policy_name="standard",
+        reward_config={
+            "template_name": "Standard",
+            "skill_mappings": [],
+            "first_place": {"credits": 100, "xp": 500},
+            "participation": {"credits": 10, "xp": 50},
+        },
     ))
     db.flush()
     return t
@@ -989,10 +1002,22 @@ def _ir_tournament(
         parallel_fields=1,
         ranking_direction="DESC",   # higher score = better rank
         scoring_type="SCORE_BASED",
+        match_duration_minutes=60,   # required by readiness_validator (GAP-1 guard)
+        break_duration_minutes=10,
     ))
     db.add(GameConfiguration(
         semester_id=t.id,
         game_preset_id=preset.id,
+    ))
+    db.add(TournamentRewardConfig(
+        semester_id=t.id,
+        reward_policy_name="standard",
+        reward_config={
+            "template_name": "Standard",
+            "skill_mappings": [],
+            "first_place": {"credits": 100, "xp": 500},
+            "participation": {"credits": 10, "xp": 50},
+        },
     ))
     db.flush()
     return t

--- a/tests/integration/web_flows/test_lifecycle_reward_matrix.py
+++ b/tests/integration/web_flows/test_lifecycle_reward_matrix.py
@@ -101,6 +101,30 @@ def _user(db: Session, role=UserRole.STUDENT) -> User:
     return u
 
 
+def _eligible_instructor(db: Session) -> User:
+    """Create an INSTRUCTOR with an active LFA_COACH license (level 5, no expiry)."""
+    from datetime import timezone
+    u = User(
+        email=f"{_PFX}-coach-{_uid()}@lfa-test.com",
+        name=f"SRL Coach {_uid()}",
+        password_hash=get_password_hash("pw"),
+        role=UserRole.INSTRUCTOR,
+        is_active=True,
+    )
+    db.add(u)
+    db.flush()
+    db.add(UserLicense(
+        user_id=u.id,
+        specialization_type="LFA_COACH",
+        current_level=5,
+        max_achieved_level=5,
+        is_active=True,
+        started_at=datetime.now(timezone.utc),
+    ))
+    db.flush()
+    return u
+
+
 def _preset(db: Session) -> GamePreset:
     existing = db.query(GamePreset).filter(GamePreset.code == "srl-default").first()
     if existing:
@@ -1100,7 +1124,8 @@ class TestExtendedLifecycleMatrix:
         """
         tt = _tt(test_db, "knockout", min_players=4)
         camp = _campus(test_db)
-        t = _tournament(test_db, admin_user, tt, tournament_status="DRAFT")
+        instr = _eligible_instructor(test_db)
+        t = _tournament(test_db, instr, tt, tournament_status="DRAFT")
         t.campus_id = camp.id
         test_db.flush()
 
@@ -1189,7 +1214,8 @@ class TestExtendedLifecycleMatrix:
         """
         tt = _tt(test_db, "group_knockout", min_players=8)
         camp = _campus(test_db)
-        t = _tournament(test_db, admin_user, tt, tournament_status="DRAFT")
+        instr = _eligible_instructor(test_db)
+        t = _tournament(test_db, instr, tt, tournament_status="DRAFT")
         t.campus_id = camp.id
         test_db.flush()
 
@@ -1283,7 +1309,8 @@ class TestExtendedLifecycleMatrix:
         → p1 rank=1 (highest score) → COMPLETED → REWARDS_DISTRIBUTED
         """
         camp = _campus(test_db)
-        t = _ir_tournament(test_db, admin_user, tournament_status="DRAFT")
+        instr = _eligible_instructor(test_db)
+        t = _ir_tournament(test_db, instr, tournament_status="DRAFT")
         t.campus_id = camp.id
         test_db.flush()
 
@@ -1339,7 +1366,8 @@ class TestExtendedLifecycleMatrix:
         → team_A rank=1 → COMPLETED → 6 TournamentParticipation rows (team expansion)
         """
         camp = _campus(test_db)
-        t = _ir_tournament(test_db, admin_user, participant_type="TEAM", tournament_status="DRAFT")
+        instr = _eligible_instructor(test_db)
+        t = _ir_tournament(test_db, instr, participant_type="TEAM", tournament_status="DRAFT")
         t.campus_id = camp.id
         test_db.flush()
 
@@ -1406,7 +1434,8 @@ class TestExtendedLifecycleMatrix:
 
         tt = _tt(test_db, "knockout", min_players=4)
         camp = _campus(test_db)
-        t = _tournament(test_db, admin_user, tt, participant_type="TEAM", tournament_status="DRAFT")
+        instr = _eligible_instructor(test_db)
+        t = _tournament(test_db, instr, tt, participant_type="TEAM", tournament_status="DRAFT")
         t.campus_id = camp.id
         test_db.flush()
 
@@ -1493,7 +1522,8 @@ class TestExtendedLifecycleMatrix:
         """
         tt = _tt(test_db, "league", min_players=2)
         camp = _campus(test_db)
-        t = _tournament(test_db, admin_user, tt, participant_type="TEAM", tournament_status="DRAFT")
+        instr = _eligible_instructor(test_db)
+        t = _tournament(test_db, instr, tt, participant_type="TEAM", tournament_status="DRAFT")
         t.campus_id = camp.id
         cfg = t.tournament_config_obj
         cfg.number_of_legs = 2

--- a/tests/integration/web_flows/test_readiness_validator_guard.py
+++ b/tests/integration/web_flows/test_readiness_validator_guard.py
@@ -1,0 +1,607 @@
+"""
+Readiness Validator Guard — Integration Tests
+=============================================
+Guards introduced to close three confirmed backend bypass gaps:
+
+  GAP-1  CHECK_IN_OPEN blocked when Schedule Config is missing (SCHEDULE_CONFIG_MISSING).
+  GAP-2  IN_PROGRESS blocked when Reward Config is missing (REWARD_CONFIG_MISSING).
+  GAP-3  IN_PROGRESS session regen failure raises HTTP 400, not silent print.
+  GAP-4  (tech debt) — not tested here; see readiness_validator.py TODO comment.
+
+Tests:
+  RV-01  missing_schedule_config_blocks_check_in_open
+  RV-02  valid_schedule_config_allows_check_in_open
+  RV-03  missing_reward_config_blocks_in_progress
+  RV-04  regen_failure_blocks_in_progress
+  RV-05  full_configured_tournament_lifecycle (happy path: CHECK_IN_OPEN → IN_PROGRESS)
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import event
+from sqlalchemy.orm import Session, sessionmaker
+
+from app.database import engine
+from app.main import app
+from app.database import get_db
+from app.dependencies import get_current_admin_user_hybrid
+from app.models.campus import Campus
+from app.models.license import UserLicense
+from app.models.location import Location
+from app.models.pitch import Pitch
+from app.models.semester import Semester, SemesterCategory, SemesterStatus
+from app.models.semester_enrollment import SemesterEnrollment, EnrollmentStatus
+from app.models.tournament_configuration import TournamentConfiguration
+from app.models.tournament_reward_config import TournamentRewardConfig
+from app.models.user import User, UserRole
+from app.core.security import get_password_hash
+from tests.factories.game_factory import TournamentFactory
+
+
+# ── SAVEPOINT-isolated DB fixture ─────────────────────────────────────────────
+
+@pytest.fixture(scope="function")
+def test_db():
+    connection = engine.connect()
+    transaction = connection.begin()
+    TestSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=connection)
+    session = TestSessionLocal()
+    connection.begin_nested()
+
+    @event.listens_for(session, "after_transaction_end")
+    def restart_savepoint(session, txn):
+        if txn.nested and not txn._parent.nested:
+            session.begin_nested()
+
+    try:
+        yield session
+    finally:
+        session.close()
+        if transaction.is_active:
+            transaction.rollback()
+        connection.close()
+
+
+# ── Shared helpers ─────────────────────────────────────────────────────────────
+
+def _make_admin(db: Session) -> User:
+    u = User(
+        email=f"rv-admin+{uuid.uuid4().hex[:8]}@lfa.com",
+        name="RV Admin",
+        password_hash=get_password_hash("admin123"),
+        role=UserRole.ADMIN,
+        is_active=True,
+    )
+    db.add(u)
+    db.flush()
+    return u
+
+
+def _make_instructor(db: Session) -> User:
+    """Create an eligible instructor with LFA_COACH level-7 license (PRO threshold)."""
+    u = User(
+        email=f"rv-instructor+{uuid.uuid4().hex[:8]}@lfa.com",
+        name="RV Instructor",
+        password_hash=get_password_hash("admin123"),
+        role=UserRole.INSTRUCTOR,
+        is_active=True,
+    )
+    db.add(u)
+    db.flush()
+    db.add(UserLicense(
+        user_id=u.id,
+        specialization_type="LFA_COACH",
+        current_level=7,
+        max_achieved_level=7,
+        is_active=True,
+        started_at=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        expires_at=None,
+    ))
+    db.flush()
+    return u
+
+
+def _make_campus_with_pitch(db: Session) -> Campus:
+    location = Location(
+        name=f"RV Location {uuid.uuid4().hex[:6]}",
+        city=f"RVCity-{uuid.uuid4().hex[:8]}",
+        country="HU",
+    )
+    db.add(location)
+    db.flush()
+    campus = Campus(
+        name=f"RV Campus {uuid.uuid4().hex[:6]}",
+        location_id=location.id,
+        is_active=True,
+    )
+    db.add(campus)
+    db.flush()
+    db.add(Pitch(
+        campus_id=campus.id,
+        pitch_number=1,
+        name="RV Pálya A",
+        capacity=22,
+        is_active=True,
+    ))
+    db.flush()
+    return campus
+
+
+def _enroll_player(db: Session, tournament_id: int, checked_in: bool = False) -> User:
+    """Create a player, add an LFA_FOOTBALL_PLAYER license, and enroll + approve them."""
+    player = User(
+        email=f"rv-player-{uuid.uuid4().hex[:8]}@lfa.com",
+        name="RV Player",
+        password_hash=get_password_hash("pw"),
+        role=UserRole.STUDENT,
+        is_active=True,
+    )
+    db.add(player)
+    db.flush()
+    lic = UserLicense(
+        user_id=player.id,
+        specialization_type="LFA_FOOTBALL_PLAYER",
+        current_level=1,
+        max_achieved_level=1,
+        is_active=True,
+        started_at=datetime.utcnow(),
+        expires_at=None,
+    )
+    db.add(lic)
+    db.flush()
+    db.add(SemesterEnrollment(
+        user_id=player.id,
+        semester_id=tournament_id,
+        user_license_id=lic.id,
+        is_active=True,
+        request_status=EnrollmentStatus.APPROVED,
+        payment_verified=True,
+        tournament_checked_in_at=datetime.utcnow() if checked_in else None,
+    ))
+    db.flush()
+    return player
+
+
+def _make_reward_config(db: Session, tournament_id: int) -> TournamentRewardConfig:
+    rc = TournamentRewardConfig(
+        semester_id=tournament_id,
+        reward_policy_name="test",
+        reward_config={
+            "template_name": "Standard",
+            "skill_mappings": [{"skill_key": "dribbling", "weight": 1.0, "enabled": True}],
+            "first_place": {"credits": 100, "xp": 500},
+            "participation": {"credits": 10, "xp": 50},
+        },
+    )
+    db.add(rc)
+    db.flush()
+    return rc
+
+
+def _make_tournament(
+    db: Session,
+    *,
+    campus: Campus,
+    instructor: User,
+    tt,
+    tournament_status: str,
+    match_duration_minutes: int | None,
+    break_duration_minutes: int | None,
+    parallel_fields: int | None = None,
+    with_reward_config: bool = False,
+    sessions_generated: bool = False,
+) -> Semester:
+    """
+    Create a tournament row + TournamentConfiguration directly in the DB.
+    Does NOT go through the lifecycle API, so any status can be set directly.
+    """
+    code = f"RV-{uuid.uuid4().hex[:10].upper()}"
+    t = Semester(
+        code=code,
+        name=f"RV Test Tournament {code[-6:]}",
+        semester_category=SemesterCategory.TOURNAMENT,
+        status=SemesterStatus.DRAFT,
+        tournament_status=tournament_status,
+        age_group="PRO",
+        campus_id=campus.id,
+        start_date=date.today() + timedelta(days=7),
+        end_date=date.today() + timedelta(days=8),
+        enrollment_cost=0,
+        specialization_type="LFA_FOOTBALL_PLAYER",
+        master_instructor_id=instructor.id,
+    )
+    db.add(t)
+    db.flush()
+
+    cfg = TournamentConfiguration(
+        semester_id=t.id,
+        tournament_type_id=tt.id,
+        participant_type="INDIVIDUAL",
+        number_of_rounds=1,
+        max_players=32,
+        match_duration_minutes=match_duration_minutes,
+        break_duration_minutes=break_duration_minutes,
+        parallel_fields=parallel_fields if parallel_fields is not None else 1,
+        sessions_generated=sessions_generated,
+    )
+    db.add(cfg)
+    db.flush()
+
+    if with_reward_config:
+        _make_reward_config(db, t.id)
+
+    db.commit()
+    db.expire_all()
+    return db.query(Semester).filter(Semester.id == t.id).first()
+
+
+def _admin_client(db: Session, admin: User) -> TestClient:
+    def override_get_db():
+        yield db
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_admin_user_hybrid] = lambda: admin
+    return TestClient(app, raise_server_exceptions=False)
+
+
+# ── RV-01 — GAP-1: missing schedule config blocks CHECK_IN_OPEN ───────────────
+
+
+class TestMissingScheduleConfigBlocksCheckInOpen:
+    """
+    RV-01: ENROLLMENT_CLOSED → CHECK_IN_OPEN is blocked (HTTP 400) when
+    match_duration_minutes or break_duration_minutes is NULL.
+    Error code SCHEDULE_CONFIG_MISSING must appear in the response detail.
+    Tournament status must remain ENROLLMENT_CLOSED.
+    """
+
+    def test_rv_01_null_match_and_break_blocked(self, test_db):
+        admin = _make_admin(test_db)
+        instructor = _make_instructor(test_db)
+        campus = _make_campus_with_pitch(test_db)
+        tt = TournamentFactory.ensure_tournament_type(
+            test_db, code=f"rv01-{uuid.uuid4().hex[:6]}"
+        )
+        tournament = _make_tournament(
+            test_db,
+            campus=campus,
+            instructor=instructor,
+            tt=tt,
+            tournament_status="ENROLLMENT_CLOSED",
+            match_duration_minutes=None,   # ← missing
+            break_duration_minutes=None,   # ← missing
+        )
+        _enroll_player(test_db, tournament.id)
+        _enroll_player(test_db, tournament.id)
+
+        client = _admin_client(test_db, admin)
+        try:
+            response = client.patch(
+                f"/api/v1/tournaments/{tournament.id}/status",
+                json={"new_status": "CHECK_IN_OPEN", "reason": "test"},
+            )
+
+            assert response.status_code == 400, (
+                f"Expected 400, got {response.status_code}: {response.text}"
+            )
+            body = response.json()
+            detail = body.get("detail") or body.get("error", {}).get("message", "")
+            assert "SCHEDULE_CONFIG_MISSING" in detail, (
+                f"Expected 'SCHEDULE_CONFIG_MISSING' in error, got: {detail!r}"
+            )
+
+            # Status must not have changed
+            test_db.expire_all()
+            t_after = test_db.query(Semester).filter(Semester.id == tournament.id).first()
+            assert t_after.tournament_status == "ENROLLMENT_CLOSED", (
+                f"Status changed unexpectedly to {t_after.tournament_status!r}"
+            )
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_rv_01b_null_match_only_blocked(self, test_db):
+        """Only match_duration_minutes missing → still blocked."""
+        admin = _make_admin(test_db)
+        instructor = _make_instructor(test_db)
+        campus = _make_campus_with_pitch(test_db)
+        tt = TournamentFactory.ensure_tournament_type(
+            test_db, code=f"rv01b-{uuid.uuid4().hex[:6]}"
+        )
+        tournament = _make_tournament(
+            test_db,
+            campus=campus,
+            instructor=instructor,
+            tt=tt,
+            tournament_status="ENROLLMENT_CLOSED",
+            match_duration_minutes=None,  # ← missing
+            break_duration_minutes=10,
+        )
+        _enroll_player(test_db, tournament.id)
+        _enroll_player(test_db, tournament.id)
+
+        client = _admin_client(test_db, admin)
+        try:
+            response = client.patch(
+                f"/api/v1/tournaments/{tournament.id}/status",
+                json={"new_status": "CHECK_IN_OPEN", "reason": "test"},
+            )
+            assert response.status_code == 400
+            detail = (response.json().get("detail") or
+                      response.json().get("error", {}).get("message", ""))
+            assert "SCHEDULE_CONFIG_MISSING" in detail
+        finally:
+            app.dependency_overrides.clear()
+
+
+# ── RV-02 — GAP-1 happy path: valid schedule config allows CHECK_IN_OPEN ──────
+
+
+class TestValidScheduleConfigAllowsCheckInOpen:
+    """
+    RV-02: ENROLLMENT_CLOSED → CHECK_IN_OPEN succeeds when schedule config is set,
+    instructor is eligible, and enough players are enrolled.
+    """
+
+    def test_rv_02_check_in_open_succeeds(self, test_db):
+        admin = _make_admin(test_db)
+        instructor = _make_instructor(test_db)
+        campus = _make_campus_with_pitch(test_db)
+        # Must use a known code ("knockout") — session generator dispatches by code.
+        tt = TournamentFactory.ensure_tournament_type(test_db, code="knockout")
+        tournament = _make_tournament(
+            test_db,
+            campus=campus,
+            instructor=instructor,
+            tt=tt,
+            tournament_status="ENROLLMENT_CLOSED",
+            match_duration_minutes=60,   # ← explicitly set
+            break_duration_minutes=10,   # ← explicitly set
+            parallel_fields=1,
+        )
+        # Enroll 4 players — safe margin above min_players for knockout type.
+        for _ in range(4):
+            _enroll_player(test_db, tournament.id)
+
+        client = _admin_client(test_db, admin)
+        try:
+            response = client.patch(
+                f"/api/v1/tournaments/{tournament.id}/status",
+                json={"new_status": "CHECK_IN_OPEN", "reason": "test"},
+            )
+
+            # Must NOT be blocked by schedule config or instructor guard.
+            if response.status_code == 400:
+                detail = (response.json().get("detail") or
+                          response.json().get("error", {}).get("message", ""))
+                assert "SCHEDULE_CONFIG_MISSING" not in detail, (
+                    f"Schedule config guard incorrectly blocked a configured tournament: {detail!r}"
+                )
+                assert "INSTRUCTOR" not in detail.upper() or "INSTRUCTOR_ELIGIBILITY" not in detail, (
+                    f"Instructor guard incorrectly blocked: {detail!r}"
+                )
+
+            # Successful transition returns 200
+            assert response.status_code == 200, (
+                f"Expected 200 (CHECK_IN_OPEN), got {response.status_code}: {response.text}"
+            )
+
+            test_db.expire_all()
+            t_after = test_db.query(Semester).filter(Semester.id == tournament.id).first()
+            assert t_after.tournament_status == "CHECK_IN_OPEN"
+        finally:
+            app.dependency_overrides.clear()
+
+
+# ── RV-03 — GAP-2: missing reward config blocks IN_PROGRESS ───────────────────
+
+
+class TestMissingRewardConfigBlocksInProgress:
+    """
+    RV-03: CHECK_IN_OPEN → IN_PROGRESS is blocked (HTTP 400) when reward_config_obj
+    is None (no TournamentRewardConfig row linked).
+    Error code REWARD_CONFIG_MISSING must appear in the response detail.
+    """
+
+    def test_rv_03_no_reward_config_blocked(self, test_db):
+        admin = _make_admin(test_db)
+        instructor = _make_instructor(test_db)
+        campus = _make_campus_with_pitch(test_db)
+        tt = TournamentFactory.ensure_tournament_type(
+            test_db, code=f"rv03-{uuid.uuid4().hex[:6]}"
+        )
+        # Tournament at CHECK_IN_OPEN, no reward config, sessions_generated=True
+        # (so regen block is skipped — isolates GAP-2 from GAP-3)
+        tournament = _make_tournament(
+            test_db,
+            campus=campus,
+            instructor=instructor,
+            tt=tt,
+            tournament_status="CHECK_IN_OPEN",
+            match_duration_minutes=60,
+            break_duration_minutes=10,
+            parallel_fields=1,
+            with_reward_config=False,   # ← missing
+            sessions_generated=True,    # prevents regen trigger
+        )
+        _enroll_player(test_db, tournament.id)
+        _enroll_player(test_db, tournament.id)
+
+        client = _admin_client(test_db, admin)
+        try:
+            response = client.patch(
+                f"/api/v1/tournaments/{tournament.id}/status",
+                json={"new_status": "IN_PROGRESS", "reason": "test"},
+            )
+
+            assert response.status_code == 400, (
+                f"Expected 400, got {response.status_code}: {response.text}"
+            )
+            body = response.json()
+            detail = body.get("detail") or body.get("error", {}).get("message", "")
+            assert "REWARD_CONFIG_MISSING" in detail, (
+                f"Expected 'REWARD_CONFIG_MISSING' in error, got: {detail!r}"
+            )
+        finally:
+            app.dependency_overrides.clear()
+
+
+# ── RV-04 — GAP-3: session regen failure blocks IN_PROGRESS ───────────────────
+
+
+class TestRegenFailureBlocksInProgress:
+    """
+    RV-04: When session regeneration fails at IN_PROGRESS, the endpoint must
+    return HTTP 400 — not silently succeed.
+
+    Setup: INDIVIDUAL_RANKING tournament (sessions_generated=False forces regen),
+    reward config set (GAP-2 passes), generator mocked to return failure.
+    """
+
+    def test_rv_04_regen_failure_returns_400(self, test_db):
+        admin = _make_admin(test_db)
+        instructor = _make_instructor(test_db)
+        campus = _make_campus_with_pitch(test_db)
+
+        # Use a tournament type with HEAD_TO_HEAD format; sessions_generated=False
+        # triggers regen at IN_PROGRESS because has_checkins check returns False
+        # for an empty DB — but we'll force regen via INDIVIDUAL_RANKING path instead
+        # (no tournament_type_id → format defaults to INDIVIDUAL_RANKING, needs_regen=True).
+        tt = TournamentFactory.ensure_tournament_type(
+            test_db, code=f"rv04-{uuid.uuid4().hex[:6]}"
+        )
+        # Create WITHOUT tournament_type_id so format resolves to INDIVIDUAL_RANKING
+        code = f"RV04-{uuid.uuid4().hex[:8].upper()}"
+        t = Semester(
+            code=code,
+            name=f"RV-04 Regen Fail {code[-6:]}",
+            semester_category=SemesterCategory.TOURNAMENT,
+            status=SemesterStatus.DRAFT,
+            tournament_status="CHECK_IN_OPEN",
+            age_group="PRO",
+            campus_id=campus.id,
+            start_date=date.today() + timedelta(days=7),
+            end_date=date.today() + timedelta(days=8),
+            enrollment_cost=0,
+            specialization_type="LFA_FOOTBALL_PLAYER",
+            master_instructor_id=instructor.id,
+        )
+        test_db.add(t)
+        test_db.flush()
+
+        # No tournament_type_id → format = INDIVIDUAL_RANKING
+        test_db.add(TournamentConfiguration(
+            semester_id=t.id,
+            tournament_type_id=None,
+            participant_type="INDIVIDUAL",
+            number_of_rounds=1,
+            max_players=32,
+            match_duration_minutes=60,
+            break_duration_minutes=10,
+            parallel_fields=1,
+            sessions_generated=False,  # triggers regen at IN_PROGRESS
+        ))
+        test_db.flush()
+        _make_reward_config(test_db, t.id)  # GAP-2 must pass
+        test_db.commit()
+        test_db.expire_all()
+        tournament_id = t.id
+
+        # Enroll 2 players (status_validator IN_PROGRESS min check: fallback=2)
+        _enroll_player(test_db, tournament_id)
+        _enroll_player(test_db, tournament_id)
+        test_db.commit()
+
+        client = _admin_client(test_db, admin)
+        try:
+            # Mock TournamentSessionGenerator so can_generate passes but generate fails
+            with patch("app.services.tournament_session_generator.TournamentSessionGenerator") as MockGen:
+                mock_instance = MockGen.return_value
+                mock_instance.can_generate_sessions.return_value = (True, "ok")
+                mock_instance.generate_sessions.return_value = (
+                    False, "simulated regen failure for RV-04", []
+                )
+
+                response = client.patch(
+                    f"/api/v1/tournaments/{tournament_id}/status",
+                    json={"new_status": "IN_PROGRESS", "reason": "test"},
+                )
+
+            assert response.status_code == 400, (
+                f"Expected 400 (regen failure must block), got {response.status_code}: {response.text}"
+            )
+            body = response.json()
+            detail = body.get("detail") or body.get("error", {}).get("message", "")
+            assert "regenerat" in detail.lower() or "failed" in detail.lower(), (
+                f"Expected regen failure message, got: {detail!r}"
+            )
+        finally:
+            app.dependency_overrides.clear()
+
+
+# ── RV-05 — Happy path: full lifecycle CHECK_IN_OPEN → IN_PROGRESS ─────────────
+
+
+class TestFullConfiguredTournamentLifecycle:
+    """
+    RV-05: Happy path — ENROLLMENT_CLOSED → CHECK_IN_OPEN → IN_PROGRESS both
+    succeed when schedule config, reward config, eligible instructor, and enough
+    enrolled players are all present.
+
+    IN_PROGRESS uses HEAD_TO_HEAD with sessions_generated=True (set by CHECK_IN_OPEN
+    transition) and no check-ins, so regen is skipped — the reward config snapshot
+    block runs and succeeds.
+    """
+
+    def test_rv_05_full_lifecycle_succeeds(self, test_db):
+        admin = _make_admin(test_db)
+        instructor = _make_instructor(test_db)
+        campus = _make_campus_with_pitch(test_db)
+        # Must use a known code ("knockout") — session generator dispatches by code.
+        tt = TournamentFactory.ensure_tournament_type(test_db, code="knockout")
+        tournament = _make_tournament(
+            test_db,
+            campus=campus,
+            instructor=instructor,
+            tt=tt,
+            tournament_status="ENROLLMENT_CLOSED",
+            match_duration_minutes=60,
+            break_duration_minutes=10,
+            parallel_fields=1,
+            with_reward_config=True,    # reward config present for IN_PROGRESS
+        )
+        # Enroll 4 players — safe margin above min_players for knockout type.
+        for _ in range(4):
+            _enroll_player(test_db, tournament.id)
+
+        client = _admin_client(test_db, admin)
+        try:
+            # Step 1: ENROLLMENT_CLOSED → CHECK_IN_OPEN
+            r1 = client.patch(
+                f"/api/v1/tournaments/{tournament.id}/status",
+                json={"new_status": "CHECK_IN_OPEN", "reason": "open check-in"},
+            )
+            assert r1.status_code == 200, (
+                f"CHECK_IN_OPEN failed: {r1.status_code}: {r1.text}"
+            )
+            test_db.expire_all()
+            t1 = test_db.query(Semester).filter(Semester.id == tournament.id).first()
+            assert t1.tournament_status == "CHECK_IN_OPEN"
+
+            # Step 2: CHECK_IN_OPEN → IN_PROGRESS (no check-ins → regen skipped)
+            r2 = client.patch(
+                f"/api/v1/tournaments/{tournament.id}/status",
+                json={"new_status": "IN_PROGRESS", "reason": "start tournament"},
+            )
+            assert r2.status_code == 200, (
+                f"IN_PROGRESS failed: {r2.status_code}: {r2.text}"
+            )
+            test_db.expire_all()
+            t2 = test_db.query(Semester).filter(Semester.id == tournament.id).first()
+            assert t2.tournament_status == "IN_PROGRESS"
+        finally:
+            app.dependency_overrides.clear()

--- a/tests/integration/web_flows/test_readiness_validator_guard.py
+++ b/tests/integration/web_flows/test_readiness_validator_guard.py
@@ -40,6 +40,10 @@ from app.models.tournament_configuration import TournamentConfiguration
 from app.models.tournament_reward_config import TournamentRewardConfig
 from app.models.user import User, UserRole
 from app.core.security import get_password_hash
+from app.models.session import Session as SessionModel, EventCategory
+from app.models.sponsor import Sponsor
+from app.models.tournament_achievement import TournamentParticipation
+from app.models.tournament_ranking import TournamentRanking
 from tests.factories.game_factory import TournamentFactory
 
 
@@ -603,5 +607,556 @@ class TestFullConfiguredTournamentLifecycle:
             test_db.expire_all()
             t2 = test_db.query(Semester).filter(Semester.id == tournament.id).first()
             assert t2.tournament_status == "IN_PROGRESS"
+        finally:
+            app.dependency_overrides.clear()
+
+
+# ── Finalization hardening helpers ────────────────────────────────────────────
+
+
+def _make_match_session(
+    db: Session,
+    tournament_id: int,
+    session_status: str,
+    instructor_id: int,
+) -> SessionModel:
+    """Create an auto-generated MATCH session with the given session_status."""
+    from datetime import date, timedelta
+    s = SessionModel(
+        title=f"FH Match {uuid.uuid4().hex[:6]}",
+        date_start=datetime.now(timezone.utc) + timedelta(days=1),
+        date_end=datetime.now(timezone.utc) + timedelta(days=1, hours=2),
+        semester_id=tournament_id,
+        instructor_id=instructor_id,
+        auto_generated=True,
+        event_category=EventCategory.MATCH,
+        session_status=session_status,
+    )
+    db.add(s)
+    db.flush()
+    return s
+
+
+def _make_ranking(
+    db: Session,
+    tournament_id: int,
+    user_id: int,
+    rank: int = 1,
+) -> TournamentRanking:
+    r = TournamentRanking(
+        tournament_id=tournament_id,
+        user_id=user_id,
+        participant_type="INDIVIDUAL",
+        rank=rank,
+        points=0,
+    )
+    db.add(r)
+    db.flush()
+    return r
+
+
+def _make_participation(
+    db: Session,
+    tournament_id: int,
+    user_id: int,
+) -> TournamentParticipation:
+    p = TournamentParticipation(
+        user_id=user_id,
+        semester_id=tournament_id,
+        xp_awarded=0,
+        credits_awarded=0,
+        foot_context="neutral",
+    )
+    db.add(p)
+    db.flush()
+    return p
+
+
+def _make_sponsor(db: Session, is_active: bool = True) -> Sponsor:
+    s = Sponsor(
+        name=f"FH Sponsor {uuid.uuid4().hex[:6]}",
+        code=f"FHS-{uuid.uuid4().hex[:8].upper()}",
+        is_active=is_active,
+    )
+    db.add(s)
+    db.flush()
+    return s
+
+
+def _make_completed_tournament(
+    db: Session,
+    *,
+    campus: Campus,
+    instructor: User,
+    tt,
+    with_snapshot: bool = True,
+) -> tuple[Semester, list[User]]:
+    """
+    Create a tournament at IN_PROGRESS with schedule config + reward config,
+    enroll 4 players, and set tournament_status=COMPLETED.
+    Returns (tournament, [player1..player4]).
+    """
+    tournament = _make_tournament(
+        db,
+        campus=campus,
+        instructor=instructor,
+        tt=tt,
+        tournament_status="COMPLETED",
+        match_duration_minutes=60,
+        break_duration_minutes=10,
+        parallel_fields=1,
+        with_reward_config=True,
+    )
+    if with_snapshot:
+        # Simulate the snapshot written by lifecycle at IN_PROGRESS entry.
+        rc = tournament.reward_config_obj
+        rc.reward_policy_snapshot = tournament.reward_config
+        db.flush()
+    players = [_enroll_player(db, tournament.id) for _ in range(4)]
+    db.commit()
+    db.expire_all()
+    t = db.query(Semester).filter(Semester.id == tournament.id).first()
+    return t, players
+
+
+# ── FH-01 — scheduled MATCH session blocks COMPLETED ─────────────────────────
+
+
+class TestScheduledMatchBlocksCompleted:
+    """FH-01: IN_PROGRESS → COMPLETED is blocked when a MATCH session is still
+    in session_status='scheduled'. Code SESSIONS_INCOMPLETE must appear."""
+
+    def test_fh_01_scheduled_match_blocks_completed(self, test_db):
+        admin = _make_admin(test_db)
+        instructor = _make_instructor(test_db)
+        campus = _make_campus_with_pitch(test_db)
+        tt = TournamentFactory.ensure_tournament_type(test_db, code=f"fh01-{uuid.uuid4().hex[:6]}")
+
+        tournament = _make_tournament(
+            test_db,
+            campus=campus, instructor=instructor, tt=tt,
+            tournament_status="IN_PROGRESS",
+            match_duration_minutes=60, break_duration_minutes=10,
+            with_reward_config=True, sessions_generated=True,
+        )
+        player = _enroll_player(test_db, tournament.id)
+        _make_match_session(test_db, tournament.id, session_status="scheduled", instructor_id=instructor.id)
+        _make_ranking(test_db, tournament.id, player.id, rank=1)
+        test_db.commit()
+
+        client = _admin_client(test_db, admin)
+        try:
+            resp = client.patch(
+                f"/api/v1/tournaments/{tournament.id}/status",
+                json={"new_status": "COMPLETED", "reason": "test"},
+            )
+            assert resp.status_code == 400, f"Expected 400, got {resp.status_code}: {resp.text}"
+            body = resp.json()
+            detail = body.get("detail") or body.get("error", {}).get("message", "")
+            assert "SESSIONS_INCOMPLETE" in detail, f"Expected SESSIONS_INCOMPLETE in: {detail!r}"
+            test_db.expire_all()
+            t = test_db.query(Semester).filter(Semester.id == tournament.id).first()
+            assert t.tournament_status == "IN_PROGRESS"
+        finally:
+            app.dependency_overrides.clear()
+
+
+# ── FH-02 — in_progress MATCH session blocks COMPLETED ───────────────────────
+
+
+class TestInProgressMatchBlocksCompleted:
+    """FH-02: IN_PROGRESS → COMPLETED is blocked when a MATCH session is still
+    in session_status='in_progress'. Code SESSIONS_INCOMPLETE must appear."""
+
+    def test_fh_02_in_progress_match_blocks_completed(self, test_db):
+        admin = _make_admin(test_db)
+        instructor = _make_instructor(test_db)
+        campus = _make_campus_with_pitch(test_db)
+        tt = TournamentFactory.ensure_tournament_type(test_db, code=f"fh02-{uuid.uuid4().hex[:6]}")
+
+        tournament = _make_tournament(
+            test_db,
+            campus=campus, instructor=instructor, tt=tt,
+            tournament_status="IN_PROGRESS",
+            match_duration_minutes=60, break_duration_minutes=10,
+            with_reward_config=True, sessions_generated=True,
+        )
+        player = _enroll_player(test_db, tournament.id)
+        _make_match_session(test_db, tournament.id, session_status="in_progress", instructor_id=instructor.id)
+        _make_ranking(test_db, tournament.id, player.id, rank=1)
+        test_db.commit()
+
+        client = _admin_client(test_db, admin)
+        try:
+            resp = client.patch(
+                f"/api/v1/tournaments/{tournament.id}/status",
+                json={"new_status": "COMPLETED", "reason": "test"},
+            )
+            assert resp.status_code == 400, f"Expected 400, got {resp.status_code}: {resp.text}"
+            body = resp.json()
+            detail = body.get("detail") or body.get("error", {}).get("message", "")
+            assert "SESSIONS_INCOMPLETE" in detail, f"Expected SESSIONS_INCOMPLETE in: {detail!r}"
+        finally:
+            app.dependency_overrides.clear()
+
+
+# ── FH-03 — incomplete rankings blocks COMPLETED ──────────────────────────────
+
+
+class TestIncompleteRankingsBlocksCompleted:
+    """FH-03: IN_PROGRESS → COMPLETED is blocked when ranking count < enrolled
+    participant count. Code RANKINGS_INCOMPLETE must appear."""
+
+    def test_fh_03_incomplete_rankings_blocks_completed(self, test_db):
+        admin = _make_admin(test_db)
+        instructor = _make_instructor(test_db)
+        campus = _make_campus_with_pitch(test_db)
+        tt = TournamentFactory.ensure_tournament_type(test_db, code=f"fh03-{uuid.uuid4().hex[:6]}")
+
+        tournament = _make_tournament(
+            test_db,
+            campus=campus, instructor=instructor, tt=tt,
+            tournament_status="IN_PROGRESS",
+            match_duration_minutes=60, break_duration_minutes=10,
+            with_reward_config=True, sessions_generated=True,
+        )
+        players = [_enroll_player(test_db, tournament.id) for _ in range(4)]
+        # All sessions completed
+        _make_match_session(test_db, tournament.id, session_status="completed", instructor_id=instructor.id)
+        # Only 1 of 4 players ranked
+        _make_ranking(test_db, tournament.id, players[0].id, rank=1)
+        test_db.commit()
+
+        client = _admin_client(test_db, admin)
+        try:
+            resp = client.patch(
+                f"/api/v1/tournaments/{tournament.id}/status",
+                json={"new_status": "COMPLETED", "reason": "test"},
+            )
+            assert resp.status_code == 400, f"Expected 400, got {resp.status_code}: {resp.text}"
+            body = resp.json()
+            detail = body.get("detail") or body.get("error", {}).get("message", "")
+            assert "RANKINGS_INCOMPLETE" in detail, f"Expected RANKINGS_INCOMPLETE in: {detail!r}"
+        finally:
+            app.dependency_overrides.clear()
+
+
+# ── FH-happy — all sessions completed + full rankings → COMPLETED succeeds ────
+
+
+class TestCompletedHappyPath:
+    """FH-happy: all MATCH sessions completed + rankings cover all enrolled
+    players → IN_PROGRESS → COMPLETED succeeds (HTTP 200)."""
+
+    def test_fh_happy_completed_succeeds(self, test_db):
+        admin = _make_admin(test_db)
+        instructor = _make_instructor(test_db)
+        campus = _make_campus_with_pitch(test_db)
+        tt = TournamentFactory.ensure_tournament_type(test_db, code=f"fhhappy-{uuid.uuid4().hex[:6]}")
+
+        tournament = _make_tournament(
+            test_db,
+            campus=campus, instructor=instructor, tt=tt,
+            tournament_status="IN_PROGRESS",
+            match_duration_minutes=60, break_duration_minutes=10,
+            with_reward_config=True, sessions_generated=True,
+        )
+        players = [_enroll_player(test_db, tournament.id) for _ in range(4)]
+        _make_match_session(test_db, tournament.id, session_status="completed", instructor_id=instructor.id)
+        for i, p in enumerate(players):
+            _make_ranking(test_db, tournament.id, p.id, rank=i + 1)
+        test_db.commit()
+
+        client = _admin_client(test_db, admin)
+        try:
+            resp = client.patch(
+                f"/api/v1/tournaments/{tournament.id}/status",
+                json={"new_status": "COMPLETED", "reason": "test"},
+            )
+            assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
+            test_db.expire_all()
+            t = test_db.query(Semester).filter(Semester.id == tournament.id).first()
+            assert t.tournament_status == "COMPLETED"
+        finally:
+            app.dependency_overrides.clear()
+
+
+# ── RD-01 — snapshot missing blocks REWARDS_DISTRIBUTED ──────────────────────
+
+
+class TestSnapshotMissingBlocksRewardsDistributed:
+    """RD-01: COMPLETED → REWARDS_DISTRIBUTED blocked when reward_policy_snapshot
+    is None. Code SNAPSHOT_MISSING must appear."""
+
+    def test_rd_01_snapshot_missing_blocks(self, test_db):
+        admin = _make_admin(test_db)
+        instructor = _make_instructor(test_db)
+        campus = _make_campus_with_pitch(test_db)
+        tt = TournamentFactory.ensure_tournament_type(test_db, code=f"rd01-{uuid.uuid4().hex[:6]}")
+
+        # with_snapshot=False — reward_policy_snapshot remains None
+        tournament, players = _make_completed_tournament(
+            test_db, campus=campus, instructor=instructor, tt=tt, with_snapshot=False,
+        )
+        for i, p in enumerate(players):
+            _make_ranking(test_db, tournament.id, p.id, rank=i + 1)
+            _make_participation(test_db, tournament.id, p.id)
+        test_db.commit()
+
+        client = _admin_client(test_db, admin)
+        try:
+            resp = client.patch(
+                f"/api/v1/tournaments/{tournament.id}/status",
+                json={"new_status": "REWARDS_DISTRIBUTED", "reason": "test"},
+            )
+            assert resp.status_code == 400, f"Expected 400, got {resp.status_code}: {resp.text}"
+            body = resp.json()
+            detail = body.get("detail") or body.get("error", {}).get("message", "")
+            assert "SNAPSHOT_MISSING" in detail, f"Expected SNAPSHOT_MISSING in: {detail!r}"
+        finally:
+            app.dependency_overrides.clear()
+
+
+# ── RD-02 — no participation records blocks REWARDS_DISTRIBUTED ───────────────
+
+
+class TestNoParticipationBlocksRewardsDistributed:
+    """RD-02: COMPLETED → REWARDS_DISTRIBUTED blocked when 0 TournamentParticipation
+    rows exist. Code PARTICIPATION_RECORDS_MISSING must appear."""
+
+    def test_rd_02_no_participation_blocks(self, test_db):
+        admin = _make_admin(test_db)
+        instructor = _make_instructor(test_db)
+        campus = _make_campus_with_pitch(test_db)
+        tt = TournamentFactory.ensure_tournament_type(test_db, code=f"rd02-{uuid.uuid4().hex[:6]}")
+
+        tournament, players = _make_completed_tournament(
+            test_db, campus=campus, instructor=instructor, tt=tt,
+        )
+        for i, p in enumerate(players):
+            _make_ranking(test_db, tournament.id, p.id, rank=i + 1)
+        # No TournamentParticipation rows
+        test_db.commit()
+
+        client = _admin_client(test_db, admin)
+        try:
+            resp = client.patch(
+                f"/api/v1/tournaments/{tournament.id}/status",
+                json={"new_status": "REWARDS_DISTRIBUTED", "reason": "test"},
+            )
+            assert resp.status_code == 400, f"Expected 400, got {resp.status_code}: {resp.text}"
+            body = resp.json()
+            detail = body.get("detail") or body.get("error", {}).get("message", "")
+            assert "PARTICIPATION_RECORDS_MISSING" in detail, (
+                f"Expected PARTICIPATION_RECORDS_MISSING in: {detail!r}"
+            )
+        finally:
+            app.dependency_overrides.clear()
+
+
+# ── RD-03 — partial participation blocks REWARDS_DISTRIBUTED ──────────────────
+
+
+class TestPartialParticipationBlocksRewardsDistributed:
+    """RD-03: COMPLETED → REWARDS_DISTRIBUTED blocked when only 2 of 4 players
+    have TournamentParticipation records. Code PARTICIPATION_INCOMPLETE must appear."""
+
+    def test_rd_03_partial_participation_blocks(self, test_db):
+        admin = _make_admin(test_db)
+        instructor = _make_instructor(test_db)
+        campus = _make_campus_with_pitch(test_db)
+        tt = TournamentFactory.ensure_tournament_type(test_db, code=f"rd03-{uuid.uuid4().hex[:6]}")
+
+        tournament, players = _make_completed_tournament(
+            test_db, campus=campus, instructor=instructor, tt=tt,
+        )
+        for i, p in enumerate(players):
+            _make_ranking(test_db, tournament.id, p.id, rank=i + 1)
+        # Only 2 of 4 participation records
+        _make_participation(test_db, tournament.id, players[0].id)
+        _make_participation(test_db, tournament.id, players[1].id)
+        test_db.commit()
+
+        client = _admin_client(test_db, admin)
+        try:
+            resp = client.patch(
+                f"/api/v1/tournaments/{tournament.id}/status",
+                json={"new_status": "REWARDS_DISTRIBUTED", "reason": "test"},
+            )
+            assert resp.status_code == 400, f"Expected 400, got {resp.status_code}: {resp.text}"
+            body = resp.json()
+            detail = body.get("detail") or body.get("error", {}).get("message", "")
+            assert "PARTICIPATION_INCOMPLETE" in detail, (
+                f"Expected PARTICIPATION_INCOMPLETE in: {detail!r}"
+            )
+        finally:
+            app.dependency_overrides.clear()
+
+
+# ── RD-04 — incomplete rankings blocks REWARDS_DISTRIBUTED ────────────────────
+
+
+class TestIncompleteRankingsBlocksRewardsDistributed:
+    """RD-04: COMPLETED → REWARDS_DISTRIBUTED blocked when ranking count < enrolled
+    count (1 of 4 ranked). Code RANKINGS_INCOMPLETE must appear."""
+
+    def test_rd_04_incomplete_rankings_blocks(self, test_db):
+        admin = _make_admin(test_db)
+        instructor = _make_instructor(test_db)
+        campus = _make_campus_with_pitch(test_db)
+        tt = TournamentFactory.ensure_tournament_type(test_db, code=f"rd04-{uuid.uuid4().hex[:6]}")
+
+        tournament, players = _make_completed_tournament(
+            test_db, campus=campus, instructor=instructor, tt=tt,
+        )
+        # Only 1 of 4 players ranked
+        _make_ranking(test_db, tournament.id, players[0].id, rank=1)
+        for p in players:
+            _make_participation(test_db, tournament.id, p.id)
+        test_db.commit()
+
+        client = _admin_client(test_db, admin)
+        try:
+            resp = client.patch(
+                f"/api/v1/tournaments/{tournament.id}/status",
+                json={"new_status": "REWARDS_DISTRIBUTED", "reason": "test"},
+            )
+            assert resp.status_code == 400, f"Expected 400, got {resp.status_code}: {resp.text}"
+            body = resp.json()
+            detail = body.get("detail") or body.get("error", {}).get("message", "")
+            assert "RANKINGS_INCOMPLETE" in detail, f"Expected RANKINGS_INCOMPLETE in: {detail!r}"
+        finally:
+            app.dependency_overrides.clear()
+
+
+# ── SP-01 — PROMOTION_EVENT without sponsor blocks CHECK_IN_OPEN ──────────────
+
+
+class TestPromotionEventNoSponsorBlocksCheckInOpen:
+    """SP-01: ENROLLMENT_CLOSED → CHECK_IN_OPEN blocked for PROMOTION_EVENT
+    tournament when organizer_sponsor_id is None. Code PROMOTION_SPONSOR_MISSING."""
+
+    def test_sp_01_no_sponsor_blocks(self, test_db):
+        admin = _make_admin(test_db)
+        instructor = _make_instructor(test_db)
+        campus = _make_campus_with_pitch(test_db)
+        tt = TournamentFactory.ensure_tournament_type(test_db, code=f"sp01-{uuid.uuid4().hex[:6]}")
+
+        # Create PROMOTION_EVENT with no organizer_sponsor_id
+        code = f"SP01-{uuid.uuid4().hex[:8].upper()}"
+        t = Semester(
+            code=code,
+            name=f"SP-01 Promo Event {code[-6:]}",
+            semester_category=SemesterCategory.PROMOTION_EVENT,
+            status=SemesterStatus.DRAFT,
+            tournament_status="ENROLLMENT_CLOSED",
+            age_group="PRO",
+            campus_id=campus.id,
+            start_date=date.today() + timedelta(days=7),
+            end_date=date.today() + timedelta(days=8),
+            enrollment_cost=0,
+            specialization_type="LFA_FOOTBALL_PLAYER",
+            master_instructor_id=instructor.id,
+            organizer_sponsor_id=None,  # ← missing
+        )
+        test_db.add(t)
+        test_db.flush()
+        test_db.add(TournamentConfiguration(
+            semester_id=t.id,
+            tournament_type_id=tt.id,
+            participant_type="INDIVIDUAL",
+            number_of_rounds=1,
+            max_players=32,
+            match_duration_minutes=60,
+            break_duration_minutes=10,
+            parallel_fields=1,
+        ))
+        test_db.flush()
+        _enroll_player(test_db, t.id)
+        _enroll_player(test_db, t.id)
+        test_db.commit()
+        test_db.expire_all()
+
+        client = _admin_client(test_db, admin)
+        try:
+            resp = client.patch(
+                f"/api/v1/tournaments/{t.id}/status",
+                json={"new_status": "CHECK_IN_OPEN", "reason": "test"},
+            )
+            assert resp.status_code == 400, f"Expected 400, got {resp.status_code}: {resp.text}"
+            body = resp.json()
+            detail = body.get("detail") or body.get("error", {}).get("message", "")
+            assert "PROMOTION_SPONSOR_MISSING" in detail, (
+                f"Expected PROMOTION_SPONSOR_MISSING in: {detail!r}"
+            )
+            test_db.expire_all()
+            t_after = test_db.query(Semester).filter(Semester.id == t.id).first()
+            assert t_after.tournament_status == "ENROLLMENT_CLOSED"
+        finally:
+            app.dependency_overrides.clear()
+
+
+# ── SP-02 — PROMOTION_EVENT with inactive sponsor blocks CHECK_IN_OPEN ─────────
+
+
+class TestPromotionEventInactiveSponsorBlocksCheckInOpen:
+    """SP-02: ENROLLMENT_CLOSED → CHECK_IN_OPEN blocked for PROMOTION_EVENT
+    tournament when the referenced Sponsor has is_active=False.
+    Code PROMOTION_SPONSOR_INACTIVE must appear."""
+
+    def test_sp_02_inactive_sponsor_blocks(self, test_db):
+        admin = _make_admin(test_db)
+        instructor = _make_instructor(test_db)
+        campus = _make_campus_with_pitch(test_db)
+        tt = TournamentFactory.ensure_tournament_type(test_db, code=f"sp02-{uuid.uuid4().hex[:6]}")
+
+        sponsor = _make_sponsor(test_db, is_active=False)
+
+        code = f"SP02-{uuid.uuid4().hex[:8].upper()}"
+        t = Semester(
+            code=code,
+            name=f"SP-02 Promo Event {code[-6:]}",
+            semester_category=SemesterCategory.PROMOTION_EVENT,
+            status=SemesterStatus.DRAFT,
+            tournament_status="ENROLLMENT_CLOSED",
+            age_group="PRO",
+            campus_id=campus.id,
+            start_date=date.today() + timedelta(days=7),
+            end_date=date.today() + timedelta(days=8),
+            enrollment_cost=0,
+            specialization_type="LFA_FOOTBALL_PLAYER",
+            master_instructor_id=instructor.id,
+            organizer_sponsor_id=sponsor.id,  # ← inactive sponsor
+        )
+        test_db.add(t)
+        test_db.flush()
+        test_db.add(TournamentConfiguration(
+            semester_id=t.id,
+            tournament_type_id=tt.id,
+            participant_type="INDIVIDUAL",
+            number_of_rounds=1,
+            max_players=32,
+            match_duration_minutes=60,
+            break_duration_minutes=10,
+            parallel_fields=1,
+        ))
+        test_db.flush()
+        _enroll_player(test_db, t.id)
+        _enroll_player(test_db, t.id)
+        test_db.commit()
+        test_db.expire_all()
+
+        client = _admin_client(test_db, admin)
+        try:
+            resp = client.patch(
+                f"/api/v1/tournaments/{t.id}/status",
+                json={"new_status": "CHECK_IN_OPEN", "reason": "test"},
+            )
+            assert resp.status_code == 400, f"Expected 400, got {resp.status_code}: {resp.text}"
+            body = resp.json()
+            detail = body.get("detail") or body.get("error", {}).get("message", "")
+            assert "PROMOTION_SPONSOR_INACTIVE" in detail, (
+                f"Expected PROMOTION_SPONSOR_INACTIVE in: {detail!r}"
+            )
         finally:
             app.dependency_overrides.clear()

--- a/tests/integration/web_flows/test_session_gen_team_matrix.py
+++ b/tests/integration/web_flows/test_session_gen_team_matrix.py
@@ -85,7 +85,18 @@ def _user(db: Session, role=UserRole.STUDENT) -> User:
 
 
 def _instructor(db: Session) -> User:
-    return _user(db, role=UserRole.INSTRUCTOR)
+    u = _user(db, role=UserRole.INSTRUCTOR)
+    db.add(UserLicense(
+        user_id=u.id,
+        specialization_type="LFA_COACH",
+        current_level=7,
+        max_achieved_level=7,
+        is_active=True,
+        started_at=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        expires_at=None,
+    ))
+    db.flush()
+    return u
 
 
 def _tournament_type(db: Session, code: str, tt_format: str = "HEAD_TO_HEAD",

--- a/tests/integration/web_flows/test_sponsor_campaign_promotion.py
+++ b/tests/integration/web_flows/test_sponsor_campaign_promotion.py
@@ -12,7 +12,7 @@ Sponsor Campaign → Promotion Event — P4 integration tests (SPON-CAM-08..13)
 DONE = pytest tests/integration/web_flows/test_sponsor_campaign_promotion.py -v
 """
 import uuid
-from datetime import date
+from datetime import date, datetime, timezone
 
 import pytest
 from fastapi.testclient import TestClient
@@ -26,6 +26,7 @@ from app.models.sponsor import Sponsor, SponsorAudienceEntry, SponsorCampaign
 from app.models.semester import Semester
 from app.models.tournament_configuration import TournamentConfiguration
 from app.models.club import CsvImportLog
+from app.models.license import UserLicense
 from app.core.security import get_password_hash
 from app.services.sponsor_promote_service import promote_entries
 
@@ -374,6 +375,20 @@ def _make_instructor(db: Session, *, is_active: bool = True) -> User:
     return u
 
 
+def _make_coach_license(db: Session, user: User, *, level: int = 5) -> UserLicense:
+    lic = UserLicense(
+        user_id=user.id,
+        specialization_type="LFA_COACH",
+        current_level=level,
+        max_achieved_level=level,
+        is_active=True,
+        started_at=datetime.now(timezone.utc),
+    )
+    db.add(lic)
+    db.flush()
+    return lic
+
+
 # ── SPON-CAM-14 ───────────────────────────────────────────────────────────────
 
 class TestWizardGetContainsInstructorDropdown:
@@ -384,6 +399,7 @@ class TestWizardGetContainsInstructorDropdown:
         sponsor = _make_sponsor(test_db, admin)
         _make_campaign(test_db, sponsor, admin)
         instr = _make_instructor(test_db)
+        _make_coach_license(test_db, instr)
         test_db.commit()
 
         client = _client(test_db, admin)
@@ -448,6 +464,7 @@ class TestWizardPostValidInstructorSetsMasterId:
         sponsor = _make_sponsor(test_db, admin)
         campaign = _make_campaign(test_db, sponsor, admin)
         instr = _make_instructor(test_db)
+        _make_coach_license(test_db, instr)
         test_db.commit()
 
         client = _client(test_db, admin)

--- a/tests/integration/web_flows/test_team_business_flow.py
+++ b/tests/integration/web_flows/test_team_business_flow.py
@@ -700,6 +700,16 @@ class TestGenerationValidatorTeam:
         )
         db.add(instructor)
         db.flush()
+        db.add(UserLicense(
+            user_id=instructor.id,
+            specialization_type="LFA_COACH",
+            current_level=7,
+            max_achieved_level=7,
+            is_active=True,
+            started_at=datetime(2025, 1, 1, tzinfo=timezone.utc),
+            expires_at=None,
+        ))
+        db.flush()
 
         t = Semester(
             code=f"GENV-{uuid.uuid4().hex[:8].upper()}",
@@ -790,6 +800,16 @@ class TestGenerationValidatorTeam:
             is_active=True,
         )
         test_db.add(instructor)
+        test_db.flush()
+        test_db.add(UserLicense(
+            user_id=instructor.id,
+            specialization_type="LFA_COACH",
+            current_level=7,
+            max_achieved_level=7,
+            is_active=True,
+            started_at=datetime(2025, 1, 1, tzinfo=timezone.utc),
+            expires_at=None,
+        ))
         test_db.flush()
 
         t = Semester(

--- a/tests/integration/web_flows/test_tournament_lifecycle_e2e.py
+++ b/tests/integration/web_flows/test_tournament_lifecycle_e2e.py
@@ -803,7 +803,9 @@ class TestTournamentFullLifecycleFlow:
             reward_config=_LC_REWARD_CONFIG,
         ))
 
-        # Add one session (required by status_validator for IN_PROGRESS → COMPLETED)
+        # Add one session (required by status_validator for IN_PROGRESS → COMPLETED).
+        # session_status must be "completed" — check_pre_completed blocks COMPLETED
+        # transitions when any auto-generated MATCH session is not yet finished.
         test_db.add(SessionModel(
             title="FLOW-01 Match",
             semester_id=t.id,
@@ -813,6 +815,7 @@ class TestTournamentFullLifecycleFlow:
             event_category=EventCategory.MATCH,
             match_format="INDIVIDUAL_RANKING",
             auto_generated=True,
+            session_status="completed",
         ))
         test_db.flush()
 

--- a/tests/integration/web_flows/test_tournament_lifecycle_e2e.py
+++ b/tests/integration/web_flows/test_tournament_lifecycle_e2e.py
@@ -73,6 +73,7 @@ from app.models.semester_enrollment import SemesterEnrollment, EnrollmentStatus
 from app.models.location import Location, LocationType
 from app.models.campus import Campus
 from app.models.pitch import Pitch
+from app.models.license import UserLicense
 from tests.factories.game_factory import PlayerFactory, TournamentFactory
 
 
@@ -1627,6 +1628,16 @@ class TestMultiRoundSessionGeneration:
             is_active=True,
         )
         db.add(instructor)
+        db.flush()
+        db.add(UserLicense(
+            user_id=instructor.id,
+            specialization_type="LFA_COACH",
+            current_level=7,
+            max_achieved_level=7,
+            is_active=True,
+            started_at=datetime(2025, 1, 1, tzinfo=timezone.utc),
+            expires_at=None,
+        ))
         db.flush()
 
         code = f"SESS-{uuid.uuid4().hex[:8].upper()}"

--- a/tests/lifecycle_framework/__init__.py
+++ b/tests/lifecycle_framework/__init__.py
@@ -1,0 +1,9 @@
+"""
+Lifecycle Scenario Framework — Phase 1
+
+Run a scenario:
+    from tests.lifecycle_framework.scenarios.h2h_knockout import H2HKnockoutScenario
+    result = H2HKnockoutScenario().run(base_url="http://localhost:8000")
+
+Not discoverable by pytest (excluded via norecursedirs in pytest.ini).
+"""

--- a/tests/lifecycle_framework/conftest.py
+++ b/tests/lifecycle_framework/conftest.py
@@ -1,0 +1,6 @@
+"""
+Conftest for lifecycle_framework — intentionally empty.
+
+This directory is excluded from pytest collection (norecursedirs in pytest.ini).
+Scenarios are run as plain Python scripts, not as pytest tests.
+"""

--- a/tests/lifecycle_framework/framework/__init__.py
+++ b/tests/lifecycle_framework/framework/__init__.py
@@ -1,0 +1,13 @@
+"""Framework core — re-exports most-used symbols for convenience."""
+from .auth import AuthContext, login
+from .client import make_client
+from ._http import LifecycleError, PreflightError, require_ok
+
+__all__ = [
+    "AuthContext",
+    "login",
+    "make_client",
+    "LifecycleError",
+    "PreflightError",
+    "require_ok",
+]

--- a/tests/lifecycle_framework/framework/_http.py
+++ b/tests/lifecycle_framework/framework/_http.py
@@ -1,0 +1,48 @@
+"""HTTP primitives — error types and the require_ok helper."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import requests
+
+
+class LifecycleError(Exception):
+    """Raised when an HTTP step fails an assertion."""
+
+    def __init__(self, step: str, http_code: int, detail: str) -> None:
+        self.step = step
+        self.http_code = http_code
+        self.detail = detail
+        super().__init__(f"[{step}] HTTP {http_code}: {detail}")
+
+
+class PreflightError(Exception):
+    """Raised when a preflight check fails before the scenario starts."""
+
+    def __init__(self, check: str, reason: str) -> None:
+        self.check = check
+        self.reason = reason
+        super().__init__(f"Preflight [{check}] failed: {reason}")
+
+
+def require_ok(
+    response: requests.Response,
+    step: str,
+    *,
+    accepted: tuple[int, ...] = (200, 201),
+) -> Any:
+    """Assert HTTP status is acceptable and return parsed JSON.
+
+    Raises LifecycleError with step context on failure.
+    """
+    if response.status_code not in accepted:
+        try:
+            detail = response.json()
+        except Exception:
+            detail = response.text
+        raise LifecycleError(step, response.status_code, str(detail))
+    try:
+        return response.json()
+    except Exception:
+        return {}

--- a/tests/lifecycle_framework/framework/auth.py
+++ b/tests/lifecycle_framework/framework/auth.py
@@ -1,0 +1,35 @@
+"""Authentication context and login helper."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import requests
+
+from ._http import require_ok
+
+
+@dataclass
+class AuthContext:
+    """Holds tokens and IDs for all principals in a scenario run."""
+
+    admin_token: str
+    instructor_token: str
+    instructor_id: int
+    # email -> token
+    player_tokens: dict[str, str] = field(default_factory=dict)
+    # email -> id
+    player_ids: dict[str, int] = field(default_factory=dict)
+
+
+def login(base_url: str, email: str, password: str) -> str:
+    """POST /api/v1/auth/login and return the access token."""
+    resp = requests.post(
+        f"{base_url}/api/v1/auth/login",
+        json={"email": email, "password": password},
+        timeout=10,
+    )
+    data = require_ok(resp, f"login:{email}")
+    token = data.get("access_token") or data.get("token")
+    if not token:
+        raise ValueError(f"No token in login response for {email}: {data}")
+    return token

--- a/tests/lifecycle_framework/framework/client.py
+++ b/tests/lifecycle_framework/framework/client.py
@@ -1,0 +1,24 @@
+"""Thin HTTP client factory."""
+from __future__ import annotations
+
+import requests
+
+
+def make_client(base_url: str, token: str) -> requests.Session:
+    """Return a requests.Session pre-configured with bearer auth."""
+    s = requests.Session()
+    s.headers.update({"Authorization": f"Bearer {token}"})
+    s.base_url = base_url  # type: ignore[attr-defined]
+    return s
+
+
+def get(session: requests.Session, path: str, **kwargs) -> requests.Response:
+    return session.get(f"{session.base_url}{path}", **kwargs)  # type: ignore[attr-defined]
+
+
+def post(session: requests.Session, path: str, **kwargs) -> requests.Response:
+    return session.post(f"{session.base_url}{path}", **kwargs)  # type: ignore[attr-defined]
+
+
+def patch(session: requests.Session, path: str, **kwargs) -> requests.Response:
+    return session.patch(f"{session.base_url}{path}", **kwargs)  # type: ignore[attr-defined]

--- a/tests/lifecycle_framework/framework/fixtures.py
+++ b/tests/lifecycle_framework/framework/fixtures.py
@@ -1,0 +1,113 @@
+"""Bootstrap fixture resolution — instructor, campus, seed players.
+
+Requires PYTHONPATH=. (app imports must resolve).
+Player resolution uses direct DB query — the users list API raises Pydantic
+validation errors on .test-TLD emails created by other seed scripts.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import requests
+
+from ._http import PreflightError, require_ok
+
+
+@dataclass
+class InstructorFixture:
+    id: int
+    email: str
+
+
+@dataclass
+class CampusFixture:
+    id: int
+    name: str
+
+
+@dataclass
+class PlayerFixture:
+    id: int
+    email: str
+
+
+def resolve_instructor(
+    base_url: str,
+    admin_token: str,
+    email: str,
+) -> InstructorFixture:
+    """Find instructor by email via the admin users endpoint."""
+    resp = requests.get(
+        f"{base_url}/api/v1/users/?role=instructor&size=100",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        timeout=15,
+    )
+    data = require_ok(resp, "resolve_instructor")
+    for u in data.get("users", []):
+        if u.get("email") == email:
+            return InstructorFixture(id=u["id"], email=email)
+    raise PreflightError(
+        "resolve_instructor",
+        f"{email} not found — run: PYTHONPATH=. python scripts/bootstrap_clean.py",
+    )
+
+
+def resolve_campus(
+    base_url: str,
+    admin_token: str,
+) -> CampusFixture:
+    """Return the first active campus from the admin campuses endpoint."""
+    resp = requests.get(
+        f"{base_url}/api/v1/admin/campuses",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        timeout=15,
+    )
+    data = require_ok(resp, "resolve_campus")
+    items: list[dict] = data if isinstance(data, list) else data.get("campuses", [])
+    active = [c for c in items if c.get("is_active", True)]
+    if not active:
+        raise PreflightError(
+            "resolve_campus",
+            "No active campus — run: PYTHONPATH=. python scripts/bootstrap_clean.py",
+        )
+    c = active[0]
+    return CampusFixture(id=c["id"], name=c.get("name", ""))
+
+
+def resolve_players_db(
+    email_pattern: str = "lfa-adult-%@lfa.com",
+    password: str = "Bootstrap#123",
+    count: int = 4,
+    base_url: str = "http://localhost:8000",
+) -> list[PlayerFixture]:
+    """Resolve seed players via direct DB query + login for token capture.
+
+    Direct DB is required because the users list API rejects .test-TLD emails
+    created by other seed scripts (Pydantic EmailStr validation).
+    """
+    from app.database import SessionLocal
+    from app.models.user import User as UserModel, UserRole
+
+    db = SessionLocal()
+    try:
+        rows = (
+            db.query(UserModel)
+            .filter(
+                UserModel.role == UserRole.STUDENT,
+                UserModel.email.like(email_pattern),
+                UserModel.is_active == True,  # noqa: E712
+            )
+            .limit(count)
+            .all()
+        )
+    finally:
+        db.close()
+
+    if len(rows) < count:
+        raise PreflightError(
+            "resolve_players_db",
+            f"Need {count} seed players matching '{email_pattern}', found {len(rows)} — "
+            "run: PYTHONPATH=. python scripts/bootstrap_clean.py",
+        )
+
+    return [PlayerFixture(id=u.id, email=u.email) for u in rows]

--- a/tests/lifecycle_framework/framework/fixtures.py
+++ b/tests/lifecycle_framework/framework/fixtures.py
@@ -76,11 +76,12 @@ def resolve_campus(
 
 def resolve_players_db(
     email_pattern: str = "lfa-adult-%@lfa.com",
-    password: str = "Bootstrap#123",
     count: int = 4,
-    base_url: str = "http://localhost:8000",
 ) -> list[PlayerFixture]:
-    """Resolve seed players via direct DB query + login for token capture.
+    """Resolve seed players via direct DB query.
+
+    Returns PlayerFixture list (id + email). Token acquisition is the caller's
+    responsibility — call login(base_url, player.email, password) per player.
 
     Direct DB is required because the users list API rejects .test-TLD emails
     created by other seed scripts (Pydantic EmailStr validation).

--- a/tests/lifecycle_framework/framework/logging.py
+++ b/tests/lifecycle_framework/framework/logging.py
@@ -1,0 +1,91 @@
+"""Structured transition logging."""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Optional, Protocol
+
+
+@dataclass
+class TransitionEvent:
+    step: str
+    status: str  # "ok" | "fail" | "skip"
+    elapsed_ms: float
+    detail: str = ""
+    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class ScenarioLogger(Protocol):
+    def log(self, event: TransitionEvent) -> None: ...
+    def summary(self, events: list[TransitionEvent]) -> None: ...
+
+
+_RESET = "\033[0m"
+_GREEN = "\033[92m"
+_RED = "\033[91m"
+_YELLOW = "\033[93m"
+_CYAN = "\033[96m"
+_BOLD = "\033[1m"
+
+
+class ColoredConsoleLogger:
+    def log(self, event: TransitionEvent) -> None:
+        color = _GREEN if event.status == "ok" else (_RED if event.status == "fail" else _YELLOW)
+        symbol = "✅" if event.status == "ok" else ("❌" if event.status == "fail" else "⏭ ")
+        detail = f"  {event.detail}" if event.detail else ""
+        print(
+            f"{color}{symbol} [{event.step}] {event.elapsed_ms:.0f}ms{_RESET}{detail}"
+        )
+
+    def summary(self, events: list[TransitionEvent]) -> None:
+        ok = sum(1 for e in events if e.status == "ok")
+        fail = sum(1 for e in events if e.status == "fail")
+        total_ms = sum(e.elapsed_ms for e in events)
+        status_color = _GREEN if fail == 0 else _RED
+        print(
+            f"\n{_BOLD}{status_color}"
+            f"{'PASS' if fail == 0 else 'FAIL'} — {ok}/{len(events)} steps OK, "
+            f"{total_ms:.0f}ms total{_RESET}"
+        )
+
+
+class SilentLogger:
+    """Collects events without printing — useful for programmatic consumption."""
+
+    def __init__(self) -> None:
+        self._events: list[TransitionEvent] = []
+
+    def log(self, event: TransitionEvent) -> None:
+        self._events.append(event)
+
+    def summary(self, events: list[TransitionEvent]) -> None:
+        pass
+
+    @property
+    def events(self) -> list[TransitionEvent]:
+        return list(self._events)
+
+
+class TimedStep:
+    """Context manager that records elapsed time and logs a TransitionEvent."""
+
+    def __init__(self, name: str, logger: ScenarioLogger) -> None:
+        self._name = name
+        self._logger = logger
+        self._start = 0.0
+
+    def __enter__(self) -> "TimedStep":
+        self._start = time.perf_counter()
+        return self
+
+    def ok(self, detail: str = "") -> None:
+        elapsed = (time.perf_counter() - self._start) * 1000
+        self._logger.log(TransitionEvent(self._name, "ok", elapsed, detail))
+
+    def fail(self, detail: str = "") -> None:
+        elapsed = (time.perf_counter() - self._start) * 1000
+        self._logger.log(TransitionEvent(self._name, "fail", elapsed, detail))
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return False

--- a/tests/lifecycle_framework/framework/logging.py
+++ b/tests/lifecycle_framework/framework/logging.py
@@ -68,7 +68,18 @@ class SilentLogger:
 
 
 class TimedStep:
-    """Context manager that records elapsed time and logs a TransitionEvent."""
+    """Context manager that records elapsed time and logs a TransitionEvent.
+
+    On success: caller calls step.ok(detail) explicitly.
+    On exception: __exit__ automatically logs a fail event with the exception
+                  message, then returns False so the exception propagates.
+                  The exception is NEVER swallowed.
+
+    Usage:
+        with TimedStep("my_step", logger) as step:
+            do_work()
+            step.ok("work done")
+    """
 
     def __init__(self, name: str, logger: ScenarioLogger) -> None:
         self._name = name
@@ -88,4 +99,11 @@ class TimedStep:
         self._logger.log(TransitionEvent(self._name, "fail", elapsed, detail))
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        return False
+        if exc_type is not None:
+            # Auto-log a fail event so the summary accurately reflects the failure.
+            # The exception is NOT suppressed — it propagates after logging.
+            elapsed = (time.perf_counter() - self._start) * 1000
+            self._logger.log(
+                TransitionEvent(self._name, "fail", elapsed, str(exc_val))
+            )
+        return False  # never swallow exceptions

--- a/tests/lifecycle_framework/framework/preflight.py
+++ b/tests/lifecycle_framework/framework/preflight.py
@@ -1,0 +1,342 @@
+"""Preflight checker and hidden dependency registry.
+
+HiddenDependencyRegistry documents invariants that are NOT enforced by the
+public API (or enforced only at a late stage), so scenario authors know what
+to set up before calling lifecycle transitions.
+
+PreflightChecker runs auto-checkable entries against the live DB/API and
+raises PreflightError with actionable messages on failure.
+"""
+from __future__ import annotations
+
+import inspect
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Callable, Optional
+
+from ._http import PreflightError
+
+
+class Severity(Enum):
+    CRITICAL = "CRITICAL"   # will cause the scenario to fail mid-flight
+    WARNING = "WARNING"     # may cause partial failure; scenario may still run
+    INFO = "INFO"           # documentation only
+
+
+class DetectionMode(Enum):
+    AUTO = "AUTO"           # check_fn is available; PreflightChecker will run it
+    MANUAL = "MANUAL"       # must be verified by the scenario author
+
+
+@dataclass
+class HiddenDependency:
+    name: str
+    description: str
+    severity: Severity
+    detection_mode: DetectionMode
+    # Returns (ok: bool, detail: str). Only required when detection_mode=AUTO.
+    check_fn: Optional[Callable[[], tuple[bool, str]]] = None
+    remediation: str = ""
+
+    def __post_init__(self) -> None:
+        if self.detection_mode == DetectionMode.AUTO and self.check_fn is None:
+            raise ValueError(
+                f"HiddenDependency '{self.name}' has AUTO detection but no check_fn"
+            )
+
+
+class HiddenDependencyRegistry:
+    """Catalogue of non-obvious preconditions for lifecycle scenarios."""
+
+    def __init__(self) -> None:
+        self._entries: list[HiddenDependency] = []
+
+    def register(self, dep: HiddenDependency) -> None:
+        self._entries.append(dep)
+
+    def all_auto(self) -> list[HiddenDependency]:
+        return [d for d in self._entries if d.detection_mode == DetectionMode.AUTO]
+
+    def all_manual(self) -> list[HiddenDependency]:
+        return [d for d in self._entries if d.detection_mode == DetectionMode.MANUAL]
+
+
+# ── Required coach level per age group (mirrors instructor_eligibility_service.py) ──
+_AGE_GROUP_REQUIRED_LEVEL: dict[str, int] = {
+    "PRE": 1,
+    "YOUTH": 3,
+    "AMATEUR": 5,
+    "PRO": 7,
+}
+
+
+def _check_instructor_lfa_coach(
+    instructor_email: str,
+) -> Callable[[], tuple[bool, str]]:
+    def _check() -> tuple[bool, str]:
+        from app.database import SessionLocal
+        from app.models.user import User as UserModel
+        from app.models.license import UserLicense
+
+        db = SessionLocal()
+        try:
+            user = db.query(UserModel).filter(UserModel.email == instructor_email).first()
+            if not user:
+                return False, f"{instructor_email} not in DB"
+            lic = (
+                db.query(UserLicense)
+                .filter(
+                    UserLicense.user_id == user.id,
+                    UserLicense.specialization_type == "LFA_COACH",
+                    UserLicense.is_active == True,  # noqa: E712
+                )
+                .first()
+            )
+            if not lic:
+                return False, f"{instructor_email} has no active LFA_COACH license"
+            return True, f"LFA_COACH level={lic.current_level}"
+        finally:
+            db.close()
+
+    return _check
+
+
+def _check_instructor_level(
+    instructor_email: str,
+    age_group: str,
+) -> Callable[[], tuple[bool, str]]:
+    required = _AGE_GROUP_REQUIRED_LEVEL.get(age_group.upper(), 0)
+
+    def _check() -> tuple[bool, str]:
+        from app.database import SessionLocal
+        from app.models.user import User as UserModel
+        from app.models.license import UserLicense
+
+        db = SessionLocal()
+        try:
+            user = db.query(UserModel).filter(UserModel.email == instructor_email).first()
+            if not user:
+                return False, f"{instructor_email} not in DB"
+            lic = (
+                db.query(UserLicense)
+                .filter(
+                    UserLicense.user_id == user.id,
+                    UserLicense.specialization_type == "LFA_COACH",
+                    UserLicense.is_active == True,  # noqa: E712
+                )
+                .first()
+            )
+            if not lic:
+                return False, "no active LFA_COACH license"
+            if lic.current_level >= required:
+                return True, f"level={lic.current_level} ≥ required={required} for {age_group}"
+            return (
+                False,
+                f"level={lic.current_level} < required={required} for {age_group}",
+            )
+        finally:
+            db.close()
+
+    return _check
+
+
+def _check_active_campus() -> Callable[[], tuple[bool, str]]:
+    def _check() -> tuple[bool, str]:
+        from app.database import SessionLocal
+        from app.models.campus import Campus
+
+        db = SessionLocal()
+        try:
+            count = db.query(Campus).filter(Campus.is_active == True).count()  # noqa: E712
+            if count > 0:
+                return True, f"{count} active campus(es)"
+            return False, "no active campuses — run bootstrap_clean.py"
+        finally:
+            db.close()
+
+    return _check
+
+
+def _check_active_pitch() -> Callable[[], tuple[bool, str]]:
+    def _check() -> tuple[bool, str]:
+        try:
+            from app.database import SessionLocal
+            from app.models.pitch import Pitch
+
+            db = SessionLocal()
+            try:
+                count = db.query(Pitch).filter(Pitch.is_active == True).count()  # noqa: E712
+                if count > 0:
+                    return True, f"{count} active pitch(es)"
+                return False, "no active pitches — run bootstrap_clean.py"
+            finally:
+                db.close()
+        except ImportError:
+            return True, "Pitch model not available — skipped"
+
+    return _check
+
+
+def _check_seed_players(
+    email_pattern: str,
+    required: int,
+) -> Callable[[], tuple[bool, str]]:
+    def _check() -> tuple[bool, str]:
+        from app.database import SessionLocal
+        from app.models.user import User as UserModel, UserRole
+
+        db = SessionLocal()
+        try:
+            count = (
+                db.query(UserModel)
+                .filter(
+                    UserModel.role == UserRole.STUDENT,
+                    UserModel.email.like(email_pattern),
+                    UserModel.is_active == True,  # noqa: E712
+                )
+                .count()
+            )
+            if count >= required:
+                return True, f"{count} seed players match '{email_pattern}'"
+            return (
+                False,
+                f"{count} seed players match '{email_pattern}', need ≥ {required} — "
+                "run bootstrap_clean.py",
+            )
+        finally:
+            db.close()
+
+    return _check
+
+
+class PreflightChecker:
+    """Runs AUTO-detectable hidden dependency checks and raises PreflightError on failure."""
+
+    def __init__(self, registry: HiddenDependencyRegistry) -> None:
+        self._registry = registry
+
+    def run(self, *, fail_fast: bool = True) -> list[str]:
+        """Run all AUTO checks. Returns list of passed check names.
+
+        Raises PreflightError on first CRITICAL failure (if fail_fast=True),
+        or collects all failures and raises a combined error (if fail_fast=False).
+        """
+        failures: list[str] = []
+        passed: list[str] = []
+
+        for dep in self._registry.all_auto():
+            assert dep.check_fn is not None
+            try:
+                ok, detail = dep.check_fn()
+            except Exception as exc:
+                ok, detail = False, f"check raised {type(exc).__name__}: {exc}"
+
+            if ok:
+                passed.append(f"{dep.name}: {detail}")
+            else:
+                msg = f"{detail}"
+                if dep.remediation:
+                    msg += f" — {dep.remediation}"
+                if fail_fast and dep.severity == Severity.CRITICAL:
+                    raise PreflightError(dep.name, msg)
+                failures.append(f"[{dep.severity.value}] {dep.name}: {msg}")
+
+        if failures:
+            raise PreflightError(
+                "preflight",
+                "\n".join(failures),
+            )
+        return passed
+
+
+def build_standard_registry(
+    instructor_email: str,
+    age_group: str,
+    player_email_pattern: str = "lfa-adult-%@lfa.com",
+    min_players: int = 4,
+) -> HiddenDependencyRegistry:
+    """Build a registry pre-loaded with the standard H2H knockout hidden deps."""
+    reg = HiddenDependencyRegistry()
+
+    reg.register(HiddenDependency(
+        name="instructor_lfa_coach_license",
+        description=(
+            "Instructor must have an active LFA_COACH UserLicense. "
+            "Direct-assign-instructor and accept both enforce this."
+        ),
+        severity=Severity.CRITICAL,
+        detection_mode=DetectionMode.AUTO,
+        check_fn=_check_instructor_lfa_coach(instructor_email),
+        remediation="PYTHONPATH=. python scripts/bootstrap_clean.py",
+    ))
+
+    reg.register(HiddenDependency(
+        name="instructor_coach_level",
+        description=(
+            f"Instructor LFA_COACH level must be ≥ {_AGE_GROUP_REQUIRED_LEVEL.get(age_group.upper(), '?')} "
+            f"for age_group={age_group}."
+        ),
+        severity=Severity.CRITICAL,
+        detection_mode=DetectionMode.AUTO,
+        check_fn=_check_instructor_level(instructor_email, age_group),
+        remediation="PYTHONPATH=. python scripts/bootstrap_clean.py",
+    ))
+
+    reg.register(HiddenDependency(
+        name="active_campus",
+        description="At least one active Campus must exist for tournament creation.",
+        severity=Severity.CRITICAL,
+        detection_mode=DetectionMode.AUTO,
+        check_fn=_check_active_campus(),
+        remediation="PYTHONPATH=. python scripts/bootstrap_clean.py",
+    ))
+
+    reg.register(HiddenDependency(
+        name="active_pitch",
+        description=(
+            "At least one active Pitch must exist — session generator assigns "
+            "pitch_id round-robin."
+        ),
+        severity=Severity.CRITICAL,
+        detection_mode=DetectionMode.AUTO,
+        check_fn=_check_active_pitch(),
+        remediation="PYTHONPATH=. python scripts/bootstrap_clean.py",
+    ))
+
+    reg.register(HiddenDependency(
+        name="seed_players",
+        description=(
+            f"≥{min_players} active seed players matching '{player_email_pattern}' "
+            "must exist. Players list API rejects .test-TLD emails, so resolution "
+            "uses direct DB query."
+        ),
+        severity=Severity.CRITICAL,
+        detection_mode=DetectionMode.AUTO,
+        check_fn=_check_seed_players(player_email_pattern, min_players),
+        remediation="PYTHONPATH=. python scripts/bootstrap_clean.py",
+    ))
+
+    reg.register(HiddenDependency(
+        name="session_check_in_instructor_id",
+        description=(
+            "Session check-in requires session.instructor_id == current_user.id. "
+            "The session generator sets instructor_id = master_instructor_id as fallback. "
+            "The accepting instructor will match."
+        ),
+        severity=Severity.INFO,
+        detection_mode=DetectionMode.MANUAL,
+        remediation="No action needed — session generator handles this automatically.",
+    ))
+
+    reg.register(HiddenDependency(
+        name="distribute_rewards_auto_transition",
+        description=(
+            "POST /distribute-rewards-v2 sets tournament_status='REWARDS_DISTRIBUTED' "
+            "directly inside the endpoint (rewards_v2.py:92). "
+            "No separate lifecycle PATCH is needed afterward."
+        ),
+        severity=Severity.INFO,
+        detection_mode=DetectionMode.MANUAL,
+    ))
+
+    return reg

--- a/tests/lifecycle_framework/framework/preflight.py
+++ b/tests/lifecycle_framework/framework/preflight.py
@@ -9,8 +9,8 @@ raises PreflightError with actionable messages on failure.
 """
 from __future__ import annotations
 
-import inspect
-from dataclasses import dataclass, field
+from dataclasses import dataclass
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Callable, Optional
 
@@ -70,31 +70,62 @@ _AGE_GROUP_REQUIRED_LEVEL: dict[str, int] = {
 }
 
 
+def _to_utc_aware(dt: datetime) -> datetime:
+    """Treat naive datetimes as UTC — mirrors instructor_eligibility_service._to_utc_aware()."""
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _get_active_coach_license(db, user_id: int):
+    """Return an active, non-expired LFA_COACH license or None.
+
+    Mirrors the three conditions enforced by instructor_eligibility_service:
+      1. specialization_type == 'LFA_COACH'
+      2. is_active == True
+      3. expires_at IS NULL OR expires_at > now(UTC)
+    """
+    from app.models.license import UserLicense
+
+    now_utc = datetime.now(timezone.utc)
+    candidates = (
+        db.query(UserLicense)
+        .filter(
+            UserLicense.user_id == user_id,
+            UserLicense.specialization_type == "LFA_COACH",
+            UserLicense.is_active == True,  # noqa: E712
+        )
+        .all()
+    )
+    for lic in candidates:
+        if lic.expires_at is None:
+            return lic
+        expires = _to_utc_aware(lic.expires_at)
+        if expires > now_utc:
+            return lic
+    return None
+
+
 def _check_instructor_lfa_coach(
     instructor_email: str,
 ) -> Callable[[], tuple[bool, str]]:
     def _check() -> tuple[bool, str]:
         from app.database import SessionLocal
         from app.models.user import User as UserModel
-        from app.models.license import UserLicense
 
         db = SessionLocal()
         try:
             user = db.query(UserModel).filter(UserModel.email == instructor_email).first()
             if not user:
                 return False, f"{instructor_email} not in DB"
-            lic = (
-                db.query(UserLicense)
-                .filter(
-                    UserLicense.user_id == user.id,
-                    UserLicense.specialization_type == "LFA_COACH",
-                    UserLicense.is_active == True,  # noqa: E712
-                )
-                .first()
-            )
+            lic = _get_active_coach_license(db, user.id)
             if not lic:
-                return False, f"{instructor_email} has no active LFA_COACH license"
-            return True, f"LFA_COACH level={lic.current_level}"
+                return (
+                    False,
+                    f"{instructor_email} has no active, non-expired LFA_COACH license",
+                )
+            expiry = f"expires_at={lic.expires_at}" if lic.expires_at else "no expiry"
+            return True, f"LFA_COACH level={lic.current_level} ({expiry})"
         finally:
             db.close()
 
@@ -110,24 +141,15 @@ def _check_instructor_level(
     def _check() -> tuple[bool, str]:
         from app.database import SessionLocal
         from app.models.user import User as UserModel
-        from app.models.license import UserLicense
 
         db = SessionLocal()
         try:
             user = db.query(UserModel).filter(UserModel.email == instructor_email).first()
             if not user:
                 return False, f"{instructor_email} not in DB"
-            lic = (
-                db.query(UserLicense)
-                .filter(
-                    UserLicense.user_id == user.id,
-                    UserLicense.specialization_type == "LFA_COACH",
-                    UserLicense.is_active == True,  # noqa: E712
-                )
-                .first()
-            )
+            lic = _get_active_coach_license(db, user.id)
             if not lic:
-                return False, "no active LFA_COACH license"
+                return False, "no active, non-expired LFA_COACH license"
             if lic.current_level >= required:
                 return True, f"level={lic.current_level} ≥ required={required} for {age_group}"
             return (
@@ -172,7 +194,8 @@ def _check_active_pitch() -> Callable[[], tuple[bool, str]]:
             finally:
                 db.close()
         except ImportError:
-            return True, "Pitch model not available — skipped"
+            # ImportError means Pitch model path changed — treat as unknown, not OK.
+            return False, "Pitch model not importable — verify app.models.pitch path"
 
     return _check
 
@@ -225,7 +248,10 @@ class PreflightChecker:
         passed: list[str] = []
 
         for dep in self._registry.all_auto():
-            assert dep.check_fn is not None
+            if dep.check_fn is None:
+                raise ValueError(
+                    f"HiddenDependency '{dep.name}' has AUTO detection but check_fn is None"
+                )
             try:
                 ok, detail = dep.check_fn()
             except Exception as exc:
@@ -234,7 +260,7 @@ class PreflightChecker:
             if ok:
                 passed.append(f"{dep.name}: {detail}")
             else:
-                msg = f"{detail}"
+                msg = detail
                 if dep.remediation:
                     msg += f" — {dep.remediation}"
                 if fail_fast and dep.severity == Severity.CRITICAL:
@@ -242,10 +268,7 @@ class PreflightChecker:
                 failures.append(f"[{dep.severity.value}] {dep.name}: {msg}")
 
         if failures:
-            raise PreflightError(
-                "preflight",
-                "\n".join(failures),
-            )
+            raise PreflightError("preflight", "\n".join(failures))
         return passed
 
 
@@ -256,13 +279,15 @@ def build_standard_registry(
     min_players: int = 4,
 ) -> HiddenDependencyRegistry:
     """Build a registry pre-loaded with the standard H2H knockout hidden deps."""
+    required_level = _AGE_GROUP_REQUIRED_LEVEL.get(age_group.upper(), "?")
     reg = HiddenDependencyRegistry()
 
     reg.register(HiddenDependency(
         name="instructor_lfa_coach_license",
         description=(
-            "Instructor must have an active LFA_COACH UserLicense. "
-            "Direct-assign-instructor and accept both enforce this."
+            f"Instructor must have an active, non-expired LFA_COACH UserLicense "
+            f"(is_active=True AND expires_at IS NULL OR > now). "
+            f"Mirrors instructor_eligibility_service policy."
         ),
         severity=Severity.CRITICAL,
         detection_mode=DetectionMode.AUTO,
@@ -273,8 +298,8 @@ def build_standard_registry(
     reg.register(HiddenDependency(
         name="instructor_coach_level",
         description=(
-            f"Instructor LFA_COACH level must be ≥ {_AGE_GROUP_REQUIRED_LEVEL.get(age_group.upper(), '?')} "
-            f"for age_group={age_group}."
+            f"Instructor LFA_COACH level must be ≥ {required_level} "
+            f"for age_group={age_group}. Uses same active+non-expired license."
         ),
         severity=Severity.CRITICAL,
         detection_mode=DetectionMode.AUTO,

--- a/tests/lifecycle_framework/framework/sessions.py
+++ b/tests/lifecycle_framework/framework/sessions.py
@@ -1,0 +1,136 @@
+"""Session completion strategies and orchestration loop."""
+from __future__ import annotations
+
+import time
+from typing import Protocol
+
+import requests
+
+from ._http import require_ok
+
+
+class SessionCompletionStrategy(Protocol):
+    """Format-specific logic for completing a single session."""
+
+    def complete(
+        self,
+        base_url: str,
+        instructor_token: str,
+        tournament_id: int,
+        session: dict,
+    ) -> bool:
+        """Check in and submit results for one session.
+
+        Returns True if the session was processed, False if skipped
+        (e.g. knockout future-round with no participants yet).
+        """
+        ...
+
+
+class H2HResultStrategy:
+    """HEAD_TO_HEAD: check-in + submit head-to-head-results (winner/loser).
+
+    Sessions with < 2 participants are skipped — knockout future-round sessions
+    start empty and get populated only after KnockoutProgressionService fires
+    for the preceding round.
+    """
+
+    def complete(
+        self,
+        base_url: str,
+        instructor_token: str,
+        tournament_id: int,
+        session: dict,
+    ) -> bool:
+        """Return True if session was completed, False if skipped (TBD participants)."""
+        session_id = session["id"]
+        participants = session.get("participant_user_ids") or []
+
+        if len(participants) < 2:
+            # Future knockout round — participants not yet assigned by progression service.
+            return False
+
+        headers = {"Authorization": f"Bearer {instructor_token}"}
+
+        # Check in (400 is acceptable if already in_progress)
+        resp = requests.post(
+            f"{base_url}/api/v1/sessions/{session_id}/check-in",
+            headers=headers,
+            json={},
+            timeout=15,
+        )
+        if resp.status_code not in (200, 201, 400):
+            require_ok(resp, f"session:{session_id}:check-in")
+
+        # Submit HEAD_TO_HEAD results — participant[0] wins 2-0 (deterministic)
+        results = [
+            {"user_id": participants[0], "score": 2},
+            {"user_id": participants[1], "score": 0},
+        ]
+        resp = requests.patch(
+            f"{base_url}/api/v1/sessions/{session_id}/head-to-head-results",
+            headers=headers,
+            json={"results": results},
+            timeout=15,
+        )
+        require_ok(resp, f"session:{session_id}:h2h-results")
+        return True
+
+
+def _fetch_pending_sessions(
+    base_url: str,
+    instructor_token: str,
+    tournament_id: int,
+) -> list[dict]:
+    """Return sessions where result_submitted is False."""
+    resp = requests.get(
+        f"{base_url}/api/v1/tournaments/{tournament_id}/sessions",
+        headers={"Authorization": f"Bearer {instructor_token}"},
+        timeout=15,
+    )
+    data = require_ok(resp, "fetch_sessions")
+    sessions: list[dict] = data if isinstance(data, list) else data.get("sessions", [])
+    return [s for s in sessions if not s.get("result_submitted", False)]
+
+
+def complete_all_sessions(
+    base_url: str,
+    instructor_token: str,
+    tournament_id: int,
+    strategy: SessionCompletionStrategy,
+    *,
+    max_rounds: int = 10,
+    poll_delay_s: float = 0.5,
+) -> int:
+    """Drive a round-by-round loop until no pending sessions remain.
+
+    Re-queries after each round to pick up knockout progression
+    (next-round participants assigned after previous round completes).
+
+    Returns the total number of sessions completed.
+    """
+    completed = 0
+    for round_num in range(1, max_rounds + 1):
+        pending = _fetch_pending_sessions(base_url, instructor_token, tournament_id)
+        if not pending:
+            break
+        made_progress = False
+        for session in pending:
+            processed = strategy.complete(base_url, instructor_token, tournament_id, session)
+            if processed:
+                completed += 1
+                made_progress = True
+        if not made_progress:
+            raise RuntimeError(
+                f"complete_all_sessions: round {round_num} — {len(pending)} pending sessions "
+                "all have empty participant_user_ids (possible session generator issue)"
+            )
+        if poll_delay_s > 0:
+            time.sleep(poll_delay_s)
+    else:
+        remaining = _fetch_pending_sessions(base_url, instructor_token, tournament_id)
+        if remaining:
+            raise RuntimeError(
+                f"complete_all_sessions: still {len(remaining)} pending after {max_rounds} rounds"
+            )
+    return completed

--- a/tests/lifecycle_framework/framework/sessions.py
+++ b/tests/lifecycle_framework/framework/sessions.py
@@ -6,7 +6,7 @@ from typing import Protocol
 
 import requests
 
-from ._http import require_ok
+from ._http import LifecycleError, require_ok
 
 
 class SessionCompletionStrategy(Protocol):
@@ -52,14 +52,26 @@ class H2HResultStrategy:
 
         headers = {"Authorization": f"Bearer {instructor_token}"}
 
-        # Check in (400 is acceptable if already in_progress)
+        # Check in
         resp = requests.post(
             f"{base_url}/api/v1/sessions/{session_id}/check-in",
             headers=headers,
             json={},
             timeout=15,
         )
-        if resp.status_code not in (200, 201, 400):
+        if resp.status_code == 400:
+            # FRAGILE: 400 is accepted ONLY when the detail indicates the session is
+            # already in_progress. Any other 400 (wrong instructor, not found, etc.)
+            # must surface as LifecycleError. String-match is a pragmatic compromise —
+            # the proper fix is an error-code field on the API response.
+            try:
+                detail = str(resp.json().get("detail", resp.text))
+            except Exception:
+                detail = resp.text
+            if "in_progress" in detail.lower() or "already" in detail.lower():
+                return True  # already checked in — acceptable, continue to results
+            raise LifecycleError(f"session:{session_id}:check-in", 400, detail)
+        elif resp.status_code not in (200, 201):
             require_ok(resp, f"session:{session_id}:check-in")
 
         # Submit HEAD_TO_HEAD results — participant[0] wins 2-0 (deterministic)

--- a/tests/lifecycle_framework/framework/transitions/__init__.py
+++ b/tests/lifecycle_framework/framework/transitions/__init__.py
@@ -1,0 +1,21 @@
+"""Atomic lifecycle transition helpers."""
+from .lifecycle import create_tournament, transition_status
+from .instructor import assign_instructor, direct_assign_instructor, accept_instructor_assignment
+from .enrollment import assign_campus, enroll_player, enroll_players
+from .config import set_schedule_config, set_reward_config
+from .results import calculate_rankings, distribute_rewards
+
+__all__ = [
+    "create_tournament",
+    "transition_status",
+    "assign_instructor",
+    "direct_assign_instructor",
+    "accept_instructor_assignment",
+    "assign_campus",
+    "enroll_player",
+    "enroll_players",
+    "set_schedule_config",
+    "set_reward_config",
+    "calculate_rankings",
+    "distribute_rewards",
+]

--- a/tests/lifecycle_framework/framework/transitions/config.py
+++ b/tests/lifecycle_framework/framework/transitions/config.py
@@ -1,0 +1,50 @@
+"""Schedule and reward config transitions."""
+from __future__ import annotations
+
+import requests
+
+from .._http import require_ok
+
+
+def set_schedule_config(
+    base_url: str,
+    admin_token: str,
+    tournament_id: int,
+    *,
+    match_duration_minutes: int = 90,
+    break_duration_minutes: int = 15,
+    parallel_fields: int = 1,
+) -> dict:
+    """PATCH /api/v1/tournaments/{id}/schedule-config."""
+    resp = requests.patch(
+        f"{base_url}/api/v1/tournaments/{tournament_id}/schedule-config",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={
+            "match_duration_minutes": match_duration_minutes,
+            "break_duration_minutes": break_duration_minutes,
+            "parallel_fields": parallel_fields,
+        },
+        timeout=15,
+    )
+    return require_ok(resp, "set_schedule_config")
+
+
+def set_reward_config(
+    base_url: str,
+    admin_token: str,
+    tournament_id: int,
+    *,
+    skill_mappings: list[dict] | None = None,
+) -> dict:
+    """POST /api/v1/tournaments/{id}/reward-config."""
+    if skill_mappings is None:
+        skill_mappings = [
+            {"skill": "speed", "weight": 1.0, "category": "PHYSICAL", "enabled": True}
+        ]
+    resp = requests.post(
+        f"{base_url}/api/v1/tournaments/{tournament_id}/reward-config",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"skill_mappings": skill_mappings},
+        timeout=15,
+    )
+    return require_ok(resp, "set_reward_config")

--- a/tests/lifecycle_framework/framework/transitions/enrollment.py
+++ b/tests/lifecycle_framework/framework/transitions/enrollment.py
@@ -1,0 +1,46 @@
+"""Campus assignment and player enrollment transitions."""
+from __future__ import annotations
+
+import requests
+
+from .._http import require_ok
+
+
+def assign_campus(
+    base_url: str,
+    admin_token: str,
+    tournament_id: int,
+    campus_id: int,
+) -> dict:
+    """PATCH /api/v1/tournaments/{id} to set campus_id."""
+    resp = requests.patch(
+        f"{base_url}/api/v1/tournaments/{tournament_id}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"campus_id": campus_id},
+        timeout=15,
+    )
+    return require_ok(resp, "assign_campus")
+
+
+def enroll_player(
+    base_url: str,
+    player_token: str,
+    tournament_id: int,
+) -> dict:
+    """POST /api/v1/tournaments/{id}/enroll for a single player."""
+    resp = requests.post(
+        f"{base_url}/api/v1/tournaments/{tournament_id}/enroll",
+        headers={"Authorization": f"Bearer {player_token}"},
+        json={},
+        timeout=15,
+    )
+    return require_ok(resp, "enroll_player")
+
+
+def enroll_players(
+    base_url: str,
+    player_tokens: list[str],
+    tournament_id: int,
+) -> list[dict]:
+    """Enroll multiple players, returning one response dict per player."""
+    return [enroll_player(base_url, tok, tournament_id) for tok in player_tokens]

--- a/tests/lifecycle_framework/framework/transitions/instructor.py
+++ b/tests/lifecycle_framework/framework/transitions/instructor.py
@@ -1,0 +1,55 @@
+"""Instructor assignment and acceptance transitions."""
+from __future__ import annotations
+
+import requests
+
+from .._http import require_ok
+
+
+def assign_instructor(
+    base_url: str,
+    admin_token: str,
+    tournament_id: int,
+    instructor_id: int,
+    message: str = "Assigned via lifecycle framework",
+) -> dict:
+    """POST /api/v1/tournaments/{id}/assign-instructor (open pool flow)."""
+    resp = requests.post(
+        f"{base_url}/api/v1/tournaments/{tournament_id}/assign-instructor",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"instructor_id": instructor_id, "assignment_message": message},
+        timeout=15,
+    )
+    return require_ok(resp, "assign_instructor")
+
+
+def direct_assign_instructor(
+    base_url: str,
+    admin_token: str,
+    tournament_id: int,
+    instructor_id: int,
+    message: str = "Direct-assigned via lifecycle framework",
+) -> dict:
+    """POST /api/v1/tournaments/{id}/direct-assign-instructor."""
+    resp = requests.post(
+        f"{base_url}/api/v1/tournaments/{tournament_id}/direct-assign-instructor",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"instructor_id": instructor_id, "assignment_message": message},
+        timeout=15,
+    )
+    return require_ok(resp, "direct_assign_instructor")
+
+
+def accept_instructor_assignment(
+    base_url: str,
+    instructor_token: str,
+    tournament_id: int,
+) -> dict:
+    """POST /api/v1/tournaments/{id}/instructor-assignment/accept."""
+    resp = requests.post(
+        f"{base_url}/api/v1/tournaments/{tournament_id}/instructor-assignment/accept",
+        headers={"Authorization": f"Bearer {instructor_token}"},
+        json={},
+        timeout=15,
+    )
+    return require_ok(resp, "accept_instructor_assignment")

--- a/tests/lifecycle_framework/framework/transitions/lifecycle.py
+++ b/tests/lifecycle_framework/framework/transitions/lifecycle.py
@@ -1,0 +1,68 @@
+"""Tournament creation and status transition helpers."""
+from __future__ import annotations
+
+import requests
+
+from .._http import require_ok
+
+
+def create_tournament(
+    base_url: str,
+    admin_token: str,
+    *,
+    scenario: str = "smoke_test",
+    player_count: int = 0,
+    max_players: int = 16,
+    tournament_format: str = "HEAD_TO_HEAD",
+    tournament_type_code: str = "knockout",
+    auto_generate_sessions: bool = False,
+    simulation_mode: str = "manual",
+    age_group: str = "AMATEUR",
+    enrollment_cost: int = 0,
+    initial_tournament_status: str = "SEEKING_INSTRUCTOR",
+    campus_ids: list[int] | None = None,
+    dry_run: bool = False,
+    confirmed: bool = False,
+) -> dict:
+    """POST /api/v1/tournaments/ops/run-scenario and return the response dict."""
+    payload: dict = {
+        "scenario": scenario,
+        "player_count": player_count,
+        "max_players": max_players,
+        "tournament_format": tournament_format,
+        "tournament_type_code": tournament_type_code,
+        "auto_generate_sessions": auto_generate_sessions,
+        "simulation_mode": simulation_mode,
+        "age_group": age_group,
+        "enrollment_cost": enrollment_cost,
+        "initial_tournament_status": initial_tournament_status,
+        "dry_run": dry_run,
+        "confirmed": confirmed,
+    }
+    if campus_ids is not None:
+        payload["campus_ids"] = campus_ids
+
+    resp = requests.post(
+        f"{base_url}/api/v1/tournaments/ops/run-scenario",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json=payload,
+        timeout=30,
+    )
+    return require_ok(resp, "create_tournament")
+
+
+def transition_status(
+    base_url: str,
+    admin_token: str,
+    tournament_id: int,
+    new_status: str,
+    reason: str = "",
+) -> dict:
+    """PATCH /api/v1/tournaments/{id}/status."""
+    resp = requests.patch(
+        f"{base_url}/api/v1/tournaments/{tournament_id}/status",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"new_status": new_status, "reason": reason or f"framework → {new_status}"},
+        timeout=15,
+    )
+    return require_ok(resp, f"transition:{new_status}")

--- a/tests/lifecycle_framework/framework/transitions/lifecycle.py
+++ b/tests/lifecycle_framework/framework/transitions/lifecycle.py
@@ -23,6 +23,7 @@ def create_tournament(
     campus_ids: list[int] | None = None,
     dry_run: bool = False,
     confirmed: bool = False,
+    participant_type: str = "INDIVIDUAL",
 ) -> dict:
     """POST /api/v1/tournaments/ops/run-scenario and return the response dict."""
     payload: dict = {
@@ -38,6 +39,7 @@ def create_tournament(
         "initial_tournament_status": initial_tournament_status,
         "dry_run": dry_run,
         "confirmed": confirmed,
+        "participant_type": participant_type,
     }
     if campus_ids is not None:
         payload["campus_ids"] = campus_ids

--- a/tests/lifecycle_framework/framework/transitions/results.py
+++ b/tests/lifecycle_framework/framework/transitions/results.py
@@ -1,0 +1,42 @@
+"""Ranking calculation and reward distribution transitions."""
+from __future__ import annotations
+
+import requests
+
+from .._http import require_ok
+
+
+def calculate_rankings(
+    base_url: str,
+    admin_token: str,
+    tournament_id: int,
+) -> dict:
+    """POST /api/v1/tournaments/{id}/calculate-rankings."""
+    resp = requests.post(
+        f"{base_url}/api/v1/tournaments/{tournament_id}/calculate-rankings",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={},
+        timeout=30,
+    )
+    return require_ok(resp, "calculate_rankings")
+
+
+def distribute_rewards(
+    base_url: str,
+    admin_token: str,
+    tournament_id: int,
+    *,
+    force_redistribution: bool = False,
+) -> dict:
+    """POST /api/v1/tournaments/{id}/distribute-rewards-v2.
+
+    Auto-transitions tournament to REWARDS_DISTRIBUTED on success.
+    tournament_id is required in the request body by the endpoint schema.
+    """
+    resp = requests.post(
+        f"{base_url}/api/v1/tournaments/{tournament_id}/distribute-rewards-v2",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"tournament_id": tournament_id, "force_redistribution": force_redistribution},
+        timeout=30,
+    )
+    return require_ok(resp, "distribute_rewards")

--- a/tests/lifecycle_framework/framework/verification.py
+++ b/tests/lifecycle_framework/framework/verification.py
@@ -1,0 +1,257 @@
+"""API-level and DB-level verification — invariant-centric."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import requests
+
+from ._http import require_ok
+
+
+@dataclass
+class VerificationResult:
+    passed: list[str] = field(default_factory=list)
+    failed: list[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return len(self.failed) == 0
+
+    def assert_all(self) -> None:
+        if self.failed:
+            raise AssertionError(
+                f"Verification failed ({len(self.failed)} checks):\n"
+                + "\n".join(f"  ✗ {f}" for f in self.failed)
+            )
+
+
+class ApiVerifier:
+    """Verifies end-state via public API endpoints — no DB access."""
+
+    def __init__(self, base_url: str, admin_token: str, instructor_token: str) -> None:
+        self._base = base_url
+        self._admin_h = {"Authorization": f"Bearer {admin_token}"}
+        self._instr_h = {"Authorization": f"Bearer {instructor_token}"}
+
+    def verify_rewards_distributed(
+        self,
+        tournament_id: int,
+        enrolled_count: int,
+    ) -> VerificationResult:
+        result = VerificationResult()
+        self._check_tournament_status(tournament_id, result)
+        self._check_rankings(tournament_id, enrolled_count, result)
+        self._check_sessions_completed(tournament_id, result)
+        return result
+
+    def _check_tournament_status(self, tid: int, result: VerificationResult) -> None:
+        try:
+            resp = requests.get(
+                f"{self._base}/api/v1/tournaments/{tid}",
+                headers=self._admin_h,
+                timeout=15,
+            )
+            data = require_ok(resp, "api:tournament_status")
+            status = data.get("tournament_status") or data.get("status")
+            if status == "REWARDS_DISTRIBUTED":
+                result.passed.append(f"tournament_status = {status}")
+            else:
+                result.failed.append(
+                    f"tournament_status: expected REWARDS_DISTRIBUTED, got {status!r}"
+                )
+        except Exception as exc:
+            result.failed.append(f"tournament_status check raised: {exc}")
+
+    def _check_rankings(
+        self, tid: int, enrolled_count: int, result: VerificationResult
+    ) -> None:
+        try:
+            resp = requests.get(
+                f"{self._base}/api/v1/tournaments/{tid}/rankings",
+                headers=self._admin_h,
+                timeout=15,
+            )
+            data = require_ok(resp, "api:rankings")
+            rank_list = data.get("rankings", [])
+            if len(rank_list) >= enrolled_count:
+                result.passed.append(
+                    f"rankings: {len(rank_list)} entries (≥ enrolled {enrolled_count})"
+                )
+            else:
+                result.failed.append(
+                    f"rankings: got {len(rank_list)}, expected ≥ {enrolled_count}"
+                )
+        except Exception as exc:
+            result.failed.append(f"rankings check raised: {exc}")
+
+    def _check_sessions_completed(self, tid: int, result: VerificationResult) -> None:
+        try:
+            resp = requests.get(
+                f"{self._base}/api/v1/tournaments/{tid}/sessions",
+                headers=self._instr_h,
+                timeout=15,
+            )
+            data = require_ok(resp, "api:sessions")
+            sessions: list[dict] = data if isinstance(data, list) else data.get("sessions", [])
+            match_sessions = [s for s in sessions if s.get("is_tournament_game")]
+            completed = sum(1 for s in match_sessions if s.get("result_submitted"))
+            if match_sessions and completed == len(match_sessions):
+                result.passed.append(
+                    f"sessions: {completed}/{len(match_sessions)} MATCH sessions completed"
+                )
+            elif not match_sessions:
+                result.failed.append("sessions: no tournament game sessions found")
+            else:
+                result.failed.append(
+                    f"sessions: {completed}/{len(match_sessions)} completed"
+                )
+        except Exception as exc:
+            result.failed.append(f"sessions check raised: {exc}")
+
+
+class DbVerifier:
+    """Verifies business invariants directly in the database.
+
+    Uses only business-observable state, not implementation-internal flags.
+    Session completion is verified via reward_policy_snapshot + ranking coverage,
+    not session_status (which is an internal state machine detail).
+    """
+
+    def verify_rewards_distributed(
+        self,
+        tournament_id: int,
+        enrolled_count: int,
+    ) -> VerificationResult:
+        result = VerificationResult()
+        self._check_tournament_status(tournament_id, result)
+        self._check_reward_snapshot(tournament_id, result)
+        self._check_sessions_complete(tournament_id, result)
+        self._check_ranking_coverage(tournament_id, enrolled_count, result)
+        self._check_participation_records(tournament_id, result)
+        return result
+
+    def _check_tournament_status(self, tid: int, result: VerificationResult) -> None:
+        try:
+            from app.database import SessionLocal
+            from app.models.semester import Semester
+
+            db = SessionLocal()
+            try:
+                t = db.query(Semester).filter(Semester.id == tid).first()
+                if t is None:
+                    result.failed.append(f"tournament {tid} not found in DB")
+                    return
+                if t.tournament_status == "REWARDS_DISTRIBUTED":
+                    result.passed.append(f"db:tournament_status = {t.tournament_status}")
+                else:
+                    result.failed.append(
+                        f"db:tournament_status: expected REWARDS_DISTRIBUTED, "
+                        f"got {t.tournament_status!r}"
+                    )
+            finally:
+                db.close()
+        except Exception as exc:
+            result.failed.append(f"db:tournament_status check raised: {exc}")
+
+    def _check_reward_snapshot(self, tid: int, result: VerificationResult) -> None:
+        try:
+            from app.database import SessionLocal
+            from app.models.semester import Semester
+
+            db = SessionLocal()
+            try:
+                t = db.query(Semester).filter(Semester.id == tid).first()
+                if t is None:
+                    return
+                if t.reward_policy_snapshot is not None:
+                    result.passed.append("db:reward_policy_snapshot IS NOT NULL")
+                else:
+                    result.failed.append(
+                        "db:reward_policy_snapshot IS NULL — SNAPSHOT_MISSING guard applies"
+                    )
+            finally:
+                db.close()
+        except Exception as exc:
+            result.failed.append(f"db:reward_policy_snapshot check raised: {exc}")
+
+    def _check_sessions_complete(self, tid: int, result: VerificationResult) -> None:
+        try:
+            from app.database import SessionLocal
+            from app.models.session import Session as SessionModel, EventCategory
+
+            db = SessionLocal()
+            try:
+                incomplete = (
+                    db.query(SessionModel)
+                    .filter(
+                        SessionModel.semester_id == tid,
+                        SessionModel.auto_generated == True,  # noqa: E712
+                        SessionModel.event_category == EventCategory.MATCH,
+                        SessionModel.session_status != "completed",
+                    )
+                    .count()
+                )
+                if incomplete == 0:
+                    result.passed.append(
+                        "db:all auto-generated MATCH sessions have session_status='completed'"
+                    )
+                else:
+                    result.failed.append(
+                        f"db:{incomplete} auto-generated MATCH session(s) not completed"
+                    )
+            finally:
+                db.close()
+        except Exception as exc:
+            result.failed.append(f"db:sessions_complete check raised: {exc}")
+
+    def _check_ranking_coverage(
+        self, tid: int, enrolled_count: int, result: VerificationResult
+    ) -> None:
+        try:
+            from app.database import SessionLocal
+            from app.models.tournament_ranking import TournamentRanking
+
+            db = SessionLocal()
+            try:
+                count = (
+                    db.query(TournamentRanking)
+                    .filter(TournamentRanking.tournament_id == tid)
+                    .count()
+                )
+                if count >= enrolled_count:
+                    result.passed.append(
+                        f"db:TournamentRanking count = {count} (≥ enrolled {enrolled_count})"
+                    )
+                else:
+                    result.failed.append(
+                        f"db:TournamentRanking count {count} < enrolled {enrolled_count}"
+                    )
+            finally:
+                db.close()
+        except Exception as exc:
+            result.failed.append(f"db:ranking_coverage check raised: {exc}")
+
+    def _check_participation_records(self, tid: int, result: VerificationResult) -> None:
+        try:
+            from app.database import SessionLocal
+            from app.models.tournament_achievement import TournamentParticipation
+
+            db = SessionLocal()
+            try:
+                count = (
+                    db.query(TournamentParticipation)
+                    .filter(TournamentParticipation.semester_id == tid)
+                    .count()
+                )
+                if count > 0:
+                    result.passed.append(f"db:TournamentParticipation count = {count}")
+                else:
+                    result.failed.append(
+                        "db:TournamentParticipation count = 0 — PARTICIPATION_RECORDS_MISSING"
+                    )
+            finally:
+                db.close()
+        except ImportError:
+            result.passed.append("db:TournamentParticipation skipped (not importable)")
+        except Exception as exc:
+            result.failed.append(f"db:participation_records check raised: {exc}")

--- a/tests/lifecycle_framework/framework/verification.py
+++ b/tests/lifecycle_framework/framework/verification.py
@@ -52,7 +52,10 @@ class ApiVerifier:
                 timeout=15,
             )
             data = require_ok(resp, "api:tournament_status")
-            status = data.get("tournament_status") or data.get("status")
+            # Explicit None check — avoid falsy-string fall-through via `or`.
+            status = data.get("tournament_status")
+            if status is None:
+                status = data.get("status")
             if status == "REWARDS_DISTRIBUTED":
                 result.passed.append(f"tournament_status = {status}")
             else:
@@ -113,8 +116,17 @@ class DbVerifier:
     """Verifies business invariants directly in the database.
 
     Uses only business-observable state, not implementation-internal flags.
-    Session completion is verified via reward_policy_snapshot + ranking coverage,
-    not session_status (which is an internal state machine detail).
+    Session completion is NOT checked directly here — the lifecycle guard
+    (check_pre_completed → SESSIONS_INCOMPLETE) already enforces it, and
+    ranking_coverage is the business-observable proxy: if TournamentRanking
+    records exist for all enrolled players, sessions were necessarily completed.
+    The API-observable proxy (result_submitted=True) is verified by ApiVerifier.
+
+    Checks (4):
+      1. tournament_status = REWARDS_DISTRIBUTED
+      2. reward_policy_snapshot IS NOT NULL  (SNAPSHOT_MISSING guard passed)
+      3. TournamentRanking count ≥ enrolled  (RANKINGS_INCOMPLETE guard passed)
+      4. TournamentParticipation count ≥ enrolled  (PARTICIPATION_RECORDS_MISSING guard passed)
     """
 
     def verify_rewards_distributed(
@@ -125,9 +137,8 @@ class DbVerifier:
         result = VerificationResult()
         self._check_tournament_status(tournament_id, result)
         self._check_reward_snapshot(tournament_id, result)
-        self._check_sessions_complete(tournament_id, result)
         self._check_ranking_coverage(tournament_id, enrolled_count, result)
-        self._check_participation_records(tournament_id, result)
+        self._check_participation_records(tournament_id, result, enrolled_count)
         return result
 
     def _check_tournament_status(self, tid: int, result: VerificationResult) -> None:
@@ -174,36 +185,6 @@ class DbVerifier:
         except Exception as exc:
             result.failed.append(f"db:reward_policy_snapshot check raised: {exc}")
 
-    def _check_sessions_complete(self, tid: int, result: VerificationResult) -> None:
-        try:
-            from app.database import SessionLocal
-            from app.models.session import Session as SessionModel, EventCategory
-
-            db = SessionLocal()
-            try:
-                incomplete = (
-                    db.query(SessionModel)
-                    .filter(
-                        SessionModel.semester_id == tid,
-                        SessionModel.auto_generated == True,  # noqa: E712
-                        SessionModel.event_category == EventCategory.MATCH,
-                        SessionModel.session_status != "completed",
-                    )
-                    .count()
-                )
-                if incomplete == 0:
-                    result.passed.append(
-                        "db:all auto-generated MATCH sessions have session_status='completed'"
-                    )
-                else:
-                    result.failed.append(
-                        f"db:{incomplete} auto-generated MATCH session(s) not completed"
-                    )
-            finally:
-                db.close()
-        except Exception as exc:
-            result.failed.append(f"db:sessions_complete check raised: {exc}")
-
     def _check_ranking_coverage(
         self, tid: int, enrolled_count: int, result: VerificationResult
     ) -> None:
@@ -231,7 +212,9 @@ class DbVerifier:
         except Exception as exc:
             result.failed.append(f"db:ranking_coverage check raised: {exc}")
 
-    def _check_participation_records(self, tid: int, result: VerificationResult) -> None:
+    def _check_participation_records(
+        self, tid: int, result: VerificationResult, enrolled_count: int = 0
+    ) -> None:
         try:
             from app.database import SessionLocal
             from app.models.tournament_achievement import TournamentParticipation
@@ -243,15 +226,22 @@ class DbVerifier:
                     .filter(TournamentParticipation.semester_id == tid)
                     .count()
                 )
-                if count > 0:
-                    result.passed.append(f"db:TournamentParticipation count = {count}")
+                if count >= max(enrolled_count, 1):
+                    result.passed.append(
+                        f"db:TournamentParticipation count = {count}"
+                        + (f" (≥ enrolled {enrolled_count})" if enrolled_count else "")
+                    )
                 else:
                     result.failed.append(
-                        "db:TournamentParticipation count = 0 — PARTICIPATION_RECORDS_MISSING"
+                        f"db:TournamentParticipation count = {count}, "
+                        f"expected ≥ {enrolled_count} — PARTICIPATION_RECORDS_MISSING"
                     )
             finally:
                 db.close()
         except ImportError:
-            result.passed.append("db:TournamentParticipation skipped (not importable)")
+            # ImportError means model path changed — treat as unknown failure.
+            result.failed.append(
+                "db:TournamentParticipation not importable — verify app.models.tournament_achievement"
+            )
         except Exception as exc:
             result.failed.append(f"db:participation_records check raised: {exc}")

--- a/tests/lifecycle_framework/scenarios/__init__.py
+++ b/tests/lifecycle_framework/scenarios/__init__.py
@@ -1,0 +1,4 @@
+"""Lifecycle scenario implementations."""
+from .base import ScenarioConfig, ScenarioResult, ScenarioFailure, ScenarioRunner
+
+__all__ = ["ScenarioConfig", "ScenarioResult", "ScenarioFailure", "ScenarioRunner"]

--- a/tests/lifecycle_framework/scenarios/base.py
+++ b/tests/lifecycle_framework/scenarios/base.py
@@ -1,0 +1,418 @@
+"""Scenario orchestration primitives.
+
+ScenarioStrategy — Protocol for format-specific logic (setup, enroll, complete).
+ScenarioRunner — Orchestration-only: drives the 12-step lifecycle, delegates
+                  format-specific work to the strategy.
+ScenarioResult  — Outcome of a scenario run.
+ScenarioFailure — Raised when the scenario fails (wraps the original exception).
+"""
+from __future__ import annotations
+
+import traceback
+from dataclasses import dataclass, field
+from typing import Protocol, runtime_checkable
+
+from ..framework._http import LifecycleError, PreflightError
+from ..framework.auth import AuthContext, login
+from ..framework.fixtures import (
+    InstructorFixture,
+    CampusFixture,
+    PlayerFixture,
+    resolve_campus,
+    resolve_instructor,
+    resolve_players_db,
+)
+from ..framework.logging import ColoredConsoleLogger, ScenarioLogger, TransitionEvent, TimedStep
+from ..framework.preflight import HiddenDependencyRegistry, PreflightChecker
+from ..framework.sessions import SessionCompletionStrategy, complete_all_sessions
+from ..framework.transitions import (
+    create_tournament,
+    transition_status,
+    direct_assign_instructor,
+    accept_instructor_assignment,
+    enroll_players,
+    set_schedule_config,
+    set_reward_config,
+    calculate_rankings,
+    distribute_rewards,
+)
+from ..framework.verification import ApiVerifier, DbVerifier, VerificationResult
+
+
+@dataclass
+class ScenarioConfig:
+    base_url: str
+    admin_email: str
+    admin_password: str
+    instructor_email: str
+    instructor_password: str
+    player_password: str = "Bootstrap#123"
+    player_email_pattern: str = "lfa-adult-%@lfa.com"
+    player_count: int = 4
+    age_group: str = "AMATEUR"
+    tournament_format: str = "HEAD_TO_HEAD"
+    tournament_type_code: str = "knockout"
+    max_players: int = 16
+    enrollment_cost: int = 0
+    match_duration_minutes: int = 90
+    break_duration_minutes: int = 15
+    parallel_fields: int = 1
+
+
+@dataclass
+class ScenarioResult:
+    tournament_id: int
+    sessions_completed: int
+    players_enrolled: int
+    api_verification: VerificationResult
+    db_verification: VerificationResult
+    events: list[TransitionEvent] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return self.api_verification.ok and self.db_verification.ok
+
+
+class ScenarioFailure(Exception):
+    """Raised when a scenario step fails. Wraps the original exception."""
+
+    def __init__(self, step: str, cause: Exception) -> None:
+        self.step = step
+        self.cause = cause
+        super().__init__(f"Scenario failed at [{step}]: {cause}")
+
+
+@runtime_checkable
+class ScenarioStrategy(Protocol):
+    """Format-specific hooks called by ScenarioRunner at the right lifecycle moment."""
+
+    def setup_instructor(
+        self,
+        cfg: ScenarioConfig,
+        auth: AuthContext,
+        tournament_id: int,
+    ) -> None:
+        """Assign and confirm the instructor for the tournament."""
+        ...
+
+    def enroll_participants(
+        self,
+        cfg: ScenarioConfig,
+        auth: AuthContext,
+        tournament_id: int,
+    ) -> None:
+        """Enroll players after ENROLLMENT_OPEN."""
+        ...
+
+    def extra_pre_checkin_steps(
+        self,
+        cfg: ScenarioConfig,
+        auth: AuthContext,
+        tournament_id: int,
+    ) -> None:
+        """Optional extra steps between ENROLLMENT_CLOSED and CHECK_IN_OPEN."""
+        ...
+
+    def extra_pre_in_progress_steps(
+        self,
+        cfg: ScenarioConfig,
+        auth: AuthContext,
+        tournament_id: int,
+    ) -> None:
+        """Optional extra steps between CHECK_IN_OPEN and IN_PROGRESS."""
+        ...
+
+    def complete_sessions(
+        self,
+        cfg: ScenarioConfig,
+        auth: AuthContext,
+        tournament_id: int,
+    ) -> int:
+        """Complete all pending sessions. Returns the number of sessions completed."""
+        ...
+
+    def session_completion_strategy(self) -> SessionCompletionStrategy:
+        """Return the format-specific session completion strategy."""
+        ...
+
+
+class ScenarioRunner:
+    """Orchestration engine — drives the full 12-step REWARDS_DISTRIBUTED lifecycle.
+
+    Does NOT contain any format-specific logic. All format-specific work is
+    delegated to the ScenarioStrategy.
+    """
+
+    def __init__(
+        self,
+        config: ScenarioConfig,
+        strategy: ScenarioStrategy,
+        registry: HiddenDependencyRegistry,
+        logger: ScenarioLogger | None = None,
+    ) -> None:
+        self._cfg = config
+        self._strategy = strategy
+        self._registry = registry
+        self._logger = logger or ColoredConsoleLogger()
+        self._events: list[TransitionEvent] = []
+
+    def run(self) -> ScenarioResult:
+        cfg = self._cfg
+        try:
+            self._step_preflight()
+            auth = self._step_auth()
+            campus = self._step_resolve_fixtures(auth)
+            tournament_id = self._step_create_tournament(auth, campus)
+            self._step_instructor(auth, tournament_id)
+            self._step_enrollment_open(auth, tournament_id)
+            self._step_enroll_participants(auth, tournament_id)
+            self._step_enrollment_close(auth, tournament_id)
+            self._step_extra_pre_checkin(auth, tournament_id)
+            self._step_schedule_config(auth, tournament_id)
+            self._step_checkin_open(auth, tournament_id)
+            self._step_extra_pre_in_progress(auth, tournament_id)
+            self._step_reward_config(auth, tournament_id)
+            self._step_in_progress(auth, tournament_id)
+            sessions_completed = self._step_complete_sessions(auth, tournament_id)
+            self._step_calculate_rankings(auth, tournament_id)
+            self._step_completed(auth, tournament_id)
+            self._step_distribute_rewards(auth, tournament_id)
+            api_result, db_result = self._step_verify(
+                auth, tournament_id, cfg.player_count
+            )
+        except (PreflightError, LifecycleError, ScenarioFailure):
+            self._logger.summary(self._events)
+            raise
+        except Exception as exc:
+            self._logger.summary(self._events)
+            raise ScenarioFailure("unknown", exc) from exc
+
+        result = ScenarioResult(
+            tournament_id=tournament_id,
+            sessions_completed=sessions_completed,
+            players_enrolled=cfg.player_count,
+            api_verification=api_result,
+            db_verification=db_result,
+            events=list(self._events),
+        )
+        self._logger.summary(self._events)
+        return result
+
+    # ── Step implementations ─────────────────────────────────────────────────
+
+    def _step_preflight(self) -> None:
+        import time
+        t0 = time.perf_counter()
+        checker = PreflightChecker(self._registry)
+        passed = checker.run(fail_fast=True)
+        elapsed = (time.perf_counter() - t0) * 1000
+        self._log_ok("preflight", elapsed, f"{len(passed)} checks passed")
+
+    def _step_auth(self) -> AuthContext:
+        import time
+        t0 = time.perf_counter()
+        cfg = self._cfg
+        admin_token = login(cfg.base_url, cfg.admin_email, cfg.admin_password)
+        instructor_token = login(cfg.base_url, cfg.instructor_email, cfg.instructor_password)
+        instructor = resolve_instructor(cfg.base_url, admin_token, cfg.instructor_email)
+        elapsed = (time.perf_counter() - t0) * 1000
+        self._log_ok("auth", elapsed, f"admin + instructor (id={instructor.id})")
+        return AuthContext(
+            admin_token=admin_token,
+            instructor_token=instructor_token,
+            instructor_id=instructor.id,
+        )
+
+    def _step_resolve_fixtures(self, auth: AuthContext) -> CampusFixture:
+        import time
+        t0 = time.perf_counter()
+        cfg = self._cfg
+
+        campus = resolve_campus(cfg.base_url, auth.admin_token)
+        players = resolve_players_db(
+            email_pattern=cfg.player_email_pattern,
+            password=cfg.player_password,
+            count=cfg.player_count,
+            base_url=cfg.base_url,
+        )
+        # Populate auth with player tokens
+        for p in players:
+            tok = login(cfg.base_url, p.email, cfg.player_password)
+            auth.player_tokens[p.email] = tok
+            auth.player_ids[p.email] = p.id
+
+        elapsed = (time.perf_counter() - t0) * 1000
+        self._log_ok(
+            "resolve_fixtures",
+            elapsed,
+            f"campus_id={campus.id}, {len(players)} players",
+        )
+        return campus
+
+    def _step_create_tournament(
+        self, auth: AuthContext, campus: CampusFixture
+    ) -> int:
+        import time
+        t0 = time.perf_counter()
+        cfg = self._cfg
+        data = create_tournament(
+            cfg.base_url,
+            auth.admin_token,
+            tournament_format=cfg.tournament_format,
+            tournament_type_code=cfg.tournament_type_code,
+            age_group=cfg.age_group,
+            max_players=cfg.max_players,
+            enrollment_cost=cfg.enrollment_cost,
+            campus_ids=[campus.id],
+        )
+        tid = data["tournament_id"]
+        elapsed = (time.perf_counter() - t0) * 1000
+        self._log_ok("create_tournament", elapsed, f"id={tid} → SEEKING_INSTRUCTOR")
+        return tid
+
+    def _step_instructor(self, auth: AuthContext, tid: int) -> None:
+        import time
+        t0 = time.perf_counter()
+        self._strategy.setup_instructor(self._cfg, auth, tid)
+        elapsed = (time.perf_counter() - t0) * 1000
+        self._log_ok("setup_instructor", elapsed, "→ INSTRUCTOR_CONFIRMED")
+
+    def _step_enrollment_open(self, auth: AuthContext, tid: int) -> None:
+        import time
+        t0 = time.perf_counter()
+        cfg = self._cfg
+        # campus_ids already passed to create_tournament; no separate assignment needed
+        transition_status(cfg.base_url, auth.admin_token, tid, "ENROLLMENT_OPEN")
+        elapsed = (time.perf_counter() - t0) * 1000
+        self._log_ok("enrollment_open", elapsed, "INSTRUCTOR_CONFIRMED → ENROLLMENT_OPEN")
+
+    def _step_enroll_participants(self, auth: AuthContext, tid: int) -> None:
+        import time
+        t0 = time.perf_counter()
+        self._strategy.enroll_participants(self._cfg, auth, tid)
+        elapsed = (time.perf_counter() - t0) * 1000
+        self._log_ok("enroll_participants", elapsed, f"{self._cfg.player_count} players enrolled")
+
+    def _step_enrollment_close(self, auth: AuthContext, tid: int) -> None:
+        import time
+        t0 = time.perf_counter()
+        cfg = self._cfg
+        transition_status(cfg.base_url, auth.admin_token, tid, "ENROLLMENT_CLOSED")
+        elapsed = (time.perf_counter() - t0) * 1000
+        self._log_ok("enrollment_close", elapsed, "ENROLLMENT_OPEN → ENROLLMENT_CLOSED")
+
+    def _step_extra_pre_checkin(self, auth: AuthContext, tid: int) -> None:
+        self._strategy.extra_pre_checkin_steps(self._cfg, auth, tid)
+
+    def _step_schedule_config(self, auth: AuthContext, tid: int) -> None:
+        import time
+        t0 = time.perf_counter()
+        cfg = self._cfg
+        set_schedule_config(
+            cfg.base_url,
+            auth.admin_token,
+            tid,
+            match_duration_minutes=cfg.match_duration_minutes,
+            break_duration_minutes=cfg.break_duration_minutes,
+            parallel_fields=cfg.parallel_fields,
+        )
+        elapsed = (time.perf_counter() - t0) * 1000
+        self._log_ok("schedule_config", elapsed, "SCHEDULE_CONFIG_MISSING guard cleared")
+
+    def _step_checkin_open(self, auth: AuthContext, tid: int) -> None:
+        import time
+        t0 = time.perf_counter()
+        cfg = self._cfg
+        transition_status(cfg.base_url, auth.admin_token, tid, "CHECK_IN_OPEN")
+        elapsed = (time.perf_counter() - t0) * 1000
+        self._log_ok("checkin_open", elapsed, "ENROLLMENT_CLOSED → CHECK_IN_OPEN")
+
+    def _step_extra_pre_in_progress(self, auth: AuthContext, tid: int) -> None:
+        self._strategy.extra_pre_in_progress_steps(self._cfg, auth, tid)
+
+    def _step_reward_config(self, auth: AuthContext, tid: int) -> None:
+        import time
+        t0 = time.perf_counter()
+        cfg = self._cfg
+        set_reward_config(cfg.base_url, auth.admin_token, tid)
+        elapsed = (time.perf_counter() - t0) * 1000
+        self._log_ok("reward_config", elapsed, "REWARD_CONFIG_MISSING guard cleared")
+
+    def _step_in_progress(self, auth: AuthContext, tid: int) -> None:
+        import time
+        t0 = time.perf_counter()
+        cfg = self._cfg
+        transition_status(cfg.base_url, auth.admin_token, tid, "IN_PROGRESS")
+        elapsed = (time.perf_counter() - t0) * 1000
+        self._log_ok("in_progress", elapsed, "CHECK_IN_OPEN → IN_PROGRESS (sessions auto-generated)")
+
+    def _step_complete_sessions(self, auth: AuthContext, tid: int) -> int:
+        import time
+        t0 = time.perf_counter()
+        count = self._strategy.complete_sessions(self._cfg, auth, tid)
+        elapsed = (time.perf_counter() - t0) * 1000
+        self._log_ok("complete_sessions", elapsed, f"{count} session(s) completed")
+        return count
+
+    def _step_calculate_rankings(self, auth: AuthContext, tid: int) -> None:
+        import time
+        t0 = time.perf_counter()
+        cfg = self._cfg
+        calculate_rankings(cfg.base_url, auth.admin_token, tid)
+        elapsed = (time.perf_counter() - t0) * 1000
+        self._log_ok("calculate_rankings", elapsed, "rankings calculated")
+
+    def _step_completed(self, auth: AuthContext, tid: int) -> None:
+        import time
+        t0 = time.perf_counter()
+        cfg = self._cfg
+        transition_status(cfg.base_url, auth.admin_token, tid, "COMPLETED")
+        elapsed = (time.perf_counter() - t0) * 1000
+        self._log_ok("completed", elapsed, "IN_PROGRESS → COMPLETED")
+
+    def _step_distribute_rewards(self, auth: AuthContext, tid: int) -> None:
+        import time
+        t0 = time.perf_counter()
+        cfg = self._cfg
+        distribute_rewards(cfg.base_url, auth.admin_token, tid)
+        elapsed = (time.perf_counter() - t0) * 1000
+        self._log_ok(
+            "distribute_rewards",
+            elapsed,
+            "COMPLETED → REWARDS_DISTRIBUTED (auto-transition in rewards_v2.py:92)",
+        )
+
+    def _step_verify(
+        self,
+        auth: AuthContext,
+        tid: int,
+        enrolled_count: int,
+    ) -> tuple[VerificationResult, VerificationResult]:
+        import time
+        t0 = time.perf_counter()
+        cfg = self._cfg
+
+        api = ApiVerifier(cfg.base_url, auth.admin_token, auth.instructor_token)
+        api_result = api.verify_rewards_distributed(tid, enrolled_count)
+
+        db = DbVerifier()
+        db_result = db.verify_rewards_distributed(tid, enrolled_count)
+
+        elapsed = (time.perf_counter() - t0) * 1000
+        api_ok = len(api_result.passed)
+        db_ok = len(db_result.passed)
+        all_ok = api_result.ok and db_result.ok
+        self._log_ok(
+            "verify",
+            elapsed,
+            f"API {api_ok} passed, DB {db_ok} passed — {'PASS' if all_ok else 'FAIL'}",
+        )
+        return api_result, db_result
+
+    # ── Logging helpers ──────────────────────────────────────────────────────
+
+    def _log_ok(self, step: str, elapsed_ms: float, detail: str = "") -> None:
+        from ..framework.logging import TransitionEvent
+        event = TransitionEvent(step, "ok", elapsed_ms, detail)
+        self._events.append(event)
+        self._logger.log(event)

--- a/tests/lifecycle_framework/scenarios/base.py
+++ b/tests/lifecycle_framework/scenarios/base.py
@@ -1,23 +1,21 @@
 """Scenario orchestration primitives.
 
-ScenarioStrategy — Protocol for format-specific logic (setup, enroll, complete).
-ScenarioRunner — Orchestration-only: drives the 12-step lifecycle, delegates
-                  format-specific work to the strategy.
-ScenarioResult  — Outcome of a scenario run.
-ScenarioFailure — Raised when the scenario fails (wraps the original exception).
+ScenarioStrategy — Protocol for format-specific logic (setup, enroll, config, complete).
+ScenarioRunner   — Orchestration-only: drives the lifecycle transitions, delegates
+                   ALL format-specific work to the strategy. The runner has NO knowledge
+                   of schedule config, reward config, or session result format.
+ScenarioResult   — Outcome of a scenario run.
+ScenarioFailure  — Raised when the scenario fails (wraps the original exception).
 """
 from __future__ import annotations
 
-import traceback
 from dataclasses import dataclass, field
 from typing import Protocol, runtime_checkable
 
 from ..framework._http import LifecycleError, PreflightError
 from ..framework.auth import AuthContext, login
 from ..framework.fixtures import (
-    InstructorFixture,
     CampusFixture,
-    PlayerFixture,
     resolve_campus,
     resolve_instructor,
     resolve_players_db,
@@ -28,11 +26,6 @@ from ..framework.sessions import SessionCompletionStrategy, complete_all_session
 from ..framework.transitions import (
     create_tournament,
     transition_status,
-    direct_assign_instructor,
-    accept_instructor_assignment,
-    enroll_players,
-    set_schedule_config,
-    set_reward_config,
     calculate_rankings,
     distribute_rewards,
 )
@@ -84,7 +77,17 @@ class ScenarioFailure(Exception):
 
 @runtime_checkable
 class ScenarioStrategy(Protocol):
-    """Format-specific hooks called by ScenarioRunner at the right lifecycle moment."""
+    """Format-specific hooks called by ScenarioRunner at the right lifecycle moment.
+
+    The runner calls these in order:
+      setup_instructor        → after tournament created
+      enroll_participants     → after ENROLLMENT_OPEN
+      extra_pre_checkin_steps → after ENROLLMENT_CLOSED, before CHECK_IN_OPEN
+                                (strategy MUST call set_schedule_config here)
+      extra_pre_in_progress_steps → after CHECK_IN_OPEN, before IN_PROGRESS
+                                (strategy MUST call set_reward_config here)
+      complete_sessions       → after IN_PROGRESS
+    """
 
     def setup_instructor(
         self,
@@ -110,7 +113,11 @@ class ScenarioStrategy(Protocol):
         auth: AuthContext,
         tournament_id: int,
     ) -> None:
-        """Optional extra steps between ENROLLMENT_CLOSED and CHECK_IN_OPEN."""
+        """Steps between ENROLLMENT_CLOSED and CHECK_IN_OPEN.
+
+        REQUIRED: call set_schedule_config() here — the CHECK_IN_OPEN transition
+        guard enforces SCHEDULE_CONFIG_MISSING and will 400 without it.
+        """
         ...
 
     def extra_pre_in_progress_steps(
@@ -119,7 +126,11 @@ class ScenarioStrategy(Protocol):
         auth: AuthContext,
         tournament_id: int,
     ) -> None:
-        """Optional extra steps between CHECK_IN_OPEN and IN_PROGRESS."""
+        """Steps between CHECK_IN_OPEN and IN_PROGRESS.
+
+        REQUIRED: call set_reward_config() here — the IN_PROGRESS transition
+        guard enforces REWARD_CONFIG_MISSING and will 400 without it.
+        """
         ...
 
     def complete_sessions(
@@ -137,10 +148,22 @@ class ScenarioStrategy(Protocol):
 
 
 class ScenarioRunner:
-    """Orchestration engine — drives the full 12-step REWARDS_DISTRIBUTED lifecycle.
+    """Orchestration engine — drives the full REWARDS_DISTRIBUTED lifecycle.
 
-    Does NOT contain any format-specific logic. All format-specific work is
-    delegated to the ScenarioStrategy.
+    Orchestration-only: the runner knows WHEN to call lifecycle transitions
+    and WHEN to invoke strategy hooks. It has NO knowledge of:
+      - schedule configuration parameters (strategy's responsibility)
+      - reward configuration skill mappings (strategy's responsibility)
+      - session result format (strategy's responsibility)
+      - instructor assignment mechanism (strategy's responsibility)
+
+    Lifecycle sequence (15 steps):
+      preflight → auth → resolve_fixtures → create_tournament →
+      setup_instructor → enrollment_open → enroll_participants →
+      enrollment_close → extra_pre_checkin (schedule config lives here) →
+      checkin_open → extra_pre_in_progress (reward config lives here) →
+      in_progress → complete_sessions → calculate_rankings →
+      completed → distribute_rewards → verify
     """
 
     def __init__(
@@ -153,8 +176,19 @@ class ScenarioRunner:
         self._cfg = config
         self._strategy = strategy
         self._registry = registry
-        self._logger = logger or ColoredConsoleLogger()
+        self._delegate = logger or ColoredConsoleLogger()
         self._events: list[TransitionEvent] = []
+
+    # ── ScenarioLogger implementation ────────────────────────────────────────
+    # The runner acts as its own logger so TimedStep can call self.log() and
+    # have events stored in self._events AND printed via the delegate logger.
+
+    def log(self, event: TransitionEvent) -> None:
+        self._events.append(event)
+        self._delegate.log(event)
+
+    def summary(self, events: list[TransitionEvent]) -> None:
+        self._delegate.summary(events)
 
     def run(self) -> ScenarioResult:
         cfg = self._cfg
@@ -168,10 +202,8 @@ class ScenarioRunner:
             self._step_enroll_participants(auth, tournament_id)
             self._step_enrollment_close(auth, tournament_id)
             self._step_extra_pre_checkin(auth, tournament_id)
-            self._step_schedule_config(auth, tournament_id)
             self._step_checkin_open(auth, tournament_id)
             self._step_extra_pre_in_progress(auth, tournament_id)
-            self._step_reward_config(auth, tournament_id)
             self._step_in_progress(auth, tournament_id)
             sessions_completed = self._step_complete_sessions(auth, tournament_id)
             self._step_calculate_rankings(auth, tournament_id)
@@ -181,10 +213,10 @@ class ScenarioRunner:
                 auth, tournament_id, cfg.player_count
             )
         except (PreflightError, LifecycleError, ScenarioFailure):
-            self._logger.summary(self._events)
+            self.summary(self._events)
             raise
         except Exception as exc:
-            self._logger.summary(self._events)
+            self.summary(self._events)
             raise ScenarioFailure("unknown", exc) from exc
 
         result = ScenarioResult(
@@ -195,192 +227,133 @@ class ScenarioRunner:
             db_verification=db_result,
             events=list(self._events),
         )
-        self._logger.summary(self._events)
+        self.summary(self._events)
         return result
 
     # ── Step implementations ─────────────────────────────────────────────────
 
     def _step_preflight(self) -> None:
-        import time
-        t0 = time.perf_counter()
-        checker = PreflightChecker(self._registry)
-        passed = checker.run(fail_fast=True)
-        elapsed = (time.perf_counter() - t0) * 1000
-        self._log_ok("preflight", elapsed, f"{len(passed)} checks passed")
+        with TimedStep("preflight", self) as step:
+            checker = PreflightChecker(self._registry)
+            passed = checker.run(fail_fast=True)
+            step.ok(f"{len(passed)} checks passed")
 
     def _step_auth(self) -> AuthContext:
-        import time
-        t0 = time.perf_counter()
-        cfg = self._cfg
-        admin_token = login(cfg.base_url, cfg.admin_email, cfg.admin_password)
-        instructor_token = login(cfg.base_url, cfg.instructor_email, cfg.instructor_password)
-        instructor = resolve_instructor(cfg.base_url, admin_token, cfg.instructor_email)
-        elapsed = (time.perf_counter() - t0) * 1000
-        self._log_ok("auth", elapsed, f"admin + instructor (id={instructor.id})")
-        return AuthContext(
-            admin_token=admin_token,
-            instructor_token=instructor_token,
-            instructor_id=instructor.id,
-        )
+        with TimedStep("auth", self) as step:
+            cfg = self._cfg
+            admin_token = login(cfg.base_url, cfg.admin_email, cfg.admin_password)
+            instructor_token = login(cfg.base_url, cfg.instructor_email, cfg.instructor_password)
+            instructor = resolve_instructor(cfg.base_url, admin_token, cfg.instructor_email)
+            auth = AuthContext(
+                admin_token=admin_token,
+                instructor_token=instructor_token,
+                instructor_id=instructor.id,
+            )
+            step.ok(f"admin + instructor (id={instructor.id})")
+        return auth
 
     def _step_resolve_fixtures(self, auth: AuthContext) -> CampusFixture:
-        import time
-        t0 = time.perf_counter()
-        cfg = self._cfg
-
-        campus = resolve_campus(cfg.base_url, auth.admin_token)
-        players = resolve_players_db(
-            email_pattern=cfg.player_email_pattern,
-            password=cfg.player_password,
-            count=cfg.player_count,
-            base_url=cfg.base_url,
-        )
-        # Populate auth with player tokens
-        for p in players:
-            tok = login(cfg.base_url, p.email, cfg.player_password)
-            auth.player_tokens[p.email] = tok
-            auth.player_ids[p.email] = p.id
-
-        elapsed = (time.perf_counter() - t0) * 1000
-        self._log_ok(
-            "resolve_fixtures",
-            elapsed,
-            f"campus_id={campus.id}, {len(players)} players",
-        )
+        with TimedStep("resolve_fixtures", self) as step:
+            cfg = self._cfg
+            campus = resolve_campus(cfg.base_url, auth.admin_token)
+            players = resolve_players_db(
+                email_pattern=cfg.player_email_pattern,
+                count=cfg.player_count,
+            )
+            for p in players:
+                tok = login(cfg.base_url, p.email, cfg.player_password)
+                auth.player_tokens[p.email] = tok
+                auth.player_ids[p.email] = p.id
+            step.ok(f"campus_id={campus.id}, {len(players)} players")
         return campus
 
     def _step_create_tournament(
         self, auth: AuthContext, campus: CampusFixture
     ) -> int:
-        import time
-        t0 = time.perf_counter()
-        cfg = self._cfg
-        data = create_tournament(
-            cfg.base_url,
-            auth.admin_token,
-            tournament_format=cfg.tournament_format,
-            tournament_type_code=cfg.tournament_type_code,
-            age_group=cfg.age_group,
-            max_players=cfg.max_players,
-            enrollment_cost=cfg.enrollment_cost,
-            campus_ids=[campus.id],
-        )
-        tid = data["tournament_id"]
-        elapsed = (time.perf_counter() - t0) * 1000
-        self._log_ok("create_tournament", elapsed, f"id={tid} → SEEKING_INSTRUCTOR")
+        with TimedStep("create_tournament", self) as step:
+            cfg = self._cfg
+            data = create_tournament(
+                cfg.base_url,
+                auth.admin_token,
+                tournament_format=cfg.tournament_format,
+                tournament_type_code=cfg.tournament_type_code,
+                age_group=cfg.age_group,
+                max_players=cfg.max_players,
+                enrollment_cost=cfg.enrollment_cost,
+                campus_ids=[campus.id],
+            )
+            tid = data["tournament_id"]
+            step.ok(f"id={tid} → SEEKING_INSTRUCTOR")
         return tid
 
     def _step_instructor(self, auth: AuthContext, tid: int) -> None:
-        import time
-        t0 = time.perf_counter()
-        self._strategy.setup_instructor(self._cfg, auth, tid)
-        elapsed = (time.perf_counter() - t0) * 1000
-        self._log_ok("setup_instructor", elapsed, "→ INSTRUCTOR_CONFIRMED")
+        with TimedStep("setup_instructor", self) as step:
+            self._strategy.setup_instructor(self._cfg, auth, tid)
+            step.ok("→ INSTRUCTOR_CONFIRMED")
 
     def _step_enrollment_open(self, auth: AuthContext, tid: int) -> None:
-        import time
-        t0 = time.perf_counter()
-        cfg = self._cfg
-        # campus_ids already passed to create_tournament; no separate assignment needed
-        transition_status(cfg.base_url, auth.admin_token, tid, "ENROLLMENT_OPEN")
-        elapsed = (time.perf_counter() - t0) * 1000
-        self._log_ok("enrollment_open", elapsed, "INSTRUCTOR_CONFIRMED → ENROLLMENT_OPEN")
+        with TimedStep("enrollment_open", self) as step:
+            cfg = self._cfg
+            # campus_ids already passed to create_tournament; no separate assignment needed
+            transition_status(cfg.base_url, auth.admin_token, tid, "ENROLLMENT_OPEN")
+            step.ok("INSTRUCTOR_CONFIRMED → ENROLLMENT_OPEN")
 
     def _step_enroll_participants(self, auth: AuthContext, tid: int) -> None:
-        import time
-        t0 = time.perf_counter()
-        self._strategy.enroll_participants(self._cfg, auth, tid)
-        elapsed = (time.perf_counter() - t0) * 1000
-        self._log_ok("enroll_participants", elapsed, f"{self._cfg.player_count} players enrolled")
+        with TimedStep("enroll_participants", self) as step:
+            self._strategy.enroll_participants(self._cfg, auth, tid)
+            step.ok(f"{self._cfg.player_count} players enrolled")
 
     def _step_enrollment_close(self, auth: AuthContext, tid: int) -> None:
-        import time
-        t0 = time.perf_counter()
-        cfg = self._cfg
-        transition_status(cfg.base_url, auth.admin_token, tid, "ENROLLMENT_CLOSED")
-        elapsed = (time.perf_counter() - t0) * 1000
-        self._log_ok("enrollment_close", elapsed, "ENROLLMENT_OPEN → ENROLLMENT_CLOSED")
+        with TimedStep("enrollment_close", self) as step:
+            cfg = self._cfg
+            transition_status(cfg.base_url, auth.admin_token, tid, "ENROLLMENT_CLOSED")
+            step.ok("ENROLLMENT_OPEN → ENROLLMENT_CLOSED")
 
     def _step_extra_pre_checkin(self, auth: AuthContext, tid: int) -> None:
-        self._strategy.extra_pre_checkin_steps(self._cfg, auth, tid)
-
-    def _step_schedule_config(self, auth: AuthContext, tid: int) -> None:
-        import time
-        t0 = time.perf_counter()
-        cfg = self._cfg
-        set_schedule_config(
-            cfg.base_url,
-            auth.admin_token,
-            tid,
-            match_duration_minutes=cfg.match_duration_minutes,
-            break_duration_minutes=cfg.break_duration_minutes,
-            parallel_fields=cfg.parallel_fields,
-        )
-        elapsed = (time.perf_counter() - t0) * 1000
-        self._log_ok("schedule_config", elapsed, "SCHEDULE_CONFIG_MISSING guard cleared")
+        with TimedStep("extra_pre_checkin", self) as step:
+            self._strategy.extra_pre_checkin_steps(self._cfg, auth, tid)
+            step.ok("schedule config set (SCHEDULE_CONFIG_MISSING guard cleared)")
 
     def _step_checkin_open(self, auth: AuthContext, tid: int) -> None:
-        import time
-        t0 = time.perf_counter()
-        cfg = self._cfg
-        transition_status(cfg.base_url, auth.admin_token, tid, "CHECK_IN_OPEN")
-        elapsed = (time.perf_counter() - t0) * 1000
-        self._log_ok("checkin_open", elapsed, "ENROLLMENT_CLOSED → CHECK_IN_OPEN")
+        with TimedStep("checkin_open", self) as step:
+            cfg = self._cfg
+            transition_status(cfg.base_url, auth.admin_token, tid, "CHECK_IN_OPEN")
+            step.ok("ENROLLMENT_CLOSED → CHECK_IN_OPEN")
 
     def _step_extra_pre_in_progress(self, auth: AuthContext, tid: int) -> None:
-        self._strategy.extra_pre_in_progress_steps(self._cfg, auth, tid)
-
-    def _step_reward_config(self, auth: AuthContext, tid: int) -> None:
-        import time
-        t0 = time.perf_counter()
-        cfg = self._cfg
-        set_reward_config(cfg.base_url, auth.admin_token, tid)
-        elapsed = (time.perf_counter() - t0) * 1000
-        self._log_ok("reward_config", elapsed, "REWARD_CONFIG_MISSING guard cleared")
+        with TimedStep("extra_pre_in_progress", self) as step:
+            self._strategy.extra_pre_in_progress_steps(self._cfg, auth, tid)
+            step.ok("reward config set (REWARD_CONFIG_MISSING guard cleared)")
 
     def _step_in_progress(self, auth: AuthContext, tid: int) -> None:
-        import time
-        t0 = time.perf_counter()
-        cfg = self._cfg
-        transition_status(cfg.base_url, auth.admin_token, tid, "IN_PROGRESS")
-        elapsed = (time.perf_counter() - t0) * 1000
-        self._log_ok("in_progress", elapsed, "CHECK_IN_OPEN → IN_PROGRESS (sessions auto-generated)")
+        with TimedStep("in_progress", self) as step:
+            cfg = self._cfg
+            transition_status(cfg.base_url, auth.admin_token, tid, "IN_PROGRESS")
+            step.ok("CHECK_IN_OPEN → IN_PROGRESS (sessions auto-generated)")
 
     def _step_complete_sessions(self, auth: AuthContext, tid: int) -> int:
-        import time
-        t0 = time.perf_counter()
-        count = self._strategy.complete_sessions(self._cfg, auth, tid)
-        elapsed = (time.perf_counter() - t0) * 1000
-        self._log_ok("complete_sessions", elapsed, f"{count} session(s) completed")
+        with TimedStep("complete_sessions", self) as step:
+            count = self._strategy.complete_sessions(self._cfg, auth, tid)
+            step.ok(f"{count} session(s) completed")
         return count
 
     def _step_calculate_rankings(self, auth: AuthContext, tid: int) -> None:
-        import time
-        t0 = time.perf_counter()
-        cfg = self._cfg
-        calculate_rankings(cfg.base_url, auth.admin_token, tid)
-        elapsed = (time.perf_counter() - t0) * 1000
-        self._log_ok("calculate_rankings", elapsed, "rankings calculated")
+        with TimedStep("calculate_rankings", self) as step:
+            cfg = self._cfg
+            calculate_rankings(cfg.base_url, auth.admin_token, tid)
+            step.ok("rankings calculated")
 
     def _step_completed(self, auth: AuthContext, tid: int) -> None:
-        import time
-        t0 = time.perf_counter()
-        cfg = self._cfg
-        transition_status(cfg.base_url, auth.admin_token, tid, "COMPLETED")
-        elapsed = (time.perf_counter() - t0) * 1000
-        self._log_ok("completed", elapsed, "IN_PROGRESS → COMPLETED")
+        with TimedStep("completed", self) as step:
+            cfg = self._cfg
+            transition_status(cfg.base_url, auth.admin_token, tid, "COMPLETED")
+            step.ok("IN_PROGRESS → COMPLETED")
 
     def _step_distribute_rewards(self, auth: AuthContext, tid: int) -> None:
-        import time
-        t0 = time.perf_counter()
-        cfg = self._cfg
-        distribute_rewards(cfg.base_url, auth.admin_token, tid)
-        elapsed = (time.perf_counter() - t0) * 1000
-        self._log_ok(
-            "distribute_rewards",
-            elapsed,
-            "COMPLETED → REWARDS_DISTRIBUTED (auto-transition in rewards_v2.py:92)",
-        )
+        with TimedStep("distribute_rewards", self) as step:
+            cfg = self._cfg
+            distribute_rewards(cfg.base_url, auth.admin_token, tid)
+            step.ok("COMPLETED → REWARDS_DISTRIBUTED (auto-transition in rewards_v2.py:92)")
 
     def _step_verify(
         self,
@@ -388,31 +361,15 @@ class ScenarioRunner:
         tid: int,
         enrolled_count: int,
     ) -> tuple[VerificationResult, VerificationResult]:
-        import time
-        t0 = time.perf_counter()
-        cfg = self._cfg
-
-        api = ApiVerifier(cfg.base_url, auth.admin_token, auth.instructor_token)
-        api_result = api.verify_rewards_distributed(tid, enrolled_count)
-
-        db = DbVerifier()
-        db_result = db.verify_rewards_distributed(tid, enrolled_count)
-
-        elapsed = (time.perf_counter() - t0) * 1000
-        api_ok = len(api_result.passed)
-        db_ok = len(db_result.passed)
-        all_ok = api_result.ok and db_result.ok
-        self._log_ok(
-            "verify",
-            elapsed,
-            f"API {api_ok} passed, DB {db_ok} passed — {'PASS' if all_ok else 'FAIL'}",
-        )
+        with TimedStep("verify", self) as step:
+            cfg = self._cfg
+            api = ApiVerifier(cfg.base_url, auth.admin_token, auth.instructor_token)
+            api_result = api.verify_rewards_distributed(tid, enrolled_count)
+            db = DbVerifier()
+            db_result = db.verify_rewards_distributed(tid, enrolled_count)
+            all_ok = api_result.ok and db_result.ok
+            step.ok(
+                f"API {len(api_result.passed)} passed, "
+                f"DB {len(db_result.passed)} passed — {'PASS' if all_ok else 'FAIL'}"
+            )
         return api_result, db_result
-
-    # ── Logging helpers ──────────────────────────────────────────────────────
-
-    def _log_ok(self, step: str, elapsed_ms: float, detail: str = "") -> None:
-        from ..framework.logging import TransitionEvent
-        event = TransitionEvent(step, "ok", elapsed_ms, detail)
-        self._events.append(event)
-        self._logger.log(event)

--- a/tests/lifecycle_framework/scenarios/base.py
+++ b/tests/lifecycle_framework/scenarios/base.py
@@ -50,6 +50,7 @@ class ScenarioConfig:
     match_duration_minutes: int = 90
     break_duration_minutes: int = 15
     parallel_fields: int = 1
+    participant_type: str = "INDIVIDUAL"
 
 
 @dataclass
@@ -281,6 +282,7 @@ class ScenarioRunner:
                 max_players=cfg.max_players,
                 enrollment_cost=cfg.enrollment_cost,
                 campus_ids=[campus.id],
+                participant_type=cfg.participant_type,
             )
             tid = data["tournament_id"]
             step.ok(f"id={tid} → SEEKING_INSTRUCTOR")

--- a/tests/lifecycle_framework/scenarios/h2h_knockout.py
+++ b/tests/lifecycle_framework/scenarios/h2h_knockout.py
@@ -1,0 +1,153 @@
+"""HEAD_TO_HEAD knockout scenario — reference implementation.
+
+Reproduces the same REWARDS_DISTRIBUTED end-state as
+scripts/seed_rewards_distributed_poc.py using the framework abstractions.
+
+Run:
+    PYTHONPATH=. python -m tests.lifecycle_framework.scenarios.h2h_knockout
+"""
+from __future__ import annotations
+
+from ..framework.auth import AuthContext
+from ..framework.logging import ColoredConsoleLogger
+from ..framework.preflight import build_standard_registry
+from ..framework.sessions import H2HResultStrategy, SessionCompletionStrategy, complete_all_sessions
+from ..framework.transitions import (
+    direct_assign_instructor,
+    accept_instructor_assignment,
+    enroll_players,
+)
+from .base import ScenarioConfig, ScenarioResult, ScenarioRunner
+
+
+class H2HKnockoutStrategy:
+    """ScenarioStrategy for HEAD_TO_HEAD knockout tournaments."""
+
+    def setup_instructor(
+        self,
+        cfg: ScenarioConfig,
+        auth: AuthContext,
+        tournament_id: int,
+    ) -> None:
+        """Direct-assign instructor then have them accept."""
+        direct_assign_instructor(
+            cfg.base_url,
+            auth.admin_token,
+            tournament_id,
+            auth.instructor_id,
+            message="Framework: H2H knockout reference scenario",
+        )
+        accept_instructor_assignment(
+            cfg.base_url,
+            auth.instructor_token,
+            tournament_id,
+        )
+
+    def enroll_participants(
+        self,
+        cfg: ScenarioConfig,
+        auth: AuthContext,
+        tournament_id: int,
+    ) -> None:
+        """Enroll all resolved seed players."""
+        tokens = list(auth.player_tokens.values())
+        enroll_players(cfg.base_url, tokens, tournament_id)
+
+    def extra_pre_checkin_steps(
+        self,
+        cfg: ScenarioConfig,
+        auth: AuthContext,
+        tournament_id: int,
+    ) -> None:
+        """No extra steps needed for H2H knockout."""
+
+    def extra_pre_in_progress_steps(
+        self,
+        cfg: ScenarioConfig,
+        auth: AuthContext,
+        tournament_id: int,
+    ) -> None:
+        """No extra steps needed for H2H knockout."""
+
+    def complete_sessions(
+        self,
+        cfg: ScenarioConfig,
+        auth: AuthContext,
+        tournament_id: int,
+    ) -> int:
+        """Drive the round-by-round H2H session completion loop."""
+        return complete_all_sessions(
+            cfg.base_url,
+            auth.instructor_token,
+            tournament_id,
+            strategy=self.session_completion_strategy(),
+        )
+
+    def session_completion_strategy(self) -> SessionCompletionStrategy:
+        return H2HResultStrategy()
+
+
+class H2HKnockoutScenario:
+    """Ready-to-run H2H knockout scenario with default bootstrap credentials."""
+
+    DEFAULT_CONFIG = ScenarioConfig(
+        base_url="http://localhost:8000",
+        admin_email="admin@lfa.com",
+        admin_password="admin123",
+        instructor_email="instructor@lfa.com",
+        instructor_password="instructor123",
+        player_password="Bootstrap#123",
+        player_email_pattern="lfa-adult-%@lfa.com",
+        player_count=4,
+        age_group="AMATEUR",
+        tournament_format="HEAD_TO_HEAD",
+        tournament_type_code="knockout",
+        max_players=16,
+        enrollment_cost=0,
+    )
+
+    def run(
+        self,
+        base_url: str = "http://localhost:8000",
+        config: ScenarioConfig | None = None,
+    ) -> ScenarioResult:
+        cfg = config or ScenarioConfig(
+            **{**self.DEFAULT_CONFIG.__dict__, "base_url": base_url}
+        )
+        strategy = H2HKnockoutStrategy()
+        registry = build_standard_registry(
+            instructor_email=cfg.instructor_email,
+            age_group=cfg.age_group,
+            player_email_pattern=cfg.player_email_pattern,
+            min_players=cfg.player_count,
+        )
+        runner = ScenarioRunner(
+            config=cfg,
+            strategy=strategy,
+            registry=registry,
+            logger=ColoredConsoleLogger(),
+        )
+        result = runner.run()
+        result.api_verification.assert_all()
+        result.db_verification.assert_all()
+        return result
+
+
+if __name__ == "__main__":
+    import sys
+
+    base_url = sys.argv[1] if len(sys.argv) > 1 else "http://localhost:8000"
+    print(f"\n{'═' * 60}")
+    print("  LFA — H2H Knockout Lifecycle Scenario")
+    print(f"  Target: {base_url}")
+    print(f"{'═' * 60}\n")
+
+    result = H2HKnockoutScenario().run(base_url=base_url)
+
+    print(f"\n{'═' * 60}")
+    print(f"  ✅  PASS — tournament_id={result.tournament_id}")
+    print(f"  Sessions completed : {result.sessions_completed}")
+    print(f"  Players enrolled   : {result.players_enrolled}")
+    print(f"  API checks passed  : {len(result.api_verification.passed)}")
+    print(f"  DB checks passed   : {len(result.db_verification.passed)}")
+    print(f"{'═' * 60}\n")

--- a/tests/lifecycle_framework/scenarios/h2h_knockout.py
+++ b/tests/lifecycle_framework/scenarios/h2h_knockout.py
@@ -16,12 +16,21 @@ from ..framework.transitions import (
     direct_assign_instructor,
     accept_instructor_assignment,
     enroll_players,
+    set_schedule_config,
+    set_reward_config,
 )
 from .base import ScenarioConfig, ScenarioResult, ScenarioRunner
 
 
 class H2HKnockoutStrategy:
-    """ScenarioStrategy for HEAD_TO_HEAD knockout tournaments."""
+    """ScenarioStrategy for HEAD_TO_HEAD knockout tournaments.
+
+    Owns ALL format-specific configuration:
+      - Instructor: direct-assign + accept
+      - Schedule config: set in extra_pre_checkin_steps (required before CHECK_IN_OPEN)
+      - Reward config: set in extra_pre_in_progress_steps (required before IN_PROGRESS)
+      - Session completion: H2HResultStrategy (check-in + head-to-head-results)
+    """
 
     def setup_instructor(
         self,
@@ -59,7 +68,15 @@ class H2HKnockoutStrategy:
         auth: AuthContext,
         tournament_id: int,
     ) -> None:
-        """No extra steps needed for H2H knockout."""
+        """Set schedule config — required before CHECK_IN_OPEN (SCHEDULE_CONFIG_MISSING guard)."""
+        set_schedule_config(
+            cfg.base_url,
+            auth.admin_token,
+            tournament_id,
+            match_duration_minutes=cfg.match_duration_minutes,
+            break_duration_minutes=cfg.break_duration_minutes,
+            parallel_fields=cfg.parallel_fields,
+        )
 
     def extra_pre_in_progress_steps(
         self,
@@ -67,7 +84,12 @@ class H2HKnockoutStrategy:
         auth: AuthContext,
         tournament_id: int,
     ) -> None:
-        """No extra steps needed for H2H knockout."""
+        """Set reward config — required before IN_PROGRESS (REWARD_CONFIG_MISSING guard)."""
+        set_reward_config(
+            cfg.base_url,
+            auth.admin_token,
+            tournament_id,
+        )
 
     def complete_sessions(
         self,

--- a/tests/lifecycle_framework/scenarios/individual_ranking.py
+++ b/tests/lifecycle_framework/scenarios/individual_ranking.py
@@ -1,0 +1,248 @@
+"""INDIVIDUAL_RANKING scenario — Phase 2A.
+
+Validates that SessionCompletionStrategy generalises beyond HEAD_TO_HEAD with zero
+changes to ScenarioRunner, the Protocol, complete_all_sessions(), or ScenarioConfig.
+
+Key structural differences from H2H:
+  - 1 session containing ALL participants (not one session per pair)
+  - result_submitted = bool(session.game_results) — requires finalization, not submit alone
+  - Two mandatory API calls per session: submit results → finalize session
+  - No check-in required (submit_game_results has no prior check-in prerequisite)
+
+Run:
+    PYTHONPATH=. python -m tests.lifecycle_framework.scenarios.individual_ranking
+"""
+from __future__ import annotations
+
+import requests
+
+from ..framework._http import require_ok
+from ..framework.auth import AuthContext
+from ..framework.logging import ColoredConsoleLogger
+from ..framework.preflight import build_standard_registry
+from ..framework.sessions import SessionCompletionStrategy, complete_all_sessions
+from ..framework.transitions import (
+    accept_instructor_assignment,
+    direct_assign_instructor,
+    enroll_players,
+    set_reward_config,
+    set_schedule_config,
+)
+from .base import ScenarioConfig, ScenarioResult, ScenarioRunner
+
+
+class IndividualResultStrategy:
+    """INDIVIDUAL_RANKING session completion: submit placement results then finalize.
+
+    INDIVIDUAL_RANKING generates one session containing all enrolled participants.
+    After submit_game_results, rounds_data is populated and session_status = completed,
+    but game_results remains NULL → result_submitted = False.
+    Finalization writes game_results → result_submitted = True, and also satisfies
+    the COMPLETED lifecycle guard (rewards.py checks game_results IS NOT NULL).
+
+    No check-in is performed — the result submission endpoint does not require it.
+    """
+
+    def complete(
+        self,
+        base_url: str,
+        instructor_token: str,
+        tournament_id: int,
+        session: dict,
+    ) -> bool:
+        """Submit + finalize one INDIVIDUAL_RANKING session.
+
+        Returns True when processed. Returns False only if participant_user_ids is
+        empty — unlike H2H knockout future-round sessions this should not occur for
+        INDIVIDUAL_RANKING (all participants are assigned at session generation time).
+        A False here signals a generation defect, not a normal pending state.
+        """
+        session_id = session["id"]
+        participants = session.get("participant_user_ids") or []
+
+        if not participants:
+            return False
+
+        headers = {"Authorization": f"Bearer {instructor_token}"}
+
+        # Step 1 — submit placement results.
+        # Deterministic: participant[0] rank=1/score=100, participant[1] rank=2/score=90, …
+        # rounds_data is set here; game_results is NOT yet set.
+        results = [
+            {"user_id": uid, "score": float(100 - idx * 10), "rank": idx + 1}
+            for idx, uid in enumerate(participants)
+        ]
+        resp = requests.patch(
+            f"{base_url}/api/v1/sessions/{session_id}/results",
+            headers=headers,
+            json={"results": results},
+            timeout=15,
+        )
+        require_ok(resp, f"session:{session_id}:individual-results")
+
+        # Step 2 — finalize session.
+        # Writes game_results → result_submitted becomes True.
+        # Required before: COMPLETED transition guard + distribute_rewards.
+        # Uses instructor_token; yellow flag: session.instructor_id must equal the
+        # direct-assigned instructor. If 403, a LifecycleError surfaces naturally
+        # via require_ok — see Phase 2A discovery report yellow-flag note.
+        resp = requests.post(
+            f"{base_url}/api/v1/tournaments/{tournament_id}/sessions/{session_id}/finalize",
+            headers=headers,
+            timeout=15,
+        )
+        require_ok(resp, f"session:{session_id}:finalize")
+
+        return True
+
+
+class IndividualRankingStrategy:
+    """ScenarioStrategy for INDIVIDUAL_RANKING tournaments.
+
+    All 6 hooks delegate to existing transition functions — no new orchestration.
+    The only format-specific logic is IndividualResultStrategy.
+    """
+
+    def setup_instructor(
+        self,
+        cfg: ScenarioConfig,
+        auth: AuthContext,
+        tournament_id: int,
+    ) -> None:
+        direct_assign_instructor(
+            cfg.base_url,
+            auth.admin_token,
+            tournament_id,
+            auth.instructor_id,
+            message="Framework: Individual ranking Phase 2A scenario",
+        )
+        accept_instructor_assignment(
+            cfg.base_url,
+            auth.instructor_token,
+            tournament_id,
+        )
+
+    def enroll_participants(
+        self,
+        cfg: ScenarioConfig,
+        auth: AuthContext,
+        tournament_id: int,
+    ) -> None:
+        tokens = list(auth.player_tokens.values())
+        enroll_players(cfg.base_url, tokens, tournament_id)
+
+    def extra_pre_checkin_steps(
+        self,
+        cfg: ScenarioConfig,
+        auth: AuthContext,
+        tournament_id: int,
+    ) -> None:
+        """Set schedule config — required before CHECK_IN_OPEN (SCHEDULE_CONFIG_MISSING guard)."""
+        set_schedule_config(
+            cfg.base_url,
+            auth.admin_token,
+            tournament_id,
+            match_duration_minutes=cfg.match_duration_minutes,
+            break_duration_minutes=cfg.break_duration_minutes,
+            parallel_fields=cfg.parallel_fields,
+        )
+
+    def extra_pre_in_progress_steps(
+        self,
+        cfg: ScenarioConfig,
+        auth: AuthContext,
+        tournament_id: int,
+    ) -> None:
+        """Set reward config — required before IN_PROGRESS (REWARD_CONFIG_MISSING guard)."""
+        set_reward_config(
+            cfg.base_url,
+            auth.admin_token,
+            tournament_id,
+        )
+
+    def complete_sessions(
+        self,
+        cfg: ScenarioConfig,
+        auth: AuthContext,
+        tournament_id: int,
+    ) -> int:
+        return complete_all_sessions(
+            cfg.base_url,
+            auth.instructor_token,
+            tournament_id,
+            strategy=self.session_completion_strategy(),
+        )
+
+    def session_completion_strategy(self) -> SessionCompletionStrategy:
+        return IndividualResultStrategy()
+
+
+class IndividualRankingScenario:
+    """Ready-to-run INDIVIDUAL_RANKING scenario with default bootstrap credentials.
+
+    tournament_type_code is present in ScenarioConfig but ignored by the ops endpoint
+    for INDIVIDUAL_RANKING — tournament_type_id is always NULL for this format.
+    scoring_type defaults to PLACEMENT inside the ops endpoint.
+    """
+
+    DEFAULT_CONFIG = ScenarioConfig(
+        base_url="http://localhost:8000",
+        admin_email="admin@lfa.com",
+        admin_password="admin123",
+        instructor_email="instructor@lfa.com",
+        instructor_password="instructor123",
+        player_password="Bootstrap#123",
+        player_email_pattern="lfa-adult-%@lfa.com",
+        player_count=4,
+        age_group="AMATEUR",
+        tournament_format="INDIVIDUAL_RANKING",
+        tournament_type_code="knockout",  # ignored by ops endpoint for INDIVIDUAL_RANKING
+        max_players=16,
+        enrollment_cost=0,
+    )
+
+    def run(
+        self,
+        base_url: str = "http://localhost:8000",
+        config: ScenarioConfig | None = None,
+    ) -> ScenarioResult:
+        cfg = config or ScenarioConfig(
+            **{**self.DEFAULT_CONFIG.__dict__, "base_url": base_url}
+        )
+        strategy = IndividualRankingStrategy()
+        registry = build_standard_registry(
+            instructor_email=cfg.instructor_email,
+            age_group=cfg.age_group,
+            player_email_pattern=cfg.player_email_pattern,
+            min_players=cfg.player_count,
+        )
+        runner = ScenarioRunner(
+            config=cfg,
+            strategy=strategy,
+            registry=registry,
+            logger=ColoredConsoleLogger(),
+        )
+        result = runner.run()
+        result.api_verification.assert_all()
+        result.db_verification.assert_all()
+        return result
+
+
+if __name__ == "__main__":
+    import sys
+
+    base_url = sys.argv[1] if len(sys.argv) > 1 else "http://localhost:8000"
+    print(f"\n{'═' * 60}")
+    print("  LFA — Individual Ranking Lifecycle Scenario")
+    print(f"  Target: {base_url}")
+    print(f"{'═' * 60}\n")
+
+    result = IndividualRankingScenario().run(base_url=base_url)
+
+    print(f"\n{'═' * 60}")
+    print(f"  ✅  PASS — tournament_id={result.tournament_id}")
+    print(f"  Sessions completed : {result.sessions_completed}")
+    print(f"  Players enrolled   : {result.players_enrolled}")
+    print(f"  API checks passed  : {len(result.api_verification.passed)}")
+    print(f"  DB checks passed   : {len(result.db_verification.passed)}")
+    print(f"{'═' * 60}\n")

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -311,6 +311,71 @@
         "title": "AddXPRequest",
         "type": "object"
       },
+      "AdminAddMemberRequest": {
+        "properties": {
+          "role": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": "PLAYER",
+            "title": "Role"
+          },
+          "user_id": {
+            "title": "User Id",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "user_id"
+        ],
+        "title": "AdminAddMemberRequest",
+        "type": "object"
+      },
+      "AdminCreateTeamRequest": {
+        "properties": {
+          "captain_user_id": {
+            "title": "Captain User Id",
+            "type": "integer"
+          },
+          "code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Code"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "specialization_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Specialization Type"
+          }
+        },
+        "required": [
+          "name",
+          "captain_user_id"
+        ],
+        "title": "AdminCreateTeamRequest",
+        "type": "object"
+      },
       "AnswerQuestionRequest": {
         "properties": {
           "answer_text": {
@@ -11055,6 +11120,16 @@
             "description": "Number of rounds for INDIVIDUAL_RANKING tournaments (1\u201320). Defaults to 1 if omitted.",
             "title": "Number Of Rounds"
           },
+          "participant_type": {
+            "default": "INDIVIDUAL",
+            "description": "Participant type for the tournament: 'INDIVIDUAL' or 'TEAM'. Default: 'INDIVIDUAL' (all existing callers are unaffected). Set to 'TEAM' to create a team-based tournament (TeamLeagueScenario prerequisite). MIXED is not accepted \u2014 no implemented flow behind it.",
+            "enum": [
+              "INDIVIDUAL",
+              "TEAM"
+            ],
+            "title": "Participant Type",
+            "type": "string"
+          },
           "player_count": {
             "default": 1024,
             "description": "Number of players to seed + enroll (0\u20131024). Use 0 for testing enrollment workflows.",
@@ -18155,6 +18230,19 @@
           "recorded_at"
         ],
         "title": "TeachingHoursResponse",
+        "type": "object"
+      },
+      "TeamEnrollRequest": {
+        "properties": {
+          "team_id": {
+            "title": "Team Id",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "team_id"
+        ],
+        "title": "TeamEnrollRequest",
         "type": "object"
       },
       "TeamResultEntry": {
@@ -51806,6 +51894,51 @@
         ]
       }
     },
+    "/api/v1/teams": {
+      "post": {
+        "description": "Admin-only: create a team with an explicit captain. Bearer-token auth.",
+        "operationId": "admin_create_team_api_v1_teams_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AdminCreateTeamRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Admin Create Team",
+        "tags": [
+          "teams"
+        ]
+      }
+    },
     "/api/v1/teams/invites/my": {
       "get": {
         "description": "Get all pending invites for the current user.",
@@ -52074,6 +52207,62 @@
           }
         ],
         "summary": "Cancel Invite",
+        "tags": [
+          "teams"
+        ]
+      }
+    },
+    "/api/v1/teams/{team_id}/members": {
+      "post": {
+        "description": "Admin-only: add a user directly to a team without the invite flow. Bearer-token auth.",
+        "operationId": "admin_add_team_member_api_v1_teams__team_id__members_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "team_id",
+            "required": true,
+            "schema": {
+              "title": "Team Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AdminAddMemberRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Admin Add Team Member",
         "tags": [
           "teams"
         ]
@@ -53952,6 +54141,62 @@
           }
         ],
         "summary": "Enroll In Tournament",
+        "tags": [
+          "tournaments"
+        ]
+      }
+    },
+    "/api/v1/tournaments/{tournament_id}/enroll-team": {
+      "post": {
+        "description": "Admin-only: enroll an existing team into a TEAM tournament.\n\nGuards (enforced by service):\n- tournament exists, participant_type == TEAM, status == ENROLLMENT_OPEN\n- team exists and is active\n- no duplicate enrollment (idempotent: returns existing enrollment on repeat call)\n- if team_enrollment_cost > 0: deducts from captain's credit balance\n\nReturns 200 whether the enrollment is new or pre-existing (idempotent).",
+        "operationId": "admin_enroll_team_api_v1_tournaments__tournament_id__enroll_team_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tournament_id",
+            "required": true,
+            "schema": {
+              "title": "Tournament Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TeamEnrollRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Admin Enroll Team",
         "tags": [
           "tournaments"
         ]

--- a/tests/unit/api/test_team_api_v1.py
+++ b/tests/unit/api/test_team_api_v1.py
@@ -1,0 +1,220 @@
+"""
+Unit tests for Team API v1 endpoints.
+
+Coverage:
+  POST /api/v1/teams  (admin_create_team)
+    T1  non-admin caller → 403
+    T2  captain_user_id not found → 404 (service raises)
+    T3  duplicate team code → 409 (service raises)
+    T4  success → 201 with id/name/code/captain_user_id
+
+  POST /api/v1/teams/{team_id}/members  (admin_add_team_member)
+    T5  non-admin caller → 403
+    T6  team not found → 404 (service raises)
+    T7  user already a member → 409 (service raises)
+    T8  success → 201 with id/team_id/user_id/role
+
+  POST /api/v1/tournaments/{tournament_id}/enroll-team  (admin_enroll_team)
+    T9   non-admin caller → 403
+    T10  team not found → 404 (service raises)
+    T11  tournament participant_type != TEAM → 400 (service raises)
+    T12  tournament status != ENROLLMENT_OPEN → 400 (service raises)
+    T13  success, cost=0 → 200, enrolled=True
+"""
+import pytest
+from unittest.mock import MagicMock, patch
+from fastapi import HTTPException
+
+from app.api.api_v1.endpoints.teams import (
+    admin_create_team,
+    AdminCreateTeamRequest,
+    admin_add_team_member,
+    AdminAddMemberRequest,
+)
+from app.api.api_v1.endpoints.tournaments.team_enrollment import (
+    admin_enroll_team,
+    TeamEnrollRequest,
+)
+from app.models.user import UserRole
+
+_TEAMS_BASE = "app.api.api_v1.endpoints.teams.team_service"
+_TE_BASE = "app.api.api_v1.endpoints.tournaments.team_enrollment.team_service"
+
+
+def _admin_user():
+    u = MagicMock()
+    u.role = UserRole.ADMIN
+    return u
+
+
+def _non_admin_user():
+    u = MagicMock()
+    u.role = UserRole.STUDENT
+    return u
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# POST /teams  — admin_create_team
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestAdminCreateTeam:
+    def test_T1_non_admin_raises_403(self):
+        db = MagicMock()
+        body = AdminCreateTeamRequest(name="Alpha", captain_user_id=1)
+        with pytest.raises(HTTPException) as exc_info:
+            admin_create_team(body=body, db=db, current_user=_non_admin_user())
+        assert exc_info.value.status_code == 403
+
+    @patch(f"{_TEAMS_BASE}.create_team")
+    def test_T2_captain_not_found_propagates_404(self, mock_create):
+        mock_create.side_effect = HTTPException(status_code=404, detail="Captain user not found")
+        db = MagicMock()
+        body = AdminCreateTeamRequest(name="Beta", captain_user_id=999)
+        with pytest.raises(HTTPException) as exc_info:
+            admin_create_team(body=body, db=db, current_user=_admin_user())
+        assert exc_info.value.status_code == 404
+
+    @patch(f"{_TEAMS_BASE}.create_team")
+    def test_T3_duplicate_code_propagates_409(self, mock_create):
+        mock_create.side_effect = HTTPException(status_code=409, detail="Team code 'X' already exists")
+        db = MagicMock()
+        body = AdminCreateTeamRequest(name="Gamma", captain_user_id=1, code="X")
+        with pytest.raises(HTTPException) as exc_info:
+            admin_create_team(body=body, db=db, current_user=_admin_user())
+        assert exc_info.value.status_code == 409
+
+    @patch(f"{_TEAMS_BASE}.create_team")
+    def test_T4_success_returns_201_fields(self, mock_create):
+        fake_team = MagicMock()
+        fake_team.id = 42
+        fake_team.name = "Delta"
+        fake_team.code = "TEAM-DELTA"
+        fake_team.captain_user_id = 7
+        mock_create.return_value = fake_team
+
+        db = MagicMock()
+        body = AdminCreateTeamRequest(name="Delta", captain_user_id=7)
+        result = admin_create_team(body=body, db=db, current_user=_admin_user())
+
+        assert result["id"] == 42
+        assert result["name"] == "Delta"
+        assert result["code"] == "TEAM-DELTA"
+        assert result["captain_user_id"] == 7
+        mock_create.assert_called_once_with(db, name="Delta", captain_user_id=7, specialization_type="", code=None)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# POST /teams/{team_id}/members  — admin_add_team_member
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestAdminAddTeamMember:
+    def test_T5_non_admin_raises_403(self):
+        db = MagicMock()
+        body = AdminAddMemberRequest(user_id=10)
+        with pytest.raises(HTTPException) as exc_info:
+            admin_add_team_member(team_id=1, body=body, db=db, current_user=_non_admin_user())
+        assert exc_info.value.status_code == 403
+
+    @patch(f"{_TEAMS_BASE}.add_team_member")
+    def test_T6_team_not_found_propagates_404(self, mock_add):
+        mock_add.side_effect = HTTPException(status_code=404, detail="Team not found")
+        db = MagicMock()
+        body = AdminAddMemberRequest(user_id=10)
+        with pytest.raises(HTTPException) as exc_info:
+            admin_add_team_member(team_id=999, body=body, db=db, current_user=_admin_user())
+        assert exc_info.value.status_code == 404
+
+    @patch(f"{_TEAMS_BASE}.add_team_member")
+    def test_T7_already_member_propagates_409(self, mock_add):
+        mock_add.side_effect = HTTPException(status_code=409, detail="User is already a team member")
+        db = MagicMock()
+        body = AdminAddMemberRequest(user_id=10)
+        with pytest.raises(HTTPException) as exc_info:
+            admin_add_team_member(team_id=1, body=body, db=db, current_user=_admin_user())
+        assert exc_info.value.status_code == 409
+
+    @patch(f"{_TEAMS_BASE}.add_team_member")
+    def test_T8_success_returns_201_fields(self, mock_add):
+        fake_member = MagicMock()
+        fake_member.id = 55
+        fake_member.team_id = 1
+        fake_member.user_id = 10
+        fake_member.role = "PLAYER"
+        mock_add.return_value = fake_member
+
+        db = MagicMock()
+        body = AdminAddMemberRequest(user_id=10)
+        result = admin_add_team_member(team_id=1, body=body, db=db, current_user=_admin_user())
+
+        assert result["id"] == 55
+        assert result["team_id"] == 1
+        assert result["user_id"] == 10
+        assert result["role"] == "PLAYER"
+        mock_add.assert_called_once_with(db, team_id=1, user_id=10, role="PLAYER")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# POST /tournaments/{tournament_id}/enroll-team  — admin_enroll_team
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestAdminEnrollTeam:
+    def test_T9_non_admin_raises_403(self):
+        db = MagicMock()
+        body = TeamEnrollRequest(team_id=5)
+        with pytest.raises(HTTPException) as exc_info:
+            admin_enroll_team(tournament_id=1, body=body, db=db, current_user=_non_admin_user())
+        assert exc_info.value.status_code == 403
+
+    @patch(f"{_TE_BASE}.admin_enroll_team_in_tournament")
+    def test_T10_team_not_found_propagates_404(self, mock_enroll):
+        mock_enroll.side_effect = HTTPException(status_code=404, detail="Team not found")
+        db = MagicMock()
+        body = TeamEnrollRequest(team_id=999)
+        with pytest.raises(HTTPException) as exc_info:
+            admin_enroll_team(tournament_id=1, body=body, db=db, current_user=_admin_user())
+        assert exc_info.value.status_code == 404
+
+    @patch(f"{_TE_BASE}.admin_enroll_team_in_tournament")
+    def test_T11_not_team_tournament_returns_400(self, mock_enroll):
+        mock_enroll.side_effect = HTTPException(
+            status_code=400,
+            detail="This tournament does not support team enrollment",
+        )
+        db = MagicMock()
+        body = TeamEnrollRequest(team_id=5)
+        with pytest.raises(HTTPException) as exc_info:
+            admin_enroll_team(tournament_id=1, body=body, db=db, current_user=_admin_user())
+        assert exc_info.value.status_code == 400
+
+    @patch(f"{_TE_BASE}.admin_enroll_team_in_tournament")
+    def test_T12_enrollment_not_open_returns_400(self, mock_enroll):
+        mock_enroll.side_effect = HTTPException(
+            status_code=400,
+            detail="Tournament enrollment is not open (current status: IN_PROGRESS)",
+        )
+        db = MagicMock()
+        body = TeamEnrollRequest(team_id=5)
+        with pytest.raises(HTTPException) as exc_info:
+            admin_enroll_team(tournament_id=1, body=body, db=db, current_user=_admin_user())
+        assert exc_info.value.status_code == 400
+        assert "ENROLLMENT_OPEN" not in str(exc_info.value.detail) or True  # status in message
+
+    @patch(f"{_TE_BASE}.admin_enroll_team_in_tournament")
+    def test_T13_success_cost_zero_returns_200_enrolled(self, mock_enroll):
+        fake_enrollment = MagicMock()
+        fake_enrollment.id = 88
+        fake_enrollment.team_id = 5
+        fake_enrollment.semester_id = 1
+        fake_enrollment.payment_verified = True
+        mock_enroll.return_value = fake_enrollment
+
+        db = MagicMock()
+        body = TeamEnrollRequest(team_id=5)
+        result = admin_enroll_team(tournament_id=1, body=body, db=db, current_user=_admin_user())
+
+        assert result["enrolled"] is True
+        assert result["enrollment_id"] == 88
+        assert result["team_id"] == 5
+        assert result["tournament_id"] == 1
+        assert result["payment_verified"] is True
+        mock_enroll.assert_called_once_with(db, team_id=5, tournament_id=1)

--- a/tests/unit/api/test_team_api_v1.py
+++ b/tests/unit/api/test_team_api_v1.py
@@ -1,5 +1,5 @@
 """
-Unit tests for Team API v1 endpoints.
+Unit tests for Team API v1 endpoints + admin_enroll_team_in_tournament cost policy.
 
 Coverage:
   POST /api/v1/teams  (admin_create_team)
@@ -20,9 +20,13 @@ Coverage:
     T11  tournament participant_type != TEAM → 400 (service raises)
     T12  tournament status != ENROLLMENT_OPEN → 400 (service raises)
     T13  success, cost=0 → 200, enrolled=True
+
+  admin_enroll_team_in_tournament — cost policy (service-level, MagicMock DB)
+    T14  cost>0, sufficient credits → deducts from captain once, creates CreditTransaction
+    T15  cost>0, pre-existing enrollment → returns existing, no debit (double-debit proof)
 """
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 from fastapi import HTTPException
 
 from app.api.api_v1.endpoints.teams import (
@@ -36,6 +40,11 @@ from app.api.api_v1.endpoints.tournaments.team_enrollment import (
     TeamEnrollRequest,
 )
 from app.models.user import UserRole
+from app.models.team import Team, TournamentTeamEnrollment
+from app.models.semester import Semester
+from app.models.tournament_configuration import TournamentConfiguration
+from app.models.license import UserLicense
+from app.models.credit_transaction import CreditTransaction
 
 _TEAMS_BASE = "app.api.api_v1.endpoints.teams.team_service"
 _TE_BASE = "app.api.api_v1.endpoints.tournaments.team_enrollment.team_service"
@@ -218,3 +227,140 @@ class TestAdminEnrollTeam:
         assert result["tournament_id"] == 1
         assert result["payment_verified"] is True
         mock_enroll.assert_called_once_with(db, team_id=5, tournament_id=1)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# admin_enroll_team_in_tournament — cost policy (service-level, MagicMock DB)
+# ─────────────────────────────────────────────────────────────────────────────
+
+_SVC = "app.services.tournament.team_service"
+
+
+def _make_db(team, tournament, cfg, existing_enrollment, license_obj):
+    """
+    Build a MagicMock db whose .query() returns the right object per model.
+
+    For UserLicense the chain is .filter().with_for_update().first().
+    For all others it is .filter().first().
+    """
+    db = MagicMock()
+
+    def _query(model):
+        q = MagicMock()
+        if model is Team:
+            q.filter.return_value.first.return_value = team
+        elif model is Semester:
+            q.filter.return_value.first.return_value = tournament
+        elif model is TournamentConfiguration:
+            q.filter.return_value.first.return_value = cfg
+        elif model is TournamentTeamEnrollment:
+            q.filter.return_value.first.return_value = existing_enrollment
+        elif model is UserLicense:
+            q.filter.return_value.with_for_update.return_value.first.return_value = license_obj
+        return q
+
+    db.query.side_effect = _query
+    return db
+
+
+class TestAdminEnrollTeamCostPolicy:
+    """
+    Service-level tests for admin_enroll_team_in_tournament cost policy.
+
+    Uses MagicMock DB — no real database required.
+    Directly tests the service function (not the endpoint wrapper).
+    """
+
+    def test_T14_cost_positive_debits_captain_once(self):
+        """First enrollment with cost>0 deducts from captain's credit balance."""
+        from app.services.tournament.team_service import admin_enroll_team_in_tournament
+
+        COST = 50
+        INITIAL_BALANCE = 200
+
+        fake_team = MagicMock()
+        fake_team.is_active = True
+        fake_team.captain_user_id = 7
+
+        fake_tournament = MagicMock()
+        fake_tournament.tournament_status = "ENROLLMENT_OPEN"
+
+        fake_cfg = MagicMock()
+        fake_cfg.participant_type = "TEAM"
+        fake_cfg.team_enrollment_cost = COST
+
+        fake_license = MagicMock()
+        fake_license.id = 99
+        fake_license.credit_balance = INITIAL_BALANCE
+
+        db = _make_db(
+            team=fake_team,
+            tournament=fake_tournament,
+            cfg=fake_cfg,
+            existing_enrollment=None,   # no prior enrollment
+            license_obj=fake_license,
+        )
+
+        admin_enroll_team_in_tournament(db, team_id=5, tournament_id=1)
+
+        # Credit was deducted from captain
+        assert fake_license.credit_balance == INITIAL_BALANCE - COST
+
+        # A CreditTransaction was added to the session
+        added_objects = [c.args[0] for c in db.add.call_args_list]
+        credit_txs = [o for o in added_objects if isinstance(o, CreditTransaction)]
+        assert len(credit_txs) == 1, f"Expected 1 CreditTransaction, got {len(credit_txs)}"
+        assert credit_txs[0].amount == -COST
+        assert credit_txs[0].balance_after == INITIAL_BALANCE - COST
+
+    def test_T15_cost_positive_duplicate_no_double_debit(self):
+        """Repeat enrollment returns existing record; captain balance is NOT touched."""
+        from app.services.tournament.team_service import admin_enroll_team_in_tournament
+
+        COST = 50
+        INITIAL_BALANCE = 200
+
+        fake_team = MagicMock()
+        fake_team.is_active = True
+        fake_team.captain_user_id = 7
+
+        fake_tournament = MagicMock()
+        fake_tournament.tournament_status = "ENROLLMENT_OPEN"
+
+        fake_cfg = MagicMock()
+        fake_cfg.participant_type = "TEAM"
+        fake_cfg.team_enrollment_cost = COST
+
+        fake_license = MagicMock()
+        fake_license.credit_balance = INITIAL_BALANCE
+
+        # Pre-existing enrollment — service must return early without debit
+        existing = MagicMock()
+        existing.id = 42
+        existing.team_id = 5
+        existing.semester_id = 1
+        existing.payment_verified = False
+
+        db = _make_db(
+            team=fake_team,
+            tournament=fake_tournament,
+            cfg=fake_cfg,
+            existing_enrollment=existing,
+            license_obj=fake_license,
+        )
+
+        result = admin_enroll_team_in_tournament(db, team_id=5, tournament_id=1)
+
+        # Returns the existing enrollment unchanged
+        assert result is existing
+
+        # Captain balance untouched
+        assert fake_license.credit_balance == INITIAL_BALANCE
+
+        # No CreditTransaction created
+        added_objects = [c.args[0] for c in db.add.call_args_list]
+        credit_txs = [o for o in added_objects if isinstance(o, CreditTransaction)]
+        assert len(credit_txs) == 0, f"Expected 0 CreditTransactions, got {len(credit_txs)}"
+
+        # db.commit() was NOT called (early return before any write)
+        db.commit.assert_not_called()

--- a/tests/unit/services/test_instructor_assignment_endpoint.py
+++ b/tests/unit/services/test_instructor_assignment_endpoint.py
@@ -153,7 +153,9 @@ class TestAcceptInstructorAssignment:
         t = _tournament(status="SEEKING_INSTRUCTOR")
         s1, s2 = MagicMock(), MagicMock()
         db = _seq_db(_q(all_=[s1, s2]))
-        with _mock_repo(t), patch(f"{_BASE}.LicenseValidator"):
+        _elig = "app.services.tournament.instructor_eligibility_service.is_eligible_master_instructor"
+        with _mock_repo(t), patch(f"{_BASE}.LicenseValidator"), \
+                patch(_elig, return_value=(True, "")):
             result = accept_instructor_assignment(1, db=db, current_user=_instructor(42))
         assert result["message"] == "Tournament assignment accepted successfully"
         assert result["sessions_updated"] == 2
@@ -164,7 +166,9 @@ class TestAcceptInstructorAssignment:
     def test_success_pending_acceptance_no_sessions(self):
         t = _tournament(status="PENDING_INSTRUCTOR_ACCEPTANCE")
         db = _seq_db(_q(all_=[]))
-        with _mock_repo(t), patch(f"{_BASE}.LicenseValidator"):
+        _elig = "app.services.tournament.instructor_eligibility_service.is_eligible_master_instructor"
+        with _mock_repo(t), patch(f"{_BASE}.LicenseValidator"), \
+                patch(_elig, return_value=(True, "")):
             result = accept_instructor_assignment(1, db=db, current_user=_instructor())
         assert result["sessions_updated"] == 0
 
@@ -172,7 +176,9 @@ class TestAcceptInstructorAssignment:
         t = _tournament(status="SEEKING_INSTRUCTOR")
         t.start_date = None
         db = _seq_db(_q(all_=[]))
-        with _mock_repo(t), patch(f"{_BASE}.LicenseValidator"):
+        _elig = "app.services.tournament.instructor_eligibility_service.is_eligible_master_instructor"
+        with _mock_repo(t), patch(f"{_BASE}.LicenseValidator"), \
+                patch(_elig, return_value=(True, "")):
             result = accept_instructor_assignment(1, db=db, current_user=_instructor())
         assert result["tournament_date"] is None
 

--- a/tests/unit/services/test_instructor_eligibility_service.py
+++ b/tests/unit/services/test_instructor_eligibility_service.py
@@ -1,0 +1,481 @@
+"""
+Instructor Eligibility Service — Unit + Integration Tests
+
+Covers rögzített domain policy (2026-05-07):
+  Master:   role=INSTRUCTOR + is_active + active non-expired LFA_COACH license
+            + current_level >= required_level(age_groups)
+  Field:    same + level >= max(1, required_level - 1)
+  payment_verified: out-of-scope
+  revoked/suspended: is_active=False covers it
+
+Test IDs:
+  E-01  eligible master instructor accepted
+  E-02  inactive user rejected
+  E-03  wrong role rejected
+  E-04  no license rejected
+  E-05  inactive license rejected
+  E-06  expired license rejected (aware datetime)
+  E-07  level too low for master rejected
+  E-08  level sufficient for master accepted
+  E-09  field instructor one level lower accepted
+  E-10  field instructor too low rejected
+  E-11  multi-age — highest age_group requirement applies
+  E-12  expires_at=None accepted (perpetual license)
+  E-13  naive expires_at in past rejected  (timezone-safe)
+  E-14  naive expires_at in future accepted (timezone-safe)
+  E-15  _to_utc_aware normalizes both naive and aware datetimes
+  E-16  get_eligible_master_instructors — only eligible in list
+  E-17  get_instructor_license_levels — correct mapping
+  E-18  resolve_tournament_age_groups — priority logic
+  E-19  check_tournament_master_instructor_eligible — no master assigned
+  E-20  check_tournament_master_instructor_eligible — assigned but ineligible
+
+Run:
+  pytest tests/unit/services/test_instructor_eligibility_service.py -v
+"""
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.core.security import get_password_hash
+from app.models.license import UserLicense
+from app.models.user import User, UserRole
+from app.services.tournament.instructor_eligibility_service import (
+    _to_utc_aware,
+    check_tournament_master_instructor_eligible,
+    get_eligible_master_instructors,
+    get_instructor_license_levels,
+    is_eligible_field_instructor,
+    is_eligible_master_instructor,
+    resolve_tournament_age_groups,
+)
+
+
+# ── Factories ─────────────────────────────────────────────────────────────────
+
+def _uid() -> str:
+    return uuid.uuid4().hex[:8]
+
+
+def _make_instructor(db: Session, *, is_active: bool = True) -> User:
+    u = User(
+        email=f"instr-{_uid()}@lfa.com",
+        name=f"Instructor {_uid()}",
+        password_hash=get_password_hash("pw"),
+        role=UserRole.INSTRUCTOR,
+        is_active=is_active,
+    )
+    db.add(u)
+    db.flush()
+    return u
+
+
+def _make_coach_license(
+    db: Session,
+    user: User,
+    *,
+    level: int = 5,
+    is_active: bool = True,
+    expires_at: datetime | None = None,
+) -> UserLicense:
+    lic = UserLicense(
+        user_id=user.id,
+        specialization_type="LFA_COACH",
+        current_level=level,
+        max_achieved_level=level,
+        is_active=is_active,
+        expires_at=expires_at,
+        started_at=datetime.now(timezone.utc),
+    )
+    db.add(lic)
+    db.flush()
+    return lic
+
+
+# ── Timezone helper tests ─────────────────────────────────────────────────────
+
+class TestToUtcAware:
+    """E-15: _to_utc_aware normalizes naive and aware datetimes."""
+
+    def test_naive_becomes_utc_aware(self):
+        naive = datetime(2026, 1, 1, 12, 0, 0)  # no tzinfo
+        result = _to_utc_aware(naive)
+        assert result.tzinfo is not None
+        assert result.tzinfo == timezone.utc
+        assert result.year == 2026
+
+    def test_already_utc_aware_unchanged_value(self):
+        aware = datetime(2026, 6, 1, 0, 0, tzinfo=timezone.utc)
+        result = _to_utc_aware(aware)
+        assert result == aware
+
+    def test_non_utc_aware_converted_to_utc(self):
+        from datetime import timezone as tz
+        import zoneinfo
+        try:
+            budapest = zoneinfo.ZoneInfo("Europe/Budapest")
+            dt = datetime(2026, 6, 1, 14, 0, tzinfo=budapest)
+            result = _to_utc_aware(dt)
+            # 14:00 CEST (UTC+2) = 12:00 UTC
+            assert result.tzinfo == timezone.utc
+            assert result.hour == 12
+        except Exception:
+            pytest.skip("zoneinfo not available or tz data missing")
+
+
+# ── Master instructor eligibility ─────────────────────────────────────────────
+
+class TestIsEligibleMasterInstructor:
+    """E-01 through E-12: master instructor policy checks."""
+
+    def test_e01_eligible_master_accepted(self, postgres_db: Session):
+        """E-01: role=INSTRUCTOR, is_active, active non-expired license, level ≥ min."""
+        instr = _make_instructor(postgres_db)
+        _make_coach_license(postgres_db, instr, level=5)
+        postgres_db.commit()
+
+        ok, reason = is_eligible_master_instructor(postgres_db, instr.id, ["AMATEUR"])
+        assert ok is True
+        assert reason == ""
+
+    def test_e02_inactive_user_rejected(self, postgres_db: Session):
+        """E-02: User.is_active=False → rejected."""
+        instr = _make_instructor(postgres_db, is_active=False)
+        _make_coach_license(postgres_db, instr, level=5)
+        postgres_db.commit()
+
+        ok, reason = is_eligible_master_instructor(postgres_db, instr.id, ["AMATEUR"])
+        assert ok is False
+        assert "inactive" in reason.lower()
+
+    def test_e03_wrong_role_rejected(self, postgres_db: Session):
+        """E-03: UserRole.ADMIN is not eligible as instructor."""
+        admin = User(
+            email=f"admin-{_uid()}@lfa.com",
+            name="Admin",
+            password_hash=get_password_hash("pw"),
+            role=UserRole.ADMIN,
+            is_active=True,
+        )
+        postgres_db.add(admin)
+        postgres_db.flush()
+        _make_coach_license(postgres_db, admin, level=8)
+        postgres_db.commit()
+
+        ok, reason = is_eligible_master_instructor(postgres_db, admin.id, ["AMATEUR"])
+        assert ok is False
+        assert "instructor" in reason.lower()
+
+    def test_e04_no_license_rejected(self, postgres_db: Session):
+        """E-04: No UserLicense row exists → rejected."""
+        instr = _make_instructor(postgres_db)
+        postgres_db.commit()
+
+        ok, reason = is_eligible_master_instructor(postgres_db, instr.id, ["AMATEUR"])
+        assert ok is False
+        assert "license" in reason.lower()
+
+    def test_e05_inactive_license_rejected(self, postgres_db: Session):
+        """E-05: UserLicense.is_active=False → rejected even if not expired."""
+        instr = _make_instructor(postgres_db)
+        _make_coach_license(postgres_db, instr, level=5, is_active=False)
+        postgres_db.commit()
+
+        ok, reason = is_eligible_master_instructor(postgres_db, instr.id, ["AMATEUR"])
+        assert ok is False
+        assert "license" in reason.lower()
+
+    def test_e06_expired_license_aware_rejected(self, postgres_db: Session):
+        """E-06: expires_at in the past (timezone-aware) → rejected."""
+        instr = _make_instructor(postgres_db)
+        past = datetime.now(timezone.utc) - timedelta(days=1)
+        _make_coach_license(postgres_db, instr, level=5, expires_at=past)
+        postgres_db.commit()
+
+        ok, reason = is_eligible_master_instructor(postgres_db, instr.id, ["AMATEUR"])
+        assert ok is False
+        assert "license" in reason.lower()
+
+    def test_e07_level_too_low_master_rejected(self, postgres_db: Session):
+        """E-07: level 3 for AMATEUR (min 5) → rejected."""
+        instr = _make_instructor(postgres_db)
+        _make_coach_license(postgres_db, instr, level=3)
+        postgres_db.commit()
+
+        ok, reason = is_eligible_master_instructor(postgres_db, instr.id, ["AMATEUR"])
+        assert ok is False
+        assert "insufficient" in reason.lower() or "level" in reason.lower()
+
+    def test_e08_level_sufficient_master_accepted(self, postgres_db: Session):
+        """E-08: level 5 for AMATEUR (min 5) → accepted (boundary value)."""
+        instr = _make_instructor(postgres_db)
+        _make_coach_license(postgres_db, instr, level=5)
+        postgres_db.commit()
+
+        ok, _ = is_eligible_master_instructor(postgres_db, instr.id, ["AMATEUR"])
+        assert ok is True
+
+    def test_e11_multi_age_highest_requirement_applies(self, postgres_db: Session):
+        """E-11: ["PRE", "AMATEUR"] → level 5 required (AMATEUR dominates)."""
+        instr_low = _make_instructor(postgres_db)
+        _make_coach_license(postgres_db, instr_low, level=3)  # ok for PRE, not AMATEUR
+
+        instr_high = _make_instructor(postgres_db)
+        _make_coach_license(postgres_db, instr_high, level=5)  # ok for both
+
+        postgres_db.commit()
+
+        ok_low, _ = is_eligible_master_instructor(postgres_db, instr_low.id, ["PRE", "AMATEUR"])
+        ok_high, _ = is_eligible_master_instructor(postgres_db, instr_high.id, ["PRE", "AMATEUR"])
+
+        assert ok_low is False
+        assert ok_high is True
+
+    def test_e12_expires_at_none_accepted(self, postgres_db: Session):
+        """E-12: expires_at=None (perpetual license) → accepted."""
+        instr = _make_instructor(postgres_db)
+        _make_coach_license(postgres_db, instr, level=5, expires_at=None)
+        postgres_db.commit()
+
+        ok, _ = is_eligible_master_instructor(postgres_db, instr.id, ["AMATEUR"])
+        assert ok is True
+
+    def test_e13_naive_past_expires_at_rejected(self, postgres_db: Session):
+        """E-13: expires_at as naive datetime in the past → rejected (timezone-safe)."""
+        instr = _make_instructor(postgres_db)
+        # Naive datetime (no tzinfo) — stored as TIMESTAMP WITHOUT TZ in PostgreSQL
+        naive_past = datetime(2020, 1, 1, 0, 0, 0)  # clearly in the past, no tzinfo
+        _make_coach_license(postgres_db, instr, level=5, expires_at=naive_past)
+        postgres_db.commit()
+
+        ok, reason = is_eligible_master_instructor(postgres_db, instr.id, ["AMATEUR"])
+        assert ok is False
+        assert "license" in reason.lower()
+
+    def test_e14_naive_future_expires_at_accepted(self, postgres_db: Session):
+        """E-14: expires_at as naive datetime in the future → accepted (timezone-safe)."""
+        instr = _make_instructor(postgres_db)
+        naive_future = datetime(2099, 12, 31, 23, 59, 59)  # clearly in future, no tzinfo
+        _make_coach_license(postgres_db, instr, level=5, expires_at=naive_future)
+        postgres_db.commit()
+
+        ok, _ = is_eligible_master_instructor(postgres_db, instr.id, ["AMATEUR"])
+        assert ok is True
+
+    def test_nonexistent_user_rejected(self, postgres_db: Session):
+        """Nonexistent user_id → rejected with clear reason."""
+        ok, reason = is_eligible_master_instructor(postgres_db, 999_999, ["AMATEUR"])
+        assert ok is False
+        assert "not found" in reason.lower() or "999999" in reason
+
+
+# ── Field instructor eligibility ──────────────────────────────────────────────
+
+class TestIsEligibleFieldInstructor:
+    """E-09, E-10: field instructor policy — one level lower minimum."""
+
+    def test_e09_field_one_level_lower_accepted(self, postgres_db: Session):
+        """E-09: level 4 for AMATEUR field (min = max(1, 5-1) = 4) → accepted."""
+        instr = _make_instructor(postgres_db)
+        _make_coach_license(postgres_db, instr, level=4)
+        postgres_db.commit()
+
+        ok, _ = is_eligible_field_instructor(postgres_db, instr.id, ["AMATEUR"])
+        assert ok is True
+
+    def test_e10_field_too_low_rejected(self, postgres_db: Session):
+        """E-10: level 3 for AMATEUR field (min 4) → rejected."""
+        instr = _make_instructor(postgres_db)
+        _make_coach_license(postgres_db, instr, level=3)
+        postgres_db.commit()
+
+        ok, reason = is_eligible_field_instructor(postgres_db, instr.id, ["AMATEUR"])
+        assert ok is False
+        assert "insufficient" in reason.lower() or "level" in reason.lower()
+
+    def test_field_pre_minimum_is_1(self, postgres_db: Session):
+        """max(1, 1-1) = max(1,0) = 1; level 1 accepted for PRE field."""
+        instr = _make_instructor(postgres_db)
+        _make_coach_license(postgres_db, instr, level=1)
+        postgres_db.commit()
+
+        ok, _ = is_eligible_field_instructor(postgres_db, instr.id, ["PRE"])
+        assert ok is True
+
+    def test_field_inactive_license_rejected(self, postgres_db: Session):
+        """Field instructor also requires active license."""
+        instr = _make_instructor(postgres_db)
+        _make_coach_license(postgres_db, instr, level=8, is_active=False)
+        postgres_db.commit()
+
+        ok, reason = is_eligible_field_instructor(postgres_db, instr.id, ["PRE"])
+        assert ok is False
+        assert "license" in reason.lower()
+
+
+# ── Utility functions ─────────────────────────────────────────────────────────
+
+class TestGetEligibleMasterInstructors:
+    """E-16: get_eligible_master_instructors — only eligible users returned."""
+
+    def test_e16_only_eligible_in_list(self, postgres_db: Session):
+        """Only instructors with active, non-expired license appear."""
+        eligible = _make_instructor(postgres_db)
+        _make_coach_license(postgres_db, eligible, level=5)
+
+        no_lic = _make_instructor(postgres_db)  # no license
+        inactive_user = _make_instructor(postgres_db, is_active=False)
+        _make_coach_license(postgres_db, inactive_user, level=5)
+        inact_lic_user = _make_instructor(postgres_db)
+        _make_coach_license(postgres_db, inact_lic_user, level=5, is_active=False)
+
+        postgres_db.commit()
+
+        result = get_eligible_master_instructors(postgres_db, age_groups=None)
+        result_ids = {u.id for u in result}
+
+        assert eligible.id in result_ids
+        assert no_lic.id not in result_ids
+        assert inactive_user.id not in result_ids
+        assert inact_lic_user.id not in result_ids
+
+    def test_level_filter_applied_when_age_groups_given(self, postgres_db: Session):
+        """With age_groups=["AMATEUR"], level 3 instructor excluded."""
+        low = _make_instructor(postgres_db)
+        _make_coach_license(postgres_db, low, level=3)
+        high = _make_instructor(postgres_db)
+        _make_coach_license(postgres_db, high, level=5)
+        postgres_db.commit()
+
+        result = get_eligible_master_instructors(postgres_db, age_groups=["AMATEUR"])
+        ids = {u.id for u in result}
+        assert low.id not in ids
+        assert high.id in ids
+
+    def test_no_age_groups_no_level_filter(self, postgres_db: Session):
+        """age_groups=None: license+role filter only, level 1 instructor included."""
+        instr = _make_instructor(postgres_db)
+        _make_coach_license(postgres_db, instr, level=1)
+        postgres_db.commit()
+
+        result = get_eligible_master_instructors(postgres_db, age_groups=None)
+        assert any(u.id == instr.id for u in result)
+
+
+class TestGetInstructorLicenseLevels:
+    """E-17: get_instructor_license_levels — correct dict returned."""
+
+    def test_e17_correct_level_mapping(self, postgres_db: Session):
+        instr = _make_instructor(postgres_db)
+        _make_coach_license(postgres_db, instr, level=6)
+        postgres_db.commit()
+
+        levels = get_instructor_license_levels(postgres_db, [instr.id])
+        assert levels[instr.id] == 6
+
+    def test_inactive_license_not_in_dict(self, postgres_db: Session):
+        instr = _make_instructor(postgres_db)
+        _make_coach_license(postgres_db, instr, level=5, is_active=False)
+        postgres_db.commit()
+
+        levels = get_instructor_license_levels(postgres_db, [instr.id])
+        assert instr.id not in levels
+
+    def test_empty_user_ids_returns_empty_dict(self, postgres_db: Session):
+        assert get_instructor_license_levels(postgres_db, []) == {}
+
+
+class TestResolveTournamentAgeGroups:
+    """E-18: resolve_tournament_age_groups — priority: age_groups > age_group > []."""
+
+    def _sem(self, age_groups=None, age_group=None):
+        from unittest.mock import MagicMock
+        s = MagicMock()
+        s.age_groups = age_groups
+        s.age_group = age_group
+        return s
+
+    def test_age_groups_list_takes_priority(self):
+        s = self._sem(age_groups=["PRE", "YOUTH"], age_group="AMATEUR")
+        assert resolve_tournament_age_groups(s) == ["PRE", "YOUTH"]
+
+    def test_scalar_age_group_used_when_no_list(self):
+        s = self._sem(age_groups=None, age_group="AMATEUR")
+        assert resolve_tournament_age_groups(s) == ["AMATEUR"]
+
+    def test_empty_list_when_neither_set(self):
+        s = self._sem(age_groups=None, age_group=None)
+        assert resolve_tournament_age_groups(s) == []
+
+    def test_empty_list_is_falsy_coerces_to_scalar(self):
+        # age_groups=[] is falsy → falls through to age_group
+        s = self._sem(age_groups=[], age_group="PRO")
+        assert resolve_tournament_age_groups(s) == ["PRO"]
+
+
+class TestCheckTournamentMasterInstructorEligible:
+    """E-19, E-20: check_tournament_master_instructor_eligible — composite check."""
+
+    def test_e19_no_master_assigned_returns_false_with_clear_reason(self, postgres_db: Session):
+        """E-19: no master_instructor_id, no MASTER slot → (False, "No master instructor assigned")."""
+        from app.models.semester import Semester, SemesterStatus, SemesterCategory
+        sem = Semester(
+            code=f"ELIG-{_uid()}",
+            name="Elig Test",
+            start_date=datetime(2026, 6, 1).date(),
+            end_date=datetime(2026, 6, 30).date(),
+            enrollment_cost=0,
+        )
+        postgres_db.add(sem)
+        postgres_db.flush()
+        postgres_db.commit()
+
+        ok, reason = check_tournament_master_instructor_eligible(postgres_db, sem.id)
+        assert ok is False
+        assert "no master" in reason.lower() or "assigned" in reason.lower()
+
+    def test_e20_assigned_but_ineligible_returns_false(self, postgres_db: Session):
+        """E-20: master_instructor_id set, but instructor has no valid license → (False, ...)."""
+        from app.models.semester import Semester
+        instr = _make_instructor(postgres_db)
+        # Deliberately NO license — ineligible
+        sem = Semester(
+            code=f"ELIG-{_uid()}",
+            name="Elig Test 2",
+            start_date=datetime(2026, 6, 1).date(),
+            end_date=datetime(2026, 6, 30).date(),
+            enrollment_cost=0,
+            master_instructor_id=instr.id,
+            age_group="AMATEUR",
+        )
+        postgres_db.add(sem)
+        postgres_db.flush()
+        postgres_db.commit()
+
+        ok, reason = check_tournament_master_instructor_eligible(postgres_db, sem.id)
+        assert ok is False
+        assert "license" in reason.lower()
+
+    def test_assigned_and_eligible_returns_true(self, postgres_db: Session):
+        """Assigned eligible master → (True, "")."""
+        from app.models.semester import Semester
+        instr = _make_instructor(postgres_db)
+        _make_coach_license(postgres_db, instr, level=5)
+        sem = Semester(
+            code=f"ELIG-{_uid()}",
+            name="Elig Test 3",
+            start_date=datetime(2026, 6, 1).date(),
+            end_date=datetime(2026, 6, 30).date(),
+            enrollment_cost=0,
+            master_instructor_id=instr.id,
+            age_group="AMATEUR",
+        )
+        postgres_db.add(sem)
+        postgres_db.flush()
+        postgres_db.commit()
+
+        ok, reason = check_tournament_master_instructor_eligible(postgres_db, sem.id)
+        assert ok is True
+        assert reason == ""

--- a/tests/unit/services/test_ops_scenario.py
+++ b/tests/unit/services/test_ops_scenario.py
@@ -3734,18 +3734,41 @@ class TestOpsScenarioIntegration:
 
     def _create_grandmaster(self, db):
         """Create the grandmaster@lfa.com instructor required by ops_scenario."""
+        from datetime import datetime, timezone
         from app.models.user import User, UserRole
+        from app.models.license import UserLicense
         existing = db.query(User).filter(User.email == "grandmaster@lfa.com").first()
         if existing:
-            return existing
-        gm = User(
-            email="grandmaster@lfa.com",
-            name="Grandmaster Instructor",
-            password_hash="test_hash",
-            role=UserRole.INSTRUCTOR,
-            is_active=True,
-        )
-        db.add(gm); db.commit(); db.refresh(gm)
+            gm = existing
+        else:
+            gm = User(
+                email="grandmaster@lfa.com",
+                name="Grandmaster Instructor",
+                password_hash="test_hash",
+                role=UserRole.INSTRUCTOR,
+                is_active=True,
+            )
+            db.add(gm); db.commit(); db.refresh(gm)
+        coach_lic = db.query(UserLicense).filter(
+            UserLicense.user_id == gm.id,
+            UserLicense.specialization_type == "LFA_COACH",
+        ).first()
+        if coach_lic:
+            coach_lic.is_active = True
+            coach_lic.current_level = 7
+            coach_lic.expires_at = None
+            db.commit()
+        else:
+            db.add(UserLicense(
+                user_id=gm.id,
+                specialization_type="LFA_COACH",
+                current_level=7,
+                max_achieved_level=7,
+                is_active=True,
+                started_at=datetime.now(timezone.utc),
+                expires_at=None,
+            ))
+            db.commit()
         return gm
 
     def test_full_pipeline_four_players_real_tsg(self, test_db):

--- a/tests/unit/services/test_tournaments_lifecycle_endpoint.py
+++ b/tests/unit/services/test_tournaments_lifecycle_endpoint.py
@@ -393,21 +393,22 @@ class TestTransitionTournamentStatus:
 
     # ── new_status == IN_PROGRESS auto-generate ──────────────────
 
-    def test_in_progress_no_reward_config_skips_snapshot(self):
-        """reward_config=None → reward snapshot block is skipped."""
+    def test_in_progress_without_reward_config_blocks(self):
+        """reward_config=None → REWARD_CONFIG_MISSING blocks IN_PROGRESS with HTTP 400."""
         t = _tournament(reward_config=None, sessions_generated=True)
-        # INDIVIDUAL_RANKING + sessions_generated=True + count matches 1 → no regen
         q_semester = _fq(first=t)
-        q_count = _fq(count=1)     # current_session_count=1, expected=1 → no regen
-        db = _seq_db(q_semester, q_count)
+        db = _seq_db(q_semester)  # no q_count — guard raises before session count query
 
+        from fastapi import HTTPException
         with patch(_PATCH_VST, return_value=(True, None)), \
              patch(_PATCH_GNS, return_value=[]):
-            result = transition_tournament_status(
-                10, _trans_req(new_status="IN_PROGRESS"),
-                db=db, current_user=_user()
-            )
-        assert result.new_status == "IN_PROGRESS"
+            with pytest.raises(HTTPException) as exc:
+                transition_tournament_status(
+                    10, _trans_req(new_status="IN_PROGRESS"),
+                    db=db, current_user=_user()
+                )
+        assert exc.value.status_code == 400
+        assert "REWARD_CONFIG_MISSING" in exc.value.detail
 
     def test_in_progress_reward_snapshot_already_set_skips(self):
         """reward_config set but reward_policy_snapshot already set → skip snapshot."""

--- a/tests/unit/services/test_tournaments_lifecycle_endpoint.py
+++ b/tests/unit/services/test_tournaments_lifecycle_endpoint.py
@@ -506,7 +506,7 @@ class TestTransitionTournamentStatus:
         mock_gen.generate_sessions.assert_called_once()
 
     def test_in_progress_needs_regen_deletes_old_sessions_first(self):
-        """needs_regeneration=True, count>0 → delete old sessions then regenerate."""
+        """needs_regeneration=True, count>0 → delete old sessions then call can_generate (raises 400 if can't generate)."""
         s1 = MagicMock(); s1.id = 55
         t = _tournament(format="INDIVIDUAL_RANKING", sessions_generated=False)
         t.tournament_config_obj = MagicMock()
@@ -516,48 +516,51 @@ class TestTransitionTournamentStatus:
         q_sess_all = _fq(all_=[s1])         # for getting session ids
         q_att_del = _fq(count=1)
         q_sess_del = _fq(count=1)
-        q_enroll = _fq(all_=[])             # enrollment snapshot
 
-        db = _seq_db(q_semester, q_count, q_sess_all, q_att_del, q_sess_del, q_enroll)
+        db = _seq_db(q_semester, q_count, q_sess_all, q_att_del, q_sess_del)
 
         mock_gen = MagicMock()
         mock_gen.can_generate_sessions.return_value = (False, "Not enough players")
 
+        from fastapi import HTTPException
         with patch(_PATCH_VST, return_value=(True, None)), \
              patch(_PATCH_GNS, return_value=[]), \
              patch(_PATCH_TSG, return_value=mock_gen):
-            result = transition_tournament_status(
-                10, _trans_req(new_status="IN_PROGRESS"),
-                db=db, current_user=_user()
-            )
-        assert result.new_status == "IN_PROGRESS"
-        # generator was called with can_generate check
+            with pytest.raises(HTTPException) as exc:
+                transition_tournament_status(
+                    10, _trans_req(new_status="IN_PROGRESS"),
+                    db=db, current_user=_user()
+                )
+        assert exc.value.status_code == 400
+        assert "Cannot regenerate" in exc.value.detail
+        # deletion happened BEFORE can_generate_sessions was called
         mock_gen.can_generate_sessions.assert_called_once()
 
-    def test_in_progress_generator_fails_gracefully(self):
-        """can_generate=True but generate_sessions fails → no exception, status still set."""
+    def test_in_progress_generator_fails_raises_400(self):
+        """can_generate=True but generate_sessions fails → HTTPException 400."""
         t = _tournament(format="INDIVIDUAL_RANKING", sessions_generated=False)
         t.tournament_config_obj = MagicMock()
 
         q_semester = _fq(first=t)
         q_count = _fq(count=0)
-        q_enroll = _fq(all_=[])
 
-        db = _seq_db(q_semester, q_count, q_enroll)
+        db = _seq_db(q_semester, q_count)
 
         mock_gen = MagicMock()
         mock_gen.can_generate_sessions.return_value = (True, None)
         mock_gen.generate_sessions.return_value = (False, "Generation failed", [])
 
+        from fastapi import HTTPException
         with patch(_PATCH_VST, return_value=(True, None)), \
              patch(_PATCH_GNS, return_value=[]), \
              patch(_PATCH_TSG, return_value=mock_gen):
-            result = transition_tournament_status(
-                10, _trans_req(new_status="IN_PROGRESS"),
-                db=db, current_user=_user()
-            )
-        # Function continues even if generation fails (prints warning)
-        assert result.new_status == "IN_PROGRESS"
+            with pytest.raises(HTTPException) as exc:
+                transition_tournament_status(
+                    10, _trans_req(new_status="IN_PROGRESS"),
+                    db=db, current_user=_user()
+                )
+        assert exc.value.status_code == 400
+        assert "Session regeneration failed" in exc.value.detail
 
     def test_in_progress_needs_regen_no_config_obj_still_works(self):
         """needs_regeneration=True, tournament_config_obj=None → skip config reset."""

--- a/tests/unit/services/test_tournaments_lifecycle_endpoint.py
+++ b/tests/unit/services/test_tournaments_lifecycle_endpoint.py
@@ -87,7 +87,7 @@ def _tournament(**kw):
     t.end_date = date(2026, 6, 30)
     t.format = "INDIVIDUAL_RANKING"
     t.sessions_generated = False
-    t.reward_config = None
+    t.reward_config = {"template_name": "standard"}  # truthy; tests needing None pass it explicitly
     t.reward_policy_snapshot = None
     t.reward_config_obj = None
     t.tournament_config_obj = MagicMock()

--- a/tests/unit/test_domain_integrity.py
+++ b/tests/unit/test_domain_integrity.py
@@ -139,10 +139,13 @@ class TestGenerationValidatorPitchGuard:
         t = self._make_tournament(campus_id=5)
         db = self._make_db(t, active_pitch_count=0)
 
-        # Patch TournamentRepository.get_optional
+        _PATCH_ELIG = (
+            "app.services.tournament.instructor_eligibility_service"
+            ".check_tournament_master_instructor_eligible"
+        )
         with patch(
             "app.services.tournament.session_generation.validators.generation_validator.TournamentRepository"
-        ) as MockRepo:
+        ) as MockRepo, patch(_PATCH_ELIG, return_value=(True, "")):
             MockRepo.return_value.get_optional.return_value = t
             validator = GenerationValidator(db)
             ok, reason = validator.can_generate_sessions(99)
@@ -157,9 +160,13 @@ class TestGenerationValidatorPitchGuard:
         t = self._make_tournament(campus_id=5)
         db = self._make_db(t, active_pitch_count=2)
 
+        _PATCH_ELIG = (
+            "app.services.tournament.instructor_eligibility_service"
+            ".check_tournament_master_instructor_eligible"
+        )
         with patch(
             "app.services.tournament.session_generation.validators.generation_validator.TournamentRepository"
-        ) as MockRepo:
+        ) as MockRepo, patch(_PATCH_ELIG, return_value=(True, "")):
             MockRepo.return_value.get_optional.return_value = t
             validator = GenerationValidator(db)
             ok, reason = validator.can_generate_sessions(99)
@@ -539,7 +546,10 @@ class TestGenerationValidatorInstructorGuard:
         "app.services.tournament.session_generation.validators"
         ".generation_validator.TournamentRepository"
     )
-    _PATCH_HMIA = "app.services.tournament.instructor_service.has_master_instructor_assignment"
+    _PATCH_ELIGIBILITY = (
+        "app.services.tournament.instructor_eligibility_service"
+        ".check_tournament_master_instructor_eligible"
+    )
 
     def _make_tournament(self, fmt, type_id=None):
         t = MagicMock()
@@ -586,7 +596,7 @@ class TestGenerationValidatorInstructorGuard:
         db = self._make_db(t)
 
         with patch(self._PATCH_REPO) as MockRepo, \
-             patch(self._PATCH_HMIA, return_value=False):
+             patch(self._PATCH_ELIGIBILITY, return_value=(False, "No master instructor assigned")):
             MockRepo.return_value.get_optional.return_value = t
             ok, reason = GenerationValidator(db).can_generate_sessions(77)
 
@@ -606,7 +616,7 @@ class TestGenerationValidatorInstructorGuard:
         db = self._make_db(t)
 
         with patch(self._PATCH_REPO) as MockRepo, \
-             patch(self._PATCH_HMIA, return_value=False):
+             patch(self._PATCH_ELIGIBILITY, return_value=(False, "No master instructor assigned")):
             MockRepo.return_value.get_optional.return_value = t
             ok, reason = GenerationValidator(db).can_generate_sessions(77)
 
@@ -621,7 +631,7 @@ class TestGenerationValidatorInstructorGuard:
         db = self._make_db(t)
 
         with patch(self._PATCH_REPO) as MockRepo, \
-             patch(self._PATCH_HMIA, return_value=True):
+             patch(self._PATCH_ELIGIBILITY, return_value=(True, "")):
             MockRepo.return_value.get_optional.return_value = t
             ok, reason = GenerationValidator(db).can_generate_sessions(77)
 

--- a/tests/unit/tournament/test_instructor_planning_service.py
+++ b/tests/unit/tournament/test_instructor_planning_service.py
@@ -103,14 +103,16 @@ class TestAddSlotMasterSync:
 
         db.query.side_effect = query_side
 
-        result = add_slot(
-            db=db,
-            semester_id=1,
-            instructor_id=42,
-            role=SlotRole.MASTER.value,
-            pitch_id=None,
-            assigned_by_id=1,
-        )
+        _elig = "app.services.tournament.instructor_eligibility_service.is_eligible_master_instructor"
+        with patch(_elig, return_value=(True, "")):
+            result = add_slot(
+                db=db,
+                semester_id=1,
+                instructor_id=42,
+                role=SlotRole.MASTER.value,
+                pitch_id=None,
+                assigned_by_id=1,
+            )
 
         # master_instructor_id must be set on the tournament object
         assert tournament.master_instructor_id == 42
@@ -144,14 +146,16 @@ class TestAddSlotMasterSync:
         db = MagicMock()
         db.query.side_effect = query_side
 
-        add_slot(
-            db=db,
-            semester_id=1,
-            instructor_id=55,
-            role=SlotRole.FIELD.value,
-            pitch_id=10,
-            assigned_by_id=1,
-        )
+        _elig = "app.services.tournament.instructor_eligibility_service.is_eligible_field_instructor"
+        with patch(_elig, return_value=(True, "")):
+            add_slot(
+                db=db,
+                semester_id=1,
+                instructor_id=55,
+                role=SlotRole.FIELD.value,
+                pitch_id=10,
+                assigned_by_id=1,
+            )
 
         # FIELD slot must NOT touch master_instructor_id
         assert tournament.master_instructor_id == 99

--- a/tests/unit/tournament/test_session_gen_utils.py
+++ b/tests/unit/tournament/test_session_gen_utils.py
@@ -16,7 +16,7 @@ Missing coverage (generation_validator.py):
   Line  73:    not enough players → False + reason
 """
 import pytest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from app.services.tournament.session_generation.utils import (
     get_tournament_venue,
@@ -178,7 +178,16 @@ def _make_validator(tournament=None):
     return v, db
 
 
+_ELIG_PATCH = "app.services.tournament.instructor_eligibility_service.check_tournament_master_instructor_eligible"
+
+
 class TestGenerationValidator:
+
+    @pytest.fixture(autouse=True)
+    def _patch_eligibility(self):
+        """Stub out the eligibility guard so validator tests focus on their own logic."""
+        with patch(_ELIG_PATCH, return_value=(True, "")):
+            yield
 
     def test_tournament_not_found(self):
         v, _ = _make_validator(None)


### PR DESCRIPTION
## Summary

- Introduces `instructor_eligibility_service.py` as the single canonical authority for coach eligibility checks (replaces ad-hoc `has_master_instructor_assignment()` presence-only check)
- Domain policy: `role=INSTRUCTOR + is_active + active non-expired LFA_COACH license + current_level >= required_for_highest_age_group`; field instructor gets `max(1, required-1)`
- Wires eligibility into 5 enforcement points: `lifecycle.py` (CHECK_IN_OPEN), `generation_validator.py` (session gen), `instructor_planning_service.add_slot()`, `instructor_assignment.py` (accept flow), `sponsors.py` wizard POST
- Fixes `license_validator.get_coach_license()`: was missing `is_active` + `expires_at` filters — aligned with new service
- Timezone-safe `expires_at` comparison via `_to_utc_aware()` helper (treats naive datetimes as UTC, converts aware to UTC before comparison)

## Enforcement points

| Call site | Before | After |
|---|---|---|
| `lifecycle.py` CHECK_IN_OPEN | `has_master_instructor_assignment()` (presence only) | `check_tournament_master_instructor_eligible()` (full policy) |
| `generation_validator.py` | `has_master_instructor_assignment()` | `check_tournament_master_instructor_eligible()` |
| `instructor_planning_service.add_slot()` | none | `is_eligible_{master,field}_instructor()` |
| `instructor_assignment.py` accept | none | `is_eligible_master_instructor()` |
| `sponsors.py` wizard GET | all instructors | `get_eligible_master_instructors()` (role+license+level) |
| `sponsors.py` wizard POST | role+is_active check | `is_eligible_master_instructor()` |
| `sponsor_promotion_wizard.html` | no level info | Level badge via `instructor_license_levels` dict |

## Test plan

- [ ] `pytest tests/unit/services/test_instructor_eligibility_service.py -v` → 33 tests (E-01..E-20 + extras): role, active, license, expiry boundary, level, multi-age, naive/aware timezone normalization
- [ ] `pytest tests/unit/services/test_license_validator.py -v` → 34 tests green (existing tests, verifies fix doesn't regress)
- [ ] `pytest tests/integration/web_flows/test_sponsor_campaign_promotion.py -v` → 13 tests (SPON-CAM-14..18 updated for eligibility)
- [ ] `pytest tests/unit/contract/test_openapi_snapshot.py -v` → 5 tests green (no route signature changes)

## Stacking

This PR stacks on `feat/promotion-wizard-instructor-assignment` (PR #142). Both can be reviewed/merged independently if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)