### PR TITLE
feat(welcome-card): FIFA Classic redesign — platform gallery, self-assessment preview, spec-switch resilience

### DIFF
--- a/alembic/versions/2026_05_13_1000_add_session_due_shown.py
+++ b/alembic/versions/2026_05_13_1000_add_session_due_shown.py
@@ -1,0 +1,28 @@
+"""adaptive_learning_sessions.session_due_shown — spaced-repetition cap tracking
+
+Revision ID: 2026_05_13_1000
+Revises: 2026_05_10_1000
+Create Date: 2026-05-13 10:00:00.000000
+
+Tracks how many due-for-review questions have been served in a session so the
+weighted selector can cap spaced-repetition monopolisation at _SESSION_DUE_CAP.
+Existing rows default to 0 (no due questions served yet).
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '2026_05_13_1000'
+down_revision = '2026_05_10_1000'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'adaptive_learning_sessions',
+        sa.Column('session_due_shown', sa.Integer(), nullable=False, server_default='0'),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('adaptive_learning_sessions', 'session_due_shown')

--- a/app/api/web_routes/dashboard.py
+++ b/app/api/web_routes/dashboard.py
@@ -413,10 +413,23 @@ async def lfa_player_card_editor(
 
     # Animated video export capability: list of platforms supported for the
     # current variant. Used by the card editor to show/hide the video button.
-    from ...services.card_export_service import ANIMATED_EXPORT_CAPABLE
+    from ...services.card_constants import (
+        ANIMATED_EXPORT_CAPABLE,
+        CANVAS_SIZES as _editor_canvas_sizes,
+        CARD_EDITOR_PLATFORM_IDS,
+    )
+    from ...services.card_platform_service import build_platform_list as _build_platform_list
     animated_capable_platforms = [
         p for (v, p) in ANIMATED_EXPORT_CAPABLE if v == active_card_variant
     ]
+
+    # Platform list for the Jinja2 picker loop (all non-default export platforms).
+    editor_platforms = _build_platform_list(CARD_EDITOR_PLATFORM_IDS)
+
+    # JSON-serialisable canvas sizes for server-rendered JS const in template.
+    canvas_sizes = {
+        pid: {"w": w, "h": h} for pid, (w, h) in _editor_canvas_sizes.items()
+    }
 
     return templates.TemplateResponse(
         "dashboard_card_editor.html",
@@ -432,6 +445,8 @@ async def lfa_player_card_editor(
             "active_card_platform": user_license.public_card_platform or "default",
             "show_variant_picker": True,  # page is LFA Football Player only
             "animated_capable_platforms": animated_capable_platforms,
+            "platforms": editor_platforms,
+            "canvas_sizes": canvas_sizes,
         },
     )
 

--- a/app/api/web_routes/profile.py
+++ b/app/api/web_routes/profile.py
@@ -154,6 +154,241 @@ async def profile_page(
     )
 
 
+# ── LFA Football Player profile constants ─────────────────────────────────────
+
+_VALID_POSITIONS: frozenset[str] = frozenset({
+    "striker", "centre_forward", "left_wing", "right_wing", "second_striker",
+    "attacking_midfield", "centre_midfield", "defensive_midfield",
+    "left_midfield", "right_midfield",
+    "centre_back", "left_back", "right_back", "left_wing_back", "right_wing_back",
+    "goalkeeper", "sweeper_keeper",
+})
+
+_VALID_GOALS: frozenset[str] = frozenset({
+    "improve_skills", "play_higher_level", "become_professional",
+    "team_football", "fitness_health", "enjoy_game",
+})
+
+_VALID_PREFERRED_FOOT: frozenset[str] = frozenset({"right", "left", "both"})
+
+_GOAL_LABELS: dict[str, str] = {
+    "improve_skills":      "Improve technical skills",
+    "play_higher_level":   "Play at a higher competitive level",
+    "become_professional": "Become a professional player",
+    "team_football":       "Join a football team",
+    "fitness_health":      "Stay fit through football",
+    "enjoy_game":          "Enjoy the game",
+}
+
+_POSITION_LABELS: dict[str, str] = {
+    "striker":            "Striker (ST)",
+    "centre_forward":     "Centre Forward (CF)",
+    "left_wing":          "Left Wing (LW)",
+    "right_wing":         "Right Wing (RW)",
+    "second_striker":     "Second Striker (SS)",
+    "attacking_midfield": "Attacking Midfielder (AM)",
+    "centre_midfield":    "Central Midfielder (CM)",
+    "defensive_midfield": "Defensive Midfielder (DM)",
+    "left_midfield":      "Left Midfielder (LM)",
+    "right_midfield":     "Right Midfielder (RM)",
+    "centre_back":        "Centre Back (CB)",
+    "left_back":          "Left Back (LB)",
+    "right_back":         "Right Back (RB)",
+    "left_wing_back":     "Left Wing-Back (LWB)",
+    "right_wing_back":    "Right Wing-Back (RWB)",
+    "goalkeeper":         "Goalkeeper (GK)",
+    "sweeper_keeper":     "Sweeper Keeper (SK)",
+}
+
+_POSITION_GROUPS: list[dict] = [
+    {"label": "Forwards",    "positions": ["striker", "centre_forward", "left_wing", "right_wing", "second_striker"]},
+    {"label": "Midfielders", "positions": ["attacking_midfield", "centre_midfield", "defensive_midfield", "left_midfield", "right_midfield"]},
+    {"label": "Defenders",   "positions": ["centre_back", "left_back", "right_back", "left_wing_back", "right_wing_back"]},
+    {"label": "Goalkeepers", "positions": ["goalkeeper", "sweeper_keeper"]},
+]
+
+
+def _lfa_license_or_redirect(
+    user_id: int, db: Session
+) -> "tuple[UserLicense, None] | tuple[None, RedirectResponse]":
+    """Return (license, None) or (None, redirect) for LFA Football Player guard."""
+    lic = db.query(UserLicense).filter(
+        UserLicense.user_id == user_id,
+        UserLicense.specialization_type == "LFA_FOOTBALL_PLAYER",
+    ).first()
+    if not lic:
+        return None, RedirectResponse(url="/dashboard?info=no_lfa_license", status_code=303)
+    if not lic.onboarding_completed:
+        return None, RedirectResponse(url="/specialization/lfa-player/onboarding", status_code=303)
+    return lic, None
+
+
+def _lfa_profile_ctx(request, user, license, error=None) -> dict:
+    """Shared context for lfa_player_profile_edit.html GET and POST (error re-render)."""
+    ms           = license.motivation_scores or {}
+    primary_pos  = ms.get("position", "")
+    all_pos      = ms.get("positions", [primary_pos] if primary_pos else [])
+    secondary_pos = [p for p in all_pos if p != primary_pos]
+    return {
+        "request":            request,
+        "user":               user,
+        "license":            license,
+        "ms":                 ms,
+        "primary_pos":        primary_pos,
+        "secondary_pos":      secondary_pos,
+        "position_labels":    _POSITION_LABELS,
+        "position_groups":    _POSITION_GROUPS,
+        "goal_labels":        _GOAL_LABELS,
+        "valid_preferred_foot": sorted(_VALID_PREFERRED_FOOT),
+        "error":              error,
+        "spec_dashboard_url":  "/dashboard/lfa-football-player",
+        "spec_dashboard_icon": "⚽",
+        "show_spec_nav":      True,
+    }
+
+
+@router.get("/profile/lfa-football-player", response_class=HTMLResponse)
+async def lfa_player_profile_page(
+    request: Request,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user_web),
+):
+    """
+    LFA Football Player specialization profile hub.
+
+    Requires a completed LFA_FOOTBALL_PLAYER license.
+    Displays spec-specific data from motivation_scores and UserLicense fields.
+    football_skills (EMA-computed) are not exposed or editable here.
+    """
+    license, redirect = _lfa_license_or_redirect(user.id, db)
+    if redirect:
+        return redirect
+
+    ms            = license.motivation_scores or {}
+    primary_pos   = ms.get("position", "")
+    all_pos       = ms.get("positions", [primary_pos] if primary_pos else [])
+    secondary_pos = [p for p in all_pos if p != primary_pos]
+
+    return templates.TemplateResponse(
+        "lfa_player_profile.html",
+        {
+            "request":                request,
+            "user":                   user,
+            "license":                license,
+            "ms":                     ms,
+            "primary_pos":            primary_pos,
+            "secondary_pos":          secondary_pos,
+            "position_labels":        _POSITION_LABELS,
+            "goal_label":             _GOAL_LABELS.get(ms.get("goals", ""), ms.get("goals", "")),
+            "average_skill_level":    ms.get("average_skill_level"),
+            "onboarding_completed_at":ms.get("onboarding_completed_at"),
+            "spec_dashboard_url":     "/dashboard/lfa-football-player",
+            "spec_dashboard_icon":    "⚽",
+            "show_spec_nav":          True,
+        },
+    )
+
+
+@router.get("/profile/lfa-football-player/edit", response_class=HTMLResponse)
+async def lfa_player_profile_edit_page(
+    request: Request,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user_web),
+):
+    """Show the LFA Football Player spec-profile edit form."""
+    license, redirect = _lfa_license_or_redirect(user.id, db)
+    if redirect:
+        return redirect
+    return templates.TemplateResponse(
+        "lfa_player_profile_edit.html",
+        _lfa_profile_ctx(request, user, license),
+    )
+
+
+@router.post("/profile/lfa-football-player/edit")
+async def lfa_player_profile_edit_submit(
+    request: Request,
+    position: str          = Form(...),
+    secondary_positions: list[str] = Form(default=[]),
+    preferred_foot: str    = Form(...),
+    goals: str             = Form(...),
+    height_cm_raw: str     = Form(default=""),
+    weight_kg_raw: str     = Form(default=""),
+    db: Session            = Depends(get_db),
+    user: User             = Depends(get_current_user_web),
+):
+    """Validate and save LFA Football Player spec-profile fields (motivation_scores only)."""
+    license, redirect = _lfa_license_or_redirect(user.id, db)
+    if redirect:
+        return redirect
+
+    errors: list[str] = []
+
+    # ── Validate categorical fields ───────────────────────────────────────────
+    if position not in _VALID_POSITIONS:
+        errors.append(f"Invalid primary position: {position!r}")
+    clean_secondary = []
+    for sp in secondary_positions:
+        if not sp:
+            continue
+        if sp not in _VALID_POSITIONS:
+            errors.append(f"Invalid secondary position: {sp!r}")
+        elif sp != position:
+            clean_secondary.append(sp)
+    if len(clean_secondary) > 3:
+        errors.append("Maximum 3 secondary positions allowed (excluding primary)")
+    if preferred_foot not in _VALID_PREFERRED_FOOT:
+        errors.append(
+            f"Preferred foot must be one of: {', '.join(sorted(_VALID_PREFERRED_FOOT))}"
+        )
+    if goals not in _VALID_GOALS:
+        errors.append(f"Invalid goal value: {goals!r}")
+
+    # ── Validate optional numeric fields ──────────────────────────────────────
+    height_cm: int | None = None
+    if height_cm_raw.strip():
+        try:
+            height_cm = int(height_cm_raw.strip())
+            if not (100 <= height_cm <= 250):
+                errors.append("Height must be between 100 and 250 cm")
+        except ValueError:
+            errors.append("Height must be a whole number")
+
+    weight_kg: int | None = None
+    if weight_kg_raw.strip():
+        try:
+            weight_kg = int(weight_kg_raw.strip())
+            if not (30 <= weight_kg <= 200):
+                errors.append("Weight must be between 30 and 200 kg")
+        except ValueError:
+            errors.append("Weight must be a whole number")
+
+    # ── Re-render form on validation error (no DB write) ──────────────────────
+    if errors:
+        return templates.TemplateResponse(
+            "lfa_player_profile_edit.html",
+            _lfa_profile_ctx(request, user, license, error="; ".join(errors)),
+            status_code=422,
+        )
+
+    ms = dict(license.motivation_scores or {})
+    ms["position"]       = position
+    ms["positions"]      = [position] + clean_secondary
+    ms["preferred_foot"] = preferred_foot
+    ms["goals"]          = goals
+    if height_cm is not None:
+        ms["height_cm"] = height_cm
+    if weight_kg is not None:
+        ms["weight_kg"] = weight_kg
+    license.motivation_scores = ms
+
+    # Backward-compat: sync primary position to User.position global field
+    user.position = position
+
+    db.commit()
+    return RedirectResponse(url="/profile/lfa-football-player?updated=true", status_code=303)
+
+
 @router.get("/profile/edit", response_class=HTMLResponse)
 async def profile_edit_page(
     request: Request,

--- a/app/api/web_routes/profile.py
+++ b/app/api/web_routes/profile.py
@@ -254,15 +254,80 @@ async def lfa_player_profile_page(
             "ms":                     ms,
             "primary_pos":            primary_pos,
             "secondary_pos":          secondary_pos,
+            "player_positions":       all_pos,
             "position_labels":        _POSITION_LABELS,
             "goal_label":             _GOAL_LABELS.get(ms.get("goals", ""), ms.get("goals", "")),
             "average_skill_level":    ms.get("average_skill_level"),
             "onboarding_completed_at":ms.get("onboarding_completed_at"),
+            "pos_updated":            request.query_params.get("updated") == "positions",
+            "pos_error":              request.query_params.get("pos_error", ""),
             "spec_dashboard_url":     "/dashboard/lfa-football-player",
             "spec_dashboard_icon":    "⚽",
             "show_spec_nav":          True,
         },
     )
+
+
+@router.post("/profile/lfa-football-player/positions", response_class=HTMLResponse)
+async def lfa_player_profile_positions_submit(
+    request: Request,
+    position: str     = Form(default=""),
+    positions_raw: str = Form(default="[]"),
+    db: Session       = Depends(get_db),
+    user: User        = Depends(get_current_user_web),
+):
+    """Update only the player's positions (primary + secondaries, max 4 total).
+
+    Accepts:
+      position      — canonical primary position (snake_case)
+      positions_raw — JSON array of all positions including primary, e.g. '["striker","left_wing"]'
+
+    Validates: canonical values, 1–4 count, primary is first element.
+    Never touches foot scores, goals, height, weight, or any other field.
+    """
+    import json as _json
+
+    license, redirect = _lfa_license_or_redirect(user.id, db)
+    if redirect:
+        return redirect
+
+    _base_url = "/profile/lfa-football-player"
+
+    # ── Parse positions JSON ──────────────────────────────────────────────────
+    try:
+        all_positions: list = _json.loads(positions_raw)
+        if not isinstance(all_positions, list):
+            raise ValueError
+    except Exception:
+        return RedirectResponse(url=f"{_base_url}?pos_error=invalid_format", status_code=303)
+
+    # ── Validate primary ──────────────────────────────────────────────────────
+    position = position.strip()
+    if not position or position not in _VALID_POSITIONS:
+        return RedirectResponse(url=f"{_base_url}?pos_error=invalid_primary", status_code=303)
+
+    # ── Validate count (1–4 total) ────────────────────────────────────────────
+    if not (1 <= len(all_positions) <= 4):
+        return RedirectResponse(url=f"{_base_url}?pos_error=invalid_count", status_code=303)
+
+    # ── Validate each canonical value ─────────────────────────────────────────
+    for p in all_positions:
+        if p not in _VALID_POSITIONS:
+            return RedirectResponse(url=f"{_base_url}?pos_error=invalid_position", status_code=303)
+
+    # ── Primary must be first in the list (enforced by JS, verified server-side) ──
+    if all_positions[0] != position:
+        return RedirectResponse(url=f"{_base_url}?pos_error=primary_not_first", status_code=303)
+
+    # ── Save — only positions keys touched ───────────────────────────────────
+    ms = dict(license.motivation_scores or {})
+    ms["position"]  = position
+    ms["positions"] = all_positions
+    license.motivation_scores = ms
+    user.position = position          # backward-compat: User.position global field
+    db.commit()
+
+    return RedirectResponse(url=f"{_base_url}?updated=positions", status_code=303)
 
 
 @router.get("/profile/lfa-football-player/edit", response_class=HTMLResponse)

--- a/app/api/web_routes/profile.py
+++ b/app/api/web_routes/profile.py
@@ -583,29 +583,22 @@ async def profile_edit_submit(
         )
 
 
-# Export format buckets — mirrors public_player.py so Welcome Card uses the
-# same export templates as Player Card without importing from that module.
-_WC_EXPORT_BUCKETS: dict[str, str] = {
-    "instagram_square":   "square",
-    "facebook_square":    "square",
-    "instagram_portrait": "portrait",
-    "instagram_story":    "story",
-    "tiktok":             "tiktok",
-    "facebook_landscape": "landscape",
-    "og":                 "landscape",
-    "banner_custom":      "banner",
-    "facebook_post":      "landscape",
-}
+# Export format buckets — sourced from the authoritative card_constants module.
+from ...services.card_constants import (
+    CANVAS_SIZES as _WC_CANVAS_SIZES,
+    EXPORT_FORMAT_BUCKETS as _WC_EXPORT_BUCKETS,
+    WC_GALLERY_PLATFORM_IDS as _WC_GALLERY_PLATFORM_IDS,
+)
+from ...services.card_platform_service import build_platform_list as _build_platform_list
 
-# Platforms exposed in the Welcome Card gallery (subset that has FIFA export templates)
-_WC_GALLERY_PLATFORMS: list[dict] = [
-    {"id": "instagram_square",   "label": "Instagram Square",   "dims": "1080 × 1080"},
-    {"id": "instagram_portrait", "label": "Instagram Portrait", "dims": "1080 × 1350"},
-    {"id": "instagram_story",    "label": "Instagram Story",    "dims": "1080 × 1920"},
-    {"id": "tiktok",             "label": "TikTok",             "dims": "1080 × 1920"},
-    {"id": "facebook_landscape", "label": "Facebook Landscape", "dims": "1200 × 630"},
-    {"id": "banner_custom",      "label": "Banner",             "dims": "1500 × 500"},
-]
+# Platforms exposed in the Welcome Card gallery — derived from authoritative sources.
+_WC_GALLERY_PLATFORMS: list[dict] = _build_platform_list(_WC_GALLERY_PLATFORM_IDS)
+
+# JSON-serialisable canvas_sizes dict passed to the gallery template so the
+# JS CANVAS_SIZES object is server-rendered instead of hardcoded.
+_WC_CANVAS_SIZES_JSON: dict = {
+    pid: {"w": w, "h": h} for pid, (w, h) in _WC_CANVAS_SIZES.items()
+}
 
 _WC_APP_LOGO_URL = "/static/images/logo-dark.png"
 _TEMPLATES_DIR   = str(BASE_DIR / "templates")
@@ -785,6 +778,7 @@ async def onboarding_welcome_card(
                 "platforms":        _WC_GALLERY_PLATFORMS,
                 "default_platform": "instagram_square",
                 "photo_url":        license.player_card_photo_url,
+                "canvas_sizes":     _WC_CANVAS_SIZES_JSON,
             },
         )
 

--- a/app/api/web_routes/profile.py
+++ b/app/api/web_routes/profile.py
@@ -23,6 +23,7 @@ from ...models.semester import Semester, SemesterStatus
 from ...utils.age_requirements import validate_specialization_for_age
 from ...utils.country_codes import COUNTRY_CODES, COUNTRY_OPTIONS, register_filters
 from ...utils.dominant_foot import calculate_dominant_badge
+from ...utils.football_positions import POSITIONS_21, VALID_POSITION_VALUES, positions_grouped
 from ...skills_config import SKILL_CATEGORIES
 from ...services.card_theme_service import get_theme as _get_theme
 from ...services.card_platform_service import get_preset as _get_platform_preset
@@ -155,14 +156,10 @@ async def profile_page(
 
 
 # ── LFA Football Player profile constants ─────────────────────────────────────
+# Derived from football_positions.py — single source of truth.
+# Adding a new position to POSITIONS_21 automatically propagates here.
 
-_VALID_POSITIONS: frozenset[str] = frozenset({
-    "striker", "centre_forward", "left_wing", "right_wing", "second_striker",
-    "attacking_midfield", "centre_midfield", "defensive_midfield",
-    "left_midfield", "right_midfield",
-    "centre_back", "left_back", "right_back", "left_wing_back", "right_wing_back",
-    "goalkeeper", "sweeper_keeper",
-})
+_VALID_POSITIONS: frozenset[str] = VALID_POSITION_VALUES
 
 _VALID_GOALS: frozenset[str] = frozenset({
     "improve_skills", "play_higher_level", "become_professional",
@@ -181,31 +178,10 @@ _GOAL_LABELS: dict[str, str] = {
 }
 
 _POSITION_LABELS: dict[str, str] = {
-    "striker":            "Striker (ST)",
-    "centre_forward":     "Centre Forward (CF)",
-    "left_wing":          "Left Wing (LW)",
-    "right_wing":         "Right Wing (RW)",
-    "second_striker":     "Second Striker (SS)",
-    "attacking_midfield": "Attacking Midfielder (AM)",
-    "centre_midfield":    "Central Midfielder (CM)",
-    "defensive_midfield": "Defensive Midfielder (DM)",
-    "left_midfield":      "Left Midfielder (LM)",
-    "right_midfield":     "Right Midfielder (RM)",
-    "centre_back":        "Centre Back (CB)",
-    "left_back":          "Left Back (LB)",
-    "right_back":         "Right Back (RB)",
-    "left_wing_back":     "Left Wing-Back (LWB)",
-    "right_wing_back":    "Right Wing-Back (RWB)",
-    "goalkeeper":         "Goalkeeper (GK)",
-    "sweeper_keeper":     "Sweeper Keeper (SK)",
+    p["value"]: f"{p['label']} ({p['short']})" for p in POSITIONS_21
 }
 
-_POSITION_GROUPS: list[dict] = [
-    {"label": "Forwards",    "positions": ["striker", "centre_forward", "left_wing", "right_wing", "second_striker"]},
-    {"label": "Midfielders", "positions": ["attacking_midfield", "centre_midfield", "defensive_midfield", "left_midfield", "right_midfield"]},
-    {"label": "Defenders",   "positions": ["centre_back", "left_back", "right_back", "left_wing_back", "right_wing_back"]},
-    {"label": "Goalkeepers", "positions": ["goalkeeper", "sweeper_keeper"]},
-]
+_POSITION_GROUPS: list[dict] = positions_grouped()
 
 
 def _lfa_license_or_redirect(

--- a/app/api/web_routes/profile.py
+++ b/app/api/web_routes/profile.py
@@ -22,6 +22,7 @@ from ...models.semester_enrollment import SemesterEnrollment
 from ...models.semester import Semester, SemesterStatus
 from ...utils.age_requirements import validate_specialization_for_age
 from ...utils.country_codes import COUNTRY_CODES, COUNTRY_OPTIONS, register_filters
+from ...utils.dominant_foot import calculate_dominant_badge
 from ...skills_config import SKILL_CATEGORIES
 from ...services.card_theme_service import get_theme as _get_theme
 from ...services.card_platform_service import get_preset as _get_platform_preset
@@ -426,10 +427,15 @@ def _build_welcome_card_context(
 
     overall_sa = round(sum(all_sa_values) / len(all_sa_values), 1) if all_sa_values else 60.0
 
-    display_name = user.name or user.email or ""
-    parts        = display_name.split()
-    initials     = "".join(p[0].upper() for p in parts[:2]) if parts else "?"
-    position     = ms.get("position", "")
+    display_name      = user.name or user.email or ""
+    parts             = display_name.split()
+    initials          = "".join(p[0].upper() for p in parts[:2]) if parts else "?"
+    position          = ms.get("position", "")
+    player_height_cm  = ms.get("height_cm")
+    player_weight_kg  = ms.get("weight_kg")
+    dominant_badge    = calculate_dominant_badge(
+        license.right_foot_score, license.left_foot_score
+    )
 
     # ── Player namespace: satisfies all `player.*` references in FIFA template ──
     player = types.SimpleNamespace(
@@ -478,7 +484,9 @@ def _build_welcome_card_context(
         # Fixed app logo shown on Welcome Card (logo-dark.png for dark FIFA background)
         "app_logo_url":          _WC_APP_LOGO_URL,
         "compact_photo_position":"left",
-        "dominant_badge":        None,
+        "player_height_cm":      player_height_cm,
+        "player_weight_kg":      player_weight_kg,
+        "dominant_badge":        dominant_badge,
         "display_name":          display_name,
         "welcome_card_mode":     True,
     }

--- a/app/api/web_routes/profile.py
+++ b/app/api/web_routes/profile.py
@@ -1,12 +1,18 @@
 """
 User profile routes
 """
-from fastapi import APIRouter, Request, Depends, Form
-from fastapi.responses import HTMLResponse, RedirectResponse
-from fastapi.templating import Jinja2Templates
-from sqlalchemy.orm import Session
+import asyncio
+import logging
+import os
+import traceback
+import types
 from pathlib import Path
 from datetime import datetime, timezone, date
+
+from fastapi import APIRouter, Depends, Form, HTTPException, Query, Request
+from fastapi.responses import HTMLResponse, RedirectResponse, Response
+from fastapi.templating import Jinja2Templates
+from sqlalchemy.orm import Session
 
 from ...database import get_db
 from ...dependencies import get_current_user_web
@@ -17,8 +23,9 @@ from ...models.semester import Semester, SemesterStatus
 from ...utils.age_requirements import validate_specialization_for_age
 from ...utils.country_codes import COUNTRY_CODES, COUNTRY_OPTIONS, register_filters
 from ...skills_config import SKILL_CATEGORIES
-import logging
-import traceback
+from ...services.card_theme_service import get_theme as _get_theme
+from ...services.card_platform_service import get_preset as _get_platform_preset
+import app.services.card_export_service as _export_svc
 
 # Setup templates
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
@@ -354,18 +361,174 @@ async def profile_edit_submit(
         )
 
 
+# Export format buckets — mirrors public_player.py so Welcome Card uses the
+# same export templates as Player Card without importing from that module.
+_WC_EXPORT_BUCKETS: dict[str, str] = {
+    "instagram_square":   "square",
+    "facebook_square":    "square",
+    "instagram_portrait": "portrait",
+    "instagram_story":    "story",
+    "tiktok":             "tiktok",
+    "facebook_landscape": "landscape",
+    "og":                 "landscape",
+    "banner_custom":      "banner",
+    "facebook_post":      "landscape",
+}
+
+# Platforms exposed in the Welcome Card gallery (subset that has FIFA export templates)
+_WC_GALLERY_PLATFORMS: list[dict] = [
+    {"id": "instagram_square",   "label": "Instagram Square",   "dims": "1080 × 1080"},
+    {"id": "instagram_portrait", "label": "Instagram Portrait", "dims": "1080 × 1350"},
+    {"id": "instagram_story",    "label": "Instagram Story",    "dims": "1080 × 1920"},
+    {"id": "tiktok",             "label": "TikTok",             "dims": "1080 × 1920"},
+    {"id": "facebook_landscape", "label": "Facebook Landscape", "dims": "1200 × 630"},
+    {"id": "banner_custom",      "label": "Banner",             "dims": "1500 × 500"},
+]
+
+_WC_APP_LOGO_URL = "/static/images/logo-dark.png"
+_TEMPLATES_DIR   = str(BASE_DIR / "templates")
+
+
+def _build_welcome_card_context(
+    request: Request,
+    user: User,
+    license: UserLicense,
+    platform: str | None,
+    export: bool,
+) -> dict:
+    """
+    Build the FIFA template context for the Welcome Card.
+
+    Self-assessment adapter:
+    FIFA Classic templates read `current_level` as the displayed skill number.
+    For Welcome Card only, this field is populated from self_assessment.
+    This must never be written back to football_skills JSONB and must never
+    be used by calculation services.
+    """
+    football_skills = license.football_skills or {}
+    ms              = license.motivation_scores or {}
+
+    # ── Build skills dict: current_level = self_assessment (adapter only) ──────
+    skills_for_fifa: dict[str, dict] = {}
+    all_sa_values: list[float] = []
+    for cat in SKILL_CATEGORIES:
+        for skill_def in cat["skills"]:
+            key = skill_def["key"]
+            raw = football_skills.get(key)
+            sa_val = float(raw.get("self_assessment", 60.0)) if isinstance(raw, dict) else 60.0
+            # Welcome Card template adapter:
+            # FIFA Classic templates read `current_level` as the displayed number.
+            # For Welcome Card only, this field is populated from self_assessment.
+            # This must never be written back to football_skills JSONB and must
+            # never be used by calculation services.
+            skills_for_fifa[key] = {"current_level": sa_val, "self_assessment": sa_val}
+            all_sa_values.append(sa_val)
+
+    overall_sa = round(sum(all_sa_values) / len(all_sa_values), 1) if all_sa_values else 60.0
+
+    display_name = user.name or user.email or ""
+    parts        = display_name.split()
+    initials     = "".join(p[0].upper() for p in parts[:2]) if parts else "?"
+    position     = ms.get("position", "")
+
+    # ── Player namespace: satisfies all `player.*` references in FIFA template ──
+    player = types.SimpleNamespace(
+        skills               = skills_for_fifa,
+        name                 = display_name,
+        position             = position,
+        positions            = ms.get("positions", []),
+        nationality          = getattr(user, "country", None) or "",
+        secondary_nationality= None,
+        age_group            = None,
+        total_tournaments    = 0,
+        photo_url            = license.player_card_photo_url,
+    )
+
+    platform_preset = _get_platform_preset(platform)
+    theme           = _get_theme("midnight")  # dark FIFA Classic default
+
+    return {
+        "request":               request,
+        "player":                player,
+        "overall":               overall_sa,
+        "tier_label":            "Self-Assessment",
+        "tier_color":            "#f59e0b",
+        "avatar_bg":             "#1e3a5f",
+        "initials":              initials,
+        "pos_color":             "#667eea",
+        "skill_categories":      SKILL_CATEGORIES,
+        "teams_info":            [],
+        "animated_mode":         False,
+        "last_skill_delta":      {},
+        "participations_history":[],
+        "theme":                 theme,
+        "card_theme_id":         theme.id,
+        "card_theme":            theme.id,
+        "card_variant_id":       "fifa",
+        "platform_class":        platform_preset.css_class,
+        "platform_id":           platform_preset.id,
+        "export_mode":           export,
+        "photo_url":             license.player_card_photo_url,
+        "portrait_photo_url":    license.card_photo_portrait_url or license.player_card_photo_url,
+        "landscape_photo_url":   license.card_photo_landscape_url or license.player_card_photo_url,
+        "compact_bg_url":        None,
+        "showcase_bg_url":       None,
+        # sponsor_logo is always None on Welcome Card — enforced at context build time
+        "sponsor_logo_url":      None,
+        # Fixed app logo shown on Welcome Card (logo-dark.png for dark FIFA background)
+        "app_logo_url":          _WC_APP_LOGO_URL,
+        "compact_photo_position":"left",
+        "dominant_badge":        None,
+        "display_name":          display_name,
+        "welcome_card_mode":     True,
+    }
+
+
+def _select_welcome_card_template(platform: str | None, export: bool) -> str:
+    """Return the FIFA template path appropriate for this platform + render mode."""
+    if platform and platform in _WC_EXPORT_BUCKETS:
+        bucket   = _WC_EXPORT_BUCKETS[platform]
+        exp_path = f"public/export/{bucket}/fifa.html"
+        if os.path.isfile(os.path.join(_TEMPLATES_DIR, exp_path)):
+            return exp_path
+    return "public/player_card_fifa.html"
+
+
+def _check_welcome_card_auth(
+    license: UserLicense | None, user_email: str
+) -> RedirectResponse | None:
+    """Return a redirect if the user is not eligible to view the Welcome Card."""
+    if not license:
+        logger.info("welcome_card_no_license", extra={"user": user_email})
+        return RedirectResponse(
+            url="/dashboard?info=complete_lfa_onboarding_first", status_code=303
+        )
+    if not license.onboarding_completed:
+        logger.info("welcome_card_onboarding_incomplete", extra={"user": user_email})
+        return RedirectResponse(
+            url="/specialization/lfa-player/onboarding", status_code=303
+        )
+    return None
+
+
 @router.get("/profile/onboarding-card", response_class=HTMLResponse)
 async def onboarding_welcome_card(
     request: Request,
-    db: Session = Depends(get_db),
-    user: User = Depends(get_current_user_web),
+    platform: str | None = Query(default=None),
+    export: bool         = Query(default=False),
+    db: Session          = Depends(get_db),
+    user: User           = Depends(get_current_user_web),
 ):
     """
-    Welcome Card — private self-assessment preview (Phase C).
+    Welcome Card preview — private self-assessment view.
 
     Data source: football_skills[*].self_assessment ONLY.
     NEVER reads current_level, baseline, system_baseline, tournament_delta,
     assessment_delta, or any EMA output.
+
+    Without ?platform=: renders the gallery hub (iframe + download buttons).
+    With ?platform=X:   renders the FIFA Classic card for that platform size.
+    With ?export=1:     switches the FIFA template to export-mode (Playwright use).
 
     Auth: own card only (get_current_user_web enforces login; ownership is
     implicit because we query by user.id).
@@ -376,83 +539,90 @@ async def onboarding_welcome_card(
         UserLicense.specialization_type == "LFA_FOOTBALL_PLAYER",
     ).first()
 
-    if not license:
-        logger.info("welcome_card_no_license", extra={"user": user.email})
-        return RedirectResponse(
-            url="/dashboard?info=complete_lfa_onboarding_first", status_code=303
+    redirect = _check_welcome_card_auth(license, user.email)
+    if redirect:
+        return redirect
+
+    if not platform:
+        # Gallery hub: iframe preview of default platform + per-platform download buttons
+        display_name = user.name or user.email or ""
+        logger.info("welcome_card_gallery_rendered", extra={"user": user.email})
+        return templates.TemplateResponse(
+            "public/welcome_card.html",
+            {
+                "request":      request,
+                "user":         user,
+                "display_name": display_name,
+                "platforms":    _WC_GALLERY_PLATFORMS,
+                "default_platform": "instagram_square",
+            },
         )
 
-    if not license.onboarding_completed:
-        logger.info("welcome_card_onboarding_incomplete", extra={"user": user.email})
-        return RedirectResponse(
-            url="/specialization/lfa-player/onboarding", status_code=303
+    logger.info("welcome_card_rendered", extra={"user": user.email, "platform": platform, "export": export})
+    ctx  = _build_welcome_card_context(request, user, license, platform, export)
+    tmpl = _select_welcome_card_template(platform, export)
+    return templates.TemplateResponse(tmpl, ctx)
+
+
+@router.get("/profile/onboarding-card/export")
+async def export_onboarding_welcome_card(
+    request: Request,
+    platform: str = Query(default="instagram_square"),
+    db: Session   = Depends(get_db),
+    user: User    = Depends(get_current_user_web),
+):
+    """
+    Export the Welcome Card as a PNG at a social-media canvas size.
+
+    Auth: own card only. Rate limit: 5 exports per 60 s per user+IP.
+    Data source: self_assessment only (same contract as the preview route).
+    """
+    from app.config import settings
+
+    license = db.query(UserLicense).filter(
+        UserLicense.user_id == user.id,
+        UserLicense.specialization_type == "LFA_FOOTBALL_PLAYER",
+    ).first()
+
+    redirect = _check_welcome_card_auth(license, user.email)
+    if redirect:
+        return redirect
+
+    if platform not in _export_svc.CANVAS_SIZES:
+        valid = list(_export_svc.CANVAS_SIZES)
+        raise HTTPException(
+            status_code=422,
+            detail=f"Unsupported export platform: {platform!r}. Valid values: {valid}",
         )
 
-    # ── Extract self_assessment values ONLY ───────────────────────────────────
-    football_skills = license.football_skills or {}
-    skill_categories_data = []
-    all_sa_values: list[float] = []
+    client_ip = request.client.host if request.client else "unknown"
+    rate_key  = f"wc:{user.id}:{client_ip}"
+    if not _export_svc.check_export_rate_limit(rate_key):
+        raise HTTPException(
+            status_code=429,
+            detail="Export rate limit exceeded (5 per minute). Please wait before exporting again.",
+        )
 
-    for cat in SKILL_CATEGORIES:
-        cat_skills = []
-        for skill_def in cat["skills"]:
-            key = skill_def["key"]
-            raw = football_skills.get(key)
-            if isinstance(raw, dict):
-                sa_value = float(raw.get("self_assessment", 60.0))
-            else:
-                sa_value = 60.0
-            cat_skills.append({
-                "key":     key,
-                "name_en": skill_def["name_en"],
-                "name_hu": skill_def.get("name_hu", skill_def["name_en"]),
-                "value":   round(sa_value, 1),
-            })
-            all_sa_values.append(sa_value)
-        cat_avg = round(sum(s["value"] for s in cat_skills) / len(cat_skills), 1) if cat_skills else 0.0
-        skill_categories_data.append({
-            "key":     cat["key"],
-            "name_en": cat["name_en"],
-            "name_hu": cat.get("name_hu", cat["name_en"]),
-            "emoji":   cat.get("emoji", ""),
-            "skills":  cat_skills,
-            "avg":     cat_avg,
-        })
+    render_url = (
+        f"http://127.0.0.1:{settings.APP_INTERNAL_PORT}"
+        f"/profile/onboarding-card?platform={platform}&export=1"
+    )
 
-    overall_sa = round(sum(all_sa_values) / len(all_sa_values), 1) if all_sa_values else 60.0
+    logger.info("welcome_card_export", extra={"user": user.email, "platform": platform})
+    try:
+        png_bytes = await asyncio.to_thread(
+            _export_svc._sync_take_screenshot, render_url, platform
+        )
+    except _export_svc.CardExportTimeoutError:
+        raise HTTPException(status_code=504, detail="Card render timed out")
 
-    # Top 5 self-assessed skills (highest values)
-    flat_skills = [s for cat in skill_categories_data for s in cat["skills"]]
-    top_skills = sorted(flat_skills, key=lambda s: s["value"], reverse=True)[:5]
-
-    # ── Physical / personal data from motivation_scores ───────────────────────
-    ms = license.motivation_scores or {}
-
-    # ── Display name + initials fallback ─────────────────────────────────────
-    display_name = user.name or user.email or ""
-    parts = display_name.split()
-    initials = "".join(p[0].upper() for p in parts[:2]) if parts else "?"
-
-    logger.info("welcome_card_rendered", extra={"user": user.email, "overall_sa": overall_sa})
-
-    return templates.TemplateResponse(
-        "public/welcome_card.html",
-        {
-            "request":          request,
-            "user":             user,
-            "license":          license,
-            "display_name":     display_name,
-            "initials":         initials,
-            "skill_categories": skill_categories_data,
-            "overall_sa":       overall_sa,
-            "top_skills":       top_skills,
-            "position":         ms.get("position", ""),
-            "positions":        ms.get("positions", []),
-            "height_cm":        ms.get("height_cm"),
-            "weight_kg":        ms.get("weight_kg"),
-            "preferred_foot":   ms.get("preferred_foot"),
-            "goals":            ms.get("goals", ""),
-            "right_foot_score": license.right_foot_score,
-            "left_foot_score":  license.left_foot_score,
+    filename = f"welcome_card_{platform}.png"
+    return Response(
+        content=png_bytes,
+        media_type="image/png",
+        headers={
+            "Content-Disposition": f'attachment; filename="{filename}"',
+            "Cache-Control":       "no-store",
+            "X-Export-Platform":   platform,
         },
     )

--- a/app/api/web_routes/profile.py
+++ b/app/api/web_routes/profile.py
@@ -47,6 +47,7 @@ async def profile_page(
     """Display user profile page"""
     user_licenses = []
     active_license = None
+    lfa_license = None
     active_enrollment = None
     current_semester = None
     available_semesters = []
@@ -56,6 +57,14 @@ async def profile_page(
 
     if user.role == UserRole.STUDENT:
         user_licenses = db.query(UserLicense).filter(UserLicense.user_id == user.id).all()
+
+        # LFA Football Player license — independent of active specialization.
+        # Used by the Welcome Card section which must remain visible after spec-switch.
+        lfa_license = next(
+            (l for l in user_licenses
+             if l.specialization_type == "LFA_FOOTBALL_PLAYER" and l.onboarding_completed),
+            None
+        )
 
         # Get ACTIVE semester enrollment for CURRENT specialization
         if user.specialization:
@@ -130,6 +139,7 @@ async def profile_page(
             "user": user,
             "user_licenses": user_licenses,
             "active_license": active_license,
+            "lfa_license": lfa_license,
             "specialization_color": specialization_color,
             "active_enrollment": active_enrollment,
             "current_semester": current_semester,
@@ -558,11 +568,12 @@ async def onboarding_welcome_card(
         return templates.TemplateResponse(
             "public/welcome_card.html",
             {
-                "request":      request,
-                "user":         user,
-                "display_name": display_name,
-                "platforms":    _WC_GALLERY_PLATFORMS,
+                "request":          request,
+                "user":             user,
+                "display_name":     display_name,
+                "platforms":        _WC_GALLERY_PLATFORMS,
                 "default_platform": "instagram_square",
+                "photo_url":        license.player_card_photo_url,
             },
         )
 

--- a/app/api/web_routes/public_player.py
+++ b/app/api/web_routes/public_player.py
@@ -294,7 +294,7 @@ def public_player_card(
         "compact_bg_url": lfa_license.card_bg_compact_url,
         "showcase_bg_url": lfa_license.card_bg_showcase_url,
         "sponsor_logo_url": lfa_license.sponsor_logo_url,
-        "app_logo_url":     "/static/images/logo-dark.png",
+        "app_logo_url":     None,  # Default FIFA card shows no LFA app logo; sponsor_logo_url is the card's logo source
         "compact_photo_position": lfa_license.card_compact_photo_position or "left",
         # Focus points default to match original CSS (compact: center bottom = 50/100, showcase: center = 50/50)
         "compact_focus_x": lfa_license.card_compact_focus_x if lfa_license.card_compact_focus_x is not None else 50,

--- a/app/api/web_routes/public_player.py
+++ b/app/api/web_routes/public_player.py
@@ -45,17 +45,7 @@ _FALLBACK_TEMPLATE = "public/player_card.html"
 # Export render layer: platform → format bucket for dedicated export templates.
 # Template path resolved as: public/export/{bucket}/{card_variant_id}.html
 # Falls back to existing editor template + export-mode class if no file found.
-_EXPORT_FORMAT_BUCKETS: dict[str, str] = {
-    "instagram_square":   "square",
-    "facebook_square":    "square",
-    "instagram_portrait": "portrait",
-    "instagram_story":    "story",
-    "tiktok":             "tiktok",
-    "facebook_landscape": "landscape",
-    "og":                 "landscape",
-    "banner_custom":      "banner",
-    "facebook_post":      "landscape",
-}
+from app.services.card_constants import EXPORT_FORMAT_BUCKETS as _EXPORT_FORMAT_BUCKETS
 
 
 @router.get("/players/{user_id}/card", response_class=HTMLResponse)

--- a/app/api/web_routes/public_player.py
+++ b/app/api/web_routes/public_player.py
@@ -56,6 +56,7 @@ def public_player_card(
     platform: Optional[str] = Query(None),
     export: Optional[bool] = Query(default=False),
     animated: Optional[bool] = Query(default=False),
+    native_export: Optional[bool] = Query(default=False),
     db: Session = Depends(get_db),
 ):
     user = db.query(User).filter(
@@ -115,9 +116,19 @@ def public_player_card(
 
     # Position from motivation_scores
     position = "Unknown"
+    player_positions: list[str] = []   # [primary, ...secondaries], empty if not onboarded
     ms = lfa_license.motivation_scores
     if ms and isinstance(ms, dict):
         position = ms.get("position", "Unknown")
+        _raw_positions = ms.get("positions", [])
+        if _raw_positions and isinstance(_raw_positions, list):
+            player_positions = _raw_positions
+        elif position != "Unknown":
+            player_positions = [position]
+
+    # Pitch display nodes for the position panel (FIFA card lower-right section).
+    from app.utils.football_positions import get_pitch_display_nodes as _get_pitch_nodes
+    position_nodes = _get_pitch_nodes(position if position != "Unknown" else "", player_positions)
 
     # Age group from date_of_birth
     age_group = "AMATEUR"
@@ -252,6 +263,7 @@ def public_player_card(
     # animated_mode: True only when both export=1 AND animated=1 are present.
     # The PNG endpoint never passes animated=1 → this is always False for PNG renders.
     animated_mode = bool(export) and bool(animated)
+    native_export_mode = bool(native_export)
 
     return templates.TemplateResponse(request, template_path, {
         "player": player,
@@ -276,7 +288,8 @@ def public_player_card(
         "card_variant_id": variant.id,
         "platform_class": platform_preset.css_class,
         "platform_id":    platform_preset.id,
-        "export_mode":    bool(export),
+        "export_mode":        bool(export),
+        "native_export_mode": native_export_mode,
         # variant-specific context
         "compact_bg_url": lfa_license.card_bg_compact_url,
         "showcase_bg_url": lfa_license.card_bg_showcase_url,
@@ -306,6 +319,9 @@ def public_player_card(
             lfa_license.right_foot_score,
             lfa_license.left_foot_score,
         ),
+        # Position panel (FIFA Default lower-right section)
+        "player_positions": player_positions,
+        "position_nodes":   position_nodes,
     })
 
 
@@ -363,11 +379,15 @@ async def export_player_card(
     if not target_license:
         raise HTTPException(status_code=404, detail="No active LFA Player license")
 
-    # Render URL — constructed server-side only; no user-controlled string
-    render_url = (
-        f"http://127.0.0.1:{settings.APP_INTERNAL_PORT}"
-        f"/players/{user_id}/card?platform={platform}&export=1"
-    )
+    # Render URL — constructed server-side only; no user-controlled string.
+    # "default" platform: use ?native_export=1 so the template applies
+    # native-export-mode CSS (card fills 820px width at natural auto height).
+    # All other platforms: standard export render with ?platform=…&export=1.
+    _base = f"http://127.0.0.1:{settings.APP_INTERNAL_PORT}/players/{user_id}/card"
+    if platform == "default":
+        render_url = f"{_base}?native_export=1"
+    else:
+        render_url = f"{_base}?platform={platform}&export=1"
 
     # Screenshot runs in a thread so it does not block the event loop
     try:

--- a/app/api/web_routes/public_player.py
+++ b/app/api/web_routes/public_player.py
@@ -127,8 +127,13 @@ def public_player_card(
             player_positions = [position]
 
     # Pitch display nodes for the position panel (FIFA card lower-right section).
-    from app.utils.football_positions import get_pitch_display_nodes as _get_pitch_nodes
+    from app.utils.football_positions import (
+        get_pitch_display_nodes as _get_pitch_nodes,
+        position_label as _position_label,
+    )
     position_nodes = _get_pitch_nodes(position if position != "Unknown" else "", player_positions)
+    primary_pos_label = _position_label(position) if position != "Unknown" else None
+    secondary_pos_labels = [_position_label(p) for p in player_positions if p != position]
 
     # Age group from date_of_birth
     age_group = "AMATEUR"
@@ -320,8 +325,10 @@ def public_player_card(
             lfa_license.left_foot_score,
         ),
         # Position panel (FIFA Default lower-right section)
-        "player_positions": player_positions,
-        "position_nodes":   position_nodes,
+        "player_positions":     player_positions,
+        "position_nodes":       position_nodes,
+        "primary_pos_label":    primary_pos_label,
+        "secondary_pos_labels": secondary_pos_labels,
     })
 
 

--- a/app/api/web_routes/public_player.py
+++ b/app/api/web_routes/public_player.py
@@ -294,7 +294,7 @@ def public_player_card(
         "compact_bg_url": lfa_license.card_bg_compact_url,
         "showcase_bg_url": lfa_license.card_bg_showcase_url,
         "sponsor_logo_url": lfa_license.sponsor_logo_url,
-        "app_logo_url":     None,  # Player Card uses text brand; Welcome Card passes logo-dark.png
+        "app_logo_url":     "/static/images/logo-dark.png",
         "compact_photo_position": lfa_license.card_compact_photo_position or "left",
         # Focus points default to match original CSS (compact: center bottom = 50/100, showcase: center = 50/50)
         "compact_focus_x": lfa_license.card_compact_focus_x if lfa_license.card_compact_focus_x is not None else 50,

--- a/app/api/web_routes/public_player.py
+++ b/app/api/web_routes/public_player.py
@@ -291,6 +291,7 @@ def public_player_card(
         "compact_bg_url": lfa_license.card_bg_compact_url,
         "showcase_bg_url": lfa_license.card_bg_showcase_url,
         "sponsor_logo_url": lfa_license.sponsor_logo_url,
+        "app_logo_url":     None,  # Player Card uses text brand; Welcome Card passes logo-dark.png
         "compact_photo_position": lfa_license.card_compact_photo_position or "left",
         # Focus points default to match original CSS (compact: center bottom = 50/100, showcase: center = 50/50)
         "compact_focus_x": lfa_license.card_compact_focus_x if lfa_license.card_compact_focus_x is not None else 50,

--- a/app/api/web_routes/tournaments/edit.py
+++ b/app/api/web_routes/tournaments/edit.py
@@ -184,6 +184,15 @@ async def admin_tournament_edit_page(
         teams = db.query(Team).filter(Team.id.in_(team_ids)).all()
         enrolled_teams = {t.id: t.name for t in teams}
 
+    # Pitch name map for session list display (pitch_id → name) — must be built
+    # before the list comprehension below that references it.
+    from app.models.pitch import Pitch as PitchModel
+    _session_pitch_ids = {s.pitch_id for s in all_match_sessions if s.pitch_id}
+    pitch_name_map: dict[int, str] = {}
+    if _session_pitch_ids:
+        for p in db.query(PitchModel).filter(PitchModel.id.in_(_session_pitch_ids)).all():
+            pitch_name_map[p.id] = p.name
+
     sessions_result_status = [
         {
             "id": s.id,
@@ -241,14 +250,6 @@ async def admin_tournament_edit_page(
         {t.id: t for t in db.query(Team).filter(Team.id.in_(_team_ids_in_rankings)).all()}
         if _team_ids_in_rankings else {}
     )
-
-    # Pitch name map for session list display (pitch_id → name)
-    from app.models.pitch import Pitch as PitchModel
-    _session_pitch_ids = {s.pitch_id for s in all_match_sessions if s.pitch_id}
-    pitch_name_map: dict[int, str] = {}
-    if _session_pitch_ids:
-        for p in db.query(PitchModel).filter(PitchModel.id.in_(_session_pitch_ids)).all():
-            pitch_name_map[p.id] = p.name
 
     # Instructor roster (Section 4.5)
     instructor_roster = _ip_service.get_roster(db, tournament_id)

--- a/app/models/quiz.py
+++ b/app/models/quiz.py
@@ -195,7 +195,10 @@ class AdaptiveLearningSession(Base):
     # Session timing
     session_time_limit_seconds = Column(Integer, default=1800)  # 30 minutes default
     session_start_time = Column(DateTime(timezone=True), nullable=True)
-    
+
+    # Spaced-repetition cap: how many due questions have been served this session
+    session_due_shown = Column(Integer, nullable=False, default=0)
+
     # Relationships
     user = relationship("User")
 

--- a/app/services/adaptive_learning.py
+++ b/app/services/adaptive_learning.py
@@ -11,9 +11,12 @@ from ..models.quiz import (
 )
 
 
+_SESSION_DUE_CAP = 3
+
+
 class AdaptiveLearningService:
     """Adaptív tanulási algoritmusok és logika"""
-    
+
     def __init__(self, db: Session):
         self.db = db
     def start_adaptive_session(
@@ -30,7 +33,7 @@ class AdaptiveLearningService:
             category=category,
             language=language,
             module_prefix=module_prefix,
-            target_difficulty=self._calculate_target_difficulty(user_id, category),
+            target_difficulty=self._calculate_target_difficulty(user_id, category, language=language),
             performance_trend=0.0,
             session_time_limit_seconds=session_duration_seconds,
             session_start_time=datetime.now(timezone.utc)
@@ -53,8 +56,10 @@ class AdaptiveLearningService:
         if self._is_session_time_expired(session):
             return {"session_complete": True, "reason": "time_expired"}
 
-        # Get user's performance data
-        performance_data = self._get_user_performance_data(user_id, session.category)
+        # Get user's performance data (language-scoped)
+        performance_data = self._get_user_performance_data(
+            user_id, session.category, language=session.language
+        )
 
         # Select question based on adaptive algorithm
         candidate_questions = self._get_candidate_questions(
@@ -65,25 +70,21 @@ class AdaptiveLearningService:
         if not candidate_questions:
             return {"session_complete": True, "reason": "pool_exhausted"}
 
-        # Exclude already-seen questions at service level, before adaptive selection.
-        available_questions = (
-            [q for q in candidate_questions if q.id not in exclude_ids]
-            if exclude_ids
-            else candidate_questions
-        )
-        if not available_questions:
-            return {"session_complete": True, "reason": "all_seen"}
-
-        # Apply adaptive selection algorithm
-        selected_question = self._select_adaptive_question(
-            available_questions,
-            performance_data,
-            session
+        # Apply weighted selection (recency penalty replaces hard exclude for small pools)
+        selected_question = self._select_weighted_question(
+            candidate_questions, performance_data, session, exclude_ids=exclude_ids
         )
 
         if not selected_question:
             return {"session_complete": True, "reason": "pool_exhausted"}
-        
+
+        # Increment session_due_shown when a due question is served
+        due_ids = {p.question_id for p in performance_data["due_for_review"]}
+        was_due = selected_question.id in due_ids
+        if was_due:
+            session.session_due_shown = (session.session_due_shown or 0) + 1
+            self.db.commit()
+
         # Return question with session info
         return {
             "id": selected_question.id,
@@ -91,7 +92,8 @@ class AdaptiveLearningService:
             "options": [{"id": opt.id, "text": opt.option_text} for opt in selected_question.answer_options],
             "type": selected_question.question_type.value if selected_question.question_type else "multiple_choice",
             "difficulty": self._get_question_difficulty(selected_question.id),
-            "session_time_remaining": self._get_session_time_remaining(session)
+            "session_time_remaining": self._get_session_time_remaining(session),
+            "was_due": was_due,
         }
     
     def record_answer(self, user_id: int, session_id: int, question_id: int, 
@@ -168,18 +170,23 @@ class AdaptiveLearningService:
             "final_difficulty": session.target_difficulty
         }
     
-    def get_user_learning_analytics(self, user_id: int, category: QuizCategory = None) -> Dict:
+    def get_user_learning_analytics(
+        self, user_id: int, category: QuizCategory = None, language: str | None = None
+    ) -> Dict:
         """Felhasználói tanulási analitika"""
-        
+
         # Get overall performance
         query = self.db.query(UserQuestionPerformance).filter(
             UserQuestionPerformance.user_id == user_id
         )
-        
-        if category:
-            # Join with questions to filter by category
-            query = query.join(QuizQuestion).join(Quiz).filter(Quiz.category == category)
-        
+
+        if category or language:
+            query = query.join(QuizQuestion).join(Quiz)
+            if category:
+                query = query.filter(Quiz.category == category)
+            if language:
+                query = query.filter(Quiz.language == language)
+
         performances = query.all()
         
         if not performances:
@@ -219,9 +226,11 @@ class AdaptiveLearningService:
     
     # Private helper methods
     
-    def _calculate_target_difficulty(self, user_id: int, category: QuizCategory) -> float:
+    def _calculate_target_difficulty(
+        self, user_id: int, category: QuizCategory, language: str = "en"
+    ) -> float:
         """Célnehézség számítása felhasználói teljesítmény alapján"""
-        analytics = self.get_user_learning_analytics(user_id, category)
+        analytics = self.get_user_learning_analytics(user_id, category, language=language)
         
         base_difficulty = 0.5  # Default medium difficulty
         
@@ -237,20 +246,25 @@ class AdaptiveLearningService:
         # Clamp between 0.1 and 0.9
         return max(0.1, min(0.9, base_difficulty))
     
-    def _get_user_performance_data(self, user_id: int, category: QuizCategory) -> Dict:
+    def _get_user_performance_data(
+        self, user_id: int, category: QuizCategory, language: str = "en"
+    ) -> Dict:
         """Felhasználói teljesítményadatok összegyűjtése"""
         performances = self.db.query(UserQuestionPerformance).join(QuizQuestion).join(Quiz).filter(
             and_(
                 UserQuestionPerformance.user_id == user_id,
-                Quiz.category == category
+                Quiz.category == category,
+                Quiz.language == language,
             )
         ).all()
-        
+
+        now = datetime.now(timezone.utc)
         return {
+            "all_performances": performances,
             "weak_concepts": [p for p in performances if p.mastery_level < 0.6],
             "strong_concepts": [p for p in performances if p.mastery_level > 0.8],
-            "due_for_review": [p for p in performances if p.next_review_at and 
-                             p.next_review_at <= datetime.now(timezone.utc)]
+            "due_for_review": [p for p in performances if p.next_review_at and
+                               p.next_review_at <= now],
         }
     
     def _get_candidate_questions(
@@ -297,26 +311,54 @@ class AdaptiveLearningService:
 
         return questions
     
-    def _select_adaptive_question(self, candidate_questions: List[QuizQuestion], 
-                                performance_data: Dict, session: AdaptiveLearningSession) -> QuizQuestion:
-        """Adaptív kérdésválasztó algoritmus"""
-        
-        # Prioritize questions due for review
-        due_questions = [q for q in candidate_questions 
-                        if any(p.question_id == q.id for p in performance_data["due_for_review"])]
-        
-        if due_questions:
-            return random.choice(due_questions)
-            
-        # Focus on weak concepts
-        weak_concept_questions = [q for q in candidate_questions 
-                                if any(p.question_id == q.id for p in performance_data["weak_concepts"])]
-        
-        if weak_concept_questions and random.random() < 0.7:  # 70% chance to focus on weak areas
-            return random.choice(weak_concept_questions)
-        
-        # Otherwise, random selection from candidates
-        return random.choice(candidate_questions)
+    def _calculate_question_weight(
+        self,
+        q_id: int,
+        due_ids: set,
+        perf_map: dict,
+        session_due_shown: int,
+        exclude_ids: set,
+    ) -> float:
+        perf = perf_map.get(q_id)
+        mastery = perf.mastery_level if perf else None
+        dw = perf.difficulty_weight if perf else 1.5
+        in_due = q_id in due_ids and session_due_shown < _SESSION_DUE_CAP
+
+        if in_due:
+            w = 2.5
+        elif q_id in due_ids:
+            w = min(dw, 1.8)
+        elif mastery is not None and mastery < 0.6:
+            w = min(dw, 1.8)
+        elif mastery is None:
+            w = 1.2
+        else:
+            w = 1.0
+
+        if q_id in exclude_ids:
+            w *= 0.1
+
+        return max(0.05, w)
+
+    def _select_weighted_question(
+        self,
+        candidates: List[QuizQuestion],
+        performance_data: Dict,
+        session: AdaptiveLearningSession,
+        exclude_ids: set | None = None,
+    ) -> Optional[QuizQuestion]:
+        """Súlyozott véletlenszerű kérdésválasztó — session cap és recency penalty."""
+        if not candidates:
+            return None
+        due_ids = {p.question_id for p in performance_data["due_for_review"]}
+        perf_map = {p.question_id: p for p in performance_data["all_performances"]}
+        session_due_shown = session.session_due_shown or 0
+        exc = exclude_ids or set()
+        weights = [
+            self._calculate_question_weight(q.id, due_ids, perf_map, session_due_shown, exc)
+            for q in candidates
+        ]
+        return random.choices(candidates, weights=weights, k=1)[0]
     
     def _calculate_performance_trend(self, session: AdaptiveLearningSession) -> float:
         """Teljesítménytrend számítása"""

--- a/app/services/card_constants.py
+++ b/app/services/card_constants.py
@@ -5,15 +5,25 @@ declarations live here.  Every other module imports from this file — never
 defines its own copy.
 
 Invariants enforced by tests/unit/services/test_card_constants.py:
-  - EXPORT_FORMAT_BUCKETS.keys() == CANVAS_SIZES.keys()
+  - EXPORT_FORMAT_BUCKETS.keys() == CANVAS_SIZES.keys() − {"default"}
   - Every platform_id in ANIMATED_EXPORT_CAPABLE exists in CANVAS_SIZES
 """
 from __future__ import annotations
 
 # ── Canvas dimensions ─────────────────────────────────────────────────────────
 # Social canvas sizes keyed by platform preset id.
-# "default" is intentionally absent (not an export target).
+#
+# "default" export canvas — measured 2026-05-12 via Playwright at 820px viewport
+# using ?native_export=1 (native-export-mode CSS: card fills width at auto height).
+# Conditions: FIFA Classic card, 4 SKILL_CATEGORIES (Outfield 19, Set Pieces 3,
+# Mental 14, Physical Fitness 8 skills), lower-section split layout (3fr skills /
+# 2fr position panel).  card-wrap.getBoundingClientRect() = 820×613 px.
+# Export path: render_url uses ?native_export=1; _sync_take_screenshot clips
+# to the card-wrap bounding rect — height is content-determined at render time.
+# The 613 here is a documented baseline; the clip always uses the live bounding
+# rect so new skills or theme changes never produce a truncated export.
 CANVAS_SIZES: dict[str, tuple[int, int]] = {
+    "default":            ( 820,  613),   # native FIFA Classic; clip = card-wrap bbox
     "instagram_square":   (1080, 1080),
     "instagram_portrait": (1080, 1350),
     "instagram_story":    (1080, 1920),

--- a/app/services/card_constants.py
+++ b/app/services/card_constants.py
@@ -1,0 +1,87 @@
+"""Authoritative export constants for the FIFA Classic / Welcome Card card system.
+
+All platform dimensions, template-bucket routing, and animated-capability
+declarations live here.  Every other module imports from this file — never
+defines its own copy.
+
+Invariants enforced by tests/unit/services/test_card_constants.py:
+  - EXPORT_FORMAT_BUCKETS.keys() == CANVAS_SIZES.keys()
+  - Every platform_id in ANIMATED_EXPORT_CAPABLE exists in CANVAS_SIZES
+"""
+from __future__ import annotations
+
+# ── Canvas dimensions ─────────────────────────────────────────────────────────
+# Social canvas sizes keyed by platform preset id.
+# "default" is intentionally absent (not an export target).
+CANVAS_SIZES: dict[str, tuple[int, int]] = {
+    "instagram_square":   (1080, 1080),
+    "instagram_portrait": (1080, 1350),
+    "instagram_story":    (1080, 1920),
+    "tiktok":             (1080, 1920),
+    "facebook_square":    (1080, 1080),
+    "facebook_landscape": (1200,  630),
+    "og":                 (1200,  630),
+    "banner_custom":      (1500,  500),
+    "facebook_post":      (1200,  630),
+}
+
+# ── Export template routing ───────────────────────────────────────────────────
+# Maps platform preset id → template bucket directory.
+# Template path resolved as: public/export/{bucket}/{card_variant_id}.html
+EXPORT_FORMAT_BUCKETS: dict[str, str] = {
+    "instagram_square":   "square",
+    "facebook_square":    "square",
+    "instagram_portrait": "portrait",
+    "instagram_story":    "story",
+    "tiktok":             "tiktok",
+    "facebook_landscape": "landscape",
+    "og":                 "landscape",
+    "banner_custom":      "banner",
+    "facebook_post":      "landscape",
+}
+
+# ── Animated video export capability registry ─────────────────────────────────
+# (variant_id, platform_id) pairs that have a dedicated animated export
+# template.  All other combinations return 422 — no fallback, no silent
+# degradation.
+ANIMATED_EXPORT_CAPABLE: frozenset[tuple[str, str]] = frozenset({
+    ("fifa",  "instagram_square"),
+    ("pulse", "instagram_square"),
+})
+
+
+def is_animated_capable(variant_id: str, platform_id: str) -> bool:
+    """Return True if (variant_id, platform_id) supports animated video export."""
+    return (variant_id, platform_id) in ANIMATED_EXPORT_CAPABLE
+
+
+# ── Gallery / editor platform ID lists ───────────────────────────────────────
+
+# Platforms shown in the Welcome Card gallery.
+# Explicit inclusion list — facebook_square, og, and facebook_post are
+# intentionally excluded: fb_square duplicates IG Square sizing, og duplicates
+# fb_landscape sizing, and facebook_post requires a 3-column layout template
+# not present in Welcome Card.
+WC_GALLERY_PLATFORM_IDS: tuple[str, ...] = (
+    "instagram_square",
+    "instagram_portrait",
+    "instagram_story",
+    "tiktok",
+    "facebook_landscape",
+    "banner_custom",
+)
+
+# Platforms shown in the Dashboard Card Editor platform picker.
+# "default" is excluded — it has no canvas size and is not an export target.
+# facebook_post was previously missing from the editor UI (functional gap).
+CARD_EDITOR_PLATFORM_IDS: tuple[str, ...] = (
+    "instagram_square",
+    "instagram_portrait",
+    "instagram_story",
+    "tiktok",
+    "facebook_square",
+    "facebook_landscape",
+    "og",
+    "banner_custom",
+    "facebook_post",
+)

--- a/app/services/card_constants.py
+++ b/app/services/card_constants.py
@@ -13,17 +13,18 @@ from __future__ import annotations
 # ── Canvas dimensions ─────────────────────────────────────────────────────────
 # Social canvas sizes keyed by platform preset id.
 #
-# "default" export canvas — measured 2026-05-12 via Playwright at 820px viewport
-# using ?native_export=1 (native-export-mode CSS: card fills width at auto height).
-# Conditions: FIFA Classic card, 4 SKILL_CATEGORIES (Outfield 19, Set Pieces 3,
-# Mental 14, Physical Fitness 8 skills), lower-section split layout (3fr skills /
-# 2fr position panel).  card-wrap.getBoundingClientRect() = 820×613 px.
+# "default" export canvas — original measurement 2026-05-12 via Playwright at 820px
+# viewport using ?native_export=1.  Layout since changed: skills panel is now a 2×2
+# grid (Outfield+Mental top row / Set Pieces+Physical bottom row) and the position
+# panel uses a portrait SVG pitch (viewBox "0 0 65 100", GK bottom, ST top).
+# CSS-derived estimate: header≈170px + tab-bar≈33px + card-body≈590px ≈ 793px →
+# rounded to 800px.  Re-measure with Playwright after deploying the new layout to
+# confirm; update this value and the comment date if the live clip differs.
 # Export path: render_url uses ?native_export=1; _sync_take_screenshot clips
-# to the card-wrap bounding rect — height is content-determined at render time.
-# The 613 here is a documented baseline; the clip always uses the live bounding
-# rect so new skills or theme changes never produce a truncated export.
+# to the card-wrap bounding rect — height is content-determined at render time,
+# so the export is never truncated regardless of what this constant says.
 CANVAS_SIZES: dict[str, tuple[int, int]] = {
-    "default":            ( 820,  613),   # native FIFA Classic; clip = card-wrap bbox
+    "default":            ( 820,  800),   # native FIFA Classic; clip = card-wrap bbox (est. 2026-05-12)
     "instagram_square":   (1080, 1080),
     "instagram_portrait": (1080, 1350),
     "instagram_story":    (1080, 1920),

--- a/app/services/card_export_service.py
+++ b/app/services/card_export_service.py
@@ -11,34 +11,15 @@ from threading import Lock
 
 logger = logging.getLogger(__name__)
 
-# Social canvas sizes — keyed by platform preset id.
-# "default" is intentionally absent (not an export target).
-# Dimensions match each platform's recommended export resolution.
-CANVAS_SIZES: dict[str, tuple[int, int]] = {
-    "instagram_square":   (1080, 1080),
-    "instagram_portrait": (1080, 1350),
-    "instagram_story":    (1080, 1920),
-    "tiktok":             (1080, 1920),
-    "facebook_square":    (1080, 1080),
-    "facebook_landscape": (1200,  630),
-    "og":                 (1200,  630),
-    "banner_custom":      (1500,  500),
-    "facebook_post":      (1200,  630),
-}
-
-# ── Animated video export capability registry ─────────────────────────────────
-# Central source of truth: (variant_id, platform_id) pairs that have a
-# dedicated animated export template.  All other combinations are unsupported
-# and the video endpoint returns 422 — no fallback, no silent degradation.
-ANIMATED_EXPORT_CAPABLE: frozenset[tuple[str, str]] = frozenset({
-    ("fifa",  "instagram_square"),
-    ("pulse", "instagram_square"),
-})
-
-
-def is_animated_capable(variant_id: str, platform_id: str) -> bool:
-    """Return True if (variant_id, platform_id) supports animated video export."""
-    return (variant_id, platform_id) in ANIMATED_EXPORT_CAPABLE
+# Re-exported from card_constants — the authoritative source for all
+# platform dimensions and animated-capability declarations.
+# External callers that already reference _export_svc.CANVAS_SIZES or
+# _export_svc.is_animated_capable() continue to work without change.
+from .card_constants import (  # noqa: E402
+    CANVAS_SIZES,
+    ANIMATED_EXPORT_CAPABLE,
+    is_animated_capable,
+)
 
 
 _GOTO_TIMEOUT_MS  = 10_000  # 10 s — generous vs. measured 0.6 s

--- a/app/services/card_export_service.py
+++ b/app/services/card_export_service.py
@@ -133,6 +133,18 @@ def _sync_take_screenshot(render_url: str, platform: str) -> bytes:  # pragma: n
     Called via asyncio.to_thread from the async export endpoint so it does
     not block the event loop.
 
+    For platform=="default" (FIFA Classic native export):
+      - render_url uses ?native_export=1 so body gets native-export-mode CSS
+        (card fills 820px width at auto height, logo hidden, tab bar hidden).
+      - Viewport is set tall (2000px) to avoid content clipping during render.
+      - Clip is derived at runtime from .card-wrap getBoundingClientRect().
+        This guarantees full capture even if content height changes with new
+        skills or theme updates — 820×613 is the measured baseline, not a hard
+        constraint.
+
+    For all other platforms:
+      - Viewport = canvas size; clip = full viewport (standard path).
+
     Raises:
         CardExportTimeoutError: if page.goto exceeds _GOTO_TIMEOUT_MS
         ValueError: if platform has no registered canvas size
@@ -140,7 +152,7 @@ def _sync_take_screenshot(render_url: str, platform: str) -> bytes:  # pragma: n
     canvas = CANVAS_SIZES.get(platform)
     if canvas is None:
         raise ValueError(f"No canvas size for platform: {platform!r}")
-    w, h = canvas
+    w, _ = canvas
 
     from playwright.sync_api import sync_playwright
     from playwright.sync_api import TimeoutError as _PWTimeout
@@ -149,12 +161,41 @@ def _sync_take_screenshot(render_url: str, platform: str) -> bytes:  # pragma: n
         with sync_playwright() as p:
             browser = p.chromium.launch(headless=True)
             try:
-                page = browser.new_page(viewport={"width": w, "height": h})
-                page.goto(render_url, wait_until="networkidle", timeout=_GOTO_TIMEOUT_MS)
-                png = page.screenshot(
-                    clip={"x": 0, "y": 0, "width": w, "height": h},
-                    type="png",
-                )
+                if platform == "default":
+                    # Native export: let the card render at its natural height.
+                    # Use a tall viewport so content is not clipped during layout.
+                    page = browser.new_page(viewport={"width": w, "height": 2000})
+                    page.goto(render_url, wait_until="networkidle", timeout=_GOTO_TIMEOUT_MS)
+                    card_rect = page.evaluate("""() => {
+                        const el = document.querySelector('.card-wrap');
+                        if (!el) return null;
+                        const r = el.getBoundingClientRect();
+                        return {
+                            x: Math.round(r.left),
+                            y: Math.round(r.top),
+                            w: Math.round(r.width),
+                            h: Math.round(r.height),
+                        };
+                    }""")
+                    if card_rect is None:
+                        raise ValueError("card-wrap element not found in default export render")
+                    png = page.screenshot(
+                        clip={
+                            "x": card_rect["x"],
+                            "y": card_rect["y"],
+                            "width":  card_rect["w"],
+                            "height": card_rect["h"],
+                        },
+                        type="png",
+                    )
+                else:
+                    h = CANVAS_SIZES[platform][1]
+                    page = browser.new_page(viewport={"width": w, "height": h})
+                    page.goto(render_url, wait_until="networkidle", timeout=_GOTO_TIMEOUT_MS)
+                    png = page.screenshot(
+                        clip={"x": 0, "y": 0, "width": w, "height": h},
+                        type="png",
+                    )
             finally:
                 browser.close()
     except _PWTimeout as exc:

--- a/app/services/card_platform_service.py
+++ b/app/services/card_platform_service.py
@@ -100,3 +100,29 @@ _FALLBACK = PLATFORM_PRESETS["default"]
 def get_preset(preset_id: str | None) -> PlatformPresetDefinition:
     """Return the preset for preset_id, falling back to 'default' for unknown ids."""
     return PLATFORM_PRESETS.get(preset_id or "default", _FALLBACK)
+
+
+def build_platform_list(platform_ids: tuple[str, ...]) -> list[dict]:
+    """Build a template-ready platform list from authoritative sources.
+
+    Each entry contains:
+      id    — platform preset id (snake_case)
+      label — human-readable name from PLATFORM_PRESETS
+      title — description string suitable for HTML title attribute
+      dims  — formatted dimension string, e.g. "1080 × 1080"
+      w, h  — integer pixel dimensions from CANVAS_SIZES
+    """
+    from .card_constants import CANVAS_SIZES  # local import avoids circular dep
+    result = []
+    for pid in platform_ids:
+        preset = get_preset(pid)
+        w, h = CANVAS_SIZES[pid]
+        result.append({
+            "id":    pid,
+            "label": preset.label,
+            "title": preset.description,
+            "dims":  f"{w} × {h}",
+            "w":     w,
+            "h":     h,
+        })
+    return result

--- a/app/static/js/pitch-selector.js
+++ b/app/static/js/pitch-selector.js
@@ -186,6 +186,19 @@
     this._onChange(null, []);
   };
 
+  /**
+   * Pre-populate the selector with an existing positions array.
+   * all[0] is treated as primary; all[1..3] as secondaries (max MAX_TOTAL total).
+   * Fires onChange so that any bound hidden inputs are updated immediately.
+   */
+  PitchSelector.prototype.setPositions = function (all) {
+    if (!Array.isArray(all) || all.length === 0) return;
+    this._primary     = all[0] || null;
+    this._secondaries = all.slice(1, MAX_TOTAL);
+    this._render();
+    this._onChange(this._primary, this.getAll());
+  };
+
   // ── DOM construction (once) ──────────────────────────────────────────────────
   PitchSelector.prototype._build = function () {
     this._root = document.createElement('div');

--- a/app/static/js/pitch-selector.js
+++ b/app/static/js/pitch-selector.js
@@ -1,0 +1,562 @@
+/**
+ * PitchSelector — vanilla JS SVG interactive football pitch position selector.
+ *
+ * Ported from pitch.jsx (authoritative coordinate and node source).
+ * No external dependencies. Self-contained CSS injected on first instantiation.
+ *
+ * UX parity with pitch.jsx:
+ *   - Desktop landscape SVG (W=720, H=468): GK left, ST right
+ *   - Mobile portrait SVG (W=420, H=740):   GK bottom, ST top
+ *   - Orientation hint in header (GK ← · ST →  /  GK ↓ · ST ↑)
+ *   - Selection counter (0 / 4)
+ *   - Reset button (shown when any selection active)
+ *   - Primary info panel (★ Primary label + position name)
+ *   - Secondary chips panel (+1 · +2 · +3)
+ *   - Primary ring-pulse SVG animation
+ *   - Secondary +N badge animation
+ *   - ST1/ST2 dual-node: both highlight when "striker" is active
+ *   - Role-coloured nodes: goalkeeper/defender/midfielder/forward
+ *
+ * API:
+ *   const ps = new PitchSelector('mount-id', (primary, all) => { ... });
+ *   ps.getPrimary()  → string|null   canonical DB value of primary selection
+ *   ps.getAll()      → string[]      [primary, ...secondaries]
+ *   ps.reset()       → void
+ */
+(function (global) {
+  'use strict';
+
+  // ── Position node list (authoritative — from pitch.jsx) ─────────────────────
+  // canonical = snake_case DB value.  ST1/ST2 share canonical "striker".
+  var PITCH_NODES = [
+    { id:'GK',  label:'GK',  name:'Goalkeeper',             role:'goalkeeper', canonical:'goalkeeper',             x:0.02, y:0.50 },
+    { id:'SK',  label:'SK',  name:'Sweeper Keeper',         role:'goalkeeper', canonical:'sweeper_keeper',         x:0.10, y:0.50 },
+    { id:'LB',  label:'LB',  name:'Left Back',              role:'defender',   canonical:'left_back',              x:0.19, y:0.15 },
+    { id:'LCB', label:'LCB', name:'Left Centre-Back',       role:'defender',   canonical:'left_centre_back',       x:0.19, y:0.37 },
+    { id:'RCB', label:'RCB', name:'Right Centre-Back',      role:'defender',   canonical:'right_centre_back',      x:0.19, y:0.63 },
+    { id:'RB',  label:'RB',  name:'Right Back',             role:'defender',   canonical:'right_back',             x:0.19, y:0.85 },
+    { id:'LWB', label:'LWB', name:'Left Wing-Back',         role:'defender',   canonical:'left_wing_back',         x:0.28, y:0.10 },
+    { id:'RWB', label:'RWB', name:'Right Wing-Back',        role:'defender',   canonical:'right_wing_back',        x:0.28, y:0.90 },
+    { id:'DM',  label:'DM',  name:'Defensive Mid',          role:'midfielder', canonical:'defensive_midfield',     x:0.37, y:0.50 },
+    { id:'LCM', label:'LCM', name:'Left Centre Mid',        role:'midfielder', canonical:'left_centre_midfield',   x:0.47, y:0.33 },
+    { id:'CM',  label:'CM',  name:'Centre Mid',             role:'midfielder', canonical:'centre_midfield',        x:0.50, y:0.50 },
+    { id:'RCM', label:'RCM', name:'Right Centre Mid',       role:'midfielder', canonical:'right_centre_midfield',  x:0.47, y:0.67 },
+    { id:'LM',  label:'LM',  name:'Left Midfielder',        role:'midfielder', canonical:'left_midfield',          x:0.55, y:0.17 },
+    { id:'RM',  label:'RM',  name:'Right Midfielder',       role:'midfielder', canonical:'right_midfield',         x:0.55, y:0.83 },
+    { id:'AM',  label:'AM',  name:'Att. Midfielder',        role:'midfielder', canonical:'attacking_midfield',     x:0.68, y:0.50 },
+    { id:'LW',  label:'LW',  name:'Left Winger',            role:'forward',    canonical:'left_wing',              x:0.73, y:0.07 },
+    { id:'RW',  label:'RW',  name:'Right Winger',           role:'forward',    canonical:'right_wing',             x:0.73, y:0.93 },
+    { id:'CF',  label:'CF',  name:'Centre Forward',         role:'forward',    canonical:'centre_forward',         x:0.83, y:0.50 },
+    { id:'ST1', label:'ST',  name:'Striker',                role:'forward',    canonical:'striker',                x:0.88, y:0.34 },
+    { id:'ST2', label:'ST',  name:'Striker',                role:'forward',    canonical:'striker',                x:0.88, y:0.66 },
+  ];
+
+  var ROLE_COLORS = {
+    goalkeeper: '#1e3a8a',
+    defender:   '#1d4ed8',
+    midfielder: '#15803d',
+    forward:    '#b91c1c',
+  };
+
+  // SVG canvas dimensions (pitch.jsx authoritative)
+  var DW = 720, DH = 468;   // desktop landscape
+  var MW = 420, MH = 740;   // mobile portrait
+
+  var MAX_SECONDARY = 3;
+  var MAX_TOTAL     = 4;    // 1 primary + 3 secondary
+  var MOBILE_BP     = 600;  // px — breakpoint for mobile layout
+
+  // ── CSS injection (once per page) ───────────────────────────────────────────
+  var _cssInjected = false;
+  function _injectCSS() {
+    if (_cssInjected) return;
+    _cssInjected = true;
+    var style = document.createElement('style');
+    style.textContent = [
+      /* Root */
+      '.ps-root { font-family: inherit; }',
+
+      /* Header bar */
+      '.ps-header {',
+      '  display: flex; align-items: center; gap: 0.45rem;',
+      '  margin-bottom: 0.7rem; flex-wrap: wrap;',
+      '}',
+      '.ps-title {',
+      '  font-size: 0.75rem; font-weight: 700; text-transform: uppercase;',
+      '  letter-spacing: 0.07em; color: var(--onboarding-text-muted, #6B7280);',
+      '  flex-shrink: 0;',
+      '}',
+      '.ps-hint {',
+      '  font-size: 0.72rem; color: var(--onboarding-text-muted, #6B7280);',
+      '  background: var(--onboarding-option-bg, #fff);',
+      '  border: 1px solid var(--onboarding-option-border, #D1D5DB);',
+      '  border-radius: 4px; padding: 0.12rem 0.4rem; flex-shrink: 0;',
+      '}',
+      '.ps-counter {',
+      '  font-size: 0.75rem; font-weight: 700;',
+      '  color: var(--onboarding-text-primary, #111);',
+      '  background: var(--onboarding-summary-bg, #FFFBE6);',
+      '  border: 1px solid var(--onboarding-summary-border, rgba(230,189,0,0.45));',
+      '  border-radius: 12px; padding: 0.12rem 0.55rem;',
+      '  min-width: 40px; text-align: center; flex-shrink: 0;',
+      '}',
+      '.ps-reset {',
+      '  margin-left: auto; font-size: 0.72rem; font-weight: 700;',
+      '  color: var(--onboarding-danger-text, #C0392B);',
+      '  background: var(--onboarding-danger-bg, #FFF0F0);',
+      '  border: 1px solid var(--onboarding-danger-border, #E74C3C);',
+      '  border-radius: 6px; padding: 0.18rem 0.65rem;',
+      '  cursor: pointer; transition: background 0.15s; flex-shrink: 0;',
+      '}',
+      '.ps-reset:hover { background: var(--onboarding-danger-hover-bg, #FFE0E0); }',
+
+      /* SVG container */
+      '.ps-svg-wrap {',
+      '  width: 100%; border-radius: 10px; overflow: hidden;',
+      '  touch-action: manipulation; user-select: none;',
+      '}',
+      '.ps-svg { display: block; width: 100%; height: auto; }',
+
+      /* Node interaction states */
+      '.ps-node { cursor: pointer; }',
+      '.ps-node--disabled { cursor: not-allowed; pointer-events: none; opacity: 0.28; }',
+
+      /* Info panel */
+      '.ps-info-panel {',
+      '  margin-top: 0.6rem;',
+      '  border: 1px solid var(--onboarding-summary-border, rgba(230,189,0,0.45));',
+      '  border-radius: 10px; padding: 0.65rem 1rem;',
+      '  background: var(--onboarding-summary-bg, #FFFBE6); min-height: 2.8rem;',
+      '}',
+      '.ps-primary-label {',
+      '  font-size: 0.72rem; font-weight: 700; text-transform: uppercase;',
+      '  letter-spacing: 0.07em; color: var(--onboarding-summary-avg, #6B5A00);',
+      '  margin-bottom: 0.28rem;',
+      '}',
+      '.ps-primary-value {',
+      '  font-size: 0.97rem; font-weight: 800;',
+      '  color: var(--onboarding-text-primary, #111);',
+      '}',
+      '.ps-secondary-row { display: flex; flex-wrap: wrap; gap: 0.38rem; margin-top: 0.45rem; }',
+      '.ps-chip {',
+      '  font-size: 0.7rem; font-weight: 700; border-radius: 20px;',
+      '  padding: 0.18rem 0.6rem;',
+      '  background: var(--onboarding-option-hover-bg, #FFFBE6);',
+      '  border: 1px solid var(--onboarding-option-hover-border, #FFD200);',
+      '  color: var(--onboarding-text-primary, #111);',
+      '}',
+      '.ps-empty-hint {',
+      '  font-size: 0.82rem; color: var(--onboarding-text-muted, #6B7280); font-style: italic;',
+      '}',
+    ].join('\n');
+    document.head.appendChild(style);
+  }
+
+  // ── Constructor ──────────────────────────────────────────────────────────────
+  function PitchSelector(mountId, onChange) {
+    this._mount    = document.getElementById(mountId);
+    this._onChange = typeof onChange === 'function' ? onChange : function () {};
+    this._primary      = null;
+    this._secondaries  = [];
+    this._mobile       = false;
+
+    _injectCSS();
+    this._build();
+
+    var self = this;
+    if (typeof ResizeObserver !== 'undefined') {
+      this._ro = new ResizeObserver(function () { self._checkLayout(); });
+      this._ro.observe(this._mount);
+    }
+    this._checkLayout();
+  }
+
+  // ── Public API ───────────────────────────────────────────────────────────────
+  PitchSelector.prototype.getPrimary = function () { return this._primary; };
+
+  PitchSelector.prototype.getAll = function () {
+    if (!this._primary) return [];
+    return [this._primary].concat(this._secondaries);
+  };
+
+  PitchSelector.prototype.reset = function () {
+    this._primary     = null;
+    this._secondaries = [];
+    this._render();
+    this._onChange(null, []);
+  };
+
+  // ── DOM construction (once) ──────────────────────────────────────────────────
+  PitchSelector.prototype._build = function () {
+    this._root = document.createElement('div');
+    this._root.className = 'ps-root';
+
+    // Header
+    this._headerEl  = document.createElement('div');
+    this._headerEl.className = 'ps-header';
+
+    this._titleEl   = document.createElement('span');
+    this._titleEl.className = 'ps-title';
+    this._titleEl.textContent = 'Select position';
+
+    this._hintEl    = document.createElement('span');
+    this._hintEl.className = 'ps-hint';
+    this._hintEl.textContent = 'GK ← · ST →';
+
+    this._counterEl = document.createElement('span');
+    this._counterEl.className = 'ps-counter';
+    this._counterEl.textContent = '0 / 4';
+
+    this._resetBtn  = document.createElement('button');
+    this._resetBtn.type = 'button';
+    this._resetBtn.className = 'ps-reset';
+    this._resetBtn.textContent = '✕ Reset';
+    this._resetBtn.style.display = 'none';
+    var self = this;
+    this._resetBtn.addEventListener('click', function () { self.reset(); });
+
+    this._headerEl.appendChild(this._titleEl);
+    this._headerEl.appendChild(this._hintEl);
+    this._headerEl.appendChild(this._counterEl);
+    this._headerEl.appendChild(this._resetBtn);
+
+    // SVG wrapper
+    this._svgWrap = document.createElement('div');
+    this._svgWrap.className = 'ps-svg-wrap';
+
+    // Info panel
+    this._infoPanel = document.createElement('div');
+    this._infoPanel.className = 'ps-info-panel';
+
+    this._root.appendChild(this._headerEl);
+    this._root.appendChild(this._svgWrap);
+    this._root.appendChild(this._infoPanel);
+    this._mount.appendChild(this._root);
+  };
+
+  // ── Layout detection ─────────────────────────────────────────────────────────
+  PitchSelector.prototype._checkLayout = function () {
+    var wasMobile = this._mobile;
+    this._mobile  = this._mount.offsetWidth < MOBILE_BP;
+    if (wasMobile !== this._mobile || !this._svgWrap.firstChild) this._render();
+  };
+
+  // ── Selection logic ──────────────────────────────────────────────────────────
+  PitchSelector.prototype._handleClick = function (canonical) {
+    if (canonical === this._primary) {
+      // Clicking the active primary → full reset
+      this._primary     = null;
+      this._secondaries = [];
+    } else if (this._secondaries.indexOf(canonical) !== -1) {
+      // Clicking a secondary → deselect it
+      this._secondaries = this._secondaries.filter(function (v) { return v !== canonical; });
+    } else if (!this._primary) {
+      // No primary yet → set as primary
+      this._primary = canonical;
+    } else if (this._secondaries.length < MAX_SECONDARY) {
+      // Under limit → add as secondary
+      this._secondaries.push(canonical);
+    }
+    // At limit, unselected → ignore click
+
+    this._render();
+    this._onChange(this._primary, this.getAll());
+  };
+
+  // ── State helpers ────────────────────────────────────────────────────────────
+  PitchSelector.prototype._nodeState = function (node) {
+    var canon      = node.canonical;
+    var total      = this.getAll().length;
+    var isPrimary  = (canon === this._primary);
+    var secIdx     = this._secondaries.indexOf(canon);
+    var isSecondary = (secIdx !== -1);
+    var isDisabled  = !isPrimary && !isSecondary && (total >= MAX_TOTAL);
+    return { isPrimary: isPrimary, isSecondary: isSecondary, isDisabled: isDisabled, secIdx: secIdx };
+  };
+
+  // ── SVG builder ──────────────────────────────────────────────────────────────
+  var NS = 'http://www.w3.org/2000/svg';
+
+  function _el(tag, attrs) {
+    var e = document.createElementNS(NS, tag);
+    if (attrs) Object.keys(attrs).forEach(function (k) { e.setAttribute(k, attrs[k]); });
+    return e;
+  }
+
+  function _lineStyle(el) {
+    el.setAttribute('fill', 'none');
+    el.setAttribute('stroke', 'rgba(255,255,255,0.32)');
+    el.setAttribute('stroke-width', '1.5');
+  }
+
+  PitchSelector.prototype._buildSVG = function () {
+    var mob  = this._mobile;
+    var W    = mob ? MW : DW;
+    var H    = mob ? MH : DH;
+    var self = this;
+
+    // Coordinate mapping from pitch.jsx
+    var nodeX = function (n) { return mob ? (n.y * MW)       : (n.x * DW); };
+    var nodeY = function (n) { return mob ? ((1 - n.x) * MH) : (n.y * DH); };
+
+    var svg = _el('svg', { viewBox: '0 0 ' + W + ' ' + H, 'class': 'ps-svg' });
+
+    // ── Pitch background ──
+    svg.appendChild(_el('rect', { x:0, y:0, width:W, height:H, fill:'#2d5a27' }));
+
+    // ── Alternate stripe bands (visual depth) ──
+    var bandW = mob ? MH / 8 : DW / 8;
+    for (var bi = 0; bi < 8; bi++) {
+      if (bi % 2 === 1) {
+        var band = _el('rect', {
+          fill: 'rgba(0,0,0,0.06)',
+        });
+        if (!mob) {
+          band.setAttribute('x',      bi * bandW);
+          band.setAttribute('y',      0);
+          band.setAttribute('width',  bandW);
+          band.setAttribute('height', DH);
+        } else {
+          band.setAttribute('x',      0);
+          band.setAttribute('y',      bi * bandW);
+          band.setAttribute('width',  MW);
+          band.setAttribute('height', bandW);
+        }
+        svg.appendChild(band);
+      }
+    }
+
+    // ── Pitch markings ──
+    var pad = 12;
+
+    // Outer border
+    var border = _el('rect', { x: pad, y: pad, width: W - 2*pad, height: H - 2*pad });
+    _lineStyle(border); svg.appendChild(border);
+
+    if (!mob) {
+      // Desktop: centre line (vertical), centre circle, penalty areas
+      var cl = _el('line', { x1: W/2, y1: pad, x2: W/2, y2: H - pad });
+      _lineStyle(cl); svg.appendChild(cl);
+
+      var cc = _el('circle', { cx: W/2, cy: H/2, r: 56 });
+      _lineStyle(cc); svg.appendChild(cc);
+
+      var hd = _el('circle', { cx: W/2, cy: H/2, r: 3, fill: 'rgba(255,255,255,0.45)' });
+      svg.appendChild(hd);
+
+      // Left penalty area (GK side)
+      var lpa = _el('rect', { x: pad, y: H/2 - 88, width: 148, height: 176 });
+      _lineStyle(lpa); svg.appendChild(lpa);
+
+      var lgb = _el('rect', { x: pad, y: H/2 - 38, width: 46, height: 76 });
+      _lineStyle(lgb); svg.appendChild(lgb);
+
+      // Right penalty area (ST side)
+      var rpa = _el('rect', { x: W - pad - 148, y: H/2 - 88, width: 148, height: 176 });
+      _lineStyle(rpa); svg.appendChild(rpa);
+
+      var rgb_ = _el('rect', { x: W - pad - 46, y: H/2 - 38, width: 46, height: 76 });
+      _lineStyle(rgb_); svg.appendChild(rgb_);
+
+    } else {
+      // Mobile: centre line (horizontal), centre circle, penalty areas
+      var mcl = _el('line', { x1: pad, y1: H/2, x2: W - pad, y2: H/2 });
+      _lineStyle(mcl); svg.appendChild(mcl);
+
+      var mcc = _el('circle', { cx: W/2, cy: H/2, r: 56 });
+      _lineStyle(mcc); svg.appendChild(mcc);
+
+      var mhd = _el('circle', { cx: W/2, cy: H/2, r: 3, fill: 'rgba(255,255,255,0.45)' });
+      svg.appendChild(mhd);
+
+      // Top penalty area (ST side)
+      var tpa = _el('rect', { x: W/2 - 88, y: pad, width: 176, height: 148 });
+      _lineStyle(tpa); svg.appendChild(tpa);
+
+      var tgb = _el('rect', { x: W/2 - 38, y: pad, width: 76, height: 46 });
+      _lineStyle(tgb); svg.appendChild(tgb);
+
+      // Bottom penalty area (GK side)
+      var bpa = _el('rect', { x: W/2 - 88, y: H - pad - 148, width: 176, height: 148 });
+      _lineStyle(bpa); svg.appendChild(bpa);
+
+      var bgb = _el('rect', { x: W/2 - 38, y: H - pad - 46, width: 76, height: 46 });
+      _lineStyle(bgb); svg.appendChild(bgb);
+    }
+
+    // ── Position nodes ────────────────────────────────────────────────────────
+    PITCH_NODES.forEach(function (node) {
+      var st = self._nodeState(node);
+      var cx = nodeX(node);
+      var cy = nodeY(node);
+      var baseColor = ROLE_COLORS[node.role] || '#374151';
+
+      var g = _el('g', {
+        'class': 'ps-node' +
+          (st.isPrimary   ? ' ps-node--primary'   : '') +
+          (st.isSecondary ? ' ps-node--secondary' : '') +
+          (st.isDisabled  ? ' ps-node--disabled'  : ''),
+        'data-canonical': node.canonical,
+      });
+
+      if (!st.isDisabled) {
+        g.addEventListener('click', function () { self._handleClick(node.canonical); });
+      }
+
+      // ── Pulse ring for primary ──
+      if (st.isPrimary) {
+        var ring = _el('circle', { cx: cx, cy: cy, r: 13, fill: 'none',
+          stroke: '#FFD200', 'stroke-width': '2', opacity: '0.65' });
+        var ra = _el('animate', { attributeName: 'r',
+          values: '13;20;13', dur: '1.4s', repeatCount: 'indefinite' });
+        var oa = _el('animate', { attributeName: 'opacity',
+          values: '0.65;0.1;0.65', dur: '1.4s', repeatCount: 'indefinite' });
+        ring.appendChild(ra);
+        ring.appendChild(oa);
+        g.appendChild(ring);
+      }
+
+      // ── Main circle ──
+      var circleAttrs = { cx: cx, cy: cy, r: '13', 'class': 'ps-node-circle' };
+      if (st.isPrimary) {
+        circleAttrs.fill = '#FFD200';
+        circleAttrs.stroke = '#C9A400';
+        circleAttrs['stroke-width'] = '2.5';
+      } else if (st.isSecondary) {
+        circleAttrs.fill = '#FFFBE6';
+        circleAttrs.stroke = '#FFD200';
+        circleAttrs['stroke-width'] = '2';
+      } else {
+        circleAttrs.fill = baseColor;
+        circleAttrs.stroke = 'rgba(255,255,255,0.35)';
+        circleAttrs['stroke-width'] = '1';
+      }
+      g.appendChild(_el('circle', circleAttrs));
+
+      // ── Label ──
+      var txtFill = st.isPrimary ? '#0B0B0B' : st.isSecondary ? '#6B5A00' : '#FFFFFF';
+      var fsize   = node.label.length > 2 ? '6.5' : '8.5';
+      var txt = _el('text', {
+        x: cx, y: cy + 3.5,
+        'text-anchor': 'middle',
+        'font-size': fsize,
+        'font-weight': '800',
+        'font-family': 'inherit',
+        fill: txtFill,
+        'pointer-events': 'none',
+      });
+      txt.textContent = node.label;
+      g.appendChild(txt);
+
+      // ── Primary ★ badge ──
+      if (st.isPrimary) {
+        var pbg = _makeBadge(cx + 10, cy - 10, '#0B0B0B', '#FFD200', '#FFD200', '★', 8);
+        g.appendChild(pbg);
+      }
+
+      // ── Secondary +N badge ──
+      if (st.isSecondary) {
+        var sbg = _makeBadge(cx + 10, cy - 10, '#FFD200', '#C9A400', '#0B0B0B', '+' + (st.secIdx + 1), 7);
+        g.appendChild(sbg);
+      }
+
+      svg.appendChild(g);
+    });
+
+    return svg;
+  };
+
+  // Build a small circular badge with a text label, with a pop animation.
+  function _makeBadge(cx, cy, fill, stroke, textFill, label, fontSize) {
+    var g = _el('g');
+
+    // animateTransform for pop — SVG-native, no CSS required
+    var at = _el('animateTransform', {
+      attributeName: 'transform',
+      type: 'scale',
+      additive: 'sum',
+      values: '0 0;1.25 1.25;1 1',
+      keyTimes: '0;0.55;1',
+      dur: '0.25s',
+      fill: 'freeze',
+    });
+    // The transform-origin workaround: use a nested group with translate
+    var inner = _el('g', { transform: 'translate(' + cx + ',' + cy + ')' });
+
+    var animG = _el('g');
+    animG.appendChild(at);
+
+    var bc = _el('circle', { cx: 0, cy: 0, r: 7, fill: fill, stroke: stroke, 'stroke-width': '1.2' });
+    var bt = _el('text', {
+      x: 0, y: fontSize === 8 ? 3 : 2.5,
+      'text-anchor': 'middle',
+      'font-size': fontSize,
+      'font-weight': '900',
+      fill: textFill,
+      'pointer-events': 'none',
+      'font-family': 'inherit',
+    });
+    bt.textContent = label;
+
+    animG.appendChild(bc);
+    animG.appendChild(bt);
+    inner.appendChild(animG);
+    g.appendChild(inner);
+    return g;
+  }
+
+  // ── Full render ──────────────────────────────────────────────────────────────
+  PitchSelector.prototype._render = function () {
+    // SVG
+    this._svgWrap.innerHTML = '';
+    this._svgWrap.appendChild(this._buildSVG());
+
+    // Header
+    var total = this.getAll().length;
+    this._counterEl.textContent = total + ' / ' + MAX_TOTAL;
+    this._hintEl.textContent = this._mobile
+      ? 'GK ↓ · ST ↑'
+      : 'GK ← · ST →';
+    this._resetBtn.style.display = this._primary ? 'inline-block' : 'none';
+
+    // Info panel
+    var html = '';
+    if (!this._primary) {
+      html = '<span class="ps-empty-hint">Select your primary position on the pitch</span>';
+    } else {
+      var pNode = null;
+      for (var i = 0; i < PITCH_NODES.length; i++) {
+        if (PITCH_NODES[i].canonical === this._primary) { pNode = PITCH_NODES[i]; break; }
+      }
+      var pLabel = pNode ? pNode.label : this._primary;
+      var pName  = pNode ? pNode.name  : this._primary;
+
+      html += '<div class="ps-primary-label">★ Primary</div>';
+      html += '<div class="ps-primary-value">' + pLabel + ' — ' + pName + '</div>';
+
+      if (this._secondaries.length > 0) {
+        html += '<div class="ps-secondary-row">';
+        for (var j = 0; j < this._secondaries.length; j++) {
+          var sCanon = this._secondaries[j];
+          var sNode  = null;
+          for (var k = 0; k < PITCH_NODES.length; k++) {
+            if (PITCH_NODES[k].canonical === sCanon) { sNode = PITCH_NODES[k]; break; }
+          }
+          var sLabel = sNode ? sNode.label : sCanon;
+          var sName  = sNode ? sNode.name  : sCanon;
+          html += '<span class="ps-chip">+' + (j + 1) + ' ' + sLabel + ' — ' + sName + '</span>';
+        }
+        html += '</div>';
+      } else {
+        html += '<div class="ps-secondary-row">'
+          + '<span class="ps-empty-hint">Tap up to 3 secondary positions</span>'
+          + '</div>';
+      }
+    }
+    this._infoPanel.innerHTML = html;
+  };
+
+  // ── Export ───────────────────────────────────────────────────────────────────
+  global.PitchSelector = PitchSelector;
+
+}(typeof window !== 'undefined' ? window : this));

--- a/app/templates/adaptive_learning_session.html
+++ b/app/templates/adaptive_learning_session.html
@@ -597,7 +597,7 @@
         </div>
         <div id="als-progress-label" class="als-progress-label">Question 0</div>
 
-        <div class="als-question-card">
+        <div id="als-question-card" class="als-question-card">
             <div id="als-question-num" class="als-question-num">Question 1</div>
             <p id="als-question-text" class="als-question-text"></p>
         </div>
@@ -1082,6 +1082,8 @@
         document.getElementById('als-feedback').style.display = 'none';
         document.getElementById('als-feedback').className = 'als-feedback';
         document.getElementById('als-next-btn-wrap').style.display = 'none';
+        document.getElementById('als-question-card').style.display = '';
+        document.getElementById('als-options').style.display = '';
         updateProgress();
         showPhase('question');
     }
@@ -1137,6 +1139,7 @@
             }
             fb.style.display = 'block';
 
+            _showAnsweredState();
             _showNextButton();
         }).catch(function () {
             showError('Network error while recording answer. Please check your connection.');
@@ -1148,6 +1151,13 @@
         var btn  = document.getElementById('als-next-btn');
         if (wrap) wrap.style.display = 'block';
         if (btn)  btn.disabled = false;
+    }
+
+    function _showAnsweredState() {
+        var card = document.getElementById('als-question-card');
+        var opts = document.getElementById('als-options');
+        if (card) card.style.display = 'none';
+        if (opts) opts.style.display = 'none';
     }
 
     /* ── Next question ─────────────────────────────────────────────────────── */

--- a/app/templates/adaptive_learning_session.html
+++ b/app/templates/adaptive_learning_session.html
@@ -251,6 +251,20 @@
     .als-next-cat-btn:hover:not(:disabled) { background: #4338ca; }
     .als-next-cat-btn:disabled { opacity: 0.45; cursor: not-allowed; }
 
+    .als-next-btn {
+        background: var(--app-primary, #4f46e5);
+        color: #fff;
+        border: none;
+        border-radius: 8px;
+        padding: 0.6rem 1.6rem;
+        font-size: 0.95rem;
+        font-weight: 600;
+        cursor: pointer;
+        transition: background 0.15s, opacity 0.15s;
+    }
+    .als-next-btn:hover:not(:disabled) { background: #4338ca; }
+    .als-next-btn:disabled { opacity: 0.45; cursor: not-allowed; }
+
     /* ── Question card ───────────────────────────────────────────────────────── */
     .als-question-card {
         background: var(--app-card);
@@ -590,8 +604,8 @@
 
         <div id="als-options" class="als-options"></div>
         <div id="als-feedback" class="als-feedback"></div>
-        <div id="als-auto-advance" style="display:none; text-align:center; font-size:0.82rem; color:var(--app-text-muted); margin-top:0.5rem;">
-            Next question in 1.5s…
+        <div id="als-next-btn-wrap" style="display:none; text-align:center; margin-top:1rem;">
+            <button id="als-next-btn" class="als-next-btn" onclick="alsNext()">Next question →</button>
         </div>
     </div>
 
@@ -1067,7 +1081,7 @@
 
         document.getElementById('als-feedback').style.display = 'none';
         document.getElementById('als-feedback').className = 'als-feedback';
-        document.getElementById('als-auto-advance').style.display = 'none';
+        document.getElementById('als-next-btn-wrap').style.display = 'none';
         updateProgress();
         showPhase('question');
     }
@@ -1123,30 +1137,29 @@
             }
             fb.style.display = 'block';
 
-            var advanceDelay = d.correct ? 1500 : 3000;
-            _scheduleNextAction(advanceDelay);
+            _showNextButton();
         }).catch(function () {
             showError('Network error while recording answer. Please check your connection.');
         });
     }
 
-    function _scheduleNextAction(delayMs) {
-        var adv = document.getElementById('als-auto-advance');
-        if (adv) {
-            adv.textContent = delayMs >= 3000 ? 'Next question in 3s…' : 'Next question in 1.5s…';
-            adv.style.display = 'block';
-        }
-        setTimeout(function () {
-            if (adv) adv.style.display = 'none';
-            alsNext();
-        }, delayMs);
+    function _showNextButton() {
+        var wrap = document.getElementById('als-next-btn-wrap');
+        var btn  = document.getElementById('als-next-btn');
+        if (wrap) wrap.style.display = 'block';
+        if (btn)  btn.disabled = false;
     }
 
     /* ── Next question ─────────────────────────────────────────────────────── */
     window.alsNext = function () {
+        var btn  = document.getElementById('als-next-btn');
+        var wrap = document.getElementById('als-next-btn-wrap');
+        if (btn) btn.disabled = true;  // double-click guard
+
         var excludeParam = state.recentIds.join(',');
         get('/adaptive-learning/session/' + state.sessionId + '/next-question?exclude_ids=' + excludeParam)
             .then(function (res) {
+                if (wrap) wrap.style.display = 'none';
                 if (!res) return;
                 var d = res.data;
                 if (d.session_complete) {
@@ -1160,6 +1173,7 @@
                 if (!d.id) { alsComplete(); return; }
                 renderQuestion(d);
             }).catch(function () {
+                if (btn)  btn.disabled = false;  // re-enable on network error
                 showError('Could not load the next question. Please try again.');
             });
     };

--- a/app/templates/dashboard_card_editor.html
+++ b/app/templates/dashboard_card_editor.html
@@ -287,7 +287,7 @@
         </div>
         <div style="margin-top: 0.75rem; display: flex; justify-content: flex-end; gap: 0.5rem; align-items: center;">
             <button id="btn-export-card" class="btn-export-card" onclick="exportCard()"
-                    {% if not active_card_platform or active_card_platform == 'default' %}disabled title="Select a platform above to download PNG"{% endif %}>⬇ Download PNG</button>
+                    title="Download PNG — Default exports the FIFA Classic card at native proportions">⬇ Download PNG</button>
             {# Video export button — hidden by default; JS shows it only for animated-capable combos #}
             <button id="btn-export-video" class="btn-export-card btn-export-video"
                     style="display:none;" onclick="exportCardVideo()"
@@ -569,8 +569,7 @@ function setPlatform(platformId) {
     if (iframe) { iframe.src = _cardIframeSrc(); }
     _applyIframeSize();
     _updateFullscreenLink();
-    const dlBtn = document.getElementById('btn-export-card');
-    if (dlBtn) dlBtn.disabled = platformId === 'default';
+    // Download PNG is always enabled — default platform exports the native FIFA card.
     _updateVideoButtonVisibility();
     _savePlatform(platformId);
 }
@@ -584,7 +583,9 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 
 async function exportCard() {
-    const platform = _currentPlatform === 'default' ? 'instagram_square' : _currentPlatform;
+    // "default" exports the FIFA Classic card at native proportions (820×auto).
+    // No instagram_square fallback — the export route handles "default" explicitly.
+    const platform = _currentPlatform;
     const btn = document.getElementById('btn-export-card');
     const origText = btn.textContent;
     btn.disabled = true;
@@ -603,7 +604,7 @@ async function exportCard() {
         alert('Export failed — please try again.');
     } finally {
         btn.textContent = origText;
-        btn.disabled = _currentPlatform === 'default';
+        btn.disabled = false;
     }
 }
 

--- a/app/templates/dashboard_card_editor.html
+++ b/app/templates/dashboard_card_editor.html
@@ -19,7 +19,7 @@
                 <a href="/notifications" class="s-hdr-btn" title="Notifications" aria-label="Notifications">🔔</a>
                 <span class="badge-dot" id="hdr-notif-badge">0</span>
             </div>
-            <a href="/profile" class="s-hdr-btn" title="Profile">👤</a>
+            <a href="/profile/lfa-football-player" class="s-hdr-btn" title="Profile">🪪</a>
             <a href="/logout"  class="s-hdr-btn" title="Logout">🚪</a>
         </div>
     </div>
@@ -225,14 +225,14 @@
     <span class="s-breadcrumb-sep">›</span>
     <a href="/dashboard/lfa-football-player" class="s-breadcrumb-item">⚽ LFA Football Player</a>
     <span class="s-breadcrumb-sep">›</span>
-    <span class="s-breadcrumb-item active">🪪 My Player Card</span>
+    <span class="s-breadcrumb-item active">🎴 My Player Card</span>
 </nav>
 
 <div class="container">
 
     <section class="section-block" style="padding: 1.25rem; margin-bottom: 1.5rem;">
         <div style="margin-bottom: 0.75rem;">
-            <h2 class="page-title" style="margin-bottom: 0.6rem;">🪪 My Player Card</h2>
+            <h2 class="page-title" style="margin-bottom: 0.6rem;">🎴 My Player Card</h2>
             <div style="display:flex; align-items:center; justify-content:space-between; gap:0.75rem;">
                 {# ── Theme picker ── #}
                 <div class="theme-picker" id="theme-picker">

--- a/app/templates/dashboard_card_editor.html
+++ b/app/templates/dashboard_card_editor.html
@@ -266,16 +266,18 @@
             </div>
             {% endif %}
             {# ── Platform picker ── #}
+            {# "default" is a static CTA — no canvas size, not an export target #}
             <div class="platform-picker" id="platform-picker">
-                <button class="platform-btn {% if not active_card_platform or active_card_platform == 'default' %}active{% endif %}" data-platform="default"            onclick="setPlatform('default')"            title="Native card proportions">Default</button>
-                <button class="platform-btn {% if active_card_platform == 'instagram_square' %}active{% endif %}"   data-platform="instagram_square"          onclick="setPlatform('instagram_square')"          title="Instagram Feed · 1080×1080">IG Square</button>
-                <button class="platform-btn {% if active_card_platform == 'instagram_portrait' %}active{% endif %}" data-platform="instagram_portrait"        onclick="setPlatform('instagram_portrait')"        title="Instagram Feed · 1080×1350">IG Portrait</button>
-                <button class="platform-btn {% if active_card_platform == 'instagram_story' %}active{% endif %}"    data-platform="instagram_story"           onclick="setPlatform('instagram_story')"           title="Instagram Story · 1080×1920">IG Story</button>
-                <button class="platform-btn {% if active_card_platform == 'tiktok' %}active{% endif %}"             data-platform="tiktok"                    onclick="setPlatform('tiktok')"                    title="TikTok · 1080×1920">TikTok</button>
-                <button class="platform-btn {% if active_card_platform == 'facebook_square' %}active{% endif %}"    data-platform="facebook_square"           onclick="setPlatform('facebook_square')"           title="Facebook Post · 1080×1080">FB Square</button>
-                <button class="platform-btn {% if active_card_platform == 'facebook_landscape' %}active{% endif %}" data-platform="facebook_landscape"        onclick="setPlatform('facebook_landscape')"        title="Facebook / OG · 1200×630">FB Landscape</button>
-                <button class="platform-btn {% if active_card_platform == 'og' %}active{% endif %}"                 data-platform="og"                        onclick="setPlatform('og')"                        title="Open Graph / LinkedIn · 1200×630">OG</button>
-                <button class="platform-btn {% if active_card_platform == 'banner_custom' %}active{% endif %}"      data-platform="banner_custom"             onclick="setPlatform('banner_custom')"             title="Facebook Cover · 1500×500">Banner</button>
+                <button class="platform-btn {% if not active_card_platform or active_card_platform == 'default' %}active{% endif %}"
+                        data-platform="default"
+                        onclick="setPlatform('default')"
+                        title="Native card proportions">Default</button>
+                {% for p in platforms %}
+                <button class="platform-btn {% if active_card_platform == p.id %}active{% endif %}"
+                        data-platform="{{ p.id }}"
+                        onclick="setPlatform('{{ p.id }}')"
+                        title="{{ p.title }}">{{ p.label }}</button>
+                {% endfor %}
             </div>
         </div>
         <div class="player-card-embed-wrap">
@@ -403,16 +405,13 @@
 function _csrf() {
     return (document.cookie.split('; ').find(r => r.startsWith('csrf_token=')) || '').split('=')[1];
 }
-const _CANVAS_SIZES = {
-    instagram_square:   [1080, 1080],
-    instagram_portrait: [1080, 1350],
-    instagram_story:    [1080, 1920],
-    tiktok:             [1080, 1920],
-    facebook_square:    [1080, 1080],
-    facebook_landscape: [1200,  630],
-    og:                 [1200,  630],
-    banner_custom:      [1500,  500],
-};
+// ── Canvas size map — server-rendered from card_constants.CANVAS_SIZES ───────
+const _CANVAS_SIZES = (function () {
+    const raw = {{ canvas_sizes | tojson }};
+    const out = {};
+    for (const pid in raw) { out[pid] = [raw[pid].w, raw[pid].h]; }
+    return out;
+}());
 
 function _cardIframeSrc() {
     if (_currentPlatform === 'default') {

--- a/app/templates/dashboard_student_new.html
+++ b/app/templates/dashboard_student_new.html
@@ -22,7 +22,7 @@
                 <a href="/notifications" class="s-hdr-btn" title="Notifications" aria-label="Notifications">🔔</a>
                 <span class="badge-dot" id="hdr-notif-badge">0</span>
             </div>
-            <a href="/profile" class="s-hdr-btn" title="Profile">👤</a>
+            <a href="{% if specialization == 'LFA_FOOTBALL_PLAYER' %}/profile/lfa-football-player{% else %}/profile{% endif %}" class="s-hdr-btn" title="Profile">{% if specialization == 'LFA_FOOTBALL_PLAYER' %}🪪{% else %}👤{% endif %}</a>
             <a href="/logout"  class="s-hdr-btn" title="Logout">🚪</a>
         </div>
     </div>
@@ -177,7 +177,7 @@
     {% if user_license %}
     <section class="section-block dash-hero-block">
         <div class="section-header">
-            <h2 class="page-title">🪪 My Player Card</h2>
+            <h2 class="page-title">🎴 My Player Card</h2>
             <a href="/dashboard/lfa-football-player/card-editor" class="section-link">✏️ Edit →</a>
         </div>
         <div class="player-card-embed-wrap" id="spec-card-wrap">
@@ -236,7 +236,7 @@
                 <span class="mod-nav-title">Events</span>
             </a>
             <a href="/dashboard/lfa-football-player/card-editor" class="mod-nav-card">
-                <span class="mod-nav-icon">🪪</span>
+                <span class="mod-nav-icon">🎴</span>
                 <span class="mod-nav-title">My Card</span>
             </a>
             <a href="/adaptive-learning" class="mod-nav-card">

--- a/app/templates/lfa_player_onboarding.html
+++ b/app/templates/lfa_player_onboarding.html
@@ -480,7 +480,7 @@
             </div>
 
             <div class="welcome-cta-row">
-                <a id="btn-go-profile"        href="/profile"                       class="btn btn-secondary">👤 Go to Profile</a>
+                <a id="btn-go-profile"        href="/profile/lfa-football-player"   class="btn btn-secondary">🪪 Go to Profile</a>
                 <a id="btn-go-dashboard"      href="/dashboard/lfa-football-player" class="btn btn-primary">⚽ Continue to Dashboard</a>
                 <a id="btn-view-welcome-card" href="/profile/onboarding-card"        class="btn btn-secondary" target="_blank">🎴 View Welcome Card</a>
                 <a id="btn-download-welcome-card" href="/profile/onboarding-card/export?platform=instagram_square" class="btn btn-secondary">⬇️ Download Welcome Card</a>
@@ -787,7 +787,11 @@
         const statusEl = document.getElementById('step7-photo-status');
         statusEl.textContent = 'Uploading…';
         try {
-            const resp = await fetch('/dashboard/lfa-player-photo', { method: 'POST', body: formData });
+            const resp = await fetch('/dashboard/lfa-player-photo', {
+                method: 'POST',
+                headers: { 'X-CSRF-Token': getCsrfToken() },
+                body: formData,
+            });
             const data = await resp.json();
             if (data.ok) {
                 const preview = document.getElementById('step7-photo-preview');
@@ -796,7 +800,7 @@
                 document.getElementById('step7-photo-placeholder').style.display = 'none';
                 statusEl.textContent = '✅ Photo saved.';
             } else {
-                statusEl.textContent = '❌ Upload failed: ' + (data.error || 'unknown error');
+                statusEl.textContent = '❌ Upload failed: ' + (data.error || data.detail || 'unknown error');
             }
         } catch {
             statusEl.textContent = '❌ Upload failed.';

--- a/app/templates/lfa_player_onboarding.html
+++ b/app/templates/lfa_player_onboarding.html
@@ -304,11 +304,6 @@
             margin-top: 1.5rem;
         }
         .welcome-cta-row .btn { min-width: 160px; }
-        .btn-disabled-placeholder {
-            opacity: 0.45;
-            cursor: not-allowed;
-            pointer-events: none;
-        }
     </style>
 </head>
 <body>
@@ -462,21 +457,33 @@
     <div class="step" id="step-7">
         <div class="welcome-screen">
             <div class="welcome-icon">🎉</div>
-            <div class="welcome-title">Az onboarding sikeresen befejeződött!</div>
             <div class="welcome-subtitle">Onboarding completed successfully</div>
 
             <div class="welcome-card-notice">
-                <div class="welcome-card-notice-label">Welcome Card — Onboarding Self-Assessment</div>
-                <p>Ez a kártya az onboarding során megadott önértékelési adatokból készül.</p>
-                <p>Nem azonos a rendes Player Carddal — nem a számított skill profilt mutatja.</p>
-                <p>Az értékek az általad megadott önértékelésből (self-assessment) származnak, nem az EMA-motor által számított szintekből.</p>
+                <div class="welcome-card-notice-label">Welcome Card — Based on your onboarding self-assessment</div>
+                <p>This card is generated from your self-assessment data collected during onboarding.</p>
+                <p>It is not the same as the regular Player Card.</p>
+                <p>Values come from your own self-assessment, not from EMA-computed levels.</p>
+            </div>
+
+            <!-- ── Step 7: Optional photo upload ──────────────────────────── -->
+            <div class="step7-photo-upload">
+                <div class="step7-photo-preview-wrap">
+                    <img id="step7-photo-preview" src="" alt="Card photo preview" style="display:none; max-width:120px; max-height:120px; border-radius:8px; object-fit:cover; margin-bottom:8px;">
+                    <div id="step7-photo-placeholder" style="color:#94a3b8; font-size:0.9rem; margin-bottom:8px;">📸 No photo uploaded yet</div>
+                </div>
+                <label class="btn btn-secondary" for="step7-photo-input" style="cursor:pointer;">
+                    📷 Upload Card Photo
+                    <input id="step7-photo-input" type="file" accept="image/jpeg,image/png,image/webp" style="display:none;">
+                </label>
+                <div id="step7-photo-status" style="font-size:0.8rem; margin-top:6px; color:#94a3b8;"></div>
             </div>
 
             <div class="welcome-cta-row">
-                <a id="btn-go-profile"       href="/profile"                  class="btn btn-secondary">👤 Go to Profile</a>
-                <a id="btn-go-dashboard"     href="/dashboard/lfa-football-player" class="btn btn-primary">⚽ Continue to Dashboard</a>
-                <a id="btn-view-welcome-card" href="/profile/onboarding-card" class="btn btn-secondary" target="_blank">🎴 View Welcome Card</a>
-                <span class="btn btn-secondary btn-disabled-placeholder" title="Welcome Card download — coming soon">⬇️ Download Welcome Card</span>
+                <a id="btn-go-profile"        href="/profile"                       class="btn btn-secondary">👤 Go to Profile</a>
+                <a id="btn-go-dashboard"      href="/dashboard/lfa-football-player" class="btn btn-primary">⚽ Continue to Dashboard</a>
+                <a id="btn-view-welcome-card" href="/profile/onboarding-card"        class="btn btn-secondary" target="_blank">🎴 View Welcome Card</a>
+                <a id="btn-download-welcome-card" href="/profile/onboarding-card/export?platform=instagram_square" class="btn btn-secondary">⬇️ Download Welcome Card</a>
             </div>
         </div>
     </div>
@@ -769,6 +776,32 @@
             window.location.href = '/specialization/lfa-player/onboarding-cancel';
         }
     }
+
+    // ── Step 7 photo upload ───────────────────────────────────────────────────
+    // Reuses existing /dashboard/lfa-player-photo endpoint — no new backend route.
+    document.getElementById('step7-photo-input').addEventListener('change', async function(e) {
+        const file = e.target.files[0];
+        if (!file) return;
+        const formData = new FormData();
+        formData.append('file', file);
+        const statusEl = document.getElementById('step7-photo-status');
+        statusEl.textContent = 'Uploading…';
+        try {
+            const resp = await fetch('/dashboard/lfa-player-photo', { method: 'POST', body: formData });
+            const data = await resp.json();
+            if (data.ok) {
+                const preview = document.getElementById('step7-photo-preview');
+                preview.src = data.photo_url;
+                preview.style.display = 'block';
+                document.getElementById('step7-photo-placeholder').style.display = 'none';
+                statusEl.textContent = '✅ Photo saved.';
+            } else {
+                statusEl.textContent = '❌ Upload failed: ' + (data.error || 'unknown error');
+            }
+        } catch {
+            statusEl.textContent = '❌ Upload failed.';
+        }
+    });
 
     // ── Init ─────────────────────────────────────────────────────────────────
     updateProgress(1);

--- a/app/templates/lfa_player_onboarding.html
+++ b/app/templates/lfa_player_onboarding.html
@@ -81,52 +81,7 @@
             color: var(--onboarding-text-muted); font-size: 0.9rem; margin-bottom: 1.5rem;
         }
 
-        /* ── Position groups (Step 1 — Phase 2) ── */
-        .position-group  { margin-bottom: 1.2rem; }
-        .group-label {
-            font-size: 0.72rem; font-weight: 700; text-transform: uppercase;
-            letter-spacing: 0.08em; color: var(--onboarding-text-muted);
-            margin-bottom: 0.45rem; padding-left: 0.15rem;
-        }
-        .position-counter {
-            font-size: 0.84rem; color: var(--onboarding-text-muted);
-            margin-bottom: 1.1rem; min-height: 1.5em;
-        }
-        .position-counter strong { color: var(--onboarding-text-primary); }
-
-        .position-grid {
-            display: grid;
-            grid-template-columns: repeat(3, 1fr);
-            gap: 0.55rem;
-            margin-bottom: 0;
-        }
-        @media (min-width: 500px) { .position-grid { grid-template-columns: repeat(5, 1fr); } }
-
-        .position-card {
-            position: relative;
-            border: 2px solid var(--onboarding-option-border);
-            border-radius: 10px;
-            padding: 0.6rem 0.35rem 0.55rem;
-            text-align: center;
-            cursor: pointer;
-            transition: all 0.18s;
-            background: var(--onboarding-option-bg);
-            user-select: none;
-        }
-        .position-card:hover:not(.at-limit) { border-color: var(--onboarding-option-hover-border); background: var(--onboarding-option-hover-bg); }
-        .position-card.primary   { border-color: var(--onboarding-option-selected-border); background: var(--onboarding-option-selected-bg); color: var(--onboarding-option-selected-text); }
-        .position-card.secondary { border-color: var(--onboarding-option-hover-border); background: var(--onboarding-option-hover-bg); }
-        .position-card.at-limit  { opacity: 0.35; cursor: not-allowed; }
-        .pos-short { font-size: 0.65rem; font-weight: 800; letter-spacing: 0.05em; opacity: 0.55; margin-bottom: 0.18rem; }
-        .pos-name  { font-weight: 700; font-size: 0.74rem; line-height: 1.2; }
-        .pos-badge {
-            position: absolute; top: -7px; right: -7px;
-            background: var(--onboarding-step-active); color: var(--onboarding-step-active-text);
-            border-radius: 20px; padding: 0 5px; font-size: 0.6rem; font-weight: 800;
-            line-height: 1.7; white-space: nowrap;
-            box-shadow: 0 1px 3px rgba(0,0,0,0.18);
-        }
-        .pos-badge.sec { background: var(--onboarding-option-hover-border); }
+        /* ── Step 1 position UI — provided by /static/js/pitch-selector.js ── */
 
         /* ── Foot dominance slider (Step 6) ── */
         .foot-slider-wrap {
@@ -333,10 +288,9 @@
     ═══════════════════════════════════════════════════════════ -->
     <div class="step active" id="step-1">
         <div class="step-title">1️⃣ What is your preferred playing position?</div>
-        <div class="step-subtitle">Select the position where you feel most comfortable on the pitch.</div>
+        <div class="step-subtitle">Select primary (★) and up to 3 secondary (+) positions on the pitch.</div>
 
-        <div id="position-counter" class="position-counter">Select your primary position</div>
-        <div id="positions-container"></div>
+        <div id="pitch-selector-mount"></div>
 
         <div class="btn-row">
             <button class="btn btn-danger" onclick="cancelOnboarding()">✖️ Cancel (refund)</button>
@@ -490,6 +444,7 @@
 
 </div><!-- /container -->
 
+<script src="/static/js/pitch-selector.js"></script>
 <script>
     // ── State ────────────────────────────────────────────────────────────────
     let currentStep       = 1;
@@ -522,113 +477,16 @@
         window.scrollTo({ top: 0, behavior: 'smooth' });
     }
 
-    // ── Position system (Step 1 — Phase 2) ──────────────────────────────────
-    const POSITION_GROUPS = [
-        { key: 'forward',    label: 'Forwards', positions: [
-            { value: 'striker',            short: 'ST',  label: 'Striker' },
-            { value: 'centre_forward',     short: 'CF',  label: 'Cen. Forward' },
-            { value: 'left_wing',          short: 'LW',  label: 'Left Wing' },
-            { value: 'right_wing',         short: 'RW',  label: 'Right Wing' },
-            { value: 'second_striker',     short: 'SS',  label: 'Second Striker' },
-        ]},
-        { key: 'midfielder', label: 'Midfielders', positions: [
-            { value: 'attacking_midfield', short: 'AM',  label: 'Att. Mid' },
-            { value: 'centre_midfield',    short: 'CM',  label: 'Cen. Mid' },
-            { value: 'defensive_midfield', short: 'DM',  label: 'Def. Mid' },
-            { value: 'left_midfield',      short: 'LM',  label: 'Left Mid' },
-            { value: 'right_midfield',     short: 'RM',  label: 'Right Mid' },
-        ]},
-        { key: 'defender',   label: 'Defenders', positions: [
-            { value: 'centre_back',        short: 'CB',  label: 'Centre Back' },
-            { value: 'left_back',          short: 'LB',  label: 'Left Back' },
-            { value: 'right_back',         short: 'RB',  label: 'Right Back' },
-            { value: 'left_wing_back',     short: 'LWB', label: 'Left WB' },
-            { value: 'right_wing_back',    short: 'RWB', label: 'Right WB' },
-        ]},
-        { key: 'goalkeeper', label: 'Goalkeepers', positions: [
-            { value: 'goalkeeper',         short: 'GK',  label: 'Goalkeeper' },
-            { value: 'sweeper_keeper',     short: 'SK',  label: 'Sweeper GK' },
-        ]},
-    ];
-    const MAX_SECONDARY = 3;
-    const _ALL_POSITIONS = POSITION_GROUPS.flatMap(g => g.positions);
-
+    // ── Position system (Step 1) — PitchSelector ────────────────────────────
     function getPositions() {
-        if (!primaryPosition) return [];
-        return [primaryPosition, ...secondaryPositions];
+        return pitchSel ? pitchSel.getAll() : [];
     }
 
-    function handlePositionClick(value) {
-        if (value === primaryPosition) {
-            // Clicking primary again → reset all
-            primaryPosition    = null;
-            secondaryPositions = [];
-        } else if (secondaryPositions.includes(value)) {
-            // Clicking a secondary → deselect it
-            secondaryPositions = secondaryPositions.filter(v => v !== value);
-        } else if (!primaryPosition) {
-            // No primary yet → set as primary
-            primaryPosition = value;
-        } else if (secondaryPositions.length < MAX_SECONDARY) {
-            // Have primary, under limit → add as secondary
-            secondaryPositions.push(value);
-        }
-        // else: at limit and not selected → ignore
-        renderPositionCards();
-        updatePositionCounter();
-        document.getElementById('btn-step1-next').disabled = !primaryPosition;
-    }
-
-    function renderPositionCards() {
-        const atLimit   = getPositions().length >= 4;
-        const container = document.getElementById('positions-container');
-        let html = '';
-        POSITION_GROUPS.forEach(group => {
-            html += `<div class="position-group">`;
-            html += `<div class="group-label">${group.label}</div>`;
-            html += `<div class="position-grid">`;
-            group.positions.forEach(pos => {
-                const isPrimary   = pos.value === primaryPosition;
-                const secIdx      = secondaryPositions.indexOf(pos.value);
-                const isSecondary = secIdx !== -1;
-                const isDisabled  = !isPrimary && !isSecondary && atLimit;
-
-                let cls   = 'position-card';
-                if (isPrimary)   cls += ' primary';
-                if (isSecondary) cls += ' secondary';
-                if (isDisabled)  cls += ' at-limit';
-
-                let badge = '';
-                if (isPrimary)        badge = `<span class="pos-badge">★</span>`;
-                else if (isSecondary) badge = `<span class="pos-badge sec">+${secIdx + 1}</span>`;
-
-                html += `<div class="${cls}" data-value="${pos.value}" onclick="handlePositionClick('${pos.value}')">`;
-                html += badge;
-                html += `<div class="pos-short">${pos.short}</div>`;
-                html += `<div class="pos-name">${pos.label}</div>`;
-                html += `</div>`;
-            });
-            html += `</div></div>`;
-        });
-        container.innerHTML = html;
-    }
-
-    function updatePositionCounter() {
-        const el = document.getElementById('position-counter');
-        if (!primaryPosition) {
-            el.textContent = 'Select your primary position';
-            return;
-        }
-        const pLabel = _ALL_POSITIONS.find(p => p.value === primaryPosition)?.label || primaryPosition;
-        let text = `Primary: <strong>${pLabel}</strong>`;
-        if (secondaryPositions.length > 0) {
-            const sLabels = secondaryPositions.map(v => _ALL_POSITIONS.find(p => p.value === v)?.label || v);
-            text += ` &nbsp;|&nbsp; Secondary: <strong>${sLabels.join(', ')}</strong> (${secondaryPositions.length}/${MAX_SECONDARY})`;
-        } else {
-            text += ` &nbsp;|&nbsp; Secondary: <em>none yet — tap up to 3 more</em>`;
-        }
-        el.innerHTML = text;
-    }
+    const pitchSel = new PitchSelector('pitch-selector-mount', function (primary, all) {
+        primaryPosition    = primary;
+        secondaryPositions = all.filter(function (v) { return v !== primary; });
+        document.getElementById('btn-step1-next').disabled = !primary;
+    });
 
     // ── Foot dominance slider ────────────────────────────────────────────────
     function updateFootLabel(value) {
@@ -809,7 +667,6 @@
 
     // ── Init ─────────────────────────────────────────────────────────────────
     updateProgress(1);
-    renderPositionCards();
 </script>
 </body>
 </html>

--- a/app/templates/lfa_player_profile.html
+++ b/app/templates/lfa_player_profile.html
@@ -224,9 +224,72 @@
 
     .back-link:hover { color: var(--hub-text-secondary); }
 
+    /* ── Positions card — view / edit modes ───────────────────────────────── */
+    .pos-view-badges  { display: flex; flex-direction: column; gap: 0.35rem; margin-bottom: 1rem; }
+    .pos-view-section { display: flex; flex-wrap: wrap; align-items: center; gap: 0.4rem; }
+    .pos-section-label {
+        font-size: 0.7rem; font-weight: 700; color: var(--hub-text-muted);
+        text-transform: uppercase; letter-spacing: 0.06em;
+        width: 44px; flex-shrink: 0;
+    }
+    .pos-badge-primary {
+        display: inline-block; padding: 0.35rem 0.85rem; border-radius: 7px;
+        font-size: 0.88rem; font-weight: 800;
+        background: var(--hub-btn-bg); color: var(--hub-btn-text);
+    }
+    .pos-badge-secondary {
+        display: inline-block; padding: 0.3rem 0.7rem; border-radius: 6px;
+        font-size: 0.8rem; font-weight: 600;
+        background: #e9f5ff; color: #2b6cb0; border: 1px solid #bee3f8;
+    }
+    .pos-empty { color: var(--hub-text-muted); font-size: 0.9rem; margin-bottom: 1rem; }
+    .pos-alert {
+        padding: 0.65rem 0.9rem; border-radius: 8px;
+        font-size: 0.85rem; font-weight: 600; margin-bottom: 1rem;
+    }
+    .pos-alert-success { background: #f0fff4; color: #276749; border: 1px solid #9ae6b4; }
+    .pos-alert-error   { background: #fff5f5; color: #c53030; border: 1px solid #feb2b2; }
+    .pos-action-row    { display: flex; gap: 0.6rem; margin-top: 0.75rem; flex-wrap: wrap; }
+
+    /* Profile-scoped: override onboarding yellow tokens in the pitch selector */
+    #ps-profile-mount .ps-info-panel {
+        background: #f8fafc;
+        border-color: var(--hub-divider, #e2e8f0);
+    }
+    #ps-profile-mount .ps-counter {
+        background: #f0f4f8;
+        border-color: var(--hub-divider, #e2e8f0);
+        color: var(--hub-text-primary, #1a202c);
+    }
+    #ps-profile-mount .ps-chip {
+        background: #e9f5ff; border-color: #bee3f8; color: #2b6cb0;
+    }
+    #ps-profile-mount .ps-primary-label { color: var(--hub-text-secondary, #4a5568); }
+    #ps-profile-mount .ps-primary-value { color: var(--hub-text-primary, #1a202c); }
+
+    /* Edit mode reveal animation */
+    @keyframes pos-edit-reveal {
+        from { opacity: 0; transform: translateY(-4px); }
+        to   { opacity: 1; transform: translateY(0); }
+    }
+    .pos-edit-entering { animation: pos-edit-reveal 0.18s ease-out; }
+
     @media (max-width: 700px) {
         .cards-grid { grid-template-columns: 1fr; }
         .page-header { flex-direction: column; align-items: flex-start; }
+    }
+
+    /* Mobile: sticky Save/Cancel so buttons stay visible on tall portrait pitch */
+    @media (max-width: 640px) {
+        .pos-action-row {
+            position: sticky;
+            bottom: 0;
+            background: var(--hub-card-bg, #fff);
+            padding: 0.5rem 0 0.25rem;
+            border-top: 1px solid var(--hub-divider, #e2e8f0);
+            z-index: 5;
+            margin-top: 0.5rem;
+        }
     }
 </style>
 {% endblock %}
@@ -333,6 +396,68 @@
             </div>
         </div>
 
+        <!-- 📍 Positions (editable via pitch selector) -->
+        <div class="card" id="card-positions">
+            <h2>📍 Positions</h2>
+
+            {% if pos_updated %}
+            <div class="pos-alert pos-alert-success">✓ Positions updated successfully.</div>
+            {% endif %}
+
+            <!-- View mode (default) -->
+            <div id="pos-view-mode">
+                {% if primary_pos %}
+                <div class="pos-view-badges">
+                    <div class="pos-view-section">
+                        <span class="pos-section-label">Primary</span>
+                        <span class="pos-badge-primary">
+                            {{ position_labels.get(primary_pos, primary_pos.replace('_', ' ').title()) }}
+                        </span>
+                    </div>
+                    {% if secondary_pos %}
+                    <div class="pos-view-section">
+                        <span class="pos-section-label">Also</span>
+                        {% for sp in secondary_pos %}
+                        <span class="pos-badge-secondary">
+                            {{ position_labels.get(sp, sp.replace('_', ' ').title()) }}
+                        </span>
+                        {% endfor %}
+                    </div>
+                    {% endif %}
+                </div>
+                {% else %}
+                <p class="pos-empty">No positions set yet.</p>
+                {% endif %}
+                <button class="btn btn-secondary btn-sm" onclick="showPosEdit()">✏️ Edit Positions</button>
+            </div>
+
+            <!-- Edit mode (hidden until toggled) -->
+            <div id="pos-edit-mode" style="display:none;">
+                {% if pos_error %}
+                <div class="pos-alert pos-alert-error">
+                    {% if pos_error == "invalid_primary" %}Invalid primary position selected.
+                    {% elif pos_error == "invalid_count" %}Select between 1 and 4 positions total.
+                    {% elif pos_error == "invalid_format" %}Invalid form data — please try again.
+                    {% elif pos_error == "invalid_position" %}One or more positions are not recognised.
+                    {% elif pos_error == "primary_not_first" %}Primary position must be selected first.
+                    {% else %}Something went wrong — please try again.
+                    {% endif %}
+                </div>
+                {% endif %}
+                <form method="post" action="/profile/lfa-football-player/positions" id="pos-form">
+                    <input type="hidden" name="position"     id="ps-input-primary" value="">
+                    <input type="hidden" name="positions_raw" id="ps-input-raw"    value="[]">
+                    <div id="ps-profile-mount"></div>
+                    <div class="pos-action-row">
+                        <button type="submit" class="btn btn-primary btn-sm"
+                                id="pos-save-btn" disabled>💾 Save Changes</button>
+                        <button type="button" class="btn btn-secondary btn-sm"
+                                onclick="hidePosEdit()">✕ Cancel</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+
         <!-- Foot Assessment (read-only) -->
         <div class="card">
             <h2>🦶 Foot Assessment</h2>
@@ -402,4 +527,49 @@
 
     </div>
 </div>
+
+<script src="/static/js/pitch-selector.js"></script>
+<script>
+(function () {
+    'use strict';
+    var _ps = null;
+    var _currentPositions = {{ player_positions | tojson }};
+
+    function _updateInputs(primary, all) {
+        document.getElementById('ps-input-primary').value = primary || '';
+        document.getElementById('ps-input-raw').value     = JSON.stringify(all || []);
+        document.getElementById('pos-save-btn').disabled  = !primary;
+    }
+
+    window.showPosEdit = function () {
+        var editMode = document.getElementById('pos-edit-mode');
+        document.getElementById('pos-view-mode').style.display = 'none';
+        editMode.style.display = '';
+        editMode.classList.add('pos-edit-entering');
+        setTimeout(function () { editMode.classList.remove('pos-edit-entering'); }, 220);
+        if (!_ps) {
+            _ps = new PitchSelector('ps-profile-mount', function (primary, all) {
+                _updateInputs(primary, all);
+            });
+            if (_currentPositions.length > 0) {
+                _ps.setPositions(_currentPositions);
+            }
+        }
+    };
+
+    window.hidePosEdit = function () {
+        document.getElementById('pos-view-mode').style.display = '';
+        document.getElementById('pos-edit-mode').style.display = 'none';
+        if (_ps) {
+            document.getElementById('ps-profile-mount').innerHTML = '';
+            _ps = null;
+        }
+    };
+
+    {% if pos_error %}
+    /* Auto-open edit mode when returning from a validation error */
+    document.addEventListener('DOMContentLoaded', function () { showPosEdit(); });
+    {% endif %}
+}());
+</script>
 {% endblock %}

--- a/app/templates/lfa_player_profile.html
+++ b/app/templates/lfa_player_profile.html
@@ -1,0 +1,405 @@
+{% extends "student_base.html" %}
+
+{% block title %}LFA Player Profile - LFA Education Center{% endblock %}
+
+{% block active_page %}lfa-player{% endblock %}
+
+{% block student_header %}
+{% set _page_icon = '🪪' %}
+{% set _page_name = 'Player Profile' %}
+{% include "includes/spec_subpage_hdr.html" %}
+{% endblock %}
+
+{% block extra_styles %}
+<style>
+    .container {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: 2rem;
+    }
+
+    .page-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 2rem;
+        flex-wrap: wrap;
+        gap: 1rem;
+    }
+
+    .page-title {
+        font-size: 2rem;
+        color: var(--hub-text-primary);
+        margin-bottom: 0.4rem;
+    }
+
+    .page-subtitle {
+        color: var(--hub-text-muted);
+        font-size: 1rem;
+    }
+
+    .page-header-actions {
+        display: flex;
+        gap: 0.6rem;
+        flex-wrap: wrap;
+        align-items: center;
+    }
+
+    .btn {
+        padding: 0.75rem 1.4rem;
+        border: none;
+        border-radius: 8px;
+        font-size: 0.95rem;
+        font-weight: 600;
+        cursor: pointer;
+        text-decoration: none;
+        display: inline-block;
+        transition: transform 0.15s, box-shadow 0.15s;
+    }
+
+    .btn-primary   { background: var(--hub-btn-bg); color: var(--hub-btn-text); }
+    .btn-secondary { background: #e2e8f0; color: #2d3748; }
+    .btn-sm        { padding: 0.45rem 0.9rem; font-size: 0.85rem; }
+
+    .btn:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 3px 10px rgba(0,0,0,0.15);
+    }
+
+    .cards-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+        gap: 1.5rem;
+    }
+
+    .card {
+        background: var(--hub-card-bg);
+        border-radius: 14px;
+        padding: 1.75rem;
+        box-shadow: var(--hub-card-shadow);
+    }
+
+    .card h2 {
+        font-size: 1.25rem;
+        color: var(--hub-text-primary);
+        margin-bottom: 1.2rem;
+        padding-bottom: 0.65rem;
+        border-bottom: 2px solid var(--hub-divider);
+    }
+
+    .info-row {
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-start;
+        padding: 0.75rem 0;
+        border-bottom: 1px solid var(--hub-divider);
+        gap: 1rem;
+    }
+
+    .info-row:last-child { border-bottom: none; }
+
+    .info-label {
+        font-weight: 600;
+        color: var(--hub-text-secondary);
+        font-size: 0.9rem;
+        flex-shrink: 0;
+    }
+
+    .info-value {
+        color: var(--hub-text-primary);
+        text-align: right;
+        font-size: 0.95rem;
+    }
+
+    .badge {
+        display: inline-block;
+        padding: 0.3rem 0.7rem;
+        border-radius: 6px;
+        font-size: 0.82rem;
+        font-weight: 700;
+    }
+
+    .badge-pos     { background: #ebf4ff; color: #2b6cb0; }
+    .badge-sec-pos { background: #f0fff4; color: #276749; font-size: 0.78rem; }
+    .badge-foot    { background: #fefcbf; color: #744210; }
+
+    .foot-bar-wrap {
+        display: flex;
+        flex-direction: column;
+        gap: 0.6rem;
+    }
+
+    .foot-bar-row {
+        display: flex;
+        align-items: center;
+        gap: 0.7rem;
+    }
+
+    .foot-bar-label {
+        font-size: 0.82rem;
+        font-weight: 600;
+        color: var(--hub-text-secondary);
+        width: 60px;
+        flex-shrink: 0;
+    }
+
+    .foot-bar-bg {
+        flex: 1;
+        height: 10px;
+        background: var(--hub-divider);
+        border-radius: 5px;
+        overflow: hidden;
+    }
+
+    .foot-bar-fill {
+        height: 100%;
+        border-radius: 5px;
+        background: var(--hub-btn-bg);
+    }
+
+    .foot-bar-pct {
+        font-size: 0.82rem;
+        font-weight: 700;
+        color: var(--hub-text-primary);
+        width: 38px;
+        text-align: right;
+        flex-shrink: 0;
+    }
+
+    .foot-note {
+        font-size: 0.78rem;
+        color: var(--hub-text-muted);
+        margin-top: 0.5rem;
+    }
+
+    /* Photo card */
+    .photo-thumb-wrap {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+        margin-bottom: 1rem;
+    }
+
+    .photo-thumb {
+        width: 72px;
+        height: 72px;
+        border-radius: 10px;
+        object-fit: cover;
+        border: 1px solid var(--hub-divider);
+    }
+
+    .photo-placeholder {
+        width: 72px;
+        height: 72px;
+        border-radius: 10px;
+        border: 2px dashed #cbd5e0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 1.6rem;
+        color: #a0aec0;
+    }
+
+    .photo-meta {
+        font-size: 0.85rem;
+        color: var(--hub-text-muted);
+    }
+
+    /* Welcome card CTAs */
+    .wc-cta-row {
+        display: flex;
+        gap: 0.6rem;
+        flex-wrap: wrap;
+        margin-top: 1rem;
+    }
+
+    /* Back link */
+    .back-link {
+        display: inline-block;
+        font-size: 0.85rem;
+        color: var(--hub-text-muted);
+        text-decoration: none;
+        margin-bottom: 1.5rem;
+    }
+
+    .back-link:hover { color: var(--hub-text-secondary); }
+
+    @media (max-width: 700px) {
+        .cards-grid { grid-template-columns: 1fr; }
+        .page-header { flex-direction: column; align-items: flex-start; }
+    }
+</style>
+{% endblock %}
+
+{% block student_content %}
+<div class="container">
+
+    <a class="back-link" href="/profile">← Back to Profile</a>
+
+    <div class="page-header">
+        <div>
+            <h2 class="page-title">🪪 LFA Player Profile</h2>
+            <p class="page-subtitle">{{ user.name }} — LFA Football Player specialization</p>
+        </div>
+        <div class="page-header-actions">
+            <a href="/profile/lfa-football-player/edit" class="btn btn-primary">✏️ Edit Profile</a>
+            <a href="/profile/onboarding-card" class="btn btn-secondary">🎴 Welcome Card</a>
+            <a href="/dashboard/lfa-football-player" class="btn btn-secondary">⚽ Dashboard</a>
+        </div>
+    </div>
+
+    <div class="cards-grid">
+
+        <!-- Player Profile -->
+        <div class="card">
+            <h2>⚽ Player Profile</h2>
+
+            {% if primary_pos %}
+            <div class="info-row">
+                <span class="info-label">Primary Position</span>
+                <span class="info-value">
+                    <span class="badge badge-pos">
+                        {{ position_labels.get(primary_pos, primary_pos.replace('_', ' ').title()) }}
+                    </span>
+                </span>
+            </div>
+            {% endif %}
+
+            {% if secondary_pos %}
+            <div class="info-row">
+                <span class="info-label">Secondary Positions</span>
+                <span class="info-value" style="display:flex; flex-wrap:wrap; gap:0.3rem; justify-content:flex-end;">
+                    {% for pos in secondary_pos %}
+                    <span class="badge badge-sec-pos">
+                        {{ position_labels.get(pos, pos.replace('_', ' ').title()) }}
+                    </span>
+                    {% endfor %}
+                </span>
+            </div>
+            {% endif %}
+
+            {% if ms.preferred_foot %}
+            <div class="info-row">
+                <span class="info-label">Preferred Foot</span>
+                <span class="info-value">
+                    <span class="badge badge-foot">
+                        {{ ms.preferred_foot | capitalize }}
+                    </span>
+                </span>
+            </div>
+            {% endif %}
+
+            {% if ms.height_cm %}
+            <div class="info-row">
+                <span class="info-label">Height</span>
+                <span class="info-value">{{ ms.height_cm }} cm</span>
+            </div>
+            {% endif %}
+
+            {% if ms.weight_kg %}
+            <div class="info-row">
+                <span class="info-label">Weight</span>
+                <span class="info-value">{{ ms.weight_kg }} kg</span>
+            </div>
+            {% endif %}
+
+            {% if goal_label %}
+            <div class="info-row">
+                <span class="info-label">Goal</span>
+                <span class="info-value">{{ goal_label }}</span>
+            </div>
+            {% endif %}
+
+            <div class="info-row">
+                <span class="info-label">Self-Assessment Avg</span>
+                <span class="info-value">
+                    {% if average_skill_level is not none %}
+                        {{ average_skill_level | round(1) }} / 100
+                    {% else %}
+                        <span style="color: var(--hub-text-muted);">N/A</span>
+                    {% endif %}
+                </span>
+            </div>
+
+            <div class="info-row">
+                <span class="info-label">Member since</span>
+                <span class="info-value">
+                    {% if onboarding_completed_at %}
+                        {{ onboarding_completed_at[:10] }}
+                    {% else %}
+                        <span style="color: var(--hub-text-muted);">—</span>
+                    {% endif %}
+                </span>
+            </div>
+        </div>
+
+        <!-- Foot Assessment (read-only) -->
+        <div class="card">
+            <h2>🦶 Foot Assessment</h2>
+            {% set rf = license.right_foot_score %}
+            {% set lf = license.left_foot_score %}
+            {% if rf is not none or lf is not none %}
+            <div class="foot-bar-wrap">
+                <div class="foot-bar-row">
+                    <span class="foot-bar-label">Right</span>
+                    <div class="foot-bar-bg">
+                        <div class="foot-bar-fill" style="width:{{ [[(rf or 0), 0] | max, 100] | min }}%;"></div>
+                    </div>
+                    <span class="foot-bar-pct">{{ (rf or 0) | round(1) }}</span>
+                </div>
+                <div class="foot-bar-row">
+                    <span class="foot-bar-label">Left</span>
+                    <div class="foot-bar-bg">
+                        <div class="foot-bar-fill" style="width:{{ [[(lf or 0), 0] | max, 100] | min }}%;"></div>
+                    </div>
+                    <span class="foot-bar-pct">{{ (lf or 0) | round(1) }}</span>
+                </div>
+            </div>
+            <p class="foot-note">Read-only assessment data — set during onboarding. Not editable via profile. Separate from EMA skill ratings.</p>
+            {% else %}
+            <p style="color: var(--hub-text-muted); font-size:0.9rem;">No foot assessment data recorded during onboarding.</p>
+            {% endif %}
+        </div>
+
+        <!-- Card Photo -->
+        <div class="card">
+            <h2>📸 Card Photo</h2>
+            <div class="photo-thumb-wrap">
+                {% if license.player_card_photo_url %}
+                <img class="photo-thumb"
+                     src="{{ license.player_card_photo_url }}"
+                     alt="Card photo">
+                <div class="photo-meta">
+                    <strong>Photo uploaded</strong><br>
+                    Used on Welcome Card and Player Card.
+                </div>
+                {% else %}
+                <div class="photo-placeholder">📸</div>
+                <div class="photo-meta">
+                    No photo yet.<br>
+                    Upload from the Welcome Card page.
+                </div>
+                {% endif %}
+            </div>
+            <a href="/profile/onboarding-card" class="btn btn-secondary btn-sm">🎴 Manage in Welcome Card</a>
+        </div>
+
+        <!-- Welcome Card -->
+        <div class="card">
+            <h2>🎴 Welcome Card</h2>
+            <p style="font-size:0.85rem; color: var(--hub-text-secondary); margin-bottom:0.5rem;">
+                Your onboarding self-assessment card — a personal snapshot from when you joined.
+            </p>
+            <p style="font-size:0.82rem; color: var(--hub-text-muted); margin-bottom:1rem;">
+                Not the same as the regular Player Card. Based on self-assessment, not EMA scores.
+            </p>
+            <div class="wc-cta-row">
+                <a href="/profile/onboarding-card" class="btn btn-primary btn-sm">View Welcome Card</a>
+                <a href="/profile/onboarding-card/export?platform=instagram_square"
+                   class="btn btn-secondary btn-sm">⬇️ Download</a>
+            </div>
+        </div>
+
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/lfa_player_profile_edit.html
+++ b/app/templates/lfa_player_profile_edit.html
@@ -1,0 +1,370 @@
+{% extends "student_base.html" %}
+
+{% block title %}Edit LFA Player Profile - LFA Education Center{% endblock %}
+
+{% block active_page %}lfa-player{% endblock %}
+
+{% block student_header %}
+{% set _page_icon = '✏️' %}
+{% set _page_name = 'Edit Profile' %}
+{% include "includes/spec_subpage_hdr.html" %}
+{% endblock %}
+
+{% block extra_styles %}
+<style>
+    .container {
+        max-width: 820px;
+        margin: 0 auto;
+        padding: 2rem;
+    }
+
+    .page-header {
+        margin-bottom: 2rem;
+    }
+
+    .page-title {
+        font-size: 1.9rem;
+        color: var(--hub-text-primary);
+        margin-bottom: 0.4rem;
+    }
+
+    .page-subtitle {
+        color: var(--hub-text-muted);
+        font-size: 0.95rem;
+    }
+
+    .back-link {
+        display: inline-block;
+        font-size: 0.85rem;
+        color: var(--hub-text-muted);
+        text-decoration: none;
+        margin-bottom: 1.5rem;
+    }
+
+    .back-link:hover { color: var(--hub-text-secondary); }
+
+    .edit-card {
+        background: var(--hub-card-bg);
+        border-radius: 14px;
+        padding: 1.75rem;
+        box-shadow: var(--hub-card-shadow);
+        margin-bottom: 1.5rem;
+    }
+
+    .edit-card h2 {
+        font-size: 1.2rem;
+        color: var(--hub-text-primary);
+        margin-bottom: 1.3rem;
+        padding-bottom: 0.65rem;
+        border-bottom: 2px solid var(--hub-divider);
+    }
+
+    .form-group {
+        margin-bottom: 1.2rem;
+    }
+
+    .form-group label {
+        display: block;
+        font-weight: 600;
+        color: var(--hub-text-secondary);
+        font-size: 0.9rem;
+        margin-bottom: 0.4rem;
+    }
+
+    .form-group small {
+        display: block;
+        color: var(--hub-text-muted);
+        font-size: 0.78rem;
+        margin-top: 0.25rem;
+    }
+
+    .form-control {
+        width: 100%;
+        padding: 0.65rem 0.9rem;
+        border: 1px solid var(--hub-divider);
+        border-radius: 8px;
+        font-size: 0.95rem;
+        color: var(--hub-text-primary);
+        background: var(--hub-card-bg);
+        transition: border-color 0.15s;
+        box-sizing: border-box;
+    }
+
+    .form-control:focus {
+        outline: none;
+        border-color: var(--brand-yellow);
+        background: var(--hub-card-bg);
+    }
+
+    /* Radio / checkbox rows */
+    .radio-group, .checkbox-group {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+    }
+
+    .radio-option, .check-option {
+        display: flex;
+        align-items: center;
+        gap: 0.35rem;
+        padding: 0.4rem 0.75rem;
+        border: 1px solid var(--hub-divider);
+        border-radius: 7px;
+        cursor: pointer;
+        font-size: 0.88rem;
+        color: var(--hub-text-secondary);
+        transition: border-color 0.12s, background 0.12s;
+    }
+
+    .radio-option:has(input:checked),
+    .check-option:has(input:checked) {
+        border-color: var(--brand-yellow);
+        background: var(--hub-info-bg);
+        color: var(--hub-text-primary);
+        font-weight: 600;
+    }
+
+    .radio-option input, .check-option input {
+        accent-color: var(--brand-yellow);
+    }
+
+    /* Position groups */
+    .pos-group-label {
+        font-size: 0.78rem;
+        font-weight: 700;
+        color: var(--hub-text-muted);
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        margin: 0.7rem 0 0.35rem;
+    }
+
+    .pos-group-label:first-child { margin-top: 0; }
+
+    /* Foot score inputs */
+    .foot-inputs {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 1rem;
+    }
+
+    /* Error banner */
+    .error-banner {
+        background: #fff5f5;
+        border: 1px solid #fc8181;
+        border-radius: 10px;
+        padding: 1rem 1.25rem;
+        color: #c53030;
+        font-size: 0.9rem;
+        font-weight: 600;
+        margin-bottom: 1.5rem;
+    }
+
+    /* Action buttons */
+    .form-actions {
+        display: flex;
+        gap: 0.8rem;
+        align-items: center;
+        flex-wrap: wrap;
+        padding: 1.5rem 0 0.5rem;
+    }
+
+    .btn-save {
+        padding: 0.8rem 2rem;
+        background: var(--hub-btn-bg);
+        color: var(--hub-btn-text);
+        border: none;
+        border-radius: 8px;
+        font-size: 1rem;
+        font-weight: 700;
+        cursor: pointer;
+        transition: transform 0.15s, box-shadow 0.15s;
+    }
+
+    .btn-save:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 4px 12px var(--hub-btn-shadow);
+    }
+
+    .btn-cancel {
+        padding: 0.8rem 1.5rem;
+        background: #e2e8f0;
+        color: #2d3748;
+        border: none;
+        border-radius: 8px;
+        font-size: 0.95rem;
+        font-weight: 600;
+        text-decoration: none;
+        display: inline-block;
+        cursor: pointer;
+        transition: background 0.15s;
+    }
+
+    .btn-cancel:hover { background: #cbd5e0; }
+
+    .scope-note {
+        font-size: 0.82rem;
+        color: var(--hub-text-muted);
+        background: var(--hub-info-bg);
+        border: 1px solid var(--hub-divider);
+        border-radius: 8px;
+        padding: 0.75rem 1rem;
+        margin-bottom: 1.5rem;
+    }
+
+    @media (max-width: 600px) {
+        .foot-inputs { grid-template-columns: 1fr; }
+    }
+</style>
+{% endblock %}
+
+{% block student_content %}
+<div class="container">
+
+    <a class="back-link" href="/profile/lfa-football-player">← Back to LFA Player Profile</a>
+
+    <div class="page-header">
+        <h2 class="page-title">✏️ Edit LFA Player Profile</h2>
+        <p class="page-subtitle">Update your LFA Football Player specialization data.</p>
+    </div>
+
+    <div class="scope-note">
+        ℹ️ This form edits only your LFA Football Player specialization profile.
+        Global account details (name, email, date of birth) are edited in
+        <a href="/profile/edit" style="color: var(--hub-link);">Account Settings</a>.
+        Skill scores (EMA ratings) are never manually editable.
+    </div>
+
+    {% if error %}
+    <div class="error-banner">⚠️ {{ error }}</div>
+    {% endif %}
+
+    <form method="POST" action="/profile/lfa-football-player/edit">
+
+        <!-- Primary Position -->
+        <div class="edit-card">
+            <h2>⚽ Position</h2>
+
+            <div class="form-group">
+                <label>Primary Position *</label>
+                {% for group in position_groups %}
+                <div class="pos-group-label">{{ group.label }}</div>
+                <div class="radio-group">
+                    {% for pos in group.positions %}
+                    <label class="radio-option">
+                        <input type="radio" name="position" value="{{ pos }}"
+                               {% if pos == primary_pos %}checked{% endif %} required>
+                        {{ position_labels.get(pos, pos) }}
+                    </label>
+                    {% endfor %}
+                </div>
+                {% endfor %}
+            </div>
+
+            <div class="form-group">
+                <label>Secondary Positions <small style="display:inline; font-weight:400;">(optional, up to 3)</small>
+                    <span id="sec-pos-counter" style="font-size:0.78rem; color: var(--hub-text-muted); font-weight:400; margin-left:0.5rem;"></span>
+                </label>
+                {% for group in position_groups %}
+                <div class="pos-group-label">{{ group.label }}</div>
+                <div class="checkbox-group">
+                    {% for pos in group.positions %}
+                    <label class="check-option">
+                        <input type="checkbox" name="secondary_positions" value="{{ pos }}"
+                               class="sec-pos-check"
+                               {% if pos in secondary_pos %}checked{% endif %}>
+                        {{ position_labels.get(pos, pos) }}
+                    </label>
+                    {% endfor %}
+                </div>
+                {% endfor %}
+                <small>The primary position is automatically excluded from secondary positions on save. Max 3.</small>
+            </div>
+        </div>
+
+        <!-- Physical Profile -->
+        <div class="edit-card">
+            <h2>📐 Physical Profile</h2>
+
+            <div class="form-group">
+                <label for="height_cm">Height (cm)</label>
+                <input type="number" id="height_cm" name="height_cm_raw"
+                       class="form-control"
+                       min="100" max="250" step="1"
+                       value="{{ ms.height_cm or '' }}"
+                       placeholder="e.g. 178">
+                <small>Leave empty to keep current value. Range: 100–250 cm.</small>
+            </div>
+
+            <div class="form-group">
+                <label for="weight_kg">Weight (kg)</label>
+                <input type="number" id="weight_kg" name="weight_kg_raw"
+                       class="form-control"
+                       min="30" max="200" step="1"
+                       value="{{ ms.weight_kg or '' }}"
+                       placeholder="e.g. 74">
+                <small>Leave empty to keep current value. Range: 30–200 kg.</small>
+            </div>
+
+            <div class="form-group">
+                <label>Preferred Foot *</label>
+                <div class="radio-group">
+                    {% for foot in valid_preferred_foot %}
+                    <label class="radio-option">
+                        <input type="radio" name="preferred_foot" value="{{ foot }}"
+                               {% if foot == ms.preferred_foot %}checked{% endif %} required>
+                        {{ foot | capitalize }}
+                    </label>
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
+
+        <!-- Goal -->
+        <div class="edit-card">
+            <h2>🎯 Primary Goal</h2>
+            <div class="form-group">
+                <label for="goals">What is your primary goal? *</label>
+                <select id="goals" name="goals" class="form-control" required>
+                    <option value="">Select your goal…</option>
+                    {% for key, label in goal_labels.items() %}
+                    <option value="{{ key }}" {% if key == ms.goals %}selected{% endif %}>
+                        {{ label }}
+                    </option>
+                    {% endfor %}
+                </select>
+            </div>
+        </div>
+
+        <div class="form-actions">
+            <button type="submit" class="btn-save">💾 Save Changes</button>
+            <a href="/profile/lfa-football-player" class="btn-cancel">Cancel</a>
+        </div>
+
+    </form>
+</div>
+
+<script>
+(function () {
+    const MAX_SEC = 3;
+    const counter = document.getElementById('sec-pos-counter');
+    const checks  = document.querySelectorAll('.sec-pos-check');
+
+    function update() {
+        const checked = Array.from(checks).filter(c => c.checked).length;
+        if (counter) counter.textContent = checked + '/' + MAX_SEC + ' selected';
+        checks.forEach(c => {
+            if (!c.checked && checked >= MAX_SEC) {
+                c.disabled = true;
+                c.closest('label').style.opacity = '0.45';
+            } else {
+                c.disabled = false;
+                c.closest('label').style.opacity = '';
+            }
+        });
+    }
+
+    checks.forEach(c => c.addEventListener('change', update));
+    update();
+})();
+</script>
+{% endblock %}

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -370,6 +370,21 @@
             {% endif %}
         </div>
 
+        <!-- Welcome Card (LFA Football Player, onboarding completed only) -->
+        {% if active_license and active_license.specialization_type == 'LFA_FOOTBALL_PLAYER' and active_license.onboarding_completed %}
+        <div class="card">
+            <h2>🎴 Welcome Card</h2>
+            <p style="font-size:0.85rem; color:#64748b; margin-bottom:0.85rem;">
+                Based on your onboarding self-assessment — not the same as the regular Player Card.
+            </p>
+            <div style="display:flex; gap:0.5rem; flex-wrap:wrap;">
+                <a href="/profile/onboarding-card" class="btn btn-primary">View Welcome Card</a>
+                <a href="/profile/onboarding-card/export?platform=instagram_square"
+                   class="btn btn-secondary">⬇️ Download</a>
+            </div>
+        </div>
+        {% endif %}
+
         <!-- Emergency Contact (if provided) -->
         {% if user.emergency_contact or user.emergency_phone %}
         <div class="card">

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -47,6 +47,15 @@
         color: white;
     }
 
+    .btn-secondary {
+        background: #e2e8f0;
+        color: #2d3748;
+    }
+
+    .btn-secondary:hover {
+        background: #cbd5e0;
+    }
+
     .btn:hover {
         transform: translateY(-2px);
         box-shadow: 0 4px 12px rgba(0,0,0,0.2);
@@ -370,8 +379,8 @@
             {% endif %}
         </div>
 
-        <!-- Welcome Card (LFA Football Player, onboarding completed only) -->
-        {% if active_license and active_license.specialization_type == 'LFA_FOOTBALL_PLAYER' and active_license.onboarding_completed %}
+        <!-- Welcome Card (LFA Football Player, onboarding completed) -->
+        {% if lfa_license %}
         <div class="card">
             <h2>🎴 Welcome Card</h2>
             <p style="font-size:0.85rem; color:#64748b; margin-bottom:0.85rem;">

--- a/app/templates/public/export/landscape/fifa.html
+++ b/app/templates/public/export/landscape/fifa.html
@@ -526,7 +526,7 @@ html, body {
             </div>
             <div class="ex-profile-row">
                 <span class="ex-profile-label">License</span>
-                <span class="ex-profile-value">Lv. {{ license_current_level }}{% if license_max_level is defined and license_max_level > license_current_level %} / {{ license_max_level }}{% endif %}</span>
+                <span class="ex-profile-value">Lv. {{ license_current_level or "—" }}{% if license_current_level and license_max_level is defined and license_max_level > license_current_level %} / {{ license_max_level }}{% endif %}</span>
             </div>
             <div class="ex-profile-row">
                 <span class="ex-profile-label">XP</span>

--- a/app/templates/public/export/square/fifa.html
+++ b/app/templates/public/export/square/fifa.html
@@ -530,7 +530,7 @@ html, body {
 
 /* Sponsor / logo in hero layer (v8) — 4th flex child of .ex-profile-col.
  * Appears only when sponsor_logo_url or app_logo_url is provided.
- * Gated by {% if %} — no layout break when absent. */
+ * Jinja2-gated — no layout break when absent. */
 .ex-hero-sponsor {
     display: flex;
     align-items: center;

--- a/app/templates/public/export/square/fifa.html
+++ b/app/templates/public/export/square/fifa.html
@@ -10,48 +10,42 @@
  * Purpose : static social export ONLY — no editor UI, no responsive CSS
  * Classes : ex- prefix throughout, no inheritance from editor templates
  *
- * Layout (v8 — correct pitch geometry (105m×68m) + sponsor in hero):
- *   .ex-hero  (flex: 0 0 35%) — photo-col 32% | profile-col flex:1
- *   .ex-skills (flex: 1 = 65%) — Col1(Outfield flex:1) | ex-col-right(flex:2)
+ * Layout (v10 — Position Map at top, 3 flat skill columns):
+ *   .ex-hero   (flex: 0 0 35%) — photo-col 32% | profile-col flex:1
+ *   .ex-skills (flex: 1 = 65%, gap:6px):
+ *     .ex-pos-panel-landscape (flex-shrink:0, h=110px, full-width)  ← TOP
+ *     .ex-skill-cats (flex:1, flex-row, gap:6px):
+ *       Col 1: Outfield (19 skills, flex:1)
+ *       Col 2: Mental   (14 skills, flex:1)
+ *       Col 3: Set Pieces (3) + Physical (8) stacked (flex:1)
  *
- * Hero photo: portrait_photo_url → photo_url (no circle, no border, cover)
+ * Height budget (v10):
+ *   Skills inner: 702−28 = 674px
+ *   Title 12px + gap 6px + panel 110px + gap 6px = 134px consumed
+ *   Skill-cats: 674−12−6−110−6 = 540px available
+ *   Outfield worst-case: 16(pad)+26(hdr)+492(19×24+18×2) = 534px → +6px buffer ✓
+ *   FIX_ROW_H = 24px: .ex-row { flex:none; min-height:24px } — all 44 skills visible
  *
- * Skill grid — nested 3-column model (v7):
- *   Col 1: Outfield (19 skills, flex:1, ~346px wide)
- *   .ex-col-right (flex:2, ~693px wide):
- *     .ex-col-right-skills (flex-row):
- *       Mental (14 skills) | Set Pieces (3) + Physical (8) — side by side
- *     .ex-pos-panel-landscape (flex:1, ~165px tall, full 693px width)
- *   Available height per skill-col: 576px
- *   All 44 skills visible without overflow clipping.
- *   FIX_ROW_H = 24px: .ex-row { flex: none; min-height: 24px }
+ * Position Map panel (v10):
+ *   .ex-pos-panel-landscape: full-width, fixed 110px, flex-row.
+ *   .ex-pos-info (180px): title · Primary pos label+name (gold) · Secondary chips.
+ *   svg.ex-pos-svg-landscape (flex:1, bg:#1a5c2a): viewBox "0 0 105 68",
+ *     preserveAspectRatio="xMidYMid meet" — pitch aránytartó, letterbox seamless.
+ *   No .ex-col-right, no .ex-col-right-skills wrappers.
+ *   Gated: {% if position_nodes %} — graceful when position not set.
  *
- * Landscape position panel (v9):
- *   Placed as 2nd flex child of .ex-col-right (below .ex-col-right-skills).
- *   Class: .ex-pos-panel-landscape (NOT .ex-cat — immune to cat animation).
- *   flex-row: .ex-pos-info (180px) | svg.ex-pos-svg-landscape (flex:1).
- *   Info column: panel title · Primary Position label+name (gold) · Secondary chips.
- *   No legend — node visual encoding (gold/white/faint) is self-explanatory.
- *   SVG: viewBox "0 0 105 68" (real 105m×68m pitch geometry).
- *   preserveAspectRatio="xMidYMid meet" — undistorted render.
- *   Coordinate transform: cx = node.x × 105, cy = node.y × 68 (GK left, ST right).
- *   Gated: "if position_nodes" — graceful empty state when position not set.
- *   Animation: self-contained fade-in (animated_mode only), no skill stagger impact.
+ * Photo column (v9, unchanged):
+ *   Clean portrait — no position badges. Position info in panel only.
  *
- * Sponsor / logo (v8, unchanged in v9):
- *   In hero layer: .ex-hero-sponsor in .ex-profile-col (4th flex child).
- *   Gated: "if sponsor_logo_url or app_logo_url" — no layout break when absent.
- *
- * Photo column (v9):
- *   Clean portrait block — no position badges, no secondary chips.
- *   All position info lives exclusively in the Position Map panel.
+ * Sponsor / logo (v8, unchanged):
+ *   Hero layer: .ex-hero-sponsor in .ex-profile-col. Jinja2-gated.
  *
  * Typography scale (% of C_H=1080):
  *   OVR 96px (8.89%), Name 40px (3.70%), Stat 28px (2.59%), Meta 20px (1.85%)
  *
  * Column assignment (index → category):
  *   [0] Outfield · [1] Set Pieces · [2] Mental · [3] Physical
- *   Rendered order: Col1=[0], Right=[2]+[1]+[3]+landscape-panel; sponsor in hero
+ *   Rendered order: panel (full-width) | Col1=[0] | Col2=[2] | Col3=[1]+[3]
  */
 
 :root {
@@ -347,6 +341,7 @@ html, body {
     background: var(--ex-body-bg);
     display: flex;
     flex-direction: column;
+    gap: 6px;
     overflow: hidden;
     padding: 14px;
     min-height: 0;
@@ -358,10 +353,11 @@ html, body {
     text-transform: uppercase;
     letter-spacing: 0.14em;
     color: rgba(255,255,255,0.30);
-    margin-bottom: 8px;
+    margin-bottom: 0;
 }
 
-/* v7: Col 1 (Outfield flex:1) + .ex-col-right (flex:2, nested Mental|SetPieces+Physical + landscape panel). */
+/* v10: 3 flat columns — Outfield | Mental | Set Pieces+Physical.
+ * No .ex-col-right nesting. All columns are direct siblings. */
 .ex-skill-cats {
     flex: 1;
     display: flex;
@@ -468,38 +464,21 @@ html, body {
 }
 
 /* ── POSITION LANDSCAPE PANEL ───────────────────────────────────────────────────────────────────────────
-   2nd flex child of .ex-col-right (below .ex-col-right-skills).
-   NOT .ex-cat → existing cat fade-slide animation never fires here.
-   v9: flex-row layout — left info column + right pitch SVG.
-   Info column: panel title · primary pos name (gold) · secondary chips.
-   NO legend — node visual encoding (gold/white/faint) is self-explanatory.
-   SVG viewBox "0 0 105 68", preserveAspectRatio="xMidYMid meet" (unchanged).
+   v10: full-width, fixed 110px, direct child of .ex-skills (BEFORE .ex-skill-cats).
+   NOT .ex-cat → cat fade-slide animation never fires here.
+   flex-row: .ex-pos-info (180px) | svg.ex-pos-svg-landscape (flex:1, bg:#1a5c2a).
+   Info: panel title · Primary Position name (gold) · Secondary chips.
+   NO legend. SVG: viewBox "0 0 105 68", xMidYMid meet, seamless green letterbox.
    ─────────────────────────────────────────────────────────────────────────────────────── */
 
-/* Nested Col 2+3 container — takes 2/3 of skill-cats width */
-.ex-col-right {
-    flex: 2 2 0%;
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-    min-height: 0;
-    overflow: visible;
-}
-/* Top horizontal skill row inside ex-col-right */
-.ex-col-right-skills {
-    display: flex;
-    flex-direction: row;
-    gap: 6px;
-    flex-shrink: 0;
-}
-/* Landscape panel: flex-row — info column left, SVG right */
+/* Landscape panel: full-width strip above skill columns */
 .ex-pos-panel-landscape {
-    flex: 1;
+    flex-shrink: 0;
+    height: 110px;
     background: var(--ex-cat-bg);
     border: 1px solid rgba(255,255,255,0.10);
     border-radius: 12px;
     overflow: hidden;
-    min-height: 60px;
     display: flex;
     flex-direction: row;
 }
@@ -550,12 +529,13 @@ html, body {
     gap: 3px;
     margin-top: 2px;
 }
-/* SVG takes remaining width of landscape panel */
+/* SVG takes remaining width — seamless green background absorbs letterbox areas */
 .ex-pos-svg-landscape {
     flex: 1;
     min-width: 0;
     display: block;
     align-self: stretch;
+    background: #1a5c2a;
 }
 
 /* Sponsor / logo in hero layer (v8) — 4th flex child of .ex-profile-col.
@@ -798,6 +778,94 @@ html, body {
     {% if skill_categories %}
     <div class="ex-skills">
         <div class="ex-skills-title">Football Skills — {{ overall | round(0) | int }} OVR</div>
+        <!-- Position Map: full-width strip above skill columns (v10) -->
+        {% if position_nodes %}
+        <div class="ex-pos-panel-landscape">
+
+            <!-- Info column: title · primary pos · secondary chips (no legend) -->
+            <div class="ex-pos-info">
+                <div class="ex-pos-panel-title">Position Map</div>
+                <div class="ex-pos-primary-label">Primary Position</div>
+                <div class="ex-pos-primary-name">
+                    {%- if primary_pos_label is defined and primary_pos_label -%}
+                        {{ primary_pos_label }}
+                    {%- else -%}
+                        {{ player.position | replace("_", " ") | title }}
+                    {%- endif -%}
+                </div>
+                {% if secondary_pos_labels is defined and secondary_pos_labels %}
+                <div class="ex-pos-secondary-label">Secondary Positions</div>
+                <div class="ex-pos-secondary-chips">
+                    {% for sp in secondary_pos_labels %}
+                    <span class="ex-sec-pos-chip">{{ sp }}</span>
+                    {% endfor %}
+                </div>
+                {% endif %}
+            </div>
+
+            <svg class="ex-pos-svg-landscape" viewBox="0 0 105 68"
+                 xmlns="http://www.w3.org/2000/svg" aria-label="Position map"
+                 preserveAspectRatio="xMidYMid meet">
+                <!-- Pitch background (105m × 68m real geometry) -->
+                <rect width="105" height="68" fill="#1a5c2a"/>
+                <!-- Field border -->
+                <rect x="0.5" y="0.5" width="104" height="67"
+                      fill="none" stroke="rgba(255,255,255,0.30)" stroke-width="0.5"/>
+                <!-- Center line (vertical at x=52.5) -->
+                <line x1="52.5" y1="0" x2="52.5" y2="68"
+                      stroke="rgba(255,255,255,0.22)" stroke-width="0.4"/>
+                <!-- Center circle (r=9.15m) -->
+                <circle cx="52.5" cy="34" r="9.15"
+                        fill="none" stroke="rgba(255,255,255,0.22)" stroke-width="0.4"/>
+                <!-- Center spot -->
+                <circle cx="52.5" cy="34" r="0.6" fill="rgba(255,255,255,0.40)"/>
+                <!-- GK penalty area (16.5m deep × 40.32m wide) -->
+                <rect x="0" y="13.84" width="16.5" height="40.32"
+                      fill="none" stroke="rgba(255,255,255,0.20)" stroke-width="0.4"/>
+                <!-- ST penalty area -->
+                <rect x="88.5" y="13.84" width="16.5" height="40.32"
+                      fill="none" stroke="rgba(255,255,255,0.20)" stroke-width="0.4"/>
+                <!-- GK 6-yard box (5.5m deep × 18.32m wide) -->
+                <rect x="0" y="24.84" width="5.5" height="18.32"
+                      fill="none" stroke="rgba(255,255,255,0.14)" stroke-width="0.3"/>
+                <!-- ST 6-yard box -->
+                <rect x="99.5" y="24.84" width="5.5" height="18.32"
+                      fill="none" stroke="rgba(255,255,255,0.14)" stroke-width="0.3"/>
+                <!-- Penalty spots (11m from goal line) -->
+                <circle cx="11" cy="34" r="0.5" fill="rgba(255,255,255,0.40)"/>
+                <circle cx="94" cy="34" r="0.5" fill="rgba(255,255,255,0.40)"/>
+
+                <!-- Pass 1: inactive nodes (very faint) -->
+                {% for node in position_nodes %}
+                {% if not node.is_selected and not node.is_primary %}
+                <circle cx="{{ (node.x * 105) | round(1) }}" cy="{{ (node.y * 68) | round(1) }}"
+                        r="0.8" fill="rgba(255,255,255,0.12)"/>
+                {% endif %}
+                {% endfor %}
+
+                <!-- Pass 2: secondary selected positions -->
+                {% for node in position_nodes %}
+                {% if node.is_selected and not node.is_primary %}
+                <circle cx="{{ (node.x * 105) | round(1) }}" cy="{{ (node.y * 68) | round(1) }}"
+                        r="1.4" fill="rgba(255,255,255,0.68)"/>
+                <circle cx="{{ (node.x * 105) | round(1) }}" cy="{{ (node.y * 68) | round(1) }}"
+                        r="2.0" fill="none" stroke="rgba(255,255,255,0.35)" stroke-width="0.4"/>
+                {% endif %}
+                {% endfor %}
+
+                <!-- Pass 3: primary position — gold, topmost -->
+                {% for node in position_nodes %}
+                {% if node.is_primary %}
+                <circle cx="{{ (node.x * 105) | round(1) }}" cy="{{ (node.y * 68) | round(1) }}"
+                        r="1.8" fill="#ECC94B" opacity="0.95"/>
+                <circle cx="{{ (node.x * 105) | round(1) }}" cy="{{ (node.y * 68) | round(1) }}"
+                        r="2.6" fill="none" stroke="#ECC94B" stroke-width="0.5" opacity="0.45"/>
+                {% endif %}
+                {% endfor %}
+            </svg>
+        </div>
+        {% endif %}
+
         <div class="ex-skill-cats">
 
             <!-- Col 1: Outfield (19 skills) -->
@@ -840,184 +908,85 @@ html, body {
                 </div>
             </div>
 
-            <!-- Nested Col 2+3: Mental | Set Pieces+Physical side by side (top),
-                 then landscape position panel below spanning full width. -->
-            <div class="ex-col-right">
-                <div class="ex-col-right-skills">
-
-                    <!-- Mental (14 skills) -->
-                    <div class="ex-skill-col">
-                        {% set cat = skill_categories[2] %}
-                        <div class="ex-cat">
-                            <div class="ex-cat-name">{{ cat.emoji }} {{ cat.name_en }}</div>
-                            <div class="ex-skill-rows">
-                                {% for skill in cat.skills %}
-                                {% set sdata = player.skills.get(skill.key, {}) %}
-                                {% set sval  = sdata.get('current_level', 50) | round(0) | int %}
-                                {% set fill  = [sval, 100] | min %}
-                                {% set delta = last_skill_delta.get(skill.key, 0) %}
-                                {% if delta > 0 %}
-                                    {% set bar_clr  = '#48bb78' %}
-                                    {% set val_clr  = '#48bb78' %}
-                                    {% set trend    = '↑' %}
-                                    {% set trend_vis = 'visible' %}
-                                {% elif delta < 0 %}
-                                    {% set bar_clr  = '#fc8181' %}
-                                    {% set val_clr  = '#fc8181' %}
-                                    {% set trend    = '↓' %}
-                                    {% set trend_vis = 'visible' %}
-                                {% else %}
-                                    {% set bar_clr  = 'rgba(255,255,255,0.20)' %}
-                                    {% set val_clr  = 'rgba(255,255,255,0.85)' %}
-                                    {% set trend    = '↑' %}
-                                    {% set trend_vis = 'hidden' %}
-                                {% endif %}
-                                <div class="ex-row">
-                                    <span class="ex-sname">{{ skill.name_en }}</span>
-                                    <div class="ex-bar-bg">
-                                        <div class="ex-bar-fill" style="width:{{ fill }}%; background:{{ bar_clr }};"></div>
-                                    </div>
-                                    <span class="ex-sval" style="color:{{ val_clr }};">{{ sval }}</span>
-                                    <span class="ex-trend" style="color:{{ bar_clr }}; visibility:{{ trend_vis }};">{{ trend }}</span>
-                                </div>
-                                {% endfor %}
+            <!-- Mental (14 skills) -->
+            <div class="ex-skill-col">
+                {% set cat = skill_categories[2] %}
+                <div class="ex-cat">
+                    <div class="ex-cat-name">{{ cat.emoji }} {{ cat.name_en }}</div>
+                    <div class="ex-skill-rows">
+                        {% for skill in cat.skills %}
+                        {% set sdata = player.skills.get(skill.key, {}) %}
+                        {% set sval  = sdata.get('current_level', 50) | round(0) | int %}
+                        {% set fill  = [sval, 100] | min %}
+                        {% set delta = last_skill_delta.get(skill.key, 0) %}
+                        {% if delta > 0 %}
+                            {% set bar_clr  = '#48bb78' %}
+                            {% set val_clr  = '#48bb78' %}
+                            {% set trend    = '↑' %}
+                            {% set trend_vis = 'visible' %}
+                        {% elif delta < 0 %}
+                            {% set bar_clr  = '#fc8181' %}
+                            {% set val_clr  = '#fc8181' %}
+                            {% set trend    = '↓' %}
+                            {% set trend_vis = 'visible' %}
+                        {% else %}
+                            {% set bar_clr  = 'rgba(255,255,255,0.20)' %}
+                            {% set val_clr  = 'rgba(255,255,255,0.85)' %}
+                            {% set trend    = '↑' %}
+                            {% set trend_vis = 'hidden' %}
+                        {% endif %}
+                        <div class="ex-row">
+                            <span class="ex-sname">{{ skill.name_en }}</span>
+                            <div class="ex-bar-bg">
+                                <div class="ex-bar-fill" style="width:{{ fill }}%; background:{{ bar_clr }};"></div>
                             </div>
+                            <span class="ex-sval" style="color:{{ val_clr }};">{{ sval }}</span>
+                            <span class="ex-trend" style="color:{{ bar_clr }}; visibility:{{ trend_vis }};">{{ trend }}</span>
                         </div>
+                        {% endfor %}
                     </div>
+                </div>
+            </div>
 
-                    <!-- Set Pieces (3 skills) + Physical (8 skills) -->
-                    <div class="ex-skill-col">
-                        {% for cat in [skill_categories[1], skill_categories[3]] %}
-                        <div class="ex-cat">
-                            <div class="ex-cat-name">{{ cat.emoji }} {{ cat.name_en }}</div>
-                            <div class="ex-skill-rows">
-                                {% for skill in cat.skills %}
-                                {% set sdata = player.skills.get(skill.key, {}) %}
-                                {% set sval  = sdata.get('current_level', 50) | round(0) | int %}
-                                {% set fill  = [sval, 100] | min %}
-                                {% set delta = last_skill_delta.get(skill.key, 0) %}
-                                {% if delta > 0 %}
-                                    {% set bar_clr  = '#48bb78' %}
-                                    {% set val_clr  = '#48bb78' %}
-                                    {% set trend    = '↑' %}
-                                    {% set trend_vis = 'visible' %}
-                                {% elif delta < 0 %}
-                                    {% set bar_clr  = '#fc8181' %}
-                                    {% set val_clr  = '#fc8181' %}
-                                    {% set trend    = '↓' %}
-                                    {% set trend_vis = 'visible' %}
-                                {% else %}
-                                    {% set bar_clr  = 'rgba(255,255,255,0.20)' %}
-                                    {% set val_clr  = 'rgba(255,255,255,0.85)' %}
-                                    {% set trend    = '↑' %}
-                                    {% set trend_vis = 'hidden' %}
-                                {% endif %}
-                                <div class="ex-row">
-                                    <span class="ex-sname">{{ skill.name_en }}</span>
-                                    <div class="ex-bar-bg">
-                                        <div class="ex-bar-fill" style="width:{{ fill }}%; background:{{ bar_clr }};"></div>
-                                    </div>
-                                    <span class="ex-sval" style="color:{{ val_clr }};">{{ sval }}</span>
-                                    <span class="ex-trend" style="color:{{ bar_clr }}; visibility:{{ trend_vis }};">{{ trend }}</span>
-                                </div>
-                                {% endfor %}
+            <!-- Set Pieces (3 skills) + Physical (8 skills) -->
+            <div class="ex-skill-col">
+                {% for cat in [skill_categories[1], skill_categories[3]] %}
+                <div class="ex-cat">
+                    <div class="ex-cat-name">{{ cat.emoji }} {{ cat.name_en }}</div>
+                    <div class="ex-skill-rows">
+                        {% for skill in cat.skills %}
+                        {% set sdata = player.skills.get(skill.key, {}) %}
+                        {% set sval  = sdata.get('current_level', 50) | round(0) | int %}
+                        {% set fill  = [sval, 100] | min %}
+                        {% set delta = last_skill_delta.get(skill.key, 0) %}
+                        {% if delta > 0 %}
+                            {% set bar_clr  = '#48bb78' %}
+                            {% set val_clr  = '#48bb78' %}
+                            {% set trend    = '↑' %}
+                            {% set trend_vis = 'visible' %}
+                        {% elif delta < 0 %}
+                            {% set bar_clr  = '#fc8181' %}
+                            {% set val_clr  = '#fc8181' %}
+                            {% set trend    = '↓' %}
+                            {% set trend_vis = 'visible' %}
+                        {% else %}
+                            {% set bar_clr  = 'rgba(255,255,255,0.20)' %}
+                            {% set val_clr  = 'rgba(255,255,255,0.85)' %}
+                            {% set trend    = '↑' %}
+                            {% set trend_vis = 'hidden' %}
+                        {% endif %}
+                        <div class="ex-row">
+                            <span class="ex-sname">{{ skill.name_en }}</span>
+                            <div class="ex-bar-bg">
+                                <div class="ex-bar-fill" style="width:{{ fill }}%; background:{{ bar_clr }};"></div>
                             </div>
+                            <span class="ex-sval" style="color:{{ val_clr }};">{{ sval }}</span>
+                            <span class="ex-trend" style="color:{{ bar_clr }}; visibility:{{ trend_vis }};">{{ trend }}</span>
                         </div>
                         {% endfor %}
                     </div>
-
                 </div>
-
-                <!-- Landscape position panel (v9): info column (left) + pitch SVG (right).
-                     Coordinate transform: cx = node.x * 105, cy = node.y * 68
-                     (GK at left x≈0.02, ST at right x≈0.88; y=0 top, y=1 bottom) -->
-                {% if position_nodes %}
-                <div class="ex-pos-panel-landscape">
-
-                    <!-- Info column: title · primary pos · secondary chips (no legend) -->
-                    <div class="ex-pos-info">
-                        <div class="ex-pos-panel-title">Position Map</div>
-                        <div class="ex-pos-primary-label">Primary Position</div>
-                        <div class="ex-pos-primary-name">
-                            {%- if primary_pos_label is defined and primary_pos_label -%}
-                                {{ primary_pos_label }}
-                            {%- else -%}
-                                {{ player.position | replace("_", " ") | title }}
-                            {%- endif -%}
-                        </div>
-                        {% if secondary_pos_labels is defined and secondary_pos_labels %}
-                        <div class="ex-pos-secondary-label">Secondary Positions</div>
-                        <div class="ex-pos-secondary-chips">
-                            {% for sp in secondary_pos_labels %}
-                            <span class="ex-sec-pos-chip">{{ sp }}</span>
-                            {% endfor %}
-                        </div>
-                        {% endif %}
-                    </div>
-
-                    <svg class="ex-pos-svg-landscape" viewBox="0 0 105 68"
-                         xmlns="http://www.w3.org/2000/svg" aria-label="Position map"
-                         preserveAspectRatio="xMidYMid meet">
-                        <!-- Pitch background (105m × 68m real geometry) -->
-                        <rect width="105" height="68" fill="#1a5c2a"/>
-                        <!-- Field border -->
-                        <rect x="0.5" y="0.5" width="104" height="67"
-                              fill="none" stroke="rgba(255,255,255,0.30)" stroke-width="0.5"/>
-                        <!-- Center line (vertical at x=52.5) -->
-                        <line x1="52.5" y1="0" x2="52.5" y2="68"
-                              stroke="rgba(255,255,255,0.22)" stroke-width="0.4"/>
-                        <!-- Center circle (r=9.15m) -->
-                        <circle cx="52.5" cy="34" r="9.15"
-                                fill="none" stroke="rgba(255,255,255,0.22)" stroke-width="0.4"/>
-                        <!-- Center spot -->
-                        <circle cx="52.5" cy="34" r="0.6" fill="rgba(255,255,255,0.40)"/>
-                        <!-- GK penalty area (16.5m deep × 40.32m wide) -->
-                        <rect x="0" y="13.84" width="16.5" height="40.32"
-                              fill="none" stroke="rgba(255,255,255,0.20)" stroke-width="0.4"/>
-                        <!-- ST penalty area -->
-                        <rect x="88.5" y="13.84" width="16.5" height="40.32"
-                              fill="none" stroke="rgba(255,255,255,0.20)" stroke-width="0.4"/>
-                        <!-- GK 6-yard box (5.5m deep × 18.32m wide) -->
-                        <rect x="0" y="24.84" width="5.5" height="18.32"
-                              fill="none" stroke="rgba(255,255,255,0.14)" stroke-width="0.3"/>
-                        <!-- ST 6-yard box -->
-                        <rect x="99.5" y="24.84" width="5.5" height="18.32"
-                              fill="none" stroke="rgba(255,255,255,0.14)" stroke-width="0.3"/>
-                        <!-- Penalty spots (11m from goal line) -->
-                        <circle cx="11" cy="34" r="0.5" fill="rgba(255,255,255,0.40)"/>
-                        <circle cx="94" cy="34" r="0.5" fill="rgba(255,255,255,0.40)"/>
-
-                        <!-- Pass 1: inactive nodes (very faint) -->
-                        {% for node in position_nodes %}
-                        {% if not node.is_selected and not node.is_primary %}
-                        <circle cx="{{ (node.x * 105) | round(1) }}" cy="{{ (node.y * 68) | round(1) }}"
-                                r="0.8" fill="rgba(255,255,255,0.12)"/>
-                        {% endif %}
-                        {% endfor %}
-
-                        <!-- Pass 2: secondary selected positions -->
-                        {% for node in position_nodes %}
-                        {% if node.is_selected and not node.is_primary %}
-                        <circle cx="{{ (node.x * 105) | round(1) }}" cy="{{ (node.y * 68) | round(1) }}"
-                                r="1.4" fill="rgba(255,255,255,0.68)"/>
-                        <circle cx="{{ (node.x * 105) | round(1) }}" cy="{{ (node.y * 68) | round(1) }}"
-                                r="2.0" fill="none" stroke="rgba(255,255,255,0.35)" stroke-width="0.4"/>
-                        {% endif %}
-                        {% endfor %}
-
-                        <!-- Pass 3: primary position — gold, topmost -->
-                        {% for node in position_nodes %}
-                        {% if node.is_primary %}
-                        <circle cx="{{ (node.x * 105) | round(1) }}" cy="{{ (node.y * 68) | round(1) }}"
-                                r="1.8" fill="#ECC94B" opacity="0.95"/>
-                        <circle cx="{{ (node.x * 105) | round(1) }}" cy="{{ (node.y * 68) | round(1) }}"
-                                r="2.6" fill="none" stroke="#ECC94B" stroke-width="0.5" opacity="0.45"/>
-                        {% endif %}
-                        {% endfor %}
-                    </svg>
-                </div>
-                {% endif %}
-
+                {% endfor %}
             </div>
 
         </div>

--- a/app/templates/public/export/square/fifa.html
+++ b/app/templates/public/export/square/fifa.html
@@ -11,8 +11,8 @@
  * Classes : ex- prefix throughout, no inheritance from editor templates
  *
  * Layout:
- *   .ex-hero  (flex: 0 0 42%) — photo-col 32% | profile-col flex:1
- *   .ex-skills (flex: 1)       — 2×2 grid, all 29 skills (58% of canvas)
+ *   .ex-hero  (flex: 0 0 37%) — photo-col 32% | profile-col flex:1
+ *   .ex-skills (flex: 1)       — 2×2 grid, all 44 skills (63% of canvas)
  *
  * Hero photo: portrait_photo_url → photo_url (no circle, no border, cover)
  * Hero profile-col: justify-content:space-between distributes 3 sections
@@ -96,9 +96,22 @@ html, body {
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 48px;
+}
+
+/* WC no-photo: monogram circle centred in the photo column */
+.ex-photo-monogram {
+    width: 120px;
+    height: 120px;
+    border-radius: 50%;
+    border: 3px solid rgba(255,255,255,0.18);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 44px;
     font-weight: 900;
-    color: rgba(255,255,255,0.20);
+    color: rgba(255,255,255,0.72);
+    background: rgba(255,255,255,0.06);
+    letter-spacing: -0.02em;
 }
 
 /* Right-edge gradient on photo — blends into profile col */
@@ -212,10 +225,17 @@ html, body {
     white-space: nowrap;
 }
 
-/* 3×2 mini-grid: profile data */
+/* 3×2 mini-grid: profile data (non-WC mode) */
 .ex-mini-grid {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
+    gap: 4px 8px;
+}
+
+/* WC mode: 2×2 compact grid (NAT · GROUP / HEIGHT · WEIGHT) */
+.ex-mini-grid--wc {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
     gap: 4px 8px;
 }
 .ex-mini-item {
@@ -538,7 +558,9 @@ html, body {
             {% if _photo %}
             <img src="{{ _photo }}" alt="{{ initials }}">
             {% else %}
-            <div class="ex-photo-placeholder" style="background: {{ avatar_bg }};">{{ initials }}</div>
+            <div class="ex-photo-placeholder" style="background: {{ avatar_bg }};">
+                <div class="ex-photo-monogram">{{ initials }}</div>
+            </div>
             {% endif %}
             <div class="ex-photo-fade"></div>
             {% if player.position and player.position != "Unknown" %}
@@ -575,7 +597,29 @@ html, body {
                 </div>
             </div>
 
-            <!-- Mini-grid: 3×2 — all 6 cells always rendered, "—" fallback for nulls -->
+            <!-- Mini-grid:
+                 WC mode  (welcome_card_mode=True) → 2×2: NAT · GROUP / HEIGHT · WEIGHT
+                 Non-WC                             → 3×2: NAT · AGE · GENDER / GROUP · HEIGHT · WEIGHT -->
+            {% if welcome_card_mode %}
+            <div class="ex-mini-grid ex-mini-grid--wc">
+                <div class="ex-mini-item">
+                    <span class="ex-mini-label">NAT.</span>
+                    <span class="ex-mini-value">{{ player.nationality | nationalities_display(player.secondary_nationality) }}</span>
+                </div>
+                <div class="ex-mini-item">
+                    <span class="ex-mini-label">GROUP</span>
+                    <span class="ex-mini-value">{{ player.age_group or "—" }}</span>
+                </div>
+                <div class="ex-mini-item">
+                    <span class="ex-mini-label">HEIGHT</span>
+                    <span class="ex-mini-value">{{ (player_height_cm ~ " cm") if player_height_cm else "—" }}</span>
+                </div>
+                <div class="ex-mini-item">
+                    <span class="ex-mini-label">WEIGHT</span>
+                    <span class="ex-mini-value">{{ (player_weight_kg ~ " kg") if player_weight_kg else "—" }}</span>
+                </div>
+            </div>
+            {% else %}
             <div class="ex-mini-grid">
                 <div class="ex-mini-item">
                     <span class="ex-mini-label">NAT.</span>
@@ -591,7 +635,7 @@ html, body {
                 </div>
                 <div class="ex-mini-item">
                     <span class="ex-mini-label">GROUP</span>
-                    <span class="ex-mini-value">{{ player.age_group }}</span>
+                    <span class="ex-mini-value">{{ player.age_group or "—" }}</span>
                 </div>
                 <div class="ex-mini-item">
                     <span class="ex-mini-label">HEIGHT</span>
@@ -602,16 +646,24 @@ html, body {
                     <span class="ex-mini-value">{{ (player_weight_kg ~ " kg") if player_weight_kg else "—" }}</span>
                 </div>
             </div>
+            {% endif %}
 
-            <!-- Stat strip: Events · License · XP -->
+            <!-- Stat strip:
+                 WC mode  → EVENTS · TIER (SA) · XP
+                 Non-WC   → EVENTS · LICENSE (Lv. X) · XP -->
             <div class="ex-stat-strip">
                 <div class="ex-stat-item">
                     <span class="ex-stat-label">EVENTS</span>
                     <span class="ex-stat-value">{{ player.total_tournaments }}</span>
                 </div>
                 <div class="ex-stat-item">
+                    {% if welcome_card_mode %}
+                    <span class="ex-stat-label">TIER</span>
+                    <span class="ex-stat-value">SA</span>
+                    {% else %}
                     <span class="ex-stat-label">LICENSE</span>
                     <span class="ex-stat-value">Lv. {{ license_current_level or 1 }}</span>
+                    {% endif %}
                 </div>
                 <div class="ex-stat-item">
                     <span class="ex-stat-label">XP</span>

--- a/app/templates/public/export/square/fifa.html
+++ b/app/templates/public/export/square/fifa.html
@@ -10,29 +10,30 @@
  * Purpose : static social export ONLY — no editor UI, no responsive CSS
  * Classes : ex- prefix throughout, no inheritance from editor templates
  *
- * Layout (v10 — Position Map at top, 3 flat skill columns):
+ * Layout (v11 — Position Map in Col 2 bottom, 3 fill-aligned columns):
  *   .ex-hero   (flex: 0 0 35%) — photo-col 32% | profile-col flex:1
  *   .ex-skills (flex: 1 = 65%, gap:6px):
- *     .ex-pos-panel-landscape (flex-shrink:0, h=110px, full-width)  ← TOP
  *     .ex-skill-cats (flex:1, flex-row, gap:6px):
- *       Col 1: Outfield (19 skills, flex:1)
- *       Col 2: Mental   (14 skills, flex:1)
- *       Col 3: Set Pieces (3) + Physical (8) stacked (flex:1)
+ *       Col 1 .ex-col-outfield:   Outfield (19 skills, cat flex:1 → fills 656px)
+ *       Col 2 .ex-col-mental-pos: Mental (14, cat flex:1) | PosMap (fixed 160px)
+ *       Col 3 .ex-col-sets-phys:  Set Pieces (3, natural) | Physical (8, cat flex:1)
  *
- * Height budget (v10):
+ * Height budget (v11):
  *   Skills inner: 702−28 = 674px
- *   Title 12px + gap 6px + panel 110px + gap 6px = 134px consumed
- *   Skill-cats: 674−12−6−110−6 = 540px available
- *   Outfield worst-case: 16(pad)+26(hdr)+492(19×24+18×2) = 534px → +6px buffer ✓
- *   FIX_ROW_H = 24px: .ex-row { flex:none; min-height:24px } — all 44 skills visible
+ *   Title 12px + gap 6px = 18px consumed (no top strip)
+ *   Skill-cats: 674−18 = 656px available  (+116px vs v10's 540px)
+ *   Column widths: (1052−12)/3 ≈ 347px each
+ *   Outfield worst-case: 534px < 656px → +122px bg fill ✓
+ *   Mental: 404px < 490px (656−6−160) → +86px bg fill ✓
+ *   Set Pieces: 118px natural ✓ · Physical: 248px < 532px → +284px bg fill ✓
+ *   All 44 skills fully visible — flex:1 cats fill to bottom, rows align top ✓
  *
- * Position Map panel (v10):
- *   .ex-pos-panel-landscape: full-width, fixed 110px, flex-row.
- *   .ex-pos-info (180px): title · Primary pos label+name (gold) · Secondary chips.
- *   svg.ex-pos-svg-landscape (flex:1, bg:#1a5c2a): viewBox "0 0 105 68",
- *     preserveAspectRatio="xMidYMid meet" — pitch aránytartó, letterbox seamless.
- *   No .ex-col-right, no .ex-col-right-skills wrappers.
- *   Jinja2-gated by position_nodes — graceful when position not set.
+ * Position Map panel (v11):
+ *   .ex-pos-panel-landscape: fixed 160px tall, inside Col 2 at bottom, flex-row.
+ *   .ex-pos-info (140px): title · Primary pos label+name (gold, 14px wrap) · chips.
+ *   svg.ex-pos-svg-landscape (flex:1 = ~206px, bg:#1a5c2a): viewBox "0 0 105 68",
+ *     preserveAspectRatio="xMidYMid meet" → pitch rendered 206×133px (83% fill).
+ *   Jinja2-gated by position_nodes — Col 2 Mental fills full 656px when absent.
  *
  * Photo column (v9, unchanged):
  *   Clean portrait — no position badges. Position info in panel only.
@@ -471,10 +472,10 @@ html, body {
    NO legend. SVG: viewBox "0 0 105 68", xMidYMid meet, seamless green letterbox.
    ─────────────────────────────────────────────────────────────────────────────────────── */
 
-/* Landscape panel: full-width strip above skill columns */
+/* Position Map panel — v11: inside Col 2 (bottom), fixed height */
 .ex-pos-panel-landscape {
     flex-shrink: 0;
-    height: 110px;
+    height: 160px;
     background: var(--ex-cat-bg);
     border: 1px solid rgba(255,255,255,0.10);
     border-radius: 12px;
@@ -482,14 +483,14 @@ html, body {
     display: flex;
     flex-direction: row;
 }
-/* Info column — left of pitch SVG */
+/* Info column — left of pitch SVG (narrower in v11: more SVG room) */
 .ex-pos-info {
-    flex: 0 0 180px;
+    flex: 0 0 140px;
     display: flex;
     flex-direction: column;
     justify-content: center;
     gap: 3px;
-    padding: 10px 14px;
+    padding: 10px 12px;
     border-right: 1px solid rgba(255,255,255,0.08);
 }
 .ex-pos-panel-title {
@@ -508,12 +509,12 @@ html, body {
     color: rgba(255,255,255,0.28);
 }
 .ex-pos-primary-name {
-    font-size: 16px;
+    font-size: 14px;
     font-weight: 800;
     color: #ECC94B;
     text-transform: uppercase;
-    letter-spacing: 0.03em;
-    line-height: 1.15;
+    letter-spacing: 0.02em;
+    line-height: 1.2;
     margin-bottom: 4px;
 }
 .ex-pos-secondary-label {
@@ -529,6 +530,12 @@ html, body {
     gap: 3px;
     margin-top: 2px;
 }
+/* v11 column flex-fill: each column's tallest (or only) cat stretches to fill height,
+ * so all three columns reach the same bottom edge. */
+.ex-col-outfield .ex-cat         { flex: 1; }   /* Outfield: single cat fills full 656px */
+.ex-col-mental-pos .ex-cat       { flex: 1; }   /* Mental: fills above Position Map */
+.ex-col-sets-phys .ex-cat:last-child { flex: 1; } /* Physical: fills below Set Pieces */
+
 /* SVG takes remaining width — seamless green background absorbs letterbox areas */
 .ex-pos-svg-landscape {
     flex: 1;
@@ -778,98 +785,10 @@ html, body {
     {% if skill_categories %}
     <div class="ex-skills">
         <div class="ex-skills-title">Football Skills — {{ overall | round(0) | int }} OVR</div>
-        <!-- Position Map: full-width strip above skill columns (v10) -->
-        {% if position_nodes %}
-        <div class="ex-pos-panel-landscape">
-
-            <!-- Info column: title · primary pos · secondary chips (no legend) -->
-            <div class="ex-pos-info">
-                <div class="ex-pos-panel-title">Position Map</div>
-                <div class="ex-pos-primary-label">Primary Position</div>
-                <div class="ex-pos-primary-name">
-                    {%- if primary_pos_label is defined and primary_pos_label -%}
-                        {{ primary_pos_label }}
-                    {%- else -%}
-                        {{ player.position | replace("_", " ") | title }}
-                    {%- endif -%}
-                </div>
-                {% if secondary_pos_labels is defined and secondary_pos_labels %}
-                <div class="ex-pos-secondary-label">Secondary Positions</div>
-                <div class="ex-pos-secondary-chips">
-                    {% for sp in secondary_pos_labels %}
-                    <span class="ex-sec-pos-chip">{{ sp }}</span>
-                    {% endfor %}
-                </div>
-                {% endif %}
-            </div>
-
-            <svg class="ex-pos-svg-landscape" viewBox="0 0 105 68"
-                 xmlns="http://www.w3.org/2000/svg" aria-label="Position map"
-                 preserveAspectRatio="xMidYMid meet">
-                <!-- Pitch background (105m × 68m real geometry) -->
-                <rect width="105" height="68" fill="#1a5c2a"/>
-                <!-- Field border -->
-                <rect x="0.5" y="0.5" width="104" height="67"
-                      fill="none" stroke="rgba(255,255,255,0.30)" stroke-width="0.5"/>
-                <!-- Center line (vertical at x=52.5) -->
-                <line x1="52.5" y1="0" x2="52.5" y2="68"
-                      stroke="rgba(255,255,255,0.22)" stroke-width="0.4"/>
-                <!-- Center circle (r=9.15m) -->
-                <circle cx="52.5" cy="34" r="9.15"
-                        fill="none" stroke="rgba(255,255,255,0.22)" stroke-width="0.4"/>
-                <!-- Center spot -->
-                <circle cx="52.5" cy="34" r="0.6" fill="rgba(255,255,255,0.40)"/>
-                <!-- GK penalty area (16.5m deep × 40.32m wide) -->
-                <rect x="0" y="13.84" width="16.5" height="40.32"
-                      fill="none" stroke="rgba(255,255,255,0.20)" stroke-width="0.4"/>
-                <!-- ST penalty area -->
-                <rect x="88.5" y="13.84" width="16.5" height="40.32"
-                      fill="none" stroke="rgba(255,255,255,0.20)" stroke-width="0.4"/>
-                <!-- GK 6-yard box (5.5m deep × 18.32m wide) -->
-                <rect x="0" y="24.84" width="5.5" height="18.32"
-                      fill="none" stroke="rgba(255,255,255,0.14)" stroke-width="0.3"/>
-                <!-- ST 6-yard box -->
-                <rect x="99.5" y="24.84" width="5.5" height="18.32"
-                      fill="none" stroke="rgba(255,255,255,0.14)" stroke-width="0.3"/>
-                <!-- Penalty spots (11m from goal line) -->
-                <circle cx="11" cy="34" r="0.5" fill="rgba(255,255,255,0.40)"/>
-                <circle cx="94" cy="34" r="0.5" fill="rgba(255,255,255,0.40)"/>
-
-                <!-- Pass 1: inactive nodes (very faint) -->
-                {% for node in position_nodes %}
-                {% if not node.is_selected and not node.is_primary %}
-                <circle cx="{{ (node.x * 105) | round(1) }}" cy="{{ (node.y * 68) | round(1) }}"
-                        r="0.8" fill="rgba(255,255,255,0.12)"/>
-                {% endif %}
-                {% endfor %}
-
-                <!-- Pass 2: secondary selected positions -->
-                {% for node in position_nodes %}
-                {% if node.is_selected and not node.is_primary %}
-                <circle cx="{{ (node.x * 105) | round(1) }}" cy="{{ (node.y * 68) | round(1) }}"
-                        r="1.4" fill="rgba(255,255,255,0.68)"/>
-                <circle cx="{{ (node.x * 105) | round(1) }}" cy="{{ (node.y * 68) | round(1) }}"
-                        r="2.0" fill="none" stroke="rgba(255,255,255,0.35)" stroke-width="0.4"/>
-                {% endif %}
-                {% endfor %}
-
-                <!-- Pass 3: primary position — gold, topmost -->
-                {% for node in position_nodes %}
-                {% if node.is_primary %}
-                <circle cx="{{ (node.x * 105) | round(1) }}" cy="{{ (node.y * 68) | round(1) }}"
-                        r="1.8" fill="#ECC94B" opacity="0.95"/>
-                <circle cx="{{ (node.x * 105) | round(1) }}" cy="{{ (node.y * 68) | round(1) }}"
-                        r="2.6" fill="none" stroke="#ECC94B" stroke-width="0.5" opacity="0.45"/>
-                {% endif %}
-                {% endfor %}
-            </svg>
-        </div>
-        {% endif %}
-
         <div class="ex-skill-cats">
 
-            <!-- Col 1: Outfield (19 skills) -->
-            <div class="ex-skill-col">
+            <!-- Col 1: Outfield (19 skills) — single cat fills full column height -->
+            <div class="ex-skill-col ex-col-outfield">
                 {% set cat = skill_categories[0] %}
                 <div class="ex-cat">
                     <div class="ex-cat-name">{{ cat.emoji }} {{ cat.name_en }}</div>
@@ -908,8 +827,8 @@ html, body {
                 </div>
             </div>
 
-            <!-- Mental (14 skills) -->
-            <div class="ex-skill-col">
+            <!-- Col 2: Mental (top, flex:1) + Position Map (bottom, 160px) -->
+            <div class="ex-skill-col ex-col-mental-pos">
                 {% set cat = skill_categories[2] %}
                 <div class="ex-cat">
                     <div class="ex-cat-name">{{ cat.emoji }} {{ cat.name_en }}</div>
@@ -946,10 +865,97 @@ html, body {
                         {% endfor %}
                     </div>
                 </div>
+
+                {% if position_nodes %}
+                <div class="ex-pos-panel-landscape">
+
+                    <!-- Info column: title · primary pos · secondary chips (no legend) -->
+                    <div class="ex-pos-info">
+                        <div class="ex-pos-panel-title">Position Map</div>
+                        <div class="ex-pos-primary-label">Primary Position</div>
+                        <div class="ex-pos-primary-name">
+                            {%- if primary_pos_label is defined and primary_pos_label -%}
+                                {{ primary_pos_label }}
+                            {%- else -%}
+                                {{ player.position | replace("_", " ") | title }}
+                            {%- endif -%}
+                        </div>
+                        {% if secondary_pos_labels is defined and secondary_pos_labels %}
+                        <div class="ex-pos-secondary-label">Secondary Positions</div>
+                        <div class="ex-pos-secondary-chips">
+                            {% for sp in secondary_pos_labels %}
+                            <span class="ex-sec-pos-chip">{{ sp }}</span>
+                            {% endfor %}
+                        </div>
+                        {% endif %}
+                    </div>
+
+                    <svg class="ex-pos-svg-landscape" viewBox="0 0 105 68"
+                         xmlns="http://www.w3.org/2000/svg" aria-label="Position map"
+                         preserveAspectRatio="xMidYMid meet">
+                        <!-- Pitch background (105m × 68m real geometry) -->
+                        <rect width="105" height="68" fill="#1a5c2a"/>
+                        <!-- Field border -->
+                        <rect x="0.5" y="0.5" width="104" height="67"
+                              fill="none" stroke="rgba(255,255,255,0.30)" stroke-width="0.5"/>
+                        <!-- Center line (vertical at x=52.5) -->
+                        <line x1="52.5" y1="0" x2="52.5" y2="68"
+                              stroke="rgba(255,255,255,0.22)" stroke-width="0.4"/>
+                        <!-- Center circle (r=9.15m) -->
+                        <circle cx="52.5" cy="34" r="9.15"
+                                fill="none" stroke="rgba(255,255,255,0.22)" stroke-width="0.4"/>
+                        <!-- Center spot -->
+                        <circle cx="52.5" cy="34" r="0.6" fill="rgba(255,255,255,0.40)"/>
+                        <!-- GK penalty area (16.5m deep × 40.32m wide) -->
+                        <rect x="0" y="13.84" width="16.5" height="40.32"
+                              fill="none" stroke="rgba(255,255,255,0.20)" stroke-width="0.4"/>
+                        <!-- ST penalty area -->
+                        <rect x="88.5" y="13.84" width="16.5" height="40.32"
+                              fill="none" stroke="rgba(255,255,255,0.20)" stroke-width="0.4"/>
+                        <!-- GK 6-yard box (5.5m deep × 18.32m wide) -->
+                        <rect x="0" y="24.84" width="5.5" height="18.32"
+                              fill="none" stroke="rgba(255,255,255,0.14)" stroke-width="0.3"/>
+                        <!-- ST 6-yard box -->
+                        <rect x="99.5" y="24.84" width="5.5" height="18.32"
+                              fill="none" stroke="rgba(255,255,255,0.14)" stroke-width="0.3"/>
+                        <!-- Penalty spots (11m from goal line) -->
+                        <circle cx="11" cy="34" r="0.5" fill="rgba(255,255,255,0.40)"/>
+                        <circle cx="94" cy="34" r="0.5" fill="rgba(255,255,255,0.40)"/>
+
+                        <!-- Pass 1: inactive nodes (very faint) -->
+                        {% for node in position_nodes %}
+                        {% if not node.is_selected and not node.is_primary %}
+                        <circle cx="{{ (node.x * 105) | round(1) }}" cy="{{ (node.y * 68) | round(1) }}"
+                                r="0.8" fill="rgba(255,255,255,0.12)"/>
+                        {% endif %}
+                        {% endfor %}
+
+                        <!-- Pass 2: secondary selected positions -->
+                        {% for node in position_nodes %}
+                        {% if node.is_selected and not node.is_primary %}
+                        <circle cx="{{ (node.x * 105) | round(1) }}" cy="{{ (node.y * 68) | round(1) }}"
+                                r="1.4" fill="rgba(255,255,255,0.68)"/>
+                        <circle cx="{{ (node.x * 105) | round(1) }}" cy="{{ (node.y * 68) | round(1) }}"
+                                r="2.0" fill="none" stroke="rgba(255,255,255,0.35)" stroke-width="0.4"/>
+                        {% endif %}
+                        {% endfor %}
+
+                        <!-- Pass 3: primary position — gold, topmost -->
+                        {% for node in position_nodes %}
+                        {% if node.is_primary %}
+                        <circle cx="{{ (node.x * 105) | round(1) }}" cy="{{ (node.y * 68) | round(1) }}"
+                                r="1.8" fill="#ECC94B" opacity="0.95"/>
+                        <circle cx="{{ (node.x * 105) | round(1) }}" cy="{{ (node.y * 68) | round(1) }}"
+                                r="2.6" fill="none" stroke="#ECC94B" stroke-width="0.5" opacity="0.45"/>
+                        {% endif %}
+                        {% endfor %}
+                    </svg>
+                </div>
+                {% endif %}
             </div>
 
-            <!-- Set Pieces (3 skills) + Physical (8 skills) -->
-            <div class="ex-skill-col">
+            <!-- Col 3: Set Pieces (3, natural) + Physical (8, flex:1 fills remaining) -->
+            <div class="ex-skill-col ex-col-sets-phys">
                 {% for cat in [skill_categories[1], skill_categories[3]] %}
                 <div class="ex-cat">
                     <div class="ex-cat-name">{{ cat.emoji }} {{ cat.name_en }}</div>

--- a/app/templates/public/export/square/fifa.html
+++ b/app/templates/public/export/square/fifa.html
@@ -10,28 +10,44 @@
  * Purpose : static social export ONLY — no editor UI, no responsive CSS
  * Classes : ex- prefix throughout, no inheritance from editor templates
  *
- * Layout:
- *   .ex-hero  (flex: 0 0 37%) — photo-col 32% | profile-col flex:1
- *   .ex-skills (flex: 1)       — 2×2 grid, all 44 skills (63% of canvas)
+ * Layout (v8 — correct pitch geometry (105m×68m) + sponsor in hero):
+ *   .ex-hero  (flex: 0 0 35%) — photo-col 32% | profile-col flex:1
+ *   .ex-skills (flex: 1 = 65%) — Col1(Outfield flex:1) | ex-col-right(flex:2)
  *
  * Hero photo: portrait_photo_url → photo_url (no circle, no border, cover)
- * Hero profile-col: justify-content:space-between distributes 3 sections
- *   across 420px inner height — Identity(122px) · ProfileData(76px) · Stats(54px)
  *
- * Skill grid — fixed-rhythm model (v3):
- *   grid-template-columns: 1fr 1fr
- *   grid-template-rows: auto auto      ← category-driven; tallest in row wins
- *   align-items: start                 ← compact categories don't stretch
- *   gap: 6px
+ * Skill grid — nested 3-column model (v7):
+ *   Col 1: Outfield (19 skills, flex:1, ~346px wide)
+ *   .ex-col-right (flex:2, ~693px wide):
+ *     .ex-col-right-skills (flex-row):
+ *       Mental (14 skills) | Set Pieces (3) + Physical (8) — side by side
+ *     .ex-pos-panel-landscape (flex:1, ~165px tall, full 693px width)
+ *   Available height per skill-col: 576px
+ *   All 44 skills visible without overflow clipping.
  *   FIX_ROW_H = 24px: .ex-row { flex: none; min-height: 24px }
- *   Every skill row across all 4 categories is exactly 24px — uniform rhythm.
- *   Short categories (Set Pieces 3 rows) show dark background below their block.
+ *
+ * Landscape position panel (v7):
+ *   Placed as 2nd flex child of .ex-col-right (below .ex-col-right-skills).
+ *   Class: .ex-pos-panel-landscape (NOT .ex-cat — immune to cat animation).
+ *   SVG: viewBox "0 0 105 68" (real 105m×68m pitch geometry).
+ *   preserveAspectRatio="xMidYMid meet" — undistorted, pitch green letterbox sides.
+ *   Coordinate transform: cx = node.x × 105, cy = node.y × 68 (GK left, ST right).
+ *   Panel bg #1a5c2a blends with pitch green — seamless letterbox effect.
+ *   No text labels — position shown in hero photo badge.
+ *   Gated: "if position_nodes" — graceful empty state when position not set.
+ *   Animation: self-contained fade-in (animated_mode only), no skill stagger impact.
+ *
+ * Sponsor / logo (v8):
+ *   Moved to hero layer: .ex-hero-sponsor in .ex-profile-col (4th flex child).
+ *   Gated: "if sponsor_logo_url or app_logo_url" — no layout break when absent.
+ *   Skills zone gains 76px → .ex-pos-panel-landscape ~242px tall (was ~166px).
  *
  * Typography scale (% of C_H=1080):
  *   OVR 96px (8.89%), Name 40px (3.70%), Stat 28px (2.59%), Meta 20px (1.85%)
  *
- * Category order in HTML: Outfield · Mental / Set Pieces · Physical
- *   (row-flow, so rendered as [0],[2],[1],[3] from skill_categories)
+ * Column assignment (index → category):
+ *   [0] Outfield · [1] Set Pieces · [2] Mental · [3] Physical
+ *   Rendered order: Col1=[0], Right=[2]+[1]+[3]+landscape-panel; sponsor in hero
  */
 
 :root {
@@ -61,11 +77,11 @@ html, body {
 }
 
 /* ── HERO ZONE ────────────────────────────────────────────────────────────────
-   Fixed at 42% of card height (≈ 454px at 1080px canvas). Upper bound.
+   Fixed at 35% of card height (≈ 378px at 1080px canvas).
    Layout: [photo-col 32% fixed] | [profile-col flex:1]
    ─────────────────────────────────────────────────────────────────────────── */
 .ex-hero {
-    flex: 0 0 42%;
+    flex: 0 0 35%;
     background: var(--ex-panel-bg);
     display: flex;
     flex-direction: row;
@@ -123,7 +139,7 @@ html, body {
     pointer-events: none;
 }
 
-/* Position badge — overlaid top-left of photo */
+/* Primary position badge — overlaid top-left of photo */
 .ex-pos-badge {
     position: absolute;
     top: 10px;
@@ -137,6 +153,29 @@ html, body {
     letter-spacing: 0.07em;
     z-index: 2;
     white-space: nowrap;
+}
+
+/* Secondary position chips — stacked below primary badge */
+.ex-sec-pos-chips {
+    position: absolute;
+    top: 40px;
+    left: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    z-index: 2;
+}
+.ex-sec-pos-chip {
+    font-size: 9px;
+    font-weight: 700;
+    color: rgba(255,255,255,0.75);
+    padding: 2px 6px;
+    border-radius: 3px;
+    background: rgba(0,0,0,0.45);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    white-space: nowrap;
+    display: inline-block;
 }
 
 /* Profile column — right side of hero */
@@ -313,15 +352,17 @@ html, body {
     z-index: 0;
 }
 
-/* ── SKILLS ZONE ──────────────────────────────────────────────────────────────
-   flex:1 → takes 1080 − 454 = 626px of remaining height.
-   2-column flex layout (v4):
-     Left col:  Outfield (fixed) + Set Pieces (flex:1, fills column)
-     Right col: Mental (fixed)   + Physical Fitness (natural, directly below Mental)
-   Sponsor slot: full-width flex-sibling below both columns.
-   Math: max-col height = Mental(258)+6+Physical(232) = 496px.
-         Slot: 575 − 496 − 6(margin) = 73px available; slot uses 70px.
-   ─────────────────────────────────────────────────────────────────────────── */
+/* ── SKILLS ZONE ────────────────────────────────────────────────────────────────────────────────
+   flex:1 → takes 1080 − 378 = 702px of remaining height (at 35% hero).
+   Nested 3-column model (v7):
+     Col 1: Outfield (19 skills, flex:1, ~346px)
+     .ex-col-right (flex:2, ~693px):
+       .ex-col-right-skills: Mental (14) | Set Pieces(3)+Physical(8)
+       .ex-pos-panel-landscape: landscape pitch SVG, ~165px tall
+   Available height per skill-col: 576px
+   All 44 skills fully visible — no overflow clipping on content layers.
+   Sponsor slot: removed from skills zone — moved to hero layer (v8).
+   ─────────────────────────────────────────────────────────────────────────────────────── */
 .ex-skills {
     flex: 1;
     background: var(--ex-body-bg);
@@ -341,42 +382,27 @@ html, body {
     margin-bottom: 8px;
 }
 
-/* 2-column flex layout (v4).
- * Each column is independently height-managed — eliminates the 85px dead gap
- * caused by CSS Grid sharing row heights across columns (Outfield taller than Mental). */
+/* v7: Col 1 (Outfield flex:1) + .ex-col-right (flex:2, nested Mental|SetPieces+Physical + landscape panel). */
 .ex-skill-cats {
     flex: 1;
     display: flex;
     flex-direction: row;
     gap: 6px;
-    overflow: hidden;
     min-height: 0;
 }
 
-/* Column wrapper: stacks its two categories vertically, independent of the other column. */
+/* Column wrapper: stacks its categories vertically. overflow: visible so
+ * all skill rows remain visible — the 35% hero gives enough height. */
 .ex-skill-col {
-    flex: 1;
+    flex: 1 1 0%;
     display: flex;
     flex-direction: column;
     gap: 6px;
     min-height: 0;
-    overflow: hidden;
+    overflow: visible;
 }
 
-/* Set Pieces (left col bottom): flex:1 fills remaining column height; logo-slot occupies
- * the freed dark area at the bottom as a static visual placeholder. */
-.ex-cat--logo-host {
-    flex: 1;
-}
-
-.ex-logo-slot {
-    flex-shrink: 0;
-    height: 96px;
-    border-top: 1px solid rgba(255,255,255,0.06);
-    margin-top: 0;
-}
-
-/* Category cell */
+/* Category cell — no overflow clipping on content (all 44 skills must be visible) */
 .ex-cat {
     background: var(--ex-cat-bg);
     border: 1px solid rgba(255,255,255,0.10);
@@ -384,8 +410,6 @@ html, body {
     padding: 8px 10px;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
-    min-height: 0;
 }
 .ex-cat-name {
     flex-shrink: 0;
@@ -402,18 +426,15 @@ html, body {
     text-overflow: ellipsis;
 }
 
-/* Skill rows container */
+/* Skill rows container — visible so rows are never clipped */
 .ex-skill-rows {
-    flex: 1;
     display: flex;
     flex-direction: column;
     gap: 2px;
-    overflow: hidden;
 }
 
-/* Individual skill row — FIX_ROW_H = 24px (v3 fixed-rhythm model).
- * flex: none + min-height: 24px decouples row height from grid/container geometry.
- * Every category has identical row heights regardless of skill count. */
+/* Individual skill row — FIX_ROW_H = 24px (fixed-rhythm model).
+ * flex: none + min-height: 24px decouples row height from container geometry. */
 .ex-row {
     flex: none;
     min-height: 24px;
@@ -467,25 +488,61 @@ html, body {
     line-height: 1;
 }
 
-/* Shared sponsor slot: full-width row below both skill columns.
- * flex-shrink:0 + margin-top:6px reserves 70px at the bottom of .ex-skills.
- * Not absolute, not in-cell — clean flex-sibling in .ex-skills flow. */
-.ex-sponsor-slot {
-    flex-shrink: 0;
-    height: 70px;
-    margin-top: 6px;
+/* ── POSITION LANDSCAPE PANEL ───────────────────────────────────────────────────────────────────────────
+   2nd flex child of .ex-col-right (below .ex-col-right-skills).
+   NOT .ex-cat → existing cat fade-slide animation never fires here.
+   v8: SVG viewBox "0 0 105 68" (real pitch), preserveAspectRatio="xMidYMid meet".
+   Panel ~242px tall (76px gained by moving sponsor to hero).
+   Background #1a5c2a — blends with pitch green in letterbox areas.
+   ─────────────────────────────────────────────────────────────────────────────────────── */
+
+/* Nested Col 2+3 container — takes 2/3 of skill-cats width */
+.ex-col-right {
+    flex: 2 2 0%;
     display: flex;
-    align-items: center;
-    justify-content: center;
-    border-top: 1px solid rgba(255,255,255,0.10);
+    flex-direction: column;
+    gap: 6px;
+    min-height: 0;
+    overflow: visible;
+}
+/* Top horizontal skill row inside ex-col-right */
+.ex-col-right-skills {
+    display: flex;
+    flex-direction: row;
+    gap: 6px;
+    flex-shrink: 0;
+}
+/* Landscape panel: takes remaining height (~165px) */
+.ex-pos-panel-landscape {
+    flex: 1;
+    background: #1a5c2a;
+    border: 1px solid rgba(255,255,255,0.10);
+    border-radius: 12px;
+    overflow: hidden;
+    min-height: 60px;
+}
+/* SVG fills entire landscape panel */
+.ex-pos-svg-landscape {
+    width: 100%;
+    height: 100%;
+    display: block;
 }
 
-/* Sponsor logo image: contained, alpha preserved, never overflows slot. */
-.ex-sponsor-slot-img {
-    max-height: 48px;
-    max-width: 70%;
+/* Sponsor / logo in hero layer (v8) — 4th flex child of .ex-profile-col.
+ * Appears only when sponsor_logo_url or app_logo_url is provided.
+ * Gated by {% if %} — no layout break when absent. */
+.ex-hero-sponsor {
+    display: flex;
+    align-items: center;
+    padding-top: 4px;
+    border-top: 1px solid rgba(255,255,255,0.06);
+}
+.ex-hero-sponsor-img {
+    max-height: 28px;
+    max-width: 55%;
     object-fit: contain;
     display: block;
+    opacity: 0.65;
 }
 </style>
 
@@ -505,7 +562,8 @@ html, body {
 .ex-ovr-num  { animation: ex-ovr-in 0.5s cubic-bezier(.34,1.56,.64,1) forwards; }
 .ex-tier-badge { opacity: 0; animation: ex-ovr-in 0.4s 0.4s ease-out forwards; }
 
-/* Skill bar fill: animate from width 0 → actual value (staggered per row) */
+/* Skill bar fill: animate from width 0 → actual value (staggered per row).
+ * Delays cover up to 19 rows (Outfield column, the longest). */
 @keyframes ex-bar-in {
     from { width: 0%; }
 }
@@ -521,8 +579,18 @@ html, body {
 .ex-row:nth-child(9)  .ex-bar-fill { animation-delay: 0.70s; }
 .ex-row:nth-child(10) .ex-bar-fill { animation-delay: 0.75s; }
 .ex-row:nth-child(11) .ex-bar-fill { animation-delay: 0.80s; }
+.ex-row:nth-child(12) .ex-bar-fill { animation-delay: 0.84s; }
+.ex-row:nth-child(13) .ex-bar-fill { animation-delay: 0.88s; }
+.ex-row:nth-child(14) .ex-bar-fill { animation-delay: 0.92s; }
+.ex-row:nth-child(15) .ex-bar-fill { animation-delay: 0.96s; }
+.ex-row:nth-child(16) .ex-bar-fill { animation-delay: 1.00s; }
+.ex-row:nth-child(17) .ex-bar-fill { animation-delay: 1.04s; }
+.ex-row:nth-child(18) .ex-bar-fill { animation-delay: 1.08s; }
+.ex-row:nth-child(19) .ex-bar-fill { animation-delay: 1.12s; }
 
-/* Category cells: slide up + fade in, staggered by grid position */
+/* Category cells: slide up + fade in, staggered by position within column.
+ * nth-child is parent-relative (per .ex-skill-col), so delays apply uniformly
+ * to all columns' first/second category. */
 @keyframes ex-cat-in {
     from { opacity: 0; transform: translateY(12px); }
     to   { opacity: 1; transform: translateY(0); }
@@ -530,8 +598,11 @@ html, body {
 .ex-cat { opacity: 0; animation: ex-cat-in 0.4s ease-out forwards; }
 .ex-cat:nth-child(1) { animation-delay: 0.15s; }
 .ex-cat:nth-child(2) { animation-delay: 0.25s; }
-.ex-cat:nth-child(3) { animation-delay: 0.20s; }
-.ex-cat:nth-child(4) { animation-delay: 0.30s; }
+
+/* Landscape position panel: self-contained fade-in, independent of skill stagger chain.
+ * Uses the same ex-cat-in keyframe already defined above.
+ * Delay 0.35s: appears after category reveals, does not shift bar timing. */
+.ex-pos-panel-landscape { opacity: 0; animation: ex-cat-in 0.4s 0.35s ease-out forwards; }
 
 /* Hero panel: subtle ambient glow pulse (continuous loop) */
 @keyframes ex-hero-glow {
@@ -563,8 +634,16 @@ html, body {
             </div>
             {% endif %}
             <div class="ex-photo-fade"></div>
-            {% if player.position and player.position != "Unknown" %}
-            <div class="ex-pos-badge" style="background: {{ pos_color }};">{{ player.position }}</div>
+            {% set _pos_label = primary_pos_label if primary_pos_label is defined and primary_pos_label else player.position %}
+            {% if _pos_label and _pos_label != "Unknown" %}
+            <div class="ex-pos-badge" style="background: {{ pos_color }};">{{ _pos_label }}</div>
+            {% endif %}
+            {% if secondary_pos_labels is defined and secondary_pos_labels %}
+            <div class="ex-sec-pos-chips">
+                {% for sp in secondary_pos_labels[:3] %}
+                <span class="ex-sec-pos-chip">{{ sp }}</span>
+                {% endfor %}
+            </div>
             {% endif %}
         </div>
 
@@ -675,6 +754,13 @@ html, body {
                 </div>
             </div>
 
+            {% if sponsor_logo_url or app_logo_url %}
+            <div class="ex-hero-sponsor">
+                <img src="{{ sponsor_logo_url or app_logo_url }}" alt="" class="ex-hero-sponsor-img"
+                     onerror="this.style.display='none'">
+            </div>
+            {% endif %}
+
         </div>
 
         <!-- OVR watermark -->
@@ -682,62 +768,22 @@ html, body {
 
     </div>
 
-    <!-- ── SKILLS ─────────────────────────────────────────────────────────────
-         2-column flex layout (v4):
-         Left col:  [0] Outfield (fixed) · [1] Set Pieces (flex:1, fills column)
-         Right col: [2] Mental (fixed)   · [3] Physical Fitness (natural, directly below)
-         Sponsor slot: shared full-width row below both columns.
-         ─────────────────────────────────────────────────────────────────── -->
+    <!-- ── SKILLS ───────────────────────────────────────────────────────────────────────────────────────
+         Nested 3-column model (v7):
+         Col 1: [0] Outfield (19 skills)
+         .ex-col-right:
+           .ex-col-right-skills: [2] Mental (14) | [1]+[3] Set Pieces+Physical
+           .ex-pos-panel-landscape: full-width landscape pitch SVG (v8: 242px tall)
+         Sponsor slot: moved to hero layer (v8) — skills zone fully freed.
+         ─────────────────────────────────────────────────────────────────────── -->
     {% if skill_categories %}
     <div class="ex-skills">
         <div class="ex-skills-title">Football Skills — {{ overall | round(0) | int }} OVR</div>
         <div class="ex-skill-cats">
 
-            <!-- Left column: Outfield + Set Pieces -->
+            <!-- Col 1: Outfield (19 skills) -->
             <div class="ex-skill-col">
-                {% for cat in [skill_categories[0], skill_categories[1]] %}
-                <div class="ex-cat{% if loop.last %} ex-cat--logo-host{% endif %}">
-                    <div class="ex-cat-name">{{ cat.emoji }} {{ cat.name_en }}</div>
-                    <div class="ex-skill-rows">
-                        {% for skill in cat.skills %}
-                        {% set sdata = player.skills.get(skill.key, {}) %}
-                        {% set sval  = sdata.get('current_level', 50) | round(0) | int %}
-                        {% set fill  = [sval, 100] | min %}
-                        {% set delta = last_skill_delta.get(skill.key, 0) %}
-                        {% if delta > 0 %}
-                            {% set bar_clr  = '#48bb78' %}
-                            {% set val_clr  = '#48bb78' %}
-                            {% set trend    = '↑' %}
-                            {% set trend_vis = 'visible' %}
-                        {% elif delta < 0 %}
-                            {% set bar_clr  = '#fc8181' %}
-                            {% set val_clr  = '#fc8181' %}
-                            {% set trend    = '↓' %}
-                            {% set trend_vis = 'visible' %}
-                        {% else %}
-                            {% set bar_clr  = 'rgba(255,255,255,0.20)' %}
-                            {% set val_clr  = 'rgba(255,255,255,0.85)' %}
-                            {% set trend    = '↑' %}
-                            {% set trend_vis = 'hidden' %}
-                        {% endif %}
-                        <div class="ex-row">
-                            <span class="ex-sname">{{ skill.name_en }}</span>
-                            <div class="ex-bar-bg">
-                                <div class="ex-bar-fill" style="width:{{ fill }}%; background:{{ bar_clr }};"></div>
-                            </div>
-                            <span class="ex-sval" style="color:{{ val_clr }};">{{ sval }}</span>
-                            <span class="ex-trend" style="color:{{ bar_clr }}; visibility:{{ trend_vis }};">{{ trend }}</span>
-                        </div>
-                        {% endfor %}
-                    </div>
-                    {% if loop.last %}<div class="ex-logo-slot"></div>{% endif %}
-                </div>
-                {% endfor %}
-            </div>
-
-            <!-- Right column: Mental + Physical Fitness -->
-            <div class="ex-skill-col">
-                {% for cat in [skill_categories[2], skill_categories[3]] %}
+                {% set cat = skill_categories[0] %}
                 <div class="ex-cat">
                     <div class="ex-cat-name">{{ cat.emoji }} {{ cat.name_en }}</div>
                     <div class="ex-skill-rows">
@@ -773,19 +819,168 @@ html, body {
                         {% endfor %}
                     </div>
                 </div>
-                {% endfor %}
+            </div>
+
+            <!-- Nested Col 2+3: Mental | Set Pieces+Physical side by side (top),
+                 then landscape position panel below spanning full width. -->
+            <div class="ex-col-right">
+                <div class="ex-col-right-skills">
+
+                    <!-- Mental (14 skills) -->
+                    <div class="ex-skill-col">
+                        {% set cat = skill_categories[2] %}
+                        <div class="ex-cat">
+                            <div class="ex-cat-name">{{ cat.emoji }} {{ cat.name_en }}</div>
+                            <div class="ex-skill-rows">
+                                {% for skill in cat.skills %}
+                                {% set sdata = player.skills.get(skill.key, {}) %}
+                                {% set sval  = sdata.get('current_level', 50) | round(0) | int %}
+                                {% set fill  = [sval, 100] | min %}
+                                {% set delta = last_skill_delta.get(skill.key, 0) %}
+                                {% if delta > 0 %}
+                                    {% set bar_clr  = '#48bb78' %}
+                                    {% set val_clr  = '#48bb78' %}
+                                    {% set trend    = '↑' %}
+                                    {% set trend_vis = 'visible' %}
+                                {% elif delta < 0 %}
+                                    {% set bar_clr  = '#fc8181' %}
+                                    {% set val_clr  = '#fc8181' %}
+                                    {% set trend    = '↓' %}
+                                    {% set trend_vis = 'visible' %}
+                                {% else %}
+                                    {% set bar_clr  = 'rgba(255,255,255,0.20)' %}
+                                    {% set val_clr  = 'rgba(255,255,255,0.85)' %}
+                                    {% set trend    = '↑' %}
+                                    {% set trend_vis = 'hidden' %}
+                                {% endif %}
+                                <div class="ex-row">
+                                    <span class="ex-sname">{{ skill.name_en }}</span>
+                                    <div class="ex-bar-bg">
+                                        <div class="ex-bar-fill" style="width:{{ fill }}%; background:{{ bar_clr }};"></div>
+                                    </div>
+                                    <span class="ex-sval" style="color:{{ val_clr }};">{{ sval }}</span>
+                                    <span class="ex-trend" style="color:{{ bar_clr }}; visibility:{{ trend_vis }};">{{ trend }}</span>
+                                </div>
+                                {% endfor %}
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Set Pieces (3 skills) + Physical (8 skills) -->
+                    <div class="ex-skill-col">
+                        {% for cat in [skill_categories[1], skill_categories[3]] %}
+                        <div class="ex-cat">
+                            <div class="ex-cat-name">{{ cat.emoji }} {{ cat.name_en }}</div>
+                            <div class="ex-skill-rows">
+                                {% for skill in cat.skills %}
+                                {% set sdata = player.skills.get(skill.key, {}) %}
+                                {% set sval  = sdata.get('current_level', 50) | round(0) | int %}
+                                {% set fill  = [sval, 100] | min %}
+                                {% set delta = last_skill_delta.get(skill.key, 0) %}
+                                {% if delta > 0 %}
+                                    {% set bar_clr  = '#48bb78' %}
+                                    {% set val_clr  = '#48bb78' %}
+                                    {% set trend    = '↑' %}
+                                    {% set trend_vis = 'visible' %}
+                                {% elif delta < 0 %}
+                                    {% set bar_clr  = '#fc8181' %}
+                                    {% set val_clr  = '#fc8181' %}
+                                    {% set trend    = '↓' %}
+                                    {% set trend_vis = 'visible' %}
+                                {% else %}
+                                    {% set bar_clr  = 'rgba(255,255,255,0.20)' %}
+                                    {% set val_clr  = 'rgba(255,255,255,0.85)' %}
+                                    {% set trend    = '↑' %}
+                                    {% set trend_vis = 'hidden' %}
+                                {% endif %}
+                                <div class="ex-row">
+                                    <span class="ex-sname">{{ skill.name_en }}</span>
+                                    <div class="ex-bar-bg">
+                                        <div class="ex-bar-fill" style="width:{{ fill }}%; background:{{ bar_clr }};"></div>
+                                    </div>
+                                    <span class="ex-sval" style="color:{{ val_clr }};">{{ sval }}</span>
+                                    <span class="ex-trend" style="color:{{ bar_clr }}; visibility:{{ trend_vis }};">{{ trend }}</span>
+                                </div>
+                                {% endfor %}
+                            </div>
+                        </div>
+                        {% endfor %}
+                    </div>
+
+                </div>
+
+                <!-- Landscape position panel: full width (~693px) below skill rows.
+                     Coordinate transform: cx = node.x * 105, cy = node.y * 68
+                     (GK at left x≈0.02, ST at right x≈0.88; y=0 top, y=1 bottom) -->
+                {% if position_nodes %}
+                <div class="ex-pos-panel-landscape">
+                    <svg class="ex-pos-svg-landscape" viewBox="0 0 105 68"
+                         xmlns="http://www.w3.org/2000/svg" aria-label="Position map"
+                         preserveAspectRatio="xMidYMid meet">
+                        <!-- Pitch background (105m × 68m real geometry) -->
+                        <rect width="105" height="68" fill="#1a5c2a"/>
+                        <!-- Field border -->
+                        <rect x="0.5" y="0.5" width="104" height="67"
+                              fill="none" stroke="rgba(255,255,255,0.30)" stroke-width="0.5"/>
+                        <!-- Center line (vertical at x=52.5) -->
+                        <line x1="52.5" y1="0" x2="52.5" y2="68"
+                              stroke="rgba(255,255,255,0.22)" stroke-width="0.4"/>
+                        <!-- Center circle (r=9.15m) -->
+                        <circle cx="52.5" cy="34" r="9.15"
+                                fill="none" stroke="rgba(255,255,255,0.22)" stroke-width="0.4"/>
+                        <!-- Center spot -->
+                        <circle cx="52.5" cy="34" r="0.6" fill="rgba(255,255,255,0.40)"/>
+                        <!-- GK penalty area (16.5m deep × 40.32m wide) -->
+                        <rect x="0" y="13.84" width="16.5" height="40.32"
+                              fill="none" stroke="rgba(255,255,255,0.20)" stroke-width="0.4"/>
+                        <!-- ST penalty area -->
+                        <rect x="88.5" y="13.84" width="16.5" height="40.32"
+                              fill="none" stroke="rgba(255,255,255,0.20)" stroke-width="0.4"/>
+                        <!-- GK 6-yard box (5.5m deep × 18.32m wide) -->
+                        <rect x="0" y="24.84" width="5.5" height="18.32"
+                              fill="none" stroke="rgba(255,255,255,0.14)" stroke-width="0.3"/>
+                        <!-- ST 6-yard box -->
+                        <rect x="99.5" y="24.84" width="5.5" height="18.32"
+                              fill="none" stroke="rgba(255,255,255,0.14)" stroke-width="0.3"/>
+                        <!-- Penalty spots (11m from goal line) -->
+                        <circle cx="11" cy="34" r="0.5" fill="rgba(255,255,255,0.40)"/>
+                        <circle cx="94" cy="34" r="0.5" fill="rgba(255,255,255,0.40)"/>
+
+                        <!-- Pass 1: inactive nodes (very faint) -->
+                        {% for node in position_nodes %}
+                        {% if not node.is_selected and not node.is_primary %}
+                        <circle cx="{{ (node.x * 105) | round(1) }}" cy="{{ (node.y * 68) | round(1) }}"
+                                r="0.8" fill="rgba(255,255,255,0.12)"/>
+                        {% endif %}
+                        {% endfor %}
+
+                        <!-- Pass 2: secondary selected positions -->
+                        {% for node in position_nodes %}
+                        {% if node.is_selected and not node.is_primary %}
+                        <circle cx="{{ (node.x * 105) | round(1) }}" cy="{{ (node.y * 68) | round(1) }}"
+                                r="1.4" fill="rgba(255,255,255,0.68)"/>
+                        <circle cx="{{ (node.x * 105) | round(1) }}" cy="{{ (node.y * 68) | round(1) }}"
+                                r="2.0" fill="none" stroke="rgba(255,255,255,0.35)" stroke-width="0.4"/>
+                        {% endif %}
+                        {% endfor %}
+
+                        <!-- Pass 3: primary position — gold, topmost -->
+                        {% for node in position_nodes %}
+                        {% if node.is_primary %}
+                        <circle cx="{{ (node.x * 105) | round(1) }}" cy="{{ (node.y * 68) | round(1) }}"
+                                r="1.8" fill="#ECC94B" opacity="0.95"/>
+                        <circle cx="{{ (node.x * 105) | round(1) }}" cy="{{ (node.y * 68) | round(1) }}"
+                                r="2.6" fill="none" stroke="#ECC94B" stroke-width="0.5" opacity="0.45"/>
+                        {% endif %}
+                        {% endfor %}
+                    </svg>
+                </div>
+                {% endif %}
+
             </div>
 
         </div>
-        <!-- Sponsor slot: shared zone below both columns, not in-cell -->
-        <div class="ex-sponsor-slot">
-            {% if sponsor_logo_url %}
-            <img src="{{ sponsor_logo_url }}" alt="" class="ex-sponsor-slot-img"
-                 onerror="this.style.display='none'">
-            {% elif app_logo_url %}
-            <img src="{{ app_logo_url }}" alt="LFA" class="ex-sponsor-slot-img">
-            {% endif %}
-        </div>
+
     </div>
     {% endif %}
 

--- a/app/templates/public/export/square/fifa.html
+++ b/app/templates/public/export/square/fifa.html
@@ -32,7 +32,7 @@
  *   svg.ex-pos-svg-landscape (flex:1, bg:#1a5c2a): viewBox "0 0 105 68",
  *     preserveAspectRatio="xMidYMid meet" — pitch aránytartó, letterbox seamless.
  *   No .ex-col-right, no .ex-col-right-skills wrappers.
- *   Gated: {% if position_nodes %} — graceful when position not set.
+ *   Jinja2-gated by position_nodes — graceful when position not set.
  *
  * Photo column (v9, unchanged):
  *   Clean portrait — no position badges. Position info in panel only.

--- a/app/templates/public/export/square/fifa.html
+++ b/app/templates/public/export/square/fifa.html
@@ -730,6 +730,8 @@ html, body {
             {% if sponsor_logo_url %}
             <img src="{{ sponsor_logo_url }}" alt="" class="ex-sponsor-slot-img"
                  onerror="this.style.display='none'">
+            {% elif app_logo_url %}
+            <img src="{{ app_logo_url }}" alt="LFA" class="ex-sponsor-slot-img">
             {% endif %}
         </div>
     </div>

--- a/app/templates/public/export/square/fifa.html
+++ b/app/templates/public/export/square/fifa.html
@@ -26,21 +26,25 @@
  *   All 44 skills visible without overflow clipping.
  *   FIX_ROW_H = 24px: .ex-row { flex: none; min-height: 24px }
  *
- * Landscape position panel (v7):
+ * Landscape position panel (v9):
  *   Placed as 2nd flex child of .ex-col-right (below .ex-col-right-skills).
  *   Class: .ex-pos-panel-landscape (NOT .ex-cat — immune to cat animation).
+ *   flex-row: .ex-pos-info (180px) | svg.ex-pos-svg-landscape (flex:1).
+ *   Info column: panel title · Primary Position label+name (gold) · Secondary chips.
+ *   No legend — node visual encoding (gold/white/faint) is self-explanatory.
  *   SVG: viewBox "0 0 105 68" (real 105m×68m pitch geometry).
- *   preserveAspectRatio="xMidYMid meet" — undistorted, pitch green letterbox sides.
+ *   preserveAspectRatio="xMidYMid meet" — undistorted render.
  *   Coordinate transform: cx = node.x × 105, cy = node.y × 68 (GK left, ST right).
- *   Panel bg #1a5c2a blends with pitch green — seamless letterbox effect.
- *   No text labels — position shown in hero photo badge.
  *   Gated: "if position_nodes" — graceful empty state when position not set.
  *   Animation: self-contained fade-in (animated_mode only), no skill stagger impact.
  *
- * Sponsor / logo (v8):
- *   Moved to hero layer: .ex-hero-sponsor in .ex-profile-col (4th flex child).
+ * Sponsor / logo (v8, unchanged in v9):
+ *   In hero layer: .ex-hero-sponsor in .ex-profile-col (4th flex child).
  *   Gated: "if sponsor_logo_url or app_logo_url" — no layout break when absent.
- *   Skills zone gains 76px → .ex-pos-panel-landscape ~242px tall (was ~166px).
+ *
+ * Photo column (v9):
+ *   Clean portrait block — no position badges, no secondary chips.
+ *   All position info lives exclusively in the Position Map panel.
  *
  * Typography scale (% of C_H=1080):
  *   OVR 96px (8.89%), Name 40px (3.70%), Stat 28px (2.59%), Meta 20px (1.85%)
@@ -139,39 +143,14 @@ html, body {
     pointer-events: none;
 }
 
-/* Primary position badge — overlaid top-left of photo */
-.ex-pos-badge {
-    position: absolute;
-    top: 10px;
-    left: 10px;
-    font-size: 12px;
-    font-weight: 800;
-    color: white;
-    padding: 3px 9px;
-    border-radius: 4px;
-    text-transform: uppercase;
-    letter-spacing: 0.07em;
-    z-index: 2;
-    white-space: nowrap;
-}
-
-/* Secondary position chips — stacked below primary badge */
-.ex-sec-pos-chips {
-    position: absolute;
-    top: 40px;
-    left: 10px;
-    display: flex;
-    flex-direction: column;
-    gap: 3px;
-    z-index: 2;
-}
+/* Secondary position chip — reused in Position Map panel info column */
 .ex-sec-pos-chip {
     font-size: 9px;
     font-weight: 700;
     color: rgba(255,255,255,0.75);
     padding: 2px 6px;
     border-radius: 3px;
-    background: rgba(0,0,0,0.45);
+    background: rgba(255,255,255,0.10);
     text-transform: uppercase;
     letter-spacing: 0.05em;
     white-space: nowrap;
@@ -491,9 +470,10 @@ html, body {
 /* ── POSITION LANDSCAPE PANEL ───────────────────────────────────────────────────────────────────────────
    2nd flex child of .ex-col-right (below .ex-col-right-skills).
    NOT .ex-cat → existing cat fade-slide animation never fires here.
-   v8: SVG viewBox "0 0 105 68" (real pitch), preserveAspectRatio="xMidYMid meet".
-   Panel ~242px tall (76px gained by moving sponsor to hero).
-   Background #1a5c2a — blends with pitch green in letterbox areas.
+   v9: flex-row layout — left info column + right pitch SVG.
+   Info column: panel title · primary pos name (gold) · secondary chips.
+   NO legend — node visual encoding (gold/white/faint) is self-explanatory.
+   SVG viewBox "0 0 105 68", preserveAspectRatio="xMidYMid meet" (unchanged).
    ─────────────────────────────────────────────────────────────────────────────────────── */
 
 /* Nested Col 2+3 container — takes 2/3 of skill-cats width */
@@ -512,20 +492,70 @@ html, body {
     gap: 6px;
     flex-shrink: 0;
 }
-/* Landscape panel: takes remaining height (~165px) */
+/* Landscape panel: flex-row — info column left, SVG right */
 .ex-pos-panel-landscape {
     flex: 1;
-    background: #1a5c2a;
+    background: var(--ex-cat-bg);
     border: 1px solid rgba(255,255,255,0.10);
     border-radius: 12px;
     overflow: hidden;
     min-height: 60px;
+    display: flex;
+    flex-direction: row;
 }
-/* SVG fills entire landscape panel */
+/* Info column — left of pitch SVG */
+.ex-pos-info {
+    flex: 0 0 180px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 3px;
+    padding: 10px 14px;
+    border-right: 1px solid rgba(255,255,255,0.08);
+}
+.ex-pos-panel-title {
+    font-size: 11px;
+    font-weight: 800;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: rgba(255,255,255,0.35);
+    margin-bottom: 4px;
+}
+.ex-pos-primary-label {
+    font-size: 9px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: rgba(255,255,255,0.28);
+}
+.ex-pos-primary-name {
+    font-size: 16px;
+    font-weight: 800;
+    color: #ECC94B;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    line-height: 1.15;
+    margin-bottom: 4px;
+}
+.ex-pos-secondary-label {
+    font-size: 9px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: rgba(255,255,255,0.28);
+}
+.ex-pos-secondary-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 3px;
+    margin-top: 2px;
+}
+/* SVG takes remaining width of landscape panel */
 .ex-pos-svg-landscape {
-    width: 100%;
-    height: 100%;
+    flex: 1;
+    min-width: 0;
     display: block;
+    align-self: stretch;
 }
 
 /* Sponsor / logo in hero layer (v8) — 4th flex child of .ex-profile-col.
@@ -634,17 +664,6 @@ html, body {
             </div>
             {% endif %}
             <div class="ex-photo-fade"></div>
-            {% set _pos_label = primary_pos_label if primary_pos_label is defined and primary_pos_label else player.position %}
-            {% if _pos_label and _pos_label != "Unknown" %}
-            <div class="ex-pos-badge" style="background: {{ pos_color }};">{{ _pos_label }}</div>
-            {% endif %}
-            {% if secondary_pos_labels is defined and secondary_pos_labels %}
-            <div class="ex-sec-pos-chips">
-                {% for sp in secondary_pos_labels[:3] %}
-                <span class="ex-sec-pos-chip">{{ sp }}</span>
-                {% endfor %}
-            </div>
-            {% endif %}
         </div>
 
         <!-- Profile column -->
@@ -909,11 +928,33 @@ html, body {
 
                 </div>
 
-                <!-- Landscape position panel: full width (~693px) below skill rows.
+                <!-- Landscape position panel (v9): info column (left) + pitch SVG (right).
                      Coordinate transform: cx = node.x * 105, cy = node.y * 68
                      (GK at left x≈0.02, ST at right x≈0.88; y=0 top, y=1 bottom) -->
                 {% if position_nodes %}
                 <div class="ex-pos-panel-landscape">
+
+                    <!-- Info column: title · primary pos · secondary chips (no legend) -->
+                    <div class="ex-pos-info">
+                        <div class="ex-pos-panel-title">Position Map</div>
+                        <div class="ex-pos-primary-label">Primary Position</div>
+                        <div class="ex-pos-primary-name">
+                            {%- if primary_pos_label is defined and primary_pos_label -%}
+                                {{ primary_pos_label }}
+                            {%- else -%}
+                                {{ player.position | replace("_", " ") | title }}
+                            {%- endif -%}
+                        </div>
+                        {% if secondary_pos_labels is defined and secondary_pos_labels %}
+                        <div class="ex-pos-secondary-label">Secondary Positions</div>
+                        <div class="ex-pos-secondary-chips">
+                            {% for sp in secondary_pos_labels %}
+                            <span class="ex-sec-pos-chip">{{ sp }}</span>
+                            {% endfor %}
+                        </div>
+                        {% endif %}
+                    </div>
+
                     <svg class="ex-pos-svg-landscape" viewBox="0 0 105 68"
                          xmlns="http://www.w3.org/2000/svg" aria-label="Position map"
                          preserveAspectRatio="xMidYMid meet">

--- a/app/templates/public/export/story/fifa.html
+++ b/app/templates/public/export/story/fifa.html
@@ -472,6 +472,8 @@ html, body {
         <div class="ex-sponsor-slot">
             {% if sponsor_logo_url %}
             <img class="ex-sponsor-slot-img" src="{{ sponsor_logo_url }}" alt="Sponsor">
+            {% elif app_logo_url %}
+            <img class="ex-sponsor-slot-img" src="{{ app_logo_url }}" alt="LFA">
             {% endif %}
         </div>
     </div>

--- a/app/templates/public/export/tiktok/fifa.html
+++ b/app/templates/public/export/tiktok/fifa.html
@@ -536,6 +536,8 @@ html, body {
     <div class="ex-sponsor-slot">
         {% if sponsor_logo_url %}
         <img class="ex-sponsor-slot-img" src="{{ sponsor_logo_url }}" alt="Sponsor">
+        {% elif app_logo_url %}
+        <img class="ex-sponsor-slot-img" src="{{ app_logo_url }}" alt="LFA">
         {% endif %}
     </div>
 

--- a/app/templates/public/player_card_fifa.html
+++ b/app/templates/public/player_card_fifa.html
@@ -97,8 +97,24 @@ body.export-mode .card-wrap  {
     max-width: none !important; border-radius: 0; overflow: hidden;
 }
 body.export-mode .tab-bar        { display: none !important; }
-body.export-mode .skills-section { display: block !important; }
+body.export-mode .card-body      { display: grid !important; }
 body.export-mode .events-section { display: none !important; }
+
+/* ── Default/native export: card fills width at natural height ─────────── */
+/* Used by the ?native_export=1 render path (Default platform PNG download). */
+body.native-export-mode {
+    padding: 0; margin: 0; align-items: flex-start;
+    justify-content: flex-start;
+}
+body.native-export-mode .page-brand,
+body.native-export-mode .page-logo { display: none; }
+body.native-export-mode .card-wrap {
+    width: 820px !important; height: auto !important;
+    max-width: none !important; border-radius: 0;
+}
+body.native-export-mode .tab-bar        { display: none !important; }
+body.native-export-mode .card-body      { display: grid !important; }
+body.native-export-mode .events-section { display: none !important; }
 
 /* ── Split header ─────────────────────────────────────────── */
 .fifa-header {
@@ -153,33 +169,75 @@ body.export-mode .events-section { display: none !important; }
     overflow-wrap: anywhere;
 }
 
-/* ── Skills section ───────────────────────────────────────── */
-.skills-section {
+/* ── Card body: skills (left ~60%) + position panel (right ~40%) ── */
+.card-body {
+    display: grid;
+    grid-template-columns: 3fr 2fr;
     background: var(--card-body-bg);
-    padding: 1.1rem 1.1rem;
+    min-height: 0;
+}
+.skills-panel {
+    padding: 1rem;
+    min-width: 0;
 }
 .skills-title {
     font-size: 0.63rem; font-weight: 800; text-transform: uppercase;
     letter-spacing: 0.13em; color: var(--card-text-faint);
-    margin-bottom: 0.85rem;
+    margin-bottom: 0.8rem;
 }
 .skill-cats {
     display: grid; grid-template-columns: repeat(4, 1fr);
-    gap: 0.65rem;
+    gap: 0.5rem;
 }
-.skill-cat { background: var(--card-cat-bg); border-radius: 9px; padding: 0.65rem; min-width: 0; }
+.skill-cat { background: var(--card-cat-bg); border-radius: 9px; padding: 0.6rem; min-width: 0; }
 .skill-cat-name {
     font-size: 0.58rem; font-weight: 800; text-transform: uppercase;
-    letter-spacing: 0.09em; color: var(--card-text-muted); margin-bottom: 0.45rem;
+    letter-spacing: 0.09em; color: var(--card-text-muted); margin-bottom: 0.4rem;
     white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
-.skill-row { display: flex; align-items: center; gap: 0.35rem; margin-bottom: 0.3rem; }
+.skill-row { display: flex; align-items: center; gap: 0.3rem; margin-bottom: 0.25rem; }
 .skill-row:last-child { margin-bottom: 0; }
-.skill-name { font-size: 0.62rem; color: var(--card-text-secondary); flex: 1; min-width: 0; overflow-wrap: break-word; line-height: 1.3; }
-.skill-val { font-size: 0.67rem; font-weight: 700; width: 28px; text-align: right; flex-shrink: 0; }
+/* Truncate names in the narrower 4-col split-layout context */
+.skill-name { font-size: 0.62rem; color: var(--card-text-secondary); flex: 1; min-width: 0;
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis; line-height: 1.3; }
+.skill-val { font-size: 0.67rem; font-weight: 700; width: 26px; text-align: right; flex-shrink: 0; }
 .skill-up { font-size: 0.6rem; color: #48bb78; font-weight: 900; flex-shrink: 0; line-height: 1; }
-.skill-bar-bg { flex: 0 0 22px; height: 5px; background: var(--card-bar-bg); border-radius: 3px; }
+.skill-bar-bg { flex: 0 0 18px; height: 4px; background: var(--card-bar-bg); border-radius: 3px; }
 .skill-bar-fill { height: 100%; border-radius: 2px; }
+
+/* ── Position panel (right, ~40%) ──────────────────────────────── */
+.position-panel {
+    background: var(--card-panel-bg);
+    padding: 0.85rem 0.85rem 0.75rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+    min-width: 0;
+    align-items: center;
+}
+.pos-panel-title {
+    font-size: 0.56rem; font-weight: 800; text-transform: uppercase;
+    letter-spacing: 0.13em; color: var(--card-text-faint);
+    align-self: flex-start;
+}
+.pitch-svg {
+    width: 100%; height: auto;
+    border-radius: 5px;
+    overflow: visible;
+}
+.pos-primary-label {
+    font-size: 0.72rem; font-weight: 700; color: var(--card-text-primary);
+    text-align: center; letter-spacing: 0.03em;
+}
+.pos-secondary-chips {
+    display: flex; flex-wrap: wrap; gap: 0.25rem; justify-content: center;
+}
+.pos-chip {
+    font-size: 0.56rem; font-weight: 700;
+    background: rgba(255,255,255,0.08);
+    color: var(--card-text-secondary);
+    border-radius: 99px; padding: 2px 7px;
+}
 
 /* ── Tab bar ─────────────────────────────────────────────── */
 .tab-bar {
@@ -232,7 +290,7 @@ body.export-mode .events-section { display: none !important; }
 
 /* ── Responsive ─────────────────────────────────────────────
    Breakpoints:
-   < 560px : tablet/large phone — 2-col skills, 2-col identity, smaller left
+   < 560px : tablet/large phone — stack card-body, 2-col skills, smaller left
    < 440px : phone portrait    — stack header vertically, 1-col skills
    < 340px : tiny phone        — extra compact
 ───────────────────────────────────────────────────────────── */
@@ -245,8 +303,13 @@ body.export-mode .events-section { display: none !important; }
     .fifa-right { padding: 1rem; gap: 0.6rem; }
     .fifa-name { font-size: 1.2rem; }
     .identity-grid { grid-template-columns: 1fr 1fr; }
+    /* Stack panels vertically; position panel above skills */
+    .card-body { grid-template-columns: 1fr; }
+    .position-panel { order: -1; }
+    /* In stacked layout, names can wrap again */
+    .skill-name { white-space: normal; overflow-wrap: break-word; overflow: visible; text-overflow: clip; }
     .skill-cats { grid-template-columns: 1fr 1fr; }
-    .skills-section { padding: 0.9rem; }
+    .skills-panel { padding: 0.9rem; }
 }
 @media (max-width: 440px) {
     .fifa-header { grid-template-columns: 1fr; }
@@ -279,8 +342,8 @@ body.export-mode.platform-facebook-landscape .fifa-left,
 body.export-mode.platform-og .fifa-left,
 body.export-mode.platform-facebook-landscape .fifa-right,
 body.export-mode.platform-og .fifa-right { min-height: 100%; }
-body.export-mode.platform-facebook-landscape .skills-section,
-body.export-mode.platform-og .skills-section {
+body.export-mode.platform-facebook-landscape .card-body,
+body.export-mode.platform-og .card-body {
     flex: 1; height: 100%; overflow: hidden;
 }
 body.export-mode.platform-facebook-landscape .skill-cats,
@@ -325,7 +388,7 @@ body.export-mode .skill-val     { font-size: var(--ex-font-skill); }
 body.export-mode .skill-bar-bg  { flex: 1 1 0 !important; max-width: none !important; }
 </style>
 </head>
-<body class="{% if platform_class %}{{ platform_class }}{% endif %}{% if export_mode %} export-mode{% endif %}">
+<body class="{% if platform_class %}{{ platform_class }}{% endif %}{% if native_export_mode %} native-export-mode{% elif export_mode %} export-mode{% endif %}">
 
 {% if app_logo_url %}
 <img class="page-logo" src="{{ app_logo_url }}" alt="LFA">
@@ -386,45 +449,115 @@ body.export-mode .skill-bar-bg  { flex: 1 1 0 !important; max-width: none !impor
         <button class="tab-btn"        id="btn-events" onclick="switchTab('events')">🏆 Events</button>
     </div>
 
-    <!-- Skills tab -->
-    {% if skill_categories %}
-    <div class="skills-section" id="tab-skills">
-        <div class="skills-title">Football Skills — {{ overall | round(0) | int }} OVR</div>
-        <div class="skill-cats">
-            {% for cat in skill_categories %}
-            <div class="skill-cat">
-                <div class="skill-cat-name">{{ cat.emoji }} {{ cat.name_en }}</div>
-                {% for skill in cat.skills %}
-                {% set sdata = player.skills.get(skill.key, {}) %}
-                {% set sval = sdata.get('current_level', 50) | round(1) %}
-                {% set fill_pct = [sval, 100] | min %}
-                {% set sdelta = last_skill_delta.get(skill.key, 0) %}
-                {# Color driven solely by last-tournament delta, not by level tier.
-                   Neutral = not affected by the most recent tournament. #}
-                {% if sdelta > 0 %}
-                    {% set bar_color = '#48bb78' %}
-                    {% set val_color = '#48bb78' %}
-                {% elif sdelta < 0 %}
-                    {% set bar_color = '#fc8181' %}
-                    {% set val_color = '#fc8181' %}
-                {% else %}
-                    {% set bar_color = 'var(--card-bar-neutral)' %}
-                    {% set val_color = 'var(--card-val-neutral)' %}
-                {% endif %}
-                <div class="skill-row">
-                    <span class="skill-name">{{ skill.name_en }}</span>
-                    <div class="skill-bar-bg"><div class="skill-bar-fill" style="width:{{ fill_pct }}%; background:{{ bar_color }};"></div></div>
-                    <span class="skill-val" style="color:{{ val_color }};">{{ sval }}</span>
-                    {% if sdelta > 0 %}<span class="skill-up">↑</span>
-                    {% elif sdelta < 0 %}<span class="skill-up" style="color:#fc8181;">↓</span>
-                    {% else %}<span class="skill-up" style="visibility:hidden">↑</span>{% endif %}
+    <!-- Skills tab: split layout — skills (left ~60%) + position panel (right ~40%) -->
+    <div class="card-body" id="tab-skills">
+
+        <!-- Left: skill categories -->
+        <div class="skills-panel">
+            {% if skill_categories %}
+            <div class="skills-title">Football Skills — {{ overall | round(0) | int }} OVR</div>
+            <div class="skill-cats">
+                {% for cat in skill_categories %}
+                <div class="skill-cat">
+                    <div class="skill-cat-name">{{ cat.emoji }} {{ cat.name_en }}</div>
+                    {% for skill in cat.skills %}
+                    {% set sdata = player.skills.get(skill.key, {}) %}
+                    {% set sval = sdata.get('current_level', 50) | round(1) %}
+                    {% set fill_pct = [sval, 100] | min %}
+                    {% set sdelta = last_skill_delta.get(skill.key, 0) %}
+                    {# Color driven solely by last-tournament delta, not by level tier. #}
+                    {% if sdelta > 0 %}
+                        {% set bar_color = '#48bb78' %}
+                        {% set val_color = '#48bb78' %}
+                    {% elif sdelta < 0 %}
+                        {% set bar_color = '#fc8181' %}
+                        {% set val_color = '#fc8181' %}
+                    {% else %}
+                        {% set bar_color = 'var(--card-bar-neutral)' %}
+                        {% set val_color = 'var(--card-val-neutral)' %}
+                    {% endif %}
+                    <div class="skill-row">
+                        <span class="skill-name" title="{{ skill.name_en }}">{{ skill.name_en }}</span>
+                        <div class="skill-bar-bg"><div class="skill-bar-fill" style="width:{{ fill_pct }}%; background:{{ bar_color }};"></div></div>
+                        <span class="skill-val" style="color:{{ val_color }};">{{ sval }}</span>
+                        {% if sdelta > 0 %}<span class="skill-up">↑</span>
+                        {% elif sdelta < 0 %}<span class="skill-up" style="color:#fc8181;">↓</span>
+                        {% else %}<span class="skill-up" style="visibility:hidden">↑</span>{% endif %}
+                    </div>
+                    {% endfor %}
                 </div>
                 {% endfor %}
             </div>
-            {% endfor %}
+            {% endif %}
         </div>
+
+        <!-- Right: position mini-pitch -->
+        <div class="position-panel">
+            <div class="pos-panel-title">Position</div>
+            <svg class="pitch-svg" viewBox="0 0 100 65" xmlns="http://www.w3.org/2000/svg" aria-label="Pitch position map">
+                <!-- Pitch background -->
+                <rect width="100" height="65" fill="#1a5c2a"/>
+                <!-- Field border -->
+                <rect x="0.5" y="0.5" width="99" height="64" fill="none" stroke="rgba(255,255,255,0.28)" stroke-width="0.45"/>
+                <!-- Center line -->
+                <line x1="50" y1="0" x2="50" y2="65" stroke="rgba(255,255,255,0.22)" stroke-width="0.4"/>
+                <!-- Center circle -->
+                <circle cx="50" cy="32.5" r="9" fill="none" stroke="rgba(255,255,255,0.22)" stroke-width="0.4"/>
+                <circle cx="50" cy="32.5" r="0.8" fill="rgba(255,255,255,0.35)"/>
+                <!-- Left penalty area -->
+                <rect x="0" y="16" width="17" height="33" fill="none" stroke="rgba(255,255,255,0.2)" stroke-width="0.35"/>
+                <!-- Right penalty area -->
+                <rect x="83" y="16" width="17" height="33" fill="none" stroke="rgba(255,255,255,0.2)" stroke-width="0.35"/>
+                <!-- Left 6-yard box -->
+                <rect x="0" y="24" width="6" height="17" fill="none" stroke="rgba(255,255,255,0.14)" stroke-width="0.3"/>
+                <!-- Right 6-yard box -->
+                <rect x="94" y="24" width="6" height="17" fill="none" stroke="rgba(255,255,255,0.14)" stroke-width="0.3"/>
+                <!-- Direction labels -->
+                <text x="2" y="4.5" font-size="3" fill="rgba(255,255,255,0.22)" font-family="sans-serif" font-weight="700">GK</text>
+                <text x="91" y="4.5" font-size="3" fill="rgba(255,255,255,0.22)" font-family="sans-serif" font-weight="700">ST</text>
+                <!-- Position nodes — inactive (faint role dots) -->
+                {% for node in position_nodes %}
+                {% if not node.is_selected and not node.is_primary %}
+                <circle cx="{{ (node.x * 100) | round(1) }}" cy="{{ (node.y * 65) | round(1) }}"
+                        r="1.8" fill="rgba(255,255,255,0.13)"/>
+                {% endif %}
+                {% endfor %}
+                <!-- Secondary selected positions -->
+                {% for node in position_nodes %}
+                {% if node.is_selected and not node.is_primary %}
+                <circle cx="{{ (node.x * 100) | round(1) }}" cy="{{ (node.y * 65) | round(1) }}"
+                        r="3.2" fill="rgba(255,255,255,0.70)"/>
+                <circle cx="{{ (node.x * 100) | round(1) }}" cy="{{ (node.y * 65) | round(1) }}"
+                        r="4.6" fill="none" stroke="rgba(255,255,255,0.38)" stroke-width="0.65"/>
+                {% endif %}
+                {% endfor %}
+                <!-- Primary position — gold, rendered last (topmost) -->
+                {% for node in position_nodes %}
+                {% if node.is_primary %}
+                <circle cx="{{ (node.x * 100) | round(1) }}" cy="{{ (node.y * 65) | round(1) }}"
+                        r="4.2" fill="#ECC94B" opacity="0.95"/>
+                <circle cx="{{ (node.x * 100) | round(1) }}" cy="{{ (node.y * 65) | round(1) }}"
+                        r="6" fill="none" stroke="#ECC94B" stroke-width="0.85" opacity="0.45"/>
+                {% endif %}
+                {% endfor %}
+            </svg>
+            <!-- Primary position name -->
+            {% if player.position and player.position != "Unknown" %}
+            <div class="pos-primary-label">
+                ★ {{ player.position | replace('_', ' ') | title }}
+            </div>
+            {% endif %}
+            <!-- Secondary positions -->
+            {% if player_positions and player_positions | length > 1 %}
+            <div class="pos-secondary-chips">
+                {% for pos in player_positions[1:] %}
+                <span class="pos-chip">{{ pos | replace('_', ' ') | title }}</span>
+                {% endfor %}
+            </div>
+            {% endif %}
+        </div>
+
     </div>
-    {% endif %}
 
     <!-- Events tab -->
     <div class="events-section" id="tab-events" style="display:none;">

--- a/app/templates/public/player_card_fifa.html
+++ b/app/templates/public/player_card_fifa.html
@@ -139,15 +139,23 @@ body.native-export-mode .events-section { display: none !important; }
     letter-spacing: 0.12em; padding: 3px 10px; border-radius: 99px; color: white;
     white-space: nowrap;
 }
-.card-logo {
-    height: 22px; width: auto; opacity: 0.75;
-    filter: brightness(0) invert(1); flex-shrink: 0;
-}
 .fifa-right {
     background: var(--card-right-bg);
     padding: 1.25rem 1.25rem 1rem;
-    display: flex; flex-direction: column; gap: 0.7rem;
+    display: flex; flex-direction: column; gap: 0;
     min-width: 0; /* prevent grid blowout */
+    position: relative; overflow: hidden;
+}
+.card-watermark {
+    position: absolute; right: 12px; bottom: 10px;
+    max-width: 88px; max-height: 48px;
+    object-fit: contain; opacity: 0.13;
+    pointer-events: none; z-index: 0;
+}
+.fifa-right-body {
+    position: relative; z-index: 1;
+    display: flex; flex-direction: column; gap: 0.7rem;
+    flex: 1; min-width: 0;
 }
 .fifa-name {
     font-size: 1.45rem; font-weight: 800; color: var(--card-right-text); line-height: 1.1;
@@ -394,9 +402,6 @@ body.export-mode .skill-bar-bg  { flex: 1 1 0 !important; max-width: none !impor
     <!-- Split header -->
     <div class="fifa-header">
         <div class="fifa-left">
-            {% if app_logo_url %}
-            <img class="card-logo" src="{{ app_logo_url }}" alt="LFA">
-            {% endif %}
             {% if photo_url %}
             <img class="fifa-avatar" src="{{ photo_url }}" alt="{{ initials }}"
                  style="background: {{ avatar_bg }}; object-fit: cover;">
@@ -407,6 +412,10 @@ body.export-mode .skill-bar-bg  { flex: 1 1 0 !important; max-width: none !impor
             <span class="fifa-tier" style="background: {{ tier_color }};">{{ tier_label }}</span>
         </div>
         <div class="fifa-right">
+            {% if sponsor_logo_url %}
+            <img class="card-watermark" src="{{ sponsor_logo_url }}" alt="">
+            {% endif %}
+            <div class="fifa-right-body">
             <div>
                 <h2 class="fifa-name">{{ player.name }}</h2>
                 {% if player.position and player.position != "Unknown" %}
@@ -448,6 +457,7 @@ body.export-mode .skill-bar-bg  { flex: 1 1 0 !important; max-width: none !impor
                 {% endfor %}
             </div>
             {% endif %}
+            </div>{# /fifa-right-body #}
         </div>
     </div>
 

--- a/app/templates/public/player_card_fifa.html
+++ b/app/templates/public/player_card_fifa.html
@@ -186,9 +186,16 @@ body.native-export-mode .events-section { display: none !important; }
     margin-bottom: 0.8rem;
 }
 .skill-cats {
-    display: grid; grid-template-columns: repeat(4, 1fr);
+    display: grid; grid-template-columns: repeat(2, 1fr);
     gap: 0.5rem;
 }
+/* Visual order: Outfield (DOM 1st) → top-left,   Mental (DOM 3rd) → top-right,
+   Set Pieces (DOM 2nd) → bottom-left, Physical Fitness (DOM 4th) → bottom-right.
+   Long columns pair together (top row), short columns pair together (bottom row). */
+.skill-cat:nth-child(1) { order: 1; }
+.skill-cat:nth-child(2) { order: 3; }
+.skill-cat:nth-child(3) { order: 2; }
+.skill-cat:nth-child(4) { order: 4; }
 .skill-cat { background: var(--card-cat-bg); border-radius: 9px; padding: 0.6rem; min-width: 0; }
 .skill-cat-name {
     font-size: 0.58rem; font-weight: 800; text-transform: uppercase;
@@ -310,6 +317,8 @@ body.native-export-mode .events-section { display: none !important; }
     .skill-name { white-space: normal; overflow-wrap: break-word; overflow: visible; text-overflow: clip; }
     .skill-cats { grid-template-columns: 1fr 1fr; }
     .skills-panel { padding: 0.9rem; }
+    /* Portrait pitch: cap height when stacked full-width (landscape would be ~260px tall at card width) */
+    .pitch-svg { max-height: 200px; width: auto; display: block; margin: 0 auto; }
 }
 @media (max-width: 440px) {
     .fifa-header { grid-template-columns: 1fr; }
@@ -494,64 +503,80 @@ body.export-mode .skill-bar-bg  { flex: 1 1 0 !important; max-width: none !impor
         <!-- Right: position mini-pitch -->
         <div class="position-panel">
             <div class="pos-panel-title">Position</div>
-            <svg class="pitch-svg" viewBox="0 0 100 65" xmlns="http://www.w3.org/2000/svg" aria-label="Pitch position map">
+            <svg class="pitch-svg" viewBox="0 0 65 100" xmlns="http://www.w3.org/2000/svg" aria-label="Pitch position map">
+                <!-- Portrait pitch: ST at top, GK at bottom.
+                     Coordinate transform from landscape node data (x=longitudinal 0→1 GK→ST, y=lateral 0→1):
+                       cx_svg = node.y × 65   (lateral → horizontal)
+                       cy_svg = (1 − node.x) × 100   (longitudinal → vertical, inverted so GK=bottom) -->
                 <!-- Pitch background -->
-                <rect width="100" height="65" fill="#1a5c2a"/>
+                <rect width="65" height="100" fill="#1a5c2a"/>
                 <!-- Field border -->
-                <rect x="0.5" y="0.5" width="99" height="64" fill="none" stroke="rgba(255,255,255,0.28)" stroke-width="0.45"/>
-                <!-- Center line -->
-                <line x1="50" y1="0" x2="50" y2="65" stroke="rgba(255,255,255,0.22)" stroke-width="0.4"/>
+                <rect x="0.5" y="0.5" width="64" height="99" fill="none" stroke="rgba(255,255,255,0.28)" stroke-width="0.45"/>
+                <!-- Center line (horizontal) -->
+                <line x1="0" y1="50" x2="65" y2="50" stroke="rgba(255,255,255,0.22)" stroke-width="0.4"/>
                 <!-- Center circle -->
-                <circle cx="50" cy="32.5" r="9" fill="none" stroke="rgba(255,255,255,0.22)" stroke-width="0.4"/>
-                <circle cx="50" cy="32.5" r="0.8" fill="rgba(255,255,255,0.35)"/>
-                <!-- Left penalty area -->
-                <rect x="0" y="16" width="17" height="33" fill="none" stroke="rgba(255,255,255,0.2)" stroke-width="0.35"/>
-                <!-- Right penalty area -->
-                <rect x="83" y="16" width="17" height="33" fill="none" stroke="rgba(255,255,255,0.2)" stroke-width="0.35"/>
-                <!-- Left 6-yard box -->
-                <rect x="0" y="24" width="6" height="17" fill="none" stroke="rgba(255,255,255,0.14)" stroke-width="0.3"/>
-                <!-- Right 6-yard box -->
-                <rect x="94" y="24" width="6" height="17" fill="none" stroke="rgba(255,255,255,0.14)" stroke-width="0.3"/>
+                <circle cx="32.5" cy="50" r="9" fill="none" stroke="rgba(255,255,255,0.22)" stroke-width="0.4"/>
+                <circle cx="32.5" cy="50" r="0.8" fill="rgba(255,255,255,0.35)"/>
+                <!-- ST penalty area (top) -->
+                <rect x="16" y="0" width="33" height="17" fill="none" stroke="rgba(255,255,255,0.2)" stroke-width="0.35"/>
+                <!-- GK penalty area (bottom) -->
+                <rect x="16" y="83" width="33" height="17" fill="none" stroke="rgba(255,255,255,0.2)" stroke-width="0.35"/>
+                <!-- ST 6-yard box (top) -->
+                <rect x="24" y="0" width="17" height="6" fill="none" stroke="rgba(255,255,255,0.14)" stroke-width="0.3"/>
+                <!-- GK 6-yard box (bottom) -->
+                <rect x="24" y="94" width="17" height="6" fill="none" stroke="rgba(255,255,255,0.14)" stroke-width="0.3"/>
                 <!-- Direction labels -->
-                <text x="2" y="4.5" font-size="3" fill="rgba(255,255,255,0.22)" font-family="sans-serif" font-weight="700">GK</text>
-                <text x="91" y="4.5" font-size="3" fill="rgba(255,255,255,0.22)" font-family="sans-serif" font-weight="700">ST</text>
-                <!-- Position nodes — inactive (faint role dots) -->
+                <text x="32.5" y="3.5" font-size="3" fill="rgba(255,255,255,0.22)" font-family="sans-serif" font-weight="700" text-anchor="middle">ST</text>
+                <text x="32.5" y="98.5" font-size="3" fill="rgba(255,255,255,0.22)" font-family="sans-serif" font-weight="700" text-anchor="middle">GK</text>
+                <!-- Pass 1: inactive nodes (faint dots, no label) -->
                 {% for node in position_nodes %}
                 {% if not node.is_selected and not node.is_primary %}
-                <circle cx="{{ (node.x * 100) | round(1) }}" cy="{{ (node.y * 65) | round(1) }}"
+                <circle cx="{{ (node.y * 65) | round(1) }}" cy="{{ ((1 - node.x) * 100) | round(1) }}"
                         r="1.8" fill="rgba(255,255,255,0.13)"/>
                 {% endif %}
                 {% endfor %}
-                <!-- Secondary selected positions -->
+                <!-- Pass 2: secondary selected positions -->
                 {% for node in position_nodes %}
                 {% if node.is_selected and not node.is_primary %}
-                <circle cx="{{ (node.x * 100) | round(1) }}" cy="{{ (node.y * 65) | round(1) }}"
+                <circle cx="{{ (node.y * 65) | round(1) }}" cy="{{ ((1 - node.x) * 100) | round(1) }}"
                         r="3.2" fill="rgba(255,255,255,0.70)"/>
-                <circle cx="{{ (node.x * 100) | round(1) }}" cy="{{ (node.y * 65) | round(1) }}"
+                <circle cx="{{ (node.y * 65) | round(1) }}" cy="{{ ((1 - node.x) * 100) | round(1) }}"
                         r="4.6" fill="none" stroke="rgba(255,255,255,0.38)" stroke-width="0.65"/>
                 {% endif %}
                 {% endfor %}
-                <!-- Primary position — gold, rendered last (topmost) -->
+                <!-- Pass 3: primary position — gold, topmost -->
                 {% for node in position_nodes %}
                 {% if node.is_primary %}
-                <circle cx="{{ (node.x * 100) | round(1) }}" cy="{{ (node.y * 65) | round(1) }}"
+                <circle cx="{{ (node.y * 65) | round(1) }}" cy="{{ ((1 - node.x) * 100) | round(1) }}"
                         r="4.2" fill="#ECC94B" opacity="0.95"/>
-                <circle cx="{{ (node.x * 100) | round(1) }}" cy="{{ (node.y * 65) | round(1) }}"
+                <circle cx="{{ (node.y * 65) | round(1) }}" cy="{{ ((1 - node.x) * 100) | round(1) }}"
                         r="6" fill="none" stroke="#ECC94B" stroke-width="0.85" opacity="0.45"/>
                 {% endif %}
                 {% endfor %}
+                <!-- Pass 4: abbreviated labels on selected + primary nodes only -->
+                {% for node in position_nodes %}
+                {% if node.is_primary or node.is_selected %}
+                <text x="{{ (node.y * 65) | round(1) }}" y="{{ ((1 - node.x) * 100) | round(1) }}"
+                      font-size="3" font-family="sans-serif" font-weight="800"
+                      fill="rgba(0,0,0,0.72)" text-anchor="middle" dominant-baseline="middle">{{ node.label }}</text>
+                {% endif %}
+                {% endfor %}
             </svg>
-            <!-- Primary position name -->
-            {% if player.position and player.position != "Unknown" %}
-            <div class="pos-primary-label">
-                ★ {{ player.position | replace('_', ' ') | title }}
-            </div>
+            <!-- Primary position: abbreviated label · full name -->
+            {% set _prim_nodes = position_nodes | selectattr('is_primary', 'equalto', true) | list %}
+            {% set primary_node = _prim_nodes[0] if _prim_nodes else none %}
+            {% if primary_node %}
+            <div class="pos-primary-label">★ {{ primary_node.label }} · {{ primary_node.name }}</div>
+            {% elif player.position and player.position != "Unknown" %}
+            <div class="pos-primary-label">★ {{ player.position | replace('_', ' ') | title }}</div>
             {% endif %}
-            <!-- Secondary positions -->
+            <!-- Secondary positions: abbreviated -->
             {% if player_positions and player_positions | length > 1 %}
             <div class="pos-secondary-chips">
                 {% for pos in player_positions[1:] %}
-                <span class="pos-chip">{{ pos | replace('_', ' ') | title }}</span>
+                {% set _sec_nodes = position_nodes | selectattr('canonical', 'equalto', pos) | list %}
+                {% set sec_node = _sec_nodes[0] if _sec_nodes else none %}
+                <span class="pos-chip">{{ sec_node.label if sec_node else pos | replace('_', ' ') | title }}</span>
                 {% endfor %}
             </div>
             {% endif %}

--- a/app/templates/public/player_card_fifa.html
+++ b/app/templates/public/player_card_fifa.html
@@ -122,35 +122,27 @@ body.native-export-mode .events-section { display: none !important; }
     grid-template-columns: 170px 1fr;
 }
 .fifa-left {
-    background: var(--card-panel-bg);
-    padding: 1.5rem 1rem;
-    display: flex; flex-direction: column;
-    align-items: center; gap: 0.5rem; text-align: center;
+    position: relative; overflow: hidden;
+    min-height: 200px;
 }
-.fifa-avatar {
-    width: 68px; height: 68px; border-radius: 50%;
+.fifa-avatar { border-radius: 0; flex-shrink: 0; font-size: 2rem; font-weight: 900; color: white; }
+img.fifa-avatar {
+    position: absolute; inset: 0;
+    width: 100%; height: 100%;
+    object-fit: cover; object-position: top center;
+}
+div.fifa-avatar {
+    position: absolute; inset: 0; width: 100%; height: 100%;
     display: flex; align-items: center; justify-content: center;
-    font-size: 1.55rem; font-weight: 900; color: white;
-    border: 3px solid rgba(255,255,255,0.18); flex-shrink: 0;
 }
-.fifa-overall { font-size: 2.8rem; font-weight: 900; color: white; line-height: 1; margin-top: 0.15rem; }
-.fifa-tier {
-    font-size: 0.58rem; font-weight: 800; text-transform: uppercase;
-    letter-spacing: 0.12em; padding: 3px 10px; border-radius: 99px; color: white;
-    white-space: nowrap;
-}
+.fifa-overall { font-size: 2.5rem; font-weight: 900; color: var(--card-accent); line-height: 1; flex-shrink: 0; }
+.fifa-name-row { display: flex; align-items: flex-start; gap: 0.65rem; }
 .fifa-right {
     background: var(--card-right-bg);
     padding: 1.25rem 1.25rem 1rem;
     display: flex; flex-direction: column; gap: 0;
     min-width: 0; /* prevent grid blowout */
     position: relative; overflow: hidden;
-}
-.card-watermark {
-    position: absolute; inset: 0;
-    width: 100%; height: 100%;
-    object-fit: contain; opacity: 0.18;
-    pointer-events: none; z-index: 0;
 }
 .fifa-right-body {
     position: relative; z-index: 1;
@@ -166,6 +158,13 @@ body.native-export-mode .events-section { display: none !important; }
     font-size: 0.7rem; font-weight: 800; color: white;
     text-transform: uppercase; letter-spacing: 0.08em;
 }
+.fifa-pos-secondary-badges { display: flex; flex-wrap: wrap; gap: 3px; margin-top: 4px; }
+.fifa-pos-secondary-badge {
+    display: inline-block; padding: 2px 8px; border-radius: 4px;
+    font-size: 0.62rem; font-weight: 700; color: var(--card-right-subtext);
+    background: var(--card-pill-bg); border: 1px solid var(--card-pill-border);
+    text-transform: uppercase; letter-spacing: 0.06em;
+}
 .identity-grid {
     display: grid; grid-template-columns: repeat(3, 1fr);
     gap: 0.5rem 0.75rem;
@@ -179,6 +178,22 @@ body.native-export-mode .events-section { display: none !important; }
     background: var(--card-pill-bg); border: 1px solid var(--card-pill-border);
     border-radius: 99px; padding: 3px 9px;
     overflow-wrap: anywhere;
+}
+
+/* ── Sponsor logo bar — below skills+position panel, above events ── */
+.card-logo-bar {
+    background: var(--card-body-bg);
+    padding: 0.6rem 1rem;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    border-top: 1px solid rgba(255,255,255,0.05);
+}
+.card-logo-bar-img {
+    max-height: 40px;
+    max-width: 160px;
+    object-fit: contain;
+    opacity: 0.75;
 }
 
 /* ── Card body: skills (left ~60%) + position panel (right ~40%) ── */
@@ -298,9 +313,7 @@ body.native-export-mode .events-section { display: none !important; }
 @media (max-width: 560px) {
     body { padding: 1rem 0.5rem 3rem; }
     .fifa-header { grid-template-columns: 130px 1fr; }
-    .fifa-left { padding: 1.1rem 0.75rem; }
-    .fifa-avatar { width: 58px; height: 58px; font-size: 1.3rem; }
-    .fifa-overall { font-size: 2.3rem; }
+    .fifa-overall { font-size: 2rem; }
     .fifa-right { padding: 1rem; gap: 0.6rem; }
     .fifa-name { font-size: 1.2rem; }
     .identity-grid { grid-template-columns: 1fr 1fr; }
@@ -315,12 +328,8 @@ body.native-export-mode .events-section { display: none !important; }
 }
 @media (max-width: 440px) {
     .fifa-header { grid-template-columns: 1fr; }
-    .fifa-left {
-        flex-direction: row; justify-content: center;
-        align-items: center; flex-wrap: wrap;
-        gap: 0.6rem 1rem; padding: 1rem 1.25rem;
-    }
-    .fifa-overall { font-size: 2.4rem; }
+    .fifa-left { min-height: 260px; }
+    .fifa-overall { font-size: 2.1rem; }
     .fifa-right { padding: 1rem; }
     .identity-grid { grid-template-columns: repeat(3, 1fr); }
 }
@@ -403,24 +412,28 @@ body.export-mode .skill-bar-bg  { flex: 1 1 0 !important; max-width: none !impor
     <div class="fifa-header">
         <div class="fifa-left">
             {% if photo_url %}
-            <img class="fifa-avatar" src="{{ photo_url }}" alt="{{ initials }}"
-                 style="background: {{ avatar_bg }}; object-fit: cover;">
+            <img class="fifa-avatar" src="{{ photo_url }}" alt="{{ initials }}">
             {% else %}
             <div class="fifa-avatar" style="background: {{ avatar_bg }};">{{ initials }}</div>
             {% endif %}
-            <div class="fifa-overall">{{ overall | round(0) | int }}</div>
-            <span class="fifa-tier" style="background: {{ tier_color }};">{{ tier_label }}</span>
         </div>
         <div class="fifa-right">
-            {% if sponsor_logo_url %}
-            <img class="card-watermark" src="{{ sponsor_logo_url }}" alt="">
-            {% endif %}
             <div class="fifa-right-body">
-            <div>
-                <h2 class="fifa-name">{{ player.name }}</h2>
-                {% if player.position and player.position != "Unknown" %}
-                <span class="fifa-pos-badge" style="background: {{ pos_color }};">{{ player.position }}</span>
-                {% endif %}
+            <div class="fifa-name-row">
+                <div class="fifa-overall">{{ overall | round(0) | int }}</div>
+                <div>
+                    <h2 class="fifa-name">{{ player.name }}</h2>
+                    {% if primary_pos_label %}
+                    <span class="fifa-pos-badge" style="background: {{ pos_color }};">{{ primary_pos_label }}</span>
+                    {% endif %}
+                    {% if secondary_pos_labels %}
+                    <div class="fifa-pos-secondary-badges">
+                        {% for lbl in secondary_pos_labels %}
+                        <span class="fifa-pos-secondary-badge">{{ lbl }}</span>
+                        {% endfor %}
+                    </div>
+                    {% endif %}
+                </div>
             </div>
 
             <div class="identity-grid">
@@ -570,9 +583,6 @@ body.export-mode .skill-bar-bg  { flex: 1 1 0 !important; max-width: none !impor
                 <rect x="24" y="0" width="17" height="6" fill="none" stroke="rgba(255,255,255,0.14)" stroke-width="0.3"/>
                 <!-- GK 6-yard box (bottom) -->
                 <rect x="24" y="94" width="17" height="6" fill="none" stroke="rgba(255,255,255,0.14)" stroke-width="0.3"/>
-                <!-- Direction labels -->
-                <text x="32.5" y="3.5" font-size="3" fill="rgba(255,255,255,0.22)" font-family="sans-serif" font-weight="700" text-anchor="middle">ST</text>
-                <text x="32.5" y="98.5" font-size="3" fill="rgba(255,255,255,0.22)" font-family="sans-serif" font-weight="700" text-anchor="middle">GK</text>
                 <!-- Pass 1: inactive nodes (faint dots, no label) -->
                 {% for node in position_nodes %}
                 {% if not node.is_selected and not node.is_primary %}
@@ -610,6 +620,12 @@ body.export-mode .skill-bar-bg  { flex: 1 1 0 !important; max-width: none !impor
         </div>
 
     </div>
+
+    {% if sponsor_logo_url %}
+    <div class="card-logo-bar">
+        <img class="card-logo-bar-img" src="{{ sponsor_logo_url }}" alt="">
+    </div>
+    {% endif %}
 
     <!-- Events tab -->
     <div class="events-section" id="tab-events" style="display:none;">

--- a/app/templates/public/player_card_fifa.html
+++ b/app/templates/public/player_card_fifa.html
@@ -139,6 +139,10 @@ body.native-export-mode .events-section { display: none !important; }
     letter-spacing: 0.12em; padding: 3px 10px; border-radius: 99px; color: white;
     white-space: nowrap;
 }
+.card-logo {
+    height: 22px; width: auto; opacity: 0.75;
+    filter: brightness(0) invert(1); flex-shrink: 0;
+}
 .fifa-right {
     background: var(--card-right-bg);
     padding: 1.25rem 1.25rem 1rem;
@@ -186,16 +190,10 @@ body.native-export-mode .events-section { display: none !important; }
     margin-bottom: 0.8rem;
 }
 .skill-cats {
-    display: grid; grid-template-columns: repeat(2, 1fr);
+    display: flex; align-items: flex-start;
     gap: 0.5rem;
 }
-/* Visual order: Outfield (DOM 1st) → top-left,   Mental (DOM 3rd) → top-right,
-   Set Pieces (DOM 2nd) → bottom-left, Physical Fitness (DOM 4th) → bottom-right.
-   Long columns pair together (top row), short columns pair together (bottom row). */
-.skill-cat:nth-child(1) { order: 1; }
-.skill-cat:nth-child(2) { order: 3; }
-.skill-cat:nth-child(3) { order: 2; }
-.skill-cat:nth-child(4) { order: 4; }
+.skill-col { flex: 1; display: flex; flex-direction: column; gap: 0.5rem; min-width: 0; }
 .skill-cat { background: var(--card-cat-bg); border-radius: 9px; padding: 0.6rem; min-width: 0; }
 .skill-cat-name {
     font-size: 0.58rem; font-weight: 800; text-transform: uppercase;
@@ -215,7 +213,7 @@ body.native-export-mode .events-section { display: none !important; }
 /* ── Position panel (right, ~40%) ──────────────────────────────── */
 .position-panel {
     background: var(--card-panel-bg);
-    padding: 0.85rem 0.85rem 0.75rem;
+    padding: 0.75rem 0.5rem;
     display: flex;
     flex-direction: column;
     gap: 0.45rem;
@@ -231,19 +229,7 @@ body.native-export-mode .events-section { display: none !important; }
     width: 100%; height: auto;
     border-radius: 5px;
     overflow: visible;
-}
-.pos-primary-label {
-    font-size: 0.72rem; font-weight: 700; color: var(--card-text-primary);
-    text-align: center; letter-spacing: 0.03em;
-}
-.pos-secondary-chips {
-    display: flex; flex-wrap: wrap; gap: 0.25rem; justify-content: center;
-}
-.pos-chip {
-    font-size: 0.56rem; font-weight: 700;
-    background: rgba(255,255,255,0.08);
-    color: var(--card-text-secondary);
-    border-radius: 99px; padding: 2px 7px;
+    flex: 1; margin: auto 0;
 }
 
 /* ── Tab bar ─────────────────────────────────────────────── */
@@ -315,9 +301,8 @@ body.native-export-mode .events-section { display: none !important; }
     .position-panel { order: -1; }
     /* In stacked layout, names can wrap again */
     .skill-name { white-space: normal; overflow-wrap: break-word; overflow: visible; text-overflow: clip; }
-    .skill-cats { grid-template-columns: 1fr 1fr; }
     .skills-panel { padding: 0.9rem; }
-    /* Portrait pitch: cap height when stacked full-width (landscape would be ~260px tall at card width) */
+    /* Portrait pitch: cap height when stacked full-width */
     .pitch-svg { max-height: 200px; width: auto; display: block; margin: 0 auto; }
 }
 @media (max-width: 440px) {
@@ -330,11 +315,10 @@ body.native-export-mode .events-section { display: none !important; }
     .fifa-overall { font-size: 2.4rem; }
     .fifa-right { padding: 1rem; }
     .identity-grid { grid-template-columns: repeat(3, 1fr); }
-    .skill-cats { grid-template-columns: 1fr 1fr; }
 }
 @media (max-width: 340px) {
     .identity-grid { grid-template-columns: 1fr 1fr; }
-    .skill-cats { grid-template-columns: 1fr; }
+    .skill-cats { flex-direction: column; }
     .fifa-name { font-size: 1.05rem; }
 }
 
@@ -410,6 +394,9 @@ body.export-mode .skill-bar-bg  { flex: 1 1 0 !important; max-width: none !impor
     <!-- Split header -->
     <div class="fifa-header">
         <div class="fifa-left">
+            {% if app_logo_url %}
+            <img class="card-logo" src="{{ app_logo_url }}" alt="LFA">
+            {% endif %}
             {% if photo_url %}
             <img class="fifa-avatar" src="{{ photo_url }}" alt="{{ initials }}"
                  style="background: {{ avatar_bg }}; object-fit: cover;">
@@ -440,6 +427,18 @@ body.export-mode .skill-bar-bg  { flex: 1 1 0 !important; max-width: none !impor
                     <span class="id-label">Tournaments</span>
                     <span class="id-value">{{ player.total_tournaments }}</span>
                 </div>
+                <div class="id-field">
+                    <span class="id-label">Height</span>
+                    <span class="id-value">{% if player_height_cm %}{{ player_height_cm }} cm{% else %}—{% endif %}</span>
+                </div>
+                <div class="id-field">
+                    <span class="id-label">Weight</span>
+                    <span class="id-value">{% if player_weight_kg %}{{ player_weight_kg }} kg{% else %}—{% endif %}</span>
+                </div>
+                <div class="id-field">
+                    <span class="id-label">Foot</span>
+                    <span class="id-value">{{ player_preferred_foot | capitalize if player_preferred_foot else "—" }}</span>
+                </div>
             </div>
 
             {% if teams_info %}
@@ -466,7 +465,9 @@ body.export-mode .skill-bar-bg  { flex: 1 1 0 !important; max-width: none !impor
             {% if skill_categories %}
             <div class="skills-title">Football Skills — {{ overall | round(0) | int }} OVR</div>
             <div class="skill-cats">
-                {% for cat in skill_categories %}
+                {# Left column: Outfield (index 0) + Set Pieces (index 1) #}
+                <div class="skill-col">
+                {% for cat in skill_categories[:2] %}
                 <div class="skill-cat">
                     <div class="skill-cat-name">{{ cat.emoji }} {{ cat.name_en }}</div>
                     {% for skill in cat.skills %}
@@ -496,6 +497,40 @@ body.export-mode .skill-bar-bg  { flex: 1 1 0 !important; max-width: none !impor
                     {% endfor %}
                 </div>
                 {% endfor %}
+                </div>
+                {# Right column: Mental (index 2) + Physical (index 3) #}
+                <div class="skill-col">
+                {% for cat in skill_categories[2:] %}
+                <div class="skill-cat">
+                    <div class="skill-cat-name">{{ cat.emoji }} {{ cat.name_en }}</div>
+                    {% for skill in cat.skills %}
+                    {% set sdata = player.skills.get(skill.key, {}) %}
+                    {% set sval = sdata.get('current_level', 50) | round(1) %}
+                    {% set fill_pct = [sval, 100] | min %}
+                    {% set sdelta = last_skill_delta.get(skill.key, 0) %}
+                    {# Color driven solely by last-tournament delta, not by level tier. #}
+                    {% if sdelta > 0 %}
+                        {% set bar_color = '#48bb78' %}
+                        {% set val_color = '#48bb78' %}
+                    {% elif sdelta < 0 %}
+                        {% set bar_color = '#fc8181' %}
+                        {% set val_color = '#fc8181' %}
+                    {% else %}
+                        {% set bar_color = 'var(--card-bar-neutral)' %}
+                        {% set val_color = 'var(--card-val-neutral)' %}
+                    {% endif %}
+                    <div class="skill-row">
+                        <span class="skill-name" title="{{ skill.name_en }}">{{ skill.name_en }}</span>
+                        <div class="skill-bar-bg"><div class="skill-bar-fill" style="width:{{ fill_pct }}%; background:{{ bar_color }};"></div></div>
+                        <span class="skill-val" style="color:{{ val_color }};">{{ sval }}</span>
+                        {% if sdelta > 0 %}<span class="skill-up">↑</span>
+                        {% elif sdelta < 0 %}<span class="skill-up" style="color:#fc8181;">↓</span>
+                        {% else %}<span class="skill-up" style="visibility:hidden">↑</span>{% endif %}
+                    </div>
+                    {% endfor %}
+                </div>
+                {% endfor %}
+                </div>
             </div>
             {% endif %}
         </div>
@@ -562,24 +597,6 @@ body.export-mode .skill-bar-bg  { flex: 1 1 0 !important; max-width: none !impor
                 {% endif %}
                 {% endfor %}
             </svg>
-            <!-- Primary position: abbreviated label · full name -->
-            {% set _prim_nodes = position_nodes | selectattr('is_primary', 'equalto', true) | list %}
-            {% set primary_node = _prim_nodes[0] if _prim_nodes else none %}
-            {% if primary_node %}
-            <div class="pos-primary-label">★ {{ primary_node.label }} · {{ primary_node.name }}</div>
-            {% elif player.position and player.position != "Unknown" %}
-            <div class="pos-primary-label">★ {{ player.position | replace('_', ' ') | title }}</div>
-            {% endif %}
-            <!-- Secondary positions: abbreviated -->
-            {% if player_positions and player_positions | length > 1 %}
-            <div class="pos-secondary-chips">
-                {% for pos in player_positions[1:] %}
-                {% set _sec_nodes = position_nodes | selectattr('canonical', 'equalto', pos) | list %}
-                {% set sec_node = _sec_nodes[0] if _sec_nodes else none %}
-                <span class="pos-chip">{{ sec_node.label if sec_node else pos | replace('_', ' ') | title }}</span>
-                {% endfor %}
-            </div>
-            {% endif %}
         </div>
 
     </div>

--- a/app/templates/public/player_card_fifa.html
+++ b/app/templates/public/player_card_fifa.html
@@ -147,9 +147,9 @@ body.native-export-mode .events-section { display: none !important; }
     position: relative; overflow: hidden;
 }
 .card-watermark {
-    position: absolute; right: 12px; bottom: 10px;
-    max-width: 88px; max-height: 48px;
-    object-fit: contain; opacity: 0.13;
+    position: absolute; inset: 0;
+    width: 100%; height: 100%;
+    object-fit: contain; opacity: 0.18;
     pointer-events: none; z-index: 0;
 }
 .fifa-right-body {

--- a/app/templates/public/player_card_fifa.html
+++ b/app/templates/public/player_card_fifa.html
@@ -12,13 +12,13 @@
     --card-body-bg:  {{ theme.body_bg  if theme is defined else '#1a202c' }};
     --card-tab-bg:   {{ theme.tab_bg   if theme is defined else '#2d3748' }};
     --card-accent:   {{ theme.accent   if theme is defined else '#667eea' }};
-    /* Right panel tokens — FIFA right panel is always white regardless of theme */
-    --card-right-bg:       #ffffff;
+    /* Right panel tokens — light lavender tint aligned with card accent #667eea family */
+    --card-right-bg:       #eef2ff;
     --card-right-text:     #1a202c;
     --card-right-subtext:  #718096;
     --card-right-value:    #2d3748;
-    --card-pill-bg:        #f0f4ff;
-    --card-pill-border:    #e2e8f0;
+    --card-pill-bg:        #dde4ff;
+    --card-pill-border:    #c7d2fe;
     --card-pill-text:      #4a5568;
     /* Dark panel text tokens */
     --card-text-primary:   rgba(255,255,255,0.88);

--- a/app/templates/public/player_card_fifa.html
+++ b/app/templates/public/player_card_fifa.html
@@ -62,6 +62,10 @@ body {
     text-transform: uppercase; color: rgba(255,255,255,0.35);
     margin-bottom: 1.25rem; text-align: center;
 }
+.page-logo {
+    display: block; height: 36px; width: auto; opacity: 0.9;
+    margin: 0 auto 1.25rem;
+}
 .card-wrap {
     width: 100%;
     max-width: min(820px, calc(100vw - 1.5rem));
@@ -323,7 +327,11 @@ body.export-mode .skill-bar-bg  { flex: 1 1 0 !important; max-width: none !impor
 </head>
 <body class="{% if platform_class %}{{ platform_class }}{% endif %}{% if export_mode %} export-mode{% endif %}">
 
+{% if app_logo_url %}
+<img class="page-logo" src="{{ app_logo_url }}" alt="LFA">
+{% else %}
 <div class="page-brand">⚽ LFA Education Center — Player Card</div>
+{% endif %}
 
 <div class="card-wrap">
 

--- a/app/templates/public/welcome_card.html
+++ b/app/templates/public/welcome_card.html
@@ -332,15 +332,13 @@
 </div>
 
 <script>
-// ── Canvas size map — mirrors card_export_service.CANVAS_SIZES ───────────────
-var CANVAS_SIZES = {
-    instagram_square:   [1080, 1080],
-    instagram_portrait: [1080, 1350],
-    instagram_story:    [1080, 1920],
-    tiktok:             [1080, 1920],
-    facebook_landscape: [1200,  630],
-    banner_custom:      [1500,  500],
-};
+// ── Canvas size map — server-rendered from card_constants.CANVAS_SIZES ───────
+var CANVAS_SIZES = (function () {
+    var raw = {{ canvas_sizes | tojson }};
+    var out = {};
+    for (var pid in raw) { out[pid] = [raw[pid].w, raw[pid].h]; }
+    return out;
+}());
 
 var _activePlatform = 'instagram_square';
 

--- a/app/templates/public/welcome_card.html
+++ b/app/templates/public/welcome_card.html
@@ -156,6 +156,89 @@
             flex-shrink: 0;
         }
         .wc-download-btn:hover { opacity: 0.85; }
+
+        /* ── Card Photo panel ── */
+        .wc-photo-panel {
+            margin-top: 1.2rem;
+            background: #1e2436;
+            border: 1px solid rgba(255,255,255,0.07);
+            border-radius: 12px;
+            padding: 0.9rem 1rem;
+        }
+        .wc-photo-panel-label {
+            font-size: 0.75rem;
+            font-weight: 700;
+            color: #64748b;
+            text-transform: uppercase;
+            letter-spacing: 0.06em;
+            margin-bottom: 0.65rem;
+        }
+        .wc-photo-content {
+            display: flex;
+            align-items: center;
+            gap: 0.85rem;
+            flex-wrap: wrap;
+        }
+        .wc-photo-thumb {
+            width: 64px;
+            height: 64px;
+            border-radius: 8px;
+            object-fit: cover;
+            border: 1px solid rgba(255,255,255,0.12);
+        }
+        .wc-photo-placeholder {
+            width: 64px;
+            height: 64px;
+            border-radius: 8px;
+            border: 1px dashed rgba(255,255,255,0.2);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 1.4rem;
+            color: #64748b;
+        }
+        .wc-photo-actions {
+            display: flex;
+            gap: 0.5rem;
+            align-items: center;
+            flex-wrap: wrap;
+        }
+        .wc-upload-label {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.3rem;
+            padding: 0.35rem 0.75rem;
+            background: rgba(255,255,255,0.07);
+            border: 1px solid rgba(255,255,255,0.15);
+            border-radius: 6px;
+            font-size: 0.78rem;
+            font-weight: 600;
+            color: #cbd5e1;
+            cursor: pointer;
+            transition: background 0.15s;
+        }
+        .wc-upload-label:hover { background: rgba(255,255,255,0.12); }
+        .wc-delete-btn {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.3rem;
+            padding: 0.35rem 0.75rem;
+            background: transparent;
+            border: 1px solid rgba(239,68,68,0.4);
+            border-radius: 6px;
+            font-size: 0.78rem;
+            font-weight: 600;
+            color: #f87171;
+            cursor: pointer;
+            transition: background 0.15s;
+        }
+        .wc-delete-btn:hover { background: rgba(239,68,68,0.1); }
+        .wc-photo-status {
+            font-size: 0.78rem;
+            margin-top: 0.5rem;
+            color: #94a3b8;
+            min-height: 1.1em;
+        }
     </style>
 </head>
 <body>
@@ -166,7 +249,7 @@
             <h1>🎴 Welcome Card</h1>
             <p>Based on your onboarding self-assessment</p>
         </div>
-        <a class="wc-back-link" href="/profile">← Back to Profile</a>
+        <a class="wc-back-link" href="/profile/lfa-football-player">← Back to Profile</a>
     </div>
 
     <div class="wc-disclaimer">
@@ -219,6 +302,33 @@
 
     </div>
 
+    <!-- Card Photo -->
+    <div class="wc-photo-panel">
+        <div class="wc-photo-panel-label">Card Photo</div>
+        <div class="wc-photo-content">
+            <img id="wc-photo-thumb" class="wc-photo-thumb"
+                 src="{{ photo_url or '' }}"
+                 alt="Card photo"
+                 style="display:{{ 'block' if photo_url else 'none' }};">
+            <div id="wc-photo-placeholder" class="wc-photo-placeholder"
+                 style="display:{{ 'none' if photo_url else 'flex' }};">
+                📸
+            </div>
+            <div class="wc-photo-actions">
+                <label class="wc-upload-label" for="wc-photo-input">
+                    ⬆️ Upload Photo
+                    <input id="wc-photo-input" type="file"
+                           accept="image/jpeg,image/png,image/webp"
+                           style="display:none;">
+                </label>
+                <button id="wc-delete-btn" class="wc-delete-btn"
+                        style="display:{{ 'inline-flex' if photo_url else 'none' }};"
+                        onclick="deletePhoto()">🗑️ Remove</button>
+            </div>
+        </div>
+        <div id="wc-photo-status" class="wc-photo-status"></div>
+    </div>
+
 </div>
 
 <script>
@@ -266,6 +376,73 @@ function selectPlatform(card) {
     document.getElementById('wc-active-label').textContent =
         label + ' · ' + dims;
     scaleIframe(pid);
+}
+
+// ── CSRF ──────────────────────────────────────────────────────────────────────
+function getCsrfToken() {
+    var m = document.cookie.match(/(?:^|; )csrf_token=([^;]+)/);
+    return m ? decodeURIComponent(m[1]) : '';
+}
+
+// ── Reload iframe preview ─────────────────────────────────────────────────────
+function reloadPreview() {
+    document.getElementById('wc-preview-iframe').contentWindow.location.reload();
+}
+
+// ── Photo upload ──────────────────────────────────────────────────────────────
+document.getElementById('wc-photo-input').addEventListener('change', async function(e) {
+    var file = e.target.files[0];
+    if (!file) return;
+    var formData = new FormData();
+    formData.append('file', file);
+    var status = document.getElementById('wc-photo-status');
+    status.textContent = 'Uploading…';
+    try {
+        var resp = await fetch('/dashboard/lfa-player-photo', {
+            method: 'POST',
+            headers: { 'X-CSRF-Token': getCsrfToken() },
+            body: formData,
+        });
+        var data = await resp.json();
+        if (data.ok) {
+            document.getElementById('wc-photo-thumb').src = data.photo_url;
+            document.getElementById('wc-photo-thumb').style.display = 'block';
+            document.getElementById('wc-photo-placeholder').style.display = 'none';
+            document.getElementById('wc-delete-btn').style.display = 'inline-flex';
+            status.textContent = '✅ Photo saved.';
+            reloadPreview();
+        } else {
+            status.textContent = '❌ Upload failed: ' + (data.error || data.detail || 'unknown error');
+        }
+    } catch {
+        status.textContent = '❌ Upload failed.';
+    }
+    e.target.value = '';
+});
+
+// ── Photo delete ──────────────────────────────────────────────────────────────
+async function deletePhoto() {
+    var status = document.getElementById('wc-photo-status');
+    status.textContent = 'Removing…';
+    try {
+        var resp = await fetch('/dashboard/lfa-player-photo/delete', {
+            method: 'POST',
+            headers: { 'X-CSRF-Token': getCsrfToken() },
+        });
+        var data = await resp.json();
+        if (data.ok) {
+            document.getElementById('wc-photo-thumb').src = '';
+            document.getElementById('wc-photo-thumb').style.display = 'none';
+            document.getElementById('wc-photo-placeholder').style.display = 'flex';
+            document.getElementById('wc-delete-btn').style.display = 'none';
+            status.textContent = '✅ Photo removed.';
+            reloadPreview();
+        } else {
+            status.textContent = '❌ Remove failed: ' + (data.error || data.detail || 'unknown error');
+        }
+    } catch {
+        status.textContent = '❌ Remove failed.';
+    }
 }
 </script>
 </body>

--- a/app/templates/public/welcome_card.html
+++ b/app/templates/public/welcome_card.html
@@ -92,15 +92,15 @@
         }
         .wc-preview-label span { color: #94a3b8; font-weight: 400; text-transform: none; letter-spacing: 0; }
         .wc-preview-frame-wrap {
+            position: relative;
             width: 100%;
-            aspect-ratio: 1 / 1;
             overflow: hidden;
             background: #0f0f1a;
-            display: flex;
-            align-items: center;
-            justify-content: center;
         }
         #wc-preview-iframe {
+            position: absolute;
+            top: 0;
+            left: 0;
             border: none;
             transform-origin: top left;
             display: block;
@@ -222,31 +222,50 @@
 </div>
 
 <script>
-// ── iframe scaling: fit the 1080×1080 card into the preview wrapper ─────────
-function scaleIframe() {
-    const wrap   = document.getElementById('wc-frame-wrap');
-    const iframe = document.getElementById('wc-preview-iframe');
-    const wrapW  = wrap.offsetWidth || 600;
-    const scale  = wrapW / 1080;
-    iframe.style.width  = '1080px';
-    iframe.style.height = '1080px';
+// ── Canvas size map — mirrors card_export_service.CANVAS_SIZES ───────────────
+var CANVAS_SIZES = {
+    instagram_square:   [1080, 1080],
+    instagram_portrait: [1080, 1350],
+    instagram_story:    [1080, 1920],
+    tiktok:             [1080, 1920],
+    facebook_landscape: [1200,  630],
+    banner_custom:      [1500,  500],
+};
+
+var _activePlatform = 'instagram_square';
+
+// ── iframe scaling: fit the platform canvas into the preview wrapper ─────────
+function scaleIframe(pid) {
+    var dims  = CANVAS_SIZES[pid] || [1080, 1080];
+    var cw    = dims[0];
+    var ch    = dims[1];
+    var wrap  = document.getElementById('wc-frame-wrap');
+    var iframe = document.getElementById('wc-preview-iframe');
+    var wrapW = wrap.offsetWidth || 600;
+    var scale = wrapW / cw;
+    iframe.style.width     = cw + 'px';
+    iframe.style.height    = ch + 'px';
     iframe.style.transform = 'scale(' + scale + ')';
-    wrap.style.height = Math.round(1080 * scale) + 'px';
+    wrap.style.height      = Math.round(ch * scale) + 'px';
 }
-window.addEventListener('load', scaleIframe);
-window.addEventListener('resize', scaleIframe);
+window.addEventListener('load',   function() { scaleIframe(_activePlatform); });
+window.addEventListener('resize', function() { scaleIframe(_activePlatform); });
 
 // ── Platform selector ────────────────────────────────────────────────────────
 function selectPlatform(card) {
-    document.querySelectorAll('.wc-platform-card').forEach(c => c.classList.remove('active'));
+    document.querySelectorAll('.wc-platform-card').forEach(function(c) {
+        c.classList.remove('active');
+    });
     card.classList.add('active');
-    const pid   = card.dataset.platform;
-    const label = card.dataset.label;
-    const dims  = card.dataset.dims;
+    var pid   = card.dataset.platform;
+    var label = card.dataset.label;
+    var dims  = card.dataset.dims;
+    _activePlatform = pid;
     document.getElementById('wc-preview-iframe').src =
         '/profile/onboarding-card?platform=' + pid;
     document.getElementById('wc-active-label').textContent =
         label + ' · ' + dims;
+    scaleIframe(pid);
 }
 </script>
 </body>

--- a/app/templates/public/welcome_card.html
+++ b/app/templates/public/welcome_card.html
@@ -16,405 +16,238 @@
             color: #e2e8f0;
         }
 
-        /* ── Page wrapper ── */
-        .wc-page { max-width: 820px; margin: 0 auto; }
+        .wc-page { max-width: 900px; margin: 0 auto; }
 
-        /* ── Disclaimer banner (top — most prominent) ── */
-        .wc-disclaimer {
-            background: linear-gradient(135deg, #78350f 0%, #92400e 100%);
-            border: 1px solid #f59e0b;
-            border-radius: 10px;
-            padding: 0.9rem 1.2rem;
-            margin-bottom: 1.5rem;
+        /* ── Header ── */
+        .wc-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            margin-bottom: 1.2rem;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+        }
+        .wc-header-left h1 {
+            font-size: 1.4rem;
+            font-weight: 800;
+            color: #f1f5f9;
+        }
+        .wc-header-left p {
+            font-size: 0.8rem;
+            color: #94a3b8;
+            margin-top: 0.15rem;
+        }
+        .wc-back-link {
             font-size: 0.85rem;
-            color: #fef3c7;
+            color: #94a3b8;
+            text-decoration: none;
+        }
+        .wc-back-link:hover { color: #f1f5f9; }
+
+        /* ── Disclaimer ── */
+        .wc-disclaimer {
+            background: linear-gradient(135deg, #1e3a5f 0%, #1a3a5c 100%);
+            border: 1px solid rgba(245,158,11,0.4);
+            border-radius: 10px;
+            padding: 0.8rem 1.1rem;
+            margin-bottom: 1.4rem;
+            font-size: 0.82rem;
+            color: #cbd5e1;
             display: flex;
             align-items: flex-start;
             gap: 0.6rem;
             line-height: 1.5;
         }
-        .wc-disclaimer .icon { font-size: 1.1rem; flex-shrink: 0; margin-top: 0.05rem; }
+        .wc-disclaimer .icon { font-size: 1rem; flex-shrink: 0; margin-top: 0.1rem; }
 
-        /* ── Card shell ── */
-        .wc-card {
-            background: linear-gradient(160deg, #1e1b4b 0%, #1a1a2e 60%, #0f172a 100%);
-            border: 2px solid #f59e0b;
-            border-radius: 20px;
-            overflow: hidden;
-            box-shadow: 0 8px 40px rgba(245, 158, 11, 0.25);
+        /* ── Layout: preview left, platforms right ── */
+        .wc-layout {
+            display: grid;
+            grid-template-columns: 1fr 280px;
+            gap: 1.2rem;
+            align-items: start;
+        }
+        @media (max-width: 700px) {
+            .wc-layout { grid-template-columns: 1fr; }
         }
 
-        /* ── Header ── */
-        .wc-header {
-            background: linear-gradient(135deg, #f59e0b 0%, #d97706 50%, #b45309 100%);
-            padding: 1.4rem 1.6rem;
+        /* ── iframe preview panel ── */
+        .wc-preview-panel {
+            background: #1e2436;
+            border: 1px solid rgba(255,255,255,0.08);
+            border-radius: 14px;
+            overflow: hidden;
+        }
+        .wc-preview-label {
+            padding: 0.6rem 1rem;
+            font-size: 0.78rem;
+            font-weight: 700;
+            color: #64748b;
+            text-transform: uppercase;
+            letter-spacing: 0.06em;
+            border-bottom: 1px solid rgba(255,255,255,0.06);
             display: flex;
             align-items: center;
             justify-content: space-between;
-            flex-wrap: wrap;
-            gap: 0.5rem;
         }
-        .wc-header-left { display: flex; flex-direction: column; gap: 0.15rem; }
-        .wc-badge {
-            font-size: 1.35rem;
-            font-weight: 900;
-            color: #1a1a2e;
-            letter-spacing: 0.04em;
-            text-transform: uppercase;
-        }
-        .wc-badge-sub {
-            font-size: 0.75rem;
-            font-weight: 700;
-            color: #451a03;
-            letter-spacing: 0.08em;
-            text-transform: uppercase;
-        }
-        .wc-sa-label {
-            background: rgba(0,0,0,0.25);
-            border-radius: 6px;
-            padding: 0.3rem 0.7rem;
-            font-size: 0.72rem;
-            font-weight: 700;
-            color: #fef3c7;
-            text-transform: uppercase;
-            letter-spacing: 0.06em;
-            white-space: nowrap;
-        }
-
-        /* ── Player info strip ── */
-        .wc-player-strip {
-            display: grid;
-            grid-template-columns: auto 1fr auto;
-            align-items: center;
-            gap: 1rem;
-            padding: 1.2rem 1.6rem;
-            background: rgba(255,255,255,0.03);
-            border-bottom: 1px solid rgba(245,158,11,0.15);
-        }
-        .wc-avatar {
-            width: 72px;
-            height: 72px;
-            border-radius: 50%;
-            border: 2px solid #f59e0b;
-            object-fit: cover;
-        }
-        .wc-avatar-initials {
-            width: 72px;
-            height: 72px;
-            border-radius: 50%;
-            border: 2px solid #f59e0b;
-            background: #f59e0b;
+        .wc-preview-label span { color: #94a3b8; font-weight: 400; text-transform: none; letter-spacing: 0; }
+        .wc-preview-frame-wrap {
+            width: 100%;
+            aspect-ratio: 1 / 1;
+            overflow: hidden;
+            background: #0f0f1a;
             display: flex;
             align-items: center;
             justify-content: center;
-            font-size: 1.4rem;
-            font-weight: 900;
-            color: #1a1a2e;
         }
-        .wc-name-block { display: flex; flex-direction: column; gap: 0.25rem; }
-        .wc-name { font-size: 1.25rem; font-weight: 800; color: #f1f5f9; }
-        .wc-nickname { font-size: 0.85rem; color: #94a3b8; font-style: italic; }
-        .wc-position-pill {
-            background: rgba(245,158,11,0.15);
-            border: 1px solid rgba(245,158,11,0.4);
-            border-radius: 20px;
-            padding: 0.15rem 0.7rem;
-            font-size: 0.8rem;
-            font-weight: 700;
-            color: #fbbf24;
-            text-transform: uppercase;
-            letter-spacing: 0.04em;
-        }
-        .wc-flags { display: flex; gap: 0.3rem; font-size: 0.9rem; }
-        .wc-overall-block {
-            text-align: center;
-            background: rgba(245,158,11,0.1);
-            border: 1px solid rgba(245,158,11,0.3);
-            border-radius: 10px;
-            padding: 0.5rem 0.9rem;
-        }
-        .wc-overall-num {
-            font-size: 2rem;
-            font-weight: 900;
-            color: #f59e0b;
-            line-height: 1;
-        }
-        .wc-overall-label {
-            font-size: 0.65rem;
-            color: #92400e;
-            font-weight: 700;
-            text-transform: uppercase;
-            letter-spacing: 0.05em;
-            margin-top: 0.1rem;
+        #wc-preview-iframe {
+            border: none;
+            transform-origin: top left;
+            display: block;
         }
 
-        /* ── Physical stats ── */
-        .wc-stats-row {
+        /* ── Platform list panel ── */
+        .wc-platforms-panel {
             display: flex;
-            flex-wrap: wrap;
+            flex-direction: column;
             gap: 0.5rem;
-            padding: 0.8rem 1.6rem;
-            border-bottom: 1px solid rgba(245,158,11,0.1);
         }
-        .wc-stat-chip {
-            background: rgba(255,255,255,0.05);
-            border: 1px solid rgba(255,255,255,0.1);
-            border-radius: 6px;
-            padding: 0.3rem 0.7rem;
-            font-size: 0.8rem;
-            color: #cbd5e1;
-        }
-        .wc-stat-chip strong { color: #f1f5f9; }
-
-        /* ── Top skills ── */
-        .wc-section { padding: 1rem 1.6rem; }
-        .wc-section-title {
-            font-size: 0.72rem;
+        .wc-platform-label {
+            font-size: 0.75rem;
             font-weight: 700;
+            color: #64748b;
             text-transform: uppercase;
-            letter-spacing: 0.08em;
-            color: #f59e0b;
-            margin-bottom: 0.75rem;
-            display: flex;
-            align-items: center;
-            gap: 0.4rem;
+            letter-spacing: 0.06em;
+            margin-bottom: 0.25rem;
         }
-        .wc-top-skills { display: flex; flex-direction: column; gap: 0.45rem; }
-        .wc-top-skill {
-            display: grid;
-            grid-template-columns: 160px 1fr 42px;
-            align-items: center;
-            gap: 0.6rem;
-        }
-        .wc-top-skill-name { font-size: 0.85rem; color: #e2e8f0; font-weight: 600; }
-        .wc-bar-track {
-            height: 8px;
-            background: rgba(255,255,255,0.07);
-            border-radius: 4px;
-            overflow: hidden;
-        }
-        .wc-bar-fill {
-            height: 100%;
-            border-radius: 4px;
-            background: linear-gradient(90deg, #f59e0b, #d97706);
-            transition: width 0.4s ease;
-        }
-        .wc-bar-val { font-size: 0.8rem; font-weight: 700; color: #fbbf24; text-align: right; }
-
-        /* ── Skill categories ── */
-        .wc-cat-grid {
-            display: grid;
-            grid-template-columns: 1fr 1fr;
-            gap: 1rem;
-        }
-        @media (max-width: 600px) { .wc-cat-grid { grid-template-columns: 1fr; } }
-
-        .wc-cat-card {
-            background: rgba(255,255,255,0.03);
-            border: 1px solid rgba(245,158,11,0.15);
-            border-radius: 12px;
-            padding: 0.9rem 1rem;
-        }
-        .wc-cat-header {
+        .wc-platform-card {
+            background: #1e2436;
+            border: 1px solid rgba(255,255,255,0.07);
+            border-radius: 10px;
+            padding: 0.65rem 0.85rem;
             display: flex;
             align-items: center;
             justify-content: space-between;
-            margin-bottom: 0.6rem;
+            gap: 0.5rem;
+            cursor: pointer;
+            transition: border-color 0.15s;
         }
-        .wc-cat-name { font-size: 0.78rem; font-weight: 700; color: #fbbf24; text-transform: uppercase; letter-spacing: 0.04em; }
-        .wc-cat-avg {
-            font-size: 0.78rem;
-            font-weight: 700;
-            color: #f59e0b;
-            background: rgba(245,158,11,0.12);
-            border-radius: 4px;
-            padding: 0.1rem 0.4rem;
+        .wc-platform-card:hover,
+        .wc-platform-card.active {
+            border-color: rgba(245,158,11,0.5);
         }
-        .wc-skill-rows { display: flex; flex-direction: column; gap: 0.3rem; }
-        .wc-skill-row {
-            display: grid;
-            grid-template-columns: 1fr 80px 32px;
+        .wc-platform-card.active { background: #1e2d3d; }
+        .wc-platform-info { display: flex; flex-direction: column; gap: 0.1rem; }
+        .wc-platform-name { font-size: 0.85rem; font-weight: 700; color: #e2e8f0; }
+        .wc-platform-dims { font-size: 0.72rem; color: #64748b; }
+        .wc-download-btn {
+            display: inline-flex;
             align-items: center;
-            gap: 0.4rem;
-        }
-        .wc-skill-name { font-size: 0.74rem; color: #94a3b8; }
-        .wc-mini-bar-track {
-            height: 5px;
-            background: rgba(255,255,255,0.06);
-            border-radius: 3px;
-            overflow: hidden;
-        }
-        .wc-mini-bar-fill {
-            height: 100%;
-            border-radius: 3px;
-            background: linear-gradient(90deg, #f59e0b, #d97706);
-        }
-        .wc-skill-val { font-size: 0.72rem; font-weight: 600; color: #fbbf24; text-align: right; }
-
-        /* ── Footer disclaimer ── */
-        .wc-footer-disc {
-            padding: 1rem 1.6rem 1.4rem;
-            border-top: 1px solid rgba(245,158,11,0.1);
+            gap: 0.3rem;
+            padding: 0.3rem 0.7rem;
+            background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
+            color: #1a1a2e;
             font-size: 0.75rem;
-            color: #64748b;
-            line-height: 1.6;
-            text-align: center;
-        }
-        .wc-footer-disc strong { color: #92400e; }
-
-        /* ── Back link ── */
-        .wc-back { margin-bottom: 1rem; }
-        .wc-back a {
-            color: #f59e0b;
+            font-weight: 700;
+            border-radius: 6px;
             text-decoration: none;
-            font-size: 0.85rem;
-            font-weight: 600;
+            white-space: nowrap;
+            transition: opacity 0.15s;
+            flex-shrink: 0;
         }
-        .wc-back a:hover { text-decoration: underline; }
+        .wc-download-btn:hover { opacity: 0.85; }
     </style>
 </head>
 <body>
 <div class="wc-page">
 
-    <!-- Back navigation -->
-    <div class="wc-back">
-        <a href="/profile">← Back to Profile</a>
+    <div class="wc-header">
+        <div class="wc-header-left">
+            <h1>🎴 Welcome Card</h1>
+            <p>Based on your onboarding self-assessment</p>
+        </div>
+        <a class="wc-back-link" href="/profile">← Back to Profile</a>
     </div>
 
-    <!-- Top disclaimer — most prominent element on the page -->
     <div class="wc-disclaimer">
-        <span class="icon">⚠️</span>
-        <div>
-            <strong>Welcome Card — Onboarding Self-Assessment</strong><br>
-            This card uses your onboarding self-assessment, not calculated player level.
-            Based on your onboarding answers — not EMA-computed skill profile.
-            Skills reflect what <em>you</em> reported at sign-up, not tournament-derived ratings.
-        </div>
+        <span class="icon">ℹ️</span>
+        <span>
+            This card is generated from your self-assessment data collected during onboarding.
+            It is not the same as the regular Player Card.
+            Values come from your own self-assessment, not from EMA-computed levels.
+        </span>
     </div>
 
-    <div class="wc-card">
+    <div class="wc-layout">
 
-        <!-- Header -->
-        <div class="wc-header">
-            <div class="wc-header-left">
-                <div class="wc-badge">🎴 Welcome Card</div>
-                <div class="wc-badge-sub">LFA Football Player</div>
+        <!-- iframe live preview -->
+        <div class="wc-preview-panel">
+            <div class="wc-preview-label">
+                Preview
+                <span id="wc-active-label">Instagram Square · 1080 × 1080</span>
             </div>
-            <div class="wc-sa-label">Self-Assessment Only</div>
+            <div class="wc-preview-frame-wrap" id="wc-frame-wrap">
+                <iframe id="wc-preview-iframe"
+                        src="/profile/onboarding-card?platform=instagram_square"
+                        title="Welcome Card Preview"
+                        scrolling="no"></iframe>
+            </div>
         </div>
 
-        <!-- Player strip -->
-        <div class="wc-player-strip">
-            <!-- Avatar -->
-            {% if license.player_card_photo_url %}
-                <img class="wc-avatar" src="{{ license.player_card_photo_url }}" alt="{{ display_name }}">
-            {% else %}
-                <div class="wc-avatar-initials">{{ initials }}</div>
-            {% endif %}
-
-            <!-- Name / position -->
-            <div class="wc-name-block">
-                <div class="wc-name">{{ display_name }}</div>
-                {% if user.nickname %}
-                    <div class="wc-nickname">"{{ user.nickname }}"</div>
-                {% endif %}
-                <div style="display:flex; gap:0.5rem; flex-wrap:wrap; margin-top:0.2rem;">
-                    {% if position %}
-                        <span class="wc-position-pill">{{ position | replace('_', ' ') | upper }}</span>
-                    {% endif %}
-                    {% for pos in positions[1:] %}
-                        <span class="wc-position-pill" style="opacity:0.65;font-size:0.72rem;">{{ pos | replace('_', ' ') | upper }}</span>
-                    {% endfor %}
+        <!-- Platform selector + download buttons -->
+        <div class="wc-platforms-panel">
+            <div class="wc-platform-label">Download sizes</div>
+            {% for p in platforms %}
+            <div class="wc-platform-card{% if p.id == default_platform %} active{% endif %}"
+                 data-platform="{{ p.id }}"
+                 data-label="{{ p.label }}"
+                 data-dims="{{ p.dims }}"
+                 onclick="selectPlatform(this)">
+                <div class="wc-platform-info">
+                    <div class="wc-platform-name">{{ p.label }}</div>
+                    <div class="wc-platform-dims">{{ p.dims }}</div>
                 </div>
-                {% if user.nationality or user.secondary_nationality %}
-                <div class="wc-flags" style="margin-top:0.3rem;">
-                    {% if user.nationality %}<span title="{{ user.nationality }}">{{ user.nationality }}</span>{% endif %}
-                    {% if user.secondary_nationality %}<span>·</span><span title="{{ user.secondary_nationality }}">{{ user.secondary_nationality }}</span>{% endif %}
-                </div>
-                {% endif %}
+                <a class="wc-download-btn"
+                   id="wc-dl-{{ p.id }}"
+                   href="/profile/onboarding-card/export?platform={{ p.id }}"
+                   onclick="event.stopPropagation();">
+                    ⬇️ Download
+                </a>
             </div>
-
-            <!-- Overall SA score -->
-            <div class="wc-overall-block">
-                <div class="wc-overall-num">{{ overall_sa | round | int }}</div>
-                <div class="wc-overall-label">SA Avg</div>
-            </div>
+            {% endfor %}
         </div>
 
-        <!-- Physical stats chips -->
-        <div class="wc-stats-row">
-            {% if height_cm %}
-                <span class="wc-stat-chip">📏 <strong>{{ height_cm }} cm</strong></span>
-            {% endif %}
-            {% if weight_kg %}
-                <span class="wc-stat-chip">⚖️ <strong>{{ weight_kg }} kg</strong></span>
-            {% endif %}
-            {% if preferred_foot %}
-                <span class="wc-stat-chip">🦶 <strong>{{ preferred_foot | capitalize }}</strong> foot</span>
-            {% endif %}
-            {% if right_foot_score is not none and left_foot_score is not none %}
-                <span class="wc-stat-chip">
-                    R <strong>{{ right_foot_score | round | int }}</strong> / L <strong>{{ left_foot_score | round | int }}</strong>
-                </span>
-            {% endif %}
-            {% if goals %}
-                <span class="wc-stat-chip">🎯 {{ goals | replace('_', ' ') | capitalize }}</span>
-            {% endif %}
-        </div>
+    </div>
 
-        <!-- Top 5 self-assessed skills -->
-        {% if top_skills %}
-        <div class="wc-section">
-            <div class="wc-section-title">⭐ Top Self-Assessed Skills</div>
-            <div class="wc-top-skills">
-                {% for skill in top_skills %}
-                <div class="wc-top-skill" data-skill="{{ skill.key }}">
-                    <span class="wc-top-skill-name">{{ skill.name_en }}</span>
-                    <div class="wc-bar-track">
-                        <div class="wc-bar-fill" style="width:{{ skill.value }}%"></div>
-                    </div>
-                    <span class="wc-bar-val">{{ skill.value | round | int }}</span>
-                </div>
-                {% endfor %}
-            </div>
-        </div>
-        {% endif %}
+</div>
 
-        <!-- Skill categories grid -->
-        <div class="wc-section">
-            <div class="wc-section-title">📊 Skill Categories — Self-Assessment</div>
-            <div class="wc-cat-grid">
-                {% for cat in skill_categories %}
-                <div class="wc-cat-card">
-                    <div class="wc-cat-header">
-                        <span class="wc-cat-name">{{ cat.emoji }} {{ cat.name_en }}</span>
-                        <span class="wc-cat-avg">{{ cat.avg }}</span>
-                    </div>
-                    <div class="wc-skill-rows">
-                        {% for skill in cat.skills %}
-                        <div class="wc-skill-row" data-skill="{{ skill.key }}">
-                            <span class="wc-skill-name">{{ skill.name_en }}</span>
-                            <div class="wc-mini-bar-track">
-                                <div class="wc-mini-bar-fill" style="width:{{ skill.value }}%"></div>
-                            </div>
-                            <span class="wc-skill-val">{{ skill.value | round | int }}</span>
-                        </div>
-                        {% endfor %}
-                    </div>
-                </div>
-                {% endfor %}
-            </div>
-        </div>
+<script>
+// ── iframe scaling: fit the 1080×1080 card into the preview wrapper ─────────
+function scaleIframe() {
+    const wrap   = document.getElementById('wc-frame-wrap');
+    const iframe = document.getElementById('wc-preview-iframe');
+    const wrapW  = wrap.offsetWidth || 600;
+    const scale  = wrapW / 1080;
+    iframe.style.width  = '1080px';
+    iframe.style.height = '1080px';
+    iframe.style.transform = 'scale(' + scale + ')';
+    wrap.style.height = Math.round(1080 * scale) + 'px';
+}
+window.addEventListener('load', scaleIframe);
+window.addEventListener('resize', scaleIframe);
 
-        <!-- Footer disclaimer -->
-        <div class="wc-footer-disc">
-            <strong>Welcome Card — Onboarding Self-Assessment</strong><br>
-            Values reflect what you reported at onboarding sign-up.<br>
-            This is not your official Player Card and does not use calculated skill levels.<br>
-            Your actual skill profile is computed by the EMA engine from tournament performance.
-        </div>
-
-    </div><!-- /wc-card -->
-</div><!-- /wc-page -->
+// ── Platform selector ────────────────────────────────────────────────────────
+function selectPlatform(card) {
+    document.querySelectorAll('.wc-platform-card').forEach(c => c.classList.remove('active'));
+    card.classList.add('active');
+    const pid   = card.dataset.platform;
+    const label = card.dataset.label;
+    const dims  = card.dataset.dims;
+    document.getElementById('wc-preview-iframe').src =
+        '/profile/onboarding-card?platform=' + pid;
+    document.getElementById('wc-active-label').textContent =
+        label + ' · ' + dims;
+}
+</script>
 </body>
 </html>

--- a/app/utils/football_positions.py
+++ b/app/utils/football_positions.py
@@ -131,3 +131,94 @@ def positions_grouped() -> List[Dict]:
         {"key": key, "label": _GROUP_LABELS[key], "positions": groups[key]}
         for key in _GROUP_ORDER
     ]
+
+
+# ── Pitch display nodes ────────────────────────────────────────────────────────
+# Coordinates are the authoritative values from pitch-selector.js PITCH_NODES.
+# x/y are fractions of the landscape SVG canvas (GK on left, ST on right).
+# "striker" has two visual nodes (ST1 at y≈0.34, ST2 at y≈0.66) so both
+# halves of the dual-node highlight when "striker" is the selected value.
+# "second_striker" and "centre_back" have no dedicated pitch node (legacy
+# taxonomy gap — consistent with interactive pitch-selector.js behaviour).
+
+_PITCH_NODES_RAW: List[Tuple[str, str, str, str, float, float]] = [
+    # (node_id, label, name, role, x, y)  — x/y from pitch-selector.js
+    ("GK",  "GK",  "Goalkeeper",             "goalkeeper", 0.02, 0.50),
+    ("SK",  "SK",  "Sweeper Keeper",          "goalkeeper", 0.10, 0.50),
+    ("LB",  "LB",  "Left Back",               "defender",   0.19, 0.15),
+    ("LCB", "LCB", "Left Centre-Back",        "defender",   0.19, 0.37),
+    ("RCB", "RCB", "Right Centre-Back",       "defender",   0.19, 0.63),
+    ("RB",  "RB",  "Right Back",              "defender",   0.19, 0.85),
+    ("LWB", "LWB", "Left Wing-Back",          "defender",   0.28, 0.10),
+    ("RWB", "RWB", "Right Wing-Back",         "defender",   0.28, 0.90),
+    ("DM",  "DM",  "Defensive Mid",           "midfielder", 0.37, 0.50),
+    ("LCM", "LCM", "Left Centre Mid",         "midfielder", 0.47, 0.33),
+    ("CM",  "CM",  "Centre Mid",              "midfielder", 0.50, 0.50),
+    ("RCM", "RCM", "Right Centre Mid",        "midfielder", 0.47, 0.67),
+    ("LM",  "LM",  "Left Midfielder",         "midfielder", 0.55, 0.17),
+    ("RM",  "RM",  "Right Midfielder",        "midfielder", 0.55, 0.83),
+    ("AM",  "AM",  "Att. Midfielder",         "midfielder", 0.68, 0.50),
+    ("LW",  "LW",  "Left Winger",             "forward",    0.73, 0.07),
+    ("RW",  "RW",  "Right Winger",            "forward",    0.73, 0.93),
+    ("CF",  "CF",  "Centre Forward",          "forward",    0.83, 0.50),
+    ("ST1", "ST",  "Striker",                 "forward",    0.88, 0.34),
+    ("ST2", "ST",  "Striker",                 "forward",    0.88, 0.66),
+]
+
+# Canonical value for each node — mirrors pitch-selector.js PITCH_NODES[i].canonical.
+_NODE_CANONICAL: Dict[str, str] = {
+    "GK":  "goalkeeper",
+    "SK":  "sweeper_keeper",
+    "LB":  "left_back",
+    "LCB": "left_centre_back",
+    "RCB": "right_centre_back",
+    "RB":  "right_back",
+    "LWB": "left_wing_back",
+    "RWB": "right_wing_back",
+    "DM":  "defensive_midfield",
+    "LCM": "left_centre_midfield",
+    "CM":  "centre_midfield",
+    "RCM": "right_centre_midfield",
+    "LM":  "left_midfield",
+    "RM":  "right_midfield",
+    "AM":  "attacking_midfield",
+    "LW":  "left_wing",
+    "RW":  "right_wing",
+    "CF":  "centre_forward",
+    "ST1": "striker",
+    "ST2": "striker",
+}
+
+
+def get_pitch_display_nodes(
+    primary_position: str,
+    all_positions: List[str],
+) -> List[Dict]:
+    """Build annotated pitch node list for the FIFA card position panel.
+
+    Each entry mirrors a node from pitch-selector.js PITCH_NODES.
+    is_primary  — True for the primary position (one node, or both ST nodes).
+    is_selected — True if the node's canonical value appears in all_positions.
+
+    ST1 and ST2 share canonical="striker"; both are marked is_selected when
+    "striker" appears in all_positions, and both is_primary when "striker" is
+    the primary position — preserving pitch-selector.js dual-node behaviour.
+
+    Positions without a pitch node (second_striker, centre_back legacy) are
+    silently absent — consistent with the interactive selector.
+    """
+    selected_set = frozenset(all_positions)
+    return [
+        {
+            "node_id":    node_id,
+            "label":      label,
+            "name":       name,
+            "role":       role,
+            "x":          x,
+            "y":          y,
+            "canonical":  _NODE_CANONICAL[node_id],
+            "is_primary": _NODE_CANONICAL[node_id] == primary_position,
+            "is_selected": _NODE_CANONICAL[node_id] in selected_set,
+        }
+        for node_id, label, name, role, x, y in _PITCH_NODES_RAW
+    ]

--- a/app/utils/football_positions.py
+++ b/app/utils/football_positions.py
@@ -1,55 +1,67 @@
 """
 Football position definitions for the LFA Player onboarding system.
 
-17-position taxonomy: 4 groups × (4 or 5 positions each).
-DB values are snake_case strings (e.g. "striker", "left_wing").
+21-position taxonomy: 4 groups × (5, 7, 7, 2 positions each).
+DB values are snake_case strings (e.g. "striker", "left_centre_back").
+
+Taxonomy history:
+  v1 (17 positions): original — centre_back/centre_midfield as single nodes
+  v2 (21 positions): LCB/RCB split → left_centre_back/right_centre_back;
+                     LCM/RCM split → left_centre_midfield/right_centre_midfield.
+  Legacy values (centre_back, centre_midfield, second_striker) remain in
+  VALID_POSITION_VALUES and LEGACY_POSITION_MAP for backward compatibility.
 """
 from __future__ import annotations
 
 from typing import Dict, List, Optional, Tuple
 
+
 # ── Canonical position registry ───────────────────────────────────────────────
 
 # (group_key, value, label, short)
 _POSITIONS: List[Tuple[str, str, str, str]] = [
-    # Forwards
-    ("forward",    "striker",             "Striker",               "ST"),
-    ("forward",    "centre_forward",      "Centre Forward",        "CF"),
-    ("forward",    "left_wing",           "Left Wing",             "LW"),
-    ("forward",    "right_wing",          "Right Wing",            "RW"),
-    ("forward",    "second_striker",      "Second Striker",        "SS"),
-    # Midfielders
-    ("midfielder", "attacking_midfield",  "Attacking Midfielder",  "AM"),
-    ("midfielder", "centre_midfield",     "Central Midfielder",    "CM"),
-    ("midfielder", "defensive_midfield",  "Defensive Midfielder",  "DM"),
-    ("midfielder", "left_midfield",       "Left Midfielder",       "LM"),
-    ("midfielder", "right_midfield",      "Right Midfielder",      "RM"),
-    # Defenders
-    ("defender",   "centre_back",         "Centre Back",           "CB"),
-    ("defender",   "left_back",           "Left Back",             "LB"),
-    ("defender",   "right_back",          "Right Back",            "RB"),
-    ("defender",   "left_wing_back",      "Left Wing Back",        "LWB"),
-    ("defender",   "right_wing_back",     "Right Wing Back",       "RWB"),
-    # Goalkeeper
-    ("goalkeeper", "goalkeeper",          "Goalkeeper",            "GK"),
-    ("goalkeeper", "sweeper_keeper",      "Sweeper Keeper",        "SK"),
+    # Forwards (5)
+    ("forward",    "striker",               "Striker",                "ST"),
+    ("forward",    "centre_forward",        "Centre Forward",         "CF"),
+    ("forward",    "left_wing",             "Left Wing",              "LW"),
+    ("forward",    "right_wing",            "Right Wing",             "RW"),
+    ("forward",    "second_striker",        "Second Striker",         "SS"),
+    # Midfielders (7)
+    ("midfielder", "attacking_midfield",    "Attacking Midfielder",   "AM"),
+    ("midfielder", "centre_midfield",       "Central Midfielder",     "CM"),
+    ("midfielder", "defensive_midfield",    "Defensive Midfielder",   "DM"),
+    ("midfielder", "left_midfield",         "Left Midfielder",        "LM"),
+    ("midfielder", "right_midfield",        "Right Midfielder",       "RM"),
+    ("midfielder", "left_centre_midfield",  "Left Centre Midfielder", "LCM"),
+    ("midfielder", "right_centre_midfield", "Right Centre Midfielder","RCM"),
+    # Defenders (7)
+    ("defender",   "centre_back",           "Centre Back",            "CB"),
+    ("defender",   "left_back",             "Left Back",              "LB"),
+    ("defender",   "right_back",            "Right Back",             "RB"),
+    ("defender",   "left_wing_back",        "Left Wing Back",         "LWB"),
+    ("defender",   "right_wing_back",       "Right Wing Back",        "RWB"),
+    ("defender",   "left_centre_back",      "Left Centre-Back",       "LCB"),
+    ("defender",   "right_centre_back",     "Right Centre-Back",      "RCB"),
+    # Goalkeepers (2)
+    ("goalkeeper", "goalkeeper",            "Goalkeeper",             "GK"),
+    ("goalkeeper", "sweeper_keeper",        "Sweeper Keeper",         "SK"),
 ]
 
-POSITIONS_17: List[Dict] = [
+POSITIONS_21: List[Dict] = [
     {"group": g, "value": v, "label": l, "short": s}
     for g, v, l, s in _POSITIONS
 ]
 
-VALID_POSITION_VALUES: frozenset = frozenset(p["value"] for p in POSITIONS_17)
+VALID_POSITION_VALUES: frozenset = frozenset(p["value"] for p in POSITIONS_21)
 
-# Maps old 4-position legacy values (uppercase or mixed) → canonical snake_case
+# Maps legacy 4-value uppercase strings → canonical snake_case.
+# All 21 canonical values also map to themselves (idempotent passthrough).
 LEGACY_POSITION_MAP: Dict[str, str] = {
     "STRIKER":    "striker",
     "MIDFIELDER": "centre_midfield",
     "DEFENDER":   "centre_back",
     "GOALKEEPER": "goalkeeper",
-    # Also accept the canonical values themselves (idempotent)
-    **{p["value"]: p["value"] for p in POSITIONS_17},
+    **{p["value"]: p["value"] for p in POSITIONS_21},
 }
 
 _GROUP_LABELS: Dict[str, str] = {
@@ -92,7 +104,7 @@ def normalize_positions(raw_list: List[str]) -> Optional[List[str]]:
 
 def position_label(value: str) -> str:
     """Return human-readable label for a canonical position value."""
-    for p in POSITIONS_17:
+    for p in POSITIONS_21:
         if p["value"] == value:
             return p["label"]
     return value
@@ -100,7 +112,7 @@ def position_label(value: str) -> str:
 
 def position_short(value: str) -> str:
     """Return abbreviation (e.g. 'ST') for a canonical position value."""
-    for p in POSITIONS_17:
+    for p in POSITIONS_21:
         if p["value"] == value:
             return p["short"]
     return value.upper()[:3]
@@ -113,7 +125,7 @@ def positions_grouped() -> List[Dict]:
     Shape: [{"key": "forward", "label": "Forwards", "positions": [...]}, ...]
     """
     groups: Dict[str, List[Dict]] = {g: [] for g in _GROUP_ORDER}
-    for p in POSITIONS_17:
+    for p in POSITIONS_21:
         groups[p["group"]].append(p)
     return [
         {"key": key, "label": _GROUP_LABELS[key], "positions": groups[key]}

--- a/scripts/e2e_lifecycle_visibility_test.py
+++ b/scripts/e2e_lifecycle_visibility_test.py
@@ -67,8 +67,10 @@ from app.models.team import Team, TeamMember, TournamentTeamEnrollment  # noqa: 
 from app.models.tournament_achievement import TournamentParticipation  # noqa: E402
 from app.models.tournament_configuration import TournamentConfiguration  # noqa: E402
 from app.models.tournament_ranking import TournamentRanking  # noqa: E402
+from app.models.tournament_instructor_slot import TournamentInstructorSlot  # noqa: E402
 from app.models.tournament_type import TournamentType  # noqa: E402
 from app.models.user import User  # noqa: E402
+from app.models.pitch import Pitch  # noqa: E402
 from app.dependencies import (  # noqa: E402
     get_current_user_web,
     get_current_admin_user_hybrid,
@@ -115,6 +117,35 @@ class _TestFailed(Exception):
 
 def fail(msg):
     raise _TestFailed(msg)
+
+
+# ── Instructor slot helper ────────────────────────────────────────────────────
+def _assign_field_instructor(tournament_id, campus_id, instructor_id):
+    """Create a CHECKED_IN FIELD TournamentInstructorSlot for the first active pitch.
+
+    Required since the Instructor Prerequisite Guard (PR #141) blocks IN_PROGRESS
+    unless at least one FIELD slot is CHECKED_IN with a valid active pitch.
+    Uses the same instructor as the MASTER legacy path (no slot row for MASTER,
+    so the unique-per-tournament constraint is not violated).
+    """
+    pitch = _db.query(Pitch).filter(
+        Pitch.campus_id == campus_id,
+        Pitch.is_active == True,  # noqa: E712
+    ).first()
+    if not pitch:
+        fail(f"No active pitch on campus {campus_id} — cannot create FIELD instructor slot")
+    slot = TournamentInstructorSlot(
+        semester_id=tournament_id,
+        instructor_id=instructor_id,
+        role="FIELD",
+        pitch_id=pitch.id,
+        status="CHECKED_IN",
+        assigned_by=instructor_id,
+    )
+    _db.add(slot)
+    _db.commit()
+    _db.expire_all()
+    ok(f"FIELD instructor slot created: pitch_id={pitch.id}, instructor_id={instructor_id}")
 
 
 # ── Auth + CSRF helpers ───────────────────────────────────────────────────────
@@ -574,6 +605,7 @@ def test_guard_d_rankings_required(club, campus, tt_id, instructor):
     _db.commit()
     _db.expire_all()
 
+    _assign_field_instructor(t.id, campus.id, instructor.id)
     _status_transition(t.id, "IN_PROGRESS")
 
     sess_count = _db.query(SessionModel).filter(SessionModel.semester_id == t.id).count()
@@ -647,6 +679,7 @@ def test_full_lifecycle_visibility(club, campus, tt_id, instructor):
     _db.commit()
     _db.expire_all()
     ok(f"master_instructor_id = {instructor.id}")
+    _assign_field_instructor(t.id, campus.id, instructor.id)
 
     # ─── → IN_PROGRESS (sessions already generated at CHECK_IN_OPEN) ──────────
     _status_transition(t.id, "IN_PROGRESS")
@@ -777,6 +810,7 @@ def test_idempotency(club, campus, tt_id, instructor):
     t_obj.master_instructor_id = instructor.id
     _db.commit()
     _db.expire_all()
+    _assign_field_instructor(t.id, campus.id, instructor.id)
     _status_transition(t.id, "IN_PROGRESS")
 
     sess_count = _db.query(SessionModel).filter(SessionModel.semester_id == t.id).count()
@@ -925,6 +959,7 @@ def test_public_api_strict(club, campus, tt_id, instructor):
     t_obj.master_instructor_id = instructor.id
     _db.commit()
     _db.expire_all()
+    _assign_field_instructor(t.id, campus.id, instructor.id)
 
     # IN_PROGRESS
     _status_transition(t.id, "IN_PROGRESS")

--- a/scripts/e2e_matrix_test.py
+++ b/scripts/e2e_matrix_test.py
@@ -46,8 +46,10 @@ from app.models.semester import Semester  # noqa: E402
 from app.models.session import Session as SessionModel  # noqa: E402
 from app.models.team import Team, TeamMember, TournamentTeamEnrollment  # noqa: E402
 from app.models.tournament_configuration import TournamentConfiguration  # noqa: E402
+from app.models.tournament_instructor_slot import TournamentInstructorSlot  # noqa: E402
 from app.models.tournament_type import TournamentType  # noqa: E402
 from app.models.user import User, UserRole  # noqa: E402
+from app.models.pitch import Pitch  # noqa: E402
 from app.dependencies import (  # noqa: E402
     get_current_user_web,
     get_current_admin_user_hybrid,
@@ -231,16 +233,35 @@ def _enroll_teams_direct(tid, teams):
 
 
 # ── Common lifecycle (after enrollment phase) ─────────────────────────────────
-def _common_lifecycle(tid, instructor_id, expected_min_sessions=1):
-    """ENROLLMENT_CLOSED → CHECK_IN_OPEN → (set instructor) → IN_PROGRESS → verify."""
+def _common_lifecycle(tid, instructor_id, campus_id, expected_min_sessions=1):
+    """ENROLLMENT_CLOSED → CHECK_IN_OPEN → (set instructor + FIELD slot) → IN_PROGRESS → verify."""
     _status_transition(tid, "ENROLLMENT_CLOSED")
     _status_transition(tid, "CHECK_IN_OPEN")
 
-    # Set instructor directly (simulates wizard Basic Info save)
+    # Set master instructor directly (simulates wizard Basic Info save)
     t = _db.query(Semester).filter(Semester.id == tid).first()
     t.master_instructor_id = instructor_id
     _db.commit()
     ok(f"master_instructor_id = {instructor_id}")
+
+    # Create FIELD instructor slot required by Instructor Prerequisite Guard (PR #141)
+    pitch = _db.query(Pitch).filter(
+        Pitch.campus_id == campus_id,
+        Pitch.is_active == True,  # noqa: E712
+    ).first()
+    if not pitch:
+        fail_local(f"No active pitch on campus {campus_id} — cannot create FIELD instructor slot")
+    slot = TournamentInstructorSlot(
+        semester_id=tid,
+        instructor_id=instructor_id,
+        role="FIELD",
+        pitch_id=pitch.id,
+        status="CHECKED_IN",
+        assigned_by=instructor_id,
+    )
+    _db.add(slot)
+    _db.commit()
+    ok(f"FIELD instructor slot created: pitch_id={pitch.id}")
 
     _db.expire_all()
     _status_transition(tid, "IN_PROGRESS")
@@ -322,7 +343,7 @@ def s1_team_league(club, campus, tt_by_code, instructor, boot_teams):
         fail_local(f"Need ≥2 teams, got {count}")
 
     _status_transition(tid, "ENROLLMENT_OPEN")
-    _common_lifecycle(tid, instructor.id, expected_min_sessions=1)
+    _common_lifecycle(tid, instructor.id, campus.id, expected_min_sessions=1)
 
 
 # ══════════════════════════════════════════════════════════════════════════════
@@ -391,7 +412,7 @@ def s2_individual_knockout(club, campus, tt_by_code, instructor, boot_teams):
         fail_local(f"Need ≥4 players for knockout, got {enrolled_count}")
 
     # 8-player knockout: 7 matches (4 R1 + 2 semis + 1 final) — check ≥4
-    _common_lifecycle(t.id, instructor.id, expected_min_sessions=4)
+    _common_lifecycle(t.id, instructor.id, campus.id, expected_min_sessions=4)
 
 
 # ══════════════════════════════════════════════════════════════════════════════
@@ -448,7 +469,7 @@ def s3_individual_group_knockout(club, campus, tt_by_code, instructor, boot_team
         fail_local(f"Need ≥8 players for group+knockout, got {enrolled_count}")
 
     # 12 players: group stage + knockout → ≥10 sessions minimum
-    _common_lifecycle(t.id, instructor.id, expected_min_sessions=10)
+    _common_lifecycle(t.id, instructor.id, campus.id, expected_min_sessions=10)
 
 
 # ══════════════════════════════════════════════════════════════════════════════
@@ -475,7 +496,7 @@ def s4_team_league_2leg(club, campus, tt_by_code, instructor, boot_teams):
 
     _status_transition(tid, "ENROLLMENT_OPEN")
     # 2 teams × 2 legs = 2 matches
-    _common_lifecycle(tid, instructor.id, expected_min_sessions=2)
+    _common_lifecycle(tid, instructor.id, campus.id, expected_min_sessions=2)
 
     # Verify exactly 2× matches (1 per leg)
     sess_count = _db.query(SessionModel).filter(SessionModel.semester_id == tid).count()
@@ -548,7 +569,7 @@ def s5_individual_league(club, campus, tt_by_code, instructor, boot_teams):
         fail_local(f"Need ≥2 players for ENROLLMENT_CLOSED, got {enrolled_count}")
 
     # Full lifecycle
-    _common_lifecycle(t.id, instructor.id, expected_min_sessions=1)
+    _common_lifecycle(t.id, instructor.id, campus.id, expected_min_sessions=1)
 
 
 # ── Main ──────────────────────────────────────────────────────────────────────

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -3604,6 +3604,47 @@
         "title": "Body_instructor_update_student_skills_instructor_students__student_id__skills__license_id__post",
         "type": "object"
       },
+      "Body_lfa_player_profile_edit_submit_profile_lfa_football_player_edit_post": {
+        "properties": {
+          "goals": {
+            "title": "Goals",
+            "type": "string"
+          },
+          "height_cm_raw": {
+            "default": "",
+            "title": "Height Cm Raw",
+            "type": "string"
+          },
+          "position": {
+            "title": "Position",
+            "type": "string"
+          },
+          "preferred_foot": {
+            "title": "Preferred Foot",
+            "type": "string"
+          },
+          "secondary_positions": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Secondary Positions",
+            "type": "array"
+          },
+          "weight_kg_raw": {
+            "default": "",
+            "title": "Weight Kg Raw",
+            "type": "string"
+          }
+        },
+        "required": [
+          "position",
+          "preferred_foot",
+          "goals"
+        ],
+        "title": "Body_lfa_player_profile_edit_submit_profile_lfa_football_player_edit_post",
+        "type": "object"
+      },
       "Body_login_form_api_v1_auth_login_form_post": {
         "properties": {
           "client_id": {
@@ -59809,6 +59850,88 @@
           }
         },
         "summary": "Profile Edit Submit",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/profile/lfa-football-player": {
+      "get": {
+        "description": "LFA Football Player specialization profile hub.\n\nRequires a completed LFA_FOOTBALL_PLAYER license.\nDisplays spec-specific data from motivation_scores and UserLicense fields.\nfootball_skills (EMA-computed) are not exposed or editable here.",
+        "operationId": "lfa_player_profile_page_profile_lfa_football_player_get",
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Lfa Player Profile Page",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/profile/lfa-football-player/edit": {
+      "get": {
+        "description": "Show the LFA Football Player spec-profile edit form.",
+        "operationId": "lfa_player_profile_edit_page_profile_lfa_football_player_edit_get",
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Lfa Player Profile Edit Page",
+        "tags": [
+          "web"
+        ]
+      },
+      "post": {
+        "description": "Validate and save LFA Football Player spec-profile fields (motivation_scores only).",
+        "operationId": "lfa_player_profile_edit_submit_profile_lfa_football_player_edit_post",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_lfa_player_profile_edit_submit_profile_lfa_football_player_edit_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Lfa Player Profile Edit Submit",
         "tags": [
           "web"
         ]

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -59816,8 +59816,36 @@
     },
     "/profile/onboarding-card": {
       "get": {
-        "description": "Welcome Card \u2014 private self-assessment preview (Phase C).\n\nData source: football_skills[*].self_assessment ONLY.\nNEVER reads current_level, baseline, system_baseline, tournament_delta,\nassessment_delta, or any EMA output.\n\nAuth: own card only (get_current_user_web enforces login; ownership is\nimplicit because we query by user.id).\nVisibility: private, no-index (meta tag in template).",
+        "description": "Welcome Card preview \u2014 private self-assessment view.\n\nData source: football_skills[*].self_assessment ONLY.\nNEVER reads current_level, baseline, system_baseline, tournament_delta,\nassessment_delta, or any EMA output.\n\nWithout ?platform=: renders the gallery hub (iframe + download buttons).\nWith ?platform=X:   renders the FIFA Classic card for that platform size.\nWith ?export=1:     switches the FIFA template to export-mode (Playwright use).\n\nAuth: own card only (get_current_user_web enforces login; ownership is\nimplicit because we query by user.id).\nVisibility: private, no-index (meta tag in template).",
         "operationId": "onboarding_welcome_card_profile_onboarding_card_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "platform",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Platform"
+            }
+          },
+          {
+            "in": "query",
+            "name": "export",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Export",
+              "type": "boolean"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -59828,9 +59856,61 @@
               }
             },
             "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
           }
         },
         "summary": "Onboarding Welcome Card",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/profile/onboarding-card/export": {
+      "get": {
+        "description": "Export the Welcome Card as a PNG at a social-media canvas size.\n\nAuth: own card only. Rate limit: 5 exports per 60 s per user+IP.\nData source: self_assessment only (same contract as the preview route).",
+        "operationId": "export_onboarding_welcome_card_profile_onboarding_card_export_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "platform",
+            "required": false,
+            "schema": {
+              "default": "instagram_square",
+              "title": "Platform",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Export Onboarding Welcome Card",
         "tags": [
           "web"
         ]

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -3645,6 +3645,22 @@
         "title": "Body_lfa_player_profile_edit_submit_profile_lfa_football_player_edit_post",
         "type": "object"
       },
+      "Body_lfa_player_profile_positions_submit_profile_lfa_football_player_positions_post": {
+        "properties": {
+          "position": {
+            "default": "",
+            "title": "Position",
+            "type": "string"
+          },
+          "positions_raw": {
+            "default": "[]",
+            "title": "Positions Raw",
+            "type": "string"
+          }
+        },
+        "title": "Body_lfa_player_profile_positions_submit_profile_lfa_football_player_positions_post",
+        "type": "object"
+      },
       "Body_login_form_api_v1_auth_login_form_post": {
         "properties": {
           "client_id": {
@@ -59621,6 +59637,23 @@
               "default": false,
               "title": "Animated"
             }
+          },
+          {
+            "in": "query",
+            "name": "native_export",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": false,
+              "title": "Native Export"
+            }
           }
         ],
         "responses": {
@@ -59932,6 +59965,47 @@
           }
         },
         "summary": "Lfa Player Profile Edit Submit",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/profile/lfa-football-player/positions": {
+      "post": {
+        "description": "Update only the player's positions (primary + secondaries, max 4 total).\n\nAccepts:\n  position      \u2014 canonical primary position (snake_case)\n  positions_raw \u2014 JSON array of all positions including primary, e.g. '[\"striker\",\"left_wing\"]'\n\nValidates: canonical values, 1\u20134 count, primary is first element.\nNever touches foot scores, goals, height, weight, or any other field.",
+        "operationId": "lfa_player_profile_positions_submit_profile_lfa_football_player_positions_post",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_lfa_player_profile_positions_submit_profile_lfa_football_player_positions_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Lfa Player Profile Positions Submit",
         "tags": [
           "web"
         ]

--- a/tests/unit/api/web_routes/test_card_editor_context.py
+++ b/tests/unit/api/web_routes/test_card_editor_context.py
@@ -1,0 +1,157 @@
+"""
+Unit tests for the card editor route context — Phase 2 platform hardcoding refactor.
+
+Verifies that the dashboard card editor route passes the correct authoritative
+context keys to the template, eliminating hardcoded JS and platform button HTML.
+
+CE-CTX-01: canvas_sizes keys in context match CANVAS_SIZES from card_constants
+CE-CTX-02: platforms list length matches CARD_EDITOR_PLATFORM_IDS length
+CE-CTX-03: platforms list includes facebook_post (closes previous UI gap)
+CE-CTX-04: platforms order matches CARD_EDITOR_PLATFORM_IDS order
+"""
+import asyncio
+from unittest.mock import MagicMock, patch
+
+from app.api.web_routes.dashboard import lfa_player_card_editor
+from app.models.user import UserRole
+from app.services.card_constants import CANVAS_SIZES, CARD_EDITOR_PLATFORM_IDS
+
+
+_BASE = "app.api.web_routes.dashboard"
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _req():
+    return MagicMock()
+
+
+def _student(uid=7):
+    u = MagicMock()
+    u.id = uid
+    u.role = UserRole.STUDENT
+    u.name = "Test Player"
+    u.email = "player@test.com"
+    u.credit_balance = 100
+    return u
+
+
+def _license(uid=7):
+    lic = MagicMock()
+    lic.user_id = uid
+    lic.specialization_type = "LFA_FOOTBALL_PLAYER"
+    lic.onboarding_completed = True
+    lic.football_skills = {"passing": 60}
+    lic.card_theme = "default"
+    lic.card_variant = "fifa"
+    lic.public_card_platform = None
+    lic.player_card_photo_url = None
+    return lic
+
+
+def _mock_db(license_return):
+    db = MagicMock()
+    query_mock = MagicMock()
+    filter_mock = MagicMock()
+    filter_mock.first.return_value = license_return
+    query_mock.filter.return_value = filter_mock
+    db.query.return_value = query_mock
+    return db
+
+
+def _call_editor(user=None, lic=None):
+    """Call the card editor route and return the TemplateResponse call args."""
+    if user is None:
+        user = _student()
+    if lic is None:
+        lic = _license(uid=user.id)
+    db = _mock_db(license_return=lic)
+
+    with patch(f"{_BASE}.templates") as mock_tmpl, \
+         patch(f"{_BASE}.SemesterEnrollment") as mock_se:
+        mock_tmpl.TemplateResponse.return_value = MagicMock()
+        # Simulate no enrollment so effective_onboarding uses onboarding_completed
+        mock_se_q = MagicMock()
+        mock_se_q.filter.return_value.first.return_value = None
+        mock_se.id = MagicMock()
+
+        with patch(f"{_BASE}.db") if False else patch(f"{_BASE}.UserLicense") as _mock_lic_cls:
+            _mock_lic_cls.user_id = MagicMock()
+            # Use the pre-built db mock directly
+            _run(lfa_player_card_editor(_req(), db=db, user=user))
+
+        tmpl, ctx = mock_tmpl.TemplateResponse.call_args.args
+        return tmpl, ctx
+
+
+class TestCardEditorContext:
+    """Card editor route must pass authoritative context keys to template."""
+
+    def _get_ctx(self):
+        user = _student()
+        lic = _license(uid=user.id)
+        db = _mock_db(license_return=lic)
+
+        with patch(f"{_BASE}.templates") as mock_tmpl:
+            mock_tmpl.TemplateResponse.return_value = MagicMock()
+            with patch(f"{_BASE}.SemesterEnrollment") as mock_se:
+                # Simulate no semester enrollment
+                inner = MagicMock()
+                inner.filter.return_value.first.return_value = None
+                mock_se.id = inner
+                db.query.return_value.filter.return_value.first.side_effect = [
+                    lic,   # license query
+                    None,  # enrollment query
+                ]
+                _run(lfa_player_card_editor(_req(), db=db, user=user))
+            _, ctx = mock_tmpl.TemplateResponse.call_args.args
+        return ctx
+
+    def test_ce_ctx01_canvas_sizes_keys_match_card_constants(self):
+        """canvas_sizes context keys must exactly match CANVAS_SIZES from card_constants."""
+        ctx = self._get_ctx()
+        assert "canvas_sizes" in ctx, (
+            "card editor route must pass 'canvas_sizes' to template"
+        )
+        assert set(ctx["canvas_sizes"].keys()) == set(CANVAS_SIZES.keys()), (
+            f"canvas_sizes keys mismatch.\n"
+            f"Context has:   {sorted(ctx['canvas_sizes'].keys())}\n"
+            f"Expected:      {sorted(CANVAS_SIZES.keys())}"
+        )
+
+    def test_ce_ctx02_platforms_length_matches_card_editor_platform_ids(self):
+        """platforms list length must equal CARD_EDITOR_PLATFORM_IDS length."""
+        ctx = self._get_ctx()
+        assert "platforms" in ctx, (
+            "card editor route must pass 'platforms' to template"
+        )
+        assert len(ctx["platforms"]) == len(CARD_EDITOR_PLATFORM_IDS), (
+            f"Expected {len(CARD_EDITOR_PLATFORM_IDS)} platforms, "
+            f"got {len(ctx['platforms'])}"
+        )
+
+    def test_ce_ctx03_platforms_includes_facebook_post(self):
+        """facebook_post must appear in platforms — closes the dashboard editor UI gap.
+
+        Previously, facebook_post was absent from the hardcoded platform picker HTML
+        and the hardcoded JS _CANVAS_SIZES object. This test ensures the gap stays closed.
+        """
+        ctx = self._get_ctx()
+        platform_ids = [p["id"] for p in ctx["platforms"]]
+        assert "facebook_post" in platform_ids, (
+            "facebook_post is missing from editor platforms context. "
+            "This is a functional gap: users cannot select the Facebook Post format. "
+            "Ensure CARD_EDITOR_PLATFORM_IDS includes 'facebook_post'."
+        )
+
+    def test_ce_ctx04_platforms_order_matches_card_editor_platform_ids(self):
+        """platforms order must match CARD_EDITOR_PLATFORM_IDS order."""
+        ctx = self._get_ctx()
+        actual_ids = [p["id"] for p in ctx["platforms"]]
+        assert actual_ids == list(CARD_EDITOR_PLATFORM_IDS), (
+            f"Platform order mismatch.\n"
+            f"Expected: {list(CARD_EDITOR_PLATFORM_IDS)}\n"
+            f"Actual:   {actual_ids}"
+        )

--- a/tests/unit/api/web_routes/test_lfa_player_profile.py
+++ b/tests/unit/api/web_routes/test_lfa_player_profile.py
@@ -1,0 +1,1167 @@
+"""
+Unit tests for /profile/lfa-football-player (Fázis 2+3+design+refactor).
+
+Test groups:
+  TestLfaPlayerProfileGuards      — redirect when no license / onboarding incomplete
+  TestLfaPlayerProfileContext     — route context keys from motivation_scores
+  TestLfaPlayerProfileTemplate    — template static assertions (links, CTAs, no skill edit)
+  TestWelcomeCardBackLink         — welcome_card.html back link updated (Fázis 2)
+  TestProfileRegressions          — /profile and /profile/edit remain globally scoped
+  TestLfaEditGuards               — GET edit redirects (no license / incomplete onboarding)
+  TestLfaEditGetContext           — GET edit context keys
+  TestLfaEditPost                 — POST: valid save, validation errors, DB safety
+  TestLfaEditTemplate             — template static assertions (form action, no skill input)
+  TestLfaNavigationCTAs           — navigation CTA audit (Fázis nav fix)
+  TestLfaDesignIntegration        — header pattern, icon, theme token regression (design fix)
+  TestLfaViewDataCompleteness     — old-license compatibility (missing avg_skill/joined_at)
+  TestLfaEditFormScope            — foot scores excluded, max-3 enforced, handler source check
+"""
+import asyncio
+import inspect
+import pathlib
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.responses import RedirectResponse
+
+from app.api.web_routes.profile import (
+    lfa_player_profile_page,
+    lfa_player_profile_edit_page,
+    lfa_player_profile_edit_submit,
+    profile_page,
+    _VALID_POSITIONS,
+    _VALID_GOALS,
+    _VALID_PREFERRED_FOOT,
+)
+from app.models.user import UserRole
+
+_BASE = "app.api.web_routes.profile"
+
+_TPL_PATH = (
+    pathlib.Path(__file__).resolve().parents[4]
+    / "app" / "templates" / "lfa_player_profile.html"
+)
+_EDIT_TPL_PATH = (
+    pathlib.Path(__file__).resolve().parents[4]
+    / "app" / "templates" / "lfa_player_profile_edit.html"
+)
+_PROFILE_TPL_PATH = (
+    pathlib.Path(__file__).resolve().parents[4]
+    / "app" / "templates" / "profile.html"
+)
+_PROFILE_EDIT_TPL_PATH = (
+    pathlib.Path(__file__).resolve().parents[4]
+    / "app" / "templates" / "profile_edit.html"
+)
+_WC_GALLERY_TPL_PATH = (
+    pathlib.Path(__file__).resolve().parents[4]
+    / "app" / "templates" / "public" / "welcome_card.html"
+)
+_DASHBOARD_TPL_PATH = (
+    pathlib.Path(__file__).resolve().parents[4]
+    / "app" / "templates" / "dashboard_student_new.html"
+)
+_ONBOARDING_TPL_PATH = (
+    pathlib.Path(__file__).resolve().parents[4]
+    / "app" / "templates" / "lfa_player_onboarding.html"
+)
+_CARD_EDITOR_TPL_PATH = (
+    pathlib.Path(__file__).resolve().parents[4]
+    / "app" / "templates" / "dashboard_card_editor.html"
+)
+_STUDENT_BASE_TPL_PATH = (
+    pathlib.Path(__file__).resolve().parents[4]
+    / "app" / "templates" / "student_base.html"
+)
+
+
+# ── Shared helpers ─────────────────────────────────────────────────────────────
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _req():
+    m = MagicMock()
+    m.client = MagicMock()
+    m.client.host = "127.0.0.1"
+    return m
+
+
+def _user(uid=10, role=UserRole.STUDENT):
+    u = MagicMock()
+    u.id    = uid
+    u.role  = role
+    u.email = "player@test.com"
+    u.name  = "Test Player"
+    u.credit_balance = 0
+    u.specialization = None
+    return u
+
+
+def _lfa_lic(completed=True, photo_url=None, right=70.0, left=30.0,
+             avg_skill=None, joined_at=None):
+    lic = MagicMock()
+    lic.specialization_type   = "LFA_FOOTBALL_PLAYER"
+    lic.onboarding_completed  = completed
+    lic.player_card_photo_url = photo_url
+    lic.right_foot_score      = right
+    lic.left_foot_score       = left
+    ms = {
+        "position":       "striker",
+        "positions":      ["striker", "centre_forward"],
+        "height_cm":      178,
+        "weight_kg":      74,
+        "preferred_foot": "right",
+        "goals":          "become_professional",
+    }
+    if avg_skill is not None:
+        ms["average_skill_level"] = avg_skill
+    if joined_at is not None:
+        ms["onboarding_completed_at"] = joined_at
+    lic.motivation_scores = ms
+    return lic
+
+
+def _mock_db(lic):
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = lic
+    db.query.return_value.filter.return_value.all.return_value = [lic] if lic else []
+    return db
+
+
+# ── 1. Auth guards ─────────────────────────────────────────────────────────────
+
+class TestLfaPlayerProfileGuards:
+    """Route redirects when license absent or onboarding incomplete."""
+
+    def test_no_license_redirects_to_dashboard(self):
+        db = _mock_db(None)
+        result = _run(lfa_player_profile_page(_req(), db=db, user=_user()))
+        assert isinstance(result, RedirectResponse)
+        assert "/dashboard" in result.headers["location"]
+
+    def test_incomplete_onboarding_redirects_to_onboarding(self):
+        db = _mock_db(_lfa_lic(completed=False))
+        result = _run(lfa_player_profile_page(_req(), db=db, user=_user()))
+        assert isinstance(result, RedirectResponse)
+        assert "onboarding" in result.headers["location"]
+
+    def test_no_license_redirect_contains_info_param(self):
+        db = _mock_db(None)
+        result = _run(lfa_player_profile_page(_req(), db=db, user=_user()))
+        assert "no_lfa_license" in result.headers["location"]
+
+    def test_completed_license_does_not_redirect(self):
+        db = _mock_db(_lfa_lic(completed=True))
+        with patch(f"{_BASE}.templates") as mock_tmpl:
+            mock_tmpl.TemplateResponse.return_value = MagicMock()
+            result = _run(lfa_player_profile_page(_req(), db=db, user=_user()))
+        assert not isinstance(result, RedirectResponse)
+
+
+# ── 2. Route context ───────────────────────────────────────────────────────────
+
+class TestLfaPlayerProfileContext:
+    """Context dict returned to the template contains the expected keys and values."""
+
+    def _ctx(self, lic=None):
+        if lic is None:
+            lic = _lfa_lic()
+        db = _mock_db(lic)
+        with patch(f"{_BASE}.templates") as mock_tmpl:
+            mock_tmpl.TemplateResponse.return_value = MagicMock()
+            _run(lfa_player_profile_page(_req(), db=db, user=_user()))
+        return mock_tmpl.TemplateResponse.call_args.args[1]
+
+    def test_template_name_is_lfa_player_profile(self):
+        db = _mock_db(_lfa_lic())
+        with patch(f"{_BASE}.templates") as mock_tmpl:
+            mock_tmpl.TemplateResponse.return_value = MagicMock()
+            _run(lfa_player_profile_page(_req(), db=db, user=_user()))
+        tmpl = mock_tmpl.TemplateResponse.call_args.args[0]
+        assert tmpl == "lfa_player_profile.html"
+
+    def test_context_has_license(self):
+        lic = _lfa_lic()
+        ctx = self._ctx(lic)
+        assert ctx["license"] is lic
+
+    def test_context_has_ms(self):
+        ctx = self._ctx()
+        assert "ms" in ctx
+        assert ctx["ms"]["position"] == "striker"
+
+    def test_context_primary_pos_from_ms(self):
+        ctx = self._ctx()
+        assert ctx["primary_pos"] == "striker"
+
+    def test_context_secondary_pos_excludes_primary(self):
+        ctx = self._ctx()
+        assert ctx["secondary_pos"] == ["centre_forward"]
+
+    def test_context_goal_label_is_human_readable(self):
+        ctx = self._ctx()
+        assert ctx["goal_label"] == "Become a professional player"
+
+    def test_context_position_labels_dict_present(self):
+        ctx = self._ctx()
+        assert "position_labels" in ctx
+        assert ctx["position_labels"]["striker"] == "Striker (ST)"
+
+    def test_context_goal_label_fallback_when_unknown(self):
+        lic = _lfa_lic()
+        lic.motivation_scores = {"goals": "unknown_goal"}
+        ctx = self._ctx(lic)
+        assert ctx["goal_label"] == "unknown_goal"
+
+    def test_context_secondary_pos_empty_when_only_primary(self):
+        lic = _lfa_lic()
+        lic.motivation_scores = {"position": "striker", "positions": ["striker"]}
+        ctx = self._ctx(lic)
+        assert ctx["secondary_pos"] == []
+
+    def test_context_show_spec_nav_true(self):
+        ctx = self._ctx()
+        assert ctx["show_spec_nav"] is True
+
+    def test_context_has_average_skill_level_when_set(self):
+        lic = _lfa_lic(avg_skill=64.2)
+        ctx = self._ctx(lic)
+        assert ctx["average_skill_level"] == 64.2
+
+    def test_context_average_skill_level_none_when_absent(self):
+        ctx = self._ctx()  # default _lfa_lic has no avg_skill key
+        assert ctx["average_skill_level"] is None
+
+    def test_context_has_onboarding_completed_at_when_set(self):
+        lic = _lfa_lic(joined_at="2026-05-08T10:00:00Z")
+        ctx = self._ctx(lic)
+        assert ctx["onboarding_completed_at"] == "2026-05-08T10:00:00Z"
+
+    def test_context_onboarding_completed_at_none_when_absent(self):
+        ctx = self._ctx()
+        assert ctx["onboarding_completed_at"] is None
+
+
+# ── 3. Template static assertions ─────────────────────────────────────────────
+
+@pytest.fixture(scope="module")
+def tpl_src():
+    return _TPL_PATH.read_text(encoding="utf-8")
+
+
+class TestLfaPlayerProfileTemplate:
+    """Static source analysis of lfa_player_profile.html."""
+
+    def test_template_file_exists(self):
+        assert _TPL_PATH.exists()
+
+    def test_extends_student_base(self, tpl_src):
+        assert 'student_base.html' in tpl_src
+
+    def test_has_page_title(self, tpl_src):
+        assert "LFA Player Profile" in tpl_src
+
+    # ── Welcome Card CTAs ──────────────────────────────────────────────────
+
+    def test_view_welcome_card_link_present(self, tpl_src):
+        assert 'href="/profile/onboarding-card"' in tpl_src
+
+    def test_download_cta_points_to_export_route(self, tpl_src):
+        assert '/profile/onboarding-card/export?platform=instagram_square' in tpl_src
+
+    def test_no_player_card_route_linked(self, tpl_src):
+        assert '/players/' not in tpl_src
+
+    # ── Motivation scores fields displayed ─────────────────────────────────
+
+    def test_primary_pos_rendered(self, tpl_src):
+        assert 'primary_pos' in tpl_src
+
+    def test_secondary_pos_rendered(self, tpl_src):
+        assert 'secondary_pos' in tpl_src
+
+    def test_height_cm_rendered(self, tpl_src):
+        assert 'ms.height_cm' in tpl_src
+
+    def test_weight_kg_rendered(self, tpl_src):
+        assert 'ms.weight_kg' in tpl_src
+
+    def test_preferred_foot_rendered(self, tpl_src):
+        assert 'ms.preferred_foot' in tpl_src
+
+    def test_goal_label_rendered(self, tpl_src):
+        assert 'goal_label' in tpl_src
+
+    # ── Foot scores are read-only (no form/input) ──────────────────────────
+
+    def test_no_skill_edit_form(self, tpl_src):
+        """football_skills must not be editable in this template."""
+        assert 'football_skills' not in tpl_src
+        assert 'current_level' not in tpl_src
+
+    def test_foot_scores_present_but_no_input(self, tpl_src):
+        assert 'right_foot_score' in tpl_src or 'foot-bar' in tpl_src
+        assert 'input type="number"' not in tpl_src
+
+    def test_foot_assessment_labeled_read_only(self, tpl_src):
+        """Foot Assessment block must carry a read-only / not-editable note."""
+        assert 'Read-only assessment data' in tpl_src
+
+    # ── New view CTAs ──────────────────────────────────────────────────────────
+
+    def test_edit_profile_cta_present(self, tpl_src):
+        """View page header must have an Edit Profile CTA."""
+        assert 'href="/profile/lfa-football-player/edit"' in tpl_src
+
+    def test_welcome_card_cta_in_header(self, tpl_src):
+        """View page header must link to Welcome Card."""
+        assert '🎴 Welcome Card' in tpl_src
+
+    # ── New read-only data fields ──────────────────────────────────────────────
+
+    def test_average_skill_level_rendered(self, tpl_src):
+        """average_skill_level context key must appear in view template."""
+        assert 'average_skill_level' in tpl_src
+
+    def test_onboarding_completed_at_rendered(self, tpl_src):
+        """Member since / onboarding_completed_at must appear in view template."""
+        assert 'onboarding_completed_at' in tpl_src
+        assert 'Member since' in tpl_src
+
+    def test_average_skill_level_na_fallback(self, tpl_src):
+        """Template must contain the N/A fallback for missing average_skill_level."""
+        assert 'N/A' in tpl_src
+
+    def test_onboarding_completed_at_dash_fallback(self, tpl_src):
+        """Template must show — when onboarding_completed_at is absent."""
+        assert '—' in tpl_src  # em-dash —
+
+    # ── Navigation ─────────────────────────────────────────────────────────
+
+    def test_back_link_to_global_profile(self, tpl_src):
+        assert 'href="/profile"' in tpl_src
+
+    def test_dashboard_link_to_lfa_dashboard(self, tpl_src):
+        assert '/dashboard/lfa-football-player' in tpl_src
+
+    # ── Jinja2 render: minimal context ────────────────────────────────────
+
+    def test_renders_without_error_with_full_context(self):
+        from jinja2 import Environment, FileSystemLoader, Undefined
+        env = Environment(
+            loader=FileSystemLoader(str(_TPL_PATH.parents[1])),
+            autoescape=True,
+            undefined=Undefined,
+        )
+        lic = _lfa_lic()
+        ctx = {
+            "request":          MagicMock(),
+            "user":             _user(),
+            "license":          lic,
+            "ms":               lic.motivation_scores,
+            "primary_pos":      "striker",
+            "secondary_pos":    ["centre_forward"],
+            "position_labels":  {"striker": "Striker (ST)", "centre_forward": "Centre Forward (CF)"},
+            "goal_label":       "Become a professional player",
+            "show_spec_nav":    True,
+            "spec_header_class": "hdr-lfa-player",
+        }
+        # student_base.html extends base.html — render only the extra_styles + student_content blocks
+        # via standalone fragment render to avoid full chain dependency
+        frag_src = _TPL_PATH.read_text()
+        # Extract student_content block
+        start = frag_src.find("{% block student_content %}")
+        end   = frag_src.find("{% endblock %}", start)
+        assert start != -1 and end != -1
+
+    def test_renders_position_label_via_get(self):
+        """position_labels.get() must produce the human-readable label."""
+        from jinja2 import Template
+        frag = "{{ position_labels.get(primary_pos, primary_pos) }}"
+        result = Template(frag).render(
+            position_labels={"striker": "Striker (ST)"},
+            primary_pos="striker",
+        )
+        assert result == "Striker (ST)"
+
+
+# ── 4. Welcome Card gallery hub — back link updated ───────────────────────────
+
+@pytest.fixture(scope="module")
+def wc_gallery_src():
+    return _WC_GALLERY_TPL_PATH.read_text(encoding="utf-8")
+
+
+class TestWelcomeCardBackLink:
+    """welcome_card.html back link now points to /profile/lfa-football-player."""
+
+    def test_back_link_points_to_lfa_player_profile(self, wc_gallery_src):
+        assert 'href="/profile/lfa-football-player"' in wc_gallery_src
+
+    def test_back_link_does_not_point_to_global_profile(self, wc_gallery_src):
+        # Must not have the bare /profile back link (would be regression)
+        assert 'href="/profile">← Back' not in wc_gallery_src
+
+
+# ── 5. Regression: /profile and /profile/edit remain globally scoped ──────────
+
+@pytest.fixture(scope="module")
+def profile_src():
+    return _PROFILE_TPL_PATH.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def profile_edit_src():
+    return _PROFILE_EDIT_TPL_PATH.read_text(encoding="utf-8")
+
+
+class TestProfileRegressions:
+    """Ensure global /profile hub and /profile/edit are not broken by Fázis 2."""
+
+    def test_profile_html_exists(self):
+        assert _PROFILE_TPL_PATH.exists()
+
+    def test_profile_edit_html_exists(self):
+        assert _PROFILE_EDIT_TPL_PATH.exists()
+
+    def test_global_profile_has_lfa_license_gate(self, profile_src):
+        """Welcome Card section is still gated on lfa_license (Fázis 1 invariant)."""
+        assert '{% if lfa_license %}' in profile_src
+
+    def test_global_profile_edit_has_no_football_skills(self, profile_edit_src):
+        """Global edit form must not expose football_skills or motivation_scores."""
+        assert 'football_skills' not in profile_edit_src
+        assert 'motivation_scores' not in profile_edit_src
+
+    def test_global_profile_edit_has_no_lfa_only_fields(self, profile_edit_src):
+        """height_cm and weight_kg are LFA-spec fields — must not appear in global edit."""
+        assert 'height_cm' not in profile_edit_src
+        assert 'weight_kg' not in profile_edit_src
+
+    def test_profile_route_context_still_has_lfa_license(self):
+        """profile_page route must still populate lfa_license in context."""
+        db = MagicMock()
+        db.query.return_value.filter.return_value.all.return_value = []
+        db.query.return_value.filter.return_value.first.return_value = None
+        user = _user()
+        user.specialization = None
+        with patch(f"{_BASE}.templates") as mock_tmpl:
+            mock_tmpl.TemplateResponse.return_value = MagicMock()
+            _run(profile_page(_req(), db=db, user=user))
+        ctx = mock_tmpl.TemplateResponse.call_args.args[1]
+        assert "lfa_license" in ctx
+
+
+# ── 6. GET /profile/lfa-football-player/edit — guards ────────────────────────
+
+class TestLfaEditGuards:
+    """GET edit route redirects when license absent or onboarding incomplete."""
+
+    def test_no_license_redirects_to_dashboard(self):
+        db = _mock_db(None)
+        result = _run(lfa_player_profile_edit_page(_req(), db=db, user=_user()))
+        assert isinstance(result, RedirectResponse)
+        assert "/dashboard" in result.headers["location"]
+
+    def test_incomplete_onboarding_redirects_to_onboarding(self):
+        db = _mock_db(_lfa_lic(completed=False))
+        result = _run(lfa_player_profile_edit_page(_req(), db=db, user=_user()))
+        assert isinstance(result, RedirectResponse)
+        assert "onboarding" in result.headers["location"]
+
+    def test_completed_license_does_not_redirect(self):
+        db = _mock_db(_lfa_lic())
+        with patch(f"{_BASE}.templates") as mock_tmpl:
+            mock_tmpl.TemplateResponse.return_value = MagicMock()
+            result = _run(lfa_player_profile_edit_page(_req(), db=db, user=_user()))
+        assert not isinstance(result, RedirectResponse)
+
+
+# ── 7. GET edit context ────────────────────────────────────────────────────────
+
+class TestLfaEditGetContext:
+    """GET edit route supplies the correct context keys for the edit form."""
+
+    def _ctx(self):
+        db = _mock_db(_lfa_lic())
+        with patch(f"{_BASE}.templates") as mock_tmpl:
+            mock_tmpl.TemplateResponse.return_value = MagicMock()
+            _run(lfa_player_profile_edit_page(_req(), db=db, user=_user()))
+        return mock_tmpl.TemplateResponse.call_args.args[1]
+
+    def test_template_name_is_edit(self):
+        db = _mock_db(_lfa_lic())
+        with patch(f"{_BASE}.templates") as mock_tmpl:
+            mock_tmpl.TemplateResponse.return_value = MagicMock()
+            _run(lfa_player_profile_edit_page(_req(), db=db, user=_user()))
+        assert mock_tmpl.TemplateResponse.call_args.args[0] == "lfa_player_profile_edit.html"
+
+    def test_context_has_ms(self):
+        ctx = self._ctx()
+        assert "ms" in ctx
+        assert ctx["ms"]["position"] == "striker"
+
+    def test_context_has_primary_pos(self):
+        assert self._ctx()["primary_pos"] == "striker"
+
+    def test_context_has_secondary_pos(self):
+        assert "secondary_pos" in self._ctx()
+
+    def test_context_has_position_groups(self):
+        ctx = self._ctx()
+        assert "position_groups" in ctx
+        assert any(g["label"] == "Forwards" for g in ctx["position_groups"])
+
+    def test_context_has_goal_labels(self):
+        ctx = self._ctx()
+        assert "goal_labels" in ctx
+        assert "become_professional" in ctx["goal_labels"]
+
+    def test_context_has_valid_preferred_foot(self):
+        ctx = self._ctx()
+        assert "valid_preferred_foot" in ctx
+        assert set(ctx["valid_preferred_foot"]) == _VALID_PREFERRED_FOOT
+
+    def test_context_error_is_none(self):
+        assert self._ctx()["error"] is None
+
+    def test_context_has_no_football_skills(self):
+        ctx = self._ctx()
+        assert "football_skills" not in ctx
+
+
+# ── 8. POST /profile/lfa-football-player/edit ─────────────────────────────────
+
+def _post(
+    position="striker",
+    preferred_foot="right",
+    goals="become_professional",
+    secondary_positions=None,
+    height_cm_raw="178",
+    weight_kg_raw="74",
+    lic=None,
+):
+    """Call lfa_player_profile_edit_submit with controllable parameters."""
+    if secondary_positions is None:
+        secondary_positions = []
+    if lic is None:
+        lic = _lfa_lic()
+    db = _mock_db(lic)
+    with patch(f"{_BASE}.templates") as mock_tmpl:
+        mock_tmpl.TemplateResponse.return_value = MagicMock()
+        result = _run(lfa_player_profile_edit_submit(
+            _req(),
+            position=position,
+            secondary_positions=secondary_positions,
+            preferred_foot=preferred_foot,
+            goals=goals,
+            height_cm_raw=height_cm_raw,
+            weight_kg_raw=weight_kg_raw,
+            db=db,
+            user=_user(),
+        ))
+    return result, db, lic, mock_tmpl
+
+
+class TestLfaEditPost:
+    """POST /profile/lfa-football-player/edit — valid save, validation errors, DB safety."""
+
+    # ── Valid submit ──────────────────────────────────────────────────────────
+
+    def test_valid_post_redirects_to_lfa_profile(self):
+        result, *_ = _post()
+        assert isinstance(result, RedirectResponse)
+        assert "/profile/lfa-football-player" in result.headers["location"]
+        assert "updated=true" in result.headers["location"]
+
+    def test_valid_post_calls_db_commit(self):
+        _, db, *_ = _post()
+        db.commit.assert_called_once()
+
+    def test_valid_post_updates_motivation_scores(self):
+        _, _, lic, _ = _post(position="centre_back", goals="fitness_health")
+        assert lic.motivation_scores["position"] == "centre_back"
+        assert lic.motivation_scores["goals"] == "fitness_health"
+
+    def test_valid_post_sets_positions_list(self):
+        _, _, lic, _ = _post(
+            position="striker",
+            secondary_positions=["centre_forward", "left_wing"],
+        )
+        positions = lic.motivation_scores["positions"]
+        assert positions[0] == "striker"
+        assert "centre_forward" in positions
+        assert "left_wing" in positions
+
+    def test_valid_post_excludes_primary_from_secondary(self):
+        """Primary position submitted in secondary_positions is silently dropped."""
+        _, _, lic, _ = _post(
+            position="striker",
+            secondary_positions=["striker", "centre_forward"],
+        )
+        positions = lic.motivation_scores["positions"]
+        assert positions.count("striker") == 1  # only as primary
+
+    def test_valid_post_does_not_modify_foot_scores(self):
+        """POST must never write right_foot_score or left_foot_score."""
+        lic = _lfa_lic(right=70.0, left=30.0)
+        _post(lic=lic)
+        assert lic.right_foot_score == 70.0
+        assert lic.left_foot_score  == 30.0
+
+    def test_valid_post_syncs_user_position(self):
+        user = _user()
+        db = _mock_db(_lfa_lic())
+        with patch(f"{_BASE}.templates") as mock_tmpl:
+            mock_tmpl.TemplateResponse.return_value = MagicMock()
+            _run(lfa_player_profile_edit_submit(
+                _req(),
+                position="goalkeeper",
+                secondary_positions=[],
+                preferred_foot="right",
+                goals="enjoy_game",
+                height_cm_raw="",
+                weight_kg_raw="",
+                db=db,
+                user=user,
+            ))
+        assert user.position == "goalkeeper"
+
+    def test_valid_post_does_not_modify_football_skills(self):
+        """Source-level guarantee: the POST handler never references football_skills."""
+        source = inspect.getsource(lfa_player_profile_edit_submit)
+        assert "football_skills" not in source
+
+    def test_valid_post_empty_height_keeps_existing(self):
+        """Empty height field → existing height_cm in motivation_scores unchanged."""
+        lic = _lfa_lic()
+        lic.motivation_scores = dict(lic.motivation_scores)
+        lic.motivation_scores["height_cm"] = 185
+        _post(height_cm_raw="", lic=lic)
+        assert lic.motivation_scores.get("height_cm") == 185
+
+    # ── Validation errors — no DB write ──────────────────────────────────────
+
+    def _assert_validation_error(self, result, db, mock_tmpl):
+        assert not isinstance(result, RedirectResponse)
+        db.commit.assert_not_called()
+        ctx = mock_tmpl.TemplateResponse.call_args.args[1]
+        assert ctx.get("error")
+
+    def test_invalid_position_returns_422(self):
+        result, db, _, mock_tmpl = _post(position="quarterback")
+        self._assert_validation_error(result, db, mock_tmpl)
+
+    def test_invalid_secondary_position_returns_422(self):
+        result, db, _, mock_tmpl = _post(secondary_positions=["not_a_position"])
+        self._assert_validation_error(result, db, mock_tmpl)
+
+    def test_invalid_preferred_foot_returns_422(self):
+        result, db, _, mock_tmpl = _post(preferred_foot="both_feet")
+        self._assert_validation_error(result, db, mock_tmpl)
+
+    def test_invalid_goals_returns_422(self):
+        result, db, _, mock_tmpl = _post(goals="world_domination")
+        self._assert_validation_error(result, db, mock_tmpl)
+
+    def test_height_below_min_returns_422(self):
+        result, db, _, mock_tmpl = _post(height_cm_raw="50")
+        self._assert_validation_error(result, db, mock_tmpl)
+
+    def test_height_above_max_returns_422(self):
+        result, db, _, mock_tmpl = _post(height_cm_raw="300")
+        self._assert_validation_error(result, db, mock_tmpl)
+
+    def test_weight_below_min_returns_422(self):
+        result, db, _, mock_tmpl = _post(weight_kg_raw="10")
+        self._assert_validation_error(result, db, mock_tmpl)
+
+    def test_weight_above_max_returns_422(self):
+        result, db, _, mock_tmpl = _post(weight_kg_raw="250")
+        self._assert_validation_error(result, db, mock_tmpl)
+
+    def test_non_numeric_height_returns_422(self):
+        result, db, _, mock_tmpl = _post(height_cm_raw="tall")
+        self._assert_validation_error(result, db, mock_tmpl)
+
+    def test_too_many_secondary_positions_returns_422(self):
+        """More than 3 secondary positions (excluding primary) must return 422."""
+        result, db, _, mock_tmpl = _post(
+            position="striker",
+            secondary_positions=[
+                "centre_forward", "left_wing", "right_wing", "second_striker"
+            ],
+        )
+        self._assert_validation_error(result, db, mock_tmpl)
+        ctx = mock_tmpl.TemplateResponse.call_args.args[1]
+        assert "3" in ctx["error"]
+
+    def test_db_commit_not_called_on_error(self):
+        _, db, _, _ = _post(position="invalid_pos")
+        db.commit.assert_not_called()
+
+
+# ── 9. Edit template static assertions ────────────────────────────────────────
+
+@pytest.fixture(scope="module")
+def edit_tpl_src():
+    return _EDIT_TPL_PATH.read_text(encoding="utf-8")
+
+
+class TestLfaEditTemplate:
+    """Static source analysis of lfa_player_profile_edit.html."""
+
+    def test_edit_template_file_exists(self):
+        assert _EDIT_TPL_PATH.exists()
+
+    def test_extends_student_base(self, edit_tpl_src):
+        assert "student_base.html" in edit_tpl_src
+
+    def test_form_method_is_post(self, edit_tpl_src):
+        assert 'method="POST"' in edit_tpl_src
+
+    def test_form_action_is_correct(self, edit_tpl_src):
+        assert 'action="/profile/lfa-football-player/edit"' in edit_tpl_src
+
+    def test_back_link_to_lfa_profile(self, edit_tpl_src):
+        assert 'href="/profile/lfa-football-player"' in edit_tpl_src
+
+    def test_no_football_skills_input(self, edit_tpl_src):
+        assert "football_skills" not in edit_tpl_src
+
+    def test_no_current_level_input(self, edit_tpl_src):
+        assert "current_level" not in edit_tpl_src
+
+    def test_no_self_assessment_input(self, edit_tpl_src):
+        assert "self_assessment" not in edit_tpl_src
+
+    def test_position_radio_inputs_present(self, edit_tpl_src):
+        assert 'name="position"' in edit_tpl_src
+        assert 'type="radio"' in edit_tpl_src
+
+    def test_secondary_positions_checkboxes_present(self, edit_tpl_src):
+        assert 'name="secondary_positions"' in edit_tpl_src
+        assert 'type="checkbox"' in edit_tpl_src
+
+    def test_preferred_foot_inputs_present(self, edit_tpl_src):
+        assert 'name="preferred_foot"' in edit_tpl_src
+
+    def test_height_input_present(self, edit_tpl_src):
+        assert 'name="height_cm_raw"' in edit_tpl_src
+
+    def test_weight_input_present(self, edit_tpl_src):
+        assert 'name="weight_kg_raw"' in edit_tpl_src
+
+    def test_foot_score_inputs_absent(self, edit_tpl_src):
+        """Foot assessment is read-only — must have no inputs in the edit form."""
+        assert 'name="right_foot_score_raw"' not in edit_tpl_src
+        assert 'name="left_foot_score_raw"' not in edit_tpl_src
+
+    def test_goals_dropdown_present(self, edit_tpl_src):
+        assert 'name="goals"' in edit_tpl_src
+
+    def test_csrf_note_via_base_template(self, edit_tpl_src):
+        # CSRF is handled globally by base.html submit interceptor.
+        # Edit template inherits from student_base → base → CSRF guard.
+        assert "student_base.html" in edit_tpl_src
+
+    def test_error_banner_shown_when_error(self, edit_tpl_src):
+        assert "error" in edit_tpl_src
+        assert "error-banner" in edit_tpl_src
+
+    def test_save_button_present(self, edit_tpl_src):
+        assert 'type="submit"' in edit_tpl_src
+
+    def test_link_to_global_profile_edit_absent_from_form(self, edit_tpl_src):
+        """The edit form action must point to the spec-profile route, not /profile/edit."""
+        # The scope note may reference /profile/edit as informational text — that's OK.
+        # The form action must be spec-specific.
+        assert 'action="/profile/lfa-football-player/edit"' in edit_tpl_src
+
+
+# ── Group 10: Navigation CTA audit ─────────────────────────────────────────────
+
+class TestLfaNavigationCTAs:
+    """
+    Verify that LFA-specific Profile CTAs point to /profile/lfa-football-player
+    and that global-context Profile links remain /profile.
+    """
+
+    @pytest.fixture
+    def dashboard_src(self):
+        return _DASHBOARD_TPL_PATH.read_text()
+
+    @pytest.fixture
+    def onboarding_src(self):
+        return _ONBOARDING_TPL_PATH.read_text()
+
+    @pytest.fixture
+    def card_editor_src(self):
+        return _CARD_EDITOR_TPL_PATH.read_text()
+
+    @pytest.fixture
+    def student_base_src(self):
+        return _STUDENT_BASE_TPL_PATH.read_text()
+
+    # ── LFA dashboard header Profile button ──────────────────────────────────
+
+    def test_dashboard_header_profile_btn_points_to_lfa_profile(self, dashboard_src):
+        """Header Profile button in LFA dashboard conditionally targets spec profile."""
+        assert "/profile/lfa-football-player" in dashboard_src
+
+    def test_dashboard_header_profile_btn_is_conditional_on_specialization(self, dashboard_src):
+        """Conditional branch must check for LFA_FOOTBALL_PLAYER so other specs keep /profile."""
+        assert "LFA_FOOTBALL_PLAYER" in dashboard_src
+        assert "specialization" in dashboard_src
+
+    def test_dashboard_header_profile_btn_has_fallback_to_global_profile(self, dashboard_src):
+        """Non-LFA specializations must fall back to /profile in the same conditional."""
+        # The conditional renders /profile as the else branch.
+        assert "else" in dashboard_src
+
+    # ── Dashboard footer links — must remain global ───────────────────────────
+
+    def test_dashboard_footer_profile_link_remains_global(self, dashboard_src):
+        """Footer nav is a utility strip; it stays /profile regardless of spec."""
+        assert 'href="/profile"' in dashboard_src
+
+    # ── LFA dashboard Profile button icon ────────────────────────────────────
+
+    def test_dashboard_lfa_profile_btn_uses_id_card_icon(self, dashboard_src):
+        """When specialization == LFA_FOOTBALL_PLAYER the Profile btn must show 🪪."""
+        assert '🪪' in dashboard_src
+
+    def test_dashboard_non_lfa_profile_btn_uses_person_icon(self, dashboard_src):
+        """The else branch (non-LFA) must show 👤."""
+        assert '👤' in dashboard_src
+
+    # ── Onboarding Step 7 "Go to Profile" button ─────────────────────────────
+
+    def test_onboarding_go_to_profile_btn_points_to_lfa_profile(self, onboarding_src):
+        """Step 7 'Go to Profile' CTA must target /profile/lfa-football-player."""
+        assert 'href="/profile/lfa-football-player"' in onboarding_src
+
+    def test_onboarding_go_to_profile_btn_uses_id_card_icon(self, onboarding_src):
+        """Step 7 'Go to Profile' CTA must use 🪪 icon (spec-profile link)."""
+        import re
+        match = re.search(r'id="btn-go-profile"[^>]*>([^<]+)', onboarding_src)
+        assert match is not None, "btn-go-profile element not found"
+        assert '🪪' in match.group(1)
+
+    def test_onboarding_go_to_profile_btn_not_pointing_to_global(self, onboarding_src):
+        """btn-go-profile element must not point to the plain /profile route."""
+        import re
+        match = re.search(r'id="btn-go-profile"[^>]*href="([^"]+)"', onboarding_src)
+        if not match:
+            match = re.search(r'href="([^"]+)"[^>]*id="btn-go-profile"', onboarding_src)
+        assert match is not None, "btn-go-profile element not found"
+        assert match.group(1) == "/profile/lfa-football-player"
+
+    # ── Card editor header Profile button ────────────────────────────────────
+
+    def test_card_editor_header_profile_btn_points_to_lfa_profile(self, card_editor_src):
+        """Card editor is LFA-specific; its header Profile button targets spec profile."""
+        assert 'href="/profile/lfa-football-player"' in card_editor_src
+
+    def test_card_editor_header_profile_btn_uses_id_card_icon(self, card_editor_src):
+        """Card editor Profile button must use 🪪 (LFA spec-profile link)."""
+        import re
+        match = re.search(r'href="/profile/lfa-football-player"[^>]*>([^<]+)', card_editor_src)
+        assert match is not None, "Profile link not found in card editor"
+        assert '🪪' in match.group(1)
+
+    def test_card_editor_header_profile_btn_not_global(self, card_editor_src):
+        """Card editor must not have a plain s-hdr-btn pointing to /profile."""
+        import re
+        # There should be no s-hdr-btn with href="/profile" (the plain global route)
+        assert 'href="/profile" class="s-hdr-btn"' not in card_editor_src
+        assert 'href="/profile"' not in card_editor_src or \
+               'href="/profile/lfa-football-player"' in card_editor_src
+
+    # ── My Card tile icon — must be 🎴, not 🪪 ────────────────────────────────
+
+    def test_dashboard_my_card_tile_uses_playing_card_icon(self, dashboard_src):
+        """My Card mod-nav tile must use 🎴 (card/deck icon), not 🪪 (ID card)."""
+        assert '🎴' in dashboard_src
+
+    def test_dashboard_my_card_hero_title_uses_playing_card_icon(self, dashboard_src):
+        """My Player Card hero section title must use 🎴."""
+        assert '🎴 My Player Card' in dashboard_src
+
+    def test_card_editor_page_title_uses_playing_card_icon(self, card_editor_src):
+        """Card editor page title must use 🎴 My Player Card."""
+        assert '🎴 My Player Card' in card_editor_src
+
+    def test_card_editor_profile_cta_still_uses_id_card_icon(self, card_editor_src):
+        """Profile CTA in card editor must still be 🪪 (unchanged)."""
+        import re
+        match = re.search(r'href="/profile/lfa-football-player"[^>]*>([^<]+)', card_editor_src)
+        assert match is not None
+        assert '🪪' in match.group(1)
+
+    # ── Regression: student_base.html global nav stays on /profile ───────────
+
+    def test_student_base_global_nav_still_on_global_profile(self, student_base_src):
+        """Global base template Profile nav link must remain /profile (context-agnostic)."""
+        assert 'href="/profile"' in student_base_src
+
+    def test_student_base_does_not_hardcode_lfa_profile(self, student_base_src):
+        """student_base.html must not hardcode /profile/lfa-football-player."""
+        assert "/profile/lfa-football-player" not in student_base_src
+
+    # ── Welcome card back link (regression guard — must not revert) ───────────
+
+    def test_welcome_card_back_link_still_on_lfa_profile(self):
+        """Welcome card back link was updated in Fázis 2; must not revert to /profile."""
+        src = _WC_GALLERY_TPL_PATH.read_text()
+        assert "/profile/lfa-football-player" in src
+
+
+# ── Group 11: Design integration — header, icon, theme ─────────────────────────
+
+class TestLfaDesignIntegration:
+    """
+    Verify the design integration fix:
+      - spec_subpage_hdr.html pattern adopted by both LFA profile templates
+      - 🪪 icon in lfa_player_profile.html page title
+      - No phantom hdr-lfa-player CSS class references
+      - #667eea / #764ba2 purple accent replaced by hub CSS vars in both templates
+      - Regressions: student_base.html and global profile.html unchanged
+    """
+
+    @pytest.fixture
+    def tpl_src(self):
+        return _TPL_PATH.read_text()
+
+    @pytest.fixture
+    def edit_src(self):
+        return _EDIT_TPL_PATH.read_text()
+
+    @pytest.fixture
+    def student_base_src(self):
+        return _STUDENT_BASE_TPL_PATH.read_text()
+
+    @pytest.fixture
+    def profile_src(self):
+        return _PROFILE_TPL_PATH.read_text()
+
+    # ── Header pattern ────────────────────────────────────────────────────────
+
+    def test_lfa_profile_includes_spec_subpage_hdr(self, tpl_src):
+        """lfa_player_profile.html must include spec_subpage_hdr.html."""
+        assert 'spec_subpage_hdr.html' in tpl_src
+
+    def test_lfa_profile_overrides_student_header_block(self, tpl_src):
+        """lfa_player_profile.html must override {% block student_header %}."""
+        assert 'block student_header' in tpl_src
+
+    def test_lfa_profile_sets_page_icon_var(self, tpl_src):
+        """lfa_player_profile.html must set _page_icon before the include."""
+        assert '_page_icon' in tpl_src
+
+    def test_lfa_edit_includes_spec_subpage_hdr(self, edit_src):
+        """lfa_player_profile_edit.html must include spec_subpage_hdr.html."""
+        assert 'spec_subpage_hdr.html' in edit_src
+
+    def test_lfa_edit_overrides_student_header_block(self, edit_src):
+        """lfa_player_profile_edit.html must override {% block student_header %}."""
+        assert 'block student_header' in edit_src
+
+    # ── Icon ─────────────────────────────────────────────────────────────────
+
+    def test_lfa_profile_page_title_has_id_card_icon(self, tpl_src):
+        """🪪 must appear in the page title / header of lfa_player_profile.html."""
+        assert '🪪' in tpl_src
+
+    def test_lfa_profile_page_icon_var_is_id_card(self, tpl_src):
+        """_page_icon must be set to 🪪 for the spec subpage header."""
+        assert "_page_icon = '🪪'" in tpl_src
+
+    def test_lfa_edit_page_icon_is_pencil(self, edit_src):
+        """Edit page must use ✏️ as its spec header icon."""
+        assert "_page_icon = '✏️'" in edit_src
+
+    def test_student_base_global_brand_unchanged(self, student_base_src):
+        """student_base.html 🏫 brand must remain untouched."""
+        assert '🏫 LFA Education Center' in student_base_src
+
+    def test_global_profile_title_unchanged(self, profile_src):
+        """Global /profile page title icon 👤 must remain unchanged."""
+        assert '👤 My Profile' in profile_src
+
+    def test_student_base_global_profile_nav_uses_person_icon(self, student_base_src):
+        """student_base.html global Profile nav must keep 👤 (links to /profile)."""
+        assert '👤</a>' in student_base_src or '>👤<' in student_base_src
+
+    # ── No phantom CSS class ─────────────────────────────────────────────────
+
+    def test_lfa_profile_no_hdr_lfa_player_class(self, tpl_src):
+        """hdr-lfa-player is not defined in student.css; must not appear in template."""
+        assert 'hdr-lfa-player' not in tpl_src
+
+    def test_lfa_edit_no_hdr_lfa_player_class(self, edit_src):
+        assert 'hdr-lfa-player' not in edit_src
+
+    def test_profile_py_no_hdr_lfa_player(self):
+        """profile.py must not reference the nonexistent hdr-lfa-player CSS class."""
+        import pathlib
+        src = (
+            pathlib.Path(__file__).resolve().parents[4]
+            / "app" / "api" / "web_routes" / "profile.py"
+        ).read_text()
+        assert 'hdr-lfa-player' not in src
+
+    # ── Theme tokens: no legacy purple accent ─────────────────────────────────
+
+    def test_lfa_profile_no_hardcoded_purple_primary(self, tpl_src):
+        """lfa_player_profile.html must not hardcode #667eea as accent/primary color."""
+        assert '#667eea' not in tpl_src
+
+    def test_lfa_profile_no_hardcoded_purple_gradient(self, tpl_src):
+        """lfa_player_profile.html must not use #764ba2 purple gradient."""
+        assert '#764ba2' not in tpl_src
+
+    def test_lfa_edit_no_hardcoded_purple_primary(self, edit_src):
+        """lfa_player_profile_edit.html must not hardcode #667eea as accent/primary color."""
+        assert '#667eea' not in edit_src
+
+    def test_lfa_profile_uses_hub_btn_token(self, tpl_src):
+        """Primary button must use --hub-btn-bg CSS var, not a hardcoded hex."""
+        assert 'var(--hub-btn-bg)' in tpl_src
+
+    def test_lfa_edit_uses_brand_yellow_accent(self, edit_src):
+        """Form focus / selected state must use --brand-yellow, not #667eea."""
+        assert 'var(--brand-yellow)' in edit_src
+
+    def test_lfa_edit_save_btn_uses_hub_token(self, edit_src):
+        """Save button must use --hub-btn-bg token."""
+        assert 'var(--hub-btn-bg)' in edit_src
+
+    # ── Regression: global profile unchanged ─────────────────────────────────
+
+    def test_global_profile_still_uses_separate_inline_css(self, profile_src):
+        """Global /profile template must not have been modified by this fix."""
+        assert '{% extends "student_base.html" %}' in profile_src
+
+    def test_welcome_card_back_link_unchanged(self):
+        """Welcome Card back link must still point to /profile/lfa-football-player."""
+        src = _WC_GALLERY_TPL_PATH.read_text()
+        assert '/profile/lfa-football-player' in src
+
+
+# ── Group 12a: View data completeness — old-license compatibility ──────────────
+
+class TestLfaViewDataCompleteness:
+    """
+    View route renders correctly for licenses that predate average_skill_level
+    and onboarding_completed_at fields in motivation_scores.
+    """
+
+    def _ctx(self, lic):
+        db = _mock_db(lic)
+        with patch(f"{_BASE}.templates") as mock_tmpl:
+            mock_tmpl.TemplateResponse.return_value = MagicMock()
+            _run(lfa_player_profile_page(_req(), db=db, user=_user()))
+        return mock_tmpl.TemplateResponse.call_args.args[1]
+
+    def test_context_average_skill_level_none_for_old_license(self):
+        """Old license with no average_skill_level in ms → context value is None."""
+        lic = _lfa_lic()  # default has no avg_skill key
+        ctx = self._ctx(lic)
+        assert ctx["average_skill_level"] is None
+
+    def test_context_onboarding_completed_at_none_for_old_license(self):
+        """Old license with no onboarding_completed_at in ms → context value is None."""
+        lic = _lfa_lic()  # default has no joined_at key
+        ctx = self._ctx(lic)
+        assert ctx["onboarding_completed_at"] is None
+
+    def test_context_average_skill_level_correct_when_present(self):
+        lic = _lfa_lic(avg_skill=71.5)
+        ctx = self._ctx(lic)
+        assert ctx["average_skill_level"] == 71.5
+
+    def test_context_onboarding_completed_at_correct_when_present(self):
+        lic = _lfa_lic(joined_at="2026-05-01T09:00:00Z")
+        ctx = self._ctx(lic)
+        assert ctx["onboarding_completed_at"] == "2026-05-01T09:00:00Z"
+
+    def test_route_renders_without_error_when_ms_is_none(self):
+        """License with motivation_scores=None must not raise."""
+        lic = _lfa_lic()
+        lic.motivation_scores = None
+        db = _mock_db(lic)
+        with patch(f"{_BASE}.templates") as mock_tmpl:
+            mock_tmpl.TemplateResponse.return_value = MagicMock()
+            result = _run(lfa_player_profile_page(_req(), db=db, user=_user()))
+        assert not isinstance(result, RedirectResponse)
+
+    def test_route_passes_ms_keys_correctly_with_all_fields(self):
+        """All expected context keys present when license has full motivation_scores."""
+        lic = _lfa_lic(avg_skill=64.0, joined_at="2026-05-08T10:00:00Z")
+        ctx = self._ctx(lic)
+        assert ctx["average_skill_level"] == 64.0
+        assert ctx["onboarding_completed_at"] == "2026-05-08T10:00:00Z"
+        assert ctx["ms"]["position"] == "striker"
+        assert ctx["goal_label"] == "Become a professional player"
+
+
+# ── Group 12b: Edit form scope — foot scores excluded, max-3 enforced ──────────
+
+class TestLfaEditFormScope:
+    """
+    Verify the post-refactor edit form scope:
+      - right_foot_score / left_foot_score are NEVER written by the POST handler
+      - maximum 3 secondary positions is enforced
+      - football_skills key is never referenced in handler source
+    """
+
+    def test_post_handler_has_no_foot_score_form_param(self):
+        """lfa_player_profile_edit_submit must not accept right_foot_score_raw."""
+        import inspect as _inspect
+        sig = _inspect.signature(lfa_player_profile_edit_submit)
+        assert "right_foot_score_raw" not in sig.parameters
+        assert "left_foot_score_raw" not in sig.parameters
+
+    def test_post_handler_source_has_no_foot_score_write(self):
+        """Handler source must not assign right_foot_score or left_foot_score."""
+        source = inspect.getsource(lfa_player_profile_edit_submit)
+        assert "right_foot_score" not in source
+        assert "left_foot_score" not in source
+
+    def test_exactly_3_secondary_positions_accepted(self):
+        """3 secondary positions (excluding primary) must succeed."""
+        result, db, _, _ = _post(
+            position="striker",
+            secondary_positions=["centre_forward", "left_wing", "right_wing"],
+        )
+        assert isinstance(result, RedirectResponse)
+        db.commit.assert_called_once()
+
+    def test_4_secondary_positions_returns_422(self):
+        """4 unique secondary positions (excluding primary) must fail with 422."""
+        result, db, _, mock_tmpl = _post(
+            position="striker",
+            secondary_positions=[
+                "centre_forward", "left_wing", "right_wing", "second_striker"
+            ],
+        )
+        assert not isinstance(result, RedirectResponse)
+        db.commit.assert_not_called()
+        ctx = mock_tmpl.TemplateResponse.call_args.args[1]
+        assert ctx.get("error")
+        assert "3" in ctx["error"]
+
+    def test_edit_template_has_no_foot_score_inputs(self):
+        """Edit template must not contain right_foot_score_raw or left_foot_score_raw inputs."""
+        src = _EDIT_TPL_PATH.read_text()
+        assert "right_foot_score_raw" not in src
+        assert "left_foot_score_raw" not in src
+
+    def test_edit_template_has_secondary_counter(self):
+        """Edit template must contain the JS secondary-position counter."""
+        src = _EDIT_TPL_PATH.read_text()
+        assert "sec-pos-counter" in src
+        assert "MAX_SEC" in src

--- a/tests/unit/api/web_routes/test_lfa_player_profile.py
+++ b/tests/unit/api/web_routes/test_lfa_player_profile.py
@@ -15,6 +15,7 @@ Test groups:
   TestLfaDesignIntegration        — header pattern, icon, theme token regression (design fix)
   TestLfaViewDataCompleteness     — old-license compatibility (missing avg_skill/joined_at)
   TestLfaEditFormScope            — foot scores excluded, max-3 enforced, handler source check
+  TestLfaPositionsEndpoint        — POST /positions: save, validation, backward-compat, template
 """
 import asyncio
 import inspect
@@ -28,6 +29,7 @@ from app.api.web_routes.profile import (
     lfa_player_profile_page,
     lfa_player_profile_edit_page,
     lfa_player_profile_edit_submit,
+    lfa_player_profile_positions_submit,
     profile_page,
     _VALID_POSITIONS,
     _VALID_GOALS,
@@ -1165,3 +1167,228 @@ class TestLfaEditFormScope:
         src = _EDIT_TPL_PATH.read_text()
         assert "sec-pos-counter" in src
         assert "MAX_SEC" in src
+
+
+# ── 14. POST /profile/lfa-football-player/positions ──────────────────────────
+
+import json as _json_mod
+import pathlib as _pathlib
+
+_PITCH_SEL_PATH = (
+    pathlib.Path(__file__).resolve().parents[4]
+    / "app" / "static" / "js" / "pitch-selector.js"
+)
+
+
+def _pos_post(
+    position="striker",
+    positions_raw=None,
+    lic=None,
+    user=None,
+):
+    """Call lfa_player_profile_positions_submit with controllable parameters."""
+    if positions_raw is None:
+        positions_raw = _json_mod.dumps([position])
+    if lic is None:
+        lic = _lfa_lic()
+    if user is None:
+        user = _user()
+    db = _mock_db(lic)
+    req = _req()
+    req.query_params = {}
+    result = _run(lfa_player_profile_positions_submit(
+        req,
+        position=position,
+        positions_raw=positions_raw,
+        db=db,
+        user=user,
+    ))
+    return result, db, lic, user
+
+
+class TestLfaPositionsEndpoint:
+    """POST /profile/lfa-football-player/positions — save, validation, backward-compat, template."""
+
+    # ── Valid submit ──────────────────────────────────────────────────────────
+
+    def test_valid_single_position_redirects_with_updated(self):
+        result, *_ = _pos_post(position="striker", positions_raw='["striker"]')
+        assert isinstance(result, RedirectResponse)
+        assert "updated=positions" in result.headers["location"]
+
+    def test_valid_four_positions_redirects(self):
+        raw = _json_mod.dumps(["striker", "centre_forward", "left_wing", "right_wing"])
+        result, db, lic, _ = _pos_post(position="striker", positions_raw=raw)
+        assert isinstance(result, RedirectResponse)
+        assert db.commit.call_count == 1
+        assert lic.motivation_scores["positions"] == [
+            "striker", "centre_forward", "left_wing", "right_wing"
+        ]
+
+    def test_valid_save_syncs_user_position(self):
+        user = _user()
+        raw = _json_mod.dumps(["goalkeeper"])
+        result, _, lic, u = _pos_post(position="goalkeeper", positions_raw=raw, user=user)
+        assert isinstance(result, RedirectResponse)
+        assert u.position == "goalkeeper"
+
+    def test_valid_save_updates_motivation_scores_position_key(self):
+        raw = _json_mod.dumps(["centre_back", "left_back"])
+        _, _, lic, _ = _pos_post(position="centre_back", positions_raw=raw)
+        assert lic.motivation_scores["position"] == "centre_back"
+        assert lic.motivation_scores["positions"][0] == "centre_back"
+
+    def test_valid_save_does_not_touch_foot_scores(self):
+        lic = _lfa_lic(right=80.0, left=20.0)
+        _pos_post(lic=lic)
+        assert lic.right_foot_score == 80.0
+        assert lic.left_foot_score == 20.0
+
+    # ── Validation errors — no DB write ──────────────────────────────────────
+
+    def test_five_positions_rejected(self):
+        raw = _json_mod.dumps([
+            "striker", "centre_forward", "left_wing", "right_wing", "second_striker"
+        ])
+        result, db, _, _ = _pos_post(position="striker", positions_raw=raw)
+        assert isinstance(result, RedirectResponse)
+        assert "pos_error=invalid_count" in result.headers["location"]
+        db.commit.assert_not_called()
+
+    def test_empty_positions_list_rejected(self):
+        result, db, _, _ = _pos_post(position="striker", positions_raw="[]")
+        assert isinstance(result, RedirectResponse)
+        assert "pos_error=invalid_count" in result.headers["location"]
+        db.commit.assert_not_called()
+
+    def test_invalid_primary_rejected(self):
+        result, db, _, _ = _pos_post(
+            position="quarterback",
+            positions_raw='["quarterback"]',
+        )
+        assert "pos_error=invalid_primary" in result.headers["location"]
+        db.commit.assert_not_called()
+
+    def test_empty_primary_rejected(self):
+        result, db, _, _ = _pos_post(position="", positions_raw='[""]')
+        assert "pos_error=invalid_primary" in result.headers["location"]
+        db.commit.assert_not_called()
+
+    def test_invalid_position_in_list_rejected(self):
+        raw = _json_mod.dumps(["striker", "not_a_real_position"])
+        result, db, _, _ = _pos_post(position="striker", positions_raw=raw)
+        assert "pos_error=invalid_position" in result.headers["location"]
+        db.commit.assert_not_called()
+
+    def test_primary_not_first_rejected(self):
+        raw = _json_mod.dumps(["centre_forward", "striker"])
+        result, db, _, _ = _pos_post(position="striker", positions_raw=raw)
+        assert "pos_error=primary_not_first" in result.headers["location"]
+        db.commit.assert_not_called()
+
+    def test_malformed_json_rejected(self):
+        result, db, _, _ = _pos_post(position="striker", positions_raw="not-json")
+        assert "pos_error=invalid_format" in result.headers["location"]
+        db.commit.assert_not_called()
+
+    def test_no_license_redirects(self):
+        db = _mock_db(None)
+        req = _req()
+        req.query_params = {}
+        result = _run(lfa_player_profile_positions_submit(
+            req,
+            position="striker",
+            positions_raw='["striker"]',
+            db=db,
+            user=_user(),
+        ))
+        assert isinstance(result, RedirectResponse)
+        assert "dashboard" in result.headers["location"] or "no_lfa_license" in result.headers["location"]
+
+    # ── Template static assertions ────────────────────────────────────────────
+
+    def test_profile_template_has_positions_mount(self):
+        src = _TPL_PATH.read_text(encoding="utf-8")
+        assert "ps-profile-mount" in src
+
+    def test_profile_template_positions_form_action(self):
+        src = _TPL_PATH.read_text(encoding="utf-8")
+        assert 'action="/profile/lfa-football-player/positions"' in src
+
+    def test_profile_template_references_player_positions(self):
+        src = _TPL_PATH.read_text(encoding="utf-8")
+        assert "player_positions" in src
+
+    # ── UX-fix: P0 — no duplicate counter ────────────────────────────────────
+
+    def test_no_external_counter_element_in_template(self):
+        """External #pos-counter removed — pitch-selector internal counter is the sole source."""
+        src = _TPL_PATH.read_text(encoding="utf-8")
+        assert 'id="pos-counter"' not in src
+
+    def test_update_inputs_js_no_counter_reference(self):
+        """_updateInputs must not touch the (now-removed) #pos-counter DOM element."""
+        src = _TPL_PATH.read_text(encoding="utf-8")
+        assert "pos-counter" not in src
+
+    # ── UX-fix: P1 — cancel/reopen resets selector state ─────────────────────
+
+    def test_hidePosEdit_resets_ps_instance(self):
+        """hidePosEdit must null _ps so re-open always reinitialises from saved DB state."""
+        src = _TPL_PATH.read_text(encoding="utf-8")
+        hide_start = src.find("hidePosEdit")
+        assert hide_start != -1, "hidePosEdit not found in template"
+        fn_brace = src.find("{", hide_start)
+        fn_end   = src.find("};", fn_brace)
+        fn_body  = src[fn_brace:fn_end]
+        assert "_ps = null" in fn_body
+
+    # ── UX-fix: P1 — profile theme scoped, not global ────────────────────────
+
+    def test_profile_theme_css_scoped_to_mount(self):
+        """Info-panel + counter overrides must be scoped to #ps-profile-mount, not global."""
+        src = _TPL_PATH.read_text(encoding="utf-8")
+        assert "#ps-profile-mount .ps-info-panel" in src
+        assert "#ps-profile-mount .ps-counter" in src
+
+    # ── UX-fix: P1 — toggle reveal animation present ─────────────────────────
+
+    def test_edit_mode_reveal_animation_present(self):
+        src = _TPL_PATH.read_text(encoding="utf-8")
+        assert "pos-edit-entering" in src
+        assert "pos-edit-reveal" in src
+
+    # ── UX-fix: P0 — mobile sticky action row ────────────────────────────────
+
+    def test_mobile_action_row_is_sticky(self):
+        """pos-action-row must use position:sticky in a max-width media query."""
+        src = _TPL_PATH.read_text(encoding="utf-8")
+        assert "sticky" in src
+        assert "pos-action-row" in src
+
+    # ── UX-fix: P2 — emoji and badge clarity ─────────────────────────────────
+
+    def test_positions_card_icon_not_football_emoji(self):
+        """Positions card must not reuse the ⚽ emoji (clashes with Player Profile card)."""
+        src = _TPL_PATH.read_text(encoding="utf-8")
+        assert "⚽ Positions" not in src
+
+    def test_positions_card_has_pin_icon(self):
+        src = _TPL_PATH.read_text(encoding="utf-8")
+        assert "📍 Positions" in src
+
+    def test_positions_card_has_primary_group_label(self):
+        src = _TPL_PATH.read_text(encoding="utf-8")
+        assert "pos-section-label" in src
+        assert ">Primary<" in src
+
+    def test_positions_card_has_also_group_label(self):
+        src = _TPL_PATH.read_text(encoding="utf-8")
+        assert ">Also<" in src
+
+    # ── JS static assertion ───────────────────────────────────────────────────
+
+    def test_pitch_selector_has_set_positions_method(self):
+        src = _PITCH_SEL_PATH.read_text(encoding="utf-8")
+        assert "setPositions" in src
+        assert "PitchSelector.prototype.setPositions" in src

--- a/tests/unit/api/web_routes/test_welcome_card.py
+++ b/tests/unit/api/web_routes/test_welcome_card.py
@@ -196,6 +196,52 @@ class TestWelcomeCardGalleryRoute:
         _, ctx = mock_tmpl.TemplateResponse.call_args.args
         assert "player" not in ctx
 
+    # WC-CTX-01..03 — Phase 2: canvas_sizes context and platform order regression
+
+    def test_wc_ctx01_canvas_sizes_keys_match_canvas_sizes_constant(self):
+        """Gallery context canvas_sizes must cover all CANVAS_SIZES platforms."""
+        from app.services.card_constants import CANVAS_SIZES
+        lic = _license()
+        db  = _mock_db(license_return=lic)
+        with patch(f"{_BASE}.templates") as mock_tmpl:
+            mock_tmpl.TemplateResponse.return_value = MagicMock()
+            _run(onboarding_welcome_card(_req(), platform=None, db=db, user=_user()))
+        _, ctx = mock_tmpl.TemplateResponse.call_args.args
+        assert "canvas_sizes" in ctx, "Gallery hub context must include 'canvas_sizes'"
+        assert set(ctx["canvas_sizes"].keys()) == set(CANVAS_SIZES.keys()), (
+            "canvas_sizes keys in context must match CANVAS_SIZES keys exactly"
+        )
+
+    def test_wc_ctx02_platforms_length_matches_wc_gallery_platform_ids(self):
+        """Gallery platforms list length must equal WC_GALLERY_PLATFORM_IDS length."""
+        from app.services.card_constants import WC_GALLERY_PLATFORM_IDS
+        lic = _license()
+        db  = _mock_db(license_return=lic)
+        with patch(f"{_BASE}.templates") as mock_tmpl:
+            mock_tmpl.TemplateResponse.return_value = MagicMock()
+            _run(onboarding_welcome_card(_req(), platform=None, db=db, user=_user()))
+        _, ctx = mock_tmpl.TemplateResponse.call_args.args
+        assert len(ctx["platforms"]) == len(WC_GALLERY_PLATFORM_IDS), (
+            f"Expected {len(WC_GALLERY_PLATFORM_IDS)} platforms, "
+            f"got {len(ctx['platforms'])}"
+        )
+
+    def test_wc_ctx03_platforms_order_matches_wc_gallery_platform_ids(self):
+        """Gallery platforms order must match WC_GALLERY_PLATFORM_IDS order."""
+        from app.services.card_constants import WC_GALLERY_PLATFORM_IDS
+        lic = _license()
+        db  = _mock_db(license_return=lic)
+        with patch(f"{_BASE}.templates") as mock_tmpl:
+            mock_tmpl.TemplateResponse.return_value = MagicMock()
+            _run(onboarding_welcome_card(_req(), platform=None, db=db, user=_user()))
+        _, ctx = mock_tmpl.TemplateResponse.call_args.args
+        actual_ids = [p["id"] for p in ctx["platforms"]]
+        assert actual_ids == list(WC_GALLERY_PLATFORM_IDS), (
+            f"Platform order mismatch.\n"
+            f"Expected: {list(WC_GALLERY_PLATFORM_IDS)}\n"
+            f"Actual:   {actual_ids}"
+        )
+
 
 # ── 3. FIFA card route (?platform=X) ──────────────────────────────────────────
 
@@ -419,18 +465,25 @@ class TestWelcomeCardGalleryTemplate:
         assert 'href="/profile/lfa-football-player"' in gallery_src
 
     def test_gallery_renders_with_minimal_context(self):
-        """Jinja2 render: gallery template must not error with minimal context."""
+        """Jinja2 render: gallery template must not error with minimal context.
+
+        canvas_sizes is required (Phase 2): the template uses {{ canvas_sizes | tojson }}
+        to generate the JS CANVAS_SIZES object instead of a hardcoded literal.
+        """
         from jinja2 import Environment, FileSystemLoader, Undefined
+        from app.services.card_constants import CANVAS_SIZES
         env = Environment(
             loader=FileSystemLoader(str(_GALLERY_TPL_PATH.parents[1])),
             autoescape=True,
             undefined=Undefined,
         )
+        canvas_sizes = {pid: {"w": w, "h": h} for pid, (w, h) in CANVAS_SIZES.items()}
         ctx = {
             "request":          MagicMock(),
             "display_name":     "Test Player",
             "platforms":        _WC_GALLERY_PLATFORMS,
             "default_platform": "instagram_square",
+            "canvas_sizes":     canvas_sizes,
         }
         html = env.get_template("public/welcome_card.html").render(**ctx)
         assert "Welcome Card" in html
@@ -725,21 +778,17 @@ class TestWelcomeCardRenderingFixes:
 
     # ── Fix B: platform-aware canvas sizing ──
 
-    def test_canvas_sizes_has_instagram_square(self, gallery_html_src):
-        assert "instagram_square" in gallery_html_src
-        assert "[1080, 1080]" in gallery_html_src
+    def test_canvas_sizes_is_server_rendered(self, gallery_html_src):
+        """Fix B (Phase 2): JS CANVAS_SIZES must be server-rendered from context,
+        not a hardcoded literal. Verifies the tojson injection marker is present."""
+        assert "canvas_sizes | tojson" in gallery_html_src, (
+            "welcome_card.html must use {{ canvas_sizes | tojson }} to populate "
+            "the JS CANVAS_SIZES object — hardcoded platform literals must not appear."
+        )
 
-    def test_canvas_sizes_has_instagram_story(self, gallery_html_src):
-        assert "instagram_story" in gallery_html_src
-        assert "[1080, 1920]" in gallery_html_src
-
-    def test_canvas_sizes_has_facebook_landscape(self, gallery_html_src):
-        assert "facebook_landscape" in gallery_html_src
-        assert "[1200,  630]" in gallery_html_src
-
-    def test_canvas_sizes_has_banner_custom(self, gallery_html_src):
-        assert "banner_custom" in gallery_html_src
-        assert "[1500,  500]" in gallery_html_src
+    def test_canvas_sizes_default_platform_still_hardcoded_in_iframe_src(self, gallery_html_src):
+        """Default iframe src still references instagram_square as the initial preview."""
+        assert "platform=instagram_square" in gallery_html_src
 
     def test_select_platform_calls_scale_iframe(self, gallery_html_src):
         """Fix B: selectPlatform() must call scaleIframe(pid) after updating src."""
@@ -864,17 +913,20 @@ class TestWelcomeCardPhotoUpload:
 
     def _render_gallery(self, photo_url=None):
         from jinja2 import Environment, FileSystemLoader, Undefined
+        from app.services.card_constants import CANVAS_SIZES
         env = Environment(
             loader=FileSystemLoader(str(_GALLERY_TPL_PATH.parents[1])),
             autoescape=True,
             undefined=Undefined,
         )
+        canvas_sizes = {pid: {"w": w, "h": h} for pid, (w, h) in CANVAS_SIZES.items()}
         ctx = {
             "request":          MagicMock(),
             "display_name":     "Test Player",
             "platforms":        _WC_GALLERY_PLATFORMS,
             "default_platform": "instagram_square",
             "photo_url":        photo_url,
+            "canvas_sizes":     canvas_sizes,
         }
         return env.get_template("public/welcome_card.html").render(**ctx)
 
@@ -1009,3 +1061,166 @@ class TestProfilePageLfaLicense:
         html = _render_wc_fragment(profile_src, lic)
         assert "/profile/onboarding-card" in html
         assert "View Welcome Card" in html
+
+
+# ── 12. Square export template — WC quality fixes ────────────────────────────
+
+_LANDSCAPE_EXPORT_TPL_PATH = (
+    pathlib.Path(__file__).resolve().parents[4]
+    / "app" / "templates" / "public" / "export" / "landscape" / "fifa.html"
+)
+
+
+@pytest.fixture(scope="module")
+def landscape_export_src():
+    return _LANDSCAPE_EXPORT_TPL_PATH.read_text(encoding="utf-8")
+
+
+class TestSquareExportWCFixes:
+    """
+    Static source assertions for export/square/fifa.html Welcome Card quality fixes.
+
+    SQ-WC-01: player.age_group bare pattern removed; or "—" fallback present in both grid paths
+    SQ-WC-02: ex-mini-grid--wc CSS class defined (2×2 WC variant)
+    SQ-WC-03: welcome_card_mode gates which grid variant renders
+    SQ-WC-04: AGE and GENDER cells absent from WC mini-grid branch
+    SQ-WC-05: WC mini-grid branch contains NAT, GROUP, HEIGHT, WEIGHT cells
+    SQ-WC-06: stat strip WC branch renders TIER label and SA value
+    SQ-WC-07: stat strip non-WC branch preserves LICENSE / Lv. logic
+    SQ-WC-08: no-photo placeholder contains ex-photo-monogram inner element
+    """
+
+    def test_sq_wc_01_age_group_bare_pattern_removed(self, square_export_src):
+        """Bare {{ player.age_group }} without fallback must not exist in square template."""
+        assert "{{ player.age_group }}" not in square_export_src, (
+            "Bare {{ player.age_group }} renders empty string when None. "
+            "Must use player.age_group or '—' in both grid paths."
+        )
+
+    def test_sq_wc_01_age_group_has_or_dash_fallback(self, square_export_src):
+        """Both WC and non-WC grid paths must use player.age_group or '—'."""
+        assert 'player.age_group or "—"' in square_export_src, (
+            "GROUP cell must use player.age_group or '—' fallback in square template."
+        )
+
+    def test_sq_wc_02_mini_grid_wc_css_class_defined(self, square_export_src):
+        """CSS class ex-mini-grid--wc must be defined for the 2×2 WC grid layout."""
+        assert ".ex-mini-grid--wc" in square_export_src, (
+            "WC 2×2 grid CSS class ex-mini-grid--wc must be defined in square template."
+        )
+
+    def test_sq_wc_03_welcome_card_mode_gates_mini_grid(self, square_export_src):
+        """welcome_card_mode Jinja2 conditional must control which grid variant renders."""
+        assert "{% if welcome_card_mode %}" in square_export_src, (
+            "Mini-grid must be gated on welcome_card_mode to switch between "
+            "2×2 WC layout and 3×2 full layout."
+        )
+
+    def test_sq_wc_04_age_cell_absent_in_wc_grid_branch(self, square_export_src):
+        """AGE cell must not appear inside the WC mini-grid branch."""
+        wc_start   = square_export_src.find("{% if welcome_card_mode %}")
+        else_start = square_export_src.find("{% else %}", wc_start)
+        assert wc_start != -1 and else_start != -1, "welcome_card_mode conditional not found"
+        wc_branch = square_export_src[wc_start:else_start]
+        assert ">AGE<" not in wc_branch, (
+            "AGE cell must be suppressed in WC mini-grid branch — "
+            "player_age is not in the Welcome Card context."
+        )
+
+    def test_sq_wc_04_gender_cell_absent_in_wc_grid_branch(self, square_export_src):
+        """GENDER cell must not appear inside the WC mini-grid branch."""
+        wc_start   = square_export_src.find("{% if welcome_card_mode %}")
+        else_start = square_export_src.find("{% else %}", wc_start)
+        wc_branch  = square_export_src[wc_start:else_start]
+        assert ">GENDER<" not in wc_branch, (
+            "GENDER cell must be suppressed in WC mini-grid branch — "
+            "player_gender is not in the Welcome Card context."
+        )
+
+    def test_sq_wc_05_wc_branch_has_nat_group_height_weight(self, square_export_src):
+        """WC mini-grid branch must contain exactly NAT, GROUP, HEIGHT, WEIGHT cells."""
+        wc_start   = square_export_src.find("{% if welcome_card_mode %}")
+        else_start = square_export_src.find("{% else %}", wc_start)
+        wc_branch  = square_export_src[wc_start:else_start]
+        for label in (">NAT.<", ">GROUP<", ">HEIGHT<", ">WEIGHT<"):
+            assert label in wc_branch, (
+                f"{label!r} cell must appear in WC mini-grid branch."
+            )
+
+    def test_sq_wc_06_stat_strip_tier_label_in_wc_branch(self, square_export_src):
+        """Stat strip WC branch must render TIER label instead of LICENSE."""
+        stat_start = square_export_src.find("<!-- Stat strip:")
+        assert stat_start != -1, "Stat strip HTML comment not found in square template"
+        stat_section = square_export_src[stat_start:stat_start + 900]
+        assert "TIER" in stat_section, (
+            "WC stat strip must render 'TIER' label in welcome_card_mode branch."
+        )
+
+    def test_sq_wc_06_stat_strip_sa_value_in_wc_branch(self, square_export_src):
+        """Stat strip WC branch must render SA value instead of Lv. N."""
+        stat_start   = square_export_src.find("<!-- Stat strip:")
+        stat_section = square_export_src[stat_start:stat_start + 900]
+        assert ">SA<" in stat_section, (
+            "WC stat strip must render '>SA<' value in welcome_card_mode branch."
+        )
+
+    def test_sq_wc_07_stat_strip_license_preserved_in_non_wc_branch(self, square_export_src):
+        """Non-WC stat strip branch must still render LICENSE / Lv. X logic unchanged."""
+        stat_start   = square_export_src.find("<!-- Stat strip:")
+        stat_section = square_export_src[stat_start:stat_start + 1200]
+        assert "LICENSE" in stat_section, (
+            "Non-WC stat strip branch must retain the LICENSE label."
+        )
+        assert "license_current_level or 1" in stat_section, (
+            "Non-WC stat strip branch must retain license_current_level or 1 fallback."
+        )
+
+    def test_sq_wc_08_photo_monogram_class_defined_in_css(self, square_export_src):
+        """CSS class ex-photo-monogram must be defined in square template."""
+        assert ".ex-photo-monogram" in square_export_src, (
+            "ex-photo-monogram CSS class must be defined for the no-photo circle badge."
+        )
+
+    def test_sq_wc_08_photo_monogram_used_in_placeholder_html(self, square_export_src):
+        """ex-photo-monogram inner div must appear inside the ex-photo-placeholder block."""
+        ph_idx       = square_export_src.find("ex-photo-placeholder")
+        monogram_idx = square_export_src.find("ex-photo-monogram", ph_idx)
+        assert ph_idx != -1, "ex-photo-placeholder not found in square template"
+        assert monogram_idx != -1, (
+            "ex-photo-monogram must appear after ex-photo-placeholder "
+            "as the inner element of the no-photo fallback."
+        )
+
+
+class TestLandscapeExportP0Fix:
+    """
+    P0 hotfix: export/landscape/fifa.html must not render bare 'Lv.' when
+    license_current_level is absent from the context (Welcome Card flow).
+
+    LS-P0-01: bare {{ license_current_level }} pattern removed — was broken render
+    LS-P0-02: fallback renders 'Lv. —' not 'Lv. ' when value is absent
+    LS-P0-03: max-level suffix guarded to prevent 'Lv. — / None' edge case
+    """
+
+    def test_ls_p0_01_bare_license_pattern_removed(self, landscape_export_src):
+        """Bare Lv. {{ license_current_level }} without fallback must not exist."""
+        assert "Lv. {{ license_current_level }}" not in landscape_export_src, (
+            "Broken P0: 'Lv. {{ license_current_level }}' renders 'Lv. ' (empty) "
+            "when license_current_level is not in the Welcome Card context. "
+            "Must use a fallback."
+        )
+
+    def test_ls_p0_02_license_has_or_dash_fallback(self, landscape_export_src):
+        """License value must fall back to '—' when license_current_level is absent."""
+        assert 'license_current_level or "—"' in landscape_export_src, (
+            "License row must use license_current_level or '—' to produce "
+            "'Lv. —' instead of 'Lv. ' in Welcome Card context."
+        )
+
+    def test_ls_p0_03_max_level_suffix_guarded_by_current_level(self, landscape_export_src):
+        """Max-level suffix must only render when license_current_level is truthy."""
+        # The fix wraps the max-level condition with `license_current_level and ...`
+        assert "license_current_level and license_max_level" in landscape_export_src, (
+            "Max-level suffix must be guarded: if license_current_level is '—', "
+            "the '/ max_level' suffix must not render."
+        )

--- a/tests/unit/api/web_routes/test_welcome_card.py
+++ b/tests/unit/api/web_routes/test_welcome_card.py
@@ -637,3 +637,158 @@ class TestWelcomeCardProfileSection:
     def test_dashboard_player_card_link_unchanged(self, dashboard_src):
         assert '/players/{{ user.id }}/card' in dashboard_src
         assert 'spec-player-card-iframe' in dashboard_src
+
+
+# ── 9. Preview / export rendering fixes (Fix A, B, C) ────────────────────────
+
+_PUBLIC_PLAYER_PY_PATH = (
+    pathlib.Path(__file__).resolve().parents[4]
+    / "app" / "api" / "web_routes" / "public_player.py"
+)
+_STORY_EXPORT_TPL_PATH = (
+    pathlib.Path(__file__).resolve().parents[4]
+    / "app" / "templates" / "public" / "export" / "story" / "fifa.html"
+)
+_TIKTOK_EXPORT_TPL_PATH = (
+    pathlib.Path(__file__).resolve().parents[4]
+    / "app" / "templates" / "public" / "export" / "tiktok" / "fifa.html"
+)
+
+
+@pytest.fixture(scope="module")
+def gallery_html_src():
+    return _GALLERY_TPL_PATH.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def public_player_src():
+    return _PUBLIC_PLAYER_PY_PATH.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def story_export_src():
+    return _STORY_EXPORT_TPL_PATH.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def tiktok_export_src():
+    return _TIKTOK_EXPORT_TPL_PATH.read_text(encoding="utf-8")
+
+
+def _wc_context(right_foot=70.0, left_foot=30.0, motivation_scores=None):
+    """Call _build_welcome_card_context with controllable foot scores and motivation data."""
+    from app.api.web_routes.profile import _build_welcome_card_context
+    lic = _license()
+    lic.right_foot_score = right_foot
+    lic.left_foot_score  = left_foot
+    if motivation_scores is not None:
+        lic.motivation_scores = motivation_scores
+    return _build_welcome_card_context(_req(), _user(), lic, "instagram_square", False)
+
+
+class TestWelcomeCardRenderingFixes:
+    """Verify Fix A (iframe alignment), Fix B (canvas sizing), Fix C (physical context)."""
+
+    # ── Fix A: no flex centering on the frame wrapper ──
+
+    def test_gallery_frame_wrap_has_no_justify_content_center(self, gallery_html_src):
+        """Fix A: justify-content:center must NOT appear in .wc-preview-frame-wrap block."""
+        start = gallery_html_src.find(".wc-preview-frame-wrap {")
+        end   = gallery_html_src.find("}", start)
+        assert start != -1, ".wc-preview-frame-wrap rule not found"
+        wrap_rule = gallery_html_src[start:end]
+        assert "justify-content" not in wrap_rule
+        assert "align-items" not in wrap_rule
+
+    def test_gallery_iframe_is_position_absolute(self, gallery_html_src):
+        """Fix A: iframe must be position:absolute so transform-origin:top-left works."""
+        start = gallery_html_src.find("#wc-preview-iframe {")
+        end   = gallery_html_src.find("}", start)
+        assert start != -1
+        iframe_rule = gallery_html_src[start:end]
+        assert "position: absolute" in iframe_rule
+        assert "top: 0" in iframe_rule
+        assert "left: 0" in iframe_rule
+
+    def test_gallery_frame_wrap_is_position_relative(self, gallery_html_src):
+        """Fix A: wrapper must be position:relative to contain the absolute iframe."""
+        start = gallery_html_src.find(".wc-preview-frame-wrap {")
+        end   = gallery_html_src.find("}", start)
+        wrap_rule = gallery_html_src[start:end]
+        assert "position: relative" in wrap_rule
+
+    # ── Fix B: platform-aware canvas sizing ──
+
+    def test_canvas_sizes_has_instagram_square(self, gallery_html_src):
+        assert "instagram_square" in gallery_html_src
+        assert "[1080, 1080]" in gallery_html_src
+
+    def test_canvas_sizes_has_instagram_story(self, gallery_html_src):
+        assert "instagram_story" in gallery_html_src
+        assert "[1080, 1920]" in gallery_html_src
+
+    def test_canvas_sizes_has_facebook_landscape(self, gallery_html_src):
+        assert "facebook_landscape" in gallery_html_src
+        assert "[1200,  630]" in gallery_html_src
+
+    def test_canvas_sizes_has_banner_custom(self, gallery_html_src):
+        assert "banner_custom" in gallery_html_src
+        assert "[1500,  500]" in gallery_html_src
+
+    def test_select_platform_calls_scale_iframe(self, gallery_html_src):
+        """Fix B: selectPlatform() must call scaleIframe(pid) after updating src."""
+        func_start = gallery_html_src.find("function selectPlatform(")
+        func_end   = gallery_html_src.find("\n}", func_start)
+        assert func_start != -1
+        func_body = gallery_html_src[func_start:func_end]
+        assert "scaleIframe" in func_body
+
+    def test_scale_iframe_uses_canvas_sizes(self, gallery_html_src):
+        """Fix B: scaleIframe must reference CANVAS_SIZES, not a hardcoded 1080."""
+        func_start = gallery_html_src.find("function scaleIframe(")
+        func_end   = gallery_html_src.find("\n}", func_start)
+        assert func_start != -1
+        func_body = gallery_html_src[func_start:func_end]
+        assert "CANVAS_SIZES" in func_body
+        # Must not hardcode 1080 for both width and height
+        assert "= '1080px'" not in func_body
+
+    # ── Fix C: physical context keys ──
+
+    def test_context_has_player_height_cm(self):
+        ctx = _wc_context(motivation_scores={"height_cm": 178, "weight_kg": 74})
+        assert ctx["player_height_cm"] == 178
+
+    def test_context_has_player_weight_kg(self):
+        ctx = _wc_context(motivation_scores={"height_cm": 178, "weight_kg": 74})
+        assert ctx["player_weight_kg"] == 74
+
+    def test_context_player_height_cm_is_none_when_absent(self):
+        ctx = _wc_context(motivation_scores={})
+        assert ctx["player_height_cm"] is None
+
+    def test_context_dominant_badge_when_foot_scores_differ(self):
+        """right=70, left=30 → right_pct=70% → 'Rl' (right-footed)."""
+        ctx = _wc_context(right_foot=70.0, left_foot=30.0)
+        assert ctx["dominant_badge"] == "Rl"
+
+    def test_context_dominant_badge_no_data_returns_rl(self):
+        """No foot scores → calculate_dominant_badge returns 'rl' (unassessed), never None."""
+        ctx = _wc_context(right_foot=None, left_foot=None)
+        assert ctx["dominant_badge"] == "rl"
+        assert ctx["dominant_badge"] is not None
+
+    # ── Regression: data contract unchanged ──
+
+    def test_player_card_route_uses_calculate_dominant_badge(self, public_player_src):
+        """Player Card route must still call calculate_dominant_badge unchanged."""
+        assert "calculate_dominant_badge" in public_player_src
+        assert "dominant_badge" in public_player_src
+
+    def test_story_template_guards_dominant_badge(self, story_export_src):
+        """Story template must guard dominant_badge with {% if %}."""
+        assert "{% if dominant_badge %}" in story_export_src
+
+    def test_tiktok_template_guards_player_height_cm(self, tiktok_export_src):
+        """TikTok template must guard player_height_cm with {% if %}."""
+        assert "{% if player_height_cm %}" in tiktok_export_src

--- a/tests/unit/api/web_routes/test_welcome_card.py
+++ b/tests/unit/api/web_routes/test_welcome_card.py
@@ -24,10 +24,12 @@ from fastapi.responses import RedirectResponse, Response
 from app.api.web_routes.profile import (
     onboarding_welcome_card,
     export_onboarding_welcome_card,
+    profile_page,
     _build_welcome_card_context,
     _WC_APP_LOGO_URL,
     _WC_GALLERY_PLATFORMS,
 )
+from app.models.license import UserLicense
 from app.models.user import UserRole
 
 _BASE = "app.api.web_routes.profile"
@@ -412,8 +414,9 @@ class TestWelcomeCardGalleryTemplate:
     def test_has_platform_download_buttons(self, gallery_src):
         assert "/profile/onboarding-card/export?platform=" in gallery_src
 
-    def test_has_back_link_to_profile(self, gallery_src):
-        assert 'href="/profile"' in gallery_src
+    def test_has_back_link_to_lfa_player_profile(self, gallery_src):
+        # Back link updated (Fázis 2): Welcome Card is LFA-specific context.
+        assert 'href="/profile/lfa-football-player"' in gallery_src
 
     def test_gallery_renders_with_minimal_context(self):
         """Jinja2 render: gallery template must not error with minimal context."""
@@ -577,16 +580,16 @@ def _wc_block(profile_src: str) -> str:
     return profile_src[start:end]
 
 
-def _render_wc_fragment(profile_src: str, active_license) -> str:
-    """Render only the Welcome Card conditional fragment as a standalone Jinja2 template."""
+def _render_wc_fragment(profile_src: str, lfa_license) -> str:
+    """Render the Welcome Card conditional block with the given lfa_license value."""
     from jinja2 import Template
     fragment = _wc_block(profile_src)
-    # Strip the HTML comment line so only the Jinja2 block remains
+    # Strip HTML comment lines so only the Jinja2 conditional block remains
     fragment = "\n".join(
         line for line in fragment.splitlines()
         if not line.strip().startswith("<!--")
     )
-    return Template(fragment).render(active_license=active_license)
+    return Template(fragment).render(lfa_license=lfa_license)
 
 
 def _lic(spec_type="LFA_FOOTBALL_PLAYER", onboarding_completed=True):
@@ -608,18 +611,21 @@ class TestWelcomeCardProfileSection:
         assert "Download" in html
 
     # ── T2: incomplete onboarding hides the section ──
+    # The route sets lfa_license=None when onboarding is not completed,
+    # so the template receives None — not a license object.
 
     def test_incomplete_onboarding_hides_welcome_card(self, profile_src):
-        html = _render_wc_fragment(profile_src, _lic(onboarding_completed=False))
+        html = _render_wc_fragment(profile_src, None)
         assert "/profile/onboarding-card" not in html
         assert "Welcome Card" not in html
 
     # ── T3: non-LFA spec hides the section ──
+    # The route sets lfa_license=None when no completed LFA_FOOTBALL_PLAYER license
+    # exists, regardless of what other licenses the user holds.
 
     def test_non_lfa_spec_hides_welcome_card(self, profile_src):
-        for spec in ("GANCUJU_PLAYER", "LFA_COACH", "INTERNSHIP"):
-            html = _render_wc_fragment(profile_src, _lic(spec_type=spec))
-            assert "/profile/onboarding-card" not in html, f"Welcome Card visible for {spec}"
+        html = _render_wc_fragment(profile_src, None)
+        assert "/profile/onboarding-card" not in html
 
     # ── T4: dashboard mod-nav has no Welcome Card quick action ──
 
@@ -792,3 +798,214 @@ class TestWelcomeCardRenderingFixes:
     def test_tiktok_template_guards_player_height_cm(self, tiktok_export_src):
         """TikTok template must guard player_height_cm with {% if %}."""
         assert "{% if player_height_cm %}" in tiktok_export_src
+
+
+# ── 10. Gallery hub photo upload panel ───────────────────────────────────────
+
+class TestWelcomeCardPhotoUpload:
+    """Gallery hub photo upload & delete panel — context, template, JS."""
+
+    # ── Route context ──────────────────────────────────────────────────────────
+
+    def _call_gallery(self, photo_url=None):
+        lic = _license()
+        lic.player_card_photo_url = photo_url
+        db = _mock_db(license_return=lic)
+        with patch(f"{_BASE}.templates") as mock_tmpl:
+            mock_tmpl.TemplateResponse.return_value = MagicMock()
+            _run(onboarding_welcome_card(_req(), platform=None, db=db, user=_user()))
+        return mock_tmpl.TemplateResponse.call_args.args[1]  # ctx dict
+
+    def test_gallery_context_has_photo_url_key(self):
+        ctx = self._call_gallery()
+        assert "photo_url" in ctx
+
+    def test_gallery_context_photo_url_is_none_when_no_photo(self):
+        ctx = self._call_gallery(photo_url=None)
+        assert ctx["photo_url"] is None
+
+    def test_gallery_context_photo_url_matches_license(self):
+        url = "/static/uploads/lfa_player_photos/10_orig_1234567890.png"
+        ctx = self._call_gallery(photo_url=url)
+        assert ctx["photo_url"] == url
+
+    # ── Template static checks ─────────────────────────────────────────────────
+
+    def test_gallery_has_photo_panel(self, gallery_html_src):
+        assert "wc-photo-panel" in gallery_html_src
+
+    def test_gallery_has_photo_file_input(self, gallery_html_src):
+        assert 'id="wc-photo-input"' in gallery_html_src
+        assert 'type="file"' in gallery_html_src
+
+    def test_gallery_upload_endpoint_is_correct(self, gallery_html_src):
+        assert "/dashboard/lfa-player-photo'" in gallery_html_src
+
+    def test_gallery_delete_endpoint_is_correct(self, gallery_html_src):
+        assert "/dashboard/lfa-player-photo/delete'" in gallery_html_src
+
+    def test_gallery_has_getcsrftoken_function(self, gallery_html_src):
+        assert "function getCsrfToken()" in gallery_html_src
+
+    def test_gallery_photo_requests_have_csrf_header(self, gallery_html_src):
+        """Both upload and delete fetches must include the X-CSRF-Token header."""
+        assert "'X-CSRF-Token': getCsrfToken()" in gallery_html_src
+
+    def test_gallery_success_reloads_iframe(self, gallery_html_src):
+        """reloadPreview() must be called on both upload and delete success."""
+        assert "function reloadPreview()" in gallery_html_src
+        assert "reloadPreview()" in gallery_html_src
+
+    def test_gallery_error_shows_backend_detail(self, gallery_html_src):
+        """Error fallback must include data.detail before 'unknown error'."""
+        assert "data.detail" in gallery_html_src
+
+    # ── Jinja2 render: thumbnail / placeholder state ───────────────────────────
+
+    def _render_gallery(self, photo_url=None):
+        from jinja2 import Environment, FileSystemLoader, Undefined
+        env = Environment(
+            loader=FileSystemLoader(str(_GALLERY_TPL_PATH.parents[1])),
+            autoescape=True,
+            undefined=Undefined,
+        )
+        ctx = {
+            "request":          MagicMock(),
+            "display_name":     "Test Player",
+            "platforms":        _WC_GALLERY_PLATFORMS,
+            "default_platform": "instagram_square",
+            "photo_url":        photo_url,
+        }
+        return env.get_template("public/welcome_card.html").render(**ctx)
+
+    def test_thumbnail_src_set_when_photo_url_present(self):
+        url = "/static/uploads/lfa_player_photos/10_orig_1234567890.png"
+        html = self._render_gallery(photo_url=url)
+        assert f'src="{url}"' in html
+
+    def test_thumbnail_visible_when_photo_url_present(self):
+        url = "/static/uploads/lfa_player_photos/10_orig_1234567890.png"
+        html = self._render_gallery(photo_url=url)
+        # img tag must NOT be hidden (display:none absent from its inline style)
+        thumb_start = html.find('id="wc-photo-thumb"')
+        assert thumb_start != -1
+        tag_end = html.find('>', thumb_start)
+        tag_html = html[thumb_start:tag_end]
+        assert "display:none" not in tag_html
+
+    def test_placeholder_visible_when_no_photo_url(self):
+        html = self._render_gallery(photo_url=None)
+        ph_start = html.find('id="wc-photo-placeholder"')
+        assert ph_start != -1
+        tag_end = html.find('>', ph_start)
+        tag_html = html[ph_start:tag_end]
+        assert "display:none" not in tag_html
+
+    def test_delete_btn_hidden_when_no_photo_url(self):
+        html = self._render_gallery(photo_url=None)
+        btn_start = html.find('id="wc-delete-btn"')
+        assert btn_start != -1
+        tag_end = html.find('>', btn_start)
+        tag_html = html[btn_start:tag_end]
+        assert "display:none" in tag_html
+
+    def test_delete_btn_visible_when_photo_url_present(self):
+        url = "/static/uploads/lfa_player_photos/10_orig_1234567890.png"
+        html = self._render_gallery(photo_url=url)
+        btn_start = html.find('id="wc-delete-btn"')
+        assert btn_start != -1
+        tag_end = html.find('>', btn_start)
+        tag_html = html[btn_start:tag_end]
+        assert "display:none" not in tag_html
+
+
+# ── 11. profile_page route — lfa_license context key ─────────────────────────
+
+class TestProfilePageLfaLicense:
+    """
+    profile_page sets lfa_license independent of user.specialization.
+    Covers the spec-switch scenario: Welcome Card remains visible after the
+    user switches active spec away from LFA_FOOTBALL_PLAYER.
+    """
+
+    def _make_db(self, user_licenses):
+        db = MagicMock()
+        db.query.return_value.filter.return_value.all.return_value = user_licenses
+        db.query.return_value.filter.return_value.first.return_value = None
+        return db
+
+    def _lfa_lic(self, completed=True):
+        lic = MagicMock()
+        lic.specialization_type = "LFA_FOOTBALL_PLAYER"
+        lic.onboarding_completed = completed
+        return lic
+
+    def _call_profile(self, user_licenses, active_spec_value=None):
+        """Invoke profile_page and return the TemplateResponse context dict."""
+        user = _user()
+        if active_spec_value is not None:
+            spec = MagicMock()
+            spec.value = active_spec_value
+            user.specialization = spec
+        else:
+            user.specialization = None
+        db = self._make_db(user_licenses)
+        with patch(f"{_BASE}.templates") as mock_tmpl:
+            mock_tmpl.TemplateResponse.return_value = MagicMock()
+            _run(profile_page(_req(), db=db, user=user))
+        return mock_tmpl.TemplateResponse.call_args.args[1]
+
+    # ── Route context: key presence ───────────────────────────────────────────
+
+    def test_context_includes_lfa_license_key(self):
+        ctx = self._call_profile([])
+        assert "lfa_license" in ctx
+
+    def test_lfa_license_none_when_no_licenses(self):
+        ctx = self._call_profile([])
+        assert ctx["lfa_license"] is None
+
+    def test_lfa_license_none_when_incomplete_onboarding(self):
+        ctx = self._call_profile([self._lfa_lic(completed=False)])
+        assert ctx["lfa_license"] is None
+
+    def test_lfa_license_set_when_completed(self):
+        lic = self._lfa_lic(completed=True)
+        ctx = self._call_profile([lic])
+        assert ctx["lfa_license"] is lic
+
+    # ── Spec-switch scenario ──────────────────────────────────────────────────
+
+    def test_lfa_license_set_when_active_spec_is_gancuju(self):
+        """
+        Active spec = GANCUJU_PLAYER, but a completed LFA_FOOTBALL_PLAYER license
+        also exists → lfa_license must be set so the Welcome Card remains visible.
+        """
+        lic = self._lfa_lic(completed=True)
+        ctx = self._call_profile([lic], active_spec_value="GANCUJU_PLAYER")
+        assert ctx["lfa_license"] is lic
+
+    def test_lfa_license_set_when_active_spec_is_lfa_coach(self):
+        lic = self._lfa_lic(completed=True)
+        ctx = self._call_profile([lic], active_spec_value="LFA_COACH")
+        assert ctx["lfa_license"] is lic
+
+    def test_lfa_license_none_when_only_gancuju_license_exists(self):
+        """User has GANCUJU license (no LFA_FOOTBALL_PLAYER) → lfa_license is None."""
+        gancuju = MagicMock()
+        gancuju.specialization_type = "GANCUJU_PLAYER"
+        gancuju.onboarding_completed = True
+        ctx = self._call_profile([gancuju])
+        assert ctx["lfa_license"] is None
+
+    # ── Template: Welcome Card visible via lfa_license (not active_license) ───
+
+    def test_welcome_card_visible_when_active_spec_is_gancuju(self, profile_src):
+        """
+        Template: Welcome Card section must appear when lfa_license is set,
+        even if the user's current active spec is GANCUJU_PLAYER.
+        """
+        lic = self._lfa_lic(completed=True)
+        html = _render_wc_fragment(profile_src, lic)
+        assert "/profile/onboarding-card" in html
+        assert "View Welcome Card" in html

--- a/tests/unit/api/web_routes/test_welcome_card.py
+++ b/tests/unit/api/web_routes/test_welcome_card.py
@@ -516,7 +516,8 @@ class TestWelcomeCardFifaLogoAudit:
 
     def test_export_square_has_app_logo_in_sponsor_slot(self, square_export_src):
         assert "app_logo_url" in square_export_src
-        assert "elif app_logo_url" in square_export_src
+        # v8: combined `or` condition — sponsor takes priority via `sponsor_logo_url or app_logo_url`
+        assert "sponsor_logo_url or app_logo_url" in square_export_src
 
     def test_export_square_sponsor_logo_takes_priority(self, square_export_src):
         """sponsor_logo_url branch must be checked before app_logo_url."""

--- a/tests/unit/api/web_routes/test_welcome_card.py
+++ b/tests/unit/api/web_routes/test_welcome_card.py
@@ -1,85 +1,95 @@
 """
-Unit tests for GET /profile/onboarding-card (Phase C — Welcome Card preview).
+Unit tests for Welcome Card redesign (Phase C+D).
 
-Route: app/api/web_routes/profile.onboarding_welcome_card
-Template: app/templates/public/welcome_card.html
+Routes:
+  GET /profile/onboarding-card          → gallery hub or FIFA card
+  GET /profile/onboarding-card/export   → PNG export
 
 Test groups:
-  TestWelcomeCardRoute   — route-level: auth redirects, no-license redirect,
-                           incomplete-onboarding redirect, 200 happy path,
-                           context keys present, only self_assessment read
-  TestWelcomeCardTemplate — static template assertions: required strings present,
-                            forbidden EMA field names absent,
-                            self_assessment rendered in skill rows
+  TestWelcomeCardGuards          — no-license + incomplete-onboarding redirects (both routes)
+  TestWelcomeCardGalleryRoute    — gallery hub (no ?platform): context + rendered HTML
+  TestWelcomeCardFifaRoute       — FIFA card render (?platform=X): adapter, logo, sponsor
+  TestWelcomeCardExport          — PNG export route: auth, platform validation, rate limit, bytes
+  TestWelcomeCardGalleryTemplate — static source assertions on welcome_card.html (gallery hub)
+  TestWelcomeCardFifaLogoAudit   — FIFA template logo changes (player_card_fifa + export/square)
+  TestWelcomeCardStep7           — Step 7 onboarding template: language, photo upload, links
 """
 import asyncio
 import pathlib
-import re
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from fastapi.responses import RedirectResponse
+from fastapi.responses import RedirectResponse, Response
 
-from app.api.web_routes.profile import onboarding_welcome_card
+from app.api.web_routes.profile import (
+    onboarding_welcome_card,
+    export_onboarding_welcome_card,
+    _build_welcome_card_context,
+    _WC_APP_LOGO_URL,
+    _WC_GALLERY_PLATFORMS,
+)
 from app.models.user import UserRole
 
 _BASE = "app.api.web_routes.profile"
 
-# ── Helpers ────────────────────────────────────────────────────────────────────
+
+# ── Shared helpers ─────────────────────────────────────────────────────────────
 
 def _run(coro):
     return asyncio.run(coro)
 
 
 def _req():
-    return MagicMock()
+    m = MagicMock()
+    m.client = MagicMock()
+    m.client.host = "127.0.0.1"
+    return m
 
 
 def _user(uid=10, role=UserRole.STUDENT):
     u = MagicMock()
-    u.id = uid
-    u.role = role
-    u.email = "player@test.com"
-    u.name = "Test Player"
+    u.id      = uid
+    u.role    = role
+    u.email   = "player@test.com"
+    u.name    = "Test Player"
+    u.country = "HU"
     u.nickname = "tester"
-    u.nationality = "HU"
     u.secondary_nationality = None
     u.credit_balance = 500
     return u
 
 
 def _license(onboarding_completed=True, football_skills=None):
+    from app.skills_config import get_all_skill_keys
     lic = MagicMock()
-    lic.specialization_type = "LFA_FOOTBALL_PLAYER"
-    lic.onboarding_completed = onboarding_completed
+    lic.specialization_type   = "LFA_FOOTBALL_PLAYER"
+    lic.onboarding_completed  = onboarding_completed
     lic.player_card_photo_url = None
-    lic.right_foot_score = 70.0
-    lic.left_foot_score = 30.0
+    lic.card_photo_portrait_url  = None
+    lic.card_photo_landscape_url = None
+    lic.right_foot_score      = 70.0
+    lic.left_foot_score       = 30.0
     lic.motivation_scores = {
-        "position":     "striker",
-        "positions":    ["striker"],
-        "height_cm":    178,
-        "weight_kg":    74,
+        "position":       "striker",
+        "positions":      ["striker"],
+        "height_cm":      178,
+        "weight_kg":      74,
         "preferred_foot": "right",
-        "goals":        "become_professional",
+        "goals":          "become_professional",
     }
-    # Build football_skills with self_assessment values for all 44 keys
-    # (including Phase 3 new skills: throwing, anticipation)
     if football_skills is None:
-        from app.skills_config import get_all_skill_keys
         football_skills = {
             key: {
                 "self_assessment":  65.0,
-                "current_level":    60.0,   # must NOT appear in rendered output
-                "system_baseline":  60.0,   # must NOT appear in rendered output
+                "current_level":    60.0,   # must NOT leak into template context
+                "system_baseline":  60.0,
                 "baseline":         60.0,
-                "tournament_delta": 0.0,    # must NOT appear in rendered output
-                "assessment_delta": 0.0,    # must NOT appear in rendered output
+                "tournament_delta": 0.0,
+                "assessment_delta": 0.0,
             }
             for key in get_all_skill_keys()
         }
     lic.football_skills = football_skills
-    lic.average_motivation_score = 65.0
     return lic
 
 
@@ -89,346 +99,449 @@ def _mock_db(license_return=None):
     return db
 
 
-# ── Route tests ───────────────────────────────────────────────────────────────
+# ── 1. Auth guards ─────────────────────────────────────────────────────────────
 
-class TestWelcomeCardRoute:
+class TestWelcomeCardGuards:
+    """Both routes redirect when license is absent or onboarding is incomplete."""
 
-    def test_no_license_redirects_to_dashboard(self):
-        user = _user()
+    # ── preview route ──
+
+    def test_preview_no_license_redirects_to_dashboard(self):
         db = _mock_db(license_return=None)
-        with patch(f"{_BASE}.templates") as mock_tmpl:
-            mock_tmpl.TemplateResponse.return_value = MagicMock()
-            result = _run(onboarding_welcome_card(request=_req(), db=db, user=user))
+        result = _run(onboarding_welcome_card(_req(), db=db, user=_user()))
         assert isinstance(result, RedirectResponse)
         assert "/dashboard" in result.headers["location"]
 
-    def test_incomplete_onboarding_redirects_to_onboarding(self):
-        user = _user()
+    def test_preview_incomplete_onboarding_redirects(self):
         lic = _license(onboarding_completed=False)
-        db = _mock_db(license_return=lic)
-        with patch(f"{_BASE}.templates") as mock_tmpl:
-            mock_tmpl.TemplateResponse.return_value = MagicMock()
-            result = _run(onboarding_welcome_card(request=_req(), db=db, user=user))
+        db  = _mock_db(license_return=lic)
+        result = _run(onboarding_welcome_card(_req(), db=db, user=_user()))
         assert isinstance(result, RedirectResponse)
         assert "onboarding" in result.headers["location"]
 
-    def test_completed_onboarding_renders_template(self):
-        user = _user()
-        lic = _license(onboarding_completed=True)
-        db = _mock_db(license_return=lic)
+    # ── export route ──
+
+    def test_export_no_license_redirects_to_dashboard(self):
+        db = _mock_db(license_return=None)
+        result = _run(export_onboarding_welcome_card(
+            _req(), platform="instagram_square", db=db, user=_user()
+        ))
+        assert isinstance(result, RedirectResponse)
+        assert "/dashboard" in result.headers["location"]
+
+    def test_export_incomplete_onboarding_redirects(self):
+        lic = _license(onboarding_completed=False)
+        db  = _mock_db(license_return=lic)
+        result = _run(export_onboarding_welcome_card(
+            _req(), platform="instagram_square", db=db, user=_user()
+        ))
+        assert isinstance(result, RedirectResponse)
+        assert "onboarding" in result.headers["location"]
+
+
+# ── 2. Gallery route (no ?platform) ───────────────────────────────────────────
+
+class TestWelcomeCardGalleryRoute:
+    """GET /profile/onboarding-card with no platform renders the gallery hub."""
+
+    def test_renders_gallery_hub_template(self):
+        lic = _license()
+        db  = _mock_db(license_return=lic)
         with patch(f"{_BASE}.templates") as mock_tmpl:
             mock_tmpl.TemplateResponse.return_value = MagicMock()
-            _run(onboarding_welcome_card(request=_req(), db=db, user=user))
-        tmpl, _ = mock_tmpl.TemplateResponse.call_args.args
+            _run(onboarding_welcome_card(_req(), platform=None, db=db, user=_user()))
+        tmpl, ctx = mock_tmpl.TemplateResponse.call_args.args
         assert tmpl == "public/welcome_card.html"
 
-    def test_context_contains_required_keys(self):
-        user = _user()
+    def test_gallery_context_has_platforms_list(self):
         lic = _license()
+        db  = _mock_db(license_return=lic)
+        with patch(f"{_BASE}.templates") as mock_tmpl:
+            mock_tmpl.TemplateResponse.return_value = MagicMock()
+            _run(onboarding_welcome_card(_req(), platform=None, db=db, user=_user()))
+        _, ctx = mock_tmpl.TemplateResponse.call_args.args
+        assert "platforms" in ctx
+        assert isinstance(ctx["platforms"], list)
+        assert len(ctx["platforms"]) >= 6
+
+    def test_gallery_context_default_platform_is_instagram_square(self):
+        lic = _license()
+        db  = _mock_db(license_return=lic)
+        with patch(f"{_BASE}.templates") as mock_tmpl:
+            mock_tmpl.TemplateResponse.return_value = MagicMock()
+            _run(onboarding_welcome_card(_req(), platform=None, db=db, user=_user()))
+        _, ctx = mock_tmpl.TemplateResponse.call_args.args
+        assert ctx.get("default_platform") == "instagram_square"
+
+    def test_gallery_context_has_display_name(self):
+        user = _user()
+        user.name = "Test Player"
+        lic = _license()
+        db  = _mock_db(license_return=lic)
+        with patch(f"{_BASE}.templates") as mock_tmpl:
+            mock_tmpl.TemplateResponse.return_value = MagicMock()
+            _run(onboarding_welcome_card(_req(), platform=None, db=db, user=user))
+        _, ctx = mock_tmpl.TemplateResponse.call_args.args
+        assert ctx.get("display_name") == "Test Player"
+
+    def test_gallery_context_no_player_object(self):
+        """Gallery hub does not build the FIFA player namespace — only FIFA route does."""
+        lic = _license()
+        db  = _mock_db(license_return=lic)
+        with patch(f"{_BASE}.templates") as mock_tmpl:
+            mock_tmpl.TemplateResponse.return_value = MagicMock()
+            _run(onboarding_welcome_card(_req(), platform=None, db=db, user=_user()))
+        _, ctx = mock_tmpl.TemplateResponse.call_args.args
+        assert "player" not in ctx
+
+
+# ── 3. FIFA card route (?platform=X) ──────────────────────────────────────────
+
+class TestWelcomeCardFifaRoute:
+    """GET /profile/onboarding-card?platform=X renders the FIFA Classic template."""
+
+    def _call_with_platform(self, platform="instagram_square", export=False, lic=None):
+        if lic is None:
+            lic = _license()
         db = _mock_db(license_return=lic)
         with patch(f"{_BASE}.templates") as mock_tmpl:
             mock_tmpl.TemplateResponse.return_value = MagicMock()
-            _run(onboarding_welcome_card(request=_req(), db=db, user=user))
-        _, ctx = mock_tmpl.TemplateResponse.call_args.args
-        for key in ("skill_categories", "overall_sa", "top_skills", "position",
-                    "height_cm", "weight_kg", "preferred_foot", "display_name", "initials"):
-            assert key in ctx, f"Missing context key: {key}"
+            _run(onboarding_welcome_card(
+                _req(), platform=platform, export=export, db=db, user=_user()
+            ))
+        return mock_tmpl.TemplateResponse.call_args.args  # (tmpl, ctx)
 
-    def test_top_skills_are_five(self):
-        user = _user()
-        lic = _license()
-        db = _mock_db(license_return=lic)
-        with patch(f"{_BASE}.templates") as mock_tmpl:
-            mock_tmpl.TemplateResponse.return_value = MagicMock()
-            _run(onboarding_welcome_card(request=_req(), db=db, user=user))
-        _, ctx = mock_tmpl.TemplateResponse.call_args.args
-        assert len(ctx["top_skills"]) == 5
+    def test_with_platform_uses_fifa_export_template(self):
+        tmpl, _ = self._call_with_platform("instagram_square")
+        assert "fifa" in tmpl
 
-    def test_skill_categories_count_matches_taxonomy(self):
-        user = _user()
-        lic = _license()
-        db = _mock_db(license_return=lic)
-        with patch(f"{_BASE}.templates") as mock_tmpl:
-            mock_tmpl.TemplateResponse.return_value = MagicMock()
-            _run(onboarding_welcome_card(request=_req(), db=db, user=user))
-        _, ctx = mock_tmpl.TemplateResponse.call_args.args
-        from app.skills_config import SKILL_CATEGORIES
-        assert len(ctx["skill_categories"]) == len(SKILL_CATEGORIES)
+    def test_context_has_player_object(self):
+        _, ctx = self._call_with_platform()
+        assert "player" in ctx
 
-    def test_context_reads_only_self_assessment_not_current_level(self):
-        """Verify that skill values in the context come from self_assessment,
-        not current_level, even when they differ."""
-        user = _user()
+    def test_player_skills_dict_current_level_equals_self_assessment(self):
+        """
+        Self-assessment adapter: FIFA template reads current_level.
+        For Welcome Card, current_level must equal the self_assessment value.
+        This is a template adapter — it must never be written to football_skills JSONB.
+        """
         from app.skills_config import get_all_skill_keys
-        # self_assessment=80, current_level=50 — context must show 80
+        sa_val = 77.0
         skills = {
-            key: {
-                "self_assessment":  80.0,
-                "current_level":    50.0,
-                "system_baseline":  60.0,
-                "baseline":         60.0,
-                "tournament_delta": 2.5,
-                "assessment_delta": 1.0,
-            }
+            key: {"self_assessment": sa_val, "current_level": 50.0}
             for key in get_all_skill_keys()
         }
         lic = _license(football_skills=skills)
-        db = _mock_db(license_return=lic)
+        _, ctx = self._call_with_platform(lic=lic)
+        player = ctx["player"]
+        for key, sdata in player.skills.items():
+            assert sdata["current_level"] == sa_val, (
+                f"Skill {key}: expected current_level={sa_val} (self_assessment), "
+                f"got {sdata['current_level']}"
+            )
+
+    def test_db_football_skills_not_modified(self):
+        """
+        The route reads self_assessment; it must NEVER write back to football_skills JSONB.
+        DB commit must not be called.
+        """
+        lic = _license()
+        db  = _mock_db(license_return=lic)
         with patch(f"{_BASE}.templates") as mock_tmpl:
             mock_tmpl.TemplateResponse.return_value = MagicMock()
-            _run(onboarding_welcome_card(request=_req(), db=db, user=user))
-        _, ctx = mock_tmpl.TemplateResponse.call_args.args
-        # Every skill in every category must have value=80 (self_assessment), not 50
-        for cat in ctx["skill_categories"]:
-            for skill in cat["skills"]:
-                assert skill["value"] == 80.0, (
-                    f"Skill {skill['key']} value={skill['value']}, expected 80 (self_assessment)"
-                )
+            _run(onboarding_welcome_card(
+                _req(), platform="instagram_square", db=db, user=_user()
+            ))
+        db.commit.assert_not_called()
+        db.add.assert_not_called()
 
-    def test_overall_sa_is_mean_of_self_assessments(self):
-        user = _user()
+    def test_sponsor_logo_url_is_none(self):
+        """Welcome Card must never display sponsor logo."""
+        _, ctx = self._call_with_platform()
+        assert ctx.get("sponsor_logo_url") is None
+
+    def test_app_logo_url_is_set(self):
+        """Welcome Card must display fixed app logo (logo-dark.png)."""
+        _, ctx = self._call_with_platform()
+        assert ctx.get("app_logo_url") == _WC_APP_LOGO_URL
+        assert "logo-dark.png" in ctx["app_logo_url"]
+
+    def test_welcome_card_mode_is_true(self):
+        _, ctx = self._call_with_platform()
+        assert ctx.get("welcome_card_mode") is True
+
+    def test_export_mode_false_by_default(self):
+        _, ctx = self._call_with_platform(export=False)
+        assert ctx.get("export_mode") is False
+
+    def test_export_mode_true_with_param(self):
+        _, ctx = self._call_with_platform(export=True)
+        assert ctx.get("export_mode") is True
+
+    def test_overall_is_mean_of_self_assessments(self):
         from app.skills_config import get_all_skill_keys
-        keys = get_all_skill_keys()
-        skills = {key: {"self_assessment": 70.0, "current_level": 60.0} for key in keys}
+        skills = {key: {"self_assessment": 70.0, "current_level": 50.0}
+                  for key in get_all_skill_keys()}
         lic = _license(football_skills=skills)
-        db = _mock_db(license_return=lic)
-        with patch(f"{_BASE}.templates") as mock_tmpl:
-            mock_tmpl.TemplateResponse.return_value = MagicMock()
-            _run(onboarding_welcome_card(request=_req(), db=db, user=user))
-        _, ctx = mock_tmpl.TemplateResponse.call_args.args
-        assert ctx["overall_sa"] == 70.0
+        _, ctx = self._call_with_platform(lic=lic)
+        assert ctx.get("overall") == 70.0
 
-    def test_physical_fields_come_from_motivation_scores(self):
-        user = _user()
+
+# ── 4. Export route ────────────────────────────────────────────────────────────
+
+class TestWelcomeCardExport:
+    """GET /profile/onboarding-card/export — PNG export."""
+
+    def test_invalid_platform_raises_422(self):
+        from fastapi import HTTPException
         lic = _license()
-        lic.motivation_scores = {
-            "position": "goalkeeper", "positions": ["goalkeeper"],
-            "height_cm": 190, "weight_kg": 85, "preferred_foot": "left", "goals": "fun",
-        }
-        db = _mock_db(license_return=lic)
-        with patch(f"{_BASE}.templates") as mock_tmpl:
-            mock_tmpl.TemplateResponse.return_value = MagicMock()
-            _run(onboarding_welcome_card(request=_req(), db=db, user=user))
-        _, ctx = mock_tmpl.TemplateResponse.call_args.args
-        assert ctx["height_cm"] == 190
-        assert ctx["weight_kg"] == 85
-        assert ctx["preferred_foot"] == "left"
-        assert ctx["position"] == "goalkeeper"
+        db  = _mock_db(license_return=lic)
+        with pytest.raises(HTTPException) as exc_info:
+            _run(export_onboarding_welcome_card(
+                _req(), platform="banana", db=db, user=_user()
+            ))
+        assert exc_info.value.status_code == 422
 
-    def test_new_phase3_skills_present_in_context(self):
-        """throwing (outfield) and anticipation (mental) must be in skill categories."""
-        user = _user()
+    def test_rate_limit_raises_429(self):
+        from fastapi import HTTPException
         lic = _license()
-        db = _mock_db(license_return=lic)
-        with patch(f"{_BASE}.templates") as mock_tmpl:
-            mock_tmpl.TemplateResponse.return_value = MagicMock()
-            _run(onboarding_welcome_card(request=_req(), db=db, user=user))
-        _, ctx = mock_tmpl.TemplateResponse.call_args.args
-        all_keys = {s["key"] for cat in ctx["skill_categories"] for s in cat["skills"]}
-        assert "throwing"     in all_keys, "Phase 3 outfield skill 'throwing' missing"
-        assert "anticipation" in all_keys, "Phase 3 mental skill 'anticipation' missing"
+        db  = _mock_db(license_return=lic)
+        with patch(f"{_BASE}._export_svc.check_export_rate_limit", return_value=False), \
+             patch("app.config.settings") as mock_settings:
+            mock_settings.APP_INTERNAL_PORT = 8000
+            with pytest.raises(HTTPException) as exc_info:
+                _run(export_onboarding_welcome_card(
+                    _req(), platform="instagram_square", db=db, user=_user()
+                ))
+        assert exc_info.value.status_code == 429
 
-    def test_initials_derived_from_user_name(self):
-        user = _user()
-        user.name = "Lionel Messi"
-        lic = _license()
-        db = _mock_db(license_return=lic)
-        with patch(f"{_BASE}.templates") as mock_tmpl:
-            mock_tmpl.TemplateResponse.return_value = MagicMock()
-            _run(onboarding_welcome_card(request=_req(), db=db, user=user))
-        _, ctx = mock_tmpl.TemplateResponse.call_args.args
-        assert ctx["initials"] == "LM"
+    def test_returns_png_response(self):
+        """Mock _sync_take_screenshot — assert PNG bytes returned with correct headers."""
+        lic       = _license()
+        db        = _mock_db(license_return=lic)
+        fake_png  = b"\x89PNG\r\n\x1a\nFAKE"
+        with patch(f"{_BASE}._export_svc.check_export_rate_limit", return_value=True), \
+             patch(f"{_BASE}._export_svc._sync_take_screenshot", return_value=fake_png), \
+             patch("app.config.settings") as mock_settings:
+            mock_settings.APP_INTERNAL_PORT = 8000
+            result = _run(export_onboarding_welcome_card(
+                _req(), platform="instagram_square", db=db, user=_user()
+            ))
+        assert isinstance(result, Response)
+        assert result.media_type == "image/png"
+        assert result.body == fake_png
+        assert "welcome_card_instagram_square.png" in result.headers["content-disposition"]
+
+    def test_export_url_uses_self_route(self):
+        """The render URL passed to Playwright must point to /profile/onboarding-card."""
+        lic     = _license()
+        db      = _mock_db(license_return=lic)
+        fake_png = b"\x89PNG"
+        captured_url = []
+
+        def _capture(url, platform):
+            captured_url.append(url)
+            return fake_png
+
+        with patch(f"{_BASE}._export_svc.check_export_rate_limit", return_value=True), \
+             patch(f"{_BASE}._export_svc._sync_take_screenshot", side_effect=_capture), \
+             patch("app.config.settings") as mock_settings:
+            mock_settings.APP_INTERNAL_PORT = 8000
+            _run(export_onboarding_welcome_card(
+                _req(), platform="instagram_square", db=db, user=_user()
+            ))
+        assert len(captured_url) == 1
+        assert "/profile/onboarding-card" in captured_url[0]
+        assert "instagram_square" in captured_url[0]
+        assert "export=1" in captured_url[0]
 
 
-# ── Template static assertions ────────────────────────────────────────────────
+# ── 5. Gallery template static assertions ─────────────────────────────────────
 
-_TEMPLATE_PATH = (
+_GALLERY_TPL_PATH = (
     pathlib.Path(__file__).resolve().parents[4]
     / "app" / "templates" / "public" / "welcome_card.html"
+)
+_FIFA_TPL_PATH = (
+    pathlib.Path(__file__).resolve().parents[4]
+    / "app" / "templates" / "public" / "player_card_fifa.html"
+)
+_SQUARE_EXPORT_TPL_PATH = (
+    pathlib.Path(__file__).resolve().parents[4]
+    / "app" / "templates" / "public" / "export" / "square" / "fifa.html"
 )
 
 
 @pytest.fixture(scope="module")
-def wc_template_src():
-    return _TEMPLATE_PATH.read_text(encoding="utf-8")
+def gallery_src():
+    return _GALLERY_TPL_PATH.read_text(encoding="utf-8")
 
 
-class TestWelcomeCardTemplate:
-    """Static analysis of welcome_card.html — no rendering required."""
-
-    def test_template_file_exists(self):
-        assert _TEMPLATE_PATH.exists(), "welcome_card.html not found"
-
-    def test_contains_welcome_card_text(self, wc_template_src):
-        assert "Welcome Card" in wc_template_src
-
-    def test_contains_self_assessment_text(self, wc_template_src):
-        assert "Self-Assessment" in wc_template_src or "self_assessment" in wc_template_src
-
-    def test_contains_disclaimer_text(self, wc_template_src):
-        assert "onboarding self-assessment" in wc_template_src.lower() or \
-               "not calculated player level" in wc_template_src
-
-    def test_has_noindex_meta_tag(self, wc_template_src):
-        assert "noindex" in wc_template_src
-
-    def test_renders_skill_key_variable(self, wc_template_src):
-        """Template must iterate and render skill.key (data-skill attribute)."""
-        assert "skill.key" in wc_template_src
-
-    def test_renders_self_assessment_value_not_current_level(self, wc_template_src):
-        """Template renders skill.value (= self_assessment). Must NOT reference
-        current_level, system_baseline, tournament_delta, or assessment_delta."""
-        assert "current_level"    not in wc_template_src
-        assert "system_baseline"  not in wc_template_src
-        assert "tournament_delta" not in wc_template_src
-        assert "assessment_delta" not in wc_template_src
-
-    def test_renders_overall_sa_variable(self, wc_template_src):
-        assert "overall_sa" in wc_template_src
-
-    def test_renders_position_variable(self, wc_template_src):
-        assert "position" in wc_template_src
-
-    def test_renders_physical_fields(self, wc_template_src):
-        assert "height_cm"  in wc_template_src
-        assert "weight_kg"  in wc_template_src
-        assert "preferred_foot" in wc_template_src
-
-    def test_renders_skill_categories_loop(self, wc_template_src):
-        assert "skill_categories" in wc_template_src
-        assert "for cat in skill_categories" in wc_template_src or \
-               "for cat in skill_categories" in wc_template_src
-
-    def test_renders_top_skills_loop(self, wc_template_src):
-        assert "top_skills" in wc_template_src
-        assert "for skill in top_skills" in wc_template_src
-
-    def test_back_link_to_profile(self, wc_template_src):
-        assert "href=\"/profile\"" in wc_template_src or "href='/profile'" in wc_template_src
+@pytest.fixture(scope="module")
+def fifa_src():
+    return _FIFA_TPL_PATH.read_text(encoding="utf-8")
 
 
-class TestWelcomeCardRendered:
-    """Render the template with Jinja2 using a mock context and assert output."""
+@pytest.fixture(scope="module")
+def square_export_src():
+    return _SQUARE_EXPORT_TPL_PATH.read_text(encoding="utf-8")
 
-    @pytest.fixture(scope="class")
-    def rendered_html(self):
+
+class TestWelcomeCardGalleryTemplate:
+    """Static source analysis of the gallery hub (welcome_card.html)."""
+
+    def test_file_exists(self):
+        assert _GALLERY_TPL_PATH.exists()
+
+    def test_has_noindex_meta(self, gallery_src):
+        assert "noindex" in gallery_src
+
+    def test_has_welcome_card_heading(self, gallery_src):
+        assert "Welcome Card" in gallery_src
+
+    def test_has_based_on_self_assessment_text(self, gallery_src):
+        assert "self-assessment" in gallery_src.lower()
+
+    def test_has_english_disclaimer(self, gallery_src):
+        assert "not the same as the regular Player Card" in gallery_src
+
+    def test_has_iframe_preview(self, gallery_src):
+        assert "<iframe" in gallery_src
+        assert "/profile/onboarding-card" in gallery_src
+
+    def test_has_platform_download_buttons(self, gallery_src):
+        assert "/profile/onboarding-card/export?platform=" in gallery_src
+
+    def test_has_back_link_to_profile(self, gallery_src):
+        assert 'href="/profile"' in gallery_src
+
+    def test_gallery_renders_with_minimal_context(self):
+        """Jinja2 render: gallery template must not error with minimal context."""
         from jinja2 import Environment, FileSystemLoader, Undefined
-        template_dir = str(_TEMPLATE_PATH.parents[1])  # app/templates
         env = Environment(
-            loader=FileSystemLoader(template_dir),
+            loader=FileSystemLoader(str(_GALLERY_TPL_PATH.parents[1])),
             autoescape=True,
             undefined=Undefined,
         )
-        # Minimal mock context
-        context = {
+        ctx = {
             "request":          MagicMock(),
-            "user":             MagicMock(name="Test Player", nickname="tester",
-                                          nationality="HU", secondary_nationality=None),
-            "license":          MagicMock(player_card_photo_url=None,
-                                          right_foot_score=70.0, left_foot_score=30.0),
             "display_name":     "Test Player",
-            "initials":         "TP",
-            "overall_sa":       65.0,
-            "position":         "striker",
-            "positions":        ["striker"],
-            "height_cm":        178,
-            "weight_kg":        74,
-            "preferred_foot":   "right",
-            "goals":            "become_professional",
-            "right_foot_score": 70.0,
-            "left_foot_score":  30.0,
-            "top_skills": [
-                {"key": "ball_control", "name_en": "Ball Control",  "value": 80.0},
-                {"key": "throwing",     "name_en": "Throwing",      "value": 78.0},
-                {"key": "anticipation", "name_en": "Anticipation",  "value": 75.0},
-                {"key": "dribbling",    "name_en": "Dribbling",     "value": 72.0},
-                {"key": "finishing",    "name_en": "Finishing",     "value": 70.0},
-            ],
-            "skill_categories": [
-                {
-                    "key": "outfield", "name_en": "Outfield", "name_hu": "Mezőnyjáték",
-                    "emoji": "🟦", "avg": 65.0,
-                    "skills": [
-                        {"key": "ball_control", "name_en": "Ball Control", "name_hu": "Labdakontroll", "value": 80.0},
-                        {"key": "throwing",     "name_en": "Throwing",     "name_hu": "Dobás",         "value": 78.0},
-                    ],
-                },
-                {
-                    "key": "mental", "name_en": "Mental", "name_hu": "Mentális",
-                    "emoji": "🧠", "avg": 65.0,
-                    "skills": [
-                        {"key": "anticipation", "name_en": "Anticipation", "name_hu": "Anticipáció", "value": 75.0},
-                    ],
-                },
-            ],
+            "platforms":        _WC_GALLERY_PLATFORMS,
+            "default_platform": "instagram_square",
         }
-        tpl = env.get_template("public/welcome_card.html")
-        return tpl.render(**context)
-
-    def test_html_contains_welcome_card(self, rendered_html):
-        assert "Welcome Card" in rendered_html
-
-    def test_html_contains_self_assessment(self, rendered_html):
-        assert "Self-Assessment" in rendered_html or "self-assessment" in rendered_html.lower()
-
-    def test_html_contains_new_outfield_skill_throwing(self, rendered_html):
-        assert "throwing" in rendered_html.lower() or "Throwing" in rendered_html
-
-    def test_html_contains_new_mental_skill_anticipation(self, rendered_html):
-        assert "anticipation" in rendered_html.lower() or "Anticipation" in rendered_html
-
-    def test_html_does_not_contain_current_level(self, rendered_html):
-        assert "current_level" not in rendered_html
-
-    def test_html_does_not_contain_system_baseline(self, rendered_html):
-        assert "system_baseline" not in rendered_html
-
-    def test_html_does_not_contain_tournament_delta(self, rendered_html):
-        assert "tournament_delta" not in rendered_html
-
-    def test_html_does_not_contain_assessment_delta(self, rendered_html):
-        assert "assessment_delta" not in rendered_html
-
-    def test_html_contains_overall_sa_value(self, rendered_html):
-        assert "65" in rendered_html  # overall_sa=65.0
-
-    def test_html_contains_player_name(self, rendered_html):
-        assert "Test Player" in rendered_html
-
-    def test_html_contains_disclaimer(self, rendered_html):
-        assert "onboarding self-assessment" in rendered_html.lower()
-
-    def test_html_has_noindex(self, rendered_html):
-        assert "noindex" in rendered_html
-
-    def test_data_skill_attributes_present(self, rendered_html):
-        """Skill rows must have data-skill attributes with the skill key."""
-        assert 'data-skill="ball_control"' in rendered_html
-        assert 'data-skill="throwing"'     in rendered_html
-        assert 'data-skill="anticipation"' in rendered_html
+        html = env.get_template("public/welcome_card.html").render(**ctx)
+        assert "Welcome Card" in html
+        assert "iframe" in html
+        assert "instagram_square" in html
 
 
-class TestWelcomeCardStep7Integration:
-    """Verify that the step-7 HTML in the onboarding template has the View Welcome Card CTA."""
+# ── 6. FIFA template logo audit ────────────────────────────────────────────────
 
-    @pytest.fixture(scope="class")
-    def onboarding_src(self):
-        path = (
-            pathlib.Path(__file__).resolve().parents[4]
-            / "app" / "templates" / "lfa_player_onboarding.html"
-        )
-        return path.read_text(encoding="utf-8")
+class TestWelcomeCardFifaLogoAudit:
+    """Static source checks that Phase 5 logo changes are in place."""
 
-    def test_view_welcome_card_link_present(self, onboarding_src):
-        assert 'id="btn-view-welcome-card"' in onboarding_src
+    def test_player_card_fifa_has_page_logo_css(self, fifa_src):
+        assert ".page-logo" in fifa_src
 
-    def test_view_welcome_card_href_correct(self, onboarding_src):
-        assert 'href="/profile/onboarding-card"' in onboarding_src
+    def test_player_card_fifa_has_app_logo_url_conditional(self, fifa_src):
+        assert "app_logo_url" in fifa_src
+        assert "{% if app_logo_url %}" in fifa_src
 
-    def test_view_welcome_card_opens_in_new_tab(self, onboarding_src):
-        assert 'target="_blank"' in onboarding_src
+    def test_player_card_fifa_text_brand_is_else_branch(self, fifa_src):
+        """Text brand must only render when app_logo_url is falsy (inside {% else %} block)."""
+        # The brand div must be preceded by {% else %} before {% endif %}
+        # Locate the page-brand div in the HTML body (not the CSS class definition)
+        brand_div_idx = fifa_src.find('<div class="page-brand">')
+        assert brand_div_idx != -1, "page-brand div not found"
+        # There must be an {% else %} between the last {% if app_logo_url %} and the brand div
+        before_brand = fifa_src[:brand_div_idx]
+        assert "{% else %}" in before_brand, "page-brand div must be inside {% else %} block"
+        assert "app_logo_url" in before_brand, "{% if app_logo_url %} must precede page-brand div"
 
-    def test_download_placeholder_still_disabled(self, onboarding_src):
-        assert "btn-disabled-placeholder" in onboarding_src
-        assert "Download Welcome Card" in onboarding_src
+    def test_export_square_has_app_logo_in_sponsor_slot(self, square_export_src):
+        assert "app_logo_url" in square_export_src
+        assert "elif app_logo_url" in square_export_src
+
+    def test_export_square_sponsor_logo_takes_priority(self, square_export_src):
+        """sponsor_logo_url branch must be checked before app_logo_url."""
+        idx_sponsor = square_export_src.find("sponsor_logo_url")
+        idx_app     = square_export_src.find("app_logo_url")
+        assert idx_sponsor < idx_app
+
+
+# ── 7. Step 7 onboarding template ─────────────────────────────────────────────
+
+@pytest.fixture(scope="module")
+def step7_src():
+    path = (
+        pathlib.Path(__file__).resolve().parents[4]
+        / "app" / "templates" / "lfa_player_onboarding.html"
+    )
+    return path.read_text(encoding="utf-8")
+
+
+class TestWelcomeCardStep7:
+    """Verify Step 7 of the onboarding template."""
+
+    # ── Phase 1: Hungarian text removed ──
+
+    def test_no_hungarian_title(self, step7_src):
+        assert "Az onboarding sikeresen befejeződött" not in step7_src
+
+    def test_no_hungarian_notice_ez_a_kartya(self, step7_src):
+        assert "Ez a kártya" not in step7_src
+
+    def test_no_hungarian_notice_nem_azonos(self, step7_src):
+        assert "Nem azonos a rendes" not in step7_src
+
+    def test_no_hungarian_notice_ema_motor(self, step7_src):
+        assert "EMA-motor" not in step7_src
+
+    # ── Phase 1: English text present ──
+
+    def test_english_subtitle_present(self, step7_src):
+        assert "Onboarding completed successfully" in step7_src
+
+    def test_english_notice_line_1(self, step7_src):
+        assert "This card is generated from your self-assessment data" in step7_src
+
+    def test_english_notice_line_2(self, step7_src):
+        assert "not the same as the regular Player Card" in step7_src
+
+    def test_english_notice_line_3(self, step7_src):
+        assert "Values come from your own self-assessment" in step7_src
+
+    # ── CTA buttons ──
+
+    def test_view_welcome_card_link_present(self, step7_src):
+        assert 'id="btn-view-welcome-card"' in step7_src
+
+    def test_view_welcome_card_href_correct(self, step7_src):
+        assert 'href="/profile/onboarding-card"' in step7_src
+
+    def test_view_welcome_card_opens_in_new_tab(self, step7_src):
+        assert 'target="_blank"' in step7_src
+
+    def test_download_link_is_active_anchor(self, step7_src):
+        """Download button must be an <a> link pointing to the export route, not a disabled placeholder."""
+        assert 'id="btn-download-welcome-card"' in step7_src
+        assert '/profile/onboarding-card/export' in step7_src
+        # Must NOT be a disabled span
+        assert 'btn-disabled-placeholder' not in step7_src
+
+    # ── Phase 4: Photo upload ──
+
+    def test_photo_upload_input_present(self, step7_src):
+        assert 'id="step7-photo-input"' in step7_src
+        assert 'type="file"' in step7_src
+
+    def test_photo_upload_uses_dashboard_endpoint(self, step7_src):
+        assert "/dashboard/lfa-player-photo" in step7_src
+
+    def test_photo_upload_is_optional(self, step7_src):
+        """Upload input must not block the CTA buttons (they are in the same step)."""
+        idx_upload = step7_src.find("step7-photo-input")
+        idx_view   = step7_src.find("btn-view-welcome-card")
+        assert idx_upload != -1 and idx_view != -1
+        # Both elements present in step-7 — the CTA row comes after the upload widget
+        assert idx_upload < idx_view or idx_upload > idx_view  # both present, order flexible

--- a/tests/unit/api/web_routes/test_welcome_card.py
+++ b/tests/unit/api/web_routes/test_welcome_card.py
@@ -545,3 +545,95 @@ class TestWelcomeCardStep7:
         assert idx_upload != -1 and idx_view != -1
         # Both elements present in step-7 — the CTA row comes after the upload widget
         assert idx_upload < idx_view or idx_upload > idx_view  # both present, order flexible
+
+
+# ── 8. Profile page Welcome Card section ──────────────────────────────────────
+
+_PROFILE_TPL_PATH = (
+    pathlib.Path(__file__).resolve().parents[4]
+    / "app" / "templates" / "profile.html"
+)
+_DASHBOARD_TPL_PATH = (
+    pathlib.Path(__file__).resolve().parents[4]
+    / "app" / "templates" / "dashboard_student_new.html"
+)
+
+
+@pytest.fixture(scope="module")
+def profile_src():
+    return _PROFILE_TPL_PATH.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def dashboard_src():
+    return _DASHBOARD_TPL_PATH.read_text(encoding="utf-8")
+
+
+def _wc_block(profile_src: str) -> str:
+    """Extract and return the Welcome Card conditional block from profile.html."""
+    start = profile_src.find("<!-- Welcome Card")
+    end   = profile_src.find("<!-- Emergency Contact", start)
+    assert start != -1 and end != -1, "Welcome Card block not found in profile.html"
+    return profile_src[start:end]
+
+
+def _render_wc_fragment(profile_src: str, active_license) -> str:
+    """Render only the Welcome Card conditional fragment as a standalone Jinja2 template."""
+    from jinja2 import Template
+    fragment = _wc_block(profile_src)
+    # Strip the HTML comment line so only the Jinja2 block remains
+    fragment = "\n".join(
+        line for line in fragment.splitlines()
+        if not line.strip().startswith("<!--")
+    )
+    return Template(fragment).render(active_license=active_license)
+
+
+def _lic(spec_type="LFA_FOOTBALL_PLAYER", onboarding_completed=True):
+    lic = MagicMock()
+    lic.specialization_type  = spec_type
+    lic.onboarding_completed = onboarding_completed
+    return lic
+
+
+class TestWelcomeCardProfileSection:
+    """Verify the Welcome Card section in profile.html is gated correctly."""
+
+    # ── T1: completed LFA Player sees the section ──
+
+    def test_completed_lfa_player_sees_welcome_card_section(self, profile_src):
+        html = _render_wc_fragment(profile_src, _lic())
+        assert "/profile/onboarding-card" in html
+        assert "View Welcome Card" in html
+        assert "Download" in html
+
+    # ── T2: incomplete onboarding hides the section ──
+
+    def test_incomplete_onboarding_hides_welcome_card(self, profile_src):
+        html = _render_wc_fragment(profile_src, _lic(onboarding_completed=False))
+        assert "/profile/onboarding-card" not in html
+        assert "Welcome Card" not in html
+
+    # ── T3: non-LFA spec hides the section ──
+
+    def test_non_lfa_spec_hides_welcome_card(self, profile_src):
+        for spec in ("GANCUJU_PLAYER", "LFA_COACH", "INTERNSHIP"):
+            html = _render_wc_fragment(profile_src, _lic(spec_type=spec))
+            assert "/profile/onboarding-card" not in html, f"Welcome Card visible for {spec}"
+
+    # ── T4: dashboard mod-nav has no Welcome Card quick action ──
+
+    def test_dashboard_mod_nav_has_no_welcome_card_link(self, dashboard_src):
+        # Extract mod-nav-section block
+        start = dashboard_src.find('class="mod-nav-section"')
+        end   = dashboard_src.find("</section>", start)
+        assert start != -1 and end != -1
+        mod_nav = dashboard_src[start:end]
+        assert "onboarding-card" not in mod_nav
+        assert "Welcome Card" not in mod_nav
+
+    # ── T5: dashboard Player Card iframe link unchanged ──
+
+    def test_dashboard_player_card_link_unchanged(self, dashboard_src):
+        assert '/players/{{ user.id }}/card' in dashboard_src
+        assert 'spec-player-card-iframe' in dashboard_src

--- a/tests/unit/services/test_adaptive_learning_service.py
+++ b/tests/unit/services/test_adaptive_learning_service.py
@@ -50,14 +50,32 @@ def _q(db, first=None, all_=None):
     return q
 
 
-def _mock_session(presented=5, correct=3, trend=0.0, start_time=None, time_limit=None):
+def _mock_session(presented=5, correct=3, trend=0.0, start_time=None, time_limit=None,
+                  session_due_shown=0):
     s = MagicMock()
     s.questions_presented = presented
     s.questions_correct = correct
     s.performance_trend = trend
     s.session_start_time = start_time
     s.session_time_limit_seconds = time_limit
+    s.session_due_shown = session_due_shown
     return s
+
+
+def _perf_data(due_ids=None, weak_ids=None, all_ids=None):
+    """Build a performance_data dict for patching _get_user_performance_data."""
+    all_ids = all_ids or []
+    return {
+        "all_performances": [MagicMock(question_id=i, mastery_level=0.5,
+                                       difficulty_weight=1.5, next_review_at=None)
+                             for i in all_ids],
+        "due_for_review": [MagicMock(question_id=i) for i in (due_ids or [])],
+        "weak_concepts": [MagicMock(question_id=i) for i in (weak_ids or [])],
+        "strong_concepts": [],
+    }
+
+
+_EMPTY_PERF = {"all_performances": [], "due_for_review": [], "weak_concepts": [], "strong_concepts": []}
 
 
 # ===========================================================================
@@ -573,33 +591,37 @@ class TestGetNextQuestion:
         assert result.get("reason") == "pool_exhausted"
 
     def test_all_candidates_available_without_blackout(self):
-        """All candidate questions are passed to adaptive selection — no 1-hour blackout applied."""
+        """All candidate questions are passed to weighted selection — no 1-hour blackout applied."""
         svc, db = _svc()
         session = MagicMock()
+        session.session_due_shown = 0
         question = MagicMock()
         question.id = 7
+        question.answer_options = []
+        question.question_type = None
         _q(db, first=session)
         with patch.object(svc, "_is_session_time_expired", return_value=False), \
-             patch.object(svc, "_get_user_performance_data", return_value={}), \
+             patch.object(svc, "_get_user_performance_data", return_value=_EMPTY_PERF), \
              patch.object(svc, "_get_candidate_questions", return_value=[question]), \
-             patch.object(svc, "_select_adaptive_question", return_value=question) as mock_select, \
+             patch.object(svc, "_select_weighted_question", return_value=question) as mock_select, \
              patch.object(svc, "_get_session_time_remaining", return_value=120):
             result = svc.get_next_question(user_id=42, session_id=1)
-        # The full candidate list must reach _select_adaptive_question
+        # The full candidate list must reach _select_weighted_question
         mock_select.assert_called_once()
         candidates_passed = mock_select.call_args[0][0]
         assert question in candidates_passed
         assert result["id"] == 7
 
     def test_no_selected_question_returns_pool_exhausted_dict(self):
-        """_select_adaptive_question returns None → pool_exhausted dict."""
+        """_select_weighted_question returns None → pool_exhausted dict."""
         svc, db = _svc()
         session = MagicMock()
-        _q(db, first=session, all_=[])   # recent questions → empty
+        session.session_due_shown = 0
+        _q(db, first=session, all_=[])
         with patch.object(svc, "_is_session_time_expired", return_value=False), \
-             patch.object(svc, "_get_user_performance_data", return_value={}), \
+             patch.object(svc, "_get_user_performance_data", return_value=_EMPTY_PERF), \
              patch.object(svc, "_get_candidate_questions", return_value=[MagicMock()]), \
-             patch.object(svc, "_select_adaptive_question", return_value=None):
+             patch.object(svc, "_select_weighted_question", return_value=None):
             result = svc.get_next_question(user_id=42, session_id=1)
         assert result == {"session_complete": True, "reason": "pool_exhausted"}
 
@@ -701,53 +723,144 @@ class TestGetUserLearningAnalyticsBranches:
 
 
 # ===========================================================================
-# _select_adaptive_question — branch coverage
+# _calculate_question_weight — AL-SEL-01..07
 # ===========================================================================
 
 @pytest.mark.unit
-class TestSelectAdaptiveQuestion:
-    """
-    Covers _select_adaptive_question:
-      L279: due_questions found → random.choice (True path)
-      L286: weak_concept_questions found AND random < 0.7 → random.choice
-      L286: weak_concept OR random >= 0.7 → fallback random.choice
-    """
+class TestCalculateQuestionWeight:
+    """Unit tests for _calculate_question_weight priority formula."""
 
-    def _perf_data(self, due_ids=None, weak_ids=None):
-        return {
-            "due_for_review": [MagicMock(question_id=i) for i in (due_ids or [])],
-            "weak_concepts": [MagicMock(question_id=i) for i in (weak_ids or [])],
+    def _run(self, q_id, due_ids=None, perf_map=None, session_due_shown=0, exclude_ids=None):
+        svc, _ = _svc()
+        return svc._calculate_question_weight(
+            q_id,
+            set(due_ids or []),
+            perf_map or {},
+            session_due_shown,
+            set(exclude_ids or []),
+        )
+
+    def test_al_sel_01_due_within_cap_gets_high_weight(self):
+        """AL-SEL-01: due question with session_due_shown < cap → weight 2.5."""
+        w = self._run(1, due_ids=[1], session_due_shown=0)
+        assert w == 2.5
+
+    def test_al_sel_02_due_cap_exhausted_falls_back_to_difficulty_weight(self):
+        """AL-SEL-02: due question but cap exhausted → min(dw, 1.8)."""
+        from unittest.mock import MagicMock
+        perf = MagicMock(); perf.mastery_level = 0.3; perf.difficulty_weight = 1.6
+        w = self._run(1, due_ids=[1], perf_map={1: perf}, session_due_shown=3)
+        assert w == min(1.6, 1.8)
+
+    def test_al_sel_03_weak_concept_gets_elevated_weight(self):
+        """AL-SEL-03: non-due weak concept (mastery < 0.6) → min(dw, 1.8)."""
+        perf = MagicMock(); perf.mastery_level = 0.3; perf.difficulty_weight = 1.7
+        w = self._run(2, due_ids=[], perf_map={2: perf}, session_due_shown=0)
+        assert w == min(1.7, 1.8)
+
+    def test_al_sel_04_never_seen_gets_slight_boost(self):
+        """AL-SEL-04: question with no performance record → weight 1.2."""
+        w = self._run(3, due_ids=[], perf_map={}, session_due_shown=0)
+        assert w == 1.2
+
+    def test_al_sel_05_strong_mastery_gets_normal_weight(self):
+        """AL-SEL-05: mastery >= 0.6, not due, not weak → weight 1.0."""
+        perf = MagicMock(); perf.mastery_level = 0.8; perf.difficulty_weight = 1.2
+        w = self._run(4, due_ids=[], perf_map={4: perf}, session_due_shown=0)
+        assert w == 1.0
+
+    def test_al_sel_06_exclude_ids_applies_recency_penalty(self):
+        """AL-SEL-06: question in exclude_ids → weight *= 0.1."""
+        w = self._run(5, due_ids=[], perf_map={}, session_due_shown=0, exclude_ids=[5])
+        assert abs(w - 1.2 * 0.1) < 1e-9  # never-seen (1.2) * penalty
+
+    def test_al_sel_07_weight_floor_is_0_05(self):
+        """AL-SEL-07: even a highly penalised question gets at least 0.05."""
+        perf = MagicMock(); perf.mastery_level = 0.9; perf.difficulty_weight = 1.0
+        # normal (1.0) * penalty (0.1) = 0.1 → max(0.05, 0.1) = 0.1; floor only bites below 0.5
+        w_normal = self._run(6, due_ids=[], perf_map={6: perf}, session_due_shown=0, exclude_ids=[6])
+        assert w_normal >= 0.05
+        # A question that would compute to exactly 0.0 still gets 0.05
+        # Simulate by passing extreme dw through the formula manually
+        svc, _ = _svc()
+        assert svc._calculate_question_weight(99, set(), {}, 0, set()) >= 0.05
+
+
+# ===========================================================================
+# _select_weighted_question
+# ===========================================================================
+
+@pytest.mark.unit
+class TestSelectWeightedQuestion:
+    """Tests for _select_weighted_question pool coverage and edge cases."""
+
+    def _sess(self, due_shown=0):
+        s = MagicMock()
+        s.session_due_shown = due_shown
+        return s
+
+    def _make_q(self, qid):
+        q = MagicMock(); q.id = qid; q.answer_options = []; q.question_type = None
+        return q
+
+    def test_empty_candidates_returns_none(self):
+        svc, _ = _svc()
+        result = svc._select_weighted_question([], _EMPTY_PERF, self._sess())
+        assert result is None
+
+    def test_single_candidate_always_returned(self):
+        svc, _ = _svc()
+        q = self._make_q(1)
+        for _ in range(10):
+            result = svc._select_weighted_question([q], _EMPTY_PERF, self._sess())
+            assert result is q
+
+    def test_due_questions_selected_more_often_within_cap(self):
+        """Due questions (cap not reached) must dominate selection over long runs."""
+        svc, _ = _svc()
+        q_due = self._make_q(10)
+        q_other = self._make_q(20)
+        due_perf = MagicMock(question_id=10)
+        pd = {
+            "all_performances": [due_perf],
+            "due_for_review": [due_perf],
+            "weak_concepts": [], "strong_concepts": [],
         }
+        counts = {10: 0, 20: 0}
+        for _ in range(200):
+            r = svc._select_weighted_question([q_due, q_other], pd, self._sess(due_shown=0))
+            counts[r.id] += 1
+        # Due question (weight 2.5) vs never-seen (weight 1.2): expect >60% due
+        assert counts[10] > 100, f"Due question selected only {counts[10]}/200 times"
 
-    def test_due_question_returned_preferentially(self):
+    def test_cap_exhausted_due_question_not_dominant(self):
+        """When session_due_shown >= cap, due questions lose their 2.5 priority."""
         svc, _ = _svc()
-        q_due = MagicMock(); q_due.id = 10
-        q_other = MagicMock(); q_other.id = 20
-        perf_data = self._perf_data(due_ids=[10])
-        with patch("random.choice", return_value=q_due):
-            result = svc._select_adaptive_question([q_due, q_other], perf_data, MagicMock())
-        assert result is q_due
+        q_due = self._make_q(10)
+        q_other = self._make_q(20)
+        due_perf = MagicMock(question_id=10, mastery_level=0.3, difficulty_weight=1.5)
+        pd = {
+            "all_performances": [due_perf],
+            "due_for_review": [due_perf],
+            "weak_concepts": [], "strong_concepts": [],
+        }
+        counts = {10: 0, 20: 0}
+        for _ in range(200):
+            r = svc._select_weighted_question([q_due, q_other], pd, self._sess(due_shown=3))
+            counts[r.id] += 1
+        # With cap exhausted, q_due weight ≤ 1.8, q_other weight 1.2 → not dominant
+        assert counts[10] < 170, f"Cap-exhausted due question still dominant: {counts[10]}/200"
 
-    def test_weak_concept_selected_when_random_below_threshold(self):
+    def test_excluded_questions_still_selectable(self):
+        """Excluded questions get recency penalty (0.1×) but CAN be returned."""
         svc, _ = _svc()
-        q_weak = MagicMock(); q_weak.id = 20
-        q_other = MagicMock(); q_other.id = 30
-        perf_data = self._perf_data(due_ids=[], weak_ids=[20])
-        with patch("random.random", return_value=0.5), \
-             patch("random.choice", return_value=q_weak):
-            result = svc._select_adaptive_question([q_weak, q_other], perf_data, MagicMock())
-        assert result is q_weak
-
-    def test_random_question_returned_when_random_above_threshold(self):
-        """random.random() >= 0.7 → fallback to random.choice from all candidates."""
-        svc, _ = _svc()
-        q_weak = MagicMock(); q_weak.id = 20
-        q_other = MagicMock(); q_other.id = 30
-        perf_data = self._perf_data(due_ids=[], weak_ids=[20])
-        with patch("random.random", return_value=0.9), \
-             patch("random.choice", return_value=q_other):
-            result = svc._select_adaptive_question([q_weak, q_other], perf_data, MagicMock())
-        assert result is q_other
+        q1 = self._make_q(1)
+        # Run 500 times; with 0.1× penalty among 1 candidate, q1 must appear
+        results = [
+            svc._select_weighted_question([q1], _EMPTY_PERF, self._sess(), exclude_ids={1})
+            for _ in range(10)
+        ]
+        assert all(r is q1 for r in results), "Single excluded candidate must still be returned"
 
 
 # ===========================================================================
@@ -830,11 +943,12 @@ class TestNoBlackoutRepetition:
 
     def _call_next(self, svc, db, candidates, selected):
         session = MagicMock()
+        session.session_due_shown = 0
         _q(db, first=session)
         with patch.object(svc, "_is_session_time_expired", return_value=False), \
-             patch.object(svc, "_get_user_performance_data", return_value={}), \
+             patch.object(svc, "_get_user_performance_data", return_value=_EMPTY_PERF), \
              patch.object(svc, "_get_candidate_questions", return_value=candidates), \
-             patch.object(svc, "_select_adaptive_question", return_value=selected) as mock_sel, \
+             patch.object(svc, "_select_weighted_question", return_value=selected) as mock_sel, \
              patch.object(svc, "_get_session_time_remaining", return_value=120):
             result = svc.get_next_question(user_id=42, session_id=1)
         return result, mock_sel
@@ -873,7 +987,7 @@ class TestNoBlackoutRepetition:
             assert result["id"] == 5
 
     def test_full_candidate_list_reaches_selector(self):
-        """All candidates must reach _select_adaptive_question — no filtering applied."""
+        """All candidates must reach _select_weighted_question — no hard filtering applied."""
         svc, db = _svc()
         questions = [MagicMock(id=i) for i in range(1, 6)]
         result, mock_sel = self._call_next(svc, db, questions, questions[0])
@@ -906,12 +1020,13 @@ class TestNoBlackoutRepetition:
         from app.models.quiz import UserQuestionPerformance
         svc, db = _svc()
         session = MagicMock()
-        q = MagicMock(); q.id = 1
+        session.session_due_shown = 0
+        q = MagicMock(); q.id = 1; q.answer_options = []; q.question_type = None
         _q(db, first=session)
         with patch.object(svc, "_is_session_time_expired", return_value=False), \
-             patch.object(svc, "_get_user_performance_data", return_value={}), \
+             patch.object(svc, "_get_user_performance_data", return_value=_EMPTY_PERF), \
              patch.object(svc, "_get_candidate_questions", return_value=[q]), \
-             patch.object(svc, "_select_adaptive_question", return_value=q), \
+             patch.object(svc, "_select_weighted_question", return_value=q), \
              patch.object(svc, "_get_session_time_remaining", return_value=120):
             svc.get_next_question(user_id=42, session_id=1)
         # Verify db.query was NOT called with UserQuestionPerformance as the sole arg
@@ -941,11 +1056,9 @@ class TestGetNextQuestionDedup:
     def _base_patches(self, svc, candidates, selected):
         return [
             patch.object(svc, "_is_session_time_expired", return_value=False),
-            patch.object(svc, "_get_user_performance_data", return_value={
-                "weak_concepts": [], "strong_concepts": [], "due_for_review": []
-            }),
+            patch.object(svc, "_get_user_performance_data", return_value=_EMPTY_PERF),
             patch.object(svc, "_get_candidate_questions", return_value=candidates),
-            patch.object(svc, "_select_adaptive_question", return_value=selected),
+            patch.object(svc, "_select_weighted_question", return_value=selected),
             patch.object(svc, "_get_session_time_remaining", return_value=55),
             patch.object(svc, "_get_question_difficulty", return_value=0.5),
         ]
@@ -964,69 +1077,81 @@ class TestGetNextQuestionDedup:
         assert result.get("session_complete") is True
         assert result.get("reason") == "pool_exhausted"
 
-    def test_exclude_ids_filters_before_selection(self):
-        """exclude_ids={1,2} with only Q1/Q2 in pool → all_seen, never calls selection."""
+    def test_exclude_ids_applies_recency_penalty_not_hard_filter(self):
+        """exclude_ids={1,2} with only Q1/Q2 — recency penalty, NOT hard exclusion.
+        Service must still return a question (not session_complete).
+        """
         svc, db = _svc()
         q1, q2 = self._make_q(1), self._make_q(2)
-        _q(db, first=MagicMock())
+        session = MagicMock()
+        session.session_due_shown = 0
+        _q(db, first=session)
         with patch.object(svc, "_is_session_time_expired", return_value=False), \
-             patch.object(svc, "_get_user_performance_data", return_value={
-                 "weak_concepts": [], "strong_concepts": [], "due_for_review": []
-             }), \
+             patch.object(svc, "_get_user_performance_data", return_value=_EMPTY_PERF), \
              patch.object(svc, "_get_candidate_questions", return_value=[q1, q2]), \
-             patch.object(svc, "_select_adaptive_question") as mock_select:
+             patch.object(svc, "_get_session_time_remaining", return_value=55), \
+             patch.object(svc, "_get_question_difficulty", return_value=0.5):
             result = svc.get_next_question(user_id=42, session_id=1, exclude_ids={1, 2})
         assert result is not None
-        assert result.get("session_complete") is True
-        assert result.get("reason") == "all_seen"
-        mock_select.assert_not_called()
+        assert not result.get("session_complete"), \
+            "Recency penalty must not cause session_complete — excluded questions remain selectable"
 
-    def test_exclude_ids_never_returns_seen_question(self):
-        """With 3 candidates and exclude_ids={1}, returned question must not be Q1."""
+    def test_exclude_ids_reduces_probability_of_seen_questions(self):
+        """With 3 candidates and exclude_ids={1}, Q1 should appear less often than Q2/Q3."""
         svc, db = _svc()
         q1, q2, q3 = self._make_q(1), self._make_q(2), self._make_q(3)
-        _q(db, first=MagicMock())
-        # Run 50 times to catch probabilistic failures
-        for _ in range(50):
+        counts = {1: 0, 2: 0, 3: 0}
+        for _ in range(200):
+            session = MagicMock()
+            session.session_due_shown = 0
+            _q(db, first=session)
             with patch.object(svc, "_is_session_time_expired", return_value=False), \
-                 patch.object(svc, "_get_user_performance_data", return_value={
-                     "weak_concepts": [], "strong_concepts": [], "due_for_review": []
-                 }), \
+                 patch.object(svc, "_get_user_performance_data", return_value=_EMPTY_PERF), \
                  patch.object(svc, "_get_candidate_questions", return_value=[q1, q2, q3]), \
                  patch.object(svc, "_get_session_time_remaining", return_value=55), \
                  patch.object(svc, "_get_question_difficulty", return_value=0.5):
                 result = svc.get_next_question(user_id=42, session_id=1, exclude_ids={1})
-            assert result is not None
-            assert not result.get("session_complete"), "Should have returned a question"
-            assert result.get("id") != 1, f"Returned excluded Q1 in iteration"
+            if result and not result.get("session_complete"):
+                counts[result["id"]] += 1
+        # Q1 has 0.1× penalty; Q2/Q3 are normal. Expected Q1 ≈ 5%, Q2+Q3 ≈ 95%.
+        # Conservatively: Q1 should appear less than half as often as Q2 alone.
+        assert counts[1] < counts[2], \
+            f"Excluded Q1 appeared {counts[1]} times vs non-excluded Q2 {counts[2]}"
 
-    def test_pool_exhausted_returns_session_complete(self):
-        """All candidates excluded → session_complete: True with all_seen reason."""
+    def test_single_candidate_with_exclude_still_returns_result(self):
+        """Single excluded candidate → recency penalty applies but question is still returned."""
         svc, db = _svc()
         q1 = self._make_q(1)
-        _q(db, first=MagicMock())
+        session = MagicMock()
+        session.session_due_shown = 0
+        _q(db, first=session)
         with patch.object(svc, "_is_session_time_expired", return_value=False), \
-             patch.object(svc, "_get_user_performance_data", return_value={
-                 "weak_concepts": [], "strong_concepts": [], "due_for_review": []
-             }), \
-             patch.object(svc, "_get_candidate_questions", return_value=[q1]):
+             patch.object(svc, "_get_user_performance_data", return_value=_EMPTY_PERF), \
+             patch.object(svc, "_get_candidate_questions", return_value=[q1]), \
+             patch.object(svc, "_get_session_time_remaining", return_value=55), \
+             patch.object(svc, "_get_question_difficulty", return_value=0.5):
             result = svc.get_next_question(user_id=42, session_id=1, exclude_ids={1})
-        assert result["session_complete"] is True
-        assert result["reason"] == "all_seen"
+        assert result is not None
+        assert not result.get("session_complete")
+        assert result["id"] == 1
 
     def test_weak_due_mismatch_falls_back_to_all_candidates(self):
-        """No weak/due matches in candidates → random selection from full pool, no exception."""
+        """No weak/due matches in candidates → weighted selection from full pool, no exception."""
         svc, db = _svc()
         q5 = self._make_q(5)
-        _q(db, first=MagicMock())
+        session = MagicMock()
+        session.session_due_shown = 0
+        _q(db, first=session)
 
         perf_q1 = MagicMock()
         perf_q1.question_id = 1
-        perf_q1.mastery_level = 0.1  # weak
+        perf_q1.mastery_level = 0.1  # weak, but not in candidates
+        perf_q1.difficulty_weight = 1.5
         perf_q1.next_review_at = None
 
         with patch.object(svc, "_is_session_time_expired", return_value=False), \
              patch.object(svc, "_get_user_performance_data", return_value={
+                 "all_performances": [perf_q1],
                  "weak_concepts": [perf_q1],   # Q1 is weak
                  "strong_concepts": [],
                  "due_for_review": [],
@@ -1034,8 +1159,125 @@ class TestGetNextQuestionDedup:
              patch.object(svc, "_get_candidate_questions", return_value=[q5]), \
              patch.object(svc, "_get_session_time_remaining", return_value=55), \
              patch.object(svc, "_get_question_difficulty", return_value=0.5):
-            # Q1 is weak but not in candidates (only Q5) → must fall back to random(candidates)
+            # Q1 is weak but not in candidates (only Q5) → must fall back to weighted(candidates)
             result = svc.get_next_question(user_id=42, session_id=1)
         assert result is not None
         assert not result.get("session_complete"), "Should return Q5 as fallback"
         assert result.get("id") == 5
+
+
+# ===========================================================================
+# Language filter — AL-LANG-01..03
+# ===========================================================================
+
+@pytest.mark.unit
+class TestLanguageFilter:
+    """Verifies that performance data queries are scoped to the session language."""
+
+    def test_al_lang_01_get_user_learning_analytics_applies_language_filter(self):
+        """AL-LANG-01: language param passed to get_user_learning_analytics → join+filter applied."""
+        svc, db = _svc()
+        q = MagicMock()
+        q.filter.return_value = q
+        q.join.return_value = q
+        q.all.return_value = []
+        db.query.return_value = q
+
+        svc.get_user_learning_analytics(user_id=42, category=QuizCategory.LESSON, language="hu")
+        # A language filter was applied → join must have been called (category+language branch)
+        q.join.assert_called()
+        # filter must have been called at least twice (category + language)
+        assert q.filter.call_count >= 2, "Expected category AND language filter calls"
+
+    def test_al_lang_02_get_user_performance_data_applies_language_filter(self):
+        """AL-LANG-02: _get_user_performance_data(language='hu') must include language in query."""
+        svc, db = _svc()
+        q = MagicMock()
+        q.filter.return_value = q
+        q.join.return_value = q
+        q.all.return_value = []
+        db.query.return_value = q
+
+        from app.models.quiz import QuizCategory
+        svc._get_user_performance_data(user_id=42, category=QuizCategory.LESSON, language="hu")
+        q.filter.assert_called()
+        # Verify language was passed as a filter — the call args should contain 'hu' somewhere
+        all_filter_args = str(q.filter.call_args_list)
+        assert "hu" in all_filter_args or q.filter.call_count >= 1
+
+    def test_al_lang_03_calculate_target_difficulty_passes_language_to_analytics(self):
+        """AL-LANG-03: _calculate_target_difficulty passes language to get_user_learning_analytics."""
+        svc, _ = _svc()
+        calls = []
+        original = svc.get_user_learning_analytics
+        def recording_analytics(user_id, category=None, language=None):
+            calls.append({"user_id": user_id, "category": category, "language": language})
+            return {
+                "overall_success_rate": 0.7,
+                "learning_velocity": 0.0,
+                "mastery_level": 0.5,
+            }
+        svc.get_user_learning_analytics = recording_analytics
+
+        svc._calculate_target_difficulty(user_id=42, category=QuizCategory.LESSON, language="hu")
+        assert len(calls) == 1
+        assert calls[0]["language"] == "hu", \
+            f"Expected language='hu' passed to analytics, got {calls[0]}"
+
+
+# ===========================================================================
+# session_due_shown — DB-backed counter increments on due question
+# ===========================================================================
+
+@pytest.mark.unit
+class TestSessionDueShown:
+    """Verifies that session_due_shown is incremented when a due question is served."""
+
+    def _make_q(self, qid):
+        q = MagicMock(); q.id = qid; q.answer_options = []; q.question_type = None
+        return q
+
+    def test_due_question_increments_session_due_shown(self):
+        """When a due question is selected, session_due_shown += 1 and db.commit() called."""
+        svc, db = _svc()
+        q_due = self._make_q(10)
+        session = MagicMock()
+        session.session_due_shown = 1
+        _q(db, first=session)
+
+        due_perf = MagicMock(question_id=10)
+        pd = {
+            "all_performances": [due_perf],
+            "due_for_review": [due_perf],
+            "weak_concepts": [], "strong_concepts": [],
+        }
+        with patch.object(svc, "_is_session_time_expired", return_value=False), \
+             patch.object(svc, "_get_user_performance_data", return_value=pd), \
+             patch.object(svc, "_get_candidate_questions", return_value=[q_due]), \
+             patch.object(svc, "_select_weighted_question", return_value=q_due), \
+             patch.object(svc, "_get_session_time_remaining", return_value=60), \
+             patch.object(svc, "_get_question_difficulty", return_value=0.5):
+            result = svc.get_next_question(user_id=42, session_id=1)
+
+        assert session.session_due_shown == 2, "due question must increment session_due_shown"
+        db.commit.assert_called()
+        assert result.get("was_due") is True
+
+    def test_non_due_question_does_not_increment_session_due_shown(self):
+        """Non-due question: session_due_shown unchanged, was_due=False in response."""
+        svc, db = _svc()
+        q_normal = self._make_q(20)
+        session = MagicMock()
+        session.session_due_shown = 1
+        _q(db, first=session)
+
+        with patch.object(svc, "_is_session_time_expired", return_value=False), \
+             patch.object(svc, "_get_user_performance_data", return_value=_EMPTY_PERF), \
+             patch.object(svc, "_get_candidate_questions", return_value=[q_normal]), \
+             patch.object(svc, "_select_weighted_question", return_value=q_normal), \
+             patch.object(svc, "_get_session_time_remaining", return_value=60), \
+             patch.object(svc, "_get_question_difficulty", return_value=0.5):
+            result = svc.get_next_question(user_id=42, session_id=1)
+
+        assert session.session_due_shown == 1, "non-due question must not change session_due_shown"
+        assert result.get("was_due") is False

--- a/tests/unit/services/test_card_constants.py
+++ b/tests/unit/services/test_card_constants.py
@@ -8,9 +8,9 @@ Verifies:
   - is_animated_capable(): helper semantics
   - Re-export identity: card_export_service re-exports same objects (not copies)
 
-CC-01: CANVAS_SIZES has exactly 9 platforms
+CC-01: CANVAS_SIZES has exactly 10 platforms (9 social + "default" native export)
 CC-02: every CANVAS_SIZES value is a (int, int) tuple
-CC-03: EXPORT_FORMAT_BUCKETS keys == CANVAS_SIZES keys (invariant)
+CC-03: EXPORT_FORMAT_BUCKETS keys == CANVAS_SIZES keys − {"default"} (invariant; "default" is native export, no bucket)
 CC-04: EXPORT_FORMAT_BUCKETS value set is the expected bucket set
 CC-05: ANIMATED_EXPORT_CAPABLE is a frozenset of 2-tuples
 CC-06: every platform_id in ANIMATED_EXPORT_CAPABLE exists in CANVAS_SIZES
@@ -34,7 +34,7 @@ import app.services.card_export_service as _export_svc
 # ── CC-01 / CC-02: CANVAS_SIZES structure ────────────────────────────────────
 
 def test_cc01_canvas_sizes_has_9_platforms():
-    assert len(CANVAS_SIZES) == 9
+    assert len(CANVAS_SIZES) == 10  # 9 social + "default" native FIFA Classic export
 
 
 def test_cc02_canvas_sizes_values_are_int_tuples():
@@ -51,10 +51,13 @@ def test_cc02_canvas_sizes_values_are_int_tuples():
 # ── CC-03 / CC-04: EXPORT_FORMAT_BUCKETS ─────────────────────────────────────
 
 def test_cc03_export_format_buckets_keys_match_canvas_sizes():
-    assert EXPORT_FORMAT_BUCKETS.keys() == CANVAS_SIZES.keys(), (
-        "EXPORT_FORMAT_BUCKETS and CANVAS_SIZES must cover identical platform keys. "
-        f"Extra in buckets: {EXPORT_FORMAT_BUCKETS.keys() - CANVAS_SIZES.keys()}. "
-        f"Extra in canvas:  {CANVAS_SIZES.keys() - EXPORT_FORMAT_BUCKETS.keys()}."
+    # "default" is the native FIFA Classic export path — it uses a dynamic clip
+    # against card-wrap BoundingClientRect, not a template bucket directory.
+    social_canvas_keys = CANVAS_SIZES.keys() - {"default"}
+    assert EXPORT_FORMAT_BUCKETS.keys() == social_canvas_keys, (
+        "EXPORT_FORMAT_BUCKETS must cover all CANVAS_SIZES platforms except 'default'. "
+        f"Extra in buckets: {EXPORT_FORMAT_BUCKETS.keys() - social_canvas_keys}. "
+        f"Extra in canvas:  {social_canvas_keys - EXPORT_FORMAT_BUCKETS.keys()}."
     )
 
 

--- a/tests/unit/services/test_card_constants.py
+++ b/tests/unit/services/test_card_constants.py
@@ -1,0 +1,177 @@
+"""
+Unit tests for app/services/card_constants.py
+
+Verifies:
+  - CANVAS_SIZES: platform coverage and value types
+  - EXPORT_FORMAT_BUCKETS: keys match CANVAS_SIZES keys (invariant)
+  - ANIMATED_EXPORT_CAPABLE: valid (variant, platform) pairs, platform coverage
+  - is_animated_capable(): helper semantics
+  - Re-export identity: card_export_service re-exports same objects (not copies)
+
+CC-01: CANVAS_SIZES has exactly 9 platforms
+CC-02: every CANVAS_SIZES value is a (int, int) tuple
+CC-03: EXPORT_FORMAT_BUCKETS keys == CANVAS_SIZES keys (invariant)
+CC-04: EXPORT_FORMAT_BUCKETS value set is the expected bucket set
+CC-05: ANIMATED_EXPORT_CAPABLE is a frozenset of 2-tuples
+CC-06: every platform_id in ANIMATED_EXPORT_CAPABLE exists in CANVAS_SIZES
+CC-07: is_animated_capable — known capable pair returns True
+CC-08: is_animated_capable — capable variant + wrong platform returns False
+CC-09: is_animated_capable — unknown variant returns False
+CC-10: re-export identity — card_export_service.CANVAS_SIZES is card_constants.CANVAS_SIZES
+CC-11: re-export identity — card_export_service.ANIMATED_EXPORT_CAPABLE is card_constants.ANIMATED_EXPORT_CAPABLE
+"""
+import pytest
+
+from app.services.card_constants import (
+    ANIMATED_EXPORT_CAPABLE,
+    CANVAS_SIZES,
+    EXPORT_FORMAT_BUCKETS,
+    is_animated_capable,
+)
+import app.services.card_export_service as _export_svc
+
+
+# ── CC-01 / CC-02: CANVAS_SIZES structure ────────────────────────────────────
+
+def test_cc01_canvas_sizes_has_9_platforms():
+    assert len(CANVAS_SIZES) == 9
+
+
+def test_cc02_canvas_sizes_values_are_int_tuples():
+    for platform, dims in CANVAS_SIZES.items():
+        assert isinstance(dims, tuple), f"{platform}: expected tuple, got {type(dims)}"
+        assert len(dims) == 2, f"{platform}: expected 2-tuple"
+        w, h = dims
+        assert isinstance(w, int) and isinstance(h, int), (
+            f"{platform}: width and height must be int, got ({type(w)}, {type(h)})"
+        )
+        assert w > 0 and h > 0, f"{platform}: dimensions must be positive"
+
+
+# ── CC-03 / CC-04: EXPORT_FORMAT_BUCKETS ─────────────────────────────────────
+
+def test_cc03_export_format_buckets_keys_match_canvas_sizes():
+    assert EXPORT_FORMAT_BUCKETS.keys() == CANVAS_SIZES.keys(), (
+        "EXPORT_FORMAT_BUCKETS and CANVAS_SIZES must cover identical platform keys. "
+        f"Extra in buckets: {EXPORT_FORMAT_BUCKETS.keys() - CANVAS_SIZES.keys()}. "
+        f"Extra in canvas:  {CANVAS_SIZES.keys() - EXPORT_FORMAT_BUCKETS.keys()}."
+    )
+
+
+def test_cc04_export_format_buckets_value_set():
+    expected_buckets = {"square", "portrait", "story", "tiktok", "landscape", "banner"}
+    actual_buckets = set(EXPORT_FORMAT_BUCKETS.values())
+    assert actual_buckets == expected_buckets, (
+        f"Unexpected bucket values: {actual_buckets - expected_buckets}. "
+        f"Missing: {expected_buckets - actual_buckets}."
+    )
+
+
+# ── CC-05 / CC-06: ANIMATED_EXPORT_CAPABLE ───────────────────────────────────
+
+def test_cc05_animated_export_capable_is_frozenset_of_2tuples():
+    assert isinstance(ANIMATED_EXPORT_CAPABLE, frozenset)
+    for item in ANIMATED_EXPORT_CAPABLE:
+        assert isinstance(item, tuple) and len(item) == 2, (
+            f"Expected 2-tuples in ANIMATED_EXPORT_CAPABLE, got: {item!r}"
+        )
+
+
+def test_cc06_animated_capable_platforms_exist_in_canvas_sizes():
+    for variant_id, platform_id in ANIMATED_EXPORT_CAPABLE:
+        assert platform_id in CANVAS_SIZES, (
+            f"ANIMATED_EXPORT_CAPABLE references unknown platform {platform_id!r} "
+            f"(variant={variant_id!r}). Add it to CANVAS_SIZES first."
+        )
+
+
+# ── CC-07 / CC-08 / CC-09: is_animated_capable() ────────────────────────────
+
+@pytest.mark.parametrize("variant, platform", [
+    ("fifa",  "instagram_square"),
+    ("pulse", "instagram_square"),
+])
+def test_cc07_is_animated_capable_known_pairs_return_true(variant, platform):
+    assert is_animated_capable(variant, platform) is True
+
+
+@pytest.mark.parametrize("variant, platform", [
+    ("fifa",  "instagram_story"),
+    ("fifa",  "banner_custom"),
+    ("pulse", "instagram_portrait"),
+    ("pulse", "tiktok"),
+])
+def test_cc08_capable_variant_wrong_platform_returns_false(variant, platform):
+    assert is_animated_capable(variant, platform) is False
+
+
+@pytest.mark.parametrize("variant, platform", [
+    ("unknown_variant", "instagram_square"),
+    ("atlas",           "instagram_square"),
+    ("compact",         "instagram_square"),
+])
+def test_cc09_unknown_variant_returns_false(variant, platform):
+    assert is_animated_capable(variant, platform) is False
+
+
+# ── CC-10 / CC-11: re-export identity ────────────────────────────────────────
+
+def test_cc10_card_export_service_canvas_sizes_is_same_object():
+    assert _export_svc.CANVAS_SIZES is CANVAS_SIZES, (
+        "card_export_service.CANVAS_SIZES must be the same object as "
+        "card_constants.CANVAS_SIZES (re-export, not a copy). "
+        "This ensures callers via _export_svc.CANVAS_SIZES stay in sync."
+    )
+
+
+def test_cc11_card_export_service_animated_capable_is_same_object():
+    assert _export_svc.ANIMATED_EXPORT_CAPABLE is ANIMATED_EXPORT_CAPABLE, (
+        "card_export_service.ANIMATED_EXPORT_CAPABLE must be the same object as "
+        "card_constants.ANIMATED_EXPORT_CAPABLE (re-export, not a copy)."
+    )
+
+
+# ── CC-12..16: WC_GALLERY_PLATFORM_IDS and CARD_EDITOR_PLATFORM_IDS ──────────
+
+from app.services.card_constants import (
+    WC_GALLERY_PLATFORM_IDS,
+    CARD_EDITOR_PLATFORM_IDS,
+)
+
+
+def test_cc12_wc_gallery_ids_all_exist_in_canvas_sizes():
+    for pid in WC_GALLERY_PLATFORM_IDS:
+        assert pid in CANVAS_SIZES, (
+            f"WC_GALLERY_PLATFORM_IDS contains {pid!r} which is absent from CANVAS_SIZES. "
+            "Add it to CANVAS_SIZES first."
+        )
+
+
+def test_cc13_wc_gallery_ids_intentional_exclusions():
+    excluded = {"facebook_square", "og", "facebook_post"}
+    for pid in excluded:
+        assert pid not in WC_GALLERY_PLATFORM_IDS, (
+            f"{pid!r} found in WC_GALLERY_PLATFORM_IDS — it should be intentionally excluded. "
+            "If the exclusion was reversed, update both the constant and this test with a comment."
+        )
+
+
+def test_cc14_card_editor_ids_all_exist_in_canvas_sizes():
+    for pid in CARD_EDITOR_PLATFORM_IDS:
+        assert pid in CANVAS_SIZES, (
+            f"CARD_EDITOR_PLATFORM_IDS contains {pid!r} which is absent from CANVAS_SIZES."
+        )
+
+
+def test_cc15_card_editor_ids_includes_facebook_post():
+    assert "facebook_post" in CARD_EDITOR_PLATFORM_IDS, (
+        "facebook_post must appear in CARD_EDITOR_PLATFORM_IDS. "
+        "It was previously missing from the dashboard editor UI — this closes that gap."
+    )
+
+
+def test_cc16_card_editor_ids_excludes_default():
+    assert "default" not in CARD_EDITOR_PLATFORM_IDS, (
+        "'default' must not be in CARD_EDITOR_PLATFORM_IDS — it has no canvas size "
+        "and is rendered as a separate static button in the editor template."
+    )

--- a/tests/unit/services/test_card_platform_service.py
+++ b/tests/unit/services/test_card_platform_service.py
@@ -1,0 +1,70 @@
+"""
+Unit tests for app/services/card_platform_service.py — build_platform_list helper.
+
+CPS-01: build_platform_list returns dicts with required keys (id/label/title/dims/w/h)
+CPS-02: dims field format is "{w} × {h}" (space-x-space)
+CPS-03: w and h values match CANVAS_SIZES for each platform
+"""
+import pytest
+
+from app.services.card_platform_service import build_platform_list
+from app.services.card_constants import (
+    CANVAS_SIZES,
+    WC_GALLERY_PLATFORM_IDS,
+    CARD_EDITOR_PLATFORM_IDS,
+)
+
+
+# ── CPS-01: required keys ─────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("platform_ids", [
+    WC_GALLERY_PLATFORM_IDS,
+    CARD_EDITOR_PLATFORM_IDS,
+])
+def test_cps01_build_platform_list_required_keys(platform_ids):
+    result = build_platform_list(platform_ids)
+    assert len(result) == len(platform_ids)
+    required = {"id", "label", "title", "dims", "w", "h"}
+    for entry in result:
+        missing = required - entry.keys()
+        assert not missing, (
+            f"Platform entry for {entry.get('id')!r} is missing keys: {missing}"
+        )
+
+
+# ── CPS-02: dims format ───────────────────────────────────────────────────────
+
+def test_cps02_dims_format():
+    result = build_platform_list(WC_GALLERY_PLATFORM_IDS)
+    for entry in result:
+        w, h = entry["w"], entry["h"]
+        expected = f"{w} × {h}"
+        assert entry["dims"] == expected, (
+            f"{entry['id']!r}: expected dims={expected!r}, got {entry['dims']!r}"
+        )
+
+
+# ── CPS-03: w/h match CANVAS_SIZES ───────────────────────────────────────────
+
+def test_cps03_dimensions_match_canvas_sizes():
+    all_ids = set(WC_GALLERY_PLATFORM_IDS) | set(CARD_EDITOR_PLATFORM_IDS)
+    result = build_platform_list(tuple(all_ids))
+    for entry in result:
+        pid = entry["id"]
+        expected_w, expected_h = CANVAS_SIZES[pid]
+        assert entry["w"] == expected_w, (
+            f"{pid!r}: w={entry['w']} != CANVAS_SIZES w={expected_w}"
+        )
+        assert entry["h"] == expected_h, (
+            f"{pid!r}: h={entry['h']} != CANVAS_SIZES h={expected_h}"
+        )
+
+
+# ── CPS-04: platform IDs in output match input order ────────────────────────
+
+def test_cps04_output_order_matches_input():
+    result = build_platform_list(WC_GALLERY_PLATFORM_IDS)
+    assert [e["id"] for e in result] == list(WC_GALLERY_PLATFORM_IDS)
+
+    result2 = build_platform_list(CARD_EDITOR_PLATFORM_IDS)
+    assert [e["id"] for e in result2] == list(CARD_EDITOR_PLATFORM_IDS)

--- a/tests/unit/services/test_fifa_default_card.py
+++ b/tests/unit/services/test_fifa_default_card.py
@@ -1,0 +1,410 @@
+"""
+FIFA Classic / Default card — targeted test suite.
+
+Test IDs and what they cover:
+
+Download PNG (DL-*)
+  DL-01  CANVAS_SIZES contains "default" → export route accepts it (no 422)
+  DL-02  default canvas is (820, 613) — the measured baseline
+  DL-03  export route rejects unknown platform (422 guard still works)
+  DL-04  "default" export render URL uses ?native_export=1, NOT instagram_square
+  DL-05  "default" export render URL does NOT contain &export=1
+
+Context (CTX-*)
+  CTX-01 player_positions passes the full positions list from motivation_scores
+  CTX-02 primary position is motivation_scores["position"]
+  CTX-03 position_nodes list is non-empty for a known primary position
+  CTX-04 fallback: motivation_scores with only "position" (no "positions" key)
+  CTX-05 fallback: motivation_scores is None → player_positions = []
+
+Position map (POS-*)
+  POS-01 "striker" primary → ST1 and ST2 both is_primary=True
+  POS-02 "striker" selected → ST1 and ST2 both is_selected=True
+  POS-03 "left_centre_back" maps to node LCB (x≈0.19, y≈0.37)
+  POS-04 "right_centre_back" maps to node RCB (x≈0.19, y≈0.63)
+  POS-05 "left_centre_midfield" maps to node LCM
+  POS-06 "right_centre_midfield" maps to node RCM
+  POS-07 "second_striker" has no pitch node (no node with canonical="second_striker")
+  POS-08 "centre_back" (legacy v1) has no dedicated pitch node
+  POS-09 total node count is 20 (20 entries in PITCH_NODES_RAW incl. ST1+ST2)
+
+Template (TPL-*)
+  TPL-01 card-body element present in player_card_fifa.html
+  TPL-02 skills-panel element present
+  TPL-03 position-panel element present
+  TPL-04 pitch-svg element present inside position-panel
+  TPL-05 events-section still present (regression: tab bar NOT deleted)
+  TPL-06 tab-bar still present
+  TPL-07 tab-btn still references switchTab (regression guard)
+  TPL-08 native-export-mode CSS class defined in the template
+  TPL-09 skills-section class is ABSENT (replaced by card-body)
+
+Editor (ED-*)
+  ED-01  Download PNG button has no "disabled" attribute in the default-platform branch
+  ED-02  setPlatform JS does NOT set dlBtn.disabled to true for "default"
+  ED-03  exportCard JS does NOT use instagram_square as fallback
+  ED-04  exportCard JS uses _currentPlatform directly (no fallback substitution)
+
+Regression (REG-*)
+  REG-01  export/square/fifa.html not modified (sha unchanged — stat check)
+  REG-02  export/landscape/fifa.html not modified
+  REG-03  export/story/fifa.html not modified
+  REG-04  export/portrait/fifa.html not modified
+  REG-05  export/tiktok/fifa.html not modified
+  REG-06  export/banner/fifa.html not modified
+"""
+import os
+import re
+from pathlib import Path
+
+import pytest
+
+# ── Paths ─────────────────────────────────────────────────────────────────────
+_ROOT = Path(__file__).parents[3]
+_TPL_FIFA     = _ROOT / "app/templates/public/player_card_fifa.html"
+_TPL_EDITOR   = _ROOT / "app/templates/dashboard_card_editor.html"
+_EXPORT_DIR   = _ROOT / "app/templates/public/export"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+# ── DL-*: Download PNG / CANVAS_SIZES ─────────────────────────────────────────
+
+def test_dl01_canvas_sizes_contains_default():
+    from app.services.card_constants import CANVAS_SIZES
+    assert "default" in CANVAS_SIZES, (
+        "CANVAS_SIZES must include 'default' so the export route accepts it without 422"
+    )
+
+
+def test_dl02_default_canvas_baseline_820():
+    from app.services.card_constants import CANVAS_SIZES
+    w, h = CANVAS_SIZES["default"]
+    assert w == 820, f"default canvas width must be 820, got {w}"
+    assert h == 613, (
+        f"default canvas height must be 613 (measured 2026-05-12 via Playwright "
+        f"at native-export-mode, FIFA Classic with 4 skill categories), got {h}"
+    )
+
+
+def test_dl03_export_route_rejects_unknown_platform():
+    """422 guard still works for unknown platforms — not broken by default addition."""
+    from app.services.card_constants import CANVAS_SIZES
+    assert "totally_unknown_platform_xyz" not in CANVAS_SIZES
+
+
+def test_dl04_default_export_url_uses_native_export_param():
+    """Export route for 'default' must build a ?native_export=1 URL."""
+    src = _read(_ROOT / "app/api/web_routes/public_player.py")
+    assert "native_export=1" in src, (
+        "export route must pass ?native_export=1 for default platform"
+    )
+    # Verify it is inside a `platform == 'default'` branch
+    assert re.search(r'platform\s*==\s*["\']default["\']', src), (
+        "export route must have an explicit platform=default branch"
+    )
+
+
+def test_dl05_default_export_url_not_export_1():
+    """Default export render URL must NOT pass &export=1 (uses native_export=1 instead)."""
+    src = _read(_ROOT / "app/api/web_routes/public_player.py")
+    # Find the string assignment for the native_export URL (not a comment)
+    # The assignment looks like: render_url = f"...?native_export=1"
+    code_lines = [l for l in src.splitlines() if "native_export=1" in l and not l.strip().startswith("#")]
+    assert code_lines, "No non-comment code line with 'native_export=1' found in public_player.py"
+    for line in code_lines:
+        # The URL should not additionally contain ?export=1 or &export=1
+        assert "?export=1" not in line and "&export=1" not in line, (
+            f"Default export render URL must not include ?export=1 or &export=1; "
+            f"found in line: {line!r}"
+        )
+
+
+# ── CTX-*: Template context ────────────────────────────────────────────────────
+
+_SENTINEL = object()  # distinguish "no ms supplied" from "ms is None"
+
+
+def _build_context(ms=_SENTINEL):
+    """Simulate the public_player.py context-building logic.
+
+    ms — the motivation_scores dict (or None to test the None-branch).
+        Omit to use a default non-None dict.
+    """
+    from app.utils.football_positions import get_pitch_display_nodes
+
+    if ms is _SENTINEL:
+        ms = {"position": "striker", "positions": ["striker", "left_wing"]}
+
+    position      = ms.get("position", "Unknown") if ms else "Unknown"
+    raw_positions = ms.get("positions", []) if ms else []
+    player_positions: list[str] = []
+    if raw_positions and isinstance(raw_positions, list):
+        player_positions = raw_positions
+    elif position != "Unknown":
+        player_positions = [position]
+    position_nodes = get_pitch_display_nodes(
+        position if position != "Unknown" else "", player_positions
+    )
+    return position, player_positions, position_nodes
+
+
+def test_ctx01_player_positions_full_list():
+    _, player_positions, _ = _build_context({
+        "position": "striker",
+        "positions": ["striker", "left_wing", "centre_forward"],
+    })
+    assert player_positions == ["striker", "left_wing", "centre_forward"]
+
+
+def test_ctx02_primary_is_motivation_scores_position():
+    position, _, _ = _build_context({"position": "left_back", "positions": ["left_back"]})
+    assert position == "left_back"
+
+
+def test_ctx03_position_nodes_non_empty_for_known_position():
+    _, _, nodes = _build_context({"position": "goalkeeper", "positions": ["goalkeeper"]})
+    selected = [n for n in nodes if n["is_primary"]]
+    assert len(selected) >= 1, "At least one node should be primary for 'goalkeeper'"
+
+
+def test_ctx04_fallback_no_positions_key():
+    """Only 'position' in motivation_scores — no 'positions' key."""
+    _, player_positions, _ = _build_context({"position": "centre_back"})
+    assert player_positions == ["centre_back"]
+
+
+def test_ctx05_fallback_none_motivation_scores():
+    """motivation_scores is None → player_positions is empty list."""
+    _, player_positions, _ = _build_context(None)
+    assert player_positions == []
+
+
+# ── POS-*: Position map ────────────────────────────────────────────────────────
+
+def _nodes_for(primary, positions=None):
+    from app.utils.football_positions import get_pitch_display_nodes
+    return get_pitch_display_nodes(primary, positions or [primary])
+
+
+def test_pos01_striker_primary_both_st_nodes():
+    nodes = _nodes_for("striker")
+    primary_nodes = [n for n in nodes if n["is_primary"]]
+    node_ids = {n["node_id"] for n in primary_nodes}
+    assert "ST1" in node_ids and "ST2" in node_ids, (
+        f"Both ST1 and ST2 must be is_primary=True for striker; got primary node_ids={node_ids}"
+    )
+
+
+def test_pos02_striker_selected_both_st_nodes():
+    nodes = _nodes_for("left_wing", ["left_wing", "striker"])
+    selected_striker = [n for n in nodes if n["canonical"] == "striker" and n["is_selected"]]
+    ids = {n["node_id"] for n in selected_striker}
+    assert "ST1" in ids and "ST2" in ids, (
+        "Both ST1 and ST2 must be is_selected=True when 'striker' is in positions list"
+    )
+
+
+def test_pos03_left_centre_back_mapping():
+    nodes = _nodes_for("left_centre_back")
+    lcb = next((n for n in nodes if n["node_id"] == "LCB"), None)
+    assert lcb is not None
+    assert lcb["canonical"] == "left_centre_back"
+    assert abs(lcb["x"] - 0.19) < 0.001
+    assert abs(lcb["y"] - 0.37) < 0.001
+
+
+def test_pos04_right_centre_back_mapping():
+    nodes = _nodes_for("right_centre_back")
+    rcb = next((n for n in nodes if n["node_id"] == "RCB"), None)
+    assert rcb is not None
+    assert rcb["canonical"] == "right_centre_back"
+    assert abs(rcb["x"] - 0.19) < 0.001
+    assert abs(rcb["y"] - 0.63) < 0.001
+
+
+def test_pos05_left_centre_midfield_mapping():
+    nodes = _nodes_for("left_centre_midfield")
+    lcm = next((n for n in nodes if n["node_id"] == "LCM"), None)
+    assert lcm is not None
+    assert lcm["canonical"] == "left_centre_midfield"
+    assert abs(lcm["x"] - 0.47) < 0.001
+
+
+def test_pos06_right_centre_midfield_mapping():
+    nodes = _nodes_for("right_centre_midfield")
+    rcm = next((n for n in nodes if n["node_id"] == "RCM"), None)
+    assert rcm is not None
+    assert rcm["canonical"] == "right_centre_midfield"
+    assert abs(rcm["x"] - 0.47) < 0.001
+
+
+def test_pos07_second_striker_no_pitch_node():
+    """second_striker has no pitch node — consistent with pitch-selector.js."""
+    nodes = _nodes_for("second_striker")
+    ss_nodes = [n for n in nodes if n["canonical"] == "second_striker"]
+    assert len(ss_nodes) == 0, (
+        "second_striker must have no pitch node (legacy position without SVG representation)"
+    )
+
+
+def test_pos08_centre_back_no_dedicated_node():
+    """centre_back (legacy v1, split into LCB/RCB in v2) has no pitch node."""
+    from app.utils.football_positions import _NODE_CANONICAL
+    assert "centre_back" not in _NODE_CANONICAL.values(), (
+        "centre_back should not appear as a canonical value in PITCH_NODES "
+        "(it was split into left_centre_back / right_centre_back in v2)"
+    )
+
+
+def test_pos09_total_node_count():
+    from app.utils.football_positions import _PITCH_NODES_RAW
+    assert len(_PITCH_NODES_RAW) == 20, (
+        f"Expected 20 pitch nodes (including ST1 + ST2), got {len(_PITCH_NODES_RAW)}"
+    )
+
+
+# ── TPL-*: Template structure ──────────────────────────────────────────────────
+
+def _fifa_html():
+    return _read(_TPL_FIFA)
+
+
+def test_tpl01_card_body_present():
+    assert 'class="card-body"' in _fifa_html() or "card-body" in _fifa_html()
+
+
+def test_tpl02_skills_panel_present():
+    assert "skills-panel" in _fifa_html()
+
+
+def test_tpl03_position_panel_present():
+    assert "position-panel" in _fifa_html()
+
+
+def test_tpl04_pitch_svg_present():
+    assert "pitch-svg" in _fifa_html()
+
+
+def test_tpl05_events_section_not_deleted():
+    """Events section must still exist — regression guard."""
+    assert "events-section" in _fifa_html(), (
+        "events-section class must remain in player_card_fifa.html — tab bar / events NOT deleted"
+    )
+
+
+def test_tpl06_tab_bar_not_deleted():
+    assert "tab-bar" in _fifa_html(), (
+        "tab-bar class must remain in player_card_fifa.html — tab bar NOT deleted"
+    )
+
+
+def test_tpl07_switchtab_still_present():
+    assert "switchTab" in _fifa_html(), (
+        "switchTab function must remain — tab switching JS not deleted"
+    )
+
+
+def test_tpl08_native_export_mode_css_defined():
+    assert "native-export-mode" in _fifa_html(), (
+        "native-export-mode CSS class must be defined for default platform export"
+    )
+
+
+def test_tpl09_skills_section_class_absent():
+    """The old .skills-section class is replaced by .card-body — must not appear."""
+    html = _fifa_html()
+    # Allow the class name to appear ONLY in CSS comments or not at all
+    # The key check: no HTML element uses class="skills-section"
+    assert 'class="skills-section"' not in html, (
+        "skills-section HTML class attribute must be gone — replaced by card-body"
+    )
+
+
+# ── ED-*: Editor template ──────────────────────────────────────────────────────
+
+def _editor_html():
+    return _read(_TPL_EDITOR)
+
+
+def test_ed01_download_button_not_disabled_for_default():
+    """Download PNG button must not have a Jinja disabled condition for default."""
+    html = _editor_html()
+    # Find the btn-export-card button region
+    btn_match = re.search(
+        r'id="btn-export-card"[^>]*>', html, re.DOTALL
+    )
+    assert btn_match, "btn-export-card button not found"
+    btn_tag = btn_match.group(0)
+    assert "disabled" not in btn_tag, (
+        f"btn-export-card must not have 'disabled' in its opening tag; got: {btn_tag!r}"
+    )
+
+
+def test_ed02_setplatform_does_not_disable_for_default():
+    """setPlatform JS must not set dlBtn.disabled based on 'default' platform."""
+    src = _editor_html()
+    # The old pattern was: dlBtn.disabled = platformId === 'default'
+    assert "dlBtn.disabled = platformId === 'default'" not in src, (
+        "setPlatform must not disable the download button for the default platform"
+    )
+
+
+def test_ed03_exportcard_no_instagram_square_fallback():
+    """exportCard must not fall back to instagram_square when platform is default."""
+    fn_body = _extract_export_card_fn(_editor_html())
+    # Strip JS comment lines before checking — only look at actual code
+    code_lines = [l for l in fn_body.splitlines() if not l.strip().startswith("//")]
+    code_only = "\n".join(code_lines)
+    assert "instagram_square" not in code_only, (
+        "exportCard() code must not reference instagram_square as a fallback — "
+        "default platform exports via /card/export?platform=default"
+    )
+
+
+def test_ed04_exportcard_uses_current_platform_directly():
+    """exportCard must use _currentPlatform directly, with no substitution."""
+    fn = _extract_export_card_fn(_editor_html())
+    # Check platform variable is set to _currentPlatform without conditional replacement
+    assert "const platform = _currentPlatform" in fn, (
+        "exportCard must assign platform = _currentPlatform without any conditional fallback"
+    )
+
+
+def _extract_export_card_fn(src: str) -> str:
+    """Extract the body of the exportCard async function."""
+    m = re.search(r"async function exportCard\(\)\s*\{(.+?)^}", src, re.DOTALL | re.MULTILINE)
+    return m.group(1) if m else src
+
+
+# ── REG-*: Export template regression ─────────────────────────────────────────
+
+_EXPORT_TEMPLATES = [
+    "square/fifa.html",
+    "landscape/fifa.html",
+    "story/fifa.html",
+    "portrait/fifa.html",
+    "tiktok/fifa.html",
+    "banner/fifa.html",
+]
+
+
+@pytest.mark.parametrize("tpl_rel", _EXPORT_TEMPLATES)
+def test_reg_export_template_not_modified(tpl_rel):
+    """Export templates must not have been touched by this feature branch."""
+    path = _EXPORT_DIR / tpl_rel
+    if not path.exists():
+        pytest.skip(f"Template not present (not yet implemented): {tpl_rel}")
+
+    # Verify the file content does NOT contain any of the new classes introduced
+    # by the FIFA default card refactor.
+    content = path.read_text(encoding="utf-8")
+    new_classes = ["card-body", "skills-panel", "position-panel", "pitch-svg", "native-export-mode"]
+    for cls in new_classes:
+        assert cls not in content, (
+            f"Export template {tpl_rel} must not contain '{cls}' — "
+            f"this class belongs only to player_card_fifa.html (FIFA Classic default card). "
+            f"Check that the export template was not accidentally modified."
+        )

--- a/tests/unit/services/test_fifa_default_card.py
+++ b/tests/unit/services/test_fifa_default_card.py
@@ -44,14 +44,18 @@ Template (TPL-*)
   TPL-13 selected/primary nodes have <text> labels in SVG (pass 4 present)
   TPL-14 pos-primary-label div is ABSENT (removed — SVG node labels are sufficient)
   TPL-15 pos-secondary-chips div is ABSENT (removed — position text cleaned up)
-  TPL-16 card-watermark CSS defined; card-logo CSS ABSENT
-  TPL-17 card-watermark img inside .fifa-right (NOT .fifa-left); card-logo markup ABSENT
+  TPL-16 card-logo-bar + card-logo-bar-img CSS defined; card-watermark + card-logo CSS ABSENT
+  TPL-17 card-logo-bar HTML present after .card-body; card-watermark + card-logo markup ABSENT
   TPL-18 identity-grid has Height, Weight, Foot fields (second row)
   TPL-19 skill_categories[:2] slice used for left column (Outfield + Set Pieces)
   TPL-20 skill_categories[2:] slice used for right column (Mental + Physical)
   TPL-21 app_logo_url is None in public_player.py Default card context (Phase 4 regression guard)
-  TPL-22 sponsor_logo_url is the watermark source (template uses sponsor_logo_url, not app_logo_url)
+  TPL-22 sponsor_logo_url is the card-logo-bar-img source (not app_logo_url, not card-watermark)
   TPL-23 fifa-right-body wrapper present; z-index:1 ensures content above watermark
+  TPL-24 img.fifa-avatar has no background inline style (avatar_bg must not leak behind photo)
+  TPL-25 primary pos badge uses primary_pos_label (display label), not player.position (canonical)
+  TPL-26 secondary pos badge CSS + markup present; secondary_pos_labels referenced
+  TPL-27 no ST/GK orientation text labels in SVG; node.label render still present
 
 Editor (ED-*)
   ED-01  Download PNG button has no "disabled" attribute in the default-platform branch
@@ -414,52 +418,52 @@ def test_tpl15_pos_secondary_chips_absent():
     )
 
 
-def test_tpl16_card_watermark_css_defined_card_logo_absent():
-    """card-watermark CSS must define full-panel layout; old card-logo CSS must be gone."""
+def test_tpl16_card_logo_bar_css_defined_watermark_absent():
+    """card-logo-bar + card-logo-bar-img CSS must be defined; card-watermark + card-logo CSS must be gone."""
     html = _fifa_html()
-    assert ".card-watermark" in html, (
-        ".card-watermark CSS class must be defined — full-panel sponsor logo inside .fifa-right"
+    assert ".card-logo-bar" in html, (
+        ".card-logo-bar CSS class must be defined — sponsor logo bar at bottom of card"
     )
-    # Full-panel layout properties
-    assert "inset: 0" in html, (
-        ".card-watermark must use inset:0 to fill the entire .fifa-right panel"
+    assert ".card-logo-bar-img" in html, (
+        ".card-logo-bar-img CSS class must be defined — sizes the sponsor logo tastefully"
     )
-    assert "width: 100%" in html, (
-        ".card-watermark must use width:100% for full-panel coverage"
+    assert "max-height: 40px" in html, (
+        ".card-logo-bar-img must set max-height: 40px"
     )
-    assert "height: 100%" in html, (
-        ".card-watermark must use height:100% for full-panel coverage"
+    assert "opacity: 0.75" in html, (
+        ".card-logo-bar-img opacity must be 0.75"
     )
-    assert "opacity: 0.18" in html, (
-        ".card-watermark opacity must be 0.18 — characterful branding, not a faint corner hint"
+    assert ".card-watermark" not in html, (
+        ".card-watermark CSS must be removed — sponsor logo moved to .card-logo-bar at card bottom"
     )
-    # Removed corner-position properties must be absent from the watermark rule
-    assert ".card-logo" not in html, (
-        ".card-logo CSS must be removed — replaced by .card-watermark in .fifa-right"
+    assert ".card-logo {" not in html, (
+        ".card-logo CSS must be removed — replaced by .card-logo-bar"
     )
     assert "filter: brightness(0) invert(1)" not in html, (
         "brightness/invert filter must be gone — user-uploaded sponsor logos must not be colour-mangled"
     )
 
 
-def test_tpl17_card_watermark_inside_fifa_right_card_logo_absent():
-    """card-watermark must be inside .fifa-right; card-logo markup must be absent."""
+def test_tpl17_card_logo_bar_html_present_watermark_absent():
+    """card-logo-bar must appear in HTML after .card-body; card-watermark + card-logo markup must be absent."""
     html = _fifa_html()
-    assert 'class="card-watermark"' in html, (
-        "An <img class='card-watermark'> element must be present for sponsor logo watermark"
+    assert 'class="card-logo-bar"' in html, (
+        "<div class='card-logo-bar'> must be present — sponsor logo bar below skills+position panel"
+    )
+    assert 'class="card-logo-bar-img"' in html, (
+        "<img class='card-logo-bar-img'> must be present inside .card-logo-bar"
+    )
+    assert 'class="card-watermark"' not in html, (
+        "<img class='card-watermark'> must be removed — sponsor logo moved to .card-logo-bar"
     )
     assert 'class="card-logo"' not in html, (
         "<img class='card-logo'> must be removed — Phase 4 mistake cleaned up"
     )
-    # Watermark must be inside .fifa-right (appear after .fifa-right, after .fifa-left in file)
-    watermark_pos   = html.find('class="card-watermark"')
-    fifa_right_pos  = html.find('class="fifa-right"')
-    fifa_left_pos   = html.find('class="fifa-left"')
-    assert watermark_pos > fifa_right_pos, (
-        "card-watermark must appear inside .fifa-right (after .fifa-right opening tag)"
-    )
-    assert watermark_pos > fifa_left_pos, (
-        "card-watermark must NOT be inside .fifa-left — it belongs in .fifa-right"
+    # Logo bar must appear after .card-body (below skills and position panel)
+    logo_bar_pos  = html.find('class="card-logo-bar"')
+    card_body_pos = html.find('class="card-body"')
+    assert logo_bar_pos > card_body_pos, (
+        ".card-logo-bar must appear after .card-body — sponsor logo at bottom of card"
     )
 
 
@@ -516,20 +520,19 @@ def test_tpl21_app_logo_url_is_none_in_default_context():
     )
 
 
-def test_tpl22_sponsor_logo_url_is_watermark_source():
-    """Template must use sponsor_logo_url for the watermark, not app_logo_url."""
+def test_tpl22_sponsor_logo_url_in_logo_bar():
+    """Template must use sponsor_logo_url in .card-logo-bar-img, not app_logo_url or card-watermark."""
     html = _fifa_html()
-    # sponsor_logo_url must be referenced in the watermark conditional block
     assert "sponsor_logo_url" in html, (
         "sponsor_logo_url must be referenced in player_card_fifa.html — "
-        "it is the user-uploaded logo and the correct source for the .card-watermark element"
+        "it is the user-uploaded logo and the correct source for .card-logo-bar-img"
     )
-    # The watermark img src must come from sponsor_logo_url
-    watermark_block_start = html.find('class="card-watermark"')
-    assert watermark_block_start != -1
-    context_around = html[max(0, watermark_block_start - 200):watermark_block_start + 50]
+    # sponsor_logo_url must appear near .card-logo-bar-img
+    logo_bar_img_pos = html.find('class="card-logo-bar-img"')
+    assert logo_bar_img_pos != -1
+    context_around = html[max(0, logo_bar_img_pos - 200):logo_bar_img_pos + 50]
     assert "sponsor_logo_url" in context_around, (
-        "card-watermark img src must reference sponsor_logo_url (not app_logo_url)"
+        ".card-logo-bar-img src must reference sponsor_logo_url (not app_logo_url)"
     )
 
 
@@ -543,6 +546,82 @@ def test_tpl23_fifa_right_body_wrapper_present():
     # CSS must define the class with position:relative and z-index
     assert ".fifa-right-body" in html, (
         ".fifa-right-body CSS class must be defined in the template"
+    )
+
+
+def test_tpl24_photo_img_has_no_background_style():
+    """img.fifa-avatar must carry no background inline style — avatar_bg must not leak behind photo."""
+    html = _fifa_html()
+    img_match = re.search(r'<img class="fifa-avatar"[^>]*>', html)
+    assert img_match, "img.fifa-avatar element must be present in the template"
+    img_tag = img_match.group(0)
+    assert "background" not in img_tag, (
+        "img.fifa-avatar must NOT have a 'background' inline style. "
+        "The avatar_bg colour was showing as a gradient/solid behind the player photo. "
+        "background belongs only on the div.fifa-avatar fallback (no-photo state)."
+    )
+
+
+def test_tpl25_primary_pos_badge_uses_display_label():
+    """Primary pos badge must render primary_pos_label (display label), not player.position (canonical)."""
+    html = _fifa_html()
+    badge_pos = html.find('class="fifa-pos-badge"')
+    assert badge_pos != -1, "fifa-pos-badge class must be present"
+    context = html[badge_pos: badge_pos + 150]
+    assert "primary_pos_label" in context, (
+        "fifa-pos-badge must render {{ primary_pos_label }} — the human-readable display label "
+        "from position_label(). Rendering player.position directly produces CENTRE_MIDFIELD "
+        "(with underscore), which is not acceptable."
+    )
+    assert "player.position" not in context, (
+        "fifa-pos-badge must NOT render {{ player.position }} directly — "
+        "it is the raw canonical key and contains underscores."
+    )
+
+
+def test_tpl25b_position_label_has_no_underscore():
+    """position_label() output for all canonical values must contain no underscore."""
+    from app.utils.football_positions import position_label, POSITIONS_21
+    for p in POSITIONS_21:
+        lbl = position_label(p["value"])
+        assert "_" not in lbl, (
+            f"position_label('{p['value']}') returned '{lbl}' which contains an underscore. "
+            "All display labels must be human-readable (spaces, no underscores)."
+        )
+
+
+def test_tpl26_secondary_pos_badge_markup_present():
+    """Secondary pos badge CSS and Jinja markup must be present; secondary_pos_labels must be referenced."""
+    html = _fifa_html()
+    assert ".fifa-pos-secondary-badge" in html, (
+        ".fifa-pos-secondary-badge CSS class must be defined"
+    )
+    assert "fifa-pos-secondary-badges" in html, (
+        ".fifa-pos-secondary-badges wrapper CSS must be defined"
+    )
+    assert "secondary_pos_labels" in html, (
+        "secondary_pos_labels variable must be referenced in the template "
+        "to render secondary position badges"
+    )
+    assert 'class="fifa-pos-secondary-badge"' in html, (
+        "<span class='fifa-pos-secondary-badge'> HTML markup must be present"
+    )
+
+
+def test_tpl27_no_st_gk_orientation_labels_in_svg():
+    """ST and GK orientation text labels must be removed from the pitch SVG."""
+    html = _fifa_html()
+    assert ">ST<" not in html, (
+        "ST orientation label must be removed from the pitch SVG — "
+        "it is a layout guide, not a selected position node"
+    )
+    assert ">GK<" not in html, (
+        "GK orientation label must be removed from the pitch SVG — "
+        "it is a layout guide, not a selected position node"
+    )
+    # Regression guard: node.label (Pass 4) must still render for selected/primary positions
+    assert "node.label" in html, (
+        "node.label must still be rendered in SVG Pass 4 for selected/primary positions"
     )
 
 

--- a/tests/unit/services/test_fifa_default_card.py
+++ b/tests/unit/services/test_fifa_default_card.py
@@ -5,7 +5,7 @@ Test IDs and what they cover:
 
 Download PNG (DL-*)
   DL-01  CANVAS_SIZES contains "default" → export route accepts it (no 422)
-  DL-02  default canvas is (820, 613) — the measured baseline
+  DL-02  default canvas width is 820; height reflects current layout estimate
   DL-03  export route rejects unknown platform (422 guard still works)
   DL-04  "default" export render URL uses ?native_export=1, NOT instagram_square
   DL-05  "default" export render URL does NOT contain &export=1
@@ -38,6 +38,12 @@ Template (TPL-*)
   TPL-07 tab-btn still references switchTab (regression guard)
   TPL-08 native-export-mode CSS class defined in the template
   TPL-09 skills-section class is ABSENT (replaced by card-body)
+  TPL-10 skill-cats CSS uses repeat(2, 1fr) — 2-column 2×2 grid, not 4-column
+  TPL-11 skill-cat nth-child order rules present for Outfield/Mental/SetPieces/Physical reorder
+  TPL-12 pitch SVG viewBox is portrait "0 0 65 100" (not landscape "0 0 100 65")
+  TPL-13 selected/primary nodes have <text> labels in SVG (pass 4 present)
+  TPL-14 primary label uses "·" separator format (abbreviation · full name)
+  TPL-15 secondary chip template uses sec_node.label (abbreviated, not full canonical)
 
 Editor (ED-*)
   ED-01  Download PNG button has no "disabled" attribute in the default-platform branch
@@ -82,10 +88,14 @@ def test_dl01_canvas_sizes_contains_default():
 def test_dl02_default_canvas_baseline_820():
     from app.services.card_constants import CANVAS_SIZES
     w, h = CANVAS_SIZES["default"]
-    assert w == 820, f"default canvas width must be 820, got {w}"
-    assert h == 613, (
-        f"default canvas height must be 613 (measured 2026-05-12 via Playwright "
-        f"at native-export-mode, FIFA Classic with 4 skill categories), got {h}"
+    assert w == 820, f"default canvas width must be 820, got {h}"
+    # Height reflects the current layout estimate (CSS-derived, ~800px after 2×2 skills +
+    # portrait pitch change; re-measure with Playwright after deploying to confirm).
+    # The exact value here is a documentation guard — export clipping uses live
+    # BoundingClientRect so the actual PNG is never truncated regardless of this value.
+    assert 700 <= h <= 1000, (
+        f"default canvas height should be in the plausible range 700–1000px "
+        f"(current layout: 2×2 skills grid + portrait pitch); got {h}"
     )
 
 
@@ -316,10 +326,88 @@ def test_tpl08_native_export_mode_css_defined():
 def test_tpl09_skills_section_class_absent():
     """The old .skills-section class is replaced by .card-body — must not appear."""
     html = _fifa_html()
-    # Allow the class name to appear ONLY in CSS comments or not at all
-    # The key check: no HTML element uses class="skills-section"
     assert 'class="skills-section"' not in html, (
         "skills-section HTML class attribute must be gone — replaced by card-body"
+    )
+
+
+def test_tpl10_skill_cats_two_column_grid():
+    """skills-panel must use a 2-column grid (2×2 layout), not the old 4-column layout."""
+    html = _fifa_html()
+    assert "repeat(2, 1fr)" in html, (
+        ".skill-cats must use grid-template-columns: repeat(2, 1fr) for the 2×2 layout"
+    )
+    assert "repeat(4, 1fr)" not in html, (
+        ".skill-cats must NOT use 4-column grid — old layout removed"
+    )
+
+
+def test_tpl11_skill_cat_order_rules_present():
+    """CSS nth-child order rules must be present to reorder Outfield/Mental/SetPieces/Physical."""
+    html = _fifa_html()
+    # All 4 order rules must be present
+    for rule in [
+        "nth-child(1) { order: 1; }",
+        "nth-child(2) { order: 3; }",
+        "nth-child(3) { order: 2; }",
+        "nth-child(4) { order: 4; }",
+    ]:
+        assert rule in html, (
+            f"CSS rule '.skill-cat:{rule}' must be in the template for 2×2 category reorder"
+        )
+
+
+def test_tpl12_pitch_svg_is_portrait_viewbox():
+    """Portrait pitch must use viewBox '0 0 65 100' (not landscape '0 0 100 65')."""
+    html = _fifa_html()
+    assert 'viewBox="0 0 65 100"' in html, (
+        "pitch-svg must use portrait viewBox '0 0 65 100' — GK at bottom, ST at top"
+    )
+    assert 'viewBox="0 0 100 65"' not in html, (
+        "landscape viewBox '0 0 100 65' must be gone — replaced by portrait orientation"
+    )
+
+
+def test_tpl13_svg_text_labels_on_selected_nodes():
+    """Pass 4: <text> elements must be rendered for selected/primary nodes in the SVG."""
+    html = _fifa_html()
+    # The pass-4 block uses node.label in a <text> element inside the Jinja2 loop
+    assert "node.label" in html, (
+        "SVG must render node.label as <text> elements for selected/primary nodes (pass 4)"
+    )
+    # The text element must include dominant-baseline="middle" for vertical centering
+    assert "dominant-baseline" in html, (
+        "<text> labels must use dominant-baseline for vertical centering on circles"
+    )
+
+
+def test_tpl14_primary_label_abbreviated_format():
+    """Primary position label must use '·' separator: abbreviated label · full name."""
+    html = _fifa_html()
+    # Check the primary_node.label and primary_node.name are both referenced
+    assert "primary_node.label" in html, (
+        "pos-primary-label must use primary_node.label (abbreviated form, e.g. CM)"
+    )
+    assert "primary_node.name" in html, (
+        "pos-primary-label must use primary_node.name (full name, e.g. Centre Midfield)"
+    )
+    # The separator · must be present in the label template
+    assert "·" in html, (
+        "pos-primary-label must use '·' separator between abbreviated and full name"
+    )
+
+
+def test_tpl15_secondary_chip_abbreviated():
+    """Secondary chips must use sec_node.label (abbreviated) not full canonical names."""
+    html = _fifa_html()
+    # The chip template must use sec_node.label
+    assert "sec_node.label" in html, (
+        "pos-chip must use sec_node.label for abbreviated secondary position chips"
+    )
+    # Must NOT fall back to raw `pos | replace('_', ' ') | title` for ALL chips —
+    # the fallback may exist as a `else` branch, but the primary path must be abbreviated.
+    assert "sec_node" in html, (
+        "secondary chip Jinja2 variable 'sec_node' must be used to look up abbreviation"
     )
 
 

--- a/tests/unit/services/test_fifa_default_card.py
+++ b/tests/unit/services/test_fifa_default_card.py
@@ -44,11 +44,14 @@ Template (TPL-*)
   TPL-13 selected/primary nodes have <text> labels in SVG (pass 4 present)
   TPL-14 pos-primary-label div is ABSENT (removed — SVG node labels are sufficient)
   TPL-15 pos-secondary-chips div is ABSENT (removed — position text cleaned up)
-  TPL-16 card-logo CSS class defined in the template
-  TPL-17 card-logo img element present inside .fifa-left (above avatar)
+  TPL-16 card-watermark CSS defined; card-logo CSS ABSENT
+  TPL-17 card-watermark img inside .fifa-right (NOT .fifa-left); card-logo markup ABSENT
   TPL-18 identity-grid has Height, Weight, Foot fields (second row)
   TPL-19 skill_categories[:2] slice used for left column (Outfield + Set Pieces)
   TPL-20 skill_categories[2:] slice used for right column (Mental + Physical)
+  TPL-21 app_logo_url is None in public_player.py Default card context (Phase 4 regression guard)
+  TPL-22 sponsor_logo_url is the watermark source (template uses sponsor_logo_url, not app_logo_url)
+  TPL-23 fifa-right-body wrapper present; z-index:1 ensures content above watermark
 
 Editor (ED-*)
   ED-01  Download PNG button has no "disabled" attribute in the default-platform branch
@@ -411,30 +414,38 @@ def test_tpl15_pos_secondary_chips_absent():
     )
 
 
-def test_tpl16_card_logo_css_defined():
-    """card-logo CSS class must be defined in the template."""
+def test_tpl16_card_watermark_css_defined_card_logo_absent():
+    """card-watermark CSS must be defined; old card-logo CSS must be gone."""
     html = _fifa_html()
-    assert ".card-logo" in html, (
-        ".card-logo CSS class must be defined — used for the LFA logo inside .fifa-left"
+    assert ".card-watermark" in html, (
+        ".card-watermark CSS class must be defined — sponsor logo watermark inside .fifa-right"
     )
-    assert "filter: brightness(0) invert(1)" in html, (
-        "card-logo must apply filter:brightness(0)invert(1) to convert dark PNG to white"
+    assert ".card-logo" not in html, (
+        ".card-logo CSS must be removed — replaced by .card-watermark in .fifa-right"
+    )
+    assert "filter: brightness(0) invert(1)" not in html, (
+        "brightness/invert filter must be gone — user-uploaded sponsor logos must not be colour-mangled"
     )
 
 
-def test_tpl17_card_logo_img_inside_fifa_left():
-    """card-logo img element must appear inside .fifa-left, before the avatar."""
+def test_tpl17_card_watermark_inside_fifa_right_card_logo_absent():
+    """card-watermark must be inside .fifa-right; card-logo markup must be absent."""
     html = _fifa_html()
-    # Both the img with class card-logo and the condition block must be present
-    assert 'class="card-logo"' in html, (
-        "An <img class='card-logo'> element must be present inside .fifa-left"
+    assert 'class="card-watermark"' in html, (
+        "An <img class='card-watermark'> element must be present for sponsor logo watermark"
     )
-    # Card logo must appear before the avatar HTML element (earlier in the file).
-    # Use class="..." form to skip CSS selector occurrences.
-    logo_pos = html.find('class="card-logo"')
-    avatar_pos = html.find('class="fifa-avatar"')
-    assert logo_pos < avatar_pos, (
-        "card-logo img must appear before fifa-avatar in the template (logo above avatar)"
+    assert 'class="card-logo"' not in html, (
+        "<img class='card-logo'> must be removed — Phase 4 mistake cleaned up"
+    )
+    # Watermark must be inside .fifa-right (appear after .fifa-right, after .fifa-left in file)
+    watermark_pos   = html.find('class="card-watermark"')
+    fifa_right_pos  = html.find('class="fifa-right"')
+    fifa_left_pos   = html.find('class="fifa-left"')
+    assert watermark_pos > fifa_right_pos, (
+        "card-watermark must appear inside .fifa-right (after .fifa-right opening tag)"
+    )
+    assert watermark_pos > fifa_left_pos, (
+        "card-watermark must NOT be inside .fifa-left — it belongs in .fifa-right"
     )
 
 
@@ -464,6 +475,60 @@ def test_tpl20_right_skill_column_uses_last_two_categories():
     html = _fifa_html()
     assert "skill_categories[2:]" in html, (
         "Right .skill-col must use skill_categories[2:] to render Mental + Physical Fitness"
+    )
+
+
+def test_tpl21_app_logo_url_is_none_in_default_context():
+    """public_player.py Default card context must have app_logo_url = None.
+
+    Phase 4 mistakenly hardcoded '/static/images/logo-dark.png' here.
+    The Default FIFA card's logo source is sponsor_logo_url (user-uploaded),
+    not the LFA app logo.
+    """
+    src = _read(_ROOT / "app/api/web_routes/public_player.py")
+    # Find the app_logo_url assignment line in the context dict
+    lines = src.splitlines()
+    app_logo_lines = [l for l in lines if '"app_logo_url"' in l and "None" in l]
+    assert app_logo_lines, (
+        "public_player.py must set 'app_logo_url': None in the Default card context. "
+        "The hardcoded LFA logo path must be removed — sponsor_logo_url is the card logo source."
+    )
+    # Must NOT contain the hardcoded logo path
+    assert "/static/images/logo-dark.png" not in src or all(
+        l.strip().startswith("#") for l in lines if "/static/images/logo-dark.png" in l
+    ), (
+        "'/static/images/logo-dark.png' must not appear as a non-comment value in public_player.py "
+        "Default card context. The LFA app logo must not be injected into the FIFA card."
+    )
+
+
+def test_tpl22_sponsor_logo_url_is_watermark_source():
+    """Template must use sponsor_logo_url for the watermark, not app_logo_url."""
+    html = _fifa_html()
+    # sponsor_logo_url must be referenced in the watermark conditional block
+    assert "sponsor_logo_url" in html, (
+        "sponsor_logo_url must be referenced in player_card_fifa.html — "
+        "it is the user-uploaded logo and the correct source for the .card-watermark element"
+    )
+    # The watermark img src must come from sponsor_logo_url
+    watermark_block_start = html.find('class="card-watermark"')
+    assert watermark_block_start != -1
+    context_around = html[max(0, watermark_block_start - 200):watermark_block_start + 50]
+    assert "sponsor_logo_url" in context_around, (
+        "card-watermark img src must reference sponsor_logo_url (not app_logo_url)"
+    )
+
+
+def test_tpl23_fifa_right_body_wrapper_present():
+    """fifa-right-body wrapper must be present to stack content above watermark (z-index:1)."""
+    html = _fifa_html()
+    assert "fifa-right-body" in html, (
+        ".fifa-right-body wrapper div must be present — it carries z-index:1 "
+        "so the name/identity-grid/clubs render above the z-index:0 .card-watermark"
+    )
+    # CSS must define the class with position:relative and z-index
+    assert ".fifa-right-body" in html, (
+        ".fifa-right-body CSS class must be defined in the template"
     )
 
 

--- a/tests/unit/services/test_fifa_default_card.py
+++ b/tests/unit/services/test_fifa_default_card.py
@@ -38,12 +38,17 @@ Template (TPL-*)
   TPL-07 tab-btn still references switchTab (regression guard)
   TPL-08 native-export-mode CSS class defined in the template
   TPL-09 skills-section class is ABSENT (replaced by card-body)
-  TPL-10 skill-cats CSS uses repeat(2, 1fr) — 2-column 2×2 grid, not 4-column
-  TPL-11 skill-cat nth-child order rules present for Outfield/Mental/SetPieces/Physical reorder
+  TPL-10 skill-cats CSS uses display:flex (two-column flex, not CSS grid)
+  TPL-11 skill-col class present; nth-child order rules ABSENT (flex replaced grid)
   TPL-12 pitch SVG viewBox is portrait "0 0 65 100" (not landscape "0 0 100 65")
   TPL-13 selected/primary nodes have <text> labels in SVG (pass 4 present)
-  TPL-14 primary label uses "·" separator format (abbreviation · full name)
-  TPL-15 secondary chip template uses sec_node.label (abbreviated, not full canonical)
+  TPL-14 pos-primary-label div is ABSENT (removed — SVG node labels are sufficient)
+  TPL-15 pos-secondary-chips div is ABSENT (removed — position text cleaned up)
+  TPL-16 card-logo CSS class defined in the template
+  TPL-17 card-logo img element present inside .fifa-left (above avatar)
+  TPL-18 identity-grid has Height, Weight, Foot fields (second row)
+  TPL-19 skill_categories[:2] slice used for left column (Outfield + Set Pieces)
+  TPL-20 skill_categories[2:] slice used for right column (Mental + Physical)
 
 Editor (ED-*)
   ED-01  Download PNG button has no "disabled" attribute in the default-platform branch
@@ -331,29 +336,34 @@ def test_tpl09_skills_section_class_absent():
     )
 
 
-def test_tpl10_skill_cats_two_column_grid():
-    """skills-panel must use a 2-column grid (2×2 layout), not the old 4-column layout."""
+def test_tpl10_skill_cats_flex_layout():
+    """skill-cats must use display:flex (two-column flex), not CSS grid."""
     html = _fifa_html()
-    assert "repeat(2, 1fr)" in html, (
-        ".skill-cats must use grid-template-columns: repeat(2, 1fr) for the 2×2 layout"
-    )
-    assert "repeat(4, 1fr)" not in html, (
-        ".skill-cats must NOT use 4-column grid — old layout removed"
+    # CSS must declare display:flex for .skill-cats
+    assert "display: flex; align-items: flex-start;" in html or (
+        ".skill-cats" in html and "display: flex" in html
+    ), ".skill-cats must use display: flex for the two-column flex layout"
+    # Must NOT use CSS grid for skill categories any more
+    assert "grid-template-columns: repeat(2, 1fr)" not in html, (
+        ".skill-cats must NOT use grid-template-columns: repeat(2, 1fr) — replaced by flex"
     )
 
 
-def test_tpl11_skill_cat_order_rules_present():
-    """CSS nth-child order rules must be present to reorder Outfield/Mental/SetPieces/Physical."""
+def test_tpl11_skill_col_present_nth_child_absent():
+    """skill-col class must exist; nth-child order rules must be gone (flex replaced grid)."""
     html = _fifa_html()
-    # All 4 order rules must be present
+    assert "skill-col" in html, (
+        ".skill-col class must be present — wraps left/right flex columns"
+    )
+    # All 4 old nth-child order rules must be gone
     for rule in [
         "nth-child(1) { order: 1; }",
         "nth-child(2) { order: 3; }",
         "nth-child(3) { order: 2; }",
         "nth-child(4) { order: 4; }",
     ]:
-        assert rule in html, (
-            f"CSS rule '.skill-cat:{rule}' must be in the template for 2×2 category reorder"
+        assert rule not in html, (
+            f"Old CSS rule '.skill-cat:{rule}' must be removed — flex columns replaced grid reorder"
         )
 
 
@@ -381,33 +391,79 @@ def test_tpl13_svg_text_labels_on_selected_nodes():
     )
 
 
-def test_tpl14_primary_label_abbreviated_format():
-    """Primary position label must use '·' separator: abbreviated label · full name."""
+def test_tpl14_pos_primary_label_absent():
+    """pos-primary-label div must be ABSENT — position text removed; SVG labels are sufficient."""
     html = _fifa_html()
-    # Check the primary_node.label and primary_node.name are both referenced
-    assert "primary_node.label" in html, (
-        "pos-primary-label must use primary_node.label (abbreviated form, e.g. CM)"
-    )
-    assert "primary_node.name" in html, (
-        "pos-primary-label must use primary_node.name (full name, e.g. Centre Midfield)"
-    )
-    # The separator · must be present in the label template
-    assert "·" in html, (
-        "pos-primary-label must use '·' separator between abbreviated and full name"
+    assert "pos-primary-label" not in html, (
+        "pos-primary-label class/div must be gone — position label text was removed "
+        "in Phase 4 to reduce clutter; abbreviated labels live in the SVG nodes only"
     )
 
 
-def test_tpl15_secondary_chip_abbreviated():
-    """Secondary chips must use sec_node.label (abbreviated) not full canonical names."""
+def test_tpl15_pos_secondary_chips_absent():
+    """pos-secondary-chips div must be ABSENT — secondary position chips removed."""
     html = _fifa_html()
-    # The chip template must use sec_node.label
-    assert "sec_node.label" in html, (
-        "pos-chip must use sec_node.label for abbreviated secondary position chips"
+    assert "pos-secondary-chips" not in html, (
+        "pos-secondary-chips class/div must be gone — secondary position chips removed in Phase 4"
     )
-    # Must NOT fall back to raw `pos | replace('_', ' ') | title` for ALL chips —
-    # the fallback may exist as a `else` branch, but the primary path must be abbreviated.
-    assert "sec_node" in html, (
-        "secondary chip Jinja2 variable 'sec_node' must be used to look up abbreviation"
+    assert "pos-chip" not in html, (
+        "pos-chip class must be gone — secondary position chips removed in Phase 4"
+    )
+
+
+def test_tpl16_card_logo_css_defined():
+    """card-logo CSS class must be defined in the template."""
+    html = _fifa_html()
+    assert ".card-logo" in html, (
+        ".card-logo CSS class must be defined — used for the LFA logo inside .fifa-left"
+    )
+    assert "filter: brightness(0) invert(1)" in html, (
+        "card-logo must apply filter:brightness(0)invert(1) to convert dark PNG to white"
+    )
+
+
+def test_tpl17_card_logo_img_inside_fifa_left():
+    """card-logo img element must appear inside .fifa-left, before the avatar."""
+    html = _fifa_html()
+    # Both the img with class card-logo and the condition block must be present
+    assert 'class="card-logo"' in html, (
+        "An <img class='card-logo'> element must be present inside .fifa-left"
+    )
+    # Card logo must appear before the avatar HTML element (earlier in the file).
+    # Use class="..." form to skip CSS selector occurrences.
+    logo_pos = html.find('class="card-logo"')
+    avatar_pos = html.find('class="fifa-avatar"')
+    assert logo_pos < avatar_pos, (
+        "card-logo img must appear before fifa-avatar in the template (logo above avatar)"
+    )
+
+
+def test_tpl18_identity_grid_has_height_weight_foot():
+    """identity-grid must render Height, Weight, and Foot fields (second row)."""
+    html = _fifa_html()
+    for label in ("Height", "Weight", "Foot"):
+        assert label in html, (
+            f"identity-grid must contain a '{label}' id-label field — "
+            "added as the second row (player physical attributes)"
+        )
+    assert "player_height_cm" in html, "player_height_cm must be referenced in the template"
+    assert "player_weight_kg" in html, "player_weight_kg must be referenced in the template"
+    assert "player_preferred_foot" in html, "player_preferred_foot must be referenced in the template"
+
+
+def test_tpl19_left_skill_column_uses_first_two_categories():
+    """Left skill-col must iterate skill_categories[:2] (Outfield + Set Pieces)."""
+    html = _fifa_html()
+    assert "skill_categories[:2]" in html, (
+        "Left .skill-col must use skill_categories[:2] to render Outfield + Set Pieces"
+    )
+
+
+def test_tpl20_right_skill_column_uses_last_two_categories():
+    """Right skill-col must iterate skill_categories[2:] (Mental + Physical)."""
+    html = _fifa_html()
+    assert "skill_categories[2:]" in html, (
+        "Right .skill-col must use skill_categories[2:] to render Mental + Physical Fitness"
     )
 
 

--- a/tests/unit/services/test_fifa_default_card.py
+++ b/tests/unit/services/test_fifa_default_card.py
@@ -415,11 +415,25 @@ def test_tpl15_pos_secondary_chips_absent():
 
 
 def test_tpl16_card_watermark_css_defined_card_logo_absent():
-    """card-watermark CSS must be defined; old card-logo CSS must be gone."""
+    """card-watermark CSS must define full-panel layout; old card-logo CSS must be gone."""
     html = _fifa_html()
     assert ".card-watermark" in html, (
-        ".card-watermark CSS class must be defined — sponsor logo watermark inside .fifa-right"
+        ".card-watermark CSS class must be defined — full-panel sponsor logo inside .fifa-right"
     )
+    # Full-panel layout properties
+    assert "inset: 0" in html, (
+        ".card-watermark must use inset:0 to fill the entire .fifa-right panel"
+    )
+    assert "width: 100%" in html, (
+        ".card-watermark must use width:100% for full-panel coverage"
+    )
+    assert "height: 100%" in html, (
+        ".card-watermark must use height:100% for full-panel coverage"
+    )
+    assert "opacity: 0.18" in html, (
+        ".card-watermark opacity must be 0.18 — characterful branding, not a faint corner hint"
+    )
+    # Removed corner-position properties must be absent from the watermark rule
     assert ".card-logo" not in html, (
         ".card-logo CSS must be removed — replaced by .card-watermark in .fifa-right"
     )

--- a/tests/unit/test_adaptive_learning_template.py
+++ b/tests/unit/test_adaptive_learning_template.py
@@ -478,3 +478,82 @@ class TestLanguageSwitcherJsGuard:
         assert '&language=en' in html or "session_language" in html, (
             "alsInit URL must embed the session language"
         )
+
+
+class TestAnsweredStateHide:
+    """After submitting an answer, question card and options must be hidden.
+    Only feedback + Next button remain visible until the user advances."""
+
+    def test_question_card_has_id(self):
+        """als-question-card must carry an id= so JS can target it."""
+        html = _render_session_page()
+        assert 'id="als-question-card"' in html, \
+            'als-question-card div missing id="als-question-card"'
+
+    def test_show_answered_state_helper_present(self):
+        """_showAnsweredState() helper must exist in the template JS."""
+        html = _render_session_page()
+        assert "_showAnsweredState" in html, \
+            "_showAnsweredState helper function missing from template"
+
+    def test_show_answered_state_called_after_answer(self):
+        """_showAnsweredState() must be called in the alsAnswer success path."""
+        html = _render_session_page()
+        # Locate alsAnswer function body
+        start = html.index("function alsAnswer(")
+        end = html.index("\n    }", start)
+        body = html[start:end]
+        assert "_showAnsweredState()" in body, \
+            "_showAnsweredState() not called inside alsAnswer success path"
+
+    def test_show_answered_state_hides_question_card(self):
+        """_showAnsweredState must set display:none on als-question-card."""
+        html = _render_session_page()
+        fn_start = html.index("function _showAnsweredState(")
+        fn_end = html.index("}", fn_start)
+        fn_body = html[fn_start:fn_end]
+        assert "als-question-card" in fn_body, \
+            "_showAnsweredState does not reference als-question-card"
+        assert "display" in fn_body and "none" in fn_body, \
+            "_showAnsweredState does not set display:none on question card"
+
+    def test_show_answered_state_hides_options(self):
+        """_showAnsweredState must set display:none on als-options."""
+        html = _render_session_page()
+        fn_start = html.index("function _showAnsweredState(")
+        fn_end = html.index("}", fn_start)
+        fn_body = html[fn_start:fn_end]
+        assert "als-options" in fn_body, \
+            "_showAnsweredState does not reference als-options"
+
+    def test_render_question_restores_question_card(self):
+        """renderQuestion must restore als-question-card visibility (display='')."""
+        html = _render_session_page()
+        fn_start = html.index("function renderQuestion(")
+        fn_end = html.index("\n    }", fn_start)
+        fn_body = html[fn_start:fn_end]
+        assert "als-question-card" in fn_body, \
+            "renderQuestion does not restore als-question-card"
+
+    def test_render_question_restores_options(self):
+        """renderQuestion must restore als-options visibility (display='')."""
+        html = _render_session_page()
+        fn_start = html.index("function renderQuestion(")
+        fn_end = html.index("\n    }", fn_start)
+        fn_body = html[fn_start:fn_end]
+        assert "als-options" in fn_body and "display" in fn_body, \
+            "renderQuestion does not restore als-options display"
+
+    def test_error_path_does_not_hide_question(self):
+        """On POST /answer failure (!res.ok), _showAnsweredState must NOT be called
+        so the question remains visible for retry."""
+        html = _render_session_page()
+        fn_start = html.index("function alsAnswer(")
+        fn_end = html.index("\n    }", fn_start)
+        fn_body = html[fn_start:fn_end]
+        # Find the !res.ok error branch
+        err_start = fn_body.index("if (!res.ok)")
+        err_end = fn_body.index("return;", err_start) + len("return;")
+        err_branch = fn_body[err_start:err_end]
+        assert "_showAnsweredState" not in err_branch, \
+            "_showAnsweredState must NOT be called in the !res.ok error branch"

--- a/tests/unit/test_adaptive_learning_template.py
+++ b/tests/unit/test_adaptive_learning_template.py
@@ -270,41 +270,49 @@ class TestNoFixedQuestionCount:
 
 
 class TestFeedbackTiming:
-    """Auto-advance delays must differ for correct vs wrong answers."""
+    """Auto-advance removed: feedback + explanation stay until user clicks Next."""
 
-    def test_correct_answer_uses_1500ms(self):
-        """Correct answer advance delay must be 1500ms."""
+    def test_no_auto_advance(self):
+        """_scheduleNextAction must be gone — no setTimeout auto-advance."""
         html = _render_session_page()
-        assert "1500" in html, "1500ms delay missing"
+        assert "_scheduleNextAction" not in html, \
+            "_scheduleNextAction still present — auto-advance not fully removed"
 
-    def test_wrong_answer_uses_3000ms(self):
-        """Wrong answer advance delay must be 3000ms."""
+    def test_show_next_button_called_after_answer(self):
+        """_showNextButton() must be called in the answer handler (replaces auto-advance)."""
         html = _render_session_page()
-        assert "3000" in html, "3000ms delay missing"
+        assert "_showNextButton()" in html, \
+            "_showNextButton() not called in answer handler"
 
-    def test_delay_is_outcome_dependent(self):
-        """advanceDelay must branch on d.correct — correct path and wrong path must differ."""
+    def test_next_button_element_present(self):
+        """als-next-btn-wrap and als-next-btn must exist in the question phase HTML."""
         html = _render_session_page()
-        # The delay logic must be conditional on d.correct
-        assert "d.correct" in html, "d.correct not referenced in delay logic"
-        assert "advanceDelay" in html, "advanceDelay variable missing"
+        assert 'id="als-next-btn-wrap"' in html, "als-next-btn-wrap element missing"
+        assert 'id="als-next-btn"' in html, "als-next-btn element missing"
 
-    def test_schedule_next_action_accepts_delay_param(self):
-        """_scheduleNextAction must accept a delay parameter, not hardcode 1000ms."""
+    def test_next_button_hidden_by_default(self):
+        """als-next-btn-wrap must start hidden (display:none)."""
         html = _render_session_page()
-        assert "_scheduleNextAction(advanceDelay)" in html, \
-            "_scheduleNextAction must be called with advanceDelay argument"
-        # Old hardcoded 1-second call must be gone
-        assert "_scheduleNextAction();" not in html, \
-            "_scheduleNextAction() called without delay — hardcoded timing still present"
+        assert 'id="als-next-btn-wrap" style="display:none' in html, \
+            "als-next-btn-wrap is not hidden by default"
 
-    def test_auto_advance_label_shows_correct_duration(self):
-        """Auto-advance label must show '1.5s' or '3s', not the old '1s'."""
+    def test_next_button_disable_guard(self):
+        """alsNext must disable the button immediately to prevent double submission."""
         html = _render_session_page()
-        assert "1.5s" in html, "'1.5s' label missing from auto-advance"
-        assert "3s" in html, "'3s' label missing from auto-advance"
-        # Old 1-second label must be gone
-        assert "in 1s" not in html, "old 'in 1s' label still present"
+        assert "btn.disabled = true" in html, \
+            "double-click guard (btn.disabled = true) missing from alsNext"
+
+    def test_next_button_reenabled_on_error(self):
+        """alsNext must re-enable the button in the catch block (slow network recovery)."""
+        html = _render_session_page()
+        assert "btn.disabled = false" in html, \
+            "error recovery (btn.disabled = false) missing from alsNext catch block"
+
+    def test_no_old_auto_advance_element(self):
+        """als-auto-advance element must be gone."""
+        html = _render_session_page()
+        assert "als-auto-advance" not in html, \
+            "als-auto-advance element still present in template"
 
 
 class TestCategoryPickerThreshold:

--- a/tests/unit/test_card_export.py
+++ b/tests/unit/test_card_export.py
@@ -10,7 +10,7 @@ Coverage:
   EX-05  valid platform (og)               → 200
   EX-06  missing platform param → defaults to "instagram_square", 200
   EX-07  invalid platform       → 422
-  EX-08  "default" platform (not exportable) → 422
+  EX-08  "default" platform → 200 (native FIFA Classic export via ?native_export=1)
   EX-09  player not found       → 404
   EX-10  no active LFA license  → 404
   EX-11  student exports other player → 403
@@ -197,10 +197,10 @@ class TestExportValidation:
         r = _export(client, "foobar")
         assert r.status_code == 422
 
-    def test_ex08_default_platform_returns_422(self, client):
-        """'default' has no canvas size — it is not an export target."""
+    def test_ex08_default_platform_returns_200(self, client):
+        """'default' is the native FIFA Classic export; uses ?native_export=1 render path."""
         r = _export(client, "default")
-        assert r.status_code == 422
+        assert r.status_code == 200
 
     def test_ex09_player_not_found_returns_404(self, client):
         from app.main import app
@@ -424,11 +424,17 @@ class TestExportErrorPaths:
 class TestCanvasSizeRegistry:
 
     def test_all_presets_have_canvas_size(self):
-        """Every non-default preset in card_platform_service must have a CANVAS_SIZES entry."""
+        """Every non-native preset must have a CANVAS_SIZES entry.
+
+        NATIVE ('default') has an entry too — it stores the documented baseline for
+        the native-export BoundingClientRect clip path (not a template canvas target).
+        """
         from app.services.card_platform_service import PLATFORM_PRESETS, LayoutStrategy
         for pid, preset in PLATFORM_PRESETS.items():
             if preset.layout_strategy == LayoutStrategy.NATIVE:
-                assert pid not in CANVAS_SIZES, f"'default' must not be in CANVAS_SIZES"
+                # NATIVE platforms may or may not have a CANVAS_SIZES entry.
+                # 'default' intentionally has one (820×800 documented baseline).
+                pass
             else:
                 assert pid in CANVAS_SIZES, f"Preset {pid!r} missing from CANVAS_SIZES"
 

--- a/tests/unit/test_football_positions.py
+++ b/tests/unit/test_football_positions.py
@@ -1,16 +1,26 @@
 """
 Unit tests for app/utils/football_positions.py
 
-FP-01: POSITIONS_17 has exactly 17 entries
-FP-02: VALID_POSITION_VALUES has exactly 17 members
-FP-03: POSITIONS_17 entries cover exactly 4 groups
+Taxonomy v2 (21 positions):
+  Forwards    (5): striker, centre_forward, left_wing, right_wing, second_striker
+  Midfielders (7): attacking_midfield, centre_midfield, defensive_midfield,
+                   left_midfield, right_midfield,
+                   left_centre_midfield, right_centre_midfield   ← NEW D2
+  Defenders   (7): centre_back, left_back, right_back,
+                   left_wing_back, right_wing_back,
+                   left_centre_back, right_centre_back           ← NEW D1
+  Goalkeepers (2): goalkeeper, sweeper_keeper
+
+FP-01: POSITIONS_21 has exactly 21 entries
+FP-02: VALID_POSITION_VALUES has exactly 21 members
+FP-03: POSITIONS_21 entries cover exactly 4 groups
 FP-04: positions_grouped() returns 4 groups in correct order
-FP-05: positions_grouped() group sizes = 5, 5, 5, 2
+FP-05: positions_grouped() group sizes = 5, 7, 7, 2
 FP-06: normalize_position — legacy uppercase STRIKER → striker
 FP-07: normalize_position — legacy MIDFIELDER → centre_midfield
 FP-08: normalize_position — legacy DEFENDER → centre_back
 FP-09: normalize_position — legacy GOALKEEPER → goalkeeper
-FP-10: normalize_position — already canonical passes through
+FP-10: normalize_position — all 21 canonical values pass through (idempotent)
 FP-11: normalize_position — unknown value returns None
 FP-12: normalize_position — empty string returns None
 FP-13: normalize_positions — valid list normalises all values
@@ -18,14 +28,22 @@ FP-14: normalize_positions — mixed legacy + canonical
 FP-15: normalize_positions — empty list returns None
 FP-16: normalize_positions — unknown value returns None
 FP-17: normalize_positions — preserves order (positions[0] = primary)
-FP-18: position_label — known value returns label
+FP-18: position_label — known values return correct labels (including new D1/D2)
 FP-19: position_label — unknown value returns the value itself
-FP-20: position_short — known values return correct abbreviations
+FP-20: position_short — known values return correct abbreviations (including LCB/RCB/LCM/RCM)
 FP-21: position_short — goalkeeper group abbreviations
+FP-22: backward compat — centre_back still valid (legacy DB records)
+FP-23: backward compat — centre_midfield still valid (legacy DB records)
+FP-24: backward compat — second_striker still valid (D4 gated removal)
+FP-25: D1 split — left_centre_back and right_centre_back are independent canonical values
+FP-26: D2 split — left_centre_midfield and right_centre_midfield are independent canonical values
+FP-27: normalize_position does NOT map centre_back → LCB or RCB (no auto-migration)
+FP-28: positions_grouped — new defender values in defender group
+FP-29: positions_grouped — new midfielder values in midfielder group
 """
 import pytest
 from app.utils.football_positions import (
-    POSITIONS_17,
+    POSITIONS_21,
     VALID_POSITION_VALUES,
     LEGACY_POSITION_MAP,
     normalize_position,
@@ -38,18 +56,18 @@ from app.utils.football_positions import (
 
 # ── FP-01 / FP-02: registry sizes ────────────────────────────────────────────
 
-def test_fp01_positions_17_has_17_entries():
-    assert len(POSITIONS_17) == 17
+def test_fp01_positions_21_has_21_entries():
+    assert len(POSITIONS_21) == 21
 
 
-def test_fp02_valid_position_values_has_17_members():
-    assert len(VALID_POSITION_VALUES) == 17
+def test_fp02_valid_position_values_has_21_members():
+    assert len(VALID_POSITION_VALUES) == 21
 
 
 # ── FP-03: 4 groups covered ───────────────────────────────────────────────────
 
 def test_fp03_positions_cover_exactly_4_groups():
-    groups = {p["group"] for p in POSITIONS_17}
+    groups = {p["group"] for p in POSITIONS_21}
     assert groups == {"forward", "midfielder", "defender", "goalkeeper"}
 
 
@@ -65,13 +83,13 @@ def test_fp04_positions_grouped_returns_4_groups():
     assert groups[3]["label"] == "Goalkeepers"
 
 
-# ── FP-05: group sizes ────────────────────────────────────────────────────────
+# ── FP-05: group sizes (5 / 7 / 7 / 2 after D1+D2 expansion) ────────────────
 
 def test_fp05_group_sizes():
     groups = {g["key"]: len(g["positions"]) for g in positions_grouped()}
     assert groups["forward"]    == 5
-    assert groups["midfielder"] == 5
-    assert groups["defender"]   == 5
+    assert groups["midfielder"] == 7
+    assert groups["defender"]   == 7
     assert groups["goalkeeper"] == 2
 
 
@@ -87,16 +105,22 @@ def test_fp06_fp09_legacy_uppercase_mapping(raw, expected):
     assert normalize_position(raw) == expected
 
 
-# ── FP-10: canonical passthrough ─────────────────────────────────────────────
+# ── FP-10: all 21 canonical values pass through ───────────────────────────────
 
 @pytest.mark.parametrize("canonical", [
-    "striker", "left_wing", "right_wing", "centre_forward", "second_striker",
+    # Forwards
+    "striker", "centre_forward", "left_wing", "right_wing", "second_striker",
+    # Midfielders (original 5 + 2 new)
     "attacking_midfield", "centre_midfield", "defensive_midfield",
     "left_midfield", "right_midfield",
+    "left_centre_midfield", "right_centre_midfield",
+    # Defenders (original 5 + 2 new)
     "centre_back", "left_back", "right_back", "left_wing_back", "right_wing_back",
+    "left_centre_back", "right_centre_back",
+    # Goalkeepers
     "goalkeeper", "sweeper_keeper",
 ])
-def test_fp10_canonical_passes_through(canonical):
+def test_fp10_all_canonical_pass_through(canonical):
     assert normalize_position(canonical) == canonical
 
 
@@ -106,6 +130,7 @@ def test_fp11_unknown_value_returns_none():
     assert normalize_position("UNKNOWN") is None
     assert normalize_position("winger") is None
     assert normalize_position("forward") is None    # group key, not a position value
+    assert normalize_position("LCB") is None        # short code, not a canonical value
 
 
 def test_fp12_empty_string_returns_none():
@@ -115,13 +140,13 @@ def test_fp12_empty_string_returns_none():
 # ── FP-13..17: normalize_positions ───────────────────────────────────────────
 
 def test_fp13_valid_list_normalises_all():
-    result = normalize_positions(["striker", "left_wing", "centre_back"])
-    assert result == ["striker", "left_wing", "centre_back"]
+    result = normalize_positions(["striker", "left_wing", "left_centre_back"])
+    assert result == ["striker", "left_wing", "left_centre_back"]
 
 
 def test_fp14_mixed_legacy_and_canonical():
-    result = normalize_positions(["STRIKER", "left_wing", "GOALKEEPER"])
-    assert result == ["striker", "left_wing", "goalkeeper"]
+    result = normalize_positions(["STRIKER", "left_centre_midfield", "GOALKEEPER"])
+    assert result == ["striker", "left_centre_midfield", "goalkeeper"]
 
 
 def test_fp15_empty_list_returns_none():
@@ -130,26 +155,32 @@ def test_fp15_empty_list_returns_none():
 
 def test_fp16_unknown_value_returns_none():
     assert normalize_positions(["striker", "bad_position"]) is None
-    assert normalize_positions(["bad_one"]) is None
+    assert normalize_positions(["left_centre_back", "LCB"]) is None   # short code invalid
 
 
 def test_fp17_preserves_order():
-    raw = ["right_wing", "striker", "centre_back"]
+    raw = ["right_centre_midfield", "striker", "left_centre_back"]
     result = normalize_positions(raw)
     assert result is not None
-    assert result[0] == "right_wing"    # primary preserved at [0]
+    assert result[0] == "right_centre_midfield"   # primary preserved at [0]
     assert result[1] == "striker"
-    assert result[2] == "centre_back"
+    assert result[2] == "left_centre_back"
 
 
 # ── FP-18 / FP-19: position_label ────────────────────────────────────────────
 
-def test_fp18_known_label():
-    assert position_label("striker")            == "Striker"
-    assert position_label("left_wing")          == "Left Wing"
-    assert position_label("sweeper_keeper")     == "Sweeper Keeper"
-    assert position_label("defensive_midfield") == "Defensive Midfielder"
-    assert position_label("centre_back")        == "Centre Back"
+def test_fp18_known_labels():
+    assert position_label("striker")               == "Striker"
+    assert position_label("left_wing")             == "Left Wing"
+    assert position_label("sweeper_keeper")        == "Sweeper Keeper"
+    assert position_label("defensive_midfield")    == "Defensive Midfielder"
+    assert position_label("centre_back")           == "Centre Back"
+    # D1 new values
+    assert position_label("left_centre_back")      == "Left Centre-Back"
+    assert position_label("right_centre_back")     == "Right Centre-Back"
+    # D2 new values
+    assert position_label("left_centre_midfield")  == "Left Centre Midfielder"
+    assert position_label("right_centre_midfield") == "Right Centre Midfielder"
 
 
 def test_fp19_unknown_label_returns_value_itself():
@@ -159,23 +190,97 @@ def test_fp19_unknown_label_returns_value_itself():
 # ── FP-20 / FP-21: position_short ────────────────────────────────────────────
 
 def test_fp20_forward_and_midfield_shorts():
-    assert position_short("striker")            == "ST"
-    assert position_short("centre_forward")     == "CF"
-    assert position_short("left_wing")          == "LW"
-    assert position_short("right_wing")         == "RW"
-    assert position_short("second_striker")     == "SS"
-    assert position_short("attacking_midfield") == "AM"
-    assert position_short("centre_midfield")    == "CM"
-    assert position_short("defensive_midfield") == "DM"
-    assert position_short("left_midfield")      == "LM"
-    assert position_short("right_midfield")     == "RM"
-    assert position_short("centre_back")        == "CB"
-    assert position_short("left_back")          == "LB"
-    assert position_short("right_back")         == "RB"
-    assert position_short("left_wing_back")     == "LWB"
-    assert position_short("right_wing_back")    == "RWB"
+    assert position_short("striker")               == "ST"
+    assert position_short("centre_forward")        == "CF"
+    assert position_short("left_wing")             == "LW"
+    assert position_short("right_wing")            == "RW"
+    assert position_short("second_striker")        == "SS"
+    assert position_short("attacking_midfield")    == "AM"
+    assert position_short("centre_midfield")       == "CM"
+    assert position_short("defensive_midfield")    == "DM"
+    assert position_short("left_midfield")         == "LM"
+    assert position_short("right_midfield")        == "RM"
+    assert position_short("centre_back")           == "CB"
+    assert position_short("left_back")             == "LB"
+    assert position_short("right_back")            == "RB"
+    assert position_short("left_wing_back")        == "LWB"
+    assert position_short("right_wing_back")       == "RWB"
+    # D1 new values
+    assert position_short("left_centre_back")      == "LCB"
+    assert position_short("right_centre_back")     == "RCB"
+    # D2 new values
+    assert position_short("left_centre_midfield")  == "LCM"
+    assert position_short("right_centre_midfield") == "RCM"
 
 
 def test_fp21_goalkeeper_shorts():
     assert position_short("goalkeeper")     == "GK"
     assert position_short("sweeper_keeper") == "SK"
+
+
+# ── FP-22..24: backward compat — legacy values still valid ────────────────────
+
+def test_fp22_centre_back_still_valid():
+    assert "centre_back" in VALID_POSITION_VALUES
+    assert normalize_position("centre_back") == "centre_back"
+
+
+def test_fp23_centre_midfield_still_valid():
+    assert "centre_midfield" in VALID_POSITION_VALUES
+    assert normalize_position("centre_midfield") == "centre_midfield"
+
+
+def test_fp24_second_striker_still_valid():
+    assert "second_striker" in VALID_POSITION_VALUES
+    assert normalize_position("second_striker") == "second_striker"
+
+
+# ── FP-25 / FP-26: D1 and D2 are independent, not aliased ────────────────────
+
+def test_fp25_d1_lcb_rcb_are_independent_canonical_values():
+    assert "left_centre_back"  in VALID_POSITION_VALUES
+    assert "right_centre_back" in VALID_POSITION_VALUES
+    assert normalize_position("left_centre_back")  == "left_centre_back"
+    assert normalize_position("right_centre_back") == "right_centre_back"
+    # They are distinct from the legacy centre_back
+    assert normalize_position("left_centre_back")  != "centre_back"
+    assert normalize_position("right_centre_back") != "centre_back"
+
+
+def test_fp26_d2_lcm_rcm_are_independent_canonical_values():
+    assert "left_centre_midfield"  in VALID_POSITION_VALUES
+    assert "right_centre_midfield" in VALID_POSITION_VALUES
+    assert normalize_position("left_centre_midfield")  == "left_centre_midfield"
+    assert normalize_position("right_centre_midfield") == "right_centre_midfield"
+    assert normalize_position("left_centre_midfield")  != "centre_midfield"
+    assert normalize_position("right_centre_midfield") != "centre_midfield"
+
+
+# ── FP-27: no silent auto-migration of legacy → new values ───────────────────
+
+def test_fp27_centre_back_does_not_map_to_lcb_or_rcb():
+    # Existing DB records with centre_back must normalize to centre_back, not LCB/RCB
+    result = normalize_position("centre_back")
+    assert result == "centre_back"
+    assert result != "left_centre_back"
+    assert result != "right_centre_back"
+
+
+# ── FP-28 / FP-29: new values appear in correct groups ───────────────────────
+
+def test_fp28_new_defender_values_in_defender_group():
+    grouped = positions_grouped()
+    defender_group = next(g for g in grouped if g["key"] == "defender")
+    defender_values = [p["value"] for p in defender_group["positions"]]
+    assert "left_centre_back"  in defender_values
+    assert "right_centre_back" in defender_values
+    assert "centre_back"       in defender_values   # legacy still present
+
+
+def test_fp29_new_midfielder_values_in_midfielder_group():
+    grouped = positions_grouped()
+    mid_group = next(g for g in grouped if g["key"] == "midfielder")
+    mid_values = [p["value"] for p in mid_group["positions"]]
+    assert "left_centre_midfield"  in mid_values
+    assert "right_centre_midfield" in mid_values
+    assert "centre_midfield"       in mid_values    # legacy still present

--- a/tests/unit/test_platform_export_layout.py
+++ b/tests/unit/test_platform_export_layout.py
@@ -1226,43 +1226,52 @@ class TestFifaSquareAllSkills:
         )
 
     def test_ex31b_square_proportional_row_heights(self, client):
-        """Square export uses .ex-cat--logo-host to bottom-align Set Pieces with Physical Fitness.
+        """Square export uses ex-col-sets-phys to co-host Set Pieces + Physical in col 3.
 
-        v4 flex-column layout: Set Pieces (3 rows, left col bottom) has flex:1 so its cell
-        expands to fill remaining left-column height, aligning its bottom edge with Physical
-        Fitness. A static .ex-logo-slot placeholder fills the freed dark area at the bottom.
-        The 24px fixed skill row height (.ex-row { flex: none; min-height: 24px }) is unchanged.
+        v11 3-column layout: Set Pieces (3 rows, natural height) and Physical Fitness
+        (8 rows, flex:1) live together in .ex-col-sets-phys — Physical expands to fill
+        remaining column height via CSS `ex-col-sets-phys .ex-cat:last-child { flex:1 }`.
+        The old v4 ex-cat--logo-host / ex-logo-slot mechanism was removed in v5.
         """
         html = self._get_fifa_export_html(client, "instagram_square")
         assert html, "Export returned empty response for instagram_square"
-        assert "ex-cat--logo-host" in html, (
-            "ex-cat--logo-host not found in Square export HTML — "
-            "Set Pieces cell must carry this class so it expands to match Physical Fitness height"
+        assert "ex-col-sets-phys" in html, (
+            "ex-col-sets-phys not found in Square export HTML — "
+            "v11 col 3 must carry this class to co-host Set Pieces + Physical Fitness"
         )
-        assert "ex-logo-slot" in html, (
-            "ex-logo-slot not found in Square export HTML — "
-            "static placeholder must be rendered inside the Set Pieces cell"
+        assert "ex-cat--logo-host" not in html, (
+            "ex-cat--logo-host found in Square export HTML — "
+            "this v4 class was removed in v5; template must not reference it"
+        )
+        assert "ex-logo-slot" not in html, (
+            "ex-logo-slot found in Square export HTML — "
+            "this v4 placeholder was removed in v5; template must not reference it"
         )
 
     def test_ex31c_sponsor_logo_slot_present_without_logo(self, client):
-        """ex-sponsor-slot div is always rendered below both skill columns; no img when URL is None.
+        """ex-hero-sponsor is always rendered; ex-sponsor-slot is absent (removed in v8).
 
-        The slot is a full-width flex-sibling of .ex-skill-cats — it exists unconditionally
-        so bottom spacing is stable regardless of whether a sponsor logo is configured.
+        v8 moved the sponsor from the skills zone into the hero layer (.ex-hero-sponsor
+        inside .ex-profile-col). The slot renders unconditionally because app_logo_url
+        is always set as a fallback — even when no sponsor_logo_url is configured.
+        The old ex-sponsor-slot mechanism was removed in v8.
         """
         html = self._get_fifa_export_html(client, "instagram_square")
         assert html, "Export returned empty response for instagram_square"
-        assert 'class="ex-sponsor-slot"' in html, (
-            "ex-sponsor-slot div not found in Square export HTML — "
-            "slot must always be rendered below both skill columns"
+        assert "ex-sponsor-slot" not in html, (
+            "ex-sponsor-slot found in Square export HTML — "
+            "this class was removed in v8; sponsor moved to hero layer (ex-hero-sponsor)"
         )
-        assert 'class="ex-sponsor-slot-img"' not in html, (
-            "ex-sponsor-slot-img found when sponsor_logo_url is None — "
-            "img must not be rendered without a logo URL"
+        assert "ex-hero-sponsor" in html, (
+            "ex-hero-sponsor not found in Square export HTML — "
+            "v8+ sponsor/logo must render in .ex-hero-sponsor inside .ex-profile-col"
+        )
+        assert "ex-hero-sponsor-img" in html, (
+            "ex-hero-sponsor-img not found — img must always render via app_logo_url fallback"
         )
 
     def test_ex31d_sponsor_logo_renders_img_when_url_present(self, client):
-        """img.ex-sponsor-slot-img renders inside ex-sponsor-slot when sponsor_logo_url is set."""
+        """img.ex-hero-sponsor-img renders inside ex-hero-sponsor when sponsor_logo_url is set."""
         from app.main import app
         from app.dependencies import get_db
 
@@ -1277,25 +1286,25 @@ class TestFifaSquareAllSkills:
             app.dependency_overrides.pop(get_db, None)
 
         assert html, "Export returned empty response"
-        assert 'class="ex-sponsor-slot-img"' in html, (
-            "ex-sponsor-slot-img not found when sponsor_logo_url is set — "
-            "img must render inside ex-sponsor-slot"
+        assert 'class="ex-hero-sponsor-img"' in html, (
+            "ex-hero-sponsor-img not found when sponsor_logo_url is set — "
+            "img must render inside ex-hero-sponsor (v8 hero layer)"
         )
         assert "/static/uploads/lfa_player_photos/7_sponsor_logo_1234567890.png" in html, (
             "sponsor_logo_url value not found in rendered img src"
         )
 
     def test_ex31e_sponsor_logo_css_constraints(self, client):
-        """CSS for ex-sponsor-slot-img contains object-fit: contain and max-height constraint."""
+        """CSS for ex-hero-sponsor-img contains object-fit: contain and max-height constraint."""
         html = self._get_fifa_export_html(client, "instagram_square")
         assert html, "Export returned empty response for instagram_square"
         assert "object-fit: contain" in html, (
             "object-fit: contain not found in Square export CSS — "
-            "required so sponsor logo preserves aspect ratio within the slot"
+            "required so sponsor/app logo preserves aspect ratio in ex-hero-sponsor"
         )
-        assert "max-height: 48px" in html, (
-            "max-height: 48px not found in Square export CSS — "
-            "required so sponsor logo never overflows the 70px ex-sponsor-slot"
+        assert "max-height: 28px" in html, (
+            "max-height: 28px not found in Square export CSS — "
+            "required so logo never overflows the ex-hero-sponsor area (v8 hero layer)"
         )
 
     def test_ex31f_sponsor_logo_onerror_fallback(self, client):

--- a/tests/unit/test_profile_position_dedup.py
+++ b/tests/unit/test_profile_position_dedup.py
@@ -1,0 +1,135 @@
+"""
+Unit tests for profile.py position constant deduplication.
+
+Verifies that _VALID_POSITIONS, _POSITION_LABELS, and _POSITION_GROUPS
+in app/api/web_routes/profile.py are derived from football_positions.py
+(single source of truth) and accept all 21 canonical values including the
+new D1 (LCB/RCB) and D2 (LCM/RCM) split positions.
+
+PROF-DEDUP-01: _VALID_POSITIONS equals VALID_POSITION_VALUES (same object)
+PROF-DEDUP-02: _VALID_POSITIONS accepts all 4 new D1/D2 canonical values
+PROF-DEDUP-03: _VALID_POSITIONS accepts legacy values (centre_back, centre_midfield, second_striker)
+PROF-DEDUP-04: _POSITION_LABELS has an entry for every value in _VALID_POSITIONS
+PROF-DEDUP-05: _POSITION_LABELS format is "Label (SHORT)" for all entries
+PROF-DEDUP-06: _POSITION_LABELS new D1 entries have correct short codes LCB/RCB
+PROF-DEDUP-07: _POSITION_LABELS new D2 entries have correct short codes LCM/RCM
+PROF-DEDUP-08: _POSITION_GROUPS contains all 21 canonical values (no orphans)
+PROF-DEDUP-09: _POSITION_GROUPS has correct group count (4 groups)
+PROF-DEDUP-10: _POSITION_GROUPS defender group contains new D1 values
+PROF-DEDUP-11: _POSITION_GROUPS midfielder group contains new D2 values
+PROF-DEDUP-12: profile edit POST guard accepts new D1/D2 canonical values (no 400)
+"""
+import pytest
+
+from app.api.web_routes.profile import (
+    _VALID_POSITIONS,
+    _POSITION_LABELS,
+    _POSITION_GROUPS,
+)
+from app.utils.football_positions import VALID_POSITION_VALUES
+
+
+# ── PROF-DEDUP-01: single source of truth ────────────────────────────────────
+
+def test_dedup01_valid_positions_is_same_as_football_positions():
+    assert _VALID_POSITIONS == VALID_POSITION_VALUES
+
+
+# ── PROF-DEDUP-02: new D1/D2 values accepted ─────────────────────────────────
+
+@pytest.mark.parametrize("value", [
+    "left_centre_back",
+    "right_centre_back",
+    "left_centre_midfield",
+    "right_centre_midfield",
+])
+def test_dedup02_new_d1_d2_values_accepted(value):
+    assert value in _VALID_POSITIONS
+
+
+# ── PROF-DEDUP-03: legacy backward-compat values still accepted ───────────────
+
+@pytest.mark.parametrize("value", [
+    "centre_back",
+    "centre_midfield",
+    "second_striker",
+])
+def test_dedup03_legacy_values_still_valid(value):
+    assert value in _VALID_POSITIONS
+
+
+# ── PROF-DEDUP-04: _POSITION_LABELS covers all valid positions ────────────────
+
+def test_dedup04_position_labels_covers_all_valid_positions():
+    missing = _VALID_POSITIONS - set(_POSITION_LABELS.keys())
+    assert not missing, f"_POSITION_LABELS missing entries for: {missing}"
+
+
+# ── PROF-DEDUP-05: label format is "Label (SHORT)" ──────────────────────────
+
+def test_dedup05_label_format_is_label_with_short_code():
+    for value, label in _POSITION_LABELS.items():
+        assert '(' in label and label.endswith(')'), (
+            f"_POSITION_LABELS['{value}'] = '{label}' does not match 'Label (SHORT)' format"
+        )
+
+
+# ── PROF-DEDUP-06/07: new short codes in labels ──────────────────────────────
+
+def test_dedup06_d1_labels_have_lcb_rcb_short_codes():
+    assert _POSITION_LABELS["left_centre_back"].endswith("(LCB)")
+    assert _POSITION_LABELS["right_centre_back"].endswith("(RCB)")
+
+
+def test_dedup07_d2_labels_have_lcm_rcm_short_codes():
+    assert _POSITION_LABELS["left_centre_midfield"].endswith("(LCM)")
+    assert _POSITION_LABELS["right_centre_midfield"].endswith("(RCM)")
+
+
+# ── PROF-DEDUP-08/09: _POSITION_GROUPS structure ─────────────────────────────
+
+def test_dedup08_position_groups_contains_all_canonical_values():
+    grouped_values = set()
+    for group in _POSITION_GROUPS:
+        for pos in group["positions"]:
+            grouped_values.add(pos["value"])
+    missing = _VALID_POSITIONS - grouped_values
+    assert not missing, f"_POSITION_GROUPS missing values: {missing}"
+
+
+def test_dedup09_position_groups_has_4_groups():
+    assert len(_POSITION_GROUPS) == 4
+    keys = [g["key"] for g in _POSITION_GROUPS]
+    assert keys == ["forward", "midfielder", "defender", "goalkeeper"]
+
+
+# ── PROF-DEDUP-10/11: new values in correct groups ───────────────────────────
+
+def test_dedup10_d1_values_in_defender_group():
+    def_group = next(g for g in _POSITION_GROUPS if g["key"] == "defender")
+    def_values = [p["value"] for p in def_group["positions"]]
+    assert "left_centre_back"  in def_values
+    assert "right_centre_back" in def_values
+
+
+def test_dedup11_d2_values_in_midfielder_group():
+    mid_group = next(g for g in _POSITION_GROUPS if g["key"] == "midfielder")
+    mid_values = [p["value"] for p in mid_group["positions"]]
+    assert "left_centre_midfield"  in mid_values
+    assert "right_centre_midfield" in mid_values
+
+
+# ── PROF-DEDUP-12: profile edit POST guard allows new values ──────────────────
+
+@pytest.mark.parametrize("position", [
+    "left_centre_back",
+    "right_centre_back",
+    "left_centre_midfield",
+    "right_centre_midfield",
+    "centre_back",        # legacy backward compat
+    "centre_midfield",    # legacy backward compat
+])
+def test_dedup12_edit_post_guard_accepts_new_positions(position):
+    assert position in _VALID_POSITIONS, (
+        f"Profile edit POST would reject '{position}' — add it to _VALID_POSITIONS"
+    )

--- a/tests/unit/test_square_card.py
+++ b/tests/unit/test_square_card.py
@@ -30,12 +30,12 @@ Coverage:
          Old "0 0 100 24" aspect-squashed viewBox must be absent
   SQ-19  position_nodes Jinja2 variable referenced in SVG rendering
          Coordinate transform: cx = node.x * 105, cy = node.y * 68 (v8 real geometry)
-  SQ-20  Landscape panel appears after skill_categories[3] reference
+  SQ-20  Landscape panel appears BEFORE .ex-skill-cats (v10 — full-width strip above columns)
   SQ-21  Column count unchanged: still exactly 3 .ex-skill-col divs with panel added
   SQ-22  Position panel gated by {% if position_nodes %} — graceful empty state
   SQ-23  .ex-pos-svg-landscape CSS defines flex or dimension (fills container)
   SQ-24  Position panel does NOT use .ex-cat class — immune to cat fade-slide animation
-  SQ-25  .ex-col-right container present in HTML body, contains skill_categories[2]
+  SQ-25  REMOVED — .ex-col-right wrapper eliminated in v10 (flat sibling columns)
   SQ-27  Landscape SVG has no {{ node.label }} text — no labels per user request
   SQ-28  preserveAspectRatio="xMidYMid meet" on landscape SVG — no stretch, no crop (v8)
   SQ-29  Position Map panel has info column: .ex-pos-info div present — v9
@@ -43,6 +43,7 @@ Coverage:
   SQ-30  .ex-pos-badge absent from HTML body (photo is clean portrait block) — v9
          .ex-sec-pos-chips absent from photo column (chips moved to pos panel)
   SQ-31  No PRIMARY/SECONDARY/OTHER legend in Position Map panel — v9
+  SQ-32  v10 flat layout: .ex-col-right and .ex-col-right-skills absent from HTML body
 """
 from __future__ import annotations
 
@@ -89,11 +90,11 @@ class TestThreeColumnLayout:
         assert "skill_categories[0]" in tpl
 
     def test_sq04_col2_mental_index_2(self, tpl):
-        """ex-col-right (right panel): uses skill_categories[2] for Mental column."""
+        """Col 2 (Mental): uses skill_categories[2]."""
         assert "skill_categories[2]" in tpl
 
     def test_sq05_col3_set_pieces_physical(self, tpl):
-        """ex-col-right stacks Set Pieces [1] + Physical [3] via a for loop."""
+        """Col 3 stacks Set Pieces [1] + Physical [3] via a for loop."""
         assert "skill_categories[1]" in tpl
         assert "skill_categories[3]" in tpl
         # Both must appear together in the right panel
@@ -331,13 +332,14 @@ class TestPositionMiniPanel:
             "SVG coordinate transform must use node.y * 68 (68m pitch height), not node.y * 24"
         )
 
-    def test_sq20_pos_panel_after_skill_categories_3(self, tpl):
-        """Landscape panel must appear after skill_categories[3] (Physical)."""
-        idx_phys  = tpl.rfind("skill_categories[3]")
-        idx_panel = tpl.find('class="ex-pos-panel-landscape"')
-        assert idx_phys > 0 and idx_panel > 0, "Both skill_categories[3] and ex-pos-panel-landscape must be present"
-        assert idx_panel > idx_phys, (
-            "ex-pos-panel-landscape must appear after skill_categories[3]"
+    def test_sq20_pos_panel_before_skill_cats(self, tpl):
+        """v10: landscape panel must appear BEFORE .ex-skill-cats (full-width strip above columns)."""
+        html_body      = tpl[tpl.rfind("</style>"):]
+        idx_panel      = html_body.find('class="ex-pos-panel-landscape"')
+        idx_skill_cats = html_body.find('class="ex-skill-cats"')
+        assert idx_panel > 0 and idx_skill_cats > 0, "Both ex-pos-panel-landscape and ex-skill-cats must be present"
+        assert idx_panel < idx_skill_cats, (
+            "v10: ex-pos-panel-landscape must appear BEFORE ex-skill-cats"
         )
 
 
@@ -388,16 +390,6 @@ class TestPositionPanelIntegrity:
         ex_cat_anim    = anim_block.find(".ex-cat {")
         assert pos_panel_anim != ex_cat_anim, (
             ".ex-pos-panel-landscape and .ex-cat must have separate animation rules"
-        )
-
-    def test_sq25_ex_col_right_container_in_html(self, tpl):
-        """v7: .ex-col-right container must be present in HTML body and wrap skill_categories[2]."""
-        html_body = tpl[tpl.rfind("</style>"):]
-        assert 'class="ex-col-right"' in html_body
-        col_right_idx = html_body.find('class="ex-col-right"')
-        cat2_idx      = html_body.find("skill_categories[2]", col_right_idx)
-        assert cat2_idx > col_right_idx, (
-            "skill_categories[2] (Mental) must appear inside .ex-col-right"
         )
 
     def test_sq27_no_node_label_in_landscape_svg(self, tpl):
@@ -515,3 +507,21 @@ class TestNoPositionLegend:
         legend_classes = [".ex-pos-legend", ".ex-legend-item", ".ex-legend-marker"]
         for cls in legend_classes:
             assert cls not in tpl, f"Legend CSS class {cls} must not be defined in v9"
+
+
+# ── SQ-32: v10 flat layout — panel above columns, no ex-col-right ─────────────
+
+class TestV10FlatLayout:
+    def test_sq32_no_ex_col_right_in_html(self, tpl):
+        """v10: .ex-col-right wrapper removed — Mental and Set Pieces are flat siblings."""
+        html_body = tpl[tpl.rfind("</style>"):]
+        assert 'class="ex-col-right"' not in html_body, (
+            ".ex-col-right wrapper must be absent in v10 — all three skill columns are flat siblings"
+        )
+
+    def test_sq32_no_ex_col_right_skills_in_html(self, tpl):
+        """v10: .ex-col-right-skills inner wrapper also removed."""
+        html_body = tpl[tpl.rfind("</style>"):]
+        assert 'class="ex-col-right-skills"' not in html_body, (
+            ".ex-col-right-skills inner wrapper must be absent in v10"
+        )

--- a/tests/unit/test_square_card.py
+++ b/tests/unit/test_square_card.py
@@ -30,7 +30,7 @@ Coverage:
          Old "0 0 100 24" aspect-squashed viewBox must be absent
   SQ-19  position_nodes Jinja2 variable referenced in SVG rendering
          Coordinate transform: cx = node.x * 105, cy = node.y * 68 (v8 real geometry)
-  SQ-20  Landscape panel appears BEFORE .ex-skill-cats (v10 — full-width strip above columns)
+  SQ-20  Landscape panel appears INSIDE .ex-skill-cats, after skill_categories[2] (v11)
   SQ-21  Column count unchanged: still exactly 3 .ex-skill-col divs with panel added
   SQ-22  Position panel gated by {% if position_nodes %} — graceful empty state
   SQ-23  .ex-pos-svg-landscape CSS defines flex or dimension (fills container)
@@ -44,6 +44,8 @@ Coverage:
          .ex-sec-pos-chips absent from photo column (chips moved to pos panel)
   SQ-31  No PRIMARY/SECONDARY/OTHER legend in Position Map panel — v9
   SQ-32  v10 flat layout: .ex-col-right and .ex-col-right-skills absent from HTML body
+  SQ-33  v11 column modifiers: ex-col-outfield, ex-col-mental-pos, ex-col-sets-phys present
+         Position Map inside ex-col-mental-pos; panel height 160px; info col 140px
 """
 from __future__ import annotations
 
@@ -81,8 +83,8 @@ class TestHeroZone:
 
 class TestThreeColumnLayout:
     def test_sq02_three_skill_col_divs(self, tpl):
-        """Exactly 3 <div class="ex-skill-col"> present in the skills section."""
-        matches = re.findall(r'class="ex-skill-col"', tpl)
+        """Exactly 3 .ex-skill-col divs present (may carry modifier classes in v11)."""
+        matches = re.findall(r'class="ex-skill-col[^"]*"', tpl)
         assert len(matches) == 3, f"Expected 3 ex-skill-col divs, found {len(matches)}"
 
     def test_sq03_col1_outfield_index_0(self, tpl):
@@ -332,14 +334,17 @@ class TestPositionMiniPanel:
             "SVG coordinate transform must use node.y * 68 (68m pitch height), not node.y * 24"
         )
 
-    def test_sq20_pos_panel_before_skill_cats(self, tpl):
-        """v10: landscape panel must appear BEFORE .ex-skill-cats (full-width strip above columns)."""
+    def test_sq20_pos_panel_inside_skill_col(self, tpl):
+        """v11: panel is INSIDE .ex-skill-cats and appears after skill_categories[2] (Mental)."""
         html_body      = tpl[tpl.rfind("</style>"):]
-        idx_panel      = html_body.find('class="ex-pos-panel-landscape"')
         idx_skill_cats = html_body.find('class="ex-skill-cats"')
-        assert idx_panel > 0 and idx_skill_cats > 0, "Both ex-pos-panel-landscape and ex-skill-cats must be present"
-        assert idx_panel < idx_skill_cats, (
-            "v10: ex-pos-panel-landscape must appear BEFORE ex-skill-cats"
+        idx_mental     = html_body.find("skill_categories[2]", idx_skill_cats)
+        idx_panel      = html_body.find('class="ex-pos-panel-landscape"', idx_mental)
+        assert idx_skill_cats > 0 and idx_mental > idx_skill_cats, (
+            "skill_categories[2] (Mental) must appear inside ex-skill-cats"
+        )
+        assert idx_panel > idx_mental, (
+            "v11: ex-pos-panel-landscape must appear after Mental cat (skill_categories[2])"
         )
 
 
@@ -347,10 +352,10 @@ class TestPositionMiniPanel:
 
 class TestPositionPanelIntegrity:
     def test_sq21_column_count_unchanged(self, tpl):
-        """Adding landscape panel must not change column count — still exactly 3 ex-skill-col divs."""
-        matches = re.findall(r'class="ex-skill-col"', tpl)
+        """Panel inside Col 2 must not add a 4th column — still exactly 3 ex-skill-col divs."""
+        matches = re.findall(r'class="ex-skill-col[^"]*"', tpl)
         assert len(matches) == 3, (
-            f"Landscape panel must not add a 4th column; found {len(matches)} ex-skill-col divs"
+            f"Position Map must not add a 4th column; found {len(matches)} ex-skill-col divs"
         )
 
     def test_sq22_pos_panel_gated_by_position_nodes(self, tpl):
@@ -525,3 +530,65 @@ class TestV10FlatLayout:
         assert 'class="ex-col-right-skills"' not in html_body, (
             ".ex-col-right-skills inner wrapper must be absent in v10"
         )
+
+
+# ── SQ-33: v11 column modifier classes + Position Map placement ───────────────
+
+class TestV11ColumnModifiers:
+    def test_sq33_col_outfield_class_present(self, tpl):
+        """v11: Col 1 must carry ex-col-outfield modifier class."""
+        html_body = tpl[tpl.rfind("</style>"):]
+        assert 'ex-col-outfield' in html_body, (
+            "ex-col-outfield modifier class must be present on Col 1 (Outfield)"
+        )
+
+    def test_sq33_col_mental_pos_class_present(self, tpl):
+        """v11: Col 2 must carry ex-col-mental-pos modifier class."""
+        html_body = tpl[tpl.rfind("</style>"):]
+        assert 'ex-col-mental-pos' in html_body, (
+            "ex-col-mental-pos modifier class must be present on Col 2 (Mental + PosMap)"
+        )
+
+    def test_sq33_col_sets_phys_class_present(self, tpl):
+        """v11: Col 3 must carry ex-col-sets-phys modifier class."""
+        html_body = tpl[tpl.rfind("</style>"):]
+        assert 'ex-col-sets-phys' in html_body, (
+            "ex-col-sets-phys modifier class must be present on Col 3 (Set Pieces + Physical)"
+        )
+
+    def test_sq33_panel_inside_col_mental_pos(self, tpl):
+        """v11: Position Map panel must be inside .ex-col-mental-pos column."""
+        html_body   = tpl[tpl.rfind("</style>"):]
+        col2_start  = html_body.find('ex-col-mental-pos')
+        col3_start  = html_body.find('ex-col-sets-phys')
+        panel_idx   = html_body.find('class="ex-pos-panel-landscape"')
+        assert col2_start > 0 and col3_start > 0 and panel_idx > 0
+        assert col2_start < panel_idx < col3_start, (
+            "v11: ex-pos-panel-landscape must be inside ex-col-mental-pos (after Mental, before Col 3)"
+        )
+
+    def test_sq33_panel_height_160px(self, tpl):
+        """v11: .ex-pos-panel-landscape CSS must declare height: 160px."""
+        panel_css_start = tpl.find(".ex-pos-panel-landscape {")
+        assert panel_css_start != -1
+        panel_css_end = tpl.find("}", panel_css_start)
+        panel_css = tpl[panel_css_start: panel_css_end + 1]
+        assert "height: 160px" in panel_css, (
+            ".ex-pos-panel-landscape must be 160px tall in v11 for legible pitch rendering"
+        )
+
+    def test_sq33_info_col_140px(self, tpl):
+        """v11: .ex-pos-info CSS must declare flex: 0 0 140px (narrowed to widen SVG area)."""
+        info_css_start = tpl.find(".ex-pos-info {")
+        assert info_css_start != -1
+        info_css_end = tpl.find("}", info_css_start)
+        info_css = tpl[info_css_start: info_css_end + 1]
+        assert "140px" in info_css, (
+            ".ex-pos-info must be 140px wide in v11 — wider SVG area for legible pitch"
+        )
+
+    def test_sq33_flex_fill_css_rules_present(self, tpl):
+        """v11: column flex-fill CSS rules must be defined for all three modifier classes."""
+        assert ".ex-col-outfield .ex-cat" in tpl, "flex-fill rule for ex-col-outfield missing"
+        assert ".ex-col-mental-pos .ex-cat" in tpl, "flex-fill rule for ex-col-mental-pos missing"
+        assert ".ex-col-sets-phys .ex-cat:last-child" in tpl, "flex-fill rule for ex-col-sets-phys missing"

--- a/tests/unit/test_square_card.py
+++ b/tests/unit/test_square_card.py
@@ -1,0 +1,394 @@
+"""
+Unit tests — FIFA Classic × Instagram Square card template
+==========================================================
+
+Static assertions against app/templates/public/export/square/fifa.html.
+No DB, no Playwright, no network — all tests read the template source as text.
+
+Coverage:
+  SQ-01  Hero zone is 35% (v5 — was 42% in v4; 35% gives 65% for skills)
+  SQ-02  Exactly 3 .ex-skill-col divs (3-column layout)
+  SQ-03  Col 1 renders skill_categories[0] (Outfield — 1st column, single cat)
+  SQ-04  .ex-col-right renders skill_categories[2] (Mental — nested right panel)
+  SQ-05  .ex-col-right renders both skill_categories[1] (Set Pieces) + [3] (Physical)
+  SQ-06  Position badge uses primary_pos_label (not raw player.position snake_case)
+  SQ-07  Secondary position chips container ex-sec-pos-chips present in HTML
+  SQ-08  .ex-sec-pos-chip CSS class defined in stylesheet
+  SQ-09  .ex-cat has no overflow:hidden (content layers must never clip skills)
+  SQ-10  .ex-skill-rows has no overflow:hidden
+  SQ-11  Animation stagger covers rows 1–19 (Outfield is longest at 19 skills)
+  SQ-12  Cat animation has ≤2 nth-child selectors (3-col: max 2 cats per column)
+  SQ-13  Sponsor in hero layer (.ex-hero-sponsor inside .ex-profile-col) — v8
+         Sponsor NOT in skills zone (.ex-sponsor-slot removed in v8)
+  SQ-14  Animated mode block is gated by {% if animated_mode %} Jinja2 block
+  SQ-15  Template file exists and contains DOCTYPE declaration
+  SQ-16  ex-cat--logo-host and ex-logo-slot are NOT in the HTML body (removed in v5)
+  SQ-17  .ex-pos-panel-landscape class present in HTML body (v7 landscape panel)
+  SQ-18  Landscape pitch SVG viewBox "0 0 105 68" (real 105m×68m geometry) — v8
+         Old "0 0 100 24" aspect-squashed viewBox must be absent
+  SQ-19  position_nodes Jinja2 variable referenced in SVG rendering
+         Coordinate transform: cx = node.x * 105, cy = node.y * 68 (v8 real geometry)
+  SQ-20  Landscape panel appears after skill_categories[3] reference
+  SQ-21  Column count unchanged: still exactly 3 .ex-skill-col divs with panel added
+  SQ-22  Position panel gated by {% if position_nodes %} — graceful empty state
+  SQ-23  .ex-pos-svg-landscape CSS defines width and height (fills container)
+  SQ-24  Position panel does NOT use .ex-cat class — immune to cat fade-slide animation
+  SQ-25  .ex-col-right container present in HTML body, contains skill_categories[2]
+  SQ-27  Landscape SVG has no {{ node.label }} text — no labels per user request
+  SQ-28  preserveAspectRatio="xMidYMid meet" on landscape SVG — no stretch, no crop (v8)
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+
+# ── Template path ──────────────────────────────────────────────────────────────
+
+_TPL_PATH = (
+    pathlib.Path(__file__).resolve().parents[2]
+    / "app" / "templates" / "public" / "export" / "square" / "fifa.html"
+)
+
+
+@pytest.fixture(scope="module")
+def tpl() -> str:
+    return _TPL_PATH.read_text(encoding="utf-8")
+
+
+# ── SQ-01: Hero zone percentage ───────────────────────────────────────────────
+
+class TestHeroZone:
+    def test_sq01_hero_flex_35_percent(self, tpl):
+        """Hero must be 35%, not 42%, so skills zone gets 65% (702px at 1080px)."""
+        assert "flex: 0 0 35%" in tpl
+
+    def test_sq01_hero_not_42_percent(self, tpl):
+        """Old 42% value must be gone — confirms this is v5, not v4."""
+        assert "flex: 0 0 42%" not in tpl
+
+
+# ── SQ-02/03/04/05: 3-column skill layout ─────────────────────────────────────
+
+class TestThreeColumnLayout:
+    def test_sq02_three_skill_col_divs(self, tpl):
+        """Exactly 3 <div class="ex-skill-col"> present in the skills section."""
+        matches = re.findall(r'class="ex-skill-col"', tpl)
+        assert len(matches) == 3, f"Expected 3 ex-skill-col divs, found {len(matches)}"
+
+    def test_sq03_col1_outfield_index_0(self, tpl):
+        """Col 1 (Outfield): uses skill_categories[0]."""
+        assert "skill_categories[0]" in tpl
+
+    def test_sq04_col2_mental_index_2(self, tpl):
+        """ex-col-right (right panel): uses skill_categories[2] for Mental column."""
+        assert "skill_categories[2]" in tpl
+
+    def test_sq05_col3_set_pieces_physical(self, tpl):
+        """ex-col-right stacks Set Pieces [1] + Physical [3] via a for loop."""
+        assert "skill_categories[1]" in tpl
+        assert "skill_categories[3]" in tpl
+        # Both must appear together in the right panel
+        col3_start = tpl.rfind("skill_categories[1]")
+        col3_end   = tpl.rfind("skill_categories[3]")
+        assert col3_start > 0 and col3_end > col3_start, (
+            "skill_categories[1] must appear before skill_categories[3] in right panel"
+        )
+
+
+# ── SQ-06/07/08: Position badge ───────────────────────────────────────────────
+
+class TestPositionBadge:
+    def test_sq06_uses_primary_pos_label(self, tpl):
+        """Position badge must use primary_pos_label (human-readable), not raw player.position."""
+        assert "primary_pos_label" in tpl
+
+    def test_sq06_not_raw_player_position_in_badge(self, tpl):
+        """raw {{ player.position }} must not appear inside the badge div."""
+        # The badge div: search for ex-pos-badge context
+        badge_idx = tpl.find('class="ex-pos-badge"')
+        assert badge_idx != -1
+        # The badge closing tag ends a short block; check no raw snake_case in 200 chars after
+        badge_region = tpl[badge_idx: badge_idx + 300]
+        assert "{{ player.position }}" not in badge_region
+
+    def test_sq07_secondary_chips_container_in_html(self, tpl):
+        """ex-sec-pos-chips container must be present in the HTML body."""
+        assert 'class="ex-sec-pos-chips"' in tpl
+
+    def test_sq08_sec_pos_chip_css_defined(self, tpl):
+        """CSS class .ex-sec-pos-chip must be defined in the stylesheet."""
+        assert ".ex-sec-pos-chip" in tpl
+
+    def test_sq07_secondary_chips_gated_by_secondary_pos_labels(self, tpl):
+        """Secondary chips must only render when secondary_pos_labels is defined and truthy."""
+        assert "secondary_pos_labels" in tpl
+        # The guard should be present
+        assert "{% if secondary_pos_labels" in tpl
+
+
+# ── SQ-09/10: No overflow clipping on content layers ─────────────────────────
+
+class TestNoOverflowClipping:
+    def test_sq09_ex_cat_no_overflow_hidden(self, tpl):
+        """.ex-cat must not have overflow: hidden — all skills must be visible."""
+        # Extract the .ex-cat CSS rule block
+        cat_rule_start = tpl.find(".ex-cat {")
+        assert cat_rule_start != -1
+        cat_rule_end = tpl.find("}", cat_rule_start)
+        cat_rule = tpl[cat_rule_start: cat_rule_end + 1]
+        assert "overflow: hidden" not in cat_rule
+
+    def test_sq10_ex_skill_rows_no_overflow_hidden(self, tpl):
+        """.ex-skill-rows must not have overflow: hidden."""
+        rows_rule_start = tpl.find(".ex-skill-rows {")
+        assert rows_rule_start != -1
+        rows_rule_end = tpl.find("}", rows_rule_start)
+        rows_rule = tpl[rows_rule_start: rows_rule_end + 1]
+        assert "overflow: hidden" not in rows_rule
+
+    def test_sq10_ex_skill_col_no_overflow_hidden(self, tpl):
+        """.ex-skill-col must use overflow: visible (not hidden) so content is not clipped."""
+        col_rule_start = tpl.find(".ex-skill-col {")
+        assert col_rule_start != -1
+        col_rule_end = tpl.find("}", col_rule_start)
+        col_rule = tpl[col_rule_start: col_rule_end + 1]
+        assert "overflow: hidden" not in col_rule
+
+
+# ── SQ-11/12: Animation stagger ───────────────────────────────────────────────
+
+class TestAnimationStagger:
+    def test_sq11_row_stagger_covers_19_rows(self, tpl):
+        """Animation row stagger must cover up to nth-child(19) for Outfield (19 skills)."""
+        assert ".ex-row:nth-child(19)" in tpl
+
+    def test_sq11_row_stagger_has_no_gaps(self, tpl):
+        """Stagger must be contiguous from 1 to 19."""
+        for n in range(1, 20):
+            assert f".ex-row:nth-child({n})" in tpl, (
+                f"Missing animation stagger for .ex-row:nth-child({n})"
+            )
+
+    def test_sq12_cat_stagger_max_two_nth_child(self, tpl):
+        """Cat animation: at most 2 nth-child selectors (max 2 cats per column in 3-col layout)."""
+        # Find the animated_mode block
+        anim_start = tpl.find("{% if animated_mode %}")
+        anim_end   = tpl.find("{% endif %}", anim_start)
+        anim_block = tpl[anim_start: anim_end]
+        cat_stagger = re.findall(r"\.ex-cat:nth-child\((\d+)\)", anim_block)
+        indices = [int(i) for i in cat_stagger]
+        assert max(indices) <= 2, (
+            f"Cat stagger should not exceed nth-child(2) in 3-col layout; found {indices}"
+        )
+        # Old 4-category selectors (nth-child(3) and nth-child(4)) must be gone
+        assert ".ex-cat:nth-child(3)" not in anim_block
+        assert ".ex-cat:nth-child(4)" not in anim_block
+
+
+# ── SQ-13: Sponsor placement (v8 — hero layer) ───────────────────────────────
+
+class TestSponsorSlot:
+    def test_sq13_sponsor_in_hero_layer(self, tpl):
+        """v8: sponsor must use .ex-hero-sponsor class (moved to hero layer)."""
+        html_body = tpl[tpl.rfind("</style>"):]
+        assert 'class="ex-hero-sponsor"' in html_body
+
+    def test_sq13_sponsor_inside_profile_col(self, tpl):
+        """v8: .ex-hero-sponsor must appear inside .ex-profile-col (hero layer, not skills zone)."""
+        html_body = tpl[tpl.rfind("</style>"):]
+        profile_col_idx = html_body.find('class="ex-profile-col"')
+        sponsor_idx = html_body.find('class="ex-hero-sponsor"', profile_col_idx)
+        skill_cats_idx = html_body.find('class="ex-skill-cats"')
+        assert profile_col_idx != -1
+        assert sponsor_idx != -1, ".ex-hero-sponsor not found after .ex-profile-col"
+        # sponsor must come before skill-cats (it's in the hero zone, above the skills zone)
+        assert sponsor_idx < skill_cats_idx, (
+            ".ex-hero-sponsor must be in the hero layer (before .ex-skill-cats), not in the skills zone"
+        )
+
+    def test_sq13_no_ex_sponsor_slot_in_body(self, tpl):
+        """v8: old .ex-sponsor-slot class must be absent — skills zone is fully freed."""
+        html_body = tpl[tpl.rfind("</style>"):]
+        assert 'class="ex-sponsor-slot"' not in html_body
+
+    def test_sq13_sponsor_gated_by_jinja2_condition(self, tpl):
+        """Sponsor block must be gated — no layout break when sponsor_logo_url is absent."""
+        assert "sponsor_logo_url" in tpl
+        assert "{% if sponsor_logo_url" in tpl or "{% if sponsor_logo_url or" in tpl
+
+
+# ── SQ-14: Animated mode gating ───────────────────────────────────────────────
+
+class TestAnimatedModeGating:
+    def test_sq14_animated_mode_jinja2_gate(self, tpl):
+        """@keyframes must only be inside the {% if animated_mode %} block."""
+        assert "{% if animated_mode %}" in tpl
+        assert "@keyframes" in tpl
+        # All @keyframes must be after the animated_mode if block
+        first_keyframe = tpl.find("@keyframes")
+        anim_gate      = tpl.find("{% if animated_mode %}")
+        assert first_keyframe > anim_gate, (
+            "@keyframes appeared before the animated_mode gate — static exports would be affected"
+        )
+
+
+# ── SQ-15: File integrity ─────────────────────────────────────────────────────
+
+class TestFileIntegrity:
+    def test_sq15_file_exists(self):
+        """Template file must exist at expected path."""
+        assert _TPL_PATH.exists(), f"Template not found: {_TPL_PATH}"
+
+    def test_sq15_has_doctype(self, tpl):
+        """Must be a complete HTML document."""
+        assert "<!DOCTYPE html>" in tpl
+
+    def test_sq15_has_ex_card_root(self, tpl):
+        """Root card div with class ex-card must be present."""
+        assert 'class="ex-card"' in tpl
+
+
+# ── SQ-16: Removed v4 artefacts ───────────────────────────────────────────────
+
+class TestRemovedV4Artefacts:
+    def test_sq16_no_logo_host_class_in_html(self, tpl):
+        """ex-cat--logo-host must not appear in HTML (v4 filler pattern removed)."""
+        # Only check the HTML body part (after </style>)
+        html_body = tpl[tpl.rfind("</style>"):]
+        assert "ex-cat--logo-host" not in html_body
+
+    def test_sq16_no_logo_slot_in_html(self, tpl):
+        """ex-logo-slot div must not appear in HTML body (v5 has no empty filler slots)."""
+        html_body = tpl[tpl.rfind("</style>"):]
+        assert 'class="ex-logo-slot"' not in html_body
+
+
+# ── SQ-17/18/19/20: Position landscape panel presence ────────────────────────
+
+class TestPositionMiniPanel:
+    def test_sq17_pos_panel_class_in_html(self, tpl):
+        """v7 landscape panel: .ex-pos-panel-landscape div must be present in the HTML body."""
+        html_body = tpl[tpl.rfind("</style>"):]
+        assert 'class="ex-pos-panel-landscape"' in html_body
+
+    def test_sq18_landscape_pitch_svg_viewbox(self, tpl):
+        """v8: Landscape pitch SVG must use viewBox '0 0 105 68' (real 105m×68m pitch geometry)."""
+        assert 'viewBox="0 0 105 68"' in tpl, (
+            "Landscape SVG must use real pitch geometry viewBox '0 0 105 68', not the old '0 0 100 24'"
+        )
+
+    def test_sq18_old_squashed_viewbox_absent(self, tpl):
+        """v8: Old aspect-squashed viewBox '0 0 100 24' must not be present."""
+        assert 'viewBox="0 0 100 24"' not in tpl
+
+    def test_sq19_position_nodes_in_svg(self, tpl):
+        """SVG rendering must reference position_nodes from template context."""
+        html_body = tpl[tpl.rfind("</style>"):]
+        # position_nodes must be used in the for loop inside the SVG block
+        assert "position_nodes" in html_body
+
+    def test_sq19_coordinate_transform_formula(self, tpl):
+        """v8: SVG must use real-geometry coordinate transform (cx=node.x*105, cy=node.y*68)."""
+        html_body = tpl[tpl.rfind("</style>"):]
+        assert "node.x * 105" in html_body, (
+            "SVG coordinate transform must use node.x * 105 (105m pitch width), not node.x * 100"
+        )
+        assert "node.y * 68" in html_body, (
+            "SVG coordinate transform must use node.y * 68 (68m pitch height), not node.y * 24"
+        )
+
+    def test_sq20_pos_panel_after_skill_categories_3(self, tpl):
+        """Landscape panel must appear after skill_categories[3] (Physical)."""
+        idx_phys  = tpl.rfind("skill_categories[3]")
+        idx_panel = tpl.find('class="ex-pos-panel-landscape"')
+        assert idx_phys > 0 and idx_panel > 0, "Both skill_categories[3] and ex-pos-panel-landscape must be present"
+        assert idx_panel > idx_phys, (
+            "ex-pos-panel-landscape must appear after skill_categories[3]"
+        )
+
+
+# ── SQ-21/22/23/24/25/27: Position panel structural integrity ─────────────────
+
+class TestPositionPanelIntegrity:
+    def test_sq21_column_count_unchanged(self, tpl):
+        """Adding landscape panel must not change column count — still exactly 3 ex-skill-col divs."""
+        matches = re.findall(r'class="ex-skill-col"', tpl)
+        assert len(matches) == 3, (
+            f"Landscape panel must not add a 4th column; found {len(matches)} ex-skill-col divs"
+        )
+
+    def test_sq22_pos_panel_gated_by_position_nodes(self, tpl):
+        """Landscape panel must be inside {% if position_nodes %} guard — graceful when no pos set."""
+        assert "{% if position_nodes %}" in tpl
+        panel_idx = tpl.find('class="ex-pos-panel-landscape"')
+        gate_idx  = tpl.rfind("{% if position_nodes %}", 0, panel_idx)
+        assert gate_idx != -1, "ex-pos-panel-landscape must be inside a {% if position_nodes %} block"
+
+    def test_sq23_pos_svg_explicit_dimensions(self, tpl):
+        """.ex-pos-svg-landscape must define width and height — fills container, no auto-stretch."""
+        svg_rule_start = tpl.find(".ex-pos-svg-landscape {")
+        assert svg_rule_start != -1, ".ex-pos-svg-landscape CSS rule must be defined"
+        svg_rule_end = tpl.find("}", svg_rule_start)
+        svg_rule = tpl[svg_rule_start: svg_rule_end + 1]
+        assert "width:" in svg_rule
+        assert "height:" in svg_rule
+
+    def test_sq24_pos_panel_not_ex_cat(self, tpl):
+        """Landscape panel must NOT use .ex-cat class — immune to cat fade-slide animation."""
+        html_body = tpl[tpl.rfind("</style>"):]
+        assert 'class="ex-pos-panel-landscape"' in html_body
+        assert 'class="ex-cat ex-pos-panel-landscape"' not in html_body
+        assert 'class="ex-pos-panel-landscape ex-cat"' not in html_body
+
+    def test_sq24_pos_panel_animated_mode_self_contained(self, tpl):
+        """In animated_mode block, .ex-pos-panel-landscape gets its own animation rule."""
+        anim_start = tpl.find("{% if animated_mode %}")
+        anim_end   = tpl.find("{% endif %}", anim_start)
+        anim_block = tpl[anim_start: anim_end]
+        assert ".ex-pos-panel-landscape" in anim_block
+        pos_panel_anim = anim_block.find(".ex-pos-panel-landscape {")
+        ex_cat_anim    = anim_block.find(".ex-cat {")
+        assert pos_panel_anim != ex_cat_anim, (
+            ".ex-pos-panel-landscape and .ex-cat must have separate animation rules"
+        )
+
+    def test_sq25_ex_col_right_container_in_html(self, tpl):
+        """v7: .ex-col-right container must be present in HTML body and wrap skill_categories[2]."""
+        html_body = tpl[tpl.rfind("</style>"):]
+        assert 'class="ex-col-right"' in html_body
+        col_right_idx = html_body.find('class="ex-col-right"')
+        cat2_idx      = html_body.find("skill_categories[2]", col_right_idx)
+        assert cat2_idx > col_right_idx, (
+            "skill_categories[2] (Mental) must appear inside .ex-col-right"
+        )
+
+    def test_sq27_no_node_label_in_landscape_svg(self, tpl):
+        """Landscape SVG must not render node.label text — position name is in the hero badge."""
+        html_body = tpl[tpl.rfind("</style>"):]
+        panel_start = html_body.find('class="ex-pos-panel-landscape"')
+        panel_end   = html_body.find("{% endif %}", panel_start)
+        assert panel_start > 0 and panel_end > panel_start
+        svg_block = html_body[panel_start:panel_end]
+        assert "node.label" not in svg_block, (
+            "Landscape SVG must not render node.label — no text labels per design spec"
+        )
+
+
+# ── SQ-28: preserveAspectRatio — v8 undistorted render ───────────────────────
+
+class TestAspectRatioIntegrity:
+    def test_sq28_preserve_aspect_ratio_meet(self, tpl):
+        """v8: landscape SVG must declare preserveAspectRatio='xMidYMid meet' — no stretch, no crop."""
+        html_body = tpl[tpl.rfind("</style>"):]
+        panel_start = html_body.find('class="ex-pos-panel-landscape"')
+        panel_end   = html_body.find("{% endif %}", panel_start)
+        svg_block   = html_body[panel_start:panel_end]
+        assert 'preserveAspectRatio="xMidYMid meet"' in svg_block, (
+            "Landscape SVG must use preserveAspectRatio='xMidYMid meet' to prevent horizontal stretch"
+        )
+
+    def test_sq28_no_stretch_viewbox(self, tpl):
+        """v8: old 100:24 squashed viewBox (artificially flat) must be absent."""
+        assert 'viewBox="0 0 100 24"' not in tpl

--- a/tests/unit/test_square_card.py
+++ b/tests/unit/test_square_card.py
@@ -11,9 +11,11 @@ Coverage:
   SQ-03  Col 1 renders skill_categories[0] (Outfield — 1st column, single cat)
   SQ-04  .ex-col-right renders skill_categories[2] (Mental — nested right panel)
   SQ-05  .ex-col-right renders both skill_categories[1] (Set Pieces) + [3] (Physical)
-  SQ-06  Position badge uses primary_pos_label (not raw player.position snake_case)
-  SQ-07  Secondary position chips container ex-sec-pos-chips present in HTML
-  SQ-08  .ex-sec-pos-chip CSS class defined in stylesheet
+  SQ-06  primary_pos_label referenced in Position Map panel (v9 — photo badges removed)
+         .ex-pos-badge class absent from HTML body
+  SQ-07  Secondary position chips in Position Map panel (ex-pos-secondary-chips)
+         Chips gated by secondary_pos_labels; full list rendered (no artificial slice)
+  SQ-08  .ex-sec-pos-chip CSS class defined in stylesheet (reused in pos panel)
   SQ-09  .ex-cat has no overflow:hidden (content layers must never clip skills)
   SQ-10  .ex-skill-rows has no overflow:hidden
   SQ-11  Animation stagger covers rows 1–19 (Outfield is longest at 19 skills)
@@ -31,11 +33,16 @@ Coverage:
   SQ-20  Landscape panel appears after skill_categories[3] reference
   SQ-21  Column count unchanged: still exactly 3 .ex-skill-col divs with panel added
   SQ-22  Position panel gated by {% if position_nodes %} — graceful empty state
-  SQ-23  .ex-pos-svg-landscape CSS defines width and height (fills container)
+  SQ-23  .ex-pos-svg-landscape CSS defines flex or dimension (fills container)
   SQ-24  Position panel does NOT use .ex-cat class — immune to cat fade-slide animation
   SQ-25  .ex-col-right container present in HTML body, contains skill_categories[2]
   SQ-27  Landscape SVG has no {{ node.label }} text — no labels per user request
   SQ-28  preserveAspectRatio="xMidYMid meet" on landscape SVG — no stretch, no crop (v8)
+  SQ-29  Position Map panel has info column: .ex-pos-info div present — v9
+         .ex-pos-panel-title CSS defined; primary_pos_label in panel context
+  SQ-30  .ex-pos-badge absent from HTML body (photo is clean portrait block) — v9
+         .ex-sec-pos-chips absent from photo column (chips moved to pos panel)
+  SQ-31  No PRIMARY/SECONDARY/OTHER legend in Position Map panel — v9
 """
 from __future__ import annotations
 
@@ -97,35 +104,60 @@ class TestThreeColumnLayout:
         )
 
 
-# ── SQ-06/07/08: Position badge ───────────────────────────────────────────────
+# ── SQ-06/07/08: Position info (v9 — photo badges removed, info in panel) ────
 
 class TestPositionBadge:
-    def test_sq06_uses_primary_pos_label(self, tpl):
-        """Position badge must use primary_pos_label (human-readable), not raw player.position."""
+    def test_sq06_primary_pos_label_referenced(self, tpl):
+        """v9: primary_pos_label must be referenced in the template (Position Map panel)."""
         assert "primary_pos_label" in tpl
 
-    def test_sq06_not_raw_player_position_in_badge(self, tpl):
-        """raw {{ player.position }} must not appear inside the badge div."""
-        # The badge div: search for ex-pos-badge context
-        badge_idx = tpl.find('class="ex-pos-badge"')
-        assert badge_idx != -1
-        # The badge closing tag ends a short block; check no raw snake_case in 200 chars after
-        badge_region = tpl[badge_idx: badge_idx + 300]
-        assert "{{ player.position }}" not in badge_region
+    def test_sq06_no_pos_badge_on_photo(self, tpl):
+        """v9: .ex-pos-badge class must be absent from the HTML body (photo is clean portrait)."""
+        html_body = tpl[tpl.rfind("</style>"):]
+        assert 'class="ex-pos-badge"' not in html_body, (
+            ".ex-pos-badge must not appear in the HTML body — photo badges were removed in v9"
+        )
 
-    def test_sq07_secondary_chips_container_in_html(self, tpl):
-        """ex-sec-pos-chips container must be present in the HTML body."""
-        assert 'class="ex-sec-pos-chips"' in tpl
+    def test_sq06_primary_pos_in_panel_context(self, tpl):
+        """v9: primary_pos_label must appear inside the .ex-pos-panel-landscape block."""
+        html_body = tpl[tpl.rfind("</style>"):]
+        panel_start = html_body.find('class="ex-pos-panel-landscape"')
+        assert panel_start != -1
+        panel_region = html_body[panel_start: panel_start + 1200]
+        assert "primary_pos_label" in panel_region, (
+            "primary_pos_label must be rendered inside .ex-pos-panel-landscape (Position Map)"
+        )
+
+    def test_sq07_secondary_chips_in_pos_panel(self, tpl):
+        """v9: secondary chips container must be in the Position Map panel, not the photo column."""
+        html_body = tpl[tpl.rfind("</style>"):]
+        # Chips container must exist somewhere in the body
+        assert 'class="ex-pos-secondary-chips"' in html_body, (
+            ".ex-pos-secondary-chips must be present inside the Position Map panel"
+        )
+        # Must appear after ex-pos-panel-landscape opens
+        panel_start = html_body.find('class="ex-pos-panel-landscape"')
+        chips_idx   = html_body.find('class="ex-pos-secondary-chips"', panel_start)
+        assert chips_idx > panel_start, (
+            ".ex-pos-secondary-chips must be inside .ex-pos-panel-landscape, not in the photo column"
+        )
+
+    def test_sq07_chips_no_artificial_slice(self, tpl):
+        """v9: secondary_pos_labels loop must not use [:4] slice — domain guarantees max 3."""
+        html_body = tpl[tpl.rfind("</style>"):]
+        panel_start = html_body.find('class="ex-pos-panel-landscape"')
+        panel_region = html_body[panel_start: panel_start + 1200]
+        assert "secondary_pos_labels[:4]" not in panel_region, (
+            "Loop must use full secondary_pos_labels (or [:3] max) — [:4] slice is not allowed"
+        )
+
+    def test_sq07_chips_gated_by_secondary_pos_labels(self, tpl):
+        """Secondary chips must be Jinja2-gated so they only render when list is non-empty."""
+        assert "{% if secondary_pos_labels" in tpl
 
     def test_sq08_sec_pos_chip_css_defined(self, tpl):
-        """CSS class .ex-sec-pos-chip must be defined in the stylesheet."""
+        """.ex-sec-pos-chip CSS must be defined — reused in Position Map panel."""
         assert ".ex-sec-pos-chip" in tpl
-
-    def test_sq07_secondary_chips_gated_by_secondary_pos_labels(self, tpl):
-        """Secondary chips must only render when secondary_pos_labels is defined and truthy."""
-        assert "secondary_pos_labels" in tpl
-        # The guard should be present
-        assert "{% if secondary_pos_labels" in tpl
 
 
 # ── SQ-09/10: No overflow clipping on content layers ─────────────────────────
@@ -327,13 +359,17 @@ class TestPositionPanelIntegrity:
         assert gate_idx != -1, "ex-pos-panel-landscape must be inside a {% if position_nodes %} block"
 
     def test_sq23_pos_svg_explicit_dimensions(self, tpl):
-        """.ex-pos-svg-landscape must define width and height — fills container, no auto-stretch."""
+        """.ex-pos-svg-landscape must define flex or explicit dimension to fill container."""
         svg_rule_start = tpl.find(".ex-pos-svg-landscape {")
         assert svg_rule_start != -1, ".ex-pos-svg-landscape CSS rule must be defined"
         svg_rule_end = tpl.find("}", svg_rule_start)
         svg_rule = tpl[svg_rule_start: svg_rule_end + 1]
-        assert "width:" in svg_rule
-        assert "height:" in svg_rule
+        # v9: flex:1 fills remaining width; OR explicit width/height — either is acceptable
+        has_flex   = "flex:" in svg_rule
+        has_width  = "width:" in svg_rule
+        assert has_flex or has_width, (
+            ".ex-pos-svg-landscape must use flex: or width: to fill the panel"
+        )
 
     def test_sq24_pos_panel_not_ex_cat(self, tpl):
         """Landscape panel must NOT use .ex-cat class — immune to cat fade-slide animation."""
@@ -383,12 +419,99 @@ class TestAspectRatioIntegrity:
         """v8: landscape SVG must declare preserveAspectRatio='xMidYMid meet' — no stretch, no crop."""
         html_body = tpl[tpl.rfind("</style>"):]
         panel_start = html_body.find('class="ex-pos-panel-landscape"')
-        panel_end   = html_body.find("{% endif %}", panel_start)
-        svg_block   = html_body[panel_start:panel_end]
-        assert 'preserveAspectRatio="xMidYMid meet"' in svg_block, (
+        assert panel_start != -1
+        # Scope to the <svg>…</svg> element directly — avoids inner {% endif %} ambiguity
+        svg_open  = html_body.find("<svg", panel_start)
+        svg_close = html_body.find("</svg>", svg_open) + len("</svg>")
+        svg_elem  = html_body[svg_open:svg_close]
+        assert 'preserveAspectRatio="xMidYMid meet"' in svg_elem, (
             "Landscape SVG must use preserveAspectRatio='xMidYMid meet' to prevent horizontal stretch"
         )
 
     def test_sq28_no_stretch_viewbox(self, tpl):
         """v8: old 100:24 squashed viewBox (artificially flat) must be absent."""
         assert 'viewBox="0 0 100 24"' not in tpl
+
+
+# ── SQ-29: Position Map info column presence — v9 ────────────────────────────
+
+class TestPositionMapInfoColumn:
+    def test_sq29_pos_info_div_in_html(self, tpl):
+        """v9: .ex-pos-info div must be present inside .ex-pos-panel-landscape."""
+        html_body = tpl[tpl.rfind("</style>"):]
+        panel_start = html_body.find('class="ex-pos-panel-landscape"')
+        assert panel_start != -1
+        panel_region = html_body[panel_start: panel_start + 1500]
+        assert 'class="ex-pos-info"' in panel_region, (
+            ".ex-pos-info info column must be present inside .ex-pos-panel-landscape"
+        )
+
+    def test_sq29_pos_panel_title_css_defined(self, tpl):
+        """v9: .ex-pos-panel-title CSS rule must be defined for the panel header."""
+        assert ".ex-pos-panel-title" in tpl
+
+    def test_sq29_pos_info_css_defined(self, tpl):
+        """v9: .ex-pos-info CSS rule must be defined."""
+        assert ".ex-pos-info {" in tpl
+
+    def test_sq29_pos_primary_name_css_defined(self, tpl):
+        """v9: .ex-pos-primary-name CSS rule must be defined (gold primary position text)."""
+        assert ".ex-pos-primary-name" in tpl
+
+    def test_sq29_pos_panel_flex_row(self, tpl):
+        """v9: .ex-pos-panel-landscape must use flex-direction: row (info left, SVG right)."""
+        panel_css_start = tpl.find(".ex-pos-panel-landscape {")
+        assert panel_css_start != -1
+        panel_css_end = tpl.find("}", panel_css_start)
+        panel_css = tpl[panel_css_start: panel_css_end + 1]
+        assert "flex-direction: row" in panel_css, (
+            ".ex-pos-panel-landscape must be flex-direction: row in v9"
+        )
+
+
+# ── SQ-30: Photo column is clean portrait block — v9 ─────────────────────────
+
+class TestCleanPhotoColumn:
+    def test_sq30_no_pos_badge_in_body(self, tpl):
+        """v9: .ex-pos-badge class must not appear anywhere in the HTML body."""
+        html_body = tpl[tpl.rfind("</style>"):]
+        assert 'class="ex-pos-badge"' not in html_body, (
+            ".ex-pos-badge removed in v9 — all position info lives in Position Map panel"
+        )
+
+    def test_sq30_no_pos_badge_css(self, tpl):
+        """v9: .ex-pos-badge CSS rule must be absent (class removed entirely)."""
+        assert ".ex-pos-badge {" not in tpl
+
+    def test_sq30_no_photo_sec_chips(self, tpl):
+        """v9: secondary chips must NOT appear inside the photo column block."""
+        html_body = tpl[tpl.rfind("</style>"):]
+        photo_col_start = html_body.find('class="ex-photo-col"')
+        photo_col_end   = html_body.find('class="ex-profile-col"', photo_col_start)
+        assert photo_col_start != -1 and photo_col_end > photo_col_start
+        photo_block = html_body[photo_col_start:photo_col_end]
+        assert 'ex-sec-pos-chip' not in photo_block, (
+            "Position chips must not be in the photo column — they live in Position Map panel"
+        )
+
+
+# ── SQ-31: No legend in Position Map panel — v9 ──────────────────────────────
+
+class TestNoPositionLegend:
+    def test_sq31_no_legend_marker_elements(self, tpl):
+        """v9: Position Map panel must not contain a PRIMARY/SECONDARY/OTHER legend."""
+        html_body = tpl[tpl.rfind("</style>"):]
+        panel_start = html_body.find('class="ex-pos-panel-landscape"')
+        panel_end   = html_body.find("{% endif %}", panel_start)
+        assert panel_start > 0 and panel_end > panel_start
+        panel_block = html_body[panel_start:panel_end]
+        # "OTHER" would only appear as a legend item — its absence confirms no legend
+        assert "OTHER" not in panel_block, (
+            "Position Map panel must not contain a legend — 'OTHER' marker found"
+        )
+
+    def test_sq31_no_legend_css_classes(self, tpl):
+        """v9: legend-specific CSS classes must not be defined."""
+        legend_classes = [".ex-pos-legend", ".ex-legend-item", ".ex-legend-marker"]
+        for cls in legend_classes:
+            assert cls not in tpl, f"Legend CSS class {cls} must not be defined in v9"


### PR DESCRIPTION
## Summary

- **FIFA Classic template**: renders from `self_assessment` skill data via EMA-computed scores; fixed app logo; removed Hungarian copy from Step 7 success screen
- **Export route**: `GET /profile/onboarding-card/export?platform=<platform>` — PNG generation, 6 export sizes (instagram_square, instagram_story, twitter_header, facebook_cover, lfa_platform, print_a4)
- **Platform gallery hub**: `/profile/onboarding-card` now renders a gallery iframe with platform picker and size selector
- **Welcome Card entry point on /profile**: profile page gains a dedicated Welcome Card card linking to the gallery
- **Spec-switch resilience**: `lfa_license` is fetched independently of `active_license` so the Welcome Card section remains visible even after the student switches specialization
- **Platform-aware canvas sizing**: preview iframe corrects alignment and uses platform-specific dimensions

## 8 commits included

| SHA | Description |
|-----|-------------|
| `6b48982` | feat: remove Hungarian copy from Step 7 |
| `1bedb63` | feat: render FIFA Classic preview from self-assessment |
| `fb4edd8` | feat: add export route and platform gallery |
| `1e80b07` | feat: enforce fixed app logo on FIFA templates |
| `245bb8d` | chore: refresh OpenAPI snapshot |
| `c87e364` | feat: add Welcome Card entry point to /profile page |
| `ac9fcfd` | fix: correct preview iframe alignment and platform-aware canvas sizing |
| `4372f55` | feat: spec-switch resilience, platform UI, updated tests |

## Test plan

- [ ] `pytest tests/unit/api/web_routes/test_welcome_card.py -v` — unit tests (no server needed)
- [ ] Visit `/profile/onboarding-card` → platform gallery renders correctly
- [ ] Visit `/profile/onboarding-card/export?platform=instagram_square` → PNG returns
- [ ] Switch specialization → Welcome Card section still visible on /profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)