### PR TITLE
feat(domain): laterality_domain guard — close GAP-4/5/6 for throwing/mental/physical

### DIFF
--- a/app/services/tournament/tournament_reward_orchestrator.py
+++ b/app/services/tournament/tournament_reward_orchestrator.py
@@ -346,6 +346,7 @@ def distribute_rewards_for_user(
                 update_lateral_component,
                 aggregate_lateral_components,
             )
+            from app.skills_config import SKILL_LATERALITY
 
             # R04: Lock UserLicense row before reading football_skills JSONB.
             # Prevents two concurrent distributions from both reading stale skills,
@@ -389,23 +390,48 @@ def distribute_rewards_for_user(
                                 continue
 
                             # ── Lateral component update (F4b) ────────────────────────
-                            # Apply this tournament's EMA delta to the foot-context bucket.
-                            # update_lateral_component initialises the bucket from the
-                            # pre-tournament current_level on first contact so that
-                            # existing skill history is preserved.
+                            # Only foot-domain skills track lateral (right/left/neutral)
+                            # buckets.  hand and none skills carry the EMA current_level
+                            # directly — no foot bucket is created for them.
                             _skill_delta = float(_raw_deltas.get(skill_key, 0.0))
                             _skill_fc = (
                                 _preset.foot_context_for(skill_key)
                                 if _preset is not None
                                 else _foot_ctx
                             )
-                            entry = update_lateral_component(entry, _skill_fc, _skill_delta)
+                            _lat_domain = SKILL_LATERALITY.get(skill_key)
 
-                            # Re-aggregate current_level from all lateral components.
-                            # Falls back to the EMA-derived sdata["current_level"] when
-                            # no lateral_components exist (backward-compatible old records).
-                            _agg = aggregate_lateral_components(entry, _right_ft, _left_ft)
-                            entry["current_level"] = _agg
+                            if _lat_domain is None:
+                                # Configuration error: skill exists in football_skills but
+                                # is absent from SKILL_LATERALITY.  Log and skip lateral
+                                # update — do not silently create a foot bucket.
+                                logger.warning(
+                                    f"Unknown laterality_domain for skill '{skill_key}': "
+                                    f"skipping lateral update. Add skill to SKILL_LATERALITY."
+                                )
+                                entry["current_level"] = float(
+                                    sdata.get("current_level",
+                                              entry.get("current_level", 60.0))
+                                )
+                            elif _lat_domain == "foot":
+                                entry = update_lateral_component(entry, _skill_fc, _skill_delta)
+                                # Re-aggregate current_level from all lateral components.
+                                # Falls back to EMA-derived value when no components exist
+                                # (backward-compatible with old records).
+                                _agg = aggregate_lateral_components(entry, _right_ft, _left_ft)
+                                entry["current_level"] = _agg
+                            else:
+                                # "hand" or "none": EMA current_level is authoritative.
+                                # No foot bucket is created; existing stale neutral buckets
+                                # (if any) are left untouched in JSONB but never updated.
+                                logger.debug(
+                                    f"Lateral update skipped for '{skill_key}' "
+                                    f"(laterality_domain='{_lat_domain}')"
+                                )
+                                entry["current_level"] = float(
+                                    sdata.get("current_level",
+                                              entry.get("current_level", 60.0))
+                                )
 
                             # ── Global tracking fields (unchanged semantics) ──────────
                             entry["tournament_delta"] = sdata["tournament_delta"]

--- a/app/skills_config.py
+++ b/app/skills_config.py
@@ -7,17 +7,25 @@ Skill count: 44 (expanded from 29 in Phase 3 — 2026-05-11)
   set_pieces:  3 skills (unchanged)
   mental:     14 skills (8 original + 6 new)
   physical:    8 skills (7 original + 1 new)
+
+Laterality taxonomy (2026-05-11):
+  foot (20): ball_control, dribbling, finishing, shot_power, long_shots, volleys,
+             crossing, passing, tackle, marking, shooting, technique, creativity,
+             long_passing, flair, touch, forward_runs, free_kicks, corners, penalties
+  hand  (1): throwing  — hand-lateral; tracked separately from foot context
+  none (23): heading + all mental (14) + all physical (8)
 """
 
-from typing import Dict, List, TypedDict
+from typing import Dict, List, Literal, TypedDict
 
 
 class SkillDefinition(TypedDict):
     """Single skill definition"""
-    key: str  # snake_case key for database
-    name_en: str  # English display name
-    name_hu: str  # Hungarian display name
-    description_hu: str  # Hungarian description
+    key: str                                               # snake_case key for database
+    name_en: str                                           # English display name
+    name_hu: str                                           # Hungarian display name
+    description_hu: str                                    # Hungarian description
+    laterality_domain: Literal["foot", "hand", "none"]    # Laterality classification
 
 
 class SkillCategory(TypedDict):
@@ -41,116 +49,135 @@ SKILL_CATEGORIES: List[SkillCategory] = [
                 "key": "ball_control",
                 "name_en": "Ball Control",
                 "name_hu": "Labdakontroll",
-                "description_hu": "A labda átvételének és kezelésének minősége különböző szituációkban."
+                "description_hu": "A labda átvételének és kezelésének minősége különböző szituációkban.",
+                "laterality_domain": "foot",
             },
             {
                 "key": "dribbling",
                 "name_en": "Dribbling",
                 "name_hu": "Cselezés",
-                "description_hu": "Ellenféllel szembeni labdavezetési és irányváltási képesség."
+                "description_hu": "Ellenféllel szembeni labdavezetési és irányváltási képesség.",
+                "laterality_domain": "foot",
             },
             {
                 "key": "finishing",
                 "name_en": "Finishing",
                 "name_hu": "Befejezés",
-                "description_hu": "Helyzetek gólra váltásának hatékonysága."
+                "description_hu": "Helyzetek gólra váltásának hatékonysága.",
+                "laterality_domain": "foot",
             },
             {
                 "key": "shot_power",
                 "name_en": "Shot Power",
                 "name_hu": "Lövőerő",
-                "description_hu": "A lövések ereje, különösen távolról vagy nagy intenzitású helyzetekben."
+                "description_hu": "A lövések ereje, különösen távolról vagy nagy intenzitású helyzetekben.",
+                "laterality_domain": "foot",
             },
             {
                 "key": "long_shots",
                 "name_en": "Long Shots",
                 "name_hu": "Távoli lövések",
-                "description_hu": "Pontosság és hatékonyság 16 méteren kívüli lövéseknél."
+                "description_hu": "Pontosság és hatékonyság 16 méteren kívüli lövéseknél.",
+                "laterality_domain": "foot",
             },
             {
                 "key": "volleys",
                 "name_en": "Volleys",
                 "name_hu": "Röplabdás lövések",
-                "description_hu": "Levegőből, pattanás nélkül elvégzett lövések minősége."
+                "description_hu": "Levegőből, pattanás nélkül elvégzett lövések minősége.",
+                "laterality_domain": "foot",
             },
             {
                 "key": "crossing",
                 "name_en": "Crossing",
                 "name_hu": "Beadások",
-                "description_hu": "Oldalról érkező labdák pontossága és használhatósága."
+                "description_hu": "Oldalról érkező labdák pontossága és használhatósága.",
+                "laterality_domain": "foot",
             },
             {
                 "key": "passing",
                 "name_en": "Passing",
                 "name_hu": "Passzok",
-                "description_hu": "Rövid és középtávú passzok pontossága és időzítése."
+                "description_hu": "Rövid és középtávú passzok pontossága és időzítése.",
+                "laterality_domain": "foot",
             },
             {
                 "key": "heading",
                 "name_en": "Heading",
                 "name_hu": "Fejelési pontosság",
-                "description_hu": "Fejesek irányíthatósága támadásban és védekezésben."
+                "description_hu": "Fejesek irányíthatósága támadásban és védekezésben.",
+                "laterality_domain": "none",
             },
             {
                 "key": "tackle",
                 "name_en": "Tackle",
                 "name_hu": "Szerelés állva",
-                "description_hu": "Labdaszerzés álló helyzetben, szabályosan."
+                "description_hu": "Labdaszerzés álló helyzetben, szabályosan.",
+                "laterality_domain": "foot",
             },
             {
                 "key": "marking",
                 "name_en": "Marking",
                 "name_hu": "Emberfogás",
-                "description_hu": "Ellenfél követése, leválás megakadályozása."
+                "description_hu": "Ellenfél követése, leválás megakadályozása.",
+                "laterality_domain": "foot",
             },
             {
                 "key": "shooting",
                 "name_en": "Shooting",
                 "name_hu": "Lövések",
-                "description_hu": "Általános lövéskészség és pontosság különböző szituációkban."
+                "description_hu": "Általános lövéskészség és pontosság különböző szituációkban.",
+                "laterality_domain": "foot",
             },
             {
                 "key": "technique",
                 "name_en": "Technique",
                 "name_hu": "Technika",
-                "description_hu": "Labdakezelési technika és mozdulatok finomsága és pontossága."
+                "description_hu": "Labdakezelési technika és mozdulatok finomsága és pontossága.",
+                "laterality_domain": "foot",
             },
             {
                 "key": "creativity",
                 "name_en": "Creativity",
                 "name_hu": "Kreativitás",
-                "description_hu": "Szokatlan, váratlan megoldások és játékvariációk alkalmazása."
+                "description_hu": "Szokatlan, váratlan megoldások és játékvariációk alkalmazása.",
+                "laterality_domain": "foot",
             },
             {
                 "key": "long_passing",
                 "name_en": "Long Passing",
                 "name_hu": "Hosszú passzok",
-                "description_hu": "Pontos hosszú passzok és mélységi indítások."
+                "description_hu": "Pontos hosszú passzok és mélységi indítások.",
+                "laterality_domain": "foot",
             },
             {
                 "key": "flair",
                 "name_en": "Flair",
                 "name_hu": "Zseniális megoldások",
-                "description_hu": "Egyedi, látványos technikai elemek és improvizált megoldások."
+                "description_hu": "Egyedi, látványos technikai elemek és improvizált megoldások.",
+                "laterality_domain": "foot",
             },
             {
                 "key": "touch",
                 "name_en": "Touch",
                 "name_hu": "Labdaérintés",
-                "description_hu": "Első érintés minősége, labda leállításának finomsága."
+                "description_hu": "Első érintés minősége, labda leállításának finomsága.",
+                "laterality_domain": "foot",
             },
             {
                 "key": "forward_runs",
                 "name_en": "Forward Runs",
                 "name_hu": "Előretörések",
-                "description_hu": "Offenzív lefutások időzítése és hatékonysága mélységi labdáknál."
+                "description_hu": "Offenzív lefutások időzítése és hatékonysága mélységi labdáknál.",
+                "laterality_domain": "foot",
             },
             {
                 "key": "throwing",
                 "name_en": "Throwing",
                 "name_hu": "Dobáskészség",
-                "description_hu": "Általános dobáskészség és pontosság — bedobásoknál és kapusnál egyaránt."
-            }
+                "description_hu": "Általános dobáskészség és pontosság — bedobásoknál és kapusnál egyaránt.",
+                "laterality_domain": "hand",
+            },
         ]
     },
     {
@@ -163,20 +190,23 @@ SKILL_CATEGORIES: List[SkillCategory] = [
                 "key": "free_kicks",
                 "name_en": "Free Kicks",
                 "name_hu": "Szabadrúgások",
-                "description_hu": "Közvetlen és közvetett szabadrúgások minősége."
+                "description_hu": "Közvetlen és közvetett szabadrúgások minősége.",
+                "laterality_domain": "foot",
             },
             {
                 "key": "corners",
                 "name_en": "Corners",
                 "name_hu": "Szögletrúgások",
-                "description_hu": "Szögletek pontossága és veszélyessége."
+                "description_hu": "Szögletek pontossága és veszélyessége.",
+                "laterality_domain": "foot",
             },
             {
                 "key": "penalties",
                 "name_en": "Penalties",
                 "name_hu": "Tizenegyesek",
-                "description_hu": "Büntetők értékesítésének megbízhatósága."
-            }
+                "description_hu": "Büntetők értékesítésének megbízhatósága.",
+                "laterality_domain": "foot",
+            },
         ]
     },
     {
@@ -189,86 +219,100 @@ SKILL_CATEGORIES: List[SkillCategory] = [
                 "key": "positioning_off",
                 "name_en": "Positioning (Off)",
                 "name_hu": "Helyezkedés támadásban",
-                "description_hu": "Üres területek felismerése, jó pozíciók felvétele."
+                "description_hu": "Üres területek felismerése, jó pozíciók felvétele.",
+                "laterality_domain": "none",
             },
             {
                 "key": "positioning_def",
                 "name_en": "Positioning (Def)",
                 "name_hu": "Helyezkedés védekezésben",
-                "description_hu": "Védekező pozíciók megtartása, zárások."
+                "description_hu": "Védekező pozíciók megtartása, zárások.",
+                "laterality_domain": "none",
             },
             {
                 "key": "vision",
                 "name_en": "Vision",
                 "name_hu": "Játéklátás",
-                "description_hu": "Passzsávok, lehetőségek felismerése."
+                "description_hu": "Passzsávok, lehetőségek felismerése.",
+                "laterality_domain": "none",
             },
             {
                 "key": "aggression",
                 "name_en": "Aggression",
                 "name_hu": "Agresszivitás",
-                "description_hu": "Párharcok intenzitása, harciasság."
+                "description_hu": "Párharcok intenzitása, harciasság.",
+                "laterality_domain": "none",
             },
             {
                 "key": "reactions",
                 "name_en": "Reactions",
                 "name_hu": "Reakcióidő",
-                "description_hu": "Váratlan helyzetekre adott gyors válaszok."
+                "description_hu": "Váratlan helyzetekre adott gyors válaszok.",
+                "laterality_domain": "none",
             },
             {
                 "key": "composure",
                 "name_en": "Composure",
                 "name_hu": "Hidegvér",
-                "description_hu": "Nyomás alatti döntéshozatal minősége."
+                "description_hu": "Nyomás alatti döntéshozatal minősége.",
+                "laterality_domain": "none",
             },
             {
                 "key": "consistency",
                 "name_en": "Consistency",
                 "name_hu": "Kiegyensúlyozottság",
-                "description_hu": "Teljesítmény stabilitása mérkőzésről mérkőzésre."
+                "description_hu": "Teljesítmény stabilitása mérkőzésről mérkőzésre.",
+                "laterality_domain": "none",
             },
             {
                 "key": "tactical_awareness",
                 "name_en": "Tactical Awareness",
                 "name_hu": "Taktikai tudatosság",
-                "description_hu": "Csapatstruktúra és játékelvek megértése."
+                "description_hu": "Csapatstruktúra és játékelvek megértése.",
+                "laterality_domain": "none",
             },
             {
                 "key": "anticipation",
                 "name_en": "Anticipation",
                 "name_hu": "Helyzetfelismerés",
-                "description_hu": "Játékhelyzetek és ellenfél szándékának előre jelzése."
+                "description_hu": "Játékhelyzetek és ellenfél szándékának előre jelzése.",
+                "laterality_domain": "none",
             },
             {
                 "key": "concentration",
                 "name_en": "Concentration",
                 "name_hu": "Koncentráció",
-                "description_hu": "Figyelmi fókusz fenntartása a mérkőzés teljes ideje alatt."
+                "description_hu": "Figyelmi fókusz fenntartása a mérkőzés teljes ideje alatt.",
+                "laterality_domain": "none",
             },
             {
                 "key": "decisions",
                 "name_en": "Decisions",
                 "name_hu": "Döntéshozatal",
-                "description_hu": "Gyors és helyes döntések labdánál és labda nélkül egyaránt."
+                "description_hu": "Gyors és helyes döntések labdánál és labda nélkül egyaránt.",
+                "laterality_domain": "none",
             },
             {
                 "key": "determination",
                 "name_en": "Determination",
                 "name_hu": "Elszántság",
-                "description_hu": "Kitartás és belső motiváció nehéz helyzetekben és lemaradásban."
+                "description_hu": "Kitartás és belső motiváció nehéz helyzetekben és lemaradásban.",
+                "laterality_domain": "none",
             },
             {
                 "key": "teamwork",
                 "name_en": "Teamwork",
                 "name_hu": "Csapatmunka",
-                "description_hu": "Együttműködési képesség csapattársakkal, önzetlenség a pályán."
+                "description_hu": "Együttműködési képesség csapattársakkal, önzetlenség a pályán.",
+                "laterality_domain": "none",
             },
             {
                 "key": "leadership",
                 "name_en": "Leadership",
                 "name_hu": "Vezetői képesség",
-                "description_hu": "Csapat irányítása, motiválása és hangolása mérkőzés közben."
-            }
+                "description_hu": "Csapat irányítása, motiválása és hangolása mérkőzés közben.",
+                "laterality_domain": "none",
+            },
         ]
     },
     {
@@ -281,50 +325,58 @@ SKILL_CATEGORIES: List[SkillCategory] = [
                 "key": "acceleration",
                 "name_en": "Acceleration",
                 "name_hu": "Gyorsulás",
-                "description_hu": "Első lépések robbanékonysága."
+                "description_hu": "Első lépések robbanékonysága.",
+                "laterality_domain": "none",
             },
             {
                 "key": "sprint_speed",
                 "name_en": "Sprint Speed",
                 "name_hu": "Végsebesség",
-                "description_hu": "Maximális futási sebesség."
+                "description_hu": "Maximális futási sebesség.",
+                "laterality_domain": "none",
             },
             {
                 "key": "agility",
                 "name_en": "Agility",
                 "name_hu": "Agilitás",
-                "description_hu": "Gyors irányváltás, testkontroll."
+                "description_hu": "Gyors irányváltás, testkontroll.",
+                "laterality_domain": "none",
             },
             {
                 "key": "jumping",
                 "name_en": "Jumping",
                 "name_hu": "Ugróképesség",
-                "description_hu": "Fejpárbajokhoz és levegőben való játékhoz."
+                "description_hu": "Fejpárbajokhoz és levegőben való játékhoz.",
+                "laterality_domain": "none",
             },
             {
                 "key": "strength",
                 "name_en": "Strength",
                 "name_hu": "Erő",
-                "description_hu": "Test-test elleni párharcokban mutatott fizikai fölény."
+                "description_hu": "Test-test elleni párharcokban mutatott fizikai fölény.",
+                "laterality_domain": "none",
             },
             {
                 "key": "stamina",
                 "name_en": "Stamina",
                 "name_hu": "Állóképesség",
-                "description_hu": "Terhelhetőség a mérkőzés teljes ideje alatt."
+                "description_hu": "Terhelhetőség a mérkőzés teljes ideje alatt.",
+                "laterality_domain": "none",
             },
             {
                 "key": "balance",
                 "name_en": "Balance",
                 "name_hu": "Egyensúly",
-                "description_hu": "Stabilitás mozgás és kontakt közben."
+                "description_hu": "Stabilitás mozgás és kontakt közben.",
+                "laterality_domain": "none",
             },
             {
                 "key": "work_rate",
                 "name_en": "Work Rate",
                 "name_hu": "Munkabírás",
-                "description_hu": "Lefutott távolság és aktivitás mérkőzésen — védekezésben és támadásban egyaránt."
-            }
+                "description_hu": "Lefutott távolság és aktivitás mérkőzésen — védekezésben és támadásban egyaránt.",
+                "laterality_domain": "none",
+            },
         ]
     }
 ]
@@ -335,6 +387,16 @@ ALL_SKILLS: Dict[str, SkillDefinition] = {}
 for category in SKILL_CATEGORIES:
     for skill in category["skills"]:
         ALL_SKILLS[skill["key"]] = skill
+
+
+# Flat laterality lookup: skill_key -> "foot" | "hand" | "none"
+# Used by the tournament reward orchestrator to guard foot-lateral bucket writes.
+# If a skill_key is absent here it is a configuration error — callers must not
+# silently fall back to "foot".
+SKILL_LATERALITY: Dict[str, str] = {
+    key: defn["laterality_domain"]
+    for key, defn in ALL_SKILLS.items()
+}
 
 
 # Default baseline for new skills (existing players migration)

--- a/tests/unit/services/test_laterality_domain_guard.py
+++ b/tests/unit/services/test_laterality_domain_guard.py
@@ -1,0 +1,377 @@
+"""
+Orchestrator laterality domain guard (Option B).
+
+Tests that the F4b loop correctly gates foot-lateral bucket writes based on
+SKILL_LATERALITY — only foot-domain skills call update_lateral_component /
+aggregate_lateral_components.  hand and none skills preserve the EMA
+current_level directly.  Unknown skill keys trigger a warning and no bucket.
+
+LD-GUARD-01  foot skill (crossing) → update_lateral_component IS called
+LD-GUARD-02  foot skill (crossing) → aggregate_lateral_components IS called
+LD-GUARD-03  throwing (hand)       → update_lateral_component NOT called
+LD-GUARD-04  throwing (hand)       → aggregate_lateral_components NOT called
+LD-GUARD-05  throwing current_level → EMA value preserved (not lateral-aggregated)
+LD-GUARD-06  stamina (none)        → update_lateral_component NOT called
+LD-GUARD-07  stamina current_level → EMA value preserved (not lateral-aggregated)
+LD-GUARD-08  unknown skill key     → no lateral call; logger.warning emitted
+
+Patch strategy (same as test_orchestrator_lateral_b4.py):
+  _LAT = "app.services.skill_progression" — module where lateral fns live
+  _ORC = "app.services.tournament.tournament_reward_orchestrator"
+
+DB isolation: SAVEPOINT-nested test_db (commits are SAVEPOINT-only).
+"""
+
+import logging
+import uuid
+import pytest
+from datetime import date, datetime
+from zoneinfo import ZoneInfo
+from unittest.mock import patch, MagicMock
+
+from sqlalchemy.orm import Session
+
+from app.models.user import User, UserRole
+from app.models.license import UserLicense
+from app.models.game_preset import GamePreset
+from app.models.specialization import SpecializationType
+from app.services.tournament.core import create_tournament_semester
+from app.services.tournament.tournament_reward_orchestrator import distribute_rewards_for_user
+from app.core.security import get_password_hash
+
+_ORC = "app.services.tournament.tournament_reward_orchestrator"
+_LAT = "app.services.skill_progression"
+
+# Skill keys under test — one per domain, plus one unknown
+_FOOT_KEY    = "crossing"             # laterality_domain = "foot"
+_HAND_KEY    = "throwing"             # laterality_domain = "hand"
+_NONE_KEY    = "stamina"              # laterality_domain = "none"
+_UNKNOWN_KEY = "unknown_fake_skill"   # not in SKILL_LATERALITY → warning path
+
+# EMA-derived values returned by the mocked skill profile
+_EMA_FOOT    = 55.0
+_EMA_HAND    = 62.0
+_EMA_NONE    = 70.0
+_EMA_UNKNOWN = 48.0
+
+_DELTAS = {
+    _FOOT_KEY:    1.0,
+    _HAND_KEY:    0.5,
+    _NONE_KEY:    0.3,
+    _UNKNOWN_KEY: 0.2,
+}
+
+# Mock profile returned by skill_progression_service.get_skill_profile
+_PROFILE = {
+    "skills": {
+        _FOOT_KEY:    {"current_level": _EMA_FOOT,    "tournament_delta": 1.0, "total_delta": 1.0, "tournament_count": 1},
+        _HAND_KEY:    {"current_level": _EMA_HAND,    "tournament_delta": 0.5, "total_delta": 0.5, "tournament_count": 1},
+        _NONE_KEY:    {"current_level": _EMA_NONE,    "tournament_delta": 0.3, "total_delta": 0.3, "tournament_count": 1},
+        _UNKNOWN_KEY: {"current_level": _EMA_UNKNOWN, "tournament_delta": 0.2, "total_delta": 0.2, "tournament_count": 1},
+    }
+}
+
+# Initial football_skills on the license.
+# throwing carries a stale neutral bucket (from before the domain guard existed)
+# to verify it is not extended by new tournament runs.
+_INITIAL_SKILLS = {
+    _FOOT_KEY:    {"current_level": 50.0},
+    _HAND_KEY:    {
+        "current_level": 61.5,
+        "lateral_components": {
+            "neutral": {
+                "level": 60.0,
+                "total_delta": -1.5,
+                "tournament_count": 2,
+                "last_delta": -0.5,
+            }
+        },
+    },
+    _NONE_KEY:    {"current_level": 69.7},
+    _UNKNOWN_KEY: {"current_level": 47.8},
+}
+
+
+# ── DB helpers ────────────────────────────────────────────────────────────────
+
+def _make_preset(db: Session) -> GamePreset:
+    gp = GamePreset(
+        code=f"ldg_{uuid.uuid4().hex[:6]}",
+        name=f"LDGuard {uuid.uuid4().hex[:4]}",
+        is_active=True,
+        game_config={
+            "version": "1.0",
+            "format_config": {},
+            "skill_config": {
+                "foot_context": "neutral",
+                "skills_tested":    [_FOOT_KEY, _HAND_KEY, _NONE_KEY, _UNKNOWN_KEY],
+                "skill_weights":    {_FOOT_KEY: 0.4, _HAND_KEY: 0.3, _NONE_KEY: 0.2, _UNKNOWN_KEY: 0.1},
+                "skill_impact_on_matches": True,
+            },
+            "simulation_config": {},
+            "metadata": {"game_category": "FOOTBALL", "difficulty_level": None, "min_players": 2},
+        },
+    )
+    db.add(gp)
+    db.commit()
+    db.refresh(gp)
+    return gp
+
+
+def _make_tournament(db: Session, *, preset_id: int):
+    return create_tournament_semester(
+        db=db,
+        tournament_date=date.today(),
+        name=f"LDG {uuid.uuid4().hex[:6]}",
+        specialization_type=SpecializationType.LFA_FOOTBALL_PLAYER,
+        format="INDIVIDUAL_RANKING",
+        game_preset_id=preset_id,
+    )
+
+
+def _make_user_with_license(db: Session) -> tuple[User, UserLicense]:
+    uid = uuid.uuid4().hex[:8]
+    u = User(
+        email=f"ldg-{uid}@lfa.com",
+        name=f"LDGuard {uid}",
+        password_hash=get_password_hash("Test123!"),
+        role=UserRole.STUDENT,
+        xp_balance=0,
+        credit_balance=0,
+    )
+    db.add(u)
+    db.flush()
+    lic = UserLicense(
+        user_id=u.id,
+        specialization_type="LFA_FOOTBALL_PLAYER",
+        is_active=True,
+        started_at=datetime.now(ZoneInfo("UTC")),
+        football_skills=dict(_INITIAL_SKILLS),
+        right_foot_score=0.7,
+        left_foot_score=0.3,
+    )
+    db.add(lic)
+    db.commit()
+    return u, lic
+
+
+def _fake_participation() -> MagicMock:
+    m = MagicMock()
+    m.skill_rating_delta = dict(_DELTAS)
+    m.foot_context = "neutral"
+    m.placement = 1
+    return m
+
+
+def _dummy_badge() -> MagicMock:
+    b = MagicMock()
+    b.badge_type = "PARTICIPATION"
+    b.badge_category = "TOURNAMENT"
+    b.title = "Test"
+    b.description = "Test"
+    b.icon = ""
+    b.rarity = "COMMON"
+    b.badge_metadata = {}
+    return b
+
+
+def _run(db: Session, *, user_id: int, tournament_id: int):
+    """
+    Run distribute_rewards_for_user with the service layer mocked.
+    Returns (mock_ulc, mock_agg) for call inspection.
+    """
+    with (
+        patch(f"{_ORC}.participation_service.calculate_skill_points_for_placement",
+              return_value=dict(_DELTAS)),
+        patch(f"{_ORC}.participation_service.convert_skill_points_to_xp", return_value=100),
+        patch(f"{_ORC}.participation_service.record_tournament_participation",
+              return_value=_fake_participation()),
+        patch(f"{_ORC}.skill_progression_service.get_skill_profile", return_value=_PROFILE),
+        patch(f"{_ORC}.badge_service.award_placement_badges", return_value=[]),
+        patch(f"{_ORC}.badge_service.award_participation_badge", return_value=_dummy_badge()),
+        patch(f"{_ORC}.badge_service.check_and_award_milestone_badges", return_value=[]),
+        patch(f"{_LAT}.update_lateral_component",
+              side_effect=lambda entry, fc, delta: entry) as mock_ulc,
+        patch(f"{_LAT}.aggregate_lateral_components", return_value=50.0) as mock_agg,
+    ):
+        distribute_rewards_for_user(
+            db=db,
+            user_id=user_id,
+            tournament_id=tournament_id,
+            placement=1,
+            total_participants=5,
+            is_sandbox_mode=False,
+        )
+    return mock_ulc, mock_agg
+
+
+def _reload(db: Session, lic: UserLicense) -> UserLicense:
+    """Force a fresh load of the license from the DB (post-SAVEPOINT commit)."""
+    db.expire(lic)
+    return db.query(UserLicense).filter(UserLicense.id == lic.id).first()
+
+
+# ── LD-GUARD-01 / 02 — foot skill ────────────────────────────────────────────
+
+class TestLateralDomainGuardFoot:
+    """crossing (foot) must go through the full lateral update path."""
+
+    def test_foot_skill_calls_update_lateral_component(self, test_db: Session):
+        """LD-GUARD-01."""
+        preset     = _make_preset(test_db)
+        tournament = _make_tournament(test_db, preset_id=preset.id)
+        user, _    = _make_user_with_license(test_db)
+
+        mock_ulc, _ = _run(test_db, user_id=user.id, tournament_id=tournament.id)
+
+        foot_calls = [c for c in mock_ulc.call_args_list if c.args[2] == _DELTAS[_FOOT_KEY]]
+        assert foot_calls, (
+            f"update_lateral_component was not called for '{_FOOT_KEY}' (foot skill). "
+            f"Total calls: {mock_ulc.call_count}"
+        )
+
+    def test_foot_skill_calls_aggregate_lateral_components(self, test_db: Session):
+        """LD-GUARD-02."""
+        preset     = _make_preset(test_db)
+        tournament = _make_tournament(test_db, preset_id=preset.id)
+        user, _    = _make_user_with_license(test_db)
+
+        _, mock_agg = _run(test_db, user_id=user.id, tournament_id=tournament.id)
+
+        assert mock_agg.call_count >= 1, (
+            f"aggregate_lateral_components was never called "
+            f"(expected at least 1 call for foot skill '{_FOOT_KEY}')"
+        )
+
+
+# ── LD-GUARD-03 / 04 / 05 — hand skill (throwing) ────────────────────────────
+
+class TestLateralDomainGuardHand:
+    """throwing (hand) must skip foot-lateral tracking entirely."""
+
+    def test_throwing_skips_update_lateral_component(self, test_db: Session):
+        """LD-GUARD-03."""
+        preset     = _make_preset(test_db)
+        tournament = _make_tournament(test_db, preset_id=preset.id)
+        user, _    = _make_user_with_license(test_db)
+
+        mock_ulc, _ = _run(test_db, user_id=user.id, tournament_id=tournament.id)
+
+        throwing_calls = [c for c in mock_ulc.call_args_list if c.args[2] == _DELTAS[_HAND_KEY]]
+        assert not throwing_calls, (
+            f"update_lateral_component was called for '{_HAND_KEY}' (hand skill) — "
+            f"must not create foot buckets. Calls: {throwing_calls}"
+        )
+
+    def test_throwing_skips_aggregate_lateral_components(self, test_db: Session):
+        """LD-GUARD-04: aggregate is only called once per foot skill, not for throwing."""
+        preset     = _make_preset(test_db)
+        tournament = _make_tournament(test_db, preset_id=preset.id)
+        user, lic  = _make_user_with_license(test_db)
+
+        _, mock_agg = _run(test_db, user_id=user.id, tournament_id=tournament.id)
+
+        # Only 1 foot skill in the set (_FOOT_KEY = crossing); aggregate called once.
+        # If throwing were aggregated, call_count would be 2.
+        assert mock_agg.call_count == 1, (
+            f"aggregate_lateral_components call_count={mock_agg.call_count}; "
+            f"expected 1 (only for '{_FOOT_KEY}'). "
+            f"throwing must not trigger aggregation."
+        )
+
+    def test_throwing_current_level_from_ema(self, test_db: Session):
+        """LD-GUARD-05: throwing.current_level is the EMA value, not lateral-aggregated."""
+        preset     = _make_preset(test_db)
+        tournament = _make_tournament(test_db, preset_id=preset.id)
+        user, lic  = _make_user_with_license(test_db)
+
+        _run(test_db, user_id=user.id, tournament_id=tournament.id)
+
+        updated = _reload(test_db, lic)
+        actual  = updated.football_skills[_HAND_KEY]["current_level"]
+        assert actual == _EMA_HAND, (
+            f"throwing current_level={actual!r}; expected EMA value {_EMA_HAND!r}. "
+            f"lateral aggregation must NOT run for hand skills."
+        )
+
+    def test_throwing_stale_neutral_bucket_not_extended(self, test_db: Session):
+        """Stale neutral bucket in throwing.lateral_components must not gain new entries."""
+        preset     = _make_preset(test_db)
+        tournament = _make_tournament(test_db, preset_id=preset.id)
+        user, lic  = _make_user_with_license(test_db)
+
+        _run(test_db, user_id=user.id, tournament_id=tournament.id)
+
+        updated = _reload(test_db, lic)
+        bucket  = updated.football_skills[_HAND_KEY].get("lateral_components", {}).get("neutral", {})
+        assert bucket.get("tournament_count") == 2, (
+            f"Stale neutral bucket tournament_count changed from 2 to "
+            f"{bucket.get('tournament_count')!r} — bucket must remain frozen."
+        )
+
+
+# ── LD-GUARD-06 / 07 — none skill (stamina) ───────────────────────────────────
+
+class TestLateralDomainGuardNone:
+    """stamina (none) must skip foot-lateral tracking entirely."""
+
+    def test_none_skill_skips_update_lateral_component(self, test_db: Session):
+        """LD-GUARD-06."""
+        preset     = _make_preset(test_db)
+        tournament = _make_tournament(test_db, preset_id=preset.id)
+        user, _    = _make_user_with_license(test_db)
+
+        mock_ulc, _ = _run(test_db, user_id=user.id, tournament_id=tournament.id)
+
+        stamina_calls = [c for c in mock_ulc.call_args_list if c.args[2] == _DELTAS[_NONE_KEY]]
+        assert not stamina_calls, (
+            f"update_lateral_component was called for '{_NONE_KEY}' (none skill) — "
+            f"must not create foot buckets. Calls: {stamina_calls}"
+        )
+
+    def test_none_skill_current_level_from_ema(self, test_db: Session):
+        """LD-GUARD-07: stamina.current_level is the EMA value, not lateral-aggregated."""
+        preset     = _make_preset(test_db)
+        tournament = _make_tournament(test_db, preset_id=preset.id)
+        user, lic  = _make_user_with_license(test_db)
+
+        _run(test_db, user_id=user.id, tournament_id=tournament.id)
+
+        updated = _reload(test_db, lic)
+        actual  = updated.football_skills[_NONE_KEY]["current_level"]
+        assert actual == _EMA_NONE, (
+            f"stamina current_level={actual!r}; expected EMA value {_EMA_NONE!r}. "
+            f"lateral aggregation must NOT run for none skills."
+        )
+
+
+# ── LD-GUARD-08 — unknown skill key ───────────────────────────────────────────
+
+class TestLateralDomainGuardUnknown:
+    """Skills absent from SKILL_LATERALITY must not create foot buckets and must log a warning."""
+
+    def test_unknown_skill_no_lateral_call_and_warning_logged(self, test_db: Session, caplog):
+        """LD-GUARD-08."""
+        preset     = _make_preset(test_db)
+        tournament = _make_tournament(test_db, preset_id=preset.id)
+        user, _    = _make_user_with_license(test_db)
+
+        with caplog.at_level(
+            logging.WARNING,
+            logger="app.services.tournament.tournament_reward_orchestrator",
+        ):
+            mock_ulc, mock_agg = _run(test_db, user_id=user.id, tournament_id=tournament.id)
+
+        unknown_lateral_calls = [
+            c for c in mock_ulc.call_args_list if c.args[2] == _DELTAS[_UNKNOWN_KEY]
+        ]
+        assert not unknown_lateral_calls, (
+            f"update_lateral_component was called for unknown key '{_UNKNOWN_KEY}'. "
+            f"Must not silently create a foot bucket for unknown skills."
+        )
+
+        warning_messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+        assert any(_UNKNOWN_KEY in msg for msg in warning_messages), (
+            f"Expected a WARNING mentioning '{_UNKNOWN_KEY}' for unknown laterality_domain. "
+            f"Warnings emitted: {warning_messages}"
+        )

--- a/tests/unit/test_skills_config_laterality.py
+++ b/tests/unit/test_skills_config_laterality.py
@@ -1,0 +1,97 @@
+"""
+Taxonomy integrity tests for skills_config.SKILL_LATERALITY.
+
+SC-LAT-01  All 44 skills have a laterality_domain field
+SC-LAT-02  laterality_domain values are limited to {"foot", "hand", "none"}
+SC-LAT-03  throwing == "hand"
+SC-LAT-04  heading  == "none"  (bilateral; not foot-dominant)
+SC-LAT-05  foot skill count == 20
+SC-LAT-06  hand skill count ==  1  (only throwing)
+SC-LAT-07  none skill count == 23
+SC-LAT-08  SKILL_LATERALITY covers all 44 keys and mirrors ALL_SKILLS
+"""
+
+from app.skills_config import ALL_SKILLS, SKILL_LATERALITY
+
+_VALID_DOMAINS = frozenset({"foot", "hand", "none"})
+
+_EXPECTED_FOOT_SKILLS = frozenset({
+    "ball_control", "dribbling", "finishing", "shot_power", "long_shots",
+    "volleys", "crossing", "passing", "tackle", "marking", "shooting",
+    "technique", "creativity", "long_passing", "flair", "touch",
+    "forward_runs", "free_kicks", "corners", "penalties",
+})
+
+_EXPECTED_NONE_SKILLS = frozenset({
+    "heading",
+    "positioning_off", "positioning_def", "vision", "aggression", "reactions",
+    "composure", "consistency", "tactical_awareness", "anticipation",
+    "concentration", "decisions", "determination", "teamwork", "leadership",
+    "acceleration", "sprint_speed", "agility", "jumping", "strength",
+    "stamina", "balance", "work_rate",
+})
+
+
+class TestSkillsConfigLateralityTaxonomy:
+
+    def test_all_skills_have_laterality_domain(self):
+        """SC-LAT-01: every key in ALL_SKILLS carries laterality_domain."""
+        missing = [k for k, v in ALL_SKILLS.items() if "laterality_domain" not in v]
+        assert not missing, f"Skills missing laterality_domain: {missing}"
+
+    def test_laterality_domain_values_are_valid(self):
+        """SC-LAT-02: no laterality_domain outside the known set."""
+        invalid = {
+            k: v["laterality_domain"]
+            for k, v in ALL_SKILLS.items()
+            if v["laterality_domain"] not in _VALID_DOMAINS
+        }
+        assert not invalid, f"Invalid laterality_domain values: {invalid}"
+
+    def test_throwing_is_hand(self):
+        """SC-LAT-03: throwing is the sole hand-lateral skill."""
+        assert ALL_SKILLS["throwing"]["laterality_domain"] == "hand"
+
+    def test_heading_is_none(self):
+        """SC-LAT-04: heading is not foot-dominant — common misclassification guard."""
+        assert ALL_SKILLS["heading"]["laterality_domain"] == "none"
+
+    def test_foot_count_is_20(self):
+        """SC-LAT-05: exactly 20 foot-lateral skills."""
+        foot_skills = {k for k, v in ALL_SKILLS.items() if v["laterality_domain"] == "foot"}
+        assert foot_skills == _EXPECTED_FOOT_SKILLS, (
+            f"Foot skill mismatch.\n"
+            f"  Extra:   {foot_skills - _EXPECTED_FOOT_SKILLS}\n"
+            f"  Missing: {_EXPECTED_FOOT_SKILLS - foot_skills}"
+        )
+
+    def test_hand_count_is_1(self):
+        """SC-LAT-06: exactly 1 hand-lateral skill (throwing)."""
+        hand_skills = [k for k, v in ALL_SKILLS.items() if v["laterality_domain"] == "hand"]
+        assert hand_skills == ["throwing"], (
+            f"Expected [\"throwing\"], got {hand_skills}"
+        )
+
+    def test_none_count_is_23(self):
+        """SC-LAT-07: exactly 23 non-lateral skills (heading + all mental + all physical)."""
+        none_skills = {k for k, v in ALL_SKILLS.items() if v["laterality_domain"] == "none"}
+        assert none_skills == _EXPECTED_NONE_SKILLS, (
+            f"None skill mismatch.\n"
+            f"  Extra:   {none_skills - _EXPECTED_NONE_SKILLS}\n"
+            f"  Missing: {_EXPECTED_NONE_SKILLS - none_skills}"
+        )
+
+    def test_skill_laterality_covers_all_44_keys(self):
+        """SC-LAT-08: SKILL_LATERALITY is a complete, consistent mirror of ALL_SKILLS."""
+        assert len(SKILL_LATERALITY) == 44, (
+            f"SKILL_LATERALITY has {len(SKILL_LATERALITY)} keys, expected 44"
+        )
+        assert set(SKILL_LATERALITY.keys()) == set(ALL_SKILLS.keys()), (
+            "SKILL_LATERALITY key set differs from ALL_SKILLS key set"
+        )
+        mismatches = {
+            k: (SKILL_LATERALITY[k], ALL_SKILLS[k]["laterality_domain"])
+            for k in ALL_SKILLS
+            if SKILL_LATERALITY[k] != ALL_SKILLS[k]["laterality_domain"]
+        }
+        assert not mismatches, f"SKILL_LATERALITY value mismatches: {mismatches}"


### PR DESCRIPTION
## Summary

- **`app/skills_config.py`**: `SkillDefinition` TypedDict gains required `laterality_domain: Literal["foot", "hand", "none"]`. All 44 skills annotated (foot=20, hand=1, none=23). `SKILL_LATERALITY` lookup dict exported.
- **`app/services/tournament/tournament_reward_orchestrator.py`**: F4b loop dispatches by domain — `"foot"` → existing lateral path unchanged; `"hand"` / `"none"` → EMA `current_level` preserved, no foot bucket created; `None` (unknown key) → `logger.warning` + EMA current_level (fail-visible, not silent).
- **`throwing`** no longer accumulates neutral foot `lateral_components` buckets. Stale neutral buckets in JSONB remain but are never extended.
- **17 new tests**: 8 taxonomy integrity (SC-LAT-01..08) + 9 orchestrator guard (LD-GUARD-01..08 + stale bucket freeze check).

## Taxonomy

| Domain | Count | Skills |
|--------|-------|--------|
| `foot` | 20 | ball_control, dribbling, finishing, shot_power, long_shots, volleys, crossing, passing, tackle, marking, shooting, technique, creativity, long_passing, flair, touch, forward_runs, free_kicks, corners, penalties |
| `hand` | 1 | throwing |
| `none` | 23 | heading + all mental (14) + all physical (8) |

## Out of scope (gated as future phase)

- Option C: hand_context, hand scores, hand dominance onboarding, DB migration — **not implemented**
- No changes to `GamePreset.foot_context_for()`, onboarding flow, or any UI

## Test plan

- [ ] `pytest tests/unit/test_skills_config_laterality.py -v` — 8 taxonomy tests (no DB)
- [ ] `pytest tests/unit/services/test_laterality_domain_guard.py -v` — 9 orchestrator guard tests
- [ ] Full unit suite: `pytest tests/unit/ -x --ignore=tests/unit/test_openapi_snapshot.py` — regression check

🤖 Generated with [Claude Code](https://claude.com/claude-code)