### PR TITLE
feat(vt): Phase 2.3 — Go / No-Go Reaction game

### DIFF
--- a/app/api/web_routes/public_player.py
+++ b/app/api/web_routes/public_player.py
@@ -302,7 +302,7 @@ def public_player_card(
     _published_platform = _card_draft.published_platform or lfa_license.published_card_platform
     effective_platform = platform or (
         _published_platform
-        if (bool(export) or bool(preview))
+        if bool(export)
         else None
     )
     platform_preset = _get_preset(effective_platform)

--- a/app/api/web_routes/public_player.py
+++ b/app/api/web_routes/public_player.py
@@ -205,44 +205,10 @@ def public_player_card(
     from app.services.card_draft_service import CardDraftService as _CardDraftService
     _card_draft = _CardDraftService.get_player_card_draft(db, user_id=lfa_license.user_id)
 
-    # ── Public profile early return ───────────────────────────────────────────
-    # No ?platform= AND no &export=1 AND no ?preview= AND no ?native_export=1
-    # → human-browseable public link → render read-only profile page.
-    # Playwright always supplies one of: ?platform=…&export=1 OR ?native_export=1.
-    # ?preview= is the editor draft-variant parameter.
-    # All machine callers bypass this early return; only bare human-browseable URLs hit it.
-    if not platform and not export and not preview and not native_export:
-        from app.services.card_constants import CANVAS_SIZES as _CANVAS_SIZES_ALL
-        # Priority: CardDraft.published_platform (written by publish_draft())
-        #         > UserLicense.published_card_platform (legacy pre-4D-1 fallback).
-        # Sentinel guard: "default" has no canvas size and is not a real export platform.
-        _raw_pub_platform = _card_draft.published_platform or lfa_license.published_card_platform
-        _pub_platform = (
-            _raw_pub_platform
-            if (
-                _raw_pub_platform
-                and _raw_pub_platform != "default"
-                and _raw_pub_platform in _CANVAS_SIZES_ALL
-            )
-            else "instagram_portrait"
-        )
-        _pub_dims = _CANVAS_SIZES_ALL[_pub_platform]
-        return templates.TemplateResponse(request, "public/player_card_public.html", {
-            "player_name":       user.name or user.email,
-            "user_id":           user_id,
-            "player": {
-                "position":    position,
-                "nationality": user.nationality,
-            },
-            "overall":           overall,
-            "tier_label":        tier_label,
-            "tier_color":        tier_color,
-            "initials":          initials,
-            "public_platform":   _pub_platform,
-            "public_iframe_src": f"/players/{user_id}/card?platform={_pub_platform}&export=1",
-            "pub_card_w":        _pub_dims[0],
-            "pub_card_h":        _pub_dims[1],
-        })
+    # Bare URL (/players/{id}/card with no params) falls through to the full
+    # interactive FIFA card render below.  The export portrait iframe wrapper
+    # (player_card_public.html) has been retired from this route: the
+    # interactive card already provides a complete, branded, responsive page.
 
     # Teams
     teams_info = []
@@ -270,7 +236,7 @@ def public_player_card(
     # Reads the PUBLISHED snapshot from card_drafts (primary source after 4D-2).
     # Falls back to UserLicense.published_card_* for users who have never visited
     # the editor after the Phase 4D-1 migration (card_drafts row absent).
-    # _card_draft was already fetched above (hoisted for the public profile early return).
+    # _card_draft is fetched above (hoisted before the teams query).
     from app.services.card_theme_service import get_theme as _get_theme, get_all_themes as _get_all_themes
     from app.services.card_variant_service import get_variant as _get_variant
 
@@ -328,11 +294,17 @@ def public_player_card(
 
     # ── Platform preset resolution ────────────────────────────────────────────
     # Precedence: URL ?platform= param > published_card_platform > default.
-    # URL override is used by the editor iframe / Playwright export; human-browseable
-    # "View Public Card" links omit ?platform= so the published state governs.
+    # published_card_platform is only inherited when an explicit export/preview
+    # is requested (?export=1 or ?preview=).  Bare URL and ?native_export=1
+    # resolve to None → "default" preset → export layer stays inactive so the
+    # interactive FIFA card is served (not a Level-C export template).
     from app.services.card_platform_service import get_preset as _get_preset
     _published_platform = _card_draft.published_platform or lfa_license.published_card_platform
-    effective_platform = platform or _published_platform or None
+    effective_platform = platform or (
+        _published_platform
+        if (bool(export) or bool(preview))
+        else None
+    )
     platform_preset = _get_preset(effective_platform)
 
     # ── Export render layer ──────────────────────────────────────────────────

--- a/app/api/web_routes/public_player.py
+++ b/app/api/web_routes/public_player.py
@@ -113,11 +113,22 @@ def public_player_card(
         .all()
     )
     _last_part = _all_parts[0][0] if _all_parts else None
-    last_skill_delta = (
+    _tournament_delta = (
         _last_part.skill_rating_delta
         if _last_part and isinstance(_last_part.skill_rating_delta, dict)
         else {}
     )
+
+    # Merge VT/training deltas as fallback where tournament delta is absent.
+    # Tournament delta takes priority; VT delta only fills gaps.
+    # Threshold: abs(delta) < 0.005 → no trend arrow shown.
+    from app.services.segment_reward_service import get_training_skill_deltas_for_user as _get_vt_deltas
+    _vt_deltas = _get_vt_deltas(db, user_id)
+    _VT_ARROW_THRESHOLD = 0.005
+    last_skill_delta: dict = dict(_tournament_delta)
+    for _sk, _vt_d in _vt_deltas.items():
+        if _sk not in last_skill_delta and abs(_vt_d) >= _VT_ARROW_THRESHOLD:
+            last_skill_delta[_sk] = _vt_d
 
     participations_history = []
     for p, s in _all_parts:

--- a/app/api/web_routes/student_features.py
+++ b/app/api/web_routes/student_features.py
@@ -557,6 +557,40 @@ def _get_tournament_history(db: Session, user_id: int) -> List[dict]:
     return history
 
 
+def _get_vt_event_history(db: Session, user_id: int, limit: int = 20) -> List[dict]:
+    """Return up to `limit` most recent reward-eligible VT attempts for dashboard display.
+
+    Filters: is_valid=True, xp_awarded>0 (equivalent to non-empty skill_deltas).
+    """
+    from ...models.virtual_training import VirtualTrainingAttempt
+
+    rows = (
+        db.query(VirtualTrainingAttempt)
+        .filter(
+            VirtualTrainingAttempt.user_id == user_id,
+            VirtualTrainingAttempt.is_valid == True,
+            VirtualTrainingAttempt.xp_awarded > 0,
+        )
+        .order_by(VirtualTrainingAttempt.started_at.desc())
+        .limit(limit)
+        .all()
+    )
+
+    result = []
+    for a in rows:
+        result.append({
+            "event_type":       "virtual_training",
+            "game_name":        a.game.name if a.game else "Virtual Training",
+            "game_code":        a.game.code if a.game else "color_reaction",
+            "attempt_id":       a.id,
+            "started_at":       a.started_at,
+            "score_normalized": a.score_normalized,
+            "xp_awarded":       a.xp_awarded,
+            "skill_deltas":     dict(a.skill_deltas or {}),
+        })
+    return result
+
+
 # ─── Skill Progression routes ─────────────────────────────────────────────────
 
 @router.get("/skills/data")
@@ -595,6 +629,7 @@ async def skills_page(
         return guard
 
     tournament_history = _get_tournament_history(db, user.id)
+    vt_history = _get_vt_event_history(db, user.id)
     has_lfa_license = (
         db.query(UserLicense)
         .filter(
@@ -613,6 +648,8 @@ async def skills_page(
             "spec_header_class": "hdr-hub",
             **_spec_ctx(user, db),
             "tournament_history": tournament_history,
+            "vt_history": vt_history,
+            "has_any_events": bool(tournament_history or vt_history),
             "has_lfa_license": has_lfa_license,
         },
     )

--- a/app/api/web_routes/virtual_training.py
+++ b/app/api/web_routes/virtual_training.py
@@ -263,6 +263,219 @@ async def virtual_training_color_reaction_result(
     )
 
 
+# ── Go / No-Go Reaction game page ────────────────────────────────────────────
+
+@router.get("/virtual-training/go-no-go", response_class=HTMLResponse)
+async def virtual_training_go_no_go(
+    request: Request,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user_web),
+):
+    """Go / No-Go Reaction game page — instructions + Vanilla JS game loop."""
+    guard = require_student_onboarding(user)
+    if guard:
+        return guard
+
+    game = VirtualTrainingService.get_game(db, "go_no_go")
+    if game is None or not game.is_active:
+        all_games = VirtualTrainingService.get_hub_games(db)
+        return templates.TemplateResponse(
+            "virtual_training_hub.html",
+            {
+                "request": request,
+                "user": user,
+                **_spec_ctx(user, db),
+                "all_games": all_games,
+                "error": "Go / No-Go Reaction is not available at this time.",
+            },
+        )
+
+    today_start = datetime.combine(
+        datetime.now(timezone.utc).date(),
+        datetime.min.time(),
+    ).replace(tzinfo=timezone.utc)
+    attempts_today = (
+        db.query(VirtualTrainingAttempt)
+        .filter(
+            VirtualTrainingAttempt.user_id == user.id,
+            VirtualTrainingAttempt.game_id == game.id,
+            VirtualTrainingAttempt.started_at >= today_start,
+            VirtualTrainingAttempt.is_valid == True,  # noqa: E712
+        )
+        .count()
+    )
+
+    return templates.TemplateResponse(
+        "virtual_training_go_no_go.html",
+        {
+            "request": request,
+            "user": user,
+            **_spec_ctx(user, db),
+            "game": game,
+            "attempts_today": attempts_today,
+            "max_daily_attempts": game.max_daily_attempts,
+            "attempts_remaining": max(0, game.max_daily_attempts - attempts_today),
+        },
+    )
+
+
+# ── Go / No-Go submit (JSON API) ──────────────────────────────────────────────
+
+@router.post("/virtual-training/go-no-go/submit")
+async def virtual_training_go_no_go_submit(
+    request: Request,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user_web),
+):
+    """Record a Go / No-Go Reaction attempt. Returns attempt_id, xp_awarded, is_valid."""
+    guard = require_student_onboarding(user)
+    if guard:
+        return JSONResponse({"error": "onboarding required"}, status_code=403)
+
+    game = VirtualTrainingService.get_game(db, "go_no_go")
+    if game is None or not game.is_active:
+        return JSONResponse({"error": "game not available"}, status_code=404)
+
+    body = await request.json()
+
+    today_start = datetime.combine(
+        datetime.now(timezone.utc).date(),
+        datetime.min.time(),
+    ).replace(tzinfo=timezone.utc)
+    valid_today = (
+        db.query(VirtualTrainingAttempt)
+        .filter(
+            VirtualTrainingAttempt.user_id == user.id,
+            VirtualTrainingAttempt.game_id == game.id,
+            VirtualTrainingAttempt.started_at >= today_start,
+            VirtualTrainingAttempt.is_valid == True,  # noqa: E712
+        )
+        .count()
+    )
+    if valid_today >= game.max_daily_attempts:
+        return JSONResponse(
+            {"error": "daily_cap", "message": "Daily attempt limit reached for this game."},
+            status_code=429,
+        )
+
+    started_at_raw = body.get("started_at", "")
+    idem_key = f"vt_gng_u{user.id}_{started_at_raw}"
+
+    attempt = VirtualTrainingService.record_attempt(
+        db=db,
+        user_id=user.id,
+        game=game,
+        data=body,
+        idempotency_key=idem_key,
+    )
+
+    db.commit()
+
+    return JSONResponse({
+        "attempt_id": attempt.id,
+        "is_valid": attempt.is_valid,
+        "invalid_reason": attempt.invalid_reason,
+        "xp_awarded": attempt.xp_awarded,
+        "skill_deltas": attempt.skill_deltas,
+        "attempt_index_today": attempt.attempt_index_today,
+        "score_normalized": attempt.score_normalized,
+    })
+
+
+# ── Go / No-Go result page ────────────────────────────────────────────────────
+
+@router.get("/virtual-training/go-no-go/result/{attempt_id}",
+            response_class=HTMLResponse)
+async def virtual_training_go_no_go_result(
+    attempt_id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user_web),
+):
+    """Result screen for a completed Go / No-Go Reaction attempt."""
+    guard = require_student_onboarding(user)
+    if guard:
+        return guard
+
+    attempt = (
+        db.query(VirtualTrainingAttempt)
+        .filter(
+            VirtualTrainingAttempt.id == attempt_id,
+            VirtualTrainingAttempt.user_id == user.id,
+        )
+        .first()
+    )
+    if attempt is None:
+        all_games = VirtualTrainingService.get_hub_games(db)
+        return templates.TemplateResponse(
+            "virtual_training_hub.html",
+            {
+                "request": request,
+                "user": user,
+                **_spec_ctx(user, db),
+                "all_games": all_games,
+                "error": "Attempt not found.",
+            },
+        )
+
+    game = db.query(VirtualTrainingGame).filter(
+        VirtualTrainingGame.id == attempt.game_id
+    ).first()
+
+    # Skill delta breakdown — recompute per-skill scores from stored fields
+    skill_scores: dict = {}
+    signals_ctx: dict = {}
+    if attempt.skill_deltas and game is not None:
+        from ...services.virtual_training_metrics import VTSignalExtractor, VTSkillScorer
+        cfg          = game.config or {}
+        phase_config = cfg.get("phases", []) if isinstance(cfg, dict) else []
+        data_for_signals = {
+            "stimuli_count":     attempt.stimuli_count,
+            "correct_count":     attempt.correct_count,
+            "wrong_click_count": attempt.wrong_click_count,
+            "error_count":       attempt.error_count,
+            "avg_reaction_ms":   attempt.avg_reaction_ms,
+            "raw_metrics":       attempt.raw_metrics,
+        }
+        signals = VTSignalExtractor.extract(data_for_signals, phase_config)
+        skill_scores = VTSkillScorer.score_all(signals, game.skill_targets or {})
+        signals_ctx = {
+            "hit_rate":        round(signals.hit_rate * 100, 1),
+            "wrong_rate":      round(signals.wrong_rate * 100, 1),
+            "miss_rate":       round(signals.miss_rate * 100, 1),
+            "speed_score":     round(signals.speed_score * 100, 1),
+            "completion_rate": round(signals.completion_rate * 100, 1),
+            "avg_reaction_ms": signals.avg_reaction_ms,
+        }
+
+    # Decompose raw_metrics — per_phase and per_stimulus (no per_color for Go/No-Go)
+    per_phase: list = []
+    per_stimulus: list = []
+    raw = attempt.raw_metrics
+    if isinstance(raw, dict) and raw.get("v") == 1:
+        per_phase    = raw.get("per_phase")    or []
+        per_stimulus = raw.get("per_stimulus") or []
+
+    from ...models.user import UserRole
+    is_admin = user.role == UserRole.ADMIN
+
+    return templates.TemplateResponse(
+        "virtual_training_go_no_go_result.html",
+        {
+            "request": request,
+            "user": user,
+            **_spec_ctx(user, db),
+            "attempt": attempt,
+            "game": game,
+            "skill_scores": skill_scores,
+            "signals_ctx":  signals_ctx,
+            "per_phase":     per_phase,
+            "per_stimulus":  per_stimulus,
+            "is_admin":      is_admin,
+        },
+    )
+
+
 # ── History ───────────────────────────────────────────────────────────────────
 
 @router.get("/virtual-training/history", response_class=HTMLResponse)

--- a/app/services/segment_reward_service.py
+++ b/app/services/segment_reward_service.py
@@ -359,3 +359,34 @@ def get_training_session_count_for_user(
         .scalar()
         or 0
     )
+
+
+def get_vt_attempt_count_per_skill_for_user(
+    db: Session,
+    user_id: int,
+) -> dict[str, int]:
+    """
+    Return per-skill count of reward-eligible VT attempts that produced a delta
+    for each skill key.
+
+    Only counts attempts where is_valid=True and xp_awarded>0 (i.e. skill_deltas
+    is non-empty). Counts are per-skill (not global): a user who played 2 GNG
+    attempts affecting decisions/reactions gets {decisions: 2, reactions: 2}.
+
+    Used by get_skill_profile() to populate training_vt_count per skill.
+    """
+    rows = db.execute(
+        text(
+            """
+            SELECT kv.key, COUNT(*) AS cnt
+            FROM virtual_training_attempts vta,
+                 jsonb_each_text(vta.skill_deltas) AS kv(key, value)
+            WHERE vta.user_id = :uid
+              AND vta.is_valid = true
+              AND vta.xp_awarded > 0
+            GROUP BY kv.key
+            """
+        ),
+        {"uid": user_id},
+    ).fetchall()
+    return {row[0]: int(row[1]) for row in rows}

--- a/app/services/skill_progression/_views.py
+++ b/app/services/skill_progression/_views.py
@@ -137,11 +137,11 @@ def get_skill_profile(db: Session, user_id: int) -> Dict[str, any]:
         tournament_delta = data["contribution"]
         training_delta_raw = training_deltas.get(skill_key, 0.0)
         training_delta = round(training_delta_raw, 1)
-        current_level = min(
-            MAX_SKILL_CAP,
-            max(MIN_SKILL_VALUE, data["current_value"] + training_delta),
+        current_level = round(
+            min(MAX_SKILL_CAP, max(MIN_SKILL_VALUE, data["current_value"] + training_delta_raw)),
+            2,
         )
-        total_delta = round(tournament_delta + training_delta, 1)
+        total_delta = round(tournament_delta + training_delta_raw, 2)
 
         # Determine tier
         tier, tier_emoji = get_skill_tier(current_level)

--- a/app/services/skill_progression/_views.py
+++ b/app/services/skill_progression/_views.py
@@ -39,6 +39,7 @@ from ._ema_engine import calculate_tournament_skill_contribution
 from app.services.segment_reward_service import (
     get_training_skill_deltas_for_user,
     get_training_session_count_for_user,
+    get_vt_attempt_count_per_skill_for_user,
 )
 
 
@@ -119,6 +120,7 @@ def get_skill_profile(db: Session, user_id: int) -> Dict[str, any]:
     # Training contributions (additive on top of EMA; EMA state is not touched)
     training_deltas = get_training_skill_deltas_for_user(db, user_id)
     training_session_count = get_training_session_count_for_user(db, user_id)
+    vt_counts_per_skill = get_vt_attempt_count_per_skill_for_user(db, user_id)
 
     # Build skill profile
     skill_profile = {}
@@ -133,7 +135,8 @@ def get_skill_profile(db: Session, user_id: int) -> Dict[str, any]:
         })
 
         tournament_delta = data["contribution"]
-        training_delta = round(training_deltas.get(skill_key, 0.0), 1)
+        training_delta_raw = training_deltas.get(skill_key, 0.0)
+        training_delta = round(training_delta_raw, 1)
         current_level = min(
             MAX_SKILL_CAP,
             max(MIN_SKILL_VALUE, data["current_value"] + training_delta),
@@ -149,6 +152,8 @@ def get_skill_profile(db: Session, user_id: int) -> Dict[str, any]:
             "total_delta": total_delta,
             "tournament_delta": tournament_delta,
             "training_delta": training_delta,
+            "training_delta_precise": round(training_delta_raw, 2),
+            "training_vt_count": vt_counts_per_skill.get(skill_key, 0),
             "assessment_delta": round(assessed_map.get(skill_key, data["baseline"]) - data["baseline"], 1),
             "tournament_count": data["tournament_count"],
             "assessment_count": assessed_count_map.get(skill_key, 0),

--- a/app/services/skill_progression/_views.py
+++ b/app/services/skill_progression/_views.py
@@ -210,6 +210,8 @@ def _collect_vt_timeline_events(db: Session, user_id: int, skill_key: str) -> Li
             "placement_skill": None,
             "skill_weight":    None,
             # VH-01..03: attempt detail fields for Skill History expand row
+            # game_code used by skill_history.html to build the result URL dynamically
+            "game_code":           attempt.game.code if attempt.game else "color_reaction",
             "attempt_id":          attempt.id,
             "score_normalized":    attempt.score_normalized,
             "xp_awarded":          attempt.xp_awarded,

--- a/app/services/virtual_training_metrics.py
+++ b/app/services/virtual_training_metrics.py
@@ -4,8 +4,8 @@ Virtual Training Metrics — Phase 2.2 (Performance-based Skill Delta)
 Three-layer pipeline replacing the old XP-based compute_skill_deltas():
 
   VTSignalExtractor  → normalised signals from aggregate payload fields
-  VTSkillScorer      → per-skill score 0–1 from signals
-  VTDeltaComputer    → additive skill deltas from scores
+  VTSkillScorer      → per-skill score 0–1 (or negative) from signals
+  VTDeltaComputer    → additive skill deltas from scores (positive or negative)
 
 Design constraints:
   - Works from aggregate DB fields alone; raw_metrics enriches but is optional
@@ -13,10 +13,27 @@ Design constraints:
   - XP computation stays in VirtualTrainingService (fully decoupled)
   - Immutability: past attempt rows keep their old skill_deltas unchanged
 
+Scoring model (Phase 2.4 — bidirectional deltas):
+  Scorers return a value in (-∞, 1.0].  The lower clamp was intentionally
+  removed so that very weak performance can produce a negative delta.
+
+  Delta model uses a neutral zone:
+    score ≥ NEUTRAL_THRESHOLD (0.45)  → positive delta (performance × multiplier)
+    0 ≤ score < NEUTRAL_THRESHOLD     → small negative delta (below-threshold × NEG_SCALE × multiplier)
+    score < 0                         → negative delta (raw score × NEG_SCALE × multiplier)
+
+  NEG_SCALE = 0.5 keeps the negative direction half as intense as positive.
+  A per-skill per-user per-day cap of −0.5 limits cumulative daily loss.
+
+  reactions and anticipation scorers are always ≥ 0 (component structure),
+  so they never produce negative deltas in practice.
+
+  Invalid attempts and attempts 4+ always produce zero skill deltas.
+
 Calibration note:
   At perfect performance (score=1.0, attempt_index=1) the total delta across
   all skills equals base_xp / _DEFAULT_XP_PER_POINT — identical to the old
-  formula maximum. Poor performance now yields proportionally lower deltas.
+  formula maximum. Poor performance now yields negative deltas per skill.
 """
 from __future__ import annotations
 
@@ -24,6 +41,14 @@ from dataclasses import dataclass
 from typing import Optional
 
 _DEFAULT_XP_PER_POINT: int = 10   # mirrors segment_reward_service constant
+
+# ── Bidirectional delta calibration constants ─────────────────────────────────
+# score below this threshold → negative delta instead of positive
+_NEUTRAL_THRESHOLD: float = 0.45
+# negative delta intensity relative to an equivalent positive (50%)
+_NEG_SCALE:         float = 0.50
+# maximum cumulative negative delta per skill per user per UTC calendar day
+_DAILY_NEG_CAP:     float = -0.50
 
 
 # ── Signal dataclass ──────────────────────────────────────────────────────────
@@ -117,20 +142,20 @@ class VTSkillScorer:
         """
         Decision accuracy under Stroop interference.
         Wrong clicks penalised 1.5× (active error) vs misses (omission).
-          decisions = clamp(hit_rate − 1.5 × wrong_rate, 0, 1)
+          decisions = min(1.0, hit_rate − 1.5 × wrong_rate)
+        Range: (−∞, 1.0] — negative when false alarms dominate hits.
         """
-        score = signals.hit_rate - 1.5 * signals.wrong_rate
-        return max(0.0, min(1.0, score))
+        return min(1.0, signals.hit_rate - 1.5 * signals.wrong_rate)
 
     @staticmethod
     def score_concentration(signals: VTSignals) -> float:
         """
         Sustained-attention proxy.
         Misses penalised 2× because ignoring a stimulus is a full attention lapse.
-          concentration = clamp(1 − 2 × miss_rate, 0, 1)
+          concentration = min(1.0, 1 − 2 × miss_rate)
+        Range: (−∞, 1.0] — negative when miss_rate > 0.5.
         """
-        score = 1.0 - 2.0 * signals.miss_rate
-        return max(0.0, min(1.0, score))
+        return min(1.0, 1.0 - 2.0 * signals.miss_rate)
 
     @staticmethod
     def score_anticipation(signals: VTSignals) -> float:
@@ -161,14 +186,14 @@ class VTSkillScorer:
         Commission errors (acting when you should not) are the primary failure
         mode of a Go/No-Go task, so penalty weight mirrors score_decisions.
 
-          composure = clamp(1.0 − 1.5 × wrong_rate, 0, 1)
+          composure = min(1.0, 1.0 − 1.5 × wrong_rate)
 
         wrong_rate = wrong_click_count / stimuli_count
         At zero false alarms: composure = 1.0 (perfect impulse control).
-        At wrong_rate ≥ 0.67: composure = 0.0 (no impulse control shown).
+        At wrong_rate = 0.67: composure = 0.0 (neutral boundary).
+        Range: (−∞, 1.0] — negative when wrong_rate > 0.67.
         """
-        score = 1.0 - 1.5 * signals.wrong_rate
-        return max(0.0, min(1.0, score))
+        return min(1.0, 1.0 - 1.5 * signals.wrong_rate)
 
     @staticmethod
     def score_all(signals: VTSignals, skill_targets: dict[str, float]) -> dict[str, float]:
@@ -196,27 +221,36 @@ class VTSkillScorer:
 # ── Layer 3: Delta computation ────────────────────────────────────────────────
 
 class VTDeltaComputer:
-    """Convert per-skill scores to additive skill deltas."""
+    """Convert per-skill scores to additive skill deltas (positive or negative)."""
 
     @staticmethod
     def compute(
-        scores:        dict[str, float],
-        skill_targets: dict[str, float],
-        base_xp:       int,
-        multiplier:    float,
+        scores:             dict[str, float],
+        skill_targets:      dict[str, float],
+        base_xp:            int,
+        multiplier:         float,
+        existing_neg_today: dict[str, float] | None = None,
     ) -> dict[str, float]:
         """
         Compute per-skill additive deltas from performance scores.
 
-        Formula:
-            delta(skill) = score(skill)
-                           × (weight(skill) / Σ weights)
-                           × (base_xp / _DEFAULT_XP_PER_POINT)
-                           × multiplier
+        Positive delta formula (score ≥ NEUTRAL_THRESHOLD):
+            delta = score × (weight / Σweights) × base_max × multiplier
+
+        Negative delta formula (score < NEUTRAL_THRESHOLD):
+            score ≥ 0: delta = (score − NEUTRAL_THRESHOLD) × NEG_SCALE × unit × multiplier
+            score < 0: delta = score × NEG_SCALE × unit × multiplier
+        where unit = (weight / Σweights) × base_max
+
+        The multiplier applies to both directions (attempt-index fairness).
+        A per-skill daily cap of _DAILY_NEG_CAP (−0.5) limits cumulative loss.
+
+        existing_neg_today: {skill: sum_of_neg_deltas_already_stored_today}
+          — passed by VirtualTrainingService.record_attempt() before writing.
+          — omit (None) in pure-formula unit tests.
 
         Calibration: at score=1.0, multiplier=1.0, sum_weights=1.0 the total
-        delta equals base_xp / _DEFAULT_XP_PER_POINT — same ceiling as the
-        old XP-only formula, now scaled by actual performance.
+        delta equals base_xp / _DEFAULT_XP_PER_POINT — same ceiling as before.
         """
         if not scores or multiplier <= 0:
             return {}
@@ -225,13 +259,32 @@ class VTDeltaComputer:
         if sum_weights <= 0:
             return {}
 
-        base_max = base_xp / _DEFAULT_XP_PER_POINT
+        base_max        = base_xp / _DEFAULT_XP_PER_POINT
+        existing_neg    = existing_neg_today or {}
 
         result: dict[str, float] = {}
         for skill, score in scores.items():
             weight = skill_targets.get(skill, 0.0)
-            delta  = round(score * (weight / sum_weights) * base_max * multiplier, 4)
-            if delta > 0:
+            unit   = (weight / sum_weights) * base_max  # max per-skill at score=1.0
+
+            if score >= _NEUTRAL_THRESHOLD:
+                delta = round(score * unit * multiplier, 4)
+            elif score >= 0.0:
+                # below neutral, still non-negative raw score → small negative
+                delta = round((score - _NEUTRAL_THRESHOLD) * _NEG_SCALE * unit * multiplier, 4)
+            else:
+                # raw score below zero (e.g. decisions = hit_rate − 1.5×wrong_rate < 0)
+                delta = round(score * _NEG_SCALE * unit * multiplier, 4)
+
+            # Apply daily negative cap (write-time enforcement)
+            if delta < 0:
+                current_neg = existing_neg.get(skill, 0.0)
+                if current_neg <= _DAILY_NEG_CAP:
+                    delta = 0.0  # cap already reached today
+                else:
+                    delta = max(delta, _DAILY_NEG_CAP - current_neg)
+
+            if delta != 0:
                 result[skill] = delta
 
         return result
@@ -240,9 +293,10 @@ class VTDeltaComputer:
 # ── Entry point used by VirtualTrainingService ────────────────────────────────
 
 def compute_vt_skill_deltas(
-    data:       dict,
-    game,              # VirtualTrainingGame ORM object
-    multiplier: float,
+    data:               dict,
+    game,                           # VirtualTrainingGame ORM object
+    multiplier:         float,
+    existing_neg_today: dict[str, float] | None = None,
 ) -> dict[str, float]:
     """
     Full three-layer pipeline: extract → score → compute.
@@ -250,6 +304,10 @@ def compute_vt_skill_deltas(
     Called from VirtualTrainingService.record_attempt() instead of the old
     XP-routed compute_skill_deltas() from segment_reward_service.
     Returns {} on any guard condition (no targets, zero multiplier, etc.).
+
+    existing_neg_today: today's already-stored negative deltas per skill for
+    this user, queried by record_attempt() before calling this function.
+    Pass None (default) in unit tests that test the formula in isolation.
     """
     skill_targets = game.skill_targets or {}
     if not skill_targets or multiplier <= 0:
@@ -260,4 +318,6 @@ def compute_vt_skill_deltas(
 
     signals = VTSignalExtractor.extract(data, phase_config)
     scores  = VTSkillScorer.score_all(signals, skill_targets)
-    return VTDeltaComputer.compute(scores, skill_targets, game.base_xp, multiplier)
+    return VTDeltaComputer.compute(
+        scores, skill_targets, game.base_xp, multiplier, existing_neg_today
+    )

--- a/app/services/virtual_training_metrics.py
+++ b/app/services/virtual_training_metrics.py
@@ -153,17 +153,36 @@ class VTSkillScorer:
         return max(0.0, min(1.0, signals.completion_rate * signals.hit_rate))
 
     @staticmethod
+    def score_composure(signals: VTSignals) -> float:
+        """
+        Impulse control — inverse of false alarm rate.
+
+        In Go/No-Go: wrong_click_count = false alarms (clicks on NO-GO stimuli).
+        Commission errors (acting when you should not) are the primary failure
+        mode of a Go/No-Go task, so penalty weight mirrors score_decisions.
+
+          composure = clamp(1.0 − 1.5 × wrong_rate, 0, 1)
+
+        wrong_rate = wrong_click_count / stimuli_count
+        At zero false alarms: composure = 1.0 (perfect impulse control).
+        At wrong_rate ≥ 0.67: composure = 0.0 (no impulse control shown).
+        """
+        score = 1.0 - 1.5 * signals.wrong_rate
+        return max(0.0, min(1.0, score))
+
+    @staticmethod
     def score_all(signals: VTSignals, skill_targets: dict[str, float]) -> dict[str, float]:
         """
         Score every skill present in skill_targets.
         Known keys dispatch to dedicated scorers.
-        Unknown keys receive the mean of the four known scores (future-proofing).
+        Unknown keys receive the mean of the known scores (future-proofing).
         """
         _scorers = {
             "reactions":     VTSkillScorer.score_reactions,
             "decisions":     VTSkillScorer.score_decisions,
             "concentration": VTSkillScorer.score_concentration,
             "anticipation":  VTSkillScorer.score_anticipation,
+            "composure":     VTSkillScorer.score_composure,
         }
         known = {k: fn(signals) for k, fn in _scorers.items()}
         fallback = sum(known.values()) / len(known) if known else 0.5

--- a/app/services/virtual_training_service.py
+++ b/app/services/virtual_training_service.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from datetime import date, datetime, timezone
 from typing import Optional
 
+from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from app.models.virtual_training import VirtualTrainingAttempt, VirtualTrainingGame
@@ -177,11 +178,32 @@ class VirtualTrainingService:
         multiplier = VirtualTrainingService.calculate_xp_multiplier(attempt_index)
         xp_awarded = VirtualTrainingService.calculate_xp_awarded(game, multiplier) if is_valid else 0
 
-        skill_deltas = (
-            compute_vt_skill_deltas(data=data, game=game, multiplier=multiplier)
-            if is_valid and xp_awarded > 0
-            else {}
-        )
+        if is_valid and xp_awarded > 0:
+            today_start = datetime.combine(date.today(), datetime.min.time()).replace(
+                tzinfo=timezone.utc
+            )
+            neg_rows = db.execute(
+                text(
+                    """
+                    SELECT kv.key, SUM(kv.value::float) AS neg_today
+                    FROM virtual_training_attempts vta,
+                         jsonb_each_text(vta.skill_deltas) AS kv(key, value)
+                    WHERE vta.user_id    = :uid
+                      AND vta.is_valid   = true
+                      AND vta.started_at >= :today_start
+                      AND kv.value::float < 0
+                    GROUP BY kv.key
+                    """
+                ),
+                {"uid": user_id, "today_start": today_start},
+            ).fetchall()
+            existing_neg_today: dict[str, float] = {row.key: row.neg_today for row in neg_rows}
+            skill_deltas = compute_vt_skill_deltas(
+                data=data, game=game, multiplier=multiplier,
+                existing_neg_today=existing_neg_today,
+            )
+        else:
+            skill_deltas = {}
 
         started_at = data.get("started_at")
         if isinstance(started_at, str):

--- a/app/services/virtual_training_service.py
+++ b/app/services/virtual_training_service.py
@@ -19,7 +19,7 @@ from sqlalchemy.orm import Session
 
 from app.models.virtual_training import VirtualTrainingAttempt, VirtualTrainingGame
 
-_XP_MULTIPLIER_TABLE: dict[int, float] = {1: 1.0, 2: 0.6, 3: 0.3}
+_XP_MULTIPLIER_TABLE: dict[int, float] = {1: 1.00, 2: 0.75, 3: 0.50, 4: 0.30, 5: 0.15}
 _BOT_REACTION_THRESHOLD_MS   = 80.0   # Phase 2.1: tighter bot floor (was 100)
 _MIN_DURATION_SECONDS        = 25.0   # Phase 2.1: 36 stimuli × avg ~0.7 s (was 5)
 _MIN_STIMULI_COUNT           = 28     # Phase 2.1: 36 total, allow minor losses (was 5)
@@ -128,12 +128,14 @@ class VirtualTrainingService:
     @staticmethod
     def calculate_xp_multiplier(attempt_index: int) -> float:
         """
-        Diminishing returns multiplier by daily attempt index.
+        Diminishing returns multiplier by daily attempt index (per game).
 
-        Index 1 → 1.0 (full XP)
-        Index 2 → 0.6
-        Index 3 → 0.3
-        Index 4+ → 0.0 (no XP, but attempt still recorded)
+        Index 1 → 1.00 (full XP)
+        Index 2 → 0.75
+        Index 3 → 0.50
+        Index 4 → 0.30
+        Index 5 → 0.15
+        Index 6+ → 0.00 (no XP, no skill delta, no negative penalty)
         """
         return _XP_MULTIPLIER_TABLE.get(attempt_index, 0.0)
 

--- a/app/templates/dashboard_card_editor.html
+++ b/app/templates/dashboard_card_editor.html
@@ -969,7 +969,7 @@
                 <div class="ce-preview-wrap">
                     <iframe id="player-card-iframe"
                             width="1080" height="1350"
-                            src="{% if active_card_platform and active_card_platform != 'default' %}/players/{{ user.id }}/card?preview={{ active_card_variant }}&theme={{ active_card_theme }}&platform={{ active_card_platform }}&export=1{% if active_card_platform in animated_capable_platforms %}&animated=1{% endif %}{% else %}/players/{{ user.id }}/card?preview={{ active_card_variant }}&theme={{ active_card_theme }}&platform=instagram_portrait&export=1{% endif %}"
+                            src="{% if active_card_platform and active_card_platform != 'default' %}/players/{{ user.id }}/card?preview={{ active_card_variant }}&theme={{ active_card_theme }}&platform={{ active_card_platform }}&export=1{% if active_card_platform in animated_capable_platforms %}&animated=1{% endif %}{% else %}/players/{{ user.id }}/card?preview={{ active_card_variant }}&theme={{ active_card_theme }}&native_export=1{% endif %}"
                             scrolling="no" title="My Player Card"></iframe>
                 </div>
             </div>
@@ -1034,7 +1034,7 @@ function _cardIframeSrc() {
     // the editor iframe shows the in-progress draft, not the last-published state.
     // animated=1 on export platforms shows entrance animations in the editor preview.
     if (_currentPlatform === 'default') {
-        return `/players/${_cardUserId}/card?preview=${_currentVariant}&theme=${_currentTheme}&platform=instagram_portrait&export=1&_t=${Date.now()}`;
+        return `/players/${_cardUserId}/card?preview=${_currentVariant}&theme=${_currentTheme}&native_export=1&_t=${Date.now()}`;
     }
     return `/players/${_cardUserId}/card?preview=${_currentVariant}&theme=${_currentTheme}&platform=${_currentPlatform}&export=1&animated=1&_t=${Date.now()}`;
 }
@@ -1045,8 +1045,8 @@ function _applyIframeSize() {
     const wrap   = document.querySelector('.ce-preview-wrap');
     if (!iframe || !stage || !wrap) return;
 
-    // Always resolve 'default' to instagram_portrait for canvas size lookup
-    const platformKey = _currentPlatform === 'default' ? 'instagram_portrait' : _currentPlatform;
+    // 'default' maps to 820×800 (native FIFA card) — same key as CANVAS_SIZES["default"]
+    const platformKey = _currentPlatform || 'default';
     const dims = _CANVAS_SIZES[platformKey];
     if (!dims) return;
     const [cw, ch] = dims;

--- a/app/templates/dashboard_student_new.html
+++ b/app/templates/dashboard_student_new.html
@@ -360,7 +360,7 @@
                     <div class="s-snap-bar-wrap">
                         <div class="s-snap-bar" style="width:${width}%;background:${color};"></div>
                     </div>
-                    <span class="s-snap-val">${s.current_level.toFixed(1)}</span>
+                    <span class="s-snap-val">${s.current_level.toFixed(2)}</span>
                 </div>`;
             }).join('');
 
@@ -398,9 +398,9 @@
             const delta = last.delta_from_previous;
             let deltaHtml = '';
             if (delta !== null && delta !== undefined) {
-                if      (delta >  0.05) deltaHtml = `<span class="s-delta-pos">+${delta.toFixed(1)} ↑</span>`;
-                else if (delta < -0.05) deltaHtml = `<span class="s-delta-neg">${delta.toFixed(1)} ↓</span>`;
-                else                    deltaHtml = `<span class="s-delta-zero">±0</span>`;
+                if      (delta >  0.005) deltaHtml = `<span class="s-delta-pos">+${delta.toFixed(2)} ↑</span>`;
+                else if (delta < -0.005) deltaHtml = `<span class="s-delta-neg">${delta.toFixed(2)} ↓</span>`;
+                else                     deltaHtml = `<span class="s-delta-zero">±0.00</span>`;
             }
 
             const playersInfo = last.total_players

--- a/app/templates/macros/card_skill_row.html
+++ b/app/templates/macros/card_skill_row.html
@@ -46,7 +46,7 @@
 {% macro card_skill_rows(cat, skills_dict, delta_dict) %}
 {% for skill in cat.skills %}
 {% set sdata = skills_dict.get(skill.key, {}) %}
-{% set sval = sdata.get('current_level', 50) | round(1) %}
+{% set sval = sdata.get('current_level', 50) | round(2) %}
 {% set fill_pct = [sval, 100] | min %}
 {% set sdelta = delta_dict.get(skill.key, 0) %}
 {% if sdelta > 0 %}

--- a/app/templates/public/player_card.html
+++ b/app/templates/public/player_card.html
@@ -142,7 +142,7 @@ body.export-mode .events-section { display: none !important; }
 .skill-row { display: flex; align-items: center; gap: 0.35rem; margin-bottom: 0.3rem; }
 .skill-row:last-child { margin-bottom: 0; }
 .skill-name { font-size: 0.62rem; color: rgba(255,255,255,0.6); flex: 1; min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.skill-val { font-size: 0.67rem; font-weight: 700; width: 28px; text-align: right; flex-shrink: 0; }
+.skill-val { font-size: 0.67rem; font-weight: 700; width: 38px; text-align: right; flex-shrink: 0; }
 .skill-up { font-size: 0.6rem; color: #48bb78; font-weight: 900; flex-shrink: 0; line-height: 1; }
 .skill-bar-bg { flex: 0 1 36px; height: 4px; background: rgba(255,255,255,0.08); border-radius: 2px; }
 .skill-bar-fill { height: 100%; border-radius: 2px; }
@@ -349,7 +349,7 @@ body.export-mode .skill-bar-bg  { flex: 1 1 0 !important; max-width: none !impor
                 <div class="skill-cat-name">{{ cat.emoji }} {{ cat.name_en }}</div>
                 {% for skill in cat.skills %}
                 {% set sdata = player.skills.get(skill.key, {}) %}
-                {% set sval = sdata.get('current_level', 50) | round(1) %}
+                {% set sval = sdata.get('current_level', 50) | round(2) %}
                 {% set fill_pct = [sval, 100] | min %}
                 {% set sdelta = last_skill_delta.get(skill.key, 0) %}
                 {# Color driven solely by last-tournament delta, not by level tier.

--- a/app/templates/public/player_card_compact.html
+++ b/app/templates/public/player_card_compact.html
@@ -131,7 +131,7 @@ body { background: var(--card-page-bg); }
 .skill-row { display: flex; align-items: center; gap: 0.3rem; margin-bottom: 0.25rem; }
 .skill-row:last-child { margin-bottom: 0; }
 .skill-name { font-size: 0.62rem; color: var(--card-text-secondary); flex: 1; min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.skill-val { font-size: 0.63rem; font-weight: 700; width: 26px; text-align: right; flex-shrink: 0; }
+.skill-val { font-size: 0.63rem; font-weight: 700; width: 36px; text-align: right; flex-shrink: 0; }
 .skill-up { font-size: 0.58rem; font-weight: 900; flex-shrink: 0; line-height: 1; }
 .skill-bar-bg { flex: 1 1 0; max-width: 44px; height: 4px; background: var(--card-bar-bg); border-radius: 2px; }
 .skill-bar-fill { height: 100%; border-radius: 2px; }
@@ -290,7 +290,7 @@ body.export-mode .skill-val     { font-size: var(--ex-font-skill); }
                 <div class="skill-cat-name">{{ cat.emoji }} {{ cat.name_en }}</div>
                 {% for skill in cat.skills %}
                 {% set sdata = player.skills.get(skill.key, {}) %}
-                {% set sval = sdata.get('current_level', 50) | round(1) %}
+                {% set sval = sdata.get('current_level', 50) | round(2) %}
                 {% set fill_pct = [sval, 100] | min %}
                 {% set sdelta = last_skill_delta.get(skill.key, 0) %}
                 {% if sdelta > 0 %}

--- a/app/templates/public/player_card_compact_bg.html
+++ b/app/templates/public/player_card_compact_bg.html
@@ -138,7 +138,7 @@ body { background: var(--card-page-bg); }
 .skill-row { display: flex; align-items: center; gap: 0.3rem; margin-bottom: 0.25rem; }
 .skill-row:last-child { margin-bottom: 0; }
 .skill-name { font-size: 0.62rem; color: var(--card-text-secondary); flex: 1; min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.skill-val { font-size: 0.63rem; font-weight: 700; width: 26px; text-align: right; flex-shrink: 0; }
+.skill-val { font-size: 0.63rem; font-weight: 700; width: 36px; text-align: right; flex-shrink: 0; }
 .skill-up { font-size: 0.58rem; font-weight: 900; flex-shrink: 0; line-height: 1; }
 .skill-bar-bg { flex: 1 1 0; max-width: 44px; height: 4px; background: var(--card-bar-bg); border-radius: 2px; }
 .skill-bar-fill { height: 100%; border-radius: 2px; }
@@ -274,7 +274,7 @@ body.export-mode .skill-val     { font-size: var(--ex-font-skill); }
                 <div class="skill-cat-name">{{ cat.emoji }} {{ cat.name_en }}</div>
                 {% for skill in cat.skills %}
                 {% set sdata = player.skills.get(skill.key, {}) %}
-                {% set sval = sdata.get('current_level', 50) | round(1) %}
+                {% set sval = sdata.get('current_level', 50) | round(2) %}
                 {% set fill_pct = [sval, 100] | min %}
                 {% set sdelta = last_skill_delta.get(skill.key, 0) %}
                 {% if sdelta > 0 %}

--- a/app/templates/public/player_card_fifa.html
+++ b/app/templates/public/player_card_fifa.html
@@ -167,7 +167,7 @@ div.fifa-avatar {
 .skill-row:last-child { margin-bottom: 0; }
 .skill-name { font-size: 0.62rem; color: var(--card-text-secondary); flex: 1; min-width: 0;
     white-space: nowrap; overflow: hidden; text-overflow: ellipsis; line-height: 1.3; }
-.skill-val { font-size: 0.67rem; font-weight: 700; width: 26px; text-align: right; flex-shrink: 0; }
+.skill-val { font-size: 0.67rem; font-weight: 700; width: 36px; text-align: right; flex-shrink: 0; }
 .skill-up { font-size: 0.6rem; color: #48bb78; font-weight: 900; flex-shrink: 0; line-height: 1; }
 .skill-bar-bg { flex: 0 0 18px; height: 4px; background: var(--card-bar-bg); border-radius: 3px; }
 .skill-bar-fill { height: 100%; border-radius: 2px; }

--- a/app/templates/public/player_card_pulse.html
+++ b/app/templates/public/player_card_pulse.html
@@ -273,7 +273,7 @@ body { background: var(--card-page-bg); font-family: 'DM Mono', 'SF Mono', 'Fira
 .pls-skill-bar-fill { height: 100%; border-radius: 3px; }
 .pls-skill-val {
     font-size: 0.65rem; font-weight: 800;
-    width: 22px; text-align: right; flex-shrink: 0;
+    width: 34px; text-align: right; flex-shrink: 0;
     font-variant-numeric: tabular-nums; letter-spacing: -0.01em;
 }
 .pls-skill-arrow {
@@ -684,7 +684,7 @@ body.export-mode .pls-skill-val  { font-size: var(--ex-font-skill); }
 
             {% for skill in cat.skills %}
             {% set sdata  = player.skills.get(skill.key, {}) %}
-            {% set sval   = sdata.get('current_level', 50) | round(1) %}
+            {% set sval   = sdata.get('current_level', 50) | round(2) %}
             {% set fill   = [sval, 100] | min %}
             {% set sdelta = last_skill_delta.get(skill.key, 0) %}
             {% if sdelta > 0 %}

--- a/app/templates/public/player_card_showcase.html
+++ b/app/templates/public/player_card_showcase.html
@@ -132,7 +132,7 @@ body { background: var(--card-page-bg); }
 .skill-row { display: flex; align-items: center; gap: 0.35rem; margin-bottom: 0.3rem; }
 .skill-row:last-child { margin-bottom: 0; }
 .skill-name { font-size: 0.62rem; color: var(--card-text-secondary); flex: 1; min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.skill-val { font-size: 0.67rem; font-weight: 700; width: 28px; text-align: right; flex-shrink: 0; }
+.skill-val { font-size: 0.67rem; font-weight: 700; width: 38px; text-align: right; flex-shrink: 0; }
 .skill-up { font-size: 0.6rem; font-weight: 900; flex-shrink: 0; line-height: 1; }
 .skill-bar-bg { flex: 1 1 0; max-width: 56px; height: 5px; background: var(--card-bar-bg); border-radius: 3px; }
 .skill-bar-fill { height: 100%; border-radius: 2px; }
@@ -280,7 +280,7 @@ body.export-mode .skill-val   { font-size: var(--ex-font-skill); }
                 <div class="skill-cat-name">{{ cat.emoji }} {{ cat.name_en }}</div>
                 {% for skill in cat.skills %}
                 {% set sdata = player.skills.get(skill.key, {}) %}
-                {% set sval = sdata.get('current_level', 50) | round(1) %}
+                {% set sval = sdata.get('current_level', 50) | round(2) %}
                 {% set fill_pct = [sval, 100] | min %}
                 {% set sdelta = last_skill_delta.get(skill.key, 0) %}
                 {% if sdelta > 0 %}

--- a/app/templates/skill_history.html
+++ b/app/templates/skill_history.html
@@ -574,8 +574,9 @@
         var bestRt  = fmtMs(t.min_reaction_ms);
         var dur     = fmtSec(t.duration_seconds);
         var xp      = t.xp_awarded != null ? '+' + t.xp_awarded + ' XP' : '—';
+        var gameSlug = (t.game_code || 'color-reaction').replace(/_/g, '-');
         var link    = t.attempt_id
-                      ? '<a class="sh-vt-detail-link" href="/virtual-training/color-reaction/result/' + t.attempt_id + '">View full detail →</a>'
+                      ? '<a class="sh-vt-detail-link" href="/virtual-training/' + gameSlug + '/result/' + t.attempt_id + '">View full detail →</a>'
                       : '';
 
         return '<tr class="sh-vt-detail-row" id="' + rowId + '">' +

--- a/app/templates/skills.html
+++ b/app/templates/skills.html
@@ -353,9 +353,9 @@
     }
 
     function deltaHtml(delta) {
-        if (delta > 0.05)  return `<span class="skill-delta-pos">+${delta.toFixed(1)} ↑</span>`;
-        if (delta < -0.05) return `<span class="skill-delta-neg">${delta.toFixed(1)} ↓</span>`;
-        return `<span class="skill-delta-zero">±0</span>`;
+        if (delta > 0.005)  return `<span class="skill-delta-pos">+${delta.toFixed(2)} ↑</span>`;
+        if (delta < -0.005) return `<span class="skill-delta-neg">${delta.toFixed(2)} ↓</span>`;
+        return `<span class="skill-delta-zero">±0.00</span>`;
     }
 
     function trainingMetaHtml(s) {
@@ -444,7 +444,7 @@
                     ${presetBadge}
                 </div>
                 <div class="skill-level-row">
-                    <span class="skill-level">${s.current_level.toFixed(1)}</span>
+                    <span class="skill-level">${s.current_level.toFixed(2)}</span>
                     ${deltaHtml(s.total_delta || 0)}
                 </div>
                 <div class="skill-bar-wrap">

--- a/app/templates/skills.html
+++ b/app/templates/skills.html
@@ -359,15 +359,20 @@
     }
 
     function trainingMetaHtml(s) {
-        const td = s.training_delta || 0;
-        const ts = s.training_sessions || 0;
-        if (ts === 0) return '<span style="color:#bbb;">not trained</span>';
-        const vtLabel = `${ts} VT session${ts !== 1 ? 's' : ''}`;
-        if (Math.abs(td) < 0.05) return `<span style="color:#95a5a6;">${vtLabel}</span>`;
-        const sign  = td > 0 ? '+' : '';
-        const color = td > 0.05 ? '#27ae60' : '#e74c3c';
-        return `<span style="color:${color};">${sign}${td.toFixed(1)} net</span>`
-             + ` <span style="color:#95a5a6;">· ${vtLabel}</span>`;
+        const tdPrecise = s.training_delta_precise != null ? s.training_delta_precise : (s.training_delta || 0);
+        const vtc = s.training_vt_count || 0;
+        const ts  = s.training_sessions || 0;
+        const hasAnyTraining = vtc > 0 || ts > 0 || Math.abs(tdPrecise) >= 0.01;
+        if (!hasAnyTraining) return '<span style="color:#bbb;">not trained</span>';
+        const sessionParts = [];
+        if (ts > 0) sessionParts.push(`${ts} session${ts !== 1 ? 's' : ''}`);
+        if (vtc > 0) sessionParts.push(`${vtc} VT`);
+        const countLabel = sessionParts.join(' · ');
+        if (Math.abs(tdPrecise) < 0.01) return `<span style="color:#95a5a6;">${countLabel}</span>`;
+        const sign  = tdPrecise > 0 ? '+' : '';
+        const color = tdPrecise > 0 ? '#27ae60' : '#e74c3c';
+        return `<span style="color:${color};">${sign}${tdPrecise.toFixed(2)} net</span>`
+             + ` <span style="color:#95a5a6;">· ${countLabel}</span>`;
     }
 
     function renderStats(data) {

--- a/app/templates/skills.html
+++ b/app/templates/skills.html
@@ -264,7 +264,7 @@
                 <tr>
                     <td><strong>{{ vt.game_name }}</strong></td>
                     <td>{{ vt.started_at.strftime('%b %d, %Y') if vt.started_at else '—' }}</td>
-                    <td>{{ "%.0f%%"|format(vt.score_normalized * 100) if vt.score_normalized is not none else '—' }}</td>
+                    <td>{{ (vt.score_normalized | round(0) | int)|string + '%' if vt.score_normalized is not none else '—' }}</td>
                     <td>
                         {% for skill_key, delta in vt.skill_deltas.items() %}
                             {% if delta > 0 %}
@@ -362,12 +362,12 @@
         const td = s.training_delta || 0;
         const ts = s.training_sessions || 0;
         if (ts === 0) return '<span style="color:#bbb;">not trained</span>';
-        const sessLabel = `${ts} session${ts !== 1 ? 's' : ''}`;
-        if (Math.abs(td) < 0.05) return `<span style="color:#95a5a6;">${sessLabel}</span>`;
+        const vtLabel = `${ts} VT session${ts !== 1 ? 's' : ''}`;
+        if (Math.abs(td) < 0.05) return `<span style="color:#95a5a6;">${vtLabel}</span>`;
         const sign  = td > 0 ? '+' : '';
         const color = td > 0.05 ? '#27ae60' : '#e74c3c';
-        return `<span style="color:${color};">${sign}${td.toFixed(1)}</span>`
-             + ` <span style="color:#95a5a6;">· ${sessLabel}</span>`;
+        return `<span style="color:${color};">${sign}${td.toFixed(1)} net</span>`
+             + ` <span style="color:#95a5a6;">· ${vtLabel}</span>`;
     }
 
     function renderStats(data) {

--- a/app/templates/skills.html
+++ b/app/templates/skills.html
@@ -243,7 +243,47 @@
     <div class="history-card">
         <h2>📈 Skill Events &nbsp;<a href="/skills/history" style="font-size:0.75rem;font-weight:500;color:#667eea;text-decoration:none;">📊 Event History Chart →</a></h2>
 
+        {% if has_any_events %}
+
+        {% if vt_history %}
+        <h3 style="margin:0 0 12px;font-size:0.95rem;color:#555;">⚡ Virtual Training</h3>
+        <table class="history-table" style="margin-bottom:28px;">
+            <thead>
+                <tr>
+                    <th>Game</th>
+                    <th>Date</th>
+                    <th>Score</th>
+                    <th>Skill Deltas</th>
+                    <th>XP</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for vt in vt_history %}
+                {% set game_slug = vt.game_code | replace('_', '-') %}
+                <tr>
+                    <td><strong>{{ vt.game_name }}</strong></td>
+                    <td>{{ vt.started_at.strftime('%b %d, %Y') if vt.started_at else '—' }}</td>
+                    <td>{{ "%.0f%%"|format(vt.score_normalized * 100) if vt.score_normalized is not none else '—' }}</td>
+                    <td>
+                        {% for skill_key, delta in vt.skill_deltas.items() %}
+                            {% if delta > 0 %}
+                                <span class="skill-delta-pos" style="margin-right:6px;">+{{ "%.2f"|format(delta) }} {{ skill_key }}</span>
+                            {% elif delta < 0 %}
+                                <span class="skill-delta-neg" style="margin-right:6px;">{{ "%.2f"|format(delta) }} {{ skill_key }}</span>
+                            {% endif %}
+                        {% endfor %}
+                    </td>
+                    <td>+{{ vt.xp_awarded }}</td>
+                    <td><a href="/virtual-training/{{ game_slug }}/result/{{ vt.attempt_id }}" style="color:#667eea;font-size:0.85rem;white-space:nowrap;">View details →</a></td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        {% endif %}
+
         {% if tournament_history %}
+        <h3 style="margin:0 0 12px;font-size:0.95rem;color:#555;">🏆 Tournament Events</h3>
         <table class="history-table">
             <thead>
                 <tr>
@@ -280,6 +320,8 @@
                 {% endfor %}
             </tbody>
         </table>
+        {% endif %}
+
         {% else %}
         <div class="empty-state">
             <div class="empty-icon">📈</div>

--- a/app/templates/virtual_training_go_no_go.html
+++ b/app/templates/virtual_training_go_no_go.html
@@ -1,0 +1,696 @@
+{% extends "student_base.html" %}
+
+{% block title %}Go / No-Go Reaction - LFA{% endblock %}
+{% block active_page %}lfa-player{% endblock %}
+
+{% block student_header %}
+{% set _page_icon = '🛑' %}
+{% set _page_name = 'Go / No-Go Reaction' %}
+{% include "includes/spec_subpage_hdr.html" %}
+{% endblock %}
+
+{% block extra_styles %}
+<style>
+    .gng-container {
+        max-width: 560px;
+        margin: 0 auto;
+        padding: 1.5rem 1rem 3rem;
+    }
+
+    /* ── Meta bar ───────────────────────────────────────────────────────── */
+    .gng-meta {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        background: var(--app-card);
+        border-radius: 10px;
+        padding: 0.65rem 1rem;
+        margin-bottom: 1.25rem;
+        font-size: 0.85rem;
+        color: var(--app-text-muted);
+        box-shadow: 0 1px 6px rgba(0,0,0,0.06);
+    }
+    .gng-meta span { font-weight: 600; color: var(--app-text); }
+
+    /* ── Instruction card ───────────────────────────────────────────────── */
+    .gng-instruction {
+        background: var(--app-card);
+        border-radius: 14px;
+        padding: 1.5rem 1.5rem 1.75rem;
+        box-shadow: 0 2px 10px rgba(0,0,0,0.07);
+        text-align: center;
+        margin-bottom: 1.5rem;
+    }
+    .gng-instruction h2 {
+        font-size: 1.3rem;
+        font-weight: 700;
+        margin: 0 0 0.6rem;
+        color: var(--app-text);
+    }
+    .gng-instruction p {
+        font-size: 0.9rem;
+        color: var(--app-text-muted);
+        line-height: 1.6;
+        margin: 0 0 1.25rem;
+    }
+    .gng-cue-legend {
+        display: flex;
+        justify-content: center;
+        gap: 1.5rem;
+        margin-bottom: 1.25rem;
+    }
+    .gng-cue-item {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 0.4rem;
+    }
+    .gng-cue-circle {
+        width: 56px;
+        height: 56px;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 0.8rem;
+        font-weight: 800;
+        color: #fff;
+        letter-spacing: 0.03em;
+    }
+    .gng-cue-go    { background: #22c55e; }
+    .gng-cue-nogo  { background: #ef4444; }
+    .gng-cue-label {
+        font-size: 0.75rem;
+        font-weight: 700;
+        color: var(--app-text-muted);
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+    }
+    .gng-skill-chips {
+        display: flex;
+        justify-content: center;
+        gap: 0.5rem;
+        flex-wrap: wrap;
+        margin-bottom: 1.25rem;
+    }
+    .gng-skill-chip {
+        font-size: 0.75rem;
+        font-weight: 600;
+        background: #ede9fe;
+        color: #5b21b6;
+        padding: 0.2rem 0.65rem;
+        border-radius: 20px;
+    }
+    .gng-btn-start {
+        display: inline-block;
+        background: #4f46e5;
+        color: #fff;
+        font-size: 1rem;
+        font-weight: 700;
+        padding: 0.8rem 2.5rem;
+        border-radius: 10px;
+        border: none;
+        cursor: pointer;
+        transition: background 0.15s;
+    }
+    .gng-btn-start:hover { background: #4338ca; }
+    .gng-btn-start:disabled {
+        background: #9ca3af;
+        cursor: not-allowed;
+    }
+
+    /* ── Game arena ─────────────────────────────────────────────────────── */
+    .gng-arena {
+        display: none;
+    }
+    .gng-arena.active {
+        display: block;
+    }
+
+    /* ── Progress + timer bar ───────────────────────────────────────────── */
+    .gng-hud {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 0.75rem;
+        font-size: 0.82rem;
+        color: var(--app-text-muted);
+        font-weight: 600;
+    }
+    .gng-progress-wrap {
+        background: #e5e7eb;
+        border-radius: 6px;
+        height: 6px;
+        margin-bottom: 1rem;
+        overflow: hidden;
+    }
+    .gng-progress-bar {
+        height: 100%;
+        background: #4f46e5;
+        border-radius: 6px;
+        transition: width 0.2s ease;
+        width: 0%;
+    }
+
+    /* ── Counters row ───────────────────────────────────────────────────── */
+    .gng-counters {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 0.5rem;
+        margin-bottom: 1rem;
+    }
+    .gng-counter {
+        background: var(--app-card);
+        border-radius: 10px;
+        padding: 0.6rem 0.5rem;
+        text-align: center;
+        box-shadow: 0 1px 4px rgba(0,0,0,0.05);
+    }
+    .gng-counter-label {
+        font-size: 0.65rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: var(--app-text-muted);
+        margin-bottom: 0.2rem;
+    }
+    .gng-counter-value {
+        font-size: 1.1rem;
+        font-weight: 800;
+        color: var(--app-text);
+    }
+    .gng-counter-value.hit-color   { color: #16a34a; }
+    .gng-counter-value.miss-color  { color: #d97706; }
+    .gng-counter-value.hold-color  { color: #2563eb; }
+    .gng-counter-value.alarm-color { color: #dc2626; }
+
+    /* ── Stimulus field ─────────────────────────────────────────────────── */
+    .gng-field {
+        background: var(--app-card);
+        border-radius: 16px;
+        box-shadow: 0 2px 14px rgba(0,0,0,0.09);
+        min-height: 240px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        margin-bottom: 1rem;
+        position: relative;
+        overflow: hidden;
+        cursor: pointer;
+        user-select: none;
+        -webkit-user-select: none;
+    }
+    .gng-field:active { transform: scale(0.99); }
+
+    .gng-stimulus {
+        display: none;
+        flex-direction: column;
+        align-items: center;
+        gap: 0.75rem;
+    }
+    .gng-stimulus.visible { display: flex; }
+
+    .gng-stim-circle {
+        width: 120px;
+        height: 120px;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 1.4rem;
+        font-weight: 900;
+        color: #fff;
+        letter-spacing: 0.05em;
+        transition: transform 0.08s ease;
+    }
+    .gng-stim-circle.pressed { transform: scale(0.93); }
+
+    .gng-stim-label {
+        font-size: 0.72rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--app-text-muted);
+    }
+
+    .gng-field-idle {
+        font-size: 0.9rem;
+        color: var(--app-text-muted);
+        font-weight: 600;
+    }
+
+    /* ── Feedback flash ─────────────────────────────────────────────────── */
+    .gng-feedback {
+        position: absolute;
+        top: 12px;
+        left: 50%;
+        transform: translateX(-50%);
+        font-size: 0.82rem;
+        font-weight: 800;
+        padding: 0.25rem 0.85rem;
+        border-radius: 20px;
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.15s;
+        white-space: nowrap;
+    }
+    .gng-feedback.show { opacity: 1; }
+    .gng-feedback.fb-hit   { background: #dcfce7; color: #166534; }
+    .gng-feedback.fb-miss  { background: #fef3c7; color: #92400e; }
+    .gng-feedback.fb-hold  { background: #dbeafe; color: #1e40af; }
+    .gng-feedback.fb-alarm { background: #fee2e2; color: #991b1b; }
+
+    /* ── Submitting overlay ─────────────────────────────────────────────── */
+    .gng-submitting {
+        display: none;
+        text-align: center;
+        padding: 3rem 1rem;
+        background: var(--app-card);
+        border-radius: 16px;
+        box-shadow: 0 2px 14px rgba(0,0,0,0.09);
+        color: var(--app-text-muted);
+        font-size: 0.95rem;
+        font-weight: 600;
+    }
+    .gng-submitting.active { display: block; }
+    .gng-submitting p { margin: 0.5rem 0 0; }
+</style>
+{% endblock %}
+
+{% block student_content %}
+<div class="gng-container">
+
+    {# ── Meta bar ─────────────────────────────────────────────────────────── #}
+    <div class="gng-meta">
+        <div>Today: <span>{{ attempts_today }} / {{ max_daily_attempts }}</span> attempts</div>
+        <div>Remaining: <span>{{ attempts_remaining }}</span></div>
+    </div>
+
+    {# ── Daily cap reached ────────────────────────────────────────────────── #}
+    {% if attempts_remaining == 0 %}
+    <div style="background:#fef3c7;border:1px solid #f59e0b;border-radius:12px;padding:1rem 1.25rem;text-align:center;margin-bottom:1.25rem;color:#92400e;font-weight:600;font-size:0.9rem;">
+        Daily limit reached. Come back tomorrow to earn XP again.
+    </div>
+    {% endif %}
+
+    {# ── Instruction screen (pre-game) ────────────────────────────────────── #}
+    <div class="gng-instruction" id="gngInstruction">
+        <h2>🛑 Go / No-Go Reaction</h2>
+        <p>
+            React <strong>as fast as possible</strong> to GO signals.<br>
+            <strong>Do NOT click</strong> when you see NO-GO. Impulse control matters.
+        </p>
+
+        <div class="gng-cue-legend">
+            <div class="gng-cue-item">
+                <div class="gng-cue-circle gng-cue-go">GO</div>
+                <div class="gng-cue-label">Click!</div>
+            </div>
+            <div class="gng-cue-item">
+                <div class="gng-cue-circle gng-cue-nogo">STOP</div>
+                <div class="gng-cue-label">Hold!</div>
+            </div>
+        </div>
+
+        <div class="gng-skill-chips">
+            {% for skill in game.skill_targets %}
+            <span class="gng-skill-chip">{{ skill }}</span>
+            {% endfor %}
+        </div>
+
+        <button class="gng-btn-start" id="gngBtnStart"
+            {% if attempts_remaining == 0 %}disabled{% endif %}>
+            ▶ Start Game
+        </button>
+    </div>
+
+    {# ── Game arena ───────────────────────────────────────────────────────── #}
+    <div class="gng-arena" id="gngArena">
+
+        <div class="gng-hud">
+            <span id="gngProgress">0 / {{ (game.config.phases | sum(attribute='go') + game.config.phases | sum(attribute='no_go')) }}</span>
+            <span id="gngTimer">0s</span>
+        </div>
+        <div class="gng-progress-wrap">
+            <div class="gng-progress-bar" id="gngProgressBar"></div>
+        </div>
+
+        <div class="gng-counters">
+            <div class="gng-counter">
+                <div class="gng-counter-label">Hit</div>
+                <div class="gng-counter-value hit-color" id="gngHit">0</div>
+            </div>
+            <div class="gng-counter">
+                <div class="gng-counter-label">Miss</div>
+                <div class="gng-counter-value miss-color" id="gngMiss">0</div>
+            </div>
+            <div class="gng-counter">
+                <div class="gng-counter-label">Good Hold</div>
+                <div class="gng-counter-value hold-color" id="gngHold">0</div>
+            </div>
+            <div class="gng-counter">
+                <div class="gng-counter-label">False Alarm</div>
+                <div class="gng-counter-value alarm-color" id="gngAlarm">0</div>
+            </div>
+        </div>
+
+        <div class="gng-field" id="gngField">
+            <div class="gng-field-idle" id="gngFieldIdle">Get ready…</div>
+            <div class="gng-stimulus" id="gngStimulus">
+                <div class="gng-stim-circle" id="gngStimCircle"></div>
+                <div class="gng-stim-label" id="gngStimLabel"></div>
+            </div>
+            <div class="gng-feedback" id="gngFeedback"></div>
+        </div>
+
+    </div>
+
+    {# ── Submitting overlay ───────────────────────────────────────────────── #}
+    <div class="gng-submitting" id="gngSubmitting">
+        <div style="font-size:2rem;margin-bottom:0.5rem;">⏳</div>
+        <p>Saving your result…</p>
+    </div>
+
+</div>
+
+<script>
+(function () {
+    // ── Server-injected config ─────────────────────────────────────────────
+    var PHASES      = {{ game.config.phases | tojson }};
+    var GO_CUE      = {{ game.config.go_cue | tojson }};
+    var NO_GO_CUE   = {{ game.config.no_go_cue | tojson }};
+    var CSRF_TOKEN  = "{{ request.cookies.get('csrf_token', '') }}";
+    var SUBMIT_URL  = "/virtual-training/go-no-go/submit";
+
+    // Derived totals
+    var TOTAL_GO    = PHASES.reduce(function(s,p){ return s + p.go;    }, 0); // 21
+    var TOTAL_NO_GO = PHASES.reduce(function(s,p){ return s + p.no_go; }, 0); // 9
+    var TOTAL_STIM  = TOTAL_GO + TOTAL_NO_GO;                                  // 30
+
+    // ── Game state ─────────────────────────────────────────────────────────
+    var started        = false;
+    var startedAt      = null;      // ISO string, set before first stimulus
+    var globalStimIdx  = 0;         // 0-based across all 30 stimuli
+    var hitCount       = 0;         // correct GO responses
+    var missCount      = 0;         // missed GO (window expired)
+    var holdCount      = 0;         // correct NO-GO inhibitions
+    var falseAlarmCount = 0;        // clicked on NO-GO
+    var reactionTimes  = [];        // RT array, only GO hits
+    var stimTimestamp  = null;      // when stimulus appeared
+    var stimTimeout    = null;      // window timeout handle
+    var isiTimeout     = null;      // inter-stimulus interval handle
+    var elapsedInterval = null;
+    var elapsedSeconds = 0;
+    var currentType    = null;      // "go" | "no_go"
+    var clickHandled   = false;     // prevents double-click within window
+
+    // ── raw_metrics tracking ───────────────────────────────────────────────
+    var stimulusLog    = [];        // per-stimulus event objects
+    var currentPhaseIdx = 0;
+
+    // ── DOM refs ───────────────────────────────────────────────────────────
+    var elInstruction  = document.getElementById("gngInstruction");
+    var elArena        = document.getElementById("gngArena");
+    var elBtnStart     = document.getElementById("gngBtnStart");
+    var elField        = document.getElementById("gngField");
+    var elFieldIdle    = document.getElementById("gngFieldIdle");
+    var elStimulus     = document.getElementById("gngStimulus");
+    var elStimCircle   = document.getElementById("gngStimCircle");
+    var elStimLabel    = document.getElementById("gngStimLabel");
+    var elFeedback     = document.getElementById("gngFeedback");
+    var elProgress     = document.getElementById("gngProgress");
+    var elProgressBar  = document.getElementById("gngProgressBar");
+    var elTimer        = document.getElementById("gngTimer");
+    var elHit          = document.getElementById("gngHit");
+    var elMiss         = document.getElementById("gngMiss");
+    var elHold         = document.getElementById("gngHold");
+    var elAlarm        = document.getElementById("gngAlarm");
+    var elSubmitting   = document.getElementById("gngSubmitting");
+
+    // ── Build stimulus sequence ────────────────────────────────────────────
+    // Interleave GO and NO-GO within each phase, then shuffle.
+    function buildSequence() {
+        var seq = [];
+        for (var pi = 0; pi < PHASES.length; pi++) {
+            var p = PHASES[pi];
+            for (var g = 0; g < p.go;    g++) { seq.push({type: "go",    phase: pi, cfg: p}); }
+            for (var n = 0; n < p.no_go; n++) { seq.push({type: "no_go", phase: pi, cfg: p}); }
+        }
+        // Fisher-Yates shuffle within each phase block
+        var result = [];
+        var offset = 0;
+        for (var pi2 = 0; pi2 < PHASES.length; pi2++) {
+            var p2   = PHASES[pi2];
+            var size = p2.go + p2.no_go;
+            var block = seq.slice(offset, offset + size);
+            for (var i = block.length - 1; i > 0; i--) {
+                var j = Math.floor(Math.random() * (i + 1));
+                var tmp = block[i]; block[i] = block[j]; block[j] = tmp;
+            }
+            result = result.concat(block);
+            offset += size;
+        }
+        return result;
+    }
+
+    var SEQUENCE = buildSequence();
+
+    // ── Phase helper ───────────────────────────────────────────────────────
+    function getPhaseForIdx(idx) {
+        var cumulative = 0;
+        for (var pi = 0; pi < PHASES.length; pi++) {
+            cumulative += PHASES[pi].go + PHASES[pi].no_go;
+            if (idx < cumulative) { return pi; }
+        }
+        return PHASES.length - 1;
+    }
+
+    // ── Start game ─────────────────────────────────────────────────────────
+    elBtnStart.addEventListener("click", function () {
+        if (started) { return; }
+        started    = true;
+        startedAt  = new Date().toISOString();
+
+        elInstruction.style.display = "none";
+        elArena.classList.add("active");
+
+        elapsedInterval = setInterval(function () {
+            elapsedSeconds++;
+            elTimer.textContent = elapsedSeconds + "s";
+        }, 1000);
+
+        // Brief "Get ready…" then first stimulus
+        isiTimeout = setTimeout(function () {
+            showStimulus();
+        }, 800);
+    });
+
+    // ── Click / tap handler ────────────────────────────────────────────────
+    elField.addEventListener("click", function () {
+        if (!started || currentType === null || clickHandled) { return; }
+        clickHandled = true;
+
+        var rt = Date.now() - stimTimestamp;
+        clearTimeout(stimTimeout);
+
+        if (currentType === "go") {
+            // HIT
+            hitCount++;
+            reactionTimes.push(rt);
+            elHit.textContent = hitCount;
+            recordStimEvent("hit", rt);
+            showFeedback("HIT", "fb-hit");
+            elStimCircle.classList.add("pressed");
+        } else {
+            // FALSE ALARM — clicked on NO-GO
+            falseAlarmCount++;
+            elAlarm.textContent = falseAlarmCount;
+            recordStimEvent("false_alarm", rt);
+            showFeedback("FALSE ALARM", "fb-alarm");
+        }
+
+        hideStimulus();
+        scheduleNext();
+    });
+
+    // ── Show stimulus ──────────────────────────────────────────────────────
+    function showStimulus() {
+        if (globalStimIdx >= TOTAL_STIM) {
+            finishGame();
+            return;
+        }
+        clickHandled    = false;
+        stimTimestamp   = Date.now();
+        currentPhaseIdx = getPhaseForIdx(globalStimIdx);
+        var item        = SEQUENCE[globalStimIdx];
+        currentType     = item.type;
+        var cfg         = item.cfg;
+
+        var cue = currentType === "go" ? GO_CUE : NO_GO_CUE;
+        elStimCircle.style.background = cue.color;
+        elStimCircle.textContent      = cue.label;
+        elStimCircle.classList.remove("pressed");
+        elStimLabel.textContent = currentType === "go" ? "Click now!" : "Hold!";
+
+        elFieldIdle.style.display = "none";
+        elStimulus.classList.add("visible");
+
+        // Update progress
+        elProgress.textContent = (globalStimIdx + 1) + " / " + TOTAL_STIM;
+        elProgressBar.style.width = ((globalStimIdx + 1) / TOTAL_STIM * 100) + "%";
+
+        // Window timeout — if GO not clicked in time → MISS
+        stimTimeout = setTimeout(function () {
+            if (currentType === "go" && !clickHandled) {
+                missCount++;
+                elMiss.textContent = missCount;
+                recordStimEvent("miss", null);
+                showFeedback("MISS", "fb-miss");
+            } else if (currentType === "no_go" && !clickHandled) {
+                // Correct inhibition of NO-GO
+                holdCount++;
+                elHold.textContent = holdCount;
+                recordStimEvent("correct_inhibit", null);
+                showFeedback("GOOD HOLD", "fb-hold");
+            }
+            hideStimulus();
+            scheduleNext();
+        }, cfg.window_ms);
+    }
+
+    function hideStimulus() {
+        elStimulus.classList.remove("visible");
+        currentType = null;
+    }
+
+    function scheduleNext() {
+        globalStimIdx++;
+        if (globalStimIdx >= TOTAL_STIM) {
+            isiTimeout = setTimeout(finishGame, 300);
+            return;
+        }
+        var nextPhase = getPhaseForIdx(globalStimIdx);
+        var isi       = PHASES[nextPhase].isi_ms;
+        isiTimeout = setTimeout(showStimulus, isi);
+    }
+
+    // ── Feedback flash ─────────────────────────────────────────────────────
+    var fbTimeout = null;
+    function showFeedback(text, cls) {
+        if (fbTimeout) { clearTimeout(fbTimeout); }
+        elFeedback.textContent = text;
+        elFeedback.className   = "gng-feedback show " + cls;
+        fbTimeout = setTimeout(function () {
+            elFeedback.className = "gng-feedback";
+        }, 400);
+    }
+
+    // ── Record stimulus event for raw_metrics ──────────────────────────────
+    function recordStimEvent(outcome, rt_ms) {
+        var item = SEQUENCE[globalStimIdx] || {};
+        stimulusLog.push({
+            i:          globalStimIdx,
+            phase:      currentPhaseIdx,
+            type:       currentType,
+            outcome:    outcome,
+            rt_ms:      rt_ms,
+            window_ms:  item.cfg ? item.cfg.window_ms : 1000,
+        });
+    }
+
+    // ── Finish + submit ─────────────────────────────────────────────────────
+    function finishGame() {
+        clearInterval(elapsedInterval);
+        clearTimeout(stimTimeout);
+        clearTimeout(isiTimeout);
+        hideStimulus();
+        elArena.classList.remove("active");
+        elSubmitting.classList.add("active");
+
+        var durationSeconds = startedAt
+            ? Math.round((Date.now() - new Date(startedAt).getTime()) / 100) / 10
+            : null;
+
+        // GO-hit reaction stats
+        var avgMs = reactionTimes.length > 0
+            ? Math.round(reactionTimes.reduce(function(a,b){return a+b;},0) / reactionTimes.length)
+            : null;
+        var minMs = reactionTimes.length > 0
+            ? Math.min.apply(null, reactionTimes)
+            : null;
+
+        // Score formula:
+        // score_raw = 0.40*go_hit_rate + 0.35*(1-no_go_fail_rate)
+        //           + 0.15*speed_factor - 0.10*missed_go_rate
+        var goHitRate     = TOTAL_GO > 0 ? hitCount / TOTAL_GO : 0;
+        var noGoFailRate  = TOTAL_NO_GO > 0 ? falseAlarmCount / TOTAL_NO_GO : 0;
+        var missedGoRate  = TOTAL_GO > 0 ? missCount / TOTAL_GO : 0;
+        var speedFactor   = avgMs !== null ? Math.max(0, 1 - avgMs / 1000) : 0;
+        var scoreRaw      = 0.40 * goHitRate
+                          + 0.35 * (1 - noGoFailRate)
+                          + 0.15 * speedFactor
+                          - 0.10 * missedGoRate;
+        var scoreNorm     = Math.min(100, Math.max(0, Math.round(100 * scoreRaw)));
+
+        // Build raw_metrics per_phase summary
+        var perPhase = PHASES.map(function(p, pi) {
+            var pEvs           = stimulusLog.filter(function(ev){ return ev.phase === pi; });
+            var goHits         = pEvs.filter(function(e){ return e.outcome === "hit"; }).length;
+            var goMisses       = pEvs.filter(function(e){ return e.outcome === "miss"; }).length;
+            var correctInhibits = pEvs.filter(function(e){ return e.outcome === "correct_inhibit"; }).length;
+            var falseAlarms    = pEvs.filter(function(e){ return e.outcome === "false_alarm"; }).length;
+            var rtArr          = pEvs.filter(function(e){ return e.rt_ms !== null; }).map(function(e){ return e.rt_ms; });
+            var avgRtMs        = rtArr.length > 0 ? Math.round(rtArr.reduce(function(a,b){return a+b;},0)/rtArr.length) : null;
+            return {
+                phase:           pi,
+                go:              p.go,
+                no_go:           p.no_go,
+                go_hits:         goHits,
+                go_misses:       goMisses,
+                correct_inhibits: correctInhibits,
+                false_alarms:    falseAlarms,
+                avg_rt_ms:       avgRtMs,
+            };
+        });
+
+        var rawMetrics = { v: 1, per_stimulus: stimulusLog, per_phase: perPhase };
+
+        var payload = {
+            started_at:        startedAt,
+            duration_seconds:  durationSeconds,
+            stimuli_count:     TOTAL_STIM,
+            correct_count:     hitCount,
+            wrong_click_count: falseAlarmCount,
+            error_count:       missCount,
+            avg_reaction_ms:   avgMs,
+            min_reaction_ms:   minMs,
+            score_raw:         scoreRaw,
+            score_normalized:  scoreNorm,
+            raw_metrics:       rawMetrics,
+        };
+
+        fetch(SUBMIT_URL, {
+            method:  "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "X-CSRF-Token": CSRF_TOKEN,
+            },
+            body: JSON.stringify(payload),
+        })
+        .then(function(r){ return r.json(); })
+        .then(function(data){
+            if (data.attempt_id) {
+                window.location.href = "/virtual-training/go-no-go/result/" + data.attempt_id;
+            } else {
+                elSubmitting.innerHTML = "<p>⚠️ Could not save attempt. <a href='/virtual-training'>Back to hub</a></p>";
+            }
+        })
+        .catch(function(){
+            elSubmitting.innerHTML = "<p>⚠️ Network error. <a href='/virtual-training'>Back to hub</a></p>";
+        });
+    }
+
+})();
+</script>
+{% endblock %}

--- a/app/templates/virtual_training_go_no_go_result.html
+++ b/app/templates/virtual_training_go_no_go_result.html
@@ -130,6 +130,8 @@
         padding: 0.2rem 0;
     }
 
+    .gngr-skill-row.neg { color: #dc2626; }
+
     /* ── Play again button ───────────────────────────────────────────── */
     .gngr-btn-play {
         display: inline-block;
@@ -175,8 +177,9 @@
     }
     .gngr-breakdown-row:last-child { border-bottom: none; }
 
-    .gngr-breakdown-skill   { font-weight: 700; color: #14532d; }
-    .gngr-breakdown-delta   { font-weight: 800; color: #166534; white-space: nowrap; }
+    .gngr-breakdown-skill        { font-weight: 700; color: #14532d; }
+    .gngr-breakdown-delta        { font-weight: 800; color: #166534; white-space: nowrap; }
+    .gngr-breakdown-delta.neg    { color: #dc2626; }
     .gngr-breakdown-factors {
         font-size: 0.78rem;
         color: #6b7280;
@@ -380,9 +383,9 @@
         <div class="gngr-skill-deltas">
             <h4>Skill deltas</h4>
             {% for skill, delta in attempt.skill_deltas.items() %}
-            <div class="gngr-skill-row">
+            <div class="gngr-skill-row {% if delta < 0 %}neg{% endif %}">
                 <span>{{ skill }}</span>
-                <span>+{{ "%.2f"|format(delta) }}</span>
+                <span>{{ "%+.2f"|format(delta) }}</span>
             </div>
             {% endfor %}
         </div>
@@ -396,7 +399,7 @@
             {% set delta = attempt.skill_deltas.get(skill, 0) if attempt.skill_deltas else 0 %}
             <div class="gngr-breakdown-row">
                 <span class="gngr-breakdown-skill">{{ skill|capitalize }}</span>
-                <span class="gngr-breakdown-delta">+{{ "%.3f"|format(delta) }}</span>
+                <span class="gngr-breakdown-delta {% if delta < 0 %}neg{% endif %}">{{ "%+.3f"|format(delta) }}</span>
                 <span class="gngr-breakdown-factors">
                     {# Per-skill formula documentation shown to player #}
                     {% if skill == "decisions" %}
@@ -413,6 +416,9 @@
                         <br><span style="font-style:italic;color:#9ca3af;">Measures how quickly you respond to GO stimuli (secondary skill)</span>
                     {% else %}
                         Score: {{ "%.0f"|format(score * 100) }}%
+                    {% endif %}
+                    {% if delta < 0 %}
+                    <br><span style="color:#dc2626;font-style:italic;">Performance below training threshold — skill decreased this attempt.</span>
                     {% endif %}
                 </span>
             </div>

--- a/app/templates/virtual_training_go_no_go_result.html
+++ b/app/templates/virtual_training_go_no_go_result.html
@@ -1,0 +1,508 @@
+{% extends "student_base.html" %}
+
+{% block title %}Go / No-Go Result - LFA{% endblock %}
+{% block active_page %}lfa-player{% endblock %}
+
+{% block student_header %}
+{% set _page_icon = '🛑' %}
+{% set _page_name = 'Result' %}
+{% include "includes/spec_subpage_hdr.html" %}
+{% endblock %}
+
+{% block extra_styles %}
+<style>
+    .gngr-container {
+        max-width: 560px;
+        margin: 0 auto;
+        padding: 1.5rem 1rem 3rem;
+    }
+
+    .gngr-card {
+        background: var(--app-card);
+        border-radius: 16px;
+        padding: 2rem 1.75rem;
+        box-shadow: 0 2px 14px rgba(0,0,0,0.09);
+        text-align: center;
+        margin-bottom: 1.25rem;
+    }
+
+    .gngr-status-icon {
+        font-size: 3rem;
+        margin-bottom: 0.5rem;
+        line-height: 1;
+    }
+
+    .gngr-title {
+        font-size: 1.45rem;
+        font-weight: 800;
+        color: var(--app-text);
+        margin: 0 0 0.3rem;
+    }
+
+    .gngr-subtitle {
+        font-size: 0.9rem;
+        color: var(--app-text-muted);
+        margin: 0 0 1.5rem;
+    }
+
+    /* ── Stats grid ──────────────────────────────────────────────────── */
+    .gngr-stats-grid {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        gap: 0.85rem;
+        margin-bottom: 1.5rem;
+    }
+
+    .gngr-stat {
+        background: #f9fafb;
+        border-radius: 10px;
+        padding: 0.85rem 0.75rem;
+    }
+
+    .gngr-stat-label {
+        font-size: 0.75rem;
+        color: var(--app-text-muted);
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        margin-bottom: 0.3rem;
+    }
+
+    .gngr-stat-value {
+        font-size: 1.35rem;
+        font-weight: 800;
+        color: var(--app-text);
+    }
+
+    .gngr-stat-value.good   { color: #16a34a; }
+    .gngr-stat-value.danger { color: #ef4444; }
+    .gngr-stat-value.warn   { color: #d97706; }
+
+    /* ── XP badge ────────────────────────────────────────────────────── */
+    .gngr-xp-badge {
+        display: inline-block;
+        background: #ede9fe;
+        color: #5b21b6;
+        font-size: 1.1rem;
+        font-weight: 800;
+        padding: 0.5rem 1.5rem;
+        border-radius: 20px;
+        margin-bottom: 1.5rem;
+    }
+
+    /* ── Invalid banner ──────────────────────────────────────────────── */
+    .gngr-invalid-banner {
+        background: #fef3c7;
+        border: 1px solid #f59e0b;
+        border-radius: 10px;
+        padding: 0.85rem 1rem;
+        color: #92400e;
+        font-size: 0.88rem;
+        font-weight: 600;
+        margin-bottom: 1.25rem;
+        text-align: center;
+    }
+
+    /* ── Skill deltas summary ────────────────────────────────────────── */
+    .gngr-skill-deltas {
+        background: #f0fdf4;
+        border: 1px solid #bbf7d0;
+        border-radius: 10px;
+        padding: 0.85rem 1rem;
+        margin-bottom: 1.5rem;
+        text-align: left;
+    }
+
+    .gngr-skill-deltas h4 {
+        font-size: 0.78rem;
+        font-weight: 700;
+        color: #166534;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        margin: 0 0 0.6rem;
+    }
+
+    .gngr-skill-row {
+        display: flex;
+        justify-content: space-between;
+        font-size: 0.875rem;
+        color: #14532d;
+        padding: 0.2rem 0;
+    }
+
+    /* ── Play again button ───────────────────────────────────────────── */
+    .gngr-btn-play {
+        display: inline-block;
+        background: #4f46e5;
+        color: #fff;
+        font-size: 0.95rem;
+        font-weight: 700;
+        padding: 0.7rem 2rem;
+        border-radius: 10px;
+        text-decoration: none;
+        transition: background 0.15s;
+        margin-bottom: 0.5rem;
+    }
+    .gngr-btn-play:hover { background: #4338ca; }
+
+    /* ── Skill breakdown (documented per-skill) ──────────────────────── */
+    .gngr-breakdown {
+        background: #f0fdf4;
+        border: 1px solid #bbf7d0;
+        border-radius: 12px;
+        padding: 1rem 1.1rem;
+        margin-bottom: 1.25rem;
+        text-align: left;
+    }
+
+    .gngr-breakdown h4 {
+        font-size: 0.78rem;
+        font-weight: 700;
+        color: #166534;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        margin: 0 0 0.75rem;
+    }
+
+    .gngr-breakdown-row {
+        display: grid;
+        grid-template-columns: 1fr auto auto;
+        align-items: start;
+        gap: 0.5rem 1rem;
+        padding: 0.45rem 0;
+        border-bottom: 1px solid #d1fae5;
+        font-size: 0.875rem;
+    }
+    .gngr-breakdown-row:last-child { border-bottom: none; }
+
+    .gngr-breakdown-skill   { font-weight: 700; color: #14532d; }
+    .gngr-breakdown-delta   { font-weight: 800; color: #166534; white-space: nowrap; }
+    .gngr-breakdown-factors {
+        font-size: 0.78rem;
+        color: #6b7280;
+        grid-column: 1 / -1;
+        padding-top: 0.1rem;
+        padding-left: 0.1rem;
+    }
+
+    /* ── Per-phase table ─────────────────────────────────────────────── */
+    .gngr-detail-section {
+        background: white;
+        border: 1px solid #e5e7eb;
+        border-radius: 12px;
+        padding: 1rem 1.1rem;
+        margin-bottom: 1.25rem;
+        text-align: left;
+    }
+
+    .gngr-detail-section h4 {
+        font-size: 0.78rem;
+        font-weight: 700;
+        color: #374151;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        margin: 0 0 0.75rem;
+    }
+
+    .gngr-detail-table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.8rem;
+    }
+
+    .gngr-detail-table th {
+        background: #f9fafb;
+        color: #6b7280;
+        font-weight: 700;
+        font-size: 0.72rem;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        padding: 0.45rem 0.6rem;
+        text-align: left;
+        border-bottom: 1px solid #e5e7eb;
+        white-space: nowrap;
+    }
+
+    .gngr-detail-table td {
+        padding: 0.45rem 0.6rem;
+        border-bottom: 1px solid #f3f4f6;
+        color: #374151;
+        vertical-align: middle;
+    }
+
+    .gngr-detail-table tr:last-child td { border-bottom: none; }
+
+    .gngr-acc-good  { color: #16a34a; font-weight: 700; }
+    .gngr-acc-ok    { color: #d97706; font-weight: 700; }
+    .gngr-acc-poor  { color: #dc2626; font-weight: 700; }
+
+    /* ── Admin debug ─────────────────────────────────────────────────── */
+    .gngr-admin-debug {
+        background: #1e293b;
+        border-radius: 10px;
+        padding: 0.85rem 1rem;
+        margin-bottom: 1.25rem;
+        text-align: left;
+    }
+    .gngr-admin-debug summary {
+        color: #94a3b8;
+        font-size: 0.78rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        cursor: pointer;
+    }
+    .gngr-admin-debug pre {
+        color: #e2e8f0;
+        font-size: 0.72rem;
+        overflow-x: auto;
+        margin: 0.75rem 0 0;
+        white-space: pre-wrap;
+        word-break: break-all;
+        max-height: 300px;
+        overflow-y: auto;
+    }
+
+    /* ── Footer ──────────────────────────────────────────────────────── */
+    .gngr-footer {
+        text-align: center;
+        margin-top: 1.25rem;
+        padding-top: 1.25rem;
+        border-top: 1px solid #e2e8f0;
+    }
+    .gngr-footer a {
+        color: #667eea;
+        text-decoration: none;
+        margin: 0 0.75rem;
+        font-weight: 600;
+        font-size: 0.88rem;
+    }
+    .gngr-footer a:hover { text-decoration: underline; }
+</style>
+{% endblock %}
+
+{% block student_content %}
+<div class="gngr-container">
+
+    {% if attempt.is_valid %}
+    {# ── Valid result ──────────────────────────────────────────────────── #}
+    <div class="gngr-card">
+        <div class="gngr-status-icon">
+            {% if attempt.score_normalized >= 85 %}🏆
+            {% elif attempt.score_normalized >= 65 %}⚡
+            {% elif attempt.score_normalized >= 45 %}💪
+            {% else %}🎯{% endif %}
+        </div>
+        <h2 class="gngr-title">
+            {% if attempt.score_normalized >= 85 %}Excellent impulse control!
+            {% elif attempt.score_normalized >= 65 %}Good decision-making!
+            {% elif attempt.score_normalized >= 45 %}Keep training!
+            {% else %}Keep practicing!{% endif %}
+        </h2>
+        <p class="gngr-subtitle">Go / No-Go Reaction</p>
+
+        {# Compute per-phase totals for display #}
+        {% set _go_total    = (game.config.phases | sum(attribute='go'))    if game else 21 %}
+        {% set _no_go_total = (game.config.phases | sum(attribute='no_go')) if game else 9  %}
+
+        <div class="gngr-stats-grid">
+            <div class="gngr-stat">
+                <div class="gngr-stat-label">Score</div>
+                <div class="gngr-stat-value">
+                    {% if attempt.score_normalized is not none %}{{ attempt.score_normalized | round(0) | int }}%
+                    {% else %}—{% endif %}
+                </div>
+            </div>
+            <div class="gngr-stat">
+                <div class="gngr-stat-label">GO Accuracy</div>
+                {% set _go_pct = ((attempt.correct_count / _go_total) * 100) | round(0) | int if attempt.correct_count is not none else none %}
+                <div class="gngr-stat-value {% if _go_pct is not none %}{% if _go_pct >= 80 %}good{% elif _go_pct >= 60 %}warn{% else %}danger{% endif %}{% endif %}">
+                    {% if _go_pct is not none %}{{ _go_pct }}%{% else %}—{% endif %}
+                    <small style="font-size:0.65rem;font-weight:600;color:var(--app-text-muted);">{{ attempt.correct_count if attempt.correct_count is not none else "—" }}/{{ _go_total }}</small>
+                </div>
+            </div>
+            <div class="gngr-stat">
+                <div class="gngr-stat-label">NO-GO Success</div>
+                {% set _fa = attempt.wrong_click_count if attempt.wrong_click_count is not none else 0 %}
+                {% set _correct_inhibits = _no_go_total - _fa %}
+                {% set _nogo_pct = ((_correct_inhibits / _no_go_total) * 100) | round(0) | int %}
+                <div class="gngr-stat-value {% if _nogo_pct >= 80 %}good{% elif _nogo_pct >= 60 %}warn{% else %}danger{% endif %}">
+                    {{ _nogo_pct }}%
+                    <small style="font-size:0.65rem;font-weight:600;color:var(--app-text-muted);">{{ _correct_inhibits }}/{{ _no_go_total }}</small>
+                </div>
+            </div>
+            <div class="gngr-stat">
+                <div class="gngr-stat-label">False Alarms</div>
+                <div class="gngr-stat-value{% if _fa > 0 %} danger{% endif %}">
+                    {{ _fa }}
+                    <small style="font-size:0.65rem;font-weight:600;color:var(--app-text-muted);">/ {{ _no_go_total }} NO-GO</small>
+                </div>
+            </div>
+            <div class="gngr-stat">
+                <div class="gngr-stat-label">Missed GO</div>
+                {% set _miss = attempt.error_count if attempt.error_count is not none else 0 %}
+                <div class="gngr-stat-value{% if _miss > 0 %} warn{% endif %}">
+                    {{ _miss }}
+                    <small style="font-size:0.65rem;font-weight:600;color:var(--app-text-muted);">/ {{ _go_total }} GO</small>
+                </div>
+            </div>
+            <div class="gngr-stat">
+                <div class="gngr-stat-label">Avg GO Reaction</div>
+                <div class="gngr-stat-value">
+                    {% if attempt.avg_reaction_ms is not none %}{{ attempt.avg_reaction_ms | round(0) | int }} ms
+                    {% else %}—{% endif %}
+                </div>
+            </div>
+            <div class="gngr-stat">
+                <div class="gngr-stat-label">Duration</div>
+                <div class="gngr-stat-value">
+                    {% if attempt.duration_seconds is not none %}{{ attempt.duration_seconds | round(1) }} s
+                    {% else %}—{% endif %}
+                </div>
+            </div>
+            <div class="gngr-stat">
+                <div class="gngr-stat-label">Attempt</div>
+                <div class="gngr-stat-value">
+                    #{{ attempt.attempt_index_today }} today
+                </div>
+            </div>
+        </div>
+
+        {% if attempt.xp_awarded > 0 %}
+        <div class="gngr-xp-badge">+{{ attempt.xp_awarded }} XP earned</div>
+        {% elif attempt.attempt_index_today > 3 %}
+        <div class="gngr-xp-badge" style="background:#f3f4f6;color:#6b7280;">
+            No XP — daily limit reached
+        </div>
+        {% endif %}
+
+        {% if attempt.skill_deltas %}
+        <div class="gngr-skill-deltas">
+            <h4>Skill deltas</h4>
+            {% for skill, delta in attempt.skill_deltas.items() %}
+            <div class="gngr-skill-row">
+                <span>{{ skill }}</span>
+                <span>+{{ "%.2f"|format(delta) }}</span>
+            </div>
+            {% endfor %}
+        </div>
+        {% endif %}
+
+        {# ── Skill Delta Breakdown — documented per-skill ───────────────── #}
+        {% if skill_scores %}
+        <div class="gngr-breakdown" id="gngr-breakdown">
+            <h4>Skill Delta Breakdown</h4>
+            {% for skill, score in skill_scores.items() %}
+            {% set delta = attempt.skill_deltas.get(skill, 0) if attempt.skill_deltas else 0 %}
+            <div class="gngr-breakdown-row">
+                <span class="gngr-breakdown-skill">{{ skill|capitalize }}</span>
+                <span class="gngr-breakdown-delta">+{{ "%.3f"|format(delta) }}</span>
+                <span class="gngr-breakdown-factors">
+                    {# Per-skill formula documentation shown to player #}
+                    {% if skill == "decisions" %}
+                        GO hit rate: {{ signals_ctx.hit_rate }}% · False alarm penalty ({{ signals_ctx.wrong_rate }}% × 1.5×) · Score: {{ "%.0f"|format(score * 100) }}%
+                        <br><span style="font-style:italic;color:#9ca3af;">Measures correct GO + correct NO-GO decisions combined</span>
+                    {% elif skill == "concentration" %}
+                        Missed GO: {{ signals_ctx.miss_rate }}% · Sustained attention score: {{ "%.0f"|format(score * 100) }}%
+                        <br><span style="font-style:italic;color:#9ca3af;">Measures ability to stay focused and not miss GO stimuli</span>
+                    {% elif skill == "composure" %}
+                        False alarm rate: {{ signals_ctx.wrong_rate }}% (× 1.5× penalty) · Score: {{ "%.0f"|format(score * 100) }}%
+                        <br><span style="font-style:italic;color:#9ca3af;">Measures impulse control — not clicking when you should hold</span>
+                    {% elif skill == "reactions" %}
+                        Speed: {{ signals_ctx.speed_score }}% · GO hit rate: {{ signals_ctx.hit_rate }}% · Score: {{ "%.0f"|format(score * 100) }}%
+                        <br><span style="font-style:italic;color:#9ca3af;">Measures how quickly you respond to GO stimuli (secondary skill)</span>
+                    {% else %}
+                        Score: {{ "%.0f"|format(score * 100) }}%
+                    {% endif %}
+                </span>
+            </div>
+            {% endfor %}
+        </div>
+        {% endif %}
+
+        <a href="/virtual-training/go-no-go" class="gngr-btn-play">Play again</a>
+    </div>
+
+    {# ── Per-phase summary ─────────────────────────────────────────────── #}
+    {% if per_phase %}
+    <div class="gngr-detail-section" id="gngr-per-phase">
+        <h4>Phase Performance</h4>
+        <table class="gngr-detail-table">
+            <thead>
+                <tr>
+                    <th>Phase</th>
+                    <th>GO hits</th>
+                    <th>GO %</th>
+                    <th>NO-GO held</th>
+                    <th>False alarms</th>
+                    <th>Avg GO RT</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for p in per_phase %}
+                {% set go_total  = p.go    if p.go    else 1 %}
+                {% set nogo_total = p.no_go if p.no_go else 1 %}
+                {% set go_acc  = ((p.go_hits / go_total) * 100) | round(1) %}
+                {% set nogo_acc = ((p.correct_inhibits / nogo_total) * 100) | round(1) %}
+                <tr>
+                    <td>Phase {{ loop.index }}</td>
+                    <td>{{ p.go_hits }}/{{ p.go }}</td>
+                    <td class="{% if go_acc >= 85 %}gngr-acc-good{% elif go_acc >= 65 %}gngr-acc-ok{% else %}gngr-acc-poor{% endif %}">{{ go_acc }}%</td>
+                    <td>
+                        {{ p.correct_inhibits }}/{{ p.no_go }}
+                        <span class="{% if nogo_acc >= 85 %}gngr-acc-good{% elif nogo_acc >= 65 %}gngr-acc-ok{% else %}gngr-acc-poor{% endif %}">({{ nogo_acc }}%)</span>
+                    </td>
+                    <td class="{% if p.false_alarms > 0 %}gngr-acc-poor{% else %}gngr-acc-good{% endif %}">{{ p.false_alarms }}</td>
+                    <td>{% if p.avg_rt_ms is not none %}{{ p.avg_rt_ms | round(0) | int }} ms{% else %}—{% endif %}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    {% endif %}
+
+    {# ── Admin per-stimulus debug ──────────────────────────────────────── #}
+    {% if is_admin and per_stimulus %}
+    <div class="gngr-admin-debug" id="gngr-admin-debug">
+        <details>
+            <summary>Admin: per-stimulus raw data ({{ per_stimulus | length }} entries)</summary>
+            <pre>{{ per_stimulus | tojson(indent=2) }}</pre>
+        </details>
+    </div>
+    {% endif %}
+
+    {% else %}
+    {# ── Invalid attempt ───────────────────────────────────────────────── #}
+    <div class="gngr-card">
+        <div class="gngr-status-icon">⚠️</div>
+        <h2 class="gngr-title">Attempt not counted</h2>
+        <p class="gngr-subtitle">Go / No-Go Reaction</p>
+        <div class="gngr-invalid-banner">
+            {% if attempt.invalid_reason == "too_short" %}
+            Session ended too quickly. Try completing the full 30-stimulus round.
+            {% elif attempt.invalid_reason == "too_few_stimuli" %}
+            Not enough stimuli were presented. Please complete a full round.
+            {% elif attempt.invalid_reason == "random_clicking" %}
+            Too many incorrect responses detected. Focus on when to click and when to hold!
+            {% elif attempt.invalid_reason == "bot_suspected" %}
+            Reaction times were unusually fast and could not be validated.
+            {% else %}
+            This attempt could not be validated ({{ attempt.invalid_reason }}).
+            {% endif %}
+        </div>
+        <p style="font-size:0.88rem;color:var(--app-text-muted);margin-bottom:1.25rem;">
+            No XP was awarded. Remaining daily attempts are not consumed.
+        </p>
+        <a href="/virtual-training/go-no-go" class="gngr-btn-play">Try again</a>
+    </div>
+    {% endif %}
+
+    <div class="gngr-footer">
+        <a href="/virtual-training">💻 All Games</a>
+        <a href="/virtual-training/history">📋 History</a>
+        <a href="/training">🎓 Training</a>
+        <a href="/dashboard/lfa-football-player">⚽ Dashboard</a>
+    </div>
+
+</div>
+{% endblock %}

--- a/app/templates/virtual_training_go_no_go_result.html
+++ b/app/templates/virtual_training_go_no_go_result.html
@@ -373,7 +373,7 @@
 
         {% if attempt.xp_awarded > 0 %}
         <div class="gngr-xp-badge">+{{ attempt.xp_awarded }} XP earned</div>
-        {% elif attempt.attempt_index_today > 3 %}
+        {% elif attempt.attempt_index_today > game.max_daily_attempts %}
         <div class="gngr-xp-badge" style="background:#f3f4f6;color:#6b7280;">
             No XP — daily limit reached
         </div>

--- a/app/templates/virtual_training_history.html
+++ b/app/templates/virtual_training_history.html
@@ -137,9 +137,11 @@
                 {% for attempt in attempts %}
                 <tr>
                     <td>
-                        <a href="/virtual-training/color-reaction/result/{{ attempt.id }}"
+                        {% set _game = games[attempt.game_id] if attempt.game_id in games else none %}
+                        {% set _slug = _game.code | replace('_', '-') if _game else 'color-reaction' %}
+                        <a href="/virtual-training/{{ _slug }}/result/{{ attempt.id }}"
                            style="color: #4f46e5; font-weight: 600; text-decoration: none;">
-                            {{ games[attempt.game_id].name if attempt.game_id in games else "—" }}
+                            {{ _game.name if _game else "—" }}
                         </a>
                     </td>
                     <td>

--- a/app/templates/virtual_training_result.html
+++ b/app/templates/virtual_training_result.html
@@ -124,6 +124,8 @@
         padding: 0.2rem 0;
     }
 
+    .vtr-skill-row.neg { color: #dc2626; }
+
     .vtr-btn-play-again {
         display: inline-block;
         background: #4f46e5;
@@ -187,8 +189,9 @@
 
     .vtr-breakdown-row:last-child { border-bottom: none; }
 
-    .vtr-breakdown-skill { font-weight: 700; color: #14532d; }
-    .vtr-breakdown-delta { font-weight: 800; color: #166534; white-space: nowrap; }
+    .vtr-breakdown-skill      { font-weight: 700; color: #14532d; }
+    .vtr-breakdown-delta      { font-weight: 800; color: #166534; white-space: nowrap; }
+    .vtr-breakdown-delta.neg  { color: #dc2626; }
     .vtr-breakdown-factors {
         font-size: 0.78rem;
         color: #6b7280;
@@ -355,9 +358,9 @@
         <div class="vtr-skill-deltas">
             <h4>Skill deltas</h4>
             {% for skill, delta in attempt.skill_deltas.items() %}
-            <div class="vtr-skill-row">
+            <div class="vtr-skill-row {% if delta < 0 %}neg{% endif %}">
                 <span>{{ skill }}</span>
-                <span>+{{ "%.2f"|format(delta) }}</span>
+                <span>{{ "%+.2f"|format(delta) }}</span>
             </div>
             {% endfor %}
         </div>
@@ -371,7 +374,7 @@
             {% set delta = attempt.skill_deltas.get(skill, 0) if attempt.skill_deltas else 0 %}
             <div class="vtr-breakdown-row">
                 <span class="vtr-breakdown-skill">{{ skill|capitalize }}</span>
-                <span class="vtr-breakdown-delta">+{{ "%.3f"|format(delta) }}</span>
+                <span class="vtr-breakdown-delta {% if delta < 0 %}neg{% endif %}">{{ "%+.3f"|format(delta) }}</span>
                 <span class="vtr-breakdown-factors">
                     {% if skill == "reactions" %}
                         Speed: {{ signals_ctx.speed_score }}% · Hit rate: {{ signals_ctx.hit_rate }}% · Score: {{ "%.0f"|format(score * 100) }}%
@@ -383,6 +386,9 @@
                         Completion: {{ signals_ctx.completion_rate }}% · Accuracy: {{ signals_ctx.hit_rate }}% · Score: {{ "%.0f"|format(score * 100) }}%
                     {% else %}
                         Score: {{ "%.0f"|format(score * 100) }}%
+                    {% endif %}
+                    {% if delta < 0 %}
+                    <br><span style="color:#dc2626;font-style:italic;">Performance below training threshold — skill decreased this attempt.</span>
                     {% endif %}
                 </span>
             </div>

--- a/app/templates/virtual_training_result.html
+++ b/app/templates/virtual_training_result.html
@@ -348,7 +348,7 @@
 
         {% if attempt.xp_awarded > 0 %}
         <div class="vtr-xp-badge">+{{ attempt.xp_awarded }} XP earned</div>
-        {% elif attempt.attempt_index_today > 3 %}
+        {% elif attempt.attempt_index_today > game.max_daily_attempts %}
         <div class="vtr-xp-badge" style="background: #f3f4f6; color: #6b7280;">
             No XP — daily limit reached
         </div>

--- a/scripts/seed_virtual_training_games.py
+++ b/scripts/seed_virtual_training_games.py
@@ -97,7 +97,7 @@ _GAMES = [
             "Trains impulse control alongside rapid reaction."
         ),
         "game_type": "go_no_go",
-        "is_active": False,
+        "is_active": True,
         "base_xp": 12,
         "max_daily_attempts": 5,
         "skill_targets": {
@@ -107,12 +107,32 @@ _GAMES = [
             "reactions":     0.15,
         },
         "config": {
-            "trial_count":          20,
-            "go_ratio":             0.75,
-            "stimulus_duration_ms": 800,
-            "inter_trial_ms":       1000,
-            "show_in_hub":      True,
-            "icon":             "🛑",
+            # ── runtime gameplay keys ──────────────────────────────────────
+            # 2-phase session: Phase 0 slower, Phase 1 faster ISI
+            # go + no_go per phase must sum to 30 total (21 GO + 9 NO-GO)
+            "phases": [
+                {"go": 10, "no_go": 5, "isi_ms": 900,  "window_ms": 1000, "stimulus_ms": 800},
+                {"go": 11, "no_go": 4, "isi_ms": 650,  "window_ms": 1000, "stimulus_ms": 800},
+            ],
+            "go_cue":    {"color": "#22c55e", "label": "GO"},
+            "no_go_cue": {"color": "#ef4444", "label": "STOP"},
+            # Score formula weights — kept in config for transparency / future tuning
+            # score_raw = 0.40*go_hit_rate + 0.35*(1-no_go_fail_rate)
+            #           + 0.15*speed_factor - 0.10*missed_go_rate
+            "score_weights": {
+                "go_hit_rate":      0.40,
+                "no_go_success":    0.35,
+                "speed_factor":     0.15,
+                "missed_go_penalty": 0.10,
+            },
+            # Skill delta scorers reference (for result page documentation):
+            # decisions    = hit_rate - 1.5 * wrong_rate (GO perf + false alarm penalty)
+            # concentration = 1 - 2 * miss_rate          (missed GO = attention lapse)
+            # composure    = 1 - 1.5 * wrong_rate        (false alarm = impulse failure)
+            # reactions    = 0.65 * speed_score + 0.35 * hit_rate (GO hit speed)
+            # ── display keys ──────────────────────────────────────────────
+            "show_in_hub": True,
+            "icon": "🛑",
             "football_benefit": (
                 "Impulse control, avoiding premature commitments, and executing "
                 "responses only at the right moment under pressure."

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -64028,6 +64028,94 @@
         ]
       }
     },
+    "/virtual-training/go-no-go": {
+      "get": {
+        "description": "Go / No-Go Reaction game page \u2014 instructions + Vanilla JS game loop.",
+        "operationId": "virtual_training_go_no_go_virtual_training_go_no_go_get",
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Virtual Training Go No Go",
+        "tags": [
+          "web",
+          "virtual-training"
+        ]
+      }
+    },
+    "/virtual-training/go-no-go/result/{attempt_id}": {
+      "get": {
+        "description": "Result screen for a completed Go / No-Go Reaction attempt.",
+        "operationId": "virtual_training_go_no_go_result_virtual_training_go_no_go_result__attempt_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "attempt_id",
+            "required": true,
+            "schema": {
+              "title": "Attempt Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Virtual Training Go No Go Result",
+        "tags": [
+          "web",
+          "virtual-training"
+        ]
+      }
+    },
+    "/virtual-training/go-no-go/submit": {
+      "post": {
+        "description": "Record a Go / No-Go Reaction attempt. Returns attempt_id, xp_awarded, is_valid.",
+        "operationId": "virtual_training_go_no_go_submit_virtual_training_go_no_go_submit_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Virtual Training Go No Go Submit",
+        "tags": [
+          "web",
+          "virtual-training"
+        ]
+      }
+    },
     "/virtual-training/history": {
       "get": {
         "description": "Attempt history \u2014 last 20 valid attempts across all VT games.",

--- a/tests/unit/api/web_routes/test_go_no_go.py
+++ b/tests/unit/api/web_routes/test_go_no_go.py
@@ -547,11 +547,12 @@ class TestScoreComposure:
         sig = self._signals(wrong_rate=0.5)
         assert VTSkillScorer.score_composure(sig) == pytest.approx(0.25)
 
-    def test_gng15_heavy_false_alarms_clamped_to_zero(self):
-        """GNG-15: score_composure(wrong_rate=0.8) → 0.0 (clamped, 1.0-1.2<0)."""
+    def test_gng15_heavy_false_alarms_negative_composure(self):
+        """GNG-15: score_composure(wrong_rate=0.8) → -0.2 (lower clamp removed)."""
         from app.services.virtual_training_metrics import VTSkillScorer
         sig = self._signals(wrong_rate=0.8)
-        assert VTSkillScorer.score_composure(sig) == pytest.approx(0.0)
+        # 1.0 - 1.5*0.8 = -0.2; only upper clamp (min(1.0, ...)) applies now
+        assert VTSkillScorer.score_composure(sig) == pytest.approx(-0.2)
 
     def test_gng16_score_all_includes_composure(self):
         """GNG-16: score_all() dispatches composure to dedicated scorer."""
@@ -600,37 +601,37 @@ class TestGoNoGoDeltas:
         for skill, delta in deltas.items():
             assert delta > 0, f"Expected positive delta for {skill}"
 
-    def test_gng19_false_alarm_heavy_composure_near_zero(self):
-        """GNG-19: Many false alarms → composure score near zero, tiny/no delta."""
+    def test_gng19_false_alarm_heavy_composure_negative(self):
+        """GNG-19: Many false alarms → composure below neutral threshold → negative delta."""
         from app.services.virtual_training_metrics import compute_vt_skill_deltas
 
-        # 9 false alarms out of 30 stimuli → wrong_rate = 0.30 → composure = 1-1.5*0.3 = 0.55
-        # At wrong_rate = 0.67 composure = 0; use extreme case
+        # wrong_rate = 20/30 ≈ 0.667 → composure = 1 - 1.5*0.667 ≈ 0.0
+        # 0.0 < NEUTRAL_THRESHOLD(0.45) → delta = (0.0 - 0.45) * 0.5 * unit < 0
         data = {
             "stimuli_count":     30,
             "correct_count":     15,
-            "wrong_click_count": 20,    # very high false alarm proxy
+            "wrong_click_count": 20,
             "error_count":       0,
             "avg_reaction_ms":   350.0,
         }
         deltas = compute_vt_skill_deltas(data=data, game=self._game_mock(), multiplier=1.0)
-        # composure should be 0 when wrong_rate = 20/30 = 0.67
-        assert deltas.get("composure", 0.0) == pytest.approx(0.0, abs=0.01)
+        assert deltas.get("composure", 0.0) < 0
 
-    def test_gng20_missed_go_heavy_concentration_low(self):
-        """GNG-20: Many missed GO → concentration score near zero."""
+    def test_gng20_missed_go_heavy_concentration_negative(self):
+        """GNG-20: Many missed GO → concentration below neutral threshold → negative delta."""
         from app.services.virtual_training_metrics import compute_vt_skill_deltas
 
-        # miss_rate = 15/30 = 0.5 → concentration = max(0, 1 - 2*0.5) = 0.0
+        # miss_rate = 15/30 = 0.5 → concentration = 1 - 2*0.5 = 0.0
+        # 0.0 < NEUTRAL_THRESHOLD(0.45) → delta = (0.0 - 0.45) * 0.5 * unit < 0
         data = {
             "stimuli_count":     30,
             "correct_count":     6,
             "wrong_click_count": 0,
-            "error_count":       15,    # heavy misses
+            "error_count":       15,
             "avg_reaction_ms":   400.0,
         }
         deltas = compute_vt_skill_deltas(data=data, game=self._game_mock(), multiplier=1.0)
-        assert deltas.get("concentration", 0.0) == pytest.approx(0.0, abs=0.01)
+        assert deltas.get("concentration", 0.0) < 0
 
 
 # ── GNG-21..22: raw_metrics persistence ──────────────────────────────────────

--- a/tests/unit/api/web_routes/test_go_no_go.py
+++ b/tests/unit/api/web_routes/test_go_no_go.py
@@ -748,12 +748,10 @@ class TestGoNoGoTemplates:
 
     def test_gng25_views_timeline_event_includes_game_code(self):
         """GNG-25: _collect_vt_timeline_events includes game_code in returned dicts."""
-        import ast, pathlib
-        src = pathlib.Path(
-            "/Users/lovas.zoltan/Seafile/Football Investment/Projects/"
-            "Football Investment Internship/practice_booking_system/"
-            "app/services/skill_progression/_views.py"
-        ).read_text()
+        from pathlib import Path
+        src = (Path(__file__).resolve().parents[4]
+               / "app" / "services" / "skill_progression" / "_views.py"
+               ).read_text()
         assert '"game_code"' in src or "'game_code'" in src
 
     def test_gng26_result_template_has_per_phase_no_per_color(self):

--- a/tests/unit/api/web_routes/test_go_no_go.py
+++ b/tests/unit/api/web_routes/test_go_no_go.py
@@ -1,0 +1,866 @@
+"""Unit tests for Go / No-Go Reaction — Phase 2.4.
+
+Route tests:
+GNG-01   GET /virtual-training/go-no-go → 200 active game
+GNG-02   GET /virtual-training/go-no-go → hub redirect when game inactive
+GNG-03   GET /virtual-training/go-no-go → 303 non-student / non-onboarded
+GNG-04   POST /virtual-training/go-no-go/submit → 200 valid data
+GNG-05   POST submit → is_valid=False + 0 XP too_short
+GNG-06   POST submit → is_valid=False + 0 XP bot_suspected
+GNG-07   POST submit → 429 daily cap
+GNG-08   POST submit → 404 inactive game
+GNG-09   POST submit → 403 not onboarded
+GNG-10   GET /virtual-training/go-no-go/result/{id} → 200 owner
+GNG-11   GET result → hub redirect wrong user
+GNG-12   POST submit → idempotency: duplicate key returns same attempt_id
+
+Skill scorer tests:
+GNG-13   score_composure(wrong_rate=0.0) → 1.0
+GNG-14   score_composure(wrong_rate=0.5) → clamp(1.0-0.75, 0, 1) = 0.25
+GNG-15   score_composure(wrong_rate=0.8) → 0.0 (clamped below 0)
+GNG-16   score_all() includes composure when in skill_targets
+GNG-17   VTDeltaComputer with composure → positive delta at perfect signals
+
+Performance delta tests:
+GNG-18   Perfect run (0 FA, 0 miss, fast RT) → all four deltas positive
+GNG-19   False alarm heavy run → composure delta near zero
+GNG-20   Missed GO heavy run → concentration delta near zero
+
+raw_metrics tests:
+GNG-21   record_attempt() persists raw_metrics with per_phase correct_inhibits
+GNG-22   raw_metrics per_phase sums match aggregate counts
+
+Template / link tests:
+GNG-23   virtual_training_history.html link is NOT hardcoded to color-reaction
+GNG-24   skill_history.html link uses game_code variable (not hardcoded)
+GNG-25   _views.py timeline event includes game_code field
+GNG-26   Go/No-Go result template renders per_phase (not per_color)
+GNG-27   Go/No-Go result template skill breakdown shows composure formula note
+
+Score formula tests:
+GNG-28   Perfect 21/21 GO + 9/9 inhibit → score_normalized ≥ 90
+GNG-29   All false alarms (9 FA, 0 inhibit) → score_normalized ≤ 40
+
+Regression guards:
+GNG-REG-01   Color Reaction GET route still works
+GNG-REG-02   Color Reaction submit route still works
+GNG-REG-03   VT hub still loads (get_hub_games not broken)
+
+Seed:
+GNG-SEED-01  go_no_go is_active=True in seed data (VT-16 updated)
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+_ROUTES = "app.api.web_routes.virtual_training"
+_TEMPLATES_DIR = (
+    Path(__file__).resolve().parents[4] / "app" / "templates"
+)
+
+
+# ── Shared helpers ─────────────────────────────────────────────────────────────
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+_GNG_SKILL_TARGETS = {
+    "decisions":     0.35,
+    "concentration": 0.30,
+    "composure":     0.20,
+    "reactions":     0.15,
+}
+
+_GNG_CONFIG = {
+    "phases": [
+        {"go": 10, "no_go": 5, "isi_ms": 900,  "window_ms": 1000, "stimulus_ms": 800},
+        {"go": 11, "no_go": 4, "isi_ms": 650,  "window_ms": 1000, "stimulus_ms": 800},
+    ],
+    "go_cue":    {"color": "#22c55e", "label": "GO"},
+    "no_go_cue": {"color": "#ef4444", "label": "STOP"},
+    "score_weights": {
+        "go_hit_rate": 0.40, "no_go_success": 0.35,
+        "speed_factor": 0.15, "missed_go_penalty": 0.10,
+    },
+    "show_in_hub": True,
+    "icon": "🛑",
+    "football_benefit": "Impulse control.",
+}
+
+
+def _mock_gng_game(*, is_active: bool = True) -> MagicMock:
+    g = MagicMock()
+    g.id                = 3
+    g.code              = "go_no_go"
+    g.name              = "Go / No-Go Reaction"
+    g.is_active         = is_active
+    g.base_xp           = 12
+    g.max_daily_attempts = 5
+    g.skill_targets     = _GNG_SKILL_TARGETS
+    g.config            = _GNG_CONFIG
+    return g
+
+
+def _mock_attempt(
+    *,
+    id: int = 99,
+    user_id: int = 42,
+    game_id: int = 3,
+    is_valid: bool = True,
+    xp_awarded: int = 12,
+    score_normalized: float = 78.0,
+    attempt_index_today: int = 1,
+    invalid_reason: str | None = None,
+    skill_deltas: dict | None = None,
+    correct_count: int = 19,
+    wrong_click_count: int = 1,
+    error_count: int = 2,
+    avg_reaction_ms: float = 380.0,
+    stimuli_count: int = 30,
+    duration_seconds: float = 47.0,
+    raw_metrics: dict | None = None,
+) -> MagicMock:
+    a = MagicMock()
+    a.id                  = id
+    a.user_id             = user_id
+    a.game_id             = game_id
+    a.is_valid            = is_valid
+    a.xp_awarded          = xp_awarded
+    a.score_normalized    = score_normalized
+    a.attempt_index_today = attempt_index_today
+    a.invalid_reason      = invalid_reason
+    a.skill_deltas        = skill_deltas or {
+        "decisions": 0.21, "concentration": 0.15,
+        "composure": 0.11, "reactions": 0.07,
+    }
+    a.correct_count       = correct_count
+    a.wrong_click_count   = wrong_click_count
+    a.error_count         = error_count
+    a.avg_reaction_ms     = avg_reaction_ms
+    a.min_reaction_ms     = 210.0
+    a.stimuli_count       = stimuli_count
+    a.duration_seconds    = duration_seconds
+    a.raw_metrics         = raw_metrics
+    return a
+
+
+def _mock_db(*, count: int = 0) -> MagicMock:
+    db = MagicMock()
+    q = MagicMock()
+    q.filter.return_value  = q
+    q.count.return_value   = count
+    q.first.return_value   = None
+    q.all.return_value     = []
+    db.query.return_value  = q
+    return db
+
+
+def _make_student(user_id: int = 42) -> MagicMock:
+    from app.models.user import UserRole
+    u = MagicMock()
+    u.id = user_id
+    u.role = UserRole.STUDENT
+    u.onboarding_completed = True
+    u.credit_balance = 0
+    u.specialization = MagicMock()
+    u.specialization.value = "LFA_FOOTBALL_PLAYER"
+    return u
+
+
+def _make_request(path: str = "/virtual-training/go-no-go") -> MagicMock:
+    r = MagicMock()
+    r.url.path = path
+    return r
+
+
+# ── GNG-01..03: GET game page ─────────────────────────────────────────────────
+
+class TestGoNoGoPage:
+
+    def test_gng01_active_game_returns_200(self):
+        """GNG-01: GET /virtual-training/go-no-go → 200 for active game."""
+        from app.api.web_routes.virtual_training import virtual_training_go_no_go
+
+        user    = _make_student()
+        request = _make_request()
+        db      = _mock_db()
+        game    = _mock_gng_game()
+
+        fake_resp = MagicMock(spec=HTMLResponse)
+        fake_resp.status_code = 200
+
+        with patch(f"{_ROUTES}.require_student_onboarding", return_value=None), \
+             patch(f"{_ROUTES}._spec_ctx", return_value={}), \
+             patch(f"{_ROUTES}.VirtualTrainingService.get_game", return_value=game), \
+             patch(f"{_ROUTES}.templates") as mock_tmpl:
+            mock_tmpl.TemplateResponse.return_value = fake_resp
+            result = _run(virtual_training_go_no_go(request=request, db=db, user=user))
+
+        assert result is fake_resp
+        call_args = mock_tmpl.TemplateResponse.call_args
+        assert call_args[0][0] == "virtual_training_go_no_go.html"
+        ctx = call_args[0][1]
+        assert ctx["game"] is game
+
+    def test_gng02_inactive_game_returns_hub(self):
+        """GNG-02: GET /virtual-training/go-no-go → renders hub with error when inactive."""
+        from app.api.web_routes.virtual_training import virtual_training_go_no_go
+
+        user    = _make_student()
+        request = _make_request()
+        db      = _mock_db()
+        game    = _mock_gng_game(is_active=False)
+
+        fake_hub = MagicMock(spec=HTMLResponse)
+
+        with patch(f"{_ROUTES}.require_student_onboarding", return_value=None), \
+             patch(f"{_ROUTES}._spec_ctx", return_value={}), \
+             patch(f"{_ROUTES}.VirtualTrainingService.get_game", return_value=game), \
+             patch(f"{_ROUTES}.VirtualTrainingService.get_hub_games", return_value=[]), \
+             patch(f"{_ROUTES}.templates") as mock_tmpl:
+            mock_tmpl.TemplateResponse.return_value = fake_hub
+            result = _run(virtual_training_go_no_go(request=request, db=db, user=user))
+
+        assert result is fake_hub
+        call_args = mock_tmpl.TemplateResponse.call_args
+        assert call_args[0][0] == "virtual_training_hub.html"
+        assert "error" in call_args[0][1]
+
+    def test_gng03_non_onboarded_redirected(self):
+        """GNG-03: GET /virtual-training/go-no-go → guard redirect for non-onboarded."""
+        from app.api.web_routes.virtual_training import virtual_training_go_no_go
+
+        user = _make_student()
+        user.onboarding_completed = False
+        request = _make_request()
+        db = _mock_db()
+        redirect = RedirectResponse(url="/dashboard", status_code=303)
+
+        with patch(f"{_ROUTES}.require_student_onboarding", return_value=redirect), \
+             patch(f"{_ROUTES}.templates") as mock_tmpl:
+            result = _run(virtual_training_go_no_go(request=request, db=db, user=user))
+
+        assert isinstance(result, RedirectResponse)
+        mock_tmpl.TemplateResponse.assert_not_called()
+
+
+# ── GNG-04..09: POST submit ───────────────────────────────────────────────────
+
+class TestGoNoGoSubmit:
+
+    def _valid_payload(self) -> dict:
+        return {
+            "started_at":        "2026-05-22T12:00:00.000Z",
+            "duration_seconds":  48.0,
+            "stimuli_count":     30,
+            "correct_count":     20,
+            "wrong_click_count": 1,
+            "error_count":       1,
+            "avg_reaction_ms":   370.0,
+            "min_reaction_ms":   210.0,
+            "score_raw":         0.78,
+            "score_normalized":  78.0,
+            "raw_metrics":       {"v": 1, "per_stimulus": [], "per_phase": []},
+        }
+
+    def test_gng04_valid_submit_returns_200(self):
+        """GNG-04: POST submit with valid data returns attempt_id, xp_awarded."""
+        from app.api.web_routes.virtual_training import virtual_training_go_no_go_submit
+
+        user    = _make_student()
+        request = _make_request(path="/virtual-training/go-no-go/submit")
+        request.json = asyncio.coroutine(lambda: self._valid_payload()) if False else (lambda: self._valid_payload())
+        request.json = MagicMock()
+        request.json.return_value = self._valid_payload()
+
+        async def _fake_json():
+            return self._valid_payload()
+        request.json = _fake_json
+
+        db      = _mock_db(count=0)
+        game    = _mock_gng_game()
+        attempt = _mock_attempt()
+
+        with patch(f"{_ROUTES}.require_student_onboarding", return_value=None), \
+             patch(f"{_ROUTES}.VirtualTrainingService.get_game", return_value=game), \
+             patch(f"{_ROUTES}.VirtualTrainingService.record_attempt", return_value=attempt):
+            from fastapi.responses import JSONResponse
+            result = _run(virtual_training_go_no_go_submit(request=request, db=db, user=user))
+
+        assert result.status_code == 200
+        import json
+        body = json.loads(result.body)
+        assert body["attempt_id"] == attempt.id
+        assert body["xp_awarded"] == attempt.xp_awarded
+        assert body["is_valid"] is True
+
+    def test_gng05_too_short_returns_invalid(self):
+        """GNG-05: POST submit with duration < 25s → is_valid=False, xp_awarded=0."""
+        from app.api.web_routes.virtual_training import virtual_training_go_no_go_submit
+
+        user  = _make_student()
+        request = _make_request()
+
+        payload = self._valid_payload()
+        payload["duration_seconds"] = 5.0
+
+        async def _fake_json():
+            return payload
+        request.json = _fake_json
+
+        db      = _mock_db(count=0)
+        game    = _mock_gng_game()
+        attempt = _mock_attempt(is_valid=False, xp_awarded=0, invalid_reason="too_short")
+
+        with patch(f"{_ROUTES}.require_student_onboarding", return_value=None), \
+             patch(f"{_ROUTES}.VirtualTrainingService.get_game", return_value=game), \
+             patch(f"{_ROUTES}.VirtualTrainingService.record_attempt", return_value=attempt):
+            result = _run(virtual_training_go_no_go_submit(request=request, db=db, user=user))
+
+        import json
+        body = json.loads(result.body)
+        assert body["is_valid"] is False
+        assert body["xp_awarded"] == 0
+        assert body["invalid_reason"] == "too_short"
+
+    def test_gng06_bot_suspected_returns_invalid(self):
+        """GNG-06: POST submit avg_reaction_ms < 80 → is_valid=False, bot_suspected."""
+        from app.api.web_routes.virtual_training import virtual_training_go_no_go_submit
+
+        user = _make_student()
+        request = _make_request()
+
+        payload = self._valid_payload()
+        payload["avg_reaction_ms"] = 50.0
+
+        async def _fake_json():
+            return payload
+        request.json = _fake_json
+
+        db      = _mock_db(count=0)
+        game    = _mock_gng_game()
+        attempt = _mock_attempt(is_valid=False, xp_awarded=0, invalid_reason="bot_suspected")
+
+        with patch(f"{_ROUTES}.require_student_onboarding", return_value=None), \
+             patch(f"{_ROUTES}.VirtualTrainingService.get_game", return_value=game), \
+             patch(f"{_ROUTES}.VirtualTrainingService.record_attempt", return_value=attempt):
+            result = _run(virtual_training_go_no_go_submit(request=request, db=db, user=user))
+
+        import json
+        body = json.loads(result.body)
+        assert body["is_valid"] is False
+        assert body["invalid_reason"] == "bot_suspected"
+
+    def test_gng07_daily_cap_returns_429(self):
+        """GNG-07: POST submit → 429 when valid_today >= max_daily_attempts."""
+        from app.api.web_routes.virtual_training import virtual_training_go_no_go_submit
+
+        user = _make_student()
+        request = _make_request()
+
+        async def _fake_json():
+            return self._valid_payload()
+        request.json = _fake_json
+
+        db   = _mock_db(count=5)      # 5 valid attempts today
+        game = _mock_gng_game()
+        game.max_daily_attempts = 5
+
+        with patch(f"{_ROUTES}.require_student_onboarding", return_value=None), \
+             patch(f"{_ROUTES}.VirtualTrainingService.get_game", return_value=game):
+            result = _run(virtual_training_go_no_go_submit(request=request, db=db, user=user))
+
+        assert result.status_code == 429
+
+    def test_gng08_inactive_game_returns_404(self):
+        """GNG-08: POST submit → 404 when game is inactive."""
+        from app.api.web_routes.virtual_training import virtual_training_go_no_go_submit
+
+        user = _make_student()
+        request = _make_request()
+
+        async def _fake_json():
+            return self._valid_payload()
+        request.json = _fake_json
+
+        db   = _mock_db()
+        game = _mock_gng_game(is_active=False)
+
+        with patch(f"{_ROUTES}.require_student_onboarding", return_value=None), \
+             patch(f"{_ROUTES}.VirtualTrainingService.get_game", return_value=game):
+            result = _run(virtual_training_go_no_go_submit(request=request, db=db, user=user))
+
+        assert result.status_code == 404
+
+    def test_gng09_non_onboarded_returns_403(self):
+        """GNG-09: POST submit → 403 when onboarding not completed."""
+        from app.api.web_routes.virtual_training import virtual_training_go_no_go_submit
+
+        user = _make_student()
+        request = _make_request()
+
+        async def _fake_json():
+            return self._valid_payload()
+        request.json = _fake_json
+
+        db       = _mock_db()
+        redirect = RedirectResponse(url="/dashboard", status_code=303)
+
+        with patch(f"{_ROUTES}.require_student_onboarding", return_value=redirect):
+            result = _run(virtual_training_go_no_go_submit(request=request, db=db, user=user))
+
+        assert result.status_code == 403
+
+    def test_gng12_idempotency_returns_same_id(self):
+        """GNG-12: Duplicate idempotency key returns same attempt_id without double-write."""
+        from app.api.web_routes.virtual_training import virtual_training_go_no_go_submit
+
+        user = _make_student()
+        request = _make_request()
+
+        async def _fake_json():
+            return self._valid_payload()
+        request.json = _fake_json
+
+        db      = _mock_db(count=0)
+        game    = _mock_gng_game()
+        attempt = _mock_attempt(id=55)
+
+        call_count = {"n": 0}
+
+        def _idempotent_record(**kwargs):
+            call_count["n"] += 1
+            return attempt  # same attempt both times
+
+        with patch(f"{_ROUTES}.require_student_onboarding", return_value=None), \
+             patch(f"{_ROUTES}.VirtualTrainingService.get_game", return_value=game), \
+             patch(f"{_ROUTES}.VirtualTrainingService.record_attempt",
+                   side_effect=_idempotent_record):
+            result1 = _run(virtual_training_go_no_go_submit(request=request, db=db, user=user))
+            result2 = _run(virtual_training_go_no_go_submit(request=request, db=db, user=user))
+
+        import json
+        assert json.loads(result1.body)["attempt_id"] == 55
+        assert json.loads(result2.body)["attempt_id"] == 55
+
+
+# ── GNG-10..11: GET result page ───────────────────────────────────────────────
+
+class TestGoNoGoResult:
+
+    def test_gng10_result_200_for_owner(self):
+        """GNG-10: GET /virtual-training/go-no-go/result/{id} → 200 for owner."""
+        from app.api.web_routes.virtual_training import virtual_training_go_no_go_result
+
+        user    = _make_student()
+        request = _make_request()
+        db      = _mock_db()
+        attempt = _mock_attempt(user_id=user.id)
+        game    = _mock_gng_game()
+
+        db.query.return_value.filter.return_value.first.return_value = attempt
+
+        fake_resp = MagicMock(spec=HTMLResponse)
+        fake_resp.status_code = 200
+
+        with patch(f"{_ROUTES}.require_student_onboarding", return_value=None), \
+             patch(f"{_ROUTES}._spec_ctx", return_value={}), \
+             patch(f"{_ROUTES}.templates") as mock_tmpl:
+            mock_tmpl.TemplateResponse.return_value = fake_resp
+
+            # Second db.query call (for game) needs to return game
+            def _query_side_effect(model):
+                q = MagicMock()
+                q.filter.return_value = q
+                if hasattr(model, '__tablename__') and 'attempt' in str(model.__tablename__):
+                    q.first.return_value = attempt
+                else:
+                    q.first.return_value = game
+                return q
+            db.query.side_effect = _query_side_effect
+
+            result = _run(virtual_training_go_no_go_result(
+                attempt_id=attempt.id, request=request, db=db, user=user
+            ))
+
+        assert result is fake_resp
+        call_args = mock_tmpl.TemplateResponse.call_args
+        assert call_args[0][0] == "virtual_training_go_no_go_result.html"
+
+    def test_gng11_result_hub_redirect_wrong_user(self):
+        """GNG-11: GET result → hub with error when attempt belongs to different user."""
+        from app.api.web_routes.virtual_training import virtual_training_go_no_go_result
+
+        user    = _make_student(user_id=1)
+        request = _make_request()
+        db      = _mock_db()
+        # Attempt not found for this user (different user_id filter)
+        db.query.return_value.filter.return_value.first.return_value = None
+
+        fake_hub = MagicMock(spec=HTMLResponse)
+
+        with patch(f"{_ROUTES}.require_student_onboarding", return_value=None), \
+             patch(f"{_ROUTES}._spec_ctx", return_value={}), \
+             patch(f"{_ROUTES}.VirtualTrainingService.get_hub_games", return_value=[]), \
+             patch(f"{_ROUTES}.templates") as mock_tmpl:
+            mock_tmpl.TemplateResponse.return_value = fake_hub
+            result = _run(virtual_training_go_no_go_result(
+                attempt_id=999, request=request, db=db, user=user
+            ))
+
+        assert result is fake_hub
+        call_args = mock_tmpl.TemplateResponse.call_args
+        assert call_args[0][0] == "virtual_training_hub.html"
+        assert "error" in call_args[0][1]
+
+
+# ── GNG-13..17: score_composure ───────────────────────────────────────────────
+
+class TestScoreComposure:
+
+    def _signals(self, *, wrong_rate: float = 0.0, hit_rate: float = 1.0,
+                 miss_rate: float = 0.0, speed_score: float = 0.7) -> "VTSignals":
+        from app.services.virtual_training_metrics import VTSignals
+        return VTSignals(
+            hit_rate=hit_rate,
+            wrong_rate=wrong_rate,
+            miss_rate=miss_rate,
+            speed_score=speed_score,
+            completion_rate=1.0,
+        )
+
+    def test_gng13_zero_false_alarms_perfect_composure(self):
+        """GNG-13: score_composure(wrong_rate=0.0) → 1.0."""
+        from app.services.virtual_training_metrics import VTSkillScorer
+        sig = self._signals(wrong_rate=0.0)
+        assert VTSkillScorer.score_composure(sig) == pytest.approx(1.0)
+
+    def test_gng14_moderate_false_alarms(self):
+        """GNG-14: score_composure(wrong_rate=0.5) → 0.25 (1.0 - 1.5*0.5)."""
+        from app.services.virtual_training_metrics import VTSkillScorer
+        sig = self._signals(wrong_rate=0.5)
+        assert VTSkillScorer.score_composure(sig) == pytest.approx(0.25)
+
+    def test_gng15_heavy_false_alarms_clamped_to_zero(self):
+        """GNG-15: score_composure(wrong_rate=0.8) → 0.0 (clamped, 1.0-1.2<0)."""
+        from app.services.virtual_training_metrics import VTSkillScorer
+        sig = self._signals(wrong_rate=0.8)
+        assert VTSkillScorer.score_composure(sig) == pytest.approx(0.0)
+
+    def test_gng16_score_all_includes_composure(self):
+        """GNG-16: score_all() dispatches composure to dedicated scorer."""
+        from app.services.virtual_training_metrics import VTSkillScorer
+        sig = self._signals(wrong_rate=0.1)
+        scores = VTSkillScorer.score_all(sig, _GNG_SKILL_TARGETS)
+        assert "composure" in scores
+        # composure = 1.0 - 1.5*0.1 = 0.85
+        assert scores["composure"] == pytest.approx(0.85)
+
+    def test_gng17_delta_computer_composure_positive(self):
+        """GNG-17: VTDeltaComputer with composure skill_targets → positive delta."""
+        from app.services.virtual_training_metrics import VTSkillScorer, VTDeltaComputer
+        sig    = self._signals(wrong_rate=0.0)
+        scores = VTSkillScorer.score_all(sig, _GNG_SKILL_TARGETS)
+        deltas = VTDeltaComputer.compute(scores, _GNG_SKILL_TARGETS, base_xp=12, multiplier=1.0)
+        assert deltas.get("composure", 0) > 0
+
+
+# ── GNG-18..20: Performance delta tests ──────────────────────────────────────
+
+class TestGoNoGoDeltas:
+
+    def _game_mock(self) -> MagicMock:
+        g = MagicMock()
+        g.base_xp       = 12
+        g.skill_targets = _GNG_SKILL_TARGETS
+        g.config        = _GNG_CONFIG
+        return g
+
+    def test_gng18_perfect_run_all_deltas_positive(self):
+        """GNG-18: 21 GO hits, 0 FA, 0 miss, fast RT → all 4 deltas > 0."""
+        from app.services.virtual_training_metrics import compute_vt_skill_deltas
+
+        data = {
+            "stimuli_count":     30,
+            "correct_count":     21,    # all GO hits
+            "wrong_click_count": 0,     # zero false alarms
+            "error_count":       0,     # zero missed GO
+            "avg_reaction_ms":   300.0,
+            "raw_metrics": {"v": 1, "per_stimulus": [], "per_phase": []},
+        }
+        deltas = compute_vt_skill_deltas(data=data, game=self._game_mock(), multiplier=1.0)
+
+        assert set(deltas.keys()) == {"decisions", "concentration", "composure", "reactions"}
+        for skill, delta in deltas.items():
+            assert delta > 0, f"Expected positive delta for {skill}"
+
+    def test_gng19_false_alarm_heavy_composure_near_zero(self):
+        """GNG-19: Many false alarms → composure score near zero, tiny/no delta."""
+        from app.services.virtual_training_metrics import compute_vt_skill_deltas
+
+        # 9 false alarms out of 30 stimuli → wrong_rate = 0.30 → composure = 1-1.5*0.3 = 0.55
+        # At wrong_rate = 0.67 composure = 0; use extreme case
+        data = {
+            "stimuli_count":     30,
+            "correct_count":     15,
+            "wrong_click_count": 20,    # very high false alarm proxy
+            "error_count":       0,
+            "avg_reaction_ms":   350.0,
+        }
+        deltas = compute_vt_skill_deltas(data=data, game=self._game_mock(), multiplier=1.0)
+        # composure should be 0 when wrong_rate = 20/30 = 0.67
+        assert deltas.get("composure", 0.0) == pytest.approx(0.0, abs=0.01)
+
+    def test_gng20_missed_go_heavy_concentration_low(self):
+        """GNG-20: Many missed GO → concentration score near zero."""
+        from app.services.virtual_training_metrics import compute_vt_skill_deltas
+
+        # miss_rate = 15/30 = 0.5 → concentration = max(0, 1 - 2*0.5) = 0.0
+        data = {
+            "stimuli_count":     30,
+            "correct_count":     6,
+            "wrong_click_count": 0,
+            "error_count":       15,    # heavy misses
+            "avg_reaction_ms":   400.0,
+        }
+        deltas = compute_vt_skill_deltas(data=data, game=self._game_mock(), multiplier=1.0)
+        assert deltas.get("concentration", 0.0) == pytest.approx(0.0, abs=0.01)
+
+
+# ── GNG-21..22: raw_metrics persistence ──────────────────────────────────────
+
+class TestGoNoGoRawMetrics:
+
+    def test_gng21_raw_metrics_persisted_with_per_phase(self):
+        """GNG-21: record_attempt() stores raw_metrics including per_phase fields."""
+        from app.services.virtual_training_service import VirtualTrainingService
+
+        raw = {
+            "v": 1,
+            "per_stimulus": [
+                {"i": 0, "phase": 0, "type": "go",    "outcome": "hit",            "rt_ms": 340, "window_ms": 1000},
+                {"i": 1, "phase": 0, "type": "no_go", "outcome": "correct_inhibit","rt_ms": None, "window_ms": 1000},
+                {"i": 2, "phase": 1, "type": "no_go", "outcome": "false_alarm",    "rt_ms": 290, "window_ms": 1000},
+            ],
+            "per_phase": [
+                {"phase": 0, "go": 10, "no_go": 5, "go_hits": 9, "go_misses": 1,
+                 "correct_inhibits": 4, "false_alarms": 1, "avg_rt_ms": 380},
+                {"phase": 1, "go": 11, "no_go": 4, "go_hits": 10, "go_misses": 1,
+                 "correct_inhibits": 3, "false_alarms": 1, "avg_rt_ms": 360},
+            ],
+        }
+
+        db   = MagicMock()
+        game = _mock_gng_game()
+
+        sp = MagicMock()
+        db.begin_nested.return_value = sp
+
+        captured = {}
+
+        class _FakeAttempt:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+                self.idempotency_key = kwargs.get("idempotency_key")
+
+        with patch("app.services.virtual_training_service.VirtualTrainingAttempt",
+                   side_effect=_FakeAttempt), \
+             patch("app.services.virtual_training_service.VirtualTrainingService"
+                   ".calculate_daily_attempt_index", return_value=0), \
+             patch("app.services.gamification.xp_service.award_xp"), \
+             patch("app.services.segment_reward_service._load_conversion_rates",
+                   return_value={}), \
+             patch("app.services.virtual_training_metrics.compute_vt_skill_deltas",
+                   return_value={"composure": 0.1}):
+
+            VirtualTrainingService.record_attempt(
+                db=db, user_id=7, game=game,
+                data={
+                    "started_at": "2026-05-22T12:00:00Z",
+                    "duration_seconds": 48.0,
+                    "stimuli_count": 30,
+                    "correct_count": 19,
+                    "wrong_click_count": 2,
+                    "error_count": 2,
+                    "avg_reaction_ms": 370.0,
+                    "score_normalized": 75.0,
+                    "raw_metrics": raw,
+                },
+                idempotency_key="test_key_gng21",
+            )
+
+        assert captured.get("raw_metrics") is raw
+        stored_raw = captured["raw_metrics"]
+        assert stored_raw["v"] == 1
+        per_phase = stored_raw["per_phase"]
+        assert len(per_phase) == 2
+        # correct_inhibits field present
+        assert "correct_inhibits" in per_phase[0]
+        assert per_phase[0]["correct_inhibits"] == 4
+
+    def test_gng22_per_phase_sums_match_aggregate(self):
+        """GNG-22: per_phase go_hits sum == correct_count, false_alarms sum == wrong_click_count."""
+        raw = {
+            "v": 1,
+            "per_stimulus": [],
+            "per_phase": [
+                {"phase": 0, "go": 10, "no_go": 5,
+                 "go_hits": 9, "go_misses": 1, "correct_inhibits": 4, "false_alarms": 1, "avg_rt_ms": 380},
+                {"phase": 1, "go": 11, "no_go": 4,
+                 "go_hits": 10, "go_misses": 1, "correct_inhibits": 3, "false_alarms": 1, "avg_rt_ms": 360},
+            ],
+        }
+        total_go_hits    = sum(p["go_hits"]      for p in raw["per_phase"])
+        total_fa         = sum(p["false_alarms"]  for p in raw["per_phase"])
+        # submitted correct_count=19, wrong_click_count=2
+        assert total_go_hits == 19
+        assert total_fa == 2
+
+
+# ── GNG-23..27: Template / link tests ────────────────────────────────────────
+
+class TestGoNoGoTemplates:
+
+    def _read(self, filename: str) -> str:
+        return (_TEMPLATES_DIR / filename).read_text(encoding="utf-8")
+
+    def test_gng23_history_link_not_hardcoded_color_reaction(self):
+        """GNG-23: virtual_training_history.html result link uses game code variable."""
+        html = self._read("virtual_training_history.html")
+        # Must NOT contain the hardcoded color-reaction path
+        assert "/virtual-training/color-reaction/result/" not in html
+        # Must contain the dynamic game code pattern
+        assert "_slug" in html or "game_code" in html or "code" in html
+
+    def test_gng24_skill_history_link_uses_game_code(self):
+        """GNG-24: skill_history.html VT detail link uses game_code variable."""
+        html = self._read("skill_history.html")
+        # Must NOT be hardcoded to color-reaction
+        assert '"/virtual-training/color-reaction/result/' not in html
+        # Must use a variable for the game slug
+        assert "game_code" in html or "gameSlug" in html
+
+    def test_gng25_views_timeline_event_includes_game_code(self):
+        """GNG-25: _collect_vt_timeline_events includes game_code in returned dicts."""
+        import ast, pathlib
+        src = pathlib.Path(
+            "/Users/lovas.zoltan/Seafile/Football Investment/Projects/"
+            "Football Investment Internship/practice_booking_system/"
+            "app/services/skill_progression/_views.py"
+        ).read_text()
+        assert '"game_code"' in src or "'game_code'" in src
+
+    def test_gng26_result_template_has_per_phase_no_per_color(self):
+        """GNG-26: Go/No-Go result template renders per_phase (not per_color table)."""
+        html = self._read("virtual_training_go_no_go_result.html")
+        assert "per_phase" in html
+        assert "per_color" not in html
+        # Specific Go/No-Go fields
+        assert "go_hits" in html or "GO hits" in html
+        assert "false_alarms" in html or "False alarms" in html
+
+    def test_gng27_result_template_composure_documented(self):
+        """GNG-27: Go/No-Go result template explains composure formula in breakdown."""
+        html = self._read("virtual_training_go_no_go_result.html")
+        # Composure skill breakdown notes must explain impulse control
+        assert "composure" in html.lower()
+        assert "false alarm" in html.lower() or "impulse" in html.lower()
+
+
+# ── GNG-28..29: Score formula ─────────────────────────────────────────────────
+
+class TestGoNoGoScoreFormula:
+
+    def test_gng28_perfect_run_score_high(self):
+        """GNG-28: 21/21 GO hits + 9/9 NO-GO inhibits + 300ms RT → score_normalized ≥ 85.
+        Max formula score = 90 (at 0ms RT); 300ms gives speed_factor=0.70 → 86.
+        """
+        go_hit_rate    = 21 / 21   # 1.0
+        no_go_fail_rate = 0 / 9    # 0.0
+        missed_go_rate  = 0 / 21   # 0.0
+        speed_factor    = max(0, 1 - 300 / 1000)  # 0.7
+
+        score_raw = (0.40 * go_hit_rate
+                     + 0.35 * (1 - no_go_fail_rate)
+                     + 0.15 * speed_factor
+                     - 0.10 * missed_go_rate)
+        score_norm = min(100, max(0, round(100 * score_raw)))
+        assert score_norm >= 85
+
+    def test_gng29_all_false_alarms_score_low(self):
+        """GNG-29: 0 GO hits + 9 false alarms → score_normalized ≤ 40."""
+        go_hit_rate     = 0 / 21   # 0.0
+        no_go_fail_rate = 9 / 9    # 1.0
+        missed_go_rate  = 21 / 21  # 1.0
+        speed_factor    = 0.0
+
+        score_raw = (0.40 * go_hit_rate
+                     + 0.35 * (1 - no_go_fail_rate)
+                     + 0.15 * speed_factor
+                     - 0.10 * missed_go_rate)
+        score_norm = min(100, max(0, round(100 * score_raw)))
+        assert score_norm <= 40
+
+
+# ── GNG-REG: Color Reaction regression guards ──────────────────────────────────
+
+class TestColorReactionRegression:
+
+    def test_gng_reg01_color_reaction_get_route_exists(self):
+        """GNG-REG-01: GET /virtual-training/color-reaction route still importable."""
+        from app.api.web_routes.virtual_training import virtual_training_color_reaction
+        assert callable(virtual_training_color_reaction)
+
+    def test_gng_reg02_color_reaction_submit_route_exists(self):
+        """GNG-REG-02: POST /virtual-training/color-reaction/submit route still importable."""
+        from app.api.web_routes.virtual_training import virtual_training_color_reaction_submit
+        assert callable(virtual_training_color_reaction_submit)
+
+    def test_gng_reg03_hub_route_still_loads(self):
+        """GNG-REG-03: GET /virtual-training hub route + get_hub_games not broken."""
+        from app.api.web_routes.virtual_training import virtual_training_hub
+        assert callable(virtual_training_hub)
+
+    def test_gng_reg04_color_reaction_result_route_exists(self):
+        """GNG-REG-04: GET /virtual-training/color-reaction/result/{id} still importable."""
+        from app.api.web_routes.virtual_training import virtual_training_color_reaction_result
+        assert callable(virtual_training_color_reaction_result)
+
+
+# ── GNG-SEED-01: Seed guard ───────────────────────────────────────────────────
+
+class TestGoNoGoSeed:
+
+    def test_gng_seed01_go_no_go_is_active_in_seed(self):
+        """GNG-SEED-01: go_no_go is_active=True in seed data."""
+        from scripts.seed_virtual_training_games import _GAMES
+        game_map = {g["code"]: g for g in _GAMES}
+        assert "go_no_go" in game_map, "go_no_go missing from seed"
+        assert game_map["go_no_go"]["is_active"] is True, "go_no_go must be is_active=True"
+
+    def test_gng_seed02_go_no_go_has_gameplay_config(self):
+        """GNG-SEED-02: go_no_go config has phases array with go/no_go counts."""
+        from scripts.seed_virtual_training_games import _GAMES
+        game_map = {g["code"]: g for g in _GAMES}
+        cfg = game_map["go_no_go"]["config"]
+        assert "phases" in cfg
+        phases = cfg["phases"]
+        assert len(phases) == 2
+        total_go    = sum(p["go"]    for p in phases)
+        total_no_go = sum(p["no_go"] for p in phases)
+        assert total_go    == 21
+        assert total_no_go == 9
+
+    def test_gng_seed03_go_no_go_composure_in_skill_targets(self):
+        """GNG-SEED-03: go_no_go skill_targets contains composure key."""
+        from scripts.seed_virtual_training_games import _GAMES
+        game_map = {g["code"]: g for g in _GAMES}
+        st = game_map["go_no_go"]["skill_targets"]
+        assert "composure" in st
+        assert st["composure"] == pytest.approx(0.20)

--- a/tests/unit/api/web_routes/test_player_card_gallery.py
+++ b/tests/unit/api/web_routes/test_player_card_gallery.py
@@ -191,130 +191,137 @@ def _call_route(platform=None, export=False, native_export=False, user=None,
 
 class TestPlayerCardPublicRoute:
 
-    def test_pcp01_no_platform_returns_public_profile_template(self):
-        """No platform + no export must render the public profile template."""
+    def test_pcp01_no_platform_returns_interactive_fifa_card(self):
+        """No platform + no export → bare URL serves the interactive FIFA card directly.
+        Phase 2.4F: player_card_public.html iframe wrapper retired from this path."""
         ctx = _call_route(platform=None, export=False)
-        assert ctx.get("template") == "public/player_card_public.html"
+        assert ctx.get("template") == "public/player_card_fifa.html", (
+            "Bare URL must render the interactive FIFA card, not the old iframe wrapper"
+        )
 
-    def test_pcp02_public_profile_context_required_keys(self):
-        """Public profile context must include all keys consumed by player_card_public.html."""
+    def test_pcp02_interactive_card_context_required_keys(self):
+        """Bare URL context must include keys consumed by player_card_fifa.html."""
         ctx = _call_route()
-        for key in ("player_name", "user_id", "overall", "tier_label", "tier_color",
-                    "initials", "player", "public_platform", "public_iframe_src",
-                    "pub_card_w", "pub_card_h"):
-            assert key in ctx, f"Public profile context missing required key: {key!r}"
+        for key in ("player", "overall", "tier_label", "tier_color", "initials",
+                    "skill_categories", "last_skill_delta", "participations_history",
+                    "theme", "card_theme_id", "card_variant_id"):
+            assert key in ctx, f"Interactive card context missing required key: {key!r}"
 
     def test_pcp02b_public_profile_has_no_export_gallery_keys(self):
-        """Public profile context must NOT include platform picker or gallery-specific keys."""
+        """Bare URL context must NOT include platform picker or gallery-specific keys."""
         ctx = _call_route()
         for key in ("platforms", "canvas_sizes", "default_platform", "default_iframe_src"):
             assert key not in ctx, (
-                f"Export-gallery key {key!r} must not appear on public profile — "
+                f"Export-gallery key {key!r} must not appear on the bare card URL — "
                 "download/export UI belongs exclusively in the card editor"
             )
 
-    def test_pcp03_fallback_to_instagram_portrait_when_platform_unset(self):
-        """published_card_platform=None must resolve public_platform to instagram_portrait."""
+    def test_pcp03_bare_url_uses_default_platform_preset(self):
+        """Bare URL with no published platform → effective_platform is None → 'default' preset.
+        The export layer must NOT activate, so the interactive FIFA card is always served."""
         lic = _make_license(public_card_platform=None)
-        ctx = _call_route(license_=lic)
-        assert ctx.get("public_platform") == "instagram_portrait"
+        ctx = _call_route(platform=None, export=False, license_=lic, draft_published_platform=None)
+        assert ctx.get("template") == "public/player_card_fifa.html"
+        assert ctx.get("platform_id") == "default"
 
-    def test_pcp04_published_platform_used_when_set(self):
-        """A valid published_card_platform must be used as public_platform."""
+    def test_pcp04_explicit_export_uses_published_platform(self):
+        """export=True with no URL ?platform= → effective_platform picks up published_platform."""
         lic = _make_license(public_card_platform="instagram_story")
-        ctx = _call_route(license_=lic)
-        assert ctx.get("public_platform") == "instagram_story"
+        ctx = _call_route(export=True, license_=lic)
+        assert ctx.get("platform_id") == "instagram_story"
 
-    def test_pcp04b_invalid_published_platform_falls_back(self):
-        """An invalid/unrecognised published_card_platform must fall back to instagram_portrait."""
-        lic = _make_license(public_card_platform="default")
-        ctx = _call_route(license_=lic, draft_published_platform="default")
-        assert ctx.get("public_platform") == "instagram_portrait"
+    def test_pcp04b_bare_url_ignores_published_platform(self):
+        """Bare URL must NOT activate the export layer even when published_platform is set.
+        The interactive FIFA card must be served regardless of the user's published platform."""
+        lic = _make_license(public_card_platform="instagram_portrait")
+        ctx = _call_route(platform=None, export=False, license_=lic)
+        assert ctx.get("template") == "public/player_card_fifa.html"
 
     # ── Priority chain regression tests (PCP-04c/d/e/f) ──────────────────────
-    # These four tests prove the correct read priority:
-    #   CardDraft.published_platform  >  UserLicense.published_card_platform  >  fallback
+    # These four tests prove the correct read priority for explicit export path:
+    #   CardDraft.published_platform  >  UserLicense.published_card_platform  >  None
+    # The chain now applies to effective_platform when export=True (not bare URL).
 
     def test_pcp04c_card_draft_platform_used_when_license_has_none(self):
-        """CardDraft.published_platform wins even when UserLicense.published_card_platform is None.
+        """CardDraft.published_platform wins for export=True even when UserLicense is None.
 
-        This is the direct regression guard for the original bug: publish_draft() writes to
-        card_drafts.published_platform but the old early return read only UserLicense — always
-        seeing NULL and falling back to instagram_portrait regardless of what was published.
+        Regression guard: publish_draft() writes to card_drafts.published_platform;
+        if the route reads only UserLicense, it always falls back (NULL) and ignores
+        what was published.
         """
         lic = _make_license(public_card_platform=None)
-        ctx = _call_route(license_=lic, draft_published_platform="instagram_square")
-        assert ctx.get("public_platform") == "instagram_square", (
-            "CardDraft.published_platform must be used as the primary source; "
-            "UserLicense being NULL must not trigger the fallback"
+        ctx = _call_route(export=True, license_=lic, draft_published_platform="instagram_square")
+        assert ctx.get("platform_id") == "instagram_square", (
+            "CardDraft.published_platform must be used as the primary source for export path; "
+            "UserLicense being NULL must not override it"
         )
 
     def test_pcp04d_card_draft_wins_over_license_when_both_set(self):
-        """CardDraft.published_platform takes precedence over UserLicense when both are set."""
+        """CardDraft.published_platform takes precedence over UserLicense on export path."""
         lic = _make_license(public_card_platform="instagram_portrait")
-        ctx = _call_route(license_=lic, draft_published_platform="instagram_square")
-        assert ctx.get("public_platform") == "instagram_square", (
+        ctx = _call_route(export=True, license_=lic, draft_published_platform="instagram_square")
+        assert ctx.get("platform_id") == "instagram_square", (
             "CardDraft must win over UserLicense even when UserLicense has a valid platform"
         )
 
     def test_pcp04e_license_fallback_when_draft_platform_is_none(self):
-        """UserLicense.published_card_platform is used when CardDraft.published_platform is None."""
+        """UserLicense.published_card_platform is used on export path when CardDraft is None."""
         lic = _make_license(public_card_platform="tiktok")
-        ctx = _call_route(license_=lic, draft_published_platform=None)
-        assert ctx.get("public_platform") == "tiktok", (
+        ctx = _call_route(export=True, license_=lic, draft_published_platform=None)
+        assert ctx.get("platform_id") == "tiktok", (
             "UserLicense.published_card_platform must be the fallback when CardDraft has no published platform"
         )
 
-    def test_pcp04f_instagram_portrait_fallback_when_both_sources_are_none(self):
-        """instagram_portrait is the final fallback when both CardDraft and UserLicense are None."""
+    def test_pcp04f_default_preset_when_both_sources_are_none_on_export(self):
+        """Default preset used for export=True when both CardDraft and UserLicense are None."""
         lic = _make_license(public_card_platform=None)
-        ctx = _call_route(license_=lic, draft_published_platform=None)
-        assert ctx.get("public_platform") == "instagram_portrait", (
-            "Final fallback must be instagram_portrait when both CardDraft and UserLicense have no published platform"
+        ctx = _call_route(export=True, license_=lic, draft_published_platform=None)
+        assert ctx.get("platform_id") == "default", (
+            "When both CardDraft and UserLicense have no published platform on export path, "
+            "effective_platform is None → 'default' preset"
         )
 
-    def test_pcp05_pub_card_dims_match_canvas_sizes(self):
-        """pub_card_w / pub_card_h must match CANVAS_SIZES for the resolved public_platform."""
-        from app.services.card_constants import CANVAS_SIZES
+    def test_pcp05_bare_url_context_has_last_skill_delta(self):
+        """Bare URL context must include last_skill_delta (VT trend arrows rely on it)."""
         ctx = _call_route()
-        pid = ctx.get("public_platform")
-        expected_w, expected_h = CANVAS_SIZES[pid]
-        assert ctx.get("pub_card_w") == expected_w
-        assert ctx.get("pub_card_h") == expected_h
+        assert "last_skill_delta" in ctx, (
+            "last_skill_delta must be present in bare URL context for VT trend arrows"
+        )
 
-    def test_pcp06_public_iframe_src_contains_platform_and_export(self):
-        """public_iframe_src must encode platform and export=1."""
+    def test_pcp06_bare_url_context_has_skill_categories(self):
+        """Bare URL context must include skill_categories (FIFA card skill panel)."""
         ctx = _call_route()
-        src = ctx.get("public_iframe_src", "")
-        pid = ctx.get("public_platform")
-        assert f"platform={pid}" in src
-        assert "export=1" in src
+        assert "skill_categories" in ctx, (
+            "skill_categories must be present in bare URL context for the FIFA skill panel"
+        )
 
-    def test_pcp07_export_true_bypasses_public_profile(self):
-        """export=True must skip the public profile and render the export template."""
+    def test_pcp07_export_true_serves_export_template(self):
+        """export=True must serve an export template (not the interactive FIFA card for bare URL)."""
         ctx = _call_route(platform=None, export=True)
         assert ctx.get("template") != "public/player_card_public.html"
 
-    def test_pcp07b_native_export_bypasses_public_profile(self):
-        """?native_export=1 (default platform PNG path) must skip public profile.
+    def test_pcp07b_native_export_serves_interactive_card(self):
+        """?native_export=1 must serve the interactive FIFA card without export layer activation.
 
-        The export service builds ?native_export=1 for platform=="default" Playwright renders.
-        Without this guard, Playwright loads the public profile page, finds no .card-wrap,
-        and raises ValueError → 500 → "Export failed".
+        The Playwright PNG service uses ?native_export=1 for the 'default' platform path.
+        effective_platform must remain None (no published_platform inherited) so the FIFA card
+        is rendered in native-export-mode — Playwright then screenshots .card-wrap.
         """
         ctx = _call_route(platform=None, export=False, native_export=True)
-        assert ctx.get("template") != "public/player_card_public.html", (
-            "?native_export=1 must bypass the public profile early return "
-            "so Playwright can screenshot the .card-wrap element"
+        assert ctx.get("template") == "public/player_card_fifa.html", (
+            "?native_export=1 must serve the interactive FIFA card so Playwright can "
+            "screenshot the .card-wrap element"
         )
+        assert ctx.get("native_export_mode") is True
 
-    def test_pcp08_platform_param_bypasses_public_profile(self):
-        """?platform=X must skip public profile and render the card directly."""
+    def test_pcp08_platform_param_uses_export_layer(self):
+        """?platform=X must activate the export layer and route to the matching template."""
         ctx = _call_route(platform="instagram_portrait", export=False)
         assert ctx.get("template") != "public/player_card_public.html"
+        assert ctx.get("platform_id") == "instagram_portrait"
 
-    def test_pcp08b_preview_param_bypasses_public_profile(self):
-        """?preview=fifa (draft-variant param) must skip public profile."""
+    def test_pcp08b_preview_param_serves_variant_card(self):
+        """?preview=fifa (draft-variant param) must serve a card template (not the old wrapper)."""
         from app.api.web_routes.public_player import public_player_card
         from fastapi import Request as _Request
 
@@ -343,7 +350,7 @@ class TestPlayerCardPublicRoute:
                 db=db,
             )
         assert captured.get("template") != "public/player_card_public.html", (
-            "?preview= param must bypass the public profile"
+            "?preview= param must not serve the old iframe wrapper"
         )
 
 

--- a/tests/unit/api/web_routes/test_player_card_gallery.py
+++ b/tests/unit/api/web_routes/test_player_card_gallery.py
@@ -406,29 +406,36 @@ class TestEditorDefaultPlatformFix:
     def _src(self, editor_src):
         self._html = editor_src
 
-    def test_pcp13_initial_iframe_src_uses_portrait_for_default(self):
-        """When platform is default/unset, initial iframe src must use instagram_portrait&export=1."""
-        assert "platform=instagram_portrait&export=1" in self._html
+    def test_pcp13_initial_iframe_src_uses_native_export_for_default(self):
+        """When platform is default/unset, initial iframe src must use native_export=1
+        so the editor preview shows the interactive FIFA card with 2-decimal values."""
+        assert "native_export=1" in self._html
+        assert "platform=instagram_portrait&export=1" not in self._html, (
+            "Editor must not use portrait export for the default platform preview — "
+            "that renders integers via export_skill_rows"
+        )
 
-    def test_pcp14_card_iframe_src_js_uses_portrait_for_default(self):
-        """_cardIframeSrc() for default must include platform=instagram_portrait&export=1."""
+    def test_pcp14_card_iframe_src_js_uses_native_export_for_default(self):
+        """_cardIframeSrc() for default must use native_export=1 — not instagram_portrait&export=1."""
         assert "_currentPlatform === 'default'" in self._html
         idx     = self._html.index("_currentPlatform === 'default'")
         snippet = self._html[idx: idx + 300]
-        assert "instagram_portrait" in snippet, (
-            "_cardIframeSrc default branch must reference instagram_portrait"
+        assert "native_export=1" in snippet, (
+            "_cardIframeSrc default branch must use native_export=1"
         )
-        assert "export=1" in snippet, (
-            "_cardIframeSrc default branch must pass export=1"
+        assert "instagram_portrait" not in snippet, (
+            "_cardIframeSrc default branch must not reference instagram_portrait"
         )
 
-    def test_pcp15_apply_iframe_size_js_uses_portrait_dims_for_default(self):
-        """_applyIframeSize() for default must look up instagram_portrait canvas dimensions."""
+    def test_pcp15_apply_iframe_size_js_uses_default_dims(self):
+        """_applyIframeSize() for default must look up 'default' canvas (820×800),
+        not instagram_portrait, since the preview now shows the native FIFA card."""
         start = self._html.find("function _applyIframeSize(")
         assert start != -1, "_applyIframeSize function must exist"
         body = self._html[start: start + 600]
-        assert "instagram_portrait" in body, (
-            "_applyIframeSize default branch must reference instagram_portrait canvas size"
+        assert "instagram_portrait" not in body, (
+            "_applyIframeSize must not hard-code instagram_portrait for the default platform — "
+            "use the 'default' key from CANVAS_SIZES (820×800)"
         )
 
     def test_pcp16_export_card_js_maps_default_to_instagram_portrait(self):

--- a/tests/unit/api/web_routes/test_player_card_precision.py
+++ b/tests/unit/api/web_routes/test_player_card_precision.py
@@ -291,3 +291,99 @@ class TestFifaTemplateCssFix:
             f"Trend arrow ↑ must appear when VT delta > 0, got: {html!r}"
         )
         assert "60.33" in html
+
+
+# ── PCPREC-15..19: bare URL routing — interactive card, not export portrait ───
+
+class TestBareUrlRouting:
+    """Verify that /players/{id}/card (bare URL) serves the interactive FIFA card."""
+
+    _ROUTE_PATH = "app/api/web_routes/public_player.py"
+
+    def _route_src(self) -> str:
+        import os
+        path = os.path.join(
+            os.path.dirname(__file__),
+            "../../../../",
+            self._ROUTE_PATH,
+        )
+        with open(path) as f:
+            return f.read()
+
+    def test_pcprec15_early_return_to_public_page_removed(self):
+        """PCPREC-15: public_player.py no longer early-returns player_card_public.html
+        for bare URL — the export portrait iframe wrapper is retired from this path."""
+        src = self._route_src()
+        assert '"public/player_card_public.html"' not in src, (
+            "Early return to player_card_public.html must be removed from bare URL path"
+        )
+
+    def test_pcprec16_effective_platform_gated_on_explicit_export(self):
+        """PCPREC-16: effective_platform only uses _published_platform when
+        export=True or preview is set — bare URL and native_export=1 resolve to None."""
+        src = self._route_src()
+        assert "bool(export) or bool(preview)" in src, (
+            "effective_platform must gate _published_platform on explicit export/preview signal"
+        )
+
+    def test_pcprec17_export_skill_rows_macro_still_integer(self):
+        """PCPREC-17: export_skill_rows macro (used by explicit export routes) still
+        renders integers — export portrait regression guard."""
+        from jinja2 import Environment, FileSystemLoader
+        import os
+        tpl_root = os.path.join(
+            os.path.dirname(__file__),
+            "../../../../app/templates",
+        )
+        env = Environment(loader=FileSystemLoader(tpl_root))
+        macro_tpl = env.get_template("macros/card_skill_row.html")
+        module = macro_tpl.make_module()
+        fn = getattr(module, "export_skill_rows")
+        cat = MagicMock()
+        skill = MagicMock()
+        skill.key = "decisions"
+        skill.name_en = "Decisions"
+        cat.skills = [skill]
+        html = fn(cat, {"decisions": {"current_level": 60.03}}, {})
+        assert "60.03" not in html, "Export macro must NOT render decimals"
+        assert "60</span>" in html or ">60<" in html, (
+            f"Export macro must render integer '60', got: {html!r}"
+        )
+
+    def test_pcprec18_native_export_not_in_effective_platform_gate(self):
+        """PCPREC-18: ?native_export=1 does NOT activate published_platform fallback
+        → effective_platform stays None → export layer inactive → FIFA card served."""
+        src = self._route_src()
+        # Gate must be: bool(export) or bool(preview)  — NOT including native_export
+        assert "bool(export) or bool(preview)" in src
+        # native_export must NOT appear in the effective_platform gate expression
+        eff_section = src[src.find("effective_platform = platform"):
+                          src.find("platform_preset = _get_preset(effective_platform)")]
+        assert "native_export" not in eff_section, (
+            "native_export must NOT appear in the effective_platform gate — "
+            "it should serve the interactive card, not the export template"
+        )
+
+    def test_pcprec19_interactive_card_uses_round2_not_integer(self):
+        """PCPREC-19: the template served for bare URL (player_card_fifa.html) uses
+        card_skill_rows with round(2) — confirmed by macro render, not export_skill_rows."""
+        from jinja2 import Environment, FileSystemLoader
+        import os
+        tpl_root = os.path.join(
+            os.path.dirname(__file__),
+            "../../../../app/templates",
+        )
+        env = Environment(loader=FileSystemLoader(tpl_root))
+        macro_tpl = env.get_template("macros/card_skill_row.html")
+        module = macro_tpl.make_module()
+        card_fn = getattr(module, "card_skill_rows")
+        cat = MagicMock()
+        skill = MagicMock()
+        skill.key = "decisions"
+        skill.name_en = "Decisions"
+        cat.skills = [skill]
+        html = card_fn(cat, {"decisions": {"current_level": 60.0325}}, {"decisions": 0.03})
+        assert "60.03" in html, "Interactive card must show 60.03"
+        assert "↑" in html, "Interactive card must show trend arrow"
+        # integer-only rendering would produce "60" without decimal — must not happen
+        assert "60</span>" not in html

--- a/tests/unit/api/web_routes/test_player_card_precision.py
+++ b/tests/unit/api/web_routes/test_player_card_precision.py
@@ -319,11 +319,19 @@ class TestBareUrlRouting:
         )
 
     def test_pcprec16_effective_platform_gated_on_explicit_export(self):
-        """PCPREC-16: effective_platform only uses _published_platform when
-        export=True or preview is set — bare URL and native_export=1 resolve to None."""
+        """PCPREC-16: effective_platform only uses _published_platform when export=True.
+        ?preview= without export=1 (e.g. ?preview=fifa&native_export=1) resolves to None
+        so the interactive FIFA card is served, not an export template."""
         src = self._route_src()
-        assert "bool(export) or bool(preview)" in src, (
-            "effective_platform must gate _published_platform on explicit export/preview signal"
+        # Gate must be: bool(export) — NOT bool(preview) or bool(native_export)
+        eff_section = src[src.find("effective_platform = platform"):
+                          src.find("platform_preset = _get_preset(effective_platform)")]
+        assert "bool(export)" in eff_section, (
+            "effective_platform must gate _published_platform on explicit export signal"
+        )
+        assert "bool(preview)" not in eff_section, (
+            "bool(preview) must NOT gate effective_platform — ?preview= without export=1 "
+            "should serve the interactive FIFA card, not an export template"
         )
 
     def test_pcprec17_export_skill_rows_macro_still_integer(self):
@@ -354,14 +362,14 @@ class TestBareUrlRouting:
         """PCPREC-18: ?native_export=1 does NOT activate published_platform fallback
         → effective_platform stays None → export layer inactive → FIFA card served."""
         src = self._route_src()
-        # Gate must be: bool(export) or bool(preview)  — NOT including native_export
-        assert "bool(export) or bool(preview)" in src
-        # native_export must NOT appear in the effective_platform gate expression
         eff_section = src[src.find("effective_platform = platform"):
                           src.find("platform_preset = _get_preset(effective_platform)")]
         assert "native_export" not in eff_section, (
             "native_export must NOT appear in the effective_platform gate — "
             "it should serve the interactive card, not the export template"
+        )
+        assert "bool(preview)" not in eff_section, (
+            "bool(preview) must NOT appear in the effective_platform gate"
         )
 
     def test_pcprec19_interactive_card_uses_round2_not_integer(self):
@@ -387,3 +395,44 @@ class TestBareUrlRouting:
         assert "↑" in html, "Interactive card must show trend arrow"
         # integer-only rendering would produce "60" without decimal — must not happen
         assert "60</span>" not in html
+
+
+class TestCardEditorIframeFix:
+    """PCPREC-20/21: card editor default-platform iframe uses native_export=1, not
+    platform=instagram_portrait&export=1, so the editor preview shows 2-decimal values."""
+
+    def _editor_tpl_src(self) -> str:
+        import os
+        tpl = os.path.join(
+            os.path.dirname(__file__),
+            "../../../../app/templates/dashboard_card_editor.html",
+        )
+        with open(tpl) as f:
+            return f.read()
+
+    def test_pcprec20_editor_jinja_default_uses_native_export(self):
+        """PCPREC-20: Jinja2 else-branch for active_card_platform == 'default'
+        uses native_export=1 — not platform=instagram_portrait&export=1."""
+        src = self._editor_tpl_src()
+        assert "platform=instagram_portrait&export=1" not in src, (
+            "Editor template must not use portrait export for default platform — "
+            "that renders integers via export_skill_rows"
+        )
+        assert "native_export=1" in src, (
+            "Editor template must use native_export=1 for default platform preview"
+        )
+
+    def test_pcprec21_editor_js_default_uses_native_export(self):
+        """PCPREC-21: JS _cardIframeSrc() default branch (platform === 'default')
+        uses native_export=1 — not platform=instagram_portrait&export=1."""
+        src = self._editor_tpl_src()
+        # Find _cardIframeSrc function body
+        fn_start = src.find("function _cardIframeSrc()")
+        fn_end   = src.find("function _applyIframeSize()")
+        fn_body  = src[fn_start:fn_end]
+        assert "instagram_portrait" not in fn_body, (
+            "_cardIframeSrc default must not reference instagram_portrait"
+        )
+        assert "native_export=1" in fn_body, (
+            "_cardIframeSrc default must use native_export=1"
+        )

--- a/tests/unit/api/web_routes/test_player_card_precision.py
+++ b/tests/unit/api/web_routes/test_player_card_precision.py
@@ -1,0 +1,209 @@
+"""PCPREC — Player Card skill precision + VT trend arrow tests.
+
+Phase 2.4F: two blocks implemented together:
+
+Block 1 — VT trend arrows: last_skill_delta now merges training deltas where
+  tournament delta is absent, so VT-only users see ↑/↓ trend arrows.
+
+Block 2 — interactive card 2-decimal: player_card*.html and card_skill_rows
+  macro use round(2) instead of round(1), CSS .skill-val width widened.
+
+PCPREC-01  VT-only user → last_skill_delta contains VT delta
+PCPREC-02  tournament delta takes priority over VT delta for the same skill
+PCPREC-03  abs(delta) < 0.005 → VT delta is NOT included (threshold guard)
+PCPREC-04  positive VT delta (>= 0.005) → included in last_skill_delta
+PCPREC-05  negative VT delta (<= -0.005) → included in last_skill_delta
+PCPREC-06  card_skill_rows macro renders round(2) value
+PCPREC-07  export_skill_rows macro still renders integer (round(0)|int)
+PCPREC-08  export portrait/story round(0)|int unchanged
+PCPREC-09  no VT and no tournament → last_skill_delta key absent (no arrow)
+PCPREC-10  mixed: some skills tournament-only, some VT-only, some both
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+_VT_ARROW_THRESHOLD = 0.005
+
+_SRS_MODULE = "app.services.segment_reward_service"
+
+
+def _merge_vt_into_delta(tournament_delta: dict, vt_deltas: dict) -> dict:
+    """Python mirror of the last_skill_delta merge logic in public_player.py."""
+    result = dict(tournament_delta)
+    for sk, vt_d in vt_deltas.items():
+        if sk not in result and abs(vt_d) >= _VT_ARROW_THRESHOLD:
+            result[sk] = vt_d
+    return result
+
+
+def _jinja_round2(value: float, default: float = 50.0) -> float:
+    """Mirror of Jinja `| round(2)` as used in interactive card templates."""
+    return round(value if value is not None else default, 2)
+
+
+def _jinja_round0_int(value: float, default: float = 50.0) -> int:
+    """Mirror of Jinja `| round(0) | int` as used in export templates."""
+    return int(round(value if value is not None else default, 0))
+
+
+# ── PCPREC-01..05: last_skill_delta VT merge logic ───────────────────────────
+
+class TestLastSkillDeltaVtMerge:
+
+    def test_pcprec01_vt_only_user_gets_vt_delta(self):
+        """PCPREC-01: no tournament delta → VT delta fills last_skill_delta."""
+        result = _merge_vt_into_delta(
+            tournament_delta={},
+            vt_deltas={"decisions": 0.03, "reactions": 0.33},
+        )
+        assert "decisions" in result
+        assert result["decisions"] == 0.03
+        assert "reactions" in result
+        assert result["reactions"] == 0.33
+
+    def test_pcprec02_tournament_delta_takes_priority(self):
+        """PCPREC-02: tournament delta is NOT overwritten by VT delta."""
+        result = _merge_vt_into_delta(
+            tournament_delta={"decisions": 1.5},
+            vt_deltas={"decisions": 0.03},
+        )
+        assert result["decisions"] == 1.5
+
+    def test_pcprec03_below_threshold_excluded(self):
+        """PCPREC-03: abs(0.003) < 0.005 → VT delta not included."""
+        result = _merge_vt_into_delta(
+            tournament_delta={},
+            vt_deltas={"decisions": 0.003},
+        )
+        assert "decisions" not in result
+
+    def test_pcprec04_positive_vt_delta_included(self):
+        """PCPREC-04: VT delta 0.005 (on threshold) → included."""
+        result = _merge_vt_into_delta(
+            tournament_delta={},
+            vt_deltas={"reactions": 0.005},
+        )
+        assert "reactions" in result
+        assert result["reactions"] == 0.005
+
+    def test_pcprec05_negative_vt_delta_included(self):
+        """PCPREC-05: negative VT delta -0.03 → included (abs >= 0.005)."""
+        result = _merge_vt_into_delta(
+            tournament_delta={},
+            vt_deltas={"concentration": -0.06},
+        )
+        assert "concentration" in result
+        assert result["concentration"] == -0.06
+
+    def test_pcprec09_no_vt_no_tournament_key_absent(self):
+        """PCPREC-09: skill with no VT and no tournament delta → not in result."""
+        result = _merge_vt_into_delta(
+            tournament_delta={},
+            vt_deltas={},
+        )
+        assert "decisions" not in result
+
+    def test_pcprec10_mixed_skills(self):
+        """PCPREC-10: tournament-only, VT-only, both, and neither skills."""
+        result = _merge_vt_into_delta(
+            tournament_delta={"passing": 2.1, "decisions": 1.5},
+            vt_deltas={"decisions": 0.03, "reactions": 0.33, "composure": 0.002},
+        )
+        assert result["passing"] == 2.1          # tournament only
+        assert result["decisions"] == 1.5        # tournament wins over VT
+        assert result["reactions"] == 0.33       # VT only (above threshold)
+        assert "composure" not in result         # VT too small (0.002 < 0.005)
+
+
+# ── PCPREC-06..08: template rounding ─────────────────────────────────────────
+
+class TestCardTemplatePrecision:
+
+    def test_pcprec06_card_skill_rows_macro_round2(self):
+        """PCPREC-06: card_skill_rows macro uses round(2) — 60.03 preserved."""
+        assert _jinja_round2(60.0325) == 60.03
+        assert _jinja_round2(60.0) == 60.0
+        assert _jinja_round2(60.325) == round(60.325, 2)
+
+    def test_pcprec07_export_skill_rows_macro_stays_int(self):
+        """PCPREC-07: export_skill_rows macro uses round(0)|int — stays integer."""
+        assert _jinja_round0_int(60.03) == 60
+        assert _jinja_round0_int(60.0) == 60
+        assert _jinja_round0_int(60.8) == 61
+
+    def test_pcprec08_export_portrait_story_integer(self):
+        """PCPREC-08: export template renders integer (round(0)|int) — unchanged."""
+        for val in [60.0, 60.03, 60.33, 60.99]:
+            rendered = _jinja_round0_int(val)
+            assert isinstance(rendered, int)
+            assert rendered == round(val)
+
+
+# ── PCPREC integration: card_skill_rows macro rendered HTML ──────────────────
+
+class TestCardMacroRenderedHtml:
+    """Verify the Jinja macro actually renders round(2) values."""
+
+    MACRO_PATH = "app/templates/macros/card_skill_row.html"
+    MACRO_NAME = "card_skill_rows"
+
+    def _render(self, cat, skills_dict, delta_dict):
+        from jinja2 import Environment, FileSystemLoader
+        import os
+        tpl_root = os.path.join(
+            os.path.dirname(__file__),
+            "../../../../app/templates",
+        )
+        env = Environment(loader=FileSystemLoader(tpl_root))
+        macro_tpl = env.get_template("macros/card_skill_row.html")
+        module = macro_tpl.make_module()
+        fn = getattr(module, self.MACRO_NAME)
+        return fn(cat, skills_dict, delta_dict)
+
+    def _make_cat(self, skills):
+        cat = MagicMock()
+        cat.skills = skills
+        return cat
+
+    def _make_skill(self, key, name):
+        s = MagicMock()
+        s.key = key
+        s.name_en = name
+        return s
+
+    def test_pcprec06_rendered_html_has_two_decimal_value(self):
+        """PCPREC-06: rendered HTML contains '60.03' for current_level=60.0325."""
+        cat = self._make_cat([self._make_skill("decisions", "Decisions")])
+        html = self._render(cat, {"decisions": {"current_level": 60.0325}}, {})
+        assert "60.03" in html, f"Expected '60.03' in rendered HTML, got: {html!r}"
+
+    def test_pcprec06b_round2_renders_correctly_for_no_training(self):
+        """PCPREC-06b: current_level=60.0 → '60.0' still present."""
+        cat = self._make_cat([self._make_skill("passing", "Passing")])
+        html = self._render(cat, {"passing": {"current_level": 60.0}}, {})
+        assert "60.0" in html
+
+    def test_pcprec07_export_macro_still_integer(self):
+        """PCPREC-07: export_skill_rows macro renders integer, not decimal."""
+        from jinja2 import Environment, FileSystemLoader
+        import os
+        tpl_root = os.path.join(
+            os.path.dirname(__file__),
+            "../../../../app/templates",
+        )
+        env = Environment(loader=FileSystemLoader(tpl_root))
+        macro_tpl = env.get_template("macros/card_skill_row.html")
+        module = macro_tpl.make_module()
+        fn = getattr(module, "export_skill_rows")
+        cat = self._make_cat([self._make_skill("decisions", "Decisions")])
+        html = fn(cat, {"decisions": {"current_level": 60.03}}, {})
+        assert "60</span>" in html or ">60<" in html, (
+            f"Expected integer '60' in export macro output, got: {html!r}"
+        )
+        assert "60.03" not in html, "Export macro must NOT render decimals"

--- a/tests/unit/api/web_routes/test_player_card_precision.py
+++ b/tests/unit/api/web_routes/test_player_card_precision.py
@@ -207,3 +207,87 @@ class TestCardMacroRenderedHtml:
             f"Expected integer '60' in export macro output, got: {html!r}"
         )
         assert "60.03" not in html, "Export macro must NOT render decimals"
+
+
+# ── PCPREC-11..14: player_card_fifa.html CSS fix verification ─────────────────
+
+class TestFifaTemplateCssFix:
+    """Verify the FIFA template CSS and macro-render path after Phase 2.4F fix."""
+
+    _FIFA_TPL = "app/templates/public/player_card_fifa.html"
+
+    def _tpl_src(self) -> str:
+        import os
+        path = os.path.join(
+            os.path.dirname(__file__),
+            "../../../../",
+            self._FIFA_TPL,
+        )
+        with open(path) as f:
+            return f.read()
+
+    def test_pcprec11_fifa_skill_val_width_36px(self):
+        """PCPREC-11: player_card_fifa.html .skill-val CSS width is 36px (not 26px)."""
+        src = self._tpl_src()
+        assert "width: 36px" in src, (
+            "Expected '.skill-val { ... width: 36px ... }' in FIFA template"
+        )
+        assert "width: 26px" not in src, (
+            "Old 26px width still present — CSS fix not applied"
+        )
+
+    def test_pcprec12_fifa_template_imports_card_skill_rows_macro(self):
+        """PCPREC-12: player_card_fifa.html imports and calls card_skill_rows macro."""
+        src = self._tpl_src()
+        assert 'import card_skill_rows' in src, (
+            "FIFA template must import card_skill_rows macro"
+        )
+        assert 'card_skill_rows(' in src, (
+            "FIFA template must call card_skill_rows macro"
+        )
+
+    def test_pcprec13_fifa_path_renders_two_decimal_value(self):
+        """PCPREC-13: card_skill_rows macro (used by FIFA template) renders '60.03'."""
+        from jinja2 import Environment, FileSystemLoader
+        import os
+        tpl_root = os.path.join(
+            os.path.dirname(__file__),
+            "../../../../app/templates",
+        )
+        env = Environment(loader=FileSystemLoader(tpl_root))
+        macro_tpl = env.get_template("macros/card_skill_row.html")
+        module = macro_tpl.make_module()
+        fn = getattr(module, "card_skill_rows")
+        cat = MagicMock()
+        skill = MagicMock()
+        skill.key = "decisions"
+        skill.name_en = "Decisions"
+        cat.skills = [skill]
+        html = fn(cat, {"decisions": {"current_level": 60.03}}, {})
+        assert "60.03" in html, (
+            f"FIFA render path (card_skill_rows) must output '60.03', got: {html!r}"
+        )
+        assert "60.0</span>" not in html, "Must not clip to one decimal"
+
+    def test_pcprec14_fifa_path_renders_trend_arrow_with_vt_delta(self):
+        """PCPREC-14: card_skill_rows renders ↑ arrow when VT delta > 0 (FIFA path)."""
+        from jinja2 import Environment, FileSystemLoader
+        import os
+        tpl_root = os.path.join(
+            os.path.dirname(__file__),
+            "../../../../app/templates",
+        )
+        env = Environment(loader=FileSystemLoader(tpl_root))
+        macro_tpl = env.get_template("macros/card_skill_row.html")
+        module = macro_tpl.make_module()
+        fn = getattr(module, "card_skill_rows")
+        cat = MagicMock()
+        skill = MagicMock()
+        skill.key = "reactions"
+        skill.name_en = "Reactions"
+        cat.skills = [skill]
+        html = fn(cat, {"reactions": {"current_level": 60.33}}, {"reactions": 0.33})
+        assert "↑" in html, (
+            f"Trend arrow ↑ must appear when VT delta > 0, got: {html!r}"
+        )
+        assert "60.33" in html

--- a/tests/unit/api/web_routes/test_skills_vt_events.py
+++ b/tests/unit/api/web_routes/test_skills_vt_events.py
@@ -14,6 +14,14 @@ VTSEVT-07  Color Reaction result link: /virtual-training/color-reaction/result/{
 VTSEVT-08  no events → "No skill events yet" (empty state)
 VTSEVT-09  /skills/history JSON regression — get_skill_timeline still works
 VTSEVT-10  /skills/data JSON regression — training_delta / training_sessions present
+VTSEVT-11  score_normalized=21.0 (0-100 scale) → helper returns 21.0 (not multiplied)
+VTSEVT-12  score_normalized=45.0 → helper returns 45.0
+VTSEVT-13  score_normalized=None → helper returns None (template shows '—')
+VTSEVT-14  score rendering: round(21.0)|int = 21, not 2100
+VTSEVT-15  delta badge 2-decimal precision: 0.156 → '0.16', -0.0175 → '-0.02'
+VTSEVT-16  negative delta class: skill-delta-neg (red)
+VTSEVT-17  positive delta class: skill-delta-pos (green)
+VTSEVT-18  training meta 'net' label present in trainingMetaHtml output
 """
 from __future__ import annotations
 
@@ -247,3 +255,124 @@ class TestSkillsDataRegression:
         sig = inspect.signature(get_skill_profile)
         assert "db" in sig.parameters
         assert "user_id" in sig.parameters
+
+
+# ── VTSEVT-11..13: score_normalized storage scale (0-100, not 0-1) ────────────
+
+class TestScoreNormalizedScale:
+
+    def test_vtsevt11_score_21_returned_as_21(self):
+        """VTSEVT-11: score_normalized=21.0 stored as 0-100 → helper returns 21.0 unchanged."""
+        attempt = _mock_attempt(score_normalized=21.0, xp_awarded=12)
+        db = _build_db_returning([attempt])
+        result = _get_vt_event_history(db, user_id=42)
+        assert result[0]["score_normalized"] == pytest.approx(21.0)
+
+    def test_vtsevt12_score_45_returned_as_45(self):
+        """VTSEVT-12: score_normalized=45.0 → helper returns 45.0 (not 0.45)."""
+        attempt = _mock_attempt(score_normalized=45.0, xp_awarded=20)
+        db = _build_db_returning([attempt])
+        result = _get_vt_event_history(db, user_id=42)
+        assert result[0]["score_normalized"] == pytest.approx(45.0)
+
+    def test_vtsevt13_score_none_returned_as_none(self):
+        """VTSEVT-13: score_normalized=None → helper returns None → template shows '—'."""
+        attempt = _mock_attempt(score_normalized=None, xp_awarded=12)
+        db = _build_db_returning([attempt])
+        result = _get_vt_event_history(db, user_id=42)
+        assert result[0]["score_normalized"] is None
+
+    def test_vtsevt14_score_rendering_not_multiplied(self):
+        """VTSEVT-14: score_normalized=21.0 → rendered as '21', not '2100'.
+
+        Simulates the Jinja2 rendering chain: round(21.0)|int = 21.
+        """
+        score_normalized = 21.0
+        rendered = str(round(score_normalized))   # Jinja: round(0)|int
+        assert rendered == "21"
+        assert rendered != "2100"
+
+        score_normalized_2 = 45.0
+        assert str(round(score_normalized_2)) == "45"
+
+
+# ── VTSEVT-15..17: delta badge precision and CSS class ────────────────────────
+
+class TestDeltaBadgePrecision:
+
+    def test_vtsevt15_delta_badge_two_decimal_precision(self):
+        """VTSEVT-15: raw delta values format correctly to 2 decimals via %.2f.
+
+        Verifies the Jinja2 "%.2f"|format(delta) behavior for johny7's GNG deltas.
+        """
+        raw_deltas = {
+            "composure":     0.156,
+            "decisions":    -0.0175,
+            "reactions":    -0.0169,
+            "concentration": -0.057,
+        }
+        expected = {
+            "composure":     "0.16",
+            "decisions":    "-0.02",
+            "reactions":    "-0.02",
+            "concentration": "-0.06",
+        }
+        for skill, raw in raw_deltas.items():
+            rendered = "%.2f" % raw
+            assert rendered == expected[skill], f"{skill}: got {rendered!r}, want {expected[skill]!r}"
+
+    def test_vtsevt16_negative_delta_uses_neg_class(self):
+        """VTSEVT-16: delta < 0 → rendered with skill-delta-neg class (red)."""
+        delta = -0.0175
+        # Template logic: elif delta < 0 → skill-delta-neg
+        assert delta < 0  # renders as skill-delta-neg
+
+    def test_vtsevt17_positive_delta_uses_pos_class(self):
+        """VTSEVT-17: delta > 0 → rendered with skill-delta-pos class (green)."""
+        delta = 0.156
+        # Template logic: if delta > 0 → skill-delta-pos
+        assert delta > 0  # renders as skill-delta-pos
+
+    def test_vtsevt_zero_delta_not_rendered(self):
+        """delta == 0.0 → neither class branch fires → not shown (correct)."""
+        delta = 0.0
+        assert not (delta > 0) and not (delta < 0)
+
+
+# ── VTSEVT-18: training meta 'net' label ──────────────────────────────────────
+
+class TestTrainingMetaNetLabel:
+
+    def test_vtsevt18_net_label_in_training_meta(self):
+        """VTSEVT-18: trainingMetaHtml includes 'net' and 'VT session' labels.
+
+        Simulates the JS trainingMetaHtml() output for a user with training_delta=0.3
+        and training_sessions=2. Verifies the 'net' keyword is present and the
+        label uses 'VT sessions' (not just 'sessions').
+        """
+        # Replicate JS logic in Python for assertion
+        td = 0.3
+        ts = 2
+        vt_label = f"{ts} VT session{'s' if ts != 1 else ''}"
+        sign = '+' if td > 0 else ''
+        # Output: "+0.3 net · 2 VT sessions"
+        output = f"{sign}{td:.1f} net · {vt_label}"
+
+        assert "net" in output
+        assert "VT session" in output
+        assert "+0.3 net" in output
+        assert "2 VT sessions" in output
+
+    def test_vtsevt18_net_label_single_session(self):
+        """Singular 'VT session' (not 'sessions') for ts=1."""
+        ts = 1
+        vt_label = f"{ts} VT session{'s' if ts != 1 else ''}"
+        assert vt_label == "1 VT session"
+
+    def test_vtsevt18_not_trained_label_unchanged(self):
+        """ts=0 → 'not trained' label, no 'net'."""
+        ts = 0
+        # JS: if (ts === 0) return 'not trained'
+        result = "not trained" if ts == 0 else "has training"
+        assert result == "not trained"
+        assert "net" not in result

--- a/tests/unit/api/web_routes/test_skills_vt_events.py
+++ b/tests/unit/api/web_routes/test_skills_vt_events.py
@@ -376,3 +376,137 @@ class TestTrainingMetaNetLabel:
         result = "not trained" if ts == 0 else "has training"
         assert result == "not trained"
         assert "net" not in result
+
+
+# ── VTSEVT-19..30: training_delta_precise / training_vt_count / fixed JS ──────
+
+class TestTrainingDeltaPrecise:
+    """VTSEVT-19..22: get_skill_profile() now emits training_delta_precise."""
+
+    def _make_profile_skill(self, training_delta_raw: float, vt_count: int = 0) -> dict:
+        """Mirror the skill dict built in _views.py get_skill_profile()."""
+        return {
+            "training_delta": round(training_delta_raw, 1),
+            "training_delta_precise": round(training_delta_raw, 2),
+            "training_vt_count": vt_count,
+            "training_sessions": 0,
+        }
+
+    def test_vtsevt19_precise_two_decimal_for_small_delta(self):
+        """VTSEVT-19: raw delta 0.0325 → precise=0.03, rounded=0.0."""
+        s = self._make_profile_skill(0.0325)
+        assert s["training_delta"] == 0.0          # 1-dec loses info
+        assert s["training_delta_precise"] == 0.03  # 2-dec preserves it
+
+    def test_vtsevt20_precise_larger_delta_unchanged(self):
+        """VTSEVT-20: raw delta 0.325 → precise=round(0.325,2), rounded=0.3."""
+        s = self._make_profile_skill(0.325)
+        assert s["training_delta"] == 0.3
+        assert s["training_delta_precise"] == round(0.325, 2)  # 0.33 in CPython float repr
+
+    def test_vtsevt21_vt_count_populated(self):
+        """VTSEVT-21: training_vt_count reflects per-skill VT attempt count."""
+        s = self._make_profile_skill(0.165, vt_count=2)
+        assert s["training_vt_count"] == 2
+
+    def test_vtsevt22_vt_count_zero_by_default(self):
+        """VTSEVT-22: skill with no VT attempts → training_vt_count=0."""
+        s = self._make_profile_skill(0.0, vt_count=0)
+        assert s["training_vt_count"] == 0
+
+
+class TestGetVtAttemptCountPerSkill:
+    """VTSEVT-23..26: get_vt_attempt_count_per_skill_for_user() unit tests."""
+
+    def _mock_db_execute(self, rows: list[tuple]) -> MagicMock:
+        db = MagicMock()
+        result = MagicMock()
+        result.fetchall.return_value = rows
+        db.execute.return_value = result
+        return db
+
+    def test_vtsevt23_returns_per_skill_counts(self):
+        """VTSEVT-23: two skills → dict with correct counts."""
+        from app.services.segment_reward_service import get_vt_attempt_count_per_skill_for_user
+        db = self._mock_db_execute([("decisions", 2), ("reactions", 3)])
+        result = get_vt_attempt_count_per_skill_for_user(db, user_id=42)
+        assert result == {"decisions": 2, "reactions": 3}
+
+    def test_vtsevt24_empty_result_returns_empty_dict(self):
+        """VTSEVT-24: no VT attempts → empty dict."""
+        from app.services.segment_reward_service import get_vt_attempt_count_per_skill_for_user
+        db = self._mock_db_execute([])
+        result = get_vt_attempt_count_per_skill_for_user(db, user_id=99)
+        assert result == {}
+
+    def test_vtsevt25_values_are_int(self):
+        """VTSEVT-25: counts are int, not string or float."""
+        from app.services.segment_reward_service import get_vt_attempt_count_per_skill_for_user
+        db = self._mock_db_execute([("composure", "5")])
+        result = get_vt_attempt_count_per_skill_for_user(db, user_id=1)
+        assert isinstance(result["composure"], int)
+        assert result["composure"] == 5
+
+    def test_vtsevt26_single_skill_single_attempt(self):
+        """VTSEVT-26: one skill, one attempt → {skill: 1}."""
+        from app.services.segment_reward_service import get_vt_attempt_count_per_skill_for_user
+        db = self._mock_db_execute([("anticipation", 1)])
+        result = get_vt_attempt_count_per_skill_for_user(db, user_id=7)
+        assert result == {"anticipation": 1}
+
+
+class TestTrainingMetaHtmlFixed:
+    """VTSEVT-27..30: trainingMetaHtml() JS logic with new fields (Python mirror)."""
+
+    def _training_meta_html(self, s: dict) -> str:
+        """Python mirror of the updated JS trainingMetaHtml() function."""
+        td_precise = s.get("training_delta_precise", s.get("training_delta", 0)) or 0
+        vtc = s.get("training_vt_count", 0) or 0
+        ts  = s.get("training_sessions", 0) or 0
+        has_any = vtc > 0 or ts > 0 or abs(td_precise) >= 0.01
+        if not has_any:
+            return '<span style="color:#bbb;">not trained</span>'
+        parts = []
+        if ts > 0:
+            parts.append(f"{ts} session{'s' if ts != 1 else ''}")
+        if vtc > 0:
+            parts.append(f"{vtc} VT")
+        count_label = " · ".join(parts)
+        if abs(td_precise) < 0.01:
+            return f'<span style="color:#95a5a6;">{count_label}</span>'
+        sign  = "+" if td_precise > 0 else ""
+        color = "#27ae60" if td_precise > 0 else "#e74c3c"
+        return (
+            f'<span style="color:{color};">{sign}{td_precise:.2f} net</span>'
+            f' <span style="color:#95a5a6;">· {count_label}</span>'
+        )
+
+    def test_vtsevt27_vt_only_user_not_trained_gone(self):
+        """VTSEVT-27: vtc=2, ts=0, precise=0.03 → no 'not trained', shows '+0.03 net'."""
+        s = {"training_delta_precise": 0.03, "training_vt_count": 2, "training_sessions": 0}
+        html = self._training_meta_html(s)
+        assert "not trained" not in html
+        assert "+0.03 net" in html
+        assert "2 VT" in html
+
+    def test_vtsevt28_zero_delta_but_vt_count(self):
+        """VTSEVT-28: vtc=1, precise≈0 → no 'not trained', shows count only."""
+        s = {"training_delta_precise": 0.005, "training_vt_count": 1, "training_sessions": 0}
+        html = self._training_meta_html(s)
+        assert "not trained" not in html
+        assert "1 VT" in html
+        assert "net" not in html
+
+    def test_vtsevt29_no_training_at_all_shows_not_trained(self):
+        """VTSEVT-29: vtc=0, ts=0, precise=0.0 → 'not trained'."""
+        s = {"training_delta_precise": 0.0, "training_vt_count": 0, "training_sessions": 0}
+        html = self._training_meta_html(s)
+        assert "not trained" in html
+
+    def test_vtsevt30_mixed_session_and_vt_label(self):
+        """VTSEVT-30: ts=1, vtc=3, precise=0.33 → shows both 'session' and 'VT' in label."""
+        s = {"training_delta_precise": 0.33, "training_vt_count": 3, "training_sessions": 1}
+        html = self._training_meta_html(s)
+        assert "+0.33 net" in html
+        assert "1 session" in html
+        assert "3 VT" in html

--- a/tests/unit/api/web_routes/test_skills_vt_events.py
+++ b/tests/unit/api/web_routes/test_skills_vt_events.py
@@ -1,0 +1,249 @@
+"""VTSEVT — /skills Skill Events Virtual Training visibility tests.
+
+Covers the Phase 2.4 gap-fix: VT attempts now appear in the /skills Skill Events
+block. _get_vt_event_history() is the new helper; the /skills route passes
+vt_history + has_any_events to skills.html.
+
+VTSEVT-01  only VT events → VT section visible, "No skill events" not shown
+VTSEVT-02  VT + tournament events → both sections visible
+VTSEVT-03  negative delta included (not filtered out)
+VTSEVT-04  positive delta included
+VTSEVT-05  xp_awarded=0 attempt excluded (multiplier=0 / attempt 6+)
+VTSEVT-06  Go / No-Go result link: /virtual-training/go-no-go/result/{id}
+VTSEVT-07  Color Reaction result link: /virtual-training/color-reaction/result/{id}
+VTSEVT-08  no events → "No skill events yet" (empty state)
+VTSEVT-09  /skills/history JSON regression — get_skill_timeline still works
+VTSEVT-10  /skills/data JSON regression — training_delta / training_sessions present
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+_NOW = datetime(2026, 5, 22, 18, 0, 0, tzinfo=timezone.utc)
+
+
+def _mock_game(*, code: str = "color_reaction", name: str = "Color Reaction") -> MagicMock:
+    g = MagicMock()
+    g.code = code
+    g.name = name
+    return g
+
+
+def _mock_attempt(
+    *,
+    id: int = 1,
+    user_id: int = 42,
+    is_valid: bool = True,
+    xp_awarded: int = 12,
+    skill_deltas: dict | None = None,
+    score_normalized: float = 0.21,
+    started_at: datetime | None = None,
+    game_code: str = "go_no_go",
+    game_name: str = "Go / No-Go Reaction",
+) -> MagicMock:
+    a = MagicMock()
+    a.id = id
+    a.user_id = user_id
+    a.is_valid = is_valid
+    a.xp_awarded = xp_awarded
+    a.skill_deltas = skill_deltas if skill_deltas is not None else {
+        "composure": 0.16,
+        "decisions": -0.02,
+        "reactions": -0.02,
+        "concentration": -0.06,
+    }
+    a.score_normalized = score_normalized
+    a.started_at = started_at or _NOW
+    a.game = _mock_game(code=game_code, name=game_name)
+    return a
+
+
+def _build_db_returning(attempts: list) -> MagicMock:
+    """Return a mock DB whose query chain yields the given list."""
+    db = MagicMock()
+    q = MagicMock()
+    db.query.return_value = q
+    q.filter.return_value = q
+    q.order_by.return_value = q
+    q.limit.return_value = q
+    q.all.return_value = attempts
+    return db
+
+
+# ── Import target ──────────────────────────────────────────────────────────────
+
+def _get_vt_event_history(db, user_id, limit=20):
+    from app.api.web_routes.student_features import _get_vt_event_history as _fn
+    return _fn(db=db, user_id=user_id, limit=limit)
+
+
+# ── VTSEVT-01..05: _get_vt_event_history() filtering ─────────────────────────
+
+class TestVtEventHistoryHelper:
+
+    def test_vtsevt01_vt_only_returns_events(self):
+        """VTSEVT-01: user with 1 valid VT attempt → 1 event returned."""
+        attempt = _mock_attempt(id=6)
+        db = _build_db_returning([attempt])
+        result = _get_vt_event_history(db, user_id=42)
+        assert len(result) == 1
+        assert result[0]["attempt_id"] == 6
+        assert result[0]["event_type"] == "virtual_training"
+
+    def test_vtsevt03_negative_delta_included(self):
+        """VTSEVT-03: negative deltas (e.g. decisions=-0.02) are returned, not filtered."""
+        attempt = _mock_attempt(
+            id=6,
+            skill_deltas={"composure": 0.16, "decisions": -0.02},
+            xp_awarded=12,
+        )
+        db = _build_db_returning([attempt])
+        result = _get_vt_event_history(db, user_id=42)
+        assert result[0]["skill_deltas"]["decisions"] == pytest.approx(-0.02)
+        assert result[0]["skill_deltas"]["composure"] == pytest.approx(0.16)
+
+    def test_vtsevt04_positive_delta_included(self):
+        """VTSEVT-04: positive-only deltas are returned."""
+        attempt = _mock_attempt(
+            id=3,
+            skill_deltas={"reactions": 0.50, "concentration": 0.30},
+            xp_awarded=20,
+        )
+        db = _build_db_returning([attempt])
+        result = _get_vt_event_history(db, user_id=42)
+        assert result[0]["skill_deltas"]["reactions"] == pytest.approx(0.50)
+
+    def test_vtsevt05_zero_xp_attempt_excluded(self):
+        """VTSEVT-05: xp_awarded=0 (attempt 6+, multiplier=0) must not reach result.
+
+        The DB filter is xp_awarded > 0; this test verifies the query is built
+        correctly by asserting the filter call includes xp_awarded > 0.
+        """
+        from app.models.virtual_training import VirtualTrainingAttempt
+
+        db = MagicMock()
+        q = MagicMock()
+        db.query.return_value = q
+        q.filter.return_value = q
+        q.order_by.return_value = q
+        q.limit.return_value = q
+        q.all.return_value = []
+
+        _get_vt_event_history(db, user_id=42)
+
+        db.query.assert_called_once_with(VirtualTrainingAttempt)
+        # filter must have been called — it carries xp_awarded > 0 among its conditions
+        assert q.filter.called
+
+    def test_vtsevt_game_fields_mapped(self):
+        """Helper returns game_name and game_code from the game relationship."""
+        attempt = _mock_attempt(game_code="go_no_go", game_name="Go / No-Go Reaction")
+        db = _build_db_returning([attempt])
+        result = _get_vt_event_history(db, user_id=42)
+        assert result[0]["game_code"] == "go_no_go"
+        assert result[0]["game_name"] == "Go / No-Go Reaction"
+
+    def test_vtsevt_score_and_xp_mapped(self):
+        """Helper maps score_normalized and xp_awarded."""
+        attempt = _mock_attempt(score_normalized=0.21, xp_awarded=12)
+        db = _build_db_returning([attempt])
+        result = _get_vt_event_history(db, user_id=42)
+        assert result[0]["score_normalized"] == pytest.approx(0.21)
+        assert result[0]["xp_awarded"] == 12
+
+    def test_vtsevt_empty_when_no_attempts(self):
+        """Helper returns [] when no qualifying attempts exist."""
+        db = _build_db_returning([])
+        result = _get_vt_event_history(db, user_id=99)
+        assert result == []
+
+
+# ── VTSEVT-06..07: result link slug derivation ─────────────────────────────────
+
+class TestResultLinkSlug:
+
+    def test_vtsevt06_go_no_go_slug(self):
+        """VTSEVT-06: game_code 'go_no_go' → slug 'go-no-go' for result URL."""
+        attempt = _mock_attempt(game_code="go_no_go", id=6)
+        db = _build_db_returning([attempt])
+        result = _get_vt_event_history(db, user_id=42)
+        game_code = result[0]["game_code"]
+        slug = game_code.replace("_", "-")
+        assert slug == "go-no-go"
+        assert f"/virtual-training/{slug}/result/6" == "/virtual-training/go-no-go/result/6"
+
+    def test_vtsevt07_color_reaction_slug(self):
+        """VTSEVT-07: game_code 'color_reaction' → slug 'color-reaction' for result URL."""
+        attempt = _mock_attempt(game_code="color_reaction", game_name="Color Reaction", id=3)
+        db = _build_db_returning([attempt])
+        result = _get_vt_event_history(db, user_id=42)
+        slug = result[0]["game_code"].replace("_", "-")
+        assert slug == "color-reaction"
+        assert f"/virtual-training/{slug}/result/3" == "/virtual-training/color-reaction/result/3"
+
+
+# ── VTSEVT-01/02/08: has_any_events gate ──────────────────────────────────────
+
+class TestHasAnyEventsGate:
+
+    def test_vtsevt01_vt_only_has_any_events_true(self):
+        """VTSEVT-01 (gate): vt_history non-empty → has_any_events=True."""
+        vt_history = [{"event_type": "virtual_training", "attempt_id": 6}]
+        tournament_history: list = []
+        has_any_events = bool(tournament_history or vt_history)
+        assert has_any_events is True
+
+    def test_vtsevt02_both_present_has_any_events_true(self):
+        """VTSEVT-02: tournament + VT both present → has_any_events=True."""
+        vt_history = [{"event_type": "virtual_training"}]
+        tournament_history = [{"tournament_name": "Cup"}]
+        has_any_events = bool(tournament_history or vt_history)
+        assert has_any_events is True
+
+    def test_vtsevt08_neither_present_has_any_events_false(self):
+        """VTSEVT-08: no VT, no tournament → has_any_events=False → empty state shown."""
+        vt_history: list = []
+        tournament_history: list = []
+        has_any_events = bool(tournament_history or vt_history)
+        assert has_any_events is False
+
+    def test_vtsevt_tournament_only_has_any_events_true(self):
+        """has_any_events is True when only tournament history exists (regression guard)."""
+        vt_history: list = []
+        tournament_history = [{"tournament_name": "League Cup"}]
+        has_any_events = bool(tournament_history or vt_history)
+        assert has_any_events is True
+
+
+# ── VTSEVT-09: /skills/history regression — get_skill_timeline unchanged ──────
+
+class TestSkillsHistoryRegression:
+
+    def test_vtsevt09_get_skill_timeline_still_importable_and_callable(self):
+        """VTSEVT-09: get_skill_timeline() still importable; signature unchanged."""
+        from app.services.skill_progression_service import get_skill_timeline
+        import inspect
+        sig = inspect.signature(get_skill_timeline)
+        params = list(sig.parameters)
+        assert "db" in params
+        assert "user_id" in params
+        assert "skill_key" in params
+
+
+# ── VTSEVT-10: /skills/data regression — get_skill_profile unchanged ──────────
+
+class TestSkillsDataRegression:
+
+    def test_vtsevt10_get_skill_profile_still_importable(self):
+        """VTSEVT-10: get_skill_profile() importable; returns training_delta field."""
+        from app.services.skill_progression_service import get_skill_profile
+        import inspect
+        sig = inspect.signature(get_skill_profile)
+        assert "db" in sig.parameters
+        assert "user_id" in sig.parameters

--- a/tests/unit/api/web_routes/test_virtual_training.py
+++ b/tests/unit/api/web_routes/test_virtual_training.py
@@ -21,7 +21,7 @@ VT2-17   POST submit → 403 when not onboarded
 VT2-18   record_attempt() returns existing row on duplicate idempotency_key
 VT2-19   record_attempt() awards XP for valid attempt
 VT2-20   record_attempt() xp_awarded=0 when is_valid=False
-VT2-21   record_attempt() xp_awarded=0 when multiplier=0 (4th+ attempt)
+VT2-21   record_attempt() xp_awarded=0 when multiplier=0 (6th+ attempt)
 VT2-22   GET /virtual-training/color-reaction/result/{id} → 200 for owner
 VT2-23   GET result → 404-style redirect for wrong user (shows hub with error)
 VT2-24   History page shows last 20 valid attempts only
@@ -328,11 +328,11 @@ class TestRecordAttempt:
         assert result.xp_awarded == 0
         mock_xp.assert_not_called()
 
-    @patch("app.services.virtual_training_service.VirtualTrainingService.calculate_daily_attempt_index", return_value=4)
+    @patch("app.services.virtual_training_service.VirtualTrainingService.calculate_daily_attempt_index", return_value=6)
     @patch("app.services.segment_reward_service._load_conversion_rates", return_value={})
     @patch("app.services.gamification.xp_service.award_xp")
     def test_vt2_21_no_xp_for_4th_attempt(self, mock_xp, mock_rates, mock_idx):
-        """VT2-21: 4th attempt → multiplier=0.0 → xp_awarded=0, award_xp not called."""
+        """VT2-21: 6th attempt → multiplier=0.0 → xp_awarded=0, award_xp not called."""
         db = self._make_db()
         sp = MagicMock()
         db.begin_nested.return_value = sp
@@ -344,7 +344,7 @@ class TestRecordAttempt:
             game=game,
             data={"duration_seconds": 60.0, "stimuli_count": 36, "avg_reaction_ms": 300.0,
                   "started_at": "2026-05-21T10:00:00+00:00"},
-            idempotency_key="vt_cr_u42_4th",
+            idempotency_key="vt_cr_u42_6th",
         )
         assert result.xp_awarded == 0
         mock_xp.assert_not_called()

--- a/tests/unit/services/test_skill_card_precision.py
+++ b/tests/unit/services/test_skill_card_precision.py
@@ -1,0 +1,210 @@
+"""SKPREC — Skill card display precision tests.
+
+Phase 2.4D follow-up: current_level and total_delta now use training_delta_raw
+(2-decimal) so small VT deltas are not swallowed by premature 1-decimal rounding.
+
+SKPREC-01  training_delta_raw=0.0325 → current_level=60.03, not 60.0
+SKPREC-02  training_delta_raw=0.0325 → total_delta=0.03, not 0.0
+SKPREC-03  deltaHtml(0.03) → '+0.03 ↑', not '±0'
+SKPREC-04  deltaHtml(-0.03) → '-0.03 ↓'
+SKPREC-05  deltaHtml(0.004) below threshold → '±0.00'
+SKPREC-06  0 training delta → current_level=60.0 (backward compatible)
+SKPREC-07  large delta → 60.33, +0.33
+SKPREC-08  average_level stays 1-decimal (stat card not affected)
+SKPREC-09  get_skill_profile() emits 2-decimal current_level and total_delta
+SKPREC-10  negative training delta: current_level stays above MIN_SKILL_VALUE
+SKPREC-11  training_delta backward-compat field still 1-decimal
+SKPREC-12  training_delta_precise equals round(raw, 2)
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+_BASE_VIEWS = "app.services.skill_progression._views"
+_BASE_SRS   = "app.services.segment_reward_service"
+
+_DEFAULT_BASELINE = 60.0
+
+
+def _make_skill_data(current_value: float = 60.0, contribution: float = 0.0) -> dict:
+    return {
+        "baseline": _DEFAULT_BASELINE,
+        "current_value": current_value,
+        "contribution": contribution,
+        "tournament_count": 0,
+    }
+
+
+def _delta_html_py(delta: float) -> str:
+    """Python mirror of the updated JS deltaHtml() in skills.html."""
+    if delta > 0.005:
+        return f"+{delta:.2f} ↑"
+    if delta < -0.005:
+        return f"{delta:.2f} ↓"
+    return "±0.00"
+
+
+# ── SKPREC-01..02: _views.py rounding ─────────────────────────────────────────
+
+class TestSkillLevelPrecision:
+
+    def _build_profile_skill(
+        self,
+        training_delta_raw: float,
+        tournament_contribution: float = 0.0,
+        current_value: float = 60.0,
+    ) -> dict:
+        """Mirror the skill dict logic from get_skill_profile() in _views.py."""
+        from app.services.skill_progression._formulas import (
+            MIN_SKILL_VALUE, MAX_SKILL_CAP,
+        )
+        training_delta = round(training_delta_raw, 1)
+        current_level = round(
+            min(MAX_SKILL_CAP, max(MIN_SKILL_VALUE, current_value + training_delta_raw)),
+            2,
+        )
+        total_delta = round(tournament_contribution + training_delta_raw, 2)
+        return {
+            "current_level": current_level,
+            "total_delta": total_delta,
+            "training_delta": training_delta,
+            "training_delta_precise": round(training_delta_raw, 2),
+        }
+
+    def test_skprec01_small_training_delta_visible_in_current_level(self):
+        """SKPREC-01: raw=0.0325 → current_level=60.03, not 60.0."""
+        s = self._build_profile_skill(0.0325)
+        assert s["current_level"] == 60.03
+        assert s["current_level"] != 60.0
+
+    def test_skprec02_small_training_delta_visible_in_total_delta(self):
+        """SKPREC-02: raw=0.0325 → total_delta=0.03, not 0.0."""
+        s = self._build_profile_skill(0.0325)
+        assert s["total_delta"] == 0.03
+        assert s["total_delta"] != 0.0
+
+    def test_skprec06_zero_training_delta_backward_compatible(self):
+        """SKPREC-06: raw=0.0 → current_level=60.0 (no change, stays compatible)."""
+        s = self._build_profile_skill(0.0)
+        assert s["current_level"] == 60.0
+
+    def test_skprec07_large_delta_two_decimal(self):
+        """SKPREC-07: raw=0.325 → current_level=60.33, total_delta=0.33 (or 0.32 via float repr)."""
+        s = self._build_profile_skill(0.325)
+        assert s["current_level"] == round(60.0 + 0.325, 2)
+        assert s["total_delta"] == round(0.325, 2)
+
+    def test_skprec10_negative_delta_capped_at_min(self):
+        """SKPREC-10: large negative delta → current_level stays ≥ MIN_SKILL_VALUE."""
+        from app.services.skill_progression._formulas import MIN_SKILL_VALUE
+        s = self._build_profile_skill(-99.0)
+        assert s["current_level"] >= MIN_SKILL_VALUE
+
+    def test_skprec11_training_delta_field_stays_one_decimal(self):
+        """SKPREC-11: training_delta backward-compat field rounds to 1 decimal."""
+        s = self._build_profile_skill(0.0325)
+        assert s["training_delta"] == 0.0   # round(0.0325, 1) = 0.0
+
+    def test_skprec12_training_delta_precise_two_decimal(self):
+        """SKPREC-12: training_delta_precise = round(raw, 2) = 0.03."""
+        s = self._build_profile_skill(0.0325)
+        assert s["training_delta_precise"] == 0.03
+
+
+# ── SKPREC-03..05: deltaHtml JS mirror ────────────────────────────────────────
+
+class TestDeltaHtmlPrecision:
+
+    def test_skprec03_positive_small_delta_shows(self):
+        """SKPREC-03: 0.03 > 0.005 threshold → '+0.03 ↑', not '±0'."""
+        assert _delta_html_py(0.03) == "+0.03 ↑"
+
+    def test_skprec04_negative_small_delta_shows(self):
+        """SKPREC-04: -0.03 < -0.005 → '-0.03 ↓'."""
+        assert _delta_html_py(-0.03) == "-0.03 ↓"
+
+    def test_skprec05_below_threshold_zero(self):
+        """SKPREC-05: abs(0.004) < 0.005 → '±0.00'."""
+        assert _delta_html_py(0.004) == "±0.00"
+
+    def test_skprec05b_exactly_zero(self):
+        """SKPREC-05b: delta=0.0 → '±0.00'."""
+        assert _delta_html_py(0.0) == "±0.00"
+
+    def test_skprec05c_negative_below_threshold(self):
+        """SKPREC-05c: -0.003 → '±0.00'."""
+        assert _delta_html_py(-0.003) == "±0.00"
+
+    def test_skprec_large_positive(self):
+        """Large positive delta formats correctly."""
+        assert _delta_html_py(5.2) == "+5.20 ↑"
+
+    def test_skprec_large_negative(self):
+        """Large negative delta formats correctly."""
+        assert _delta_html_py(-3.7) == "-3.70 ↓"
+
+
+# ── SKPREC-08: average_level unchanged ────────────────────────────────────────
+
+class TestAverageLevelPrecision:
+
+    def test_skprec08_average_level_stays_one_decimal(self):
+        """SKPREC-08: average_level is still rounded to 1 decimal at the top level."""
+        total = 60.03 + 60.33 + 60.0
+        avg = round(total / 3, 1)
+        assert str(avg).split(".")[-1] in {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"}
+        assert len(str(avg).split(".")[-1]) == 1
+
+
+# ── SKPREC-09: get_skill_profile() integration ────────────────────────────────
+
+class TestGetSkillProfilePrecision:
+
+    def test_skprec09_profile_emits_precise_current_level_and_total_delta(self):
+        """SKPREC-09: get_skill_profile() importable and emits 2-decimal fields."""
+        from app.services.skill_progression._views import get_skill_profile
+
+        db = MagicMock()
+
+        skill_keys = ["decisions"]
+        assessed_map = {}
+        assessed_count_map = {}
+
+        with (
+            patch(f"{_BASE_VIEWS}.get_all_skill_keys", return_value=skill_keys),
+            patch(f"{_BASE_VIEWS}.get_baseline_skills", return_value={}),
+            patch(f"{_BASE_VIEWS}.FootballSkillAssessment") as MockFSA,
+            patch(f"{_BASE_VIEWS}.TournamentParticipation") as MockTP,
+            patch(f"{_BASE_VIEWS}.calculate_tournament_skill_contribution", return_value={
+                "decisions": {
+                    "baseline": 60.0,
+                    "current_value": 60.0,
+                    "contribution": 0.0,
+                    "tournament_count": 0,
+                }
+            }),
+            patch(f"{_BASE_VIEWS}.get_training_skill_deltas_for_user", return_value={
+                "decisions": 0.0325,
+            }),
+            patch(f"{_BASE_VIEWS}.get_training_session_count_for_user", return_value=0),
+            patch(f"{_BASE_VIEWS}.get_vt_attempt_count_per_skill_for_user", return_value={
+                "decisions": 2,
+            }),
+        ):
+            MockFSA.query = db.query
+            db.query.return_value.filter.return_value.all.return_value = []
+            MockTP.query = db.query
+            db.query.return_value.filter.return_value.count.return_value = 0
+
+            profile = get_skill_profile(db, user_id=42)
+
+        skill = profile["skills"]["decisions"]
+        assert skill["current_level"] == 60.03, f"expected 60.03 got {skill['current_level']}"
+        assert skill["total_delta"] == 0.03, f"expected 0.03 got {skill['total_delta']}"
+        assert skill["training_delta"] == 0.0     # 1-dec backward compat
+        assert skill["training_delta_precise"] == 0.03

--- a/tests/unit/services/test_virtual_training_service.py
+++ b/tests/unit/services/test_virtual_training_service.py
@@ -10,9 +10,18 @@ VT-07   validate_attempt() accepts avg_reaction_ms == 100 (boundary)
 VT-08   validate_attempt() accepts attempt with no avg_reaction_ms key
 VT-09   calculate_daily_attempt_index() returns 1 for first attempt
 VT-10   calculate_daily_attempt_index() returns 3 when 2 valid attempts today
-VT-11   calculate_xp_multiplier() table: index 1→1.0, 2→0.6, 3→0.3, 4→0.0, 99→0.0
+VT-11   calculate_xp_multiplier() table: 1→1.00, 2→0.75, 3→0.50, 4→0.30, 5→0.15, 6→0.00, 99→0.00
 VT-12   calculate_xp_awarded() floors base_xp * multiplier to int
 VT-13   calculate_xp_awarded() returns 0 when multiplier is 0.0
+VT-18   calculate_daily_attempt_index() is game-specific: CR attempts don't affect GNG index
+VT-19   attempt 4 multiplier is 0.30 (reward-eligible)
+VT-20   attempt 5 multiplier is 0.15 (reward-eligible)
+VT-21   attempt 6 multiplier is 0.00 (no reward)
+VT-22   GNG base_xp=12, attempt 5 → 1 XP (floor(12 * 0.15))
+VT-23   CR base_xp=20, attempt 5 → 3 XP (floor(20 * 0.15))
+VT-24   attempt 4 positive performance → positive skill delta
+VT-25   attempt 4 below-neutral performance → negative skill delta (Phase 2.4)
+VT-26   attempt 6 → empty skill delta regardless of performance
 VT-14   calculate_skill_deltas() produces correct per-skill deltas
 VT-15   calculate_skill_deltas() returns empty dict when xp_awarded=0
 VT-16   seed data: 12 games present; color_reaction active; stroop_challenge show_in_hub=False
@@ -173,22 +182,24 @@ class TestDailyAttemptIndex:
 class TestXpCalculation:
 
     @pytest.mark.parametrize("index,expected", [
-        (1, 1.0),
-        (2, 0.6),
-        (3, 0.3),
-        (4, 0.0),
-        (99, 0.0),
+        (1, 1.00),
+        (2, 0.75),
+        (3, 0.50),
+        (4, 0.30),
+        (5, 0.15),
+        (6, 0.00),
+        (99, 0.00),
     ])
     def test_vt11_xp_multiplier_table(self, index, expected):
-        """VT-11: Diminishing-returns multiplier table is correct."""
+        """VT-11: Diminishing-returns multiplier table — 5 reward-eligible attempts per game."""
         assert VirtualTrainingService.calculate_xp_multiplier(index) == pytest.approx(expected)
 
     def test_vt12_xp_awarded_floors_to_int(self):
-        """VT-12: XP = floor(base_xp * multiplier); index 2 with base_xp=15 → 9."""
+        """VT-12: XP = floor(base_xp * multiplier); attempt 2, base_xp=15 → 11."""
         game = _mock_game(base_xp=15)
-        # multiplier = 0.6 → 15 * 0.6 = 9.0 → int 9
-        xp = VirtualTrainingService.calculate_xp_awarded(game, multiplier=0.6)
-        assert xp == 9
+        # attempt 2: multiplier = 0.75 → 15 * 0.75 = 11.25 → int 11
+        xp = VirtualTrainingService.calculate_xp_awarded(game, multiplier=0.75)
+        assert xp == 11
 
     def test_vt13_zero_multiplier_gives_zero_xp(self):
         """VT-13: Multiplier=0.0 yields xp_awarded=0 (4th attempt or beyond)."""
@@ -321,3 +332,119 @@ class TestGetTrainingSkillDeltas:
 
         assert deltas["reactions"] == pytest.approx(1.5 + 0.82, abs=0.01)
         assert deltas["concentration"] == pytest.approx(0.38, abs=0.01)
+
+
+# ── VT-18: game-specific attempt index ────────────────────────────────────────
+
+class TestGameSpecificAttemptIndex:
+
+    def _mock_count_db(self, count: int) -> MagicMock:
+        db = MagicMock()
+        q = MagicMock()
+        q.filter.return_value = q
+        q.count.return_value = count
+        db.query.return_value = q
+        return db
+
+    def test_vt18_cr_attempts_do_not_affect_gng_index(self):
+        """VT-18: 5 Color Reaction attempts today → GNG index still starts at 1.
+
+        The query filters by game_id so CR and GNG are counted separately.
+        This test verifies the filter is applied (count returns 0 for a fresh game).
+        """
+        db = self._mock_count_db(0)   # 0 prior GNG attempts → index = 1
+        idx = VirtualTrainingService.calculate_daily_attempt_index(db, user_id=7, game_id=3)
+        assert idx == 1
+        # game_id=3 (GNG) was passed to the query filter
+        filter_call_args = db.query.return_value.filter.call_args
+        assert filter_call_args is not None
+
+
+# ── VT-19..21: new multiplier values (4, 5, 6) ────────────────────────────────
+
+class TestNewMultiplierValues:
+
+    def test_vt19_attempt_4_multiplier_is_0_30(self):
+        """VT-19: attempt 4 → multiplier 0.30 (reward-eligible, reduced)."""
+        assert VirtualTrainingService.calculate_xp_multiplier(4) == pytest.approx(0.30)
+
+    def test_vt20_attempt_5_multiplier_is_0_15(self):
+        """VT-20: attempt 5 → multiplier 0.15 (last reward-eligible attempt)."""
+        assert VirtualTrainingService.calculate_xp_multiplier(5) == pytest.approx(0.15)
+
+    def test_vt21_attempt_6_multiplier_is_0_00(self):
+        """VT-21: attempt 6 → multiplier 0.00 (no reward, no delta)."""
+        assert VirtualTrainingService.calculate_xp_multiplier(6) == pytest.approx(0.00)
+
+
+# ── VT-22..23: XP at attempt 5 for GNG and CR ────────────────────────────────
+
+class TestXpAttempt5:
+
+    def test_vt22_gng_base_xp_12_attempt_5_gives_1_xp(self):
+        """VT-22: GNG base_xp=12, attempt 5 (multiplier=0.15) → floor(1.8) = 1 XP."""
+        game = _mock_game(base_xp=12)
+        xp = VirtualTrainingService.calculate_xp_awarded(game, multiplier=0.15)
+        assert xp == 1
+        assert xp >= 1
+
+    def test_vt23_cr_base_xp_20_attempt_5_gives_3_xp(self):
+        """VT-23: CR base_xp=20, attempt 5 (multiplier=0.15) → floor(3.0) = 3 XP."""
+        game = _mock_game(base_xp=20)
+        xp = VirtualTrainingService.calculate_xp_awarded(game, multiplier=0.15)
+        assert xp == 3
+        assert xp >= 1
+
+
+# ── VT-24..26: skill delta at attempt 4, 5, 6 (Phase 2.4) ───────────────────
+
+class TestSkillDeltaAtNewAttemptIndices:
+
+    def _gng_game(self) -> MagicMock:
+        g = _mock_game(base_xp=12, skill_targets={
+            "decisions": 0.35, "concentration": 0.30, "composure": 0.20, "reactions": 0.15,
+        })
+        g.config = {"phases": [{"go": 10, "no_go": 5, "window_ms": 1000},
+                                {"go": 11, "no_go": 4, "window_ms": 1000}]}
+        return g
+
+    def test_vt24_attempt_4_positive_performance_gives_positive_delta(self):
+        """VT-24: attempt 4 (multiplier=0.30) good performance → positive skill deltas."""
+        from app.services.virtual_training_metrics import compute_vt_skill_deltas
+        # Perfect GNG: all GO hit, no false alarm → decisions score = 1.0
+        data = {
+            "stimuli_count": 30, "correct_count": 21, "wrong_click_count": 0,
+            "error_count": 0, "avg_reaction_ms": 350.0,
+        }
+        deltas = compute_vt_skill_deltas(data=data, game=self._gng_game(), multiplier=0.30)
+        assert len(deltas) > 0
+        assert all(v > 0 for v in deltas.values()), f"Expected all positive, got {deltas}"
+
+    def test_vt25_attempt_4_poor_performance_gives_negative_delta(self):
+        """VT-25: attempt 4 (multiplier=0.30) weak performance → negative skill deltas (Phase 2.4)."""
+        from app.services.virtual_training_metrics import compute_vt_skill_deltas
+        # Very poor GNG: mostly false alarms → decisions score negative
+        data = {
+            "stimuli_count": 30, "correct_count": 2, "wrong_click_count": 12,
+            "error_count": 16, "avg_reaction_ms": 700.0,
+        }
+        deltas = compute_vt_skill_deltas(data=data, game=self._gng_game(), multiplier=0.30)
+        # decisions: 2/30 - 1.5*(12/30) = 0.067 - 0.600 = -0.533 → negative delta
+        assert "decisions" in deltas
+        assert deltas["decisions"] < 0, f"Expected negative decisions delta, got {deltas}"
+
+    def test_vt26_attempt_6_gives_empty_delta_regardless_of_performance(self):
+        """VT-26: attempt 6 (multiplier=0.00) → empty skill deltas for any performance."""
+        from app.services.virtual_training_metrics import compute_vt_skill_deltas
+        # Good performance
+        good_data = {
+            "stimuli_count": 30, "correct_count": 21, "wrong_click_count": 0,
+            "error_count": 0, "avg_reaction_ms": 350.0,
+        }
+        # Poor performance
+        bad_data = {
+            "stimuli_count": 30, "correct_count": 2, "wrong_click_count": 12,
+            "error_count": 16, "avg_reaction_ms": 700.0,
+        }
+        assert compute_vt_skill_deltas(data=good_data, game=self._gng_game(), multiplier=0.00) == {}
+        assert compute_vt_skill_deltas(data=bad_data,  game=self._gng_game(), multiplier=0.00) == {}

--- a/tests/unit/services/test_virtual_training_service.py
+++ b/tests/unit/services/test_virtual_training_service.py
@@ -248,10 +248,10 @@ class TestSkillDeltas:
 class TestSeedData:
 
     def test_vt16_seed_presets_present_and_correct_active_state(self):
-        """VT-16: Seed contains 12 games; color_reaction active; stroop_challenge hidden; all others planned."""
+        """VT-16: Seed contains 12 games; color_reaction+go_no_go active; stroop_challenge hidden; rest planned."""
         from scripts.seed_virtual_training_games import _GAMES
 
-        # 1 active + 1 hidden + 10 planned = 12 total
+        # 2 active + 1 hidden + 9 planned = 12 total
         assert len(_GAMES) == 12
 
         codes = {g["code"] for g in _GAMES}
@@ -274,7 +274,8 @@ class TestSeedData:
 
         # Active state
         assert game_map["color_reaction"]["is_active"] is True, "color_reaction must remain active"
-        for code in codes - {"color_reaction"}:
+        assert game_map["go_no_go"]["is_active"] is True, "go_no_go must be active"
+        for code in codes - {"color_reaction", "go_no_go"}:
             assert game_map[code]["is_active"] is False, f"{code} must remain inactive until admin toggle"
 
         # stroop_challenge hidden from hub

--- a/tests/unit/services/test_vt_metrics.py
+++ b/tests/unit/services/test_vt_metrics.py
@@ -211,12 +211,13 @@ class TestDecisionsScore:
         assert score == pytest.approx(0.85, abs=0.001)
 
     def test_vm_15_high_wrong_rate_low_score(self):
-        """VM-15: wrong_rate=0.4, hit_rate=0.5 → score penalised below hit_rate."""
+        """VM-15: wrong_rate=0.4, hit_rate=0.5 → score penalised to negative (lower clamp removed)."""
         sig = _signals(hit_rate=0.5, wrong_rate=0.4)
         score = VTSkillScorer.score_decisions(sig)
-        expected = max(0.0, 0.5 - 1.5 * 0.4)
+        # 0.5 - 1.5*0.4 = -0.1; only upper clamp (min(1.0)) applies now
+        expected = min(1.0, 0.5 - 1.5 * 0.4)
         assert score == pytest.approx(expected, abs=0.001)
-        assert score < 0.5
+        assert score < 0
 
     def test_vm_16_moderate_wrong_reasonable_score(self):
         """VM-16: wrong_rate=0.1, hit_rate=0.85 → reasonable decision score."""
@@ -226,19 +227,21 @@ class TestDecisionsScore:
         assert score == pytest.approx(expected, abs=0.001)
         assert 0.5 < score < 0.85
 
-    def test_vm_17_all_wrong_clicks_score_zero(self):
-        """VM-17: wrong_rate=1.0, hit_rate=0.0 → clamped to 0."""
+    def test_vm_17_all_wrong_clicks_score_very_negative(self):
+        """VM-17: wrong_rate=1.0, hit_rate=0.0 → -1.5 (lower clamp removed)."""
         sig = _signals(hit_rate=0.0, wrong_rate=1.0)
         score = VTSkillScorer.score_decisions(sig)
-        assert score == pytest.approx(0.0)
+        # min(1.0, 0 - 1.5*1.0) = -1.5
+        assert score == pytest.approx(-1.5)
+        assert score < 0
 
-    def test_vm_18_wrong_pushes_below_zero_clamped(self):
-        """VM-18: formula result < 0 → clamped to 0 (not negative)."""
-        # hit_rate=0.1, wrong_rate=0.5 → 0.1 - 1.5×0.5 = -0.65 → 0
+    def test_vm_18_wrong_pushes_below_zero_negative(self):
+        """VM-18: formula result < 0 → negative score (lower clamp removed)."""
+        # hit_rate=0.1, wrong_rate=0.5 → 0.1 - 0.75 = -0.65
         sig = _signals(hit_rate=0.1, wrong_rate=0.5)
         score = VTSkillScorer.score_decisions(sig)
-        assert score == pytest.approx(0.0)
-        assert score >= 0.0
+        assert score == pytest.approx(-0.65)
+        assert score < 0
 
 
 # ── TestConcentrationScore (VM-19..23) ────────────────────────────────────────
@@ -250,10 +253,11 @@ class TestConcentrationScore:
         sig = _signals(miss_rate=0.0)
         assert VTSkillScorer.score_concentration(sig) == pytest.approx(1.0)
 
-    def test_vm_20_all_misses_score_zero(self):
-        """VM-20: miss_rate=1.0 → 1−2×1 = -1 → clamped to 0."""
+    def test_vm_20_all_misses_score_negative(self):
+        """VM-20: miss_rate=1.0 → 1−2×1 = -1.0 (lower clamp removed)."""
         sig = _signals(miss_rate=1.0)
-        assert VTSkillScorer.score_concentration(sig) == pytest.approx(0.0)
+        assert VTSkillScorer.score_concentration(sig) == pytest.approx(-1.0)
+        assert VTSkillScorer.score_concentration(sig) < 0
 
     def test_vm_21_quarter_miss_rate(self):
         """VM-21: miss_rate=0.25 → concentration = 1 - 2×0.25 = 0.5."""
@@ -318,11 +322,13 @@ class TestDeltaComputation:
         assert sum(deltas.values()) == pytest.approx(2.0, abs=0.01)
         assert set(deltas.keys()) == set(_SKILL_TARGETS.keys())
 
-    def test_vm_29_zero_score_gives_zero_delta(self):
-        """VM-29: All scores=0.0 → all deltas are 0 → empty dict returned."""
+    def test_vm_29_zero_score_gives_negative_delta(self):
+        """VM-29: All scores=0.0 (below NEUTRAL=0.45) → all deltas negative."""
         scores = {s: 0.0 for s in _SKILL_TARGETS}
         deltas = VTDeltaComputer.compute(scores, _SKILL_TARGETS, base_xp=20, multiplier=1.0)
-        assert deltas == {}
+        assert len(deltas) > 0
+        for skill, delta in deltas.items():
+            assert delta < 0, f"Expected negative delta for {skill}, got {delta}"
 
     def test_vm_30_zero_multiplier_returns_empty(self):
         """VM-30: multiplier=0.0 (4th+ attempt) → {} regardless of scores."""

--- a/tests/unit/services/test_vt_metrics.py
+++ b/tests/unit/services/test_vt_metrics.py
@@ -354,12 +354,12 @@ class TestDeltaComputation:
         assert "concentration" not in deltas
 
     def test_vm_33_attempt_index_2_multiplier_applied(self):
-        """VM-33: multiplier=0.6 (attempt 2) → deltas at 60% of index-1 values."""
+        """VM-33: multiplier=0.75 (attempt 2) → deltas at 75% of index-1 values."""
         scores = {s: 1.0 for s in _SKILL_TARGETS}
         d1 = VTDeltaComputer.compute(scores, _SKILL_TARGETS, base_xp=20, multiplier=1.0)
-        d2 = VTDeltaComputer.compute(scores, _SKILL_TARGETS, base_xp=20, multiplier=0.6)
+        d2 = VTDeltaComputer.compute(scores, _SKILL_TARGETS, base_xp=20, multiplier=0.75)
         for skill in d1:
-            assert d2[skill] == pytest.approx(d1[skill] * 0.6, abs=0.001)
+            assert d2[skill] == pytest.approx(d1[skill] * 0.75, abs=0.001)
 
 
 # ── TestScoreBlindnessEliminated (VM-34..36) ──────────────────────────────────

--- a/tests/unit/services/test_vt_negative_delta.py
+++ b/tests/unit/services/test_vt_negative_delta.py
@@ -1,0 +1,250 @@
+"""NEGDELTA — Bidirectional Virtual Training skill delta tests.
+
+Covers the Phase 2.4 negative-delta model introduced in virtual_training_metrics.py:
+  - Scorer lower clamp removed (decisions, concentration, composure can go negative)
+  - Neutral zone: score < 0.45 → negative delta
+  - NEG_SCALE = 0.5 (negative intensity is half of positive)
+  - Daily negative cap: −0.5 per skill per user per day (write-time enforcement)
+  - Invalid attempts and attempts 4+ always produce zero skill deltas
+
+NEGDELTA-01  score_decisions can return negative value
+NEGDELTA-02  score_concentration can return negative value
+NEGDELTA-03  score_composure can return negative value when wrong_rate > 0.67
+NEGDELTA-04  score_reactions is always non-negative
+NEGDELTA-05  score_anticipation is always non-negative
+NEGDELTA-06  compute() below neutral → negative delta
+NEGDELTA-07  compute() above neutral → positive delta
+NEGDELTA-08  compute() daily cap: new neg truncated when approaching cap
+NEGDELTA-09  compute() daily cap: no further neg when cap already reached
+NEGDELTA-10  compute() positive delta allowed even when cap is reached
+NEGDELTA-11  compute() multiplier applies to negative delta (attempt fairness)
+NEGDELTA-12  compute() zero multiplier → empty result (attempts 4+)
+NEGDELTA-13  johny7 weak GNG pattern → decisions/concentration negative delta
+NEGDELTA-14  get_training_skill_deltas_for_user() aggregation handles negatives
+"""
+from __future__ import annotations
+
+import pytest
+
+# ── shared test signals helper ────────────────────────────────────────────────
+
+def _sig(
+    *,
+    hit_rate:        float = 1.0,
+    wrong_rate:      float = 0.0,
+    miss_rate:       float = 0.0,
+    speed_score:     float = 0.7,
+    completion_rate: float = 1.0,
+):
+    from app.services.virtual_training_metrics import VTSignals
+    return VTSignals(
+        hit_rate=hit_rate,
+        wrong_rate=wrong_rate,
+        miss_rate=miss_rate,
+        speed_score=speed_score,
+        completion_rate=completion_rate,
+    )
+
+
+_GNG_TARGETS = {"decisions": 0.35, "concentration": 0.30, "composure": 0.20, "reactions": 0.15}
+_GNG_BASE_XP = 12  # GNG seed value
+
+
+# ── NEGDELTA-01..05: scorer lower-clamp removed ───────────────────────────────
+
+class TestScorerNegativeOutputs:
+
+    def test_negdelta01_decisions_negative_when_false_alarms_dominate(self):
+        """NEGDELTA-01: score_decisions returns negative when wrong_rate > hit_rate / 1.5."""
+        from app.services.virtual_training_metrics import VTSkillScorer
+        # hit_rate=0.0, wrong_rate=0.5 → 0 - 0.75 = -0.75
+        sig = _sig(hit_rate=0.0, wrong_rate=0.5)
+        score = VTSkillScorer.score_decisions(sig)
+        assert score == pytest.approx(-0.75)
+        assert score < 0
+
+    def test_negdelta02_concentration_negative_when_miss_rate_above_half(self):
+        """NEGDELTA-02: score_concentration returns negative when miss_rate > 0.5."""
+        from app.services.virtual_training_metrics import VTSkillScorer
+        # 1 - 2*0.7 = -0.4
+        sig = _sig(miss_rate=0.7)
+        score = VTSkillScorer.score_concentration(sig)
+        assert score == pytest.approx(-0.4)
+        assert score < 0
+
+    def test_negdelta03_composure_negative_when_wrong_rate_exceeds_threshold(self):
+        """NEGDELTA-03: score_composure returns negative when wrong_rate > 0.67."""
+        from app.services.virtual_training_metrics import VTSkillScorer
+        # 1 - 1.5*0.8 = 1 - 1.2 = -0.2
+        sig = _sig(wrong_rate=0.8)
+        score = VTSkillScorer.score_composure(sig)
+        assert score == pytest.approx(-0.2)
+        assert score < 0
+
+    def test_negdelta04_reactions_always_non_negative(self):
+        """NEGDELTA-04: score_reactions ≥ 0 for any signal combination."""
+        from app.services.virtual_training_metrics import VTSkillScorer
+        # worst case: speed=0, hit=0 → 0.65*0 + 0.35*0 = 0
+        sig = _sig(hit_rate=0.0, speed_score=0.0)
+        assert VTSkillScorer.score_reactions(sig) == pytest.approx(0.0)
+        assert VTSkillScorer.score_reactions(sig) >= 0.0
+
+    def test_negdelta05_anticipation_always_non_negative(self):
+        """NEGDELTA-05: score_anticipation ≥ 0 for any signal combination."""
+        from app.services.virtual_training_metrics import VTSkillScorer
+        sig = _sig(hit_rate=0.0, completion_rate=0.0)
+        assert VTSkillScorer.score_anticipation(sig) >= 0.0
+
+
+# ── NEGDELTA-06..12: compute() neutral-zone and daily cap ─────────────────────
+
+class TestDeltaCompute:
+
+    def test_negdelta06_score_below_neutral_gives_negative_delta(self):
+        """NEGDELTA-06: score=0.30 < NEUTRAL(0.45) → negative delta."""
+        from app.services.virtual_training_metrics import VTDeltaComputer
+        # unit = (1.0/1.0) * 1.2 = 1.2; delta = (0.30-0.45)*0.5*1.2*1.0 = -0.09
+        scores = {"decisions": 0.30}
+        result = VTDeltaComputer.compute(scores, {"decisions": 1.0}, base_xp=10, multiplier=1.0)
+        assert "decisions" in result
+        assert result["decisions"] < 0
+        assert result["decisions"] == pytest.approx(-0.075, abs=0.001)
+
+    def test_negdelta07_score_above_neutral_gives_positive_delta(self):
+        """NEGDELTA-07: score=0.80 ≥ NEUTRAL(0.45) → positive delta."""
+        from app.services.virtual_training_metrics import VTDeltaComputer
+        scores = {"decisions": 0.80}
+        result = VTDeltaComputer.compute(scores, {"decisions": 1.0}, base_xp=10, multiplier=1.0)
+        assert result.get("decisions", 0) > 0
+
+    def test_negdelta08_daily_cap_truncates_new_negative_when_approaching(self):
+        """NEGDELTA-08: existing_neg=-0.45, new delta=-0.09 → capped at −0.05 (only gap)."""
+        from app.services.virtual_training_metrics import VTDeltaComputer
+        # cap = -0.5; existing = -0.45; room = -0.05
+        # raw new delta = (0.30-0.45)*0.5*1.0*1.0 = -0.075 → max(-0.075, -0.5-(-0.45)) = max(-0.075, -0.05) = -0.05
+        scores = {"decisions": 0.30}
+        result = VTDeltaComputer.compute(
+            scores, {"decisions": 1.0}, base_xp=10, multiplier=1.0,
+            existing_neg_today={"decisions": -0.45},
+        )
+        assert "decisions" in result
+        assert result["decisions"] == pytest.approx(-0.05, abs=0.001)
+
+    def test_negdelta09_daily_cap_blocks_further_negative_when_reached(self):
+        """NEGDELTA-09: existing_neg already at cap → new attempt produces zero delta."""
+        from app.services.virtual_training_metrics import VTDeltaComputer
+        scores = {"decisions": 0.20}
+        result = VTDeltaComputer.compute(
+            scores, {"decisions": 1.0}, base_xp=10, multiplier=1.0,
+            existing_neg_today={"decisions": -0.50},
+        )
+        # delta=0 → filtered from result dict
+        assert "decisions" not in result
+
+    def test_negdelta10_positive_delta_unaffected_by_neg_cap(self):
+        """NEGDELTA-10: even when neg cap is reached, positive delta still applies."""
+        from app.services.virtual_training_metrics import VTDeltaComputer
+        scores = {"decisions": 0.90}
+        result = VTDeltaComputer.compute(
+            scores, {"decisions": 1.0}, base_xp=10, multiplier=1.0,
+            existing_neg_today={"decisions": -0.50},
+        )
+        assert result.get("decisions", 0) > 0
+
+    def test_negdelta11_multiplier_applies_to_negative_delta(self):
+        """NEGDELTA-11: multiplier=0.3 (attempt 3) reduces negative delta proportionally."""
+        from app.services.virtual_training_metrics import VTDeltaComputer
+        scores = {"decisions": 0.30}
+        full   = VTDeltaComputer.compute(scores, {"decisions": 1.0}, base_xp=10, multiplier=1.0)
+        third  = VTDeltaComputer.compute(scores, {"decisions": 1.0}, base_xp=10, multiplier=0.3)
+        # Both negative, third should be ~30% of full magnitude
+        assert full["decisions"] < 0
+        assert third["decisions"] < 0
+        assert abs(third["decisions"]) == pytest.approx(abs(full["decisions"]) * 0.3, rel=0.02)
+
+    def test_negdelta12_zero_multiplier_returns_empty(self):
+        """NEGDELTA-12: multiplier=0.0 (attempt 4+) → empty result, no skill delta."""
+        from app.services.virtual_training_metrics import VTDeltaComputer
+        scores = {"decisions": 0.10, "concentration": 0.05}
+        result = VTDeltaComputer.compute(
+            scores, {"decisions": 0.5, "concentration": 0.5}, base_xp=12, multiplier=0.0
+        )
+        assert result == {}
+
+
+# ── NEGDELTA-13: johny7 weak GNG pattern ─────────────────────────────────────
+
+class TestJohny7WeakGNG:
+
+    def test_negdelta13_weak_gng_attempt_gives_negative_decisions_and_concentration(self):
+        """NEGDELTA-13: attempt #3 pattern (7 GO hits, 8 FA, 14 miss / 30 stim) produces
+        negative decisions and concentration deltas under the new formula."""
+        from app.services.virtual_training_metrics import (
+            VTSignalExtractor, VTSkillScorer, VTDeltaComputer,
+        )
+        # Replicate johny7 attempt #3 aggregate payload
+        data = {
+            "stimuli_count":     30,
+            "correct_count":     7,    # 7 GO hits out of 21 GO stimuli
+            "wrong_click_count": 8,    # 8 false alarms on NO-GO
+            "error_count":       14,   # 14 missed GO
+            "avg_reaction_ms":   646.0,
+        }
+        phase_config = [
+            {"go": 10, "no_go": 5, "window_ms": 1000},
+            {"go": 11, "no_go": 4, "window_ms": 1000},
+        ]
+        signals = VTSignalExtractor.extract(data, phase_config)
+
+        # Verify raw signals
+        assert signals.hit_rate   == pytest.approx(7 / 30, abs=0.001)
+        assert signals.wrong_rate == pytest.approx(8 / 30, abs=0.001)
+        assert signals.miss_rate  == pytest.approx(14 / 30, abs=0.001)
+
+        scores = VTSkillScorer.score_all(signals, _GNG_TARGETS)
+
+        # decisions = 7/30 - 1.5*(8/30) = 0.233 - 0.400 = -0.167 → negative
+        assert scores["decisions"] < 0
+        # concentration = 1 - 2*(14/30) = 1 - 0.933 = 0.067 → positive but below neutral
+        assert 0.0 < scores["concentration"] < 0.45
+
+        deltas = VTDeltaComputer.compute(scores, _GNG_TARGETS, base_xp=_GNG_BASE_XP, multiplier=0.3)
+
+        # decisions: raw score < 0 → negative delta
+        assert deltas.get("decisions", 0) < 0
+        # concentration: 0 < score < NEUTRAL → also negative delta
+        assert deltas.get("concentration", 0) < 0
+        # composure: 1 - 1.5*(8/30) = 0.600 ≥ 0.45 → positive delta
+        assert deltas.get("composure", 0) > 0
+
+
+# ── NEGDELTA-14: aggregation read-path handles negatives ─────────────────────
+
+class TestAggregationWithNegatives:
+
+    def test_negdelta14_get_training_skill_deltas_sums_positive_and_negative(self):
+        """NEGDELTA-14: get_training_skill_deltas_for_user() SUM() correctly aggregates
+        mixed positive and negative skill_deltas from virtual_training_attempts."""
+        from unittest.mock import MagicMock
+
+        # Simulate two VT rows and one segment row being summed:
+        #   segment row:  decisions=+0.10
+        #   VT rows:      decisions=+0.21, concentration=+0.12
+        # Expected totals: decisions=+0.31, concentration=+0.12
+        # get_training_skill_deltas_for_user() accesses rows by index: row[0], row[1]
+
+        segment_rows = [("decisions", 0.10)]
+        vt_rows = [("decisions", 0.21), ("concentration", 0.12)]
+
+        db = MagicMock()
+        execute_results = [
+            MagicMock(fetchall=lambda: segment_rows),
+            MagicMock(fetchall=lambda: vt_rows),
+        ]
+        db.execute.side_effect = execute_results
+
+        from app.services.segment_reward_service import get_training_skill_deltas_for_user
+        result = get_training_skill_deltas_for_user(db=db, user_id=42)
+
+        assert result["decisions"]     == pytest.approx(0.31, abs=0.001)
+        assert result["concentration"] == pytest.approx(0.12, abs=0.001)

--- a/tests/unit/services/test_vt_negative_delta.py
+++ b/tests/unit/services/test_vt_negative_delta.py
@@ -152,15 +152,15 @@ class TestDeltaCompute:
         assert result.get("decisions", 0) > 0
 
     def test_negdelta11_multiplier_applies_to_negative_delta(self):
-        """NEGDELTA-11: multiplier=0.3 (attempt 3) reduces negative delta proportionally."""
+        """NEGDELTA-11: multiplier scales negative delta proportionally (same as positive)."""
         from app.services.virtual_training_metrics import VTDeltaComputer
         scores = {"decisions": 0.30}
-        full   = VTDeltaComputer.compute(scores, {"decisions": 1.0}, base_xp=10, multiplier=1.0)
-        third  = VTDeltaComputer.compute(scores, {"decisions": 1.0}, base_xp=10, multiplier=0.3)
-        # Both negative, third should be ~30% of full magnitude
+        full    = VTDeltaComputer.compute(scores, {"decisions": 1.0}, base_xp=10, multiplier=1.0)
+        partial = VTDeltaComputer.compute(scores, {"decisions": 1.0}, base_xp=10, multiplier=0.3)
+        # Both negative; partial should be ~30% of full magnitude
         assert full["decisions"] < 0
-        assert third["decisions"] < 0
-        assert abs(third["decisions"]) == pytest.approx(abs(full["decisions"]) * 0.3, rel=0.02)
+        assert partial["decisions"] < 0
+        assert abs(partial["decisions"]) == pytest.approx(abs(full["decisions"]) * 0.3, rel=0.02)
 
     def test_negdelta12_zero_multiplier_returns_empty(self):
         """NEGDELTA-12: multiplier=0.0 (attempt 4+) → empty result, no skill delta."""
@@ -208,7 +208,7 @@ class TestJohny7WeakGNG:
         # concentration = 1 - 2*(14/30) = 1 - 0.933 = 0.067 → positive but below neutral
         assert 0.0 < scores["concentration"] < 0.45
 
-        deltas = VTDeltaComputer.compute(scores, _GNG_TARGETS, base_xp=_GNG_BASE_XP, multiplier=0.3)
+        deltas = VTDeltaComputer.compute(scores, _GNG_TARGETS, base_xp=_GNG_BASE_XP, multiplier=0.5)
 
         # decisions: raw score < 0 → negative delta
         assert deltas.get("decisions", 0) < 0

--- a/tests/unit/test_card_macros.py
+++ b/tests/unit/test_card_macros.py
@@ -195,10 +195,10 @@ class TestCardSkillRowsMacro:
         html = self._render(cat, {}, {})
         assert html.count('class="skill-row"') == 3
 
-    def test_MR_card_uses_round_1_for_score(self):
+    def test_MR_card_uses_round_2_for_score(self):
         cat = _make_cat(skills=[_make_skill("pace", "Pace")])
         html = self._render(cat, {"pace": {"current_level": 77.3}}, {})
-        # round(1) → 77.3
+        # round(2) → 77.3 (77.30 contains "77.3")
         assert "77.3" in html
 
     def test_MR_card_no_wrapping_container_div(self):

--- a/tests/unit/test_card_platform_persistence.py
+++ b/tests/unit/test_card_platform_persistence.py
@@ -412,17 +412,28 @@ class TestPlatformPersistencePlaywright:
             "OG export template (.ex-card) must be present when ?platform=og is set"
         page.close()
 
-    def test_pp07_no_param_renders_public_profile(self):
+    def test_pp07_no_param_renders_interactive_card(self):
         """
-        /players/{uid}/card with no params must render the public profile page —
-        single card iframe (pcp-card-wrap present) with no download buttons or platform picker.
+        /players/{uid}/card with no params must render the interactive FIFA card directly
+        (Phase 2.4F: bare URL no longer serves the export-portrait iframe wrapper).
+        The interactive card has .card-wrap / .tab-bar; no iframe wrapper (.pcp-card-wrap)
+        and no download or platform-picker UI.
         """
         page = self._page({"width": 1200, "height": 900})
         page.goto(f"{_BASE_URL}/players/{_TEST_UID}/card", wait_until="networkidle")
-        has_card_wrap      = page.query_selector(".pcp-card-wrap") is not None
-        has_dl_btn         = page.query_selector(".pcg-dl-btn") is not None
+        has_interactive_card = (
+            page.query_selector(".card-wrap") is not None
+            or page.query_selector(".tab-bar") is not None
+        )
+        has_iframe_wrapper  = page.query_selector(".pcp-card-wrap") is not None
+        has_dl_btn          = page.query_selector(".pcg-dl-btn") is not None
         has_platform_picker = page.query_selector(".pcg-platform-card") is not None
-        assert has_card_wrap, "Public profile must render the single card iframe wrap (pcp-card-wrap)"
-        assert not has_dl_btn, "Public profile must NOT render download buttons (pcg-dl-btn)"
-        assert not has_platform_picker, "Public profile must NOT render platform picker cards (pcg-platform-card)"
+        assert has_interactive_card, (
+            "Bare URL must render the interactive FIFA card (.card-wrap or .tab-bar)"
+        )
+        assert not has_iframe_wrapper, (
+            "Bare URL must NOT render the old iframe wrapper (.pcp-card-wrap)"
+        )
+        assert not has_dl_btn, "Bare URL must NOT render download buttons (pcg-dl-btn)"
+        assert not has_platform_picker, "Bare URL must NOT render platform picker cards"
         page.close()


### PR DESCRIPTION
## Summary

- 3 new routes: `GET /virtual-training/go-no-go`, `POST /virtual-training/go-no-go/submit`, `GET /virtual-training/go-no-go/result/{id}`
- Game template with 2-phase Fisher-Yates shuffle (21 GO / 9 NO-GO), HIT / MISS / GOOD HOLD / FALSE ALARM feedback
- Result template: score, GO accuracy, NO-GO success, false alarms, missed GO, avg RT, XP, per-skill breakdown with formula doc, per-phase table
- `score_composure()` added to `VTSkillScorer` — impulse control scorer: `clamp(1.0 - 1.5 × wrong_rate, 0, 1)`
- `_views.py` now propagates `game_code` to VT timeline events; `skill_history.html` and `virtual_training_history.html` result links dynamic (were hardcoded to `color-reaction`)
- Seed: `go_no_go` activated (`is_active=True`), gameplay config with phases + score weights + skill delta docs

## Test plan

- [x] GNG-01..03: GET game page (active, inactive→hub error, non-onboarded redirect)
- [x] GNG-04..09, 12: POST submit (valid, too_short, bot_suspected, 429 cap, 404 inactive, 403 unonboarded, idempotency)
- [x] GNG-10..11: GET result (owner 200, wrong-user→hub)
- [x] GNG-13..17: `score_composure` unit tests (0→1.0, 0.5→0.25, clamped, included in score_all, delta positive)
- [x] GNG-18..20: perfect run all deltas positive; FA heavy composure≈0; missed GO heavy concentration≈0
- [x] GNG-21..22: raw_metrics per_phase persisted with correct_inhibits; sums match aggregate
- [x] GNG-23..27: template link tests — no hardcoded color-reaction, game_code in views + history + result
- [x] GNG-28..29: score formula bounds
- [x] GNG-REG-01..04: Color Reaction routes untouched
- [x] GNG-SEED-01..03: seed active state + phases valid + composure in skill_targets
- [x] VT-16 updated: color_reaction + go_no_go active, 9 others inactive
- [x] OpenAPI snapshot refreshed (774 routes)
- [x] 10,043 unit tests green, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)