### PR TITLE
feat(vt): Phase 2.4 — Hand & Finger Performance Stats UI

### DIFF
--- a/app/api/web_routes/virtual_training.py
+++ b/app/api/web_routes/virtual_training.py
@@ -543,3 +543,44 @@ async def virtual_training_history(
             "games": games,
         },
     )
+
+
+# ── Hand/Finger Performance Stats ─────────────────────────────────────────────
+
+_VALID_GAME_CODES: frozenset[str] = frozenset({"color_reaction", "go_no_go"})
+
+
+@router.get("/virtual-training/hand-finger-stats", response_class=HTMLResponse)
+async def virtual_training_hand_finger_stats(
+    request: Request,
+    game: str = "all",
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user_web),
+):
+    """Hand/Finger performance aggregation — system-assigned v3 attempts only."""
+    guard = require_student_onboarding(user)
+    if guard:
+        return guard
+
+    # Resolve game query param → game_id (invalid param falls back to "all")
+    game_code = game if game in _VALID_GAME_CODES else "all"
+    game_id: int | None = None
+    if game_code != "all":
+        g = VirtualTrainingService.get_game(db, game_code)
+        if g:
+            game_id = g.id
+        else:
+            game_code = "all"
+
+    stats = VirtualTrainingService.get_hand_finger_stats(db, user.id, game_id)
+
+    return templates.TemplateResponse(
+        "virtual_training_hand_finger_stats.html",
+        {
+            "request":     request,
+            "user":        user,
+            **_spec_ctx(user, db),
+            "stats":       stats,
+            "game_filter": game_code,
+        },
+    )

--- a/app/services/virtual_training_service.py
+++ b/app/services/virtual_training_service.py
@@ -46,6 +46,16 @@ _FREE_PROTOCOL: dict = {
     "assignment_source": "system", "self_declared": True, "not_verified": True,
 }
 
+_MIN_SAMPLES: int = 3   # minimum eligible attempts per (hand, finger) cell to show data
+
+# Canonical finger display order for the stats page
+_FINGER_ORDER: list[tuple[str, str, str]] = [
+    ("right", "index", "Right Index"),
+    ("right", "thumb", "Right Thumb"),
+    ("left",  "index", "Left Index"),
+    ("left",  "thumb", "Left Thumb"),
+]
+
 
 class VirtualTrainingService:
 
@@ -414,3 +424,166 @@ class VirtualTrainingService:
             )
 
         return attempt
+
+    # ── Hand/Finger Performance Stats (Phase 2.5) ─────────────────────────────
+
+    @staticmethod
+    def get_hand_finger_stats(
+        db: Session,
+        user_id: int,
+        game_id: int | None = None,
+    ) -> dict:
+        """
+        Aggregate hand/finger performance from system-assigned v3 attempts.
+
+        Eligible filter: is_valid=TRUE, raw_metrics.v>=3, hand_profile present,
+        assignment_source="system".  v1/v2 and free-protocol attempts excluded.
+
+        game_id=None → all VT games combined.
+
+        Returns:
+          {
+            "min_samples":  3,
+            "finger_rows":  [...],   # 4 entries: ri/rt/li/lt in canonical order
+            "by_hand":      {"right": {...}, "left": {...}},
+            "skill_totals": {"right_index": {"reactions": 0.34, ...}, ...},
+          }
+        """
+        from collections import defaultdict
+
+        _base = """
+            a.user_id = :uid
+            AND a.is_valid = TRUE
+            AND a.raw_metrics IS NOT NULL
+            AND (a.raw_metrics->>'v')::int >= 3
+            AND a.raw_metrics ? 'hand_profile'
+            AND a.raw_metrics->'hand_profile'->>'assignment_source' = 'system'
+        """
+        params: dict = {"uid": user_id}
+        if game_id is not None:
+            _base += " AND a.game_id = :gid"
+            params["gid"] = game_id
+
+        # ── 1. Per-(hand, finger) aggregate metrics ───────────────────────────
+        finger_sql = text(f"""
+            SELECT
+                raw_metrics->'hand_profile'->>'hand'   AS hand,
+                raw_metrics->'hand_profile'->>'finger' AS finger,
+                raw_metrics->'hand_profile'->>'label'  AS label,
+                COUNT(*)                               AS attempt_count,
+                ROUND(AVG(a.score_normalized)::numeric, 1)  AS avg_score,
+                ROUND(AVG(a.avg_reaction_ms)::numeric, 0)   AS avg_rt_ms,
+                ROUND(MIN(a.avg_reaction_ms)::numeric, 0)   AS best_rt_ms,
+                ROUND(100.0 * AVG(
+                    a.correct_count::float / NULLIF(a.stimuli_count, 0)
+                )::numeric, 1) AS accuracy_pct,
+                ROUND(100.0 * AVG(
+                    a.error_count::float / NULLIF(a.stimuli_count, 0)
+                )::numeric, 1) AS miss_pct,
+                ROUND(100.0 * AVG(
+                    a.wrong_click_count::float / NULLIF(a.stimuli_count, 0)
+                )::numeric, 1) AS wrong_pct,
+                ROUND(100.0 * AVG(
+                    COALESCE(
+                        (a.raw_metrics->'late_summary'->>'late_click_count')::float, 0
+                    ) / NULLIF(a.stimuli_count, 0)
+                )::numeric, 1) AS late_pct
+            FROM virtual_training_attempts a
+            WHERE {_base}
+            GROUP BY hand, finger, label
+            ORDER BY hand, finger
+        """)
+
+        seen: dict[str, dict] = {}
+        for r in db.execute(finger_sql, params).fetchall():
+            cnt = int(r.attempt_count)
+            seen[f"{r.hand}_{r.finger}"] = {
+                "hand":          r.hand,
+                "finger":        r.finger,
+                "label":         r.label or f"{r.hand.capitalize()} {r.finger.capitalize()}",
+                "attempt_count": cnt,
+                "has_data":      cnt >= _MIN_SAMPLES,
+                "avg_score":     float(r.avg_score)    if r.avg_score    is not None else None,
+                "avg_rt_ms":     int(r.avg_rt_ms)      if r.avg_rt_ms    is not None else None,
+                "best_rt_ms":    int(r.best_rt_ms)     if r.best_rt_ms   is not None else None,
+                "accuracy_pct":  float(r.accuracy_pct) if r.accuracy_pct is not None else None,
+                "miss_pct":      float(r.miss_pct)     if r.miss_pct     is not None else None,
+                "wrong_pct":     float(r.wrong_pct)    if r.wrong_pct    is not None else None,
+                "late_pct":      float(r.late_pct)     if r.late_pct     is not None else None,
+            }
+
+        finger_rows = []
+        for hand, finger, default_label in _FINGER_ORDER:
+            key = f"{hand}_{finger}"
+            if key in seen:
+                finger_rows.append(seen[key])
+            else:
+                finger_rows.append({
+                    "hand": hand, "finger": finger, "label": default_label,
+                    "attempt_count": 0, "has_data": False,
+                })
+
+        # ── 2. Per-hand aggregate metrics ─────────────────────────────────────
+        hand_sql = text(f"""
+            SELECT
+                raw_metrics->'hand_profile'->>'hand' AS hand,
+                COUNT(*)                             AS attempt_count,
+                ROUND(AVG(a.score_normalized)::numeric, 1)  AS avg_score,
+                ROUND(AVG(a.avg_reaction_ms)::numeric, 0)   AS avg_rt_ms,
+                ROUND(100.0 * AVG(
+                    a.correct_count::float / NULLIF(a.stimuli_count, 0)
+                )::numeric, 1) AS accuracy_pct
+            FROM virtual_training_attempts a
+            WHERE {_base}
+            GROUP BY hand
+            ORDER BY hand
+        """)
+
+        by_hand: dict[str, dict] = {
+            "right": {"attempt_count": 0, "has_data": False},
+            "left":  {"attempt_count": 0, "has_data": False},
+        }
+        for r in db.execute(hand_sql, params).fetchall():
+            if r.hand in by_hand:
+                cnt = int(r.attempt_count)
+                by_hand[r.hand] = {
+                    "attempt_count": cnt,
+                    "has_data":      cnt >= _MIN_SAMPLES,
+                    "avg_score":     float(r.avg_score)    if r.avg_score    is not None else None,
+                    "avg_rt_ms":     int(r.avg_rt_ms)      if r.avg_rt_ms    is not None else None,
+                    "accuracy_pct":  float(r.accuracy_pct) if r.accuracy_pct is not None else None,
+                }
+
+        # ── 3. Skill delta totals per (hand_finger) ───────────────────────────
+        delta_sql = text(f"""
+            SELECT
+                raw_metrics->'hand_profile'->>'hand'   AS hand,
+                raw_metrics->'hand_profile'->>'finger' AS finger,
+                a.skill_deltas
+            FROM virtual_training_attempts a
+            WHERE {_base}
+            ORDER BY a.completed_at
+        """)
+
+        skill_acc: dict[str, dict[str, float]] = defaultdict(lambda: defaultdict(float))
+        for r in db.execute(delta_sql, params).fetchall():
+            deltas = r.skill_deltas
+            if not isinstance(deltas, dict) or not deltas:
+                continue
+            combo = f"{r.hand}_{r.finger}"
+            for skill, delta in deltas.items():
+                try:
+                    skill_acc[combo][skill] = round(
+                        skill_acc[combo][skill] + float(delta), 4
+                    )
+                except (TypeError, ValueError):
+                    pass
+
+        skill_totals = {k: dict(v) for k, v in skill_acc.items()}
+
+        return {
+            "min_samples":  _MIN_SAMPLES,
+            "finger_rows":  finger_rows,
+            "by_hand":      by_hand,
+            "skill_totals": skill_totals,
+        }

--- a/app/services/virtual_training_service.py
+++ b/app/services/virtual_training_service.py
@@ -502,7 +502,7 @@ class VirtualTrainingService:
                 "finger":        r.finger,
                 "label":         r.label or f"{r.hand.capitalize()} {r.finger.capitalize()}",
                 "attempt_count": cnt,
-                "has_data":      cnt >= _MIN_SAMPLES,
+                "state":         "ready" if cnt >= _MIN_SAMPLES else "low_sample",
                 "avg_score":     float(r.avg_score)    if r.avg_score    is not None else None,
                 "avg_rt_ms":     int(r.avg_rt_ms)      if r.avg_rt_ms    is not None else None,
                 "best_rt_ms":    int(r.best_rt_ms)     if r.best_rt_ms   is not None else None,
@@ -520,7 +520,7 @@ class VirtualTrainingService:
             else:
                 finger_rows.append({
                     "hand": hand, "finger": finger, "label": default_label,
-                    "attempt_count": 0, "has_data": False,
+                    "attempt_count": 0, "state": "no_data",
                 })
 
         # ── 2. Per-hand aggregate metrics ─────────────────────────────────────
@@ -540,15 +540,15 @@ class VirtualTrainingService:
         """)
 
         by_hand: dict[str, dict] = {
-            "right": {"attempt_count": 0, "has_data": False},
-            "left":  {"attempt_count": 0, "has_data": False},
+            "right": {"attempt_count": 0, "state": "no_data"},
+            "left":  {"attempt_count": 0, "state": "no_data"},
         }
         for r in db.execute(hand_sql, params).fetchall():
             if r.hand in by_hand:
                 cnt = int(r.attempt_count)
                 by_hand[r.hand] = {
                     "attempt_count": cnt,
-                    "has_data":      cnt >= _MIN_SAMPLES,
+                    "state":         "ready" if cnt >= _MIN_SAMPLES else "low_sample",
                     "avg_score":     float(r.avg_score)    if r.avg_score    is not None else None,
                     "avg_rt_ms":     int(r.avg_rt_ms)      if r.avg_rt_ms    is not None else None,
                     "accuracy_pct":  float(r.accuracy_pct) if r.accuracy_pct is not None else None,

--- a/app/templates/virtual_training_hand_finger_stats.html
+++ b/app/templates/virtual_training_hand_finger_stats.html
@@ -83,9 +83,14 @@
         box-shadow: 0 2px 8px rgba(0,0,0,0.05);
     }
 
-    .vt-hf-hand-card.active {
+    .vt-hf-hand-card.ready {
         border-color: #c7d2fe;
         box-shadow: 0 2px 10px rgba(79,70,229,0.10);
+    }
+
+    .vt-hf-hand-card.low-sample {
+        border-color: #fde68a;
+        box-shadow: 0 2px 10px rgba(217,119,6,0.08);
     }
 
     .vt-hf-hand-label {
@@ -123,6 +128,31 @@
         border-radius: 6px;
         padding: 0.15rem 0.5rem;
         margin-bottom: 0.5rem;
+    }
+
+    /* ── Confidence badges ─────────────────────────────────────────────── */
+    .vt-hf-confidence {
+        display: inline-block;
+        font-size: 0.68rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        border-radius: 5px;
+        padding: 0.1rem 0.45rem;
+        margin-top: 0.55rem;
+    }
+
+    .vt-hf-confidence.low {
+        color: #92400e;
+        background: #fef3c7;
+        border: 1px solid #fde68a;
+    }
+
+    .vt-hf-nudge {
+        font-size: 0.73rem;
+        color: var(--app-text-muted);
+        margin-top: 0.4rem;
+        line-height: 1.45;
     }
 
     /* ── By Finger table ───────────────────────────────────────────────── */
@@ -163,6 +193,7 @@
     .vt-hf-table tr:last-child td { border-bottom: none; }
 
     .vt-hf-table tr.no-data td { color: var(--app-text-muted); font-style: italic; }
+    .vt-hf-table tr.low-sample td { background: #fffdf0; }
 
     .vt-hf-label-cell {
         font-weight: 700;
@@ -170,6 +201,19 @@
     }
 
     .vt-hf-dim { color: var(--app-text-muted); font-size: 0.75rem; }
+
+    .vt-hf-low-badge {
+        display: inline-block;
+        font-size: 0.65rem;
+        font-weight: 700;
+        color: #92400e;
+        background: #fef3c7;
+        border: 1px solid #fde68a;
+        border-radius: 4px;
+        padding: 0.05rem 0.35rem;
+        margin-left: 0.3rem;
+        vertical-align: middle;
+    }
 
     /* ── Skill delta bars ──────────────────────────────────────────────── */
     .vt-hf-delta-section {
@@ -281,7 +325,7 @@
     <div class="vt-hf-disclaimer">
         ⚠ Data reflects system-assigned protocols only.
         Self-declared · Not automatically verified.
-        At least {{ stats.min_samples }} valid attempts per protocol are needed to show statistics.
+        At least {{ stats.min_samples }} valid attempts per protocol are needed for reliable comparison.
     </div>
 
     {# ── By Hand ──────────────────────────────────────────────────────────── #}
@@ -290,10 +334,17 @@
 
         {% for side in ["right", "left"] %}
         {% set hd = stats.by_hand[side] %}
-        <div class="vt-hf-hand-card{% if hd.has_data %} active{% endif %}">
+        {%- set _hd_state = hd.state | default("no_data") -%}
+        <div class="vt-hf-hand-card{% if _hd_state == 'ready' %} ready{% elif _hd_state == 'low_sample' %} low-sample{% endif %}">
             <div class="vt-hf-hand-label">{{ side | upper }} HAND</div>
 
-            {% if hd.has_data %}
+            {% if _hd_state == 'no_data' %}
+            <div class="vt-hf-nodata">
+                No data yet. Play a game to see stats here.
+            </div>
+
+            {% else %}
+            {# low_sample or ready — both show real metrics #}
             <div class="vt-hf-hand-stat">
                 <span>Attempts</span>
                 <b>{{ hd.attempt_count }}</b>
@@ -317,12 +368,16 @@
             </div>
             {% endif %}
 
-            {% else %}
-            <span class="vt-hf-nodata-tag">Not enough data</span>
-            <div class="vt-hf-nodata">
-                Complete at least {{ stats.min_samples }} valid
-                system-assigned attempts for this hand.
+            {% if _hd_state == 'low_sample' %}
+            <div>
+                <span class="vt-hf-confidence low">LOW confidence</span>
             </div>
+            {%- set _hd_remaining = stats.min_samples - hd.attempt_count -%}
+            <div class="vt-hf-nudge">
+                Complete {{ _hd_remaining }} more valid attempt{{ 's' if _hd_remaining != 1 else '' }} for reliable comparison.
+            </div>
+            {% endif %}
+
             {% endif %}
         </div>
         {% endfor %}
@@ -346,20 +401,38 @@
             </thead>
             <tbody>
             {% for row in stats.finger_rows %}
-            <tr{% if not row.has_data %} class="no-data"{% endif %}>
-                <td class="vt-hf-label-cell">{{ row.label }}</td>
-                {% if row.has_data %}
+            {%- set _row_state = row.state | default("no_data") -%}
+            <tr{% if _row_state == 'no_data' %} class="no-data"{% elif _row_state == 'low_sample' %} class="low-sample"{% endif %}>
+                <td class="vt-hf-label-cell">
+                    {{ row.label }}
+                    {% if _row_state == 'low_sample' %}<span class="vt-hf-low-badge">LOW</span>{% endif %}
+                </td>
+
+                {% if _row_state == 'no_data' %}
+                <td>0</td>
+                <td colspan="5" class="vt-hf-dim">No data yet</td>
+
+                {% else %}
+                {# low_sample or ready — show real metrics #}
                 <td>{{ row.attempt_count }}</td>
                 <td>{% if row.avg_score is not none %}{{ row.avg_score }}%{% else %}—{% endif %}</td>
                 <td>{% if row.avg_rt_ms is not none %}{{ row.avg_rt_ms }} ms{% else %}—{% endif %}</td>
                 <td>{% if row.accuracy_pct is not none %}{{ row.accuracy_pct }}%{% else %}—{% endif %}</td>
                 <td>{% if row.miss_pct is not none %}{{ row.miss_pct }}%{% else %}—{% endif %}</td>
                 <td>{% if row.late_pct is not none %}{{ row.late_pct }}%{% else %}—{% endif %}</td>
-                {% else %}
-                <td>{{ row.attempt_count }}</td>
-                <td colspan="5" class="vt-hf-dim">not enough data ({{ row.attempt_count }}/{{ stats.min_samples }})</td>
+
+                {% if _row_state == 'low_sample' %}
+                {# nudge row below the data row #}
+                {% endif %}
                 {% endif %}
             </tr>
+            {% if _row_state == 'low_sample' %}
+            <tr class="low-sample">
+                <td colspan="7" class="vt-hf-nudge" style="padding-top:0.2rem;padding-bottom:0.55rem;">
+                    Complete {{ stats.min_samples - row.attempt_count }} more valid attempt{{ 's' if (stats.min_samples - row.attempt_count) != 1 else '' }} for reliable comparison.
+                </td>
+            </tr>
+            {% endif %}
             {% endfor %}
             </tbody>
         </table>
@@ -372,12 +445,16 @@
         {% set _has_any_delta = false %}
         {% for row in stats.finger_rows %}
         {% set _combo = row.hand ~ "_" ~ row.finger %}
-        {% if row.has_data and stats.skill_totals.get(_combo) %}
+        {%- set _row_state = row.state | default("no_data") -%}
+        {% if _row_state != 'no_data' and stats.skill_totals.get(_combo) %}
         {% set _has_any_delta = true %}
         {% set _deltas = stats.skill_totals[_combo] %}
 
         <div class="vt-hf-delta-combo">
-            <div class="vt-hf-delta-combo-title">{{ row.label }}</div>
+            <div class="vt-hf-delta-combo-title">
+                {{ row.label }}
+                {% if _row_state == 'low_sample' %}<span class="vt-hf-low-badge">LOW</span>{% endif %}
+            </div>
             {% for skill, delta in _deltas.items() | sort %}
             {%- set _abs = delta | abs -%}
             {%- set _bar_w = [(_abs / 1.0 * 100) | int, 100] | min -%}
@@ -401,7 +478,7 @@
         {% if not _has_any_delta %}
         <div class="vt-hf-nodata-delta">
             No skill delta data yet.
-            Complete at least {{ stats.min_samples }} valid system-assigned attempts to see skill impact.
+            Complete at least 1 valid system-assigned attempt to see skill impact.
         </div>
         {% endif %}
 

--- a/app/templates/virtual_training_hand_finger_stats.html
+++ b/app/templates/virtual_training_hand_finger_stats.html
@@ -1,0 +1,418 @@
+{% extends "student_base.html" %}
+
+{% block title %}Hand & Finger Performance - LFA{% endblock %}
+{% block active_page %}lfa-player{% endblock %}
+
+{% block student_header %}
+{% set _page_icon = '🖐' %}
+{% set _page_name = 'Hand & Finger Performance' %}
+{% include "includes/spec_subpage_hdr.html" %}
+{% endblock %}
+
+{% block extra_styles %}
+<style>
+    .vt-hf-container {
+        max-width: 680px;
+        margin: 0 auto;
+        padding: 1.5rem 1rem 3rem;
+    }
+
+    /* ── Game filter tabs ──────────────────────────────────────────────── */
+    .vt-hf-tabs {
+        display: flex;
+        gap: 0.5rem;
+        margin-bottom: 1.25rem;
+        flex-wrap: wrap;
+    }
+
+    .vt-hf-tab {
+        font-size: 0.82rem;
+        font-weight: 700;
+        padding: 0.4rem 0.9rem;
+        border-radius: 20px;
+        border: 1.5px solid #c7d2fe;
+        color: #4f46e5;
+        background: var(--app-card);
+        text-decoration: none;
+        transition: background 0.13s, color 0.13s;
+    }
+
+    .vt-hf-tab:hover { background: #ede9fe; }
+
+    .vt-hf-tab.active {
+        background: #4f46e5;
+        color: #fff;
+        border-color: #4f46e5;
+    }
+
+    /* ── Disclaimer ────────────────────────────────────────────────────── */
+    .vt-hf-disclaimer {
+        font-size: 0.75rem;
+        color: var(--app-text-muted);
+        background: #fef9ee;
+        border: 1px solid #fde68a;
+        border-radius: 8px;
+        padding: 0.5rem 0.9rem;
+        margin-bottom: 1.5rem;
+        line-height: 1.5;
+    }
+
+    /* ── Section titles ────────────────────────────────────────────────── */
+    .vt-hf-section-title {
+        font-size: 0.78rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--app-text-muted);
+        margin: 0 0 0.75rem;
+    }
+
+    /* ── By Hand cards ─────────────────────────────────────────────────── */
+    .vt-hf-hand-row {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 1rem;
+        margin-bottom: 2rem;
+    }
+
+    .vt-hf-hand-card {
+        background: var(--app-card);
+        border: 1.5px solid #e2e8f0;
+        border-radius: 14px;
+        padding: 1.1rem 1.2rem;
+        box-shadow: 0 2px 8px rgba(0,0,0,0.05);
+    }
+
+    .vt-hf-hand-card.active {
+        border-color: #c7d2fe;
+        box-shadow: 0 2px 10px rgba(79,70,229,0.10);
+    }
+
+    .vt-hf-hand-label {
+        font-size: 0.75rem;
+        font-weight: 800;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: #4f46e5;
+        margin-bottom: 0.65rem;
+    }
+
+    .vt-hf-hand-stat {
+        display: flex;
+        justify-content: space-between;
+        font-size: 0.83rem;
+        color: var(--app-text-muted);
+        margin-bottom: 0.25rem;
+    }
+
+    .vt-hf-hand-stat b { color: var(--app-text); }
+
+    .vt-hf-nodata {
+        font-size: 0.8rem;
+        color: var(--app-text-muted);
+        line-height: 1.55;
+    }
+
+    .vt-hf-nodata-tag {
+        display: inline-block;
+        font-size: 0.72rem;
+        font-weight: 700;
+        color: #92400e;
+        background: #fef3c7;
+        border: 1px solid #fde68a;
+        border-radius: 6px;
+        padding: 0.15rem 0.5rem;
+        margin-bottom: 0.5rem;
+    }
+
+    /* ── By Finger table ───────────────────────────────────────────────── */
+    .vt-hf-table-wrap {
+        overflow-x: auto;
+        margin-bottom: 2rem;
+        border-radius: 12px;
+        box-shadow: 0 2px 8px rgba(0,0,0,0.05);
+    }
+
+    .vt-hf-table {
+        width: 100%;
+        border-collapse: collapse;
+        background: var(--app-card);
+        font-size: 0.82rem;
+    }
+
+    .vt-hf-table th {
+        text-align: left;
+        font-size: 0.72rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        color: var(--app-text-muted);
+        background: #f8f9fc;
+        padding: 0.6rem 0.9rem;
+        border-bottom: 1px solid #e2e8f0;
+        white-space: nowrap;
+    }
+
+    .vt-hf-table td {
+        padding: 0.65rem 0.9rem;
+        border-bottom: 1px solid #f1f5f9;
+        color: var(--app-text);
+        white-space: nowrap;
+    }
+
+    .vt-hf-table tr:last-child td { border-bottom: none; }
+
+    .vt-hf-table tr.no-data td { color: var(--app-text-muted); font-style: italic; }
+
+    .vt-hf-label-cell {
+        font-weight: 700;
+        color: #3730a3;
+    }
+
+    .vt-hf-dim { color: var(--app-text-muted); font-size: 0.75rem; }
+
+    /* ── Skill delta bars ──────────────────────────────────────────────── */
+    .vt-hf-delta-section {
+        margin-bottom: 2rem;
+    }
+
+    .vt-hf-delta-combo {
+        margin-bottom: 1.25rem;
+    }
+
+    .vt-hf-delta-combo-title {
+        font-size: 0.78rem;
+        font-weight: 700;
+        color: #4f46e5;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        margin-bottom: 0.6rem;
+    }
+
+    .vt-hf-delta-row {
+        display: flex;
+        align-items: center;
+        gap: 0.6rem;
+        margin-bottom: 0.4rem;
+    }
+
+    .vt-hf-delta-skill {
+        width: 110px;
+        flex-shrink: 0;
+        font-size: 0.78rem;
+        color: var(--app-text-muted);
+        text-transform: capitalize;
+    }
+
+    .vt-hf-bar-track {
+        flex: 1;
+        height: 8px;
+        background: #f1f5f9;
+        border-radius: 4px;
+        overflow: hidden;
+    }
+
+    .vt-hf-bar-fill {
+        height: 100%;
+        border-radius: 4px;
+        min-width: 2px;
+    }
+
+    .vt-hf-bar-fill.pos { background: #10b981; }
+    .vt-hf-bar-fill.neg { background: #ef4444; }
+
+    .vt-hf-delta-val {
+        width: 52px;
+        text-align: right;
+        font-size: 0.78rem;
+        font-weight: 700;
+        flex-shrink: 0;
+    }
+
+    .vt-hf-delta-val.pos { color: #059669; }
+    .vt-hf-delta-val.neg { color: #dc2626; }
+
+    .vt-hf-nodata-delta {
+        font-size: 0.82rem;
+        color: var(--app-text-muted);
+        font-style: italic;
+    }
+
+    /* ── Footer ────────────────────────────────────────────────────────── */
+    .vt-hf-footer {
+        text-align: center;
+        margin-top: 2rem;
+        padding-top: 1.5rem;
+        border-top: 1px solid #e2e8f0;
+    }
+
+    .vt-hf-footer a {
+        color: #667eea;
+        text-decoration: none;
+        margin: 0 0.75rem;
+        font-weight: 600;
+        font-size: 0.88rem;
+    }
+
+    .vt-hf-footer a:hover { text-decoration: underline; }
+</style>
+{% endblock %}
+
+{% block student_content %}
+<div class="vt-hf-container">
+
+    {# ── Game filter tabs ─────────────────────────────────────────────────── #}
+    <div class="vt-hf-tabs">
+        <a href="?game=all"
+           class="vt-hf-tab{% if game_filter == 'all' %} active{% endif %}">
+            🎮 All Games
+        </a>
+        <a href="?game=color_reaction"
+           class="vt-hf-tab{% if game_filter == 'color_reaction' %} active{% endif %}">
+            ⚡ Color Reaction
+        </a>
+        <a href="?game=go_no_go"
+           class="vt-hf-tab{% if game_filter == 'go_no_go' %} active{% endif %}">
+            🛑 Go / No-Go
+        </a>
+    </div>
+
+    {# ── Disclaimer ───────────────────────────────────────────────────────── #}
+    <div class="vt-hf-disclaimer">
+        ⚠ Data reflects system-assigned protocols only.
+        Self-declared · Not automatically verified.
+        At least {{ stats.min_samples }} valid attempts per protocol are needed to show statistics.
+    </div>
+
+    {# ── By Hand ──────────────────────────────────────────────────────────── #}
+    <h2 class="vt-hf-section-title">By Hand</h2>
+    <div class="vt-hf-hand-row">
+
+        {% for side in ["right", "left"] %}
+        {% set hd = stats.by_hand[side] %}
+        <div class="vt-hf-hand-card{% if hd.has_data %} active{% endif %}">
+            <div class="vt-hf-hand-label">{{ side | upper }} HAND</div>
+
+            {% if hd.has_data %}
+            <div class="vt-hf-hand-stat">
+                <span>Attempts</span>
+                <b>{{ hd.attempt_count }}</b>
+            </div>
+            {% if hd.avg_score is not none %}
+            <div class="vt-hf-hand-stat">
+                <span>Avg score</span>
+                <b>{{ hd.avg_score }}%</b>
+            </div>
+            {% endif %}
+            {% if hd.avg_rt_ms is not none %}
+            <div class="vt-hf-hand-stat">
+                <span>Avg RT</span>
+                <b>{{ hd.avg_rt_ms }} ms</b>
+            </div>
+            {% endif %}
+            {% if hd.accuracy_pct is not none %}
+            <div class="vt-hf-hand-stat">
+                <span>Accuracy</span>
+                <b>{{ hd.accuracy_pct }}%</b>
+            </div>
+            {% endif %}
+
+            {% else %}
+            <span class="vt-hf-nodata-tag">Not enough data</span>
+            <div class="vt-hf-nodata">
+                Complete at least {{ stats.min_samples }} valid
+                system-assigned attempts for this hand.
+            </div>
+            {% endif %}
+        </div>
+        {% endfor %}
+
+    </div>
+
+    {# ── By Finger ────────────────────────────────────────────────────────── #}
+    <h2 class="vt-hf-section-title">By Finger</h2>
+    <div class="vt-hf-table-wrap">
+        <table class="vt-hf-table">
+            <thead>
+                <tr>
+                    <th>Protocol</th>
+                    <th>Attempts</th>
+                    <th>Avg Score</th>
+                    <th>Avg RT</th>
+                    <th>Accuracy</th>
+                    <th>Miss</th>
+                    <th>Late</th>
+                </tr>
+            </thead>
+            <tbody>
+            {% for row in stats.finger_rows %}
+            <tr{% if not row.has_data %} class="no-data"{% endif %}>
+                <td class="vt-hf-label-cell">{{ row.label }}</td>
+                {% if row.has_data %}
+                <td>{{ row.attempt_count }}</td>
+                <td>{% if row.avg_score is not none %}{{ row.avg_score }}%{% else %}—{% endif %}</td>
+                <td>{% if row.avg_rt_ms is not none %}{{ row.avg_rt_ms }} ms{% else %}—{% endif %}</td>
+                <td>{% if row.accuracy_pct is not none %}{{ row.accuracy_pct }}%{% else %}—{% endif %}</td>
+                <td>{% if row.miss_pct is not none %}{{ row.miss_pct }}%{% else %}—{% endif %}</td>
+                <td>{% if row.late_pct is not none %}{{ row.late_pct }}%{% else %}—{% endif %}</td>
+                {% else %}
+                <td>{{ row.attempt_count }}</td>
+                <td colspan="5" class="vt-hf-dim">not enough data ({{ row.attempt_count }}/{{ stats.min_samples }})</td>
+                {% endif %}
+            </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+
+    {# ── Skill Deltas by Hand/Finger ──────────────────────────────────────── #}
+    <h2 class="vt-hf-section-title">Skill Deltas by Protocol</h2>
+    <div class="vt-hf-delta-section">
+
+        {% set _has_any_delta = false %}
+        {% for row in stats.finger_rows %}
+        {% set _combo = row.hand ~ "_" ~ row.finger %}
+        {% if row.has_data and stats.skill_totals.get(_combo) %}
+        {% set _has_any_delta = true %}
+        {% set _deltas = stats.skill_totals[_combo] %}
+
+        <div class="vt-hf-delta-combo">
+            <div class="vt-hf-delta-combo-title">{{ row.label }}</div>
+            {% for skill, delta in _deltas.items() | sort %}
+            {%- set _abs = delta | abs -%}
+            {%- set _bar_w = [(_abs / 1.0 * 100) | int, 100] | min -%}
+            {%- set _pos = delta >= 0 -%}
+            <div class="vt-hf-delta-row">
+                <span class="vt-hf-delta-skill">{{ skill }}</span>
+                <div class="vt-hf-bar-track">
+                    <div class="vt-hf-bar-fill {% if _pos %}pos{% else %}neg{% endif %}"
+                         style="width: {{ _bar_w }}%;"></div>
+                </div>
+                <span class="vt-hf-delta-val {% if _pos %}pos{% else %}neg{% endif %}">
+                    {% if _pos %}+{% endif %}{{ "%.2f" | format(delta) }}
+                </span>
+            </div>
+            {% endfor %}
+        </div>
+
+        {% endif %}
+        {% endfor %}
+
+        {% if not _has_any_delta %}
+        <div class="vt-hf-nodata-delta">
+            No skill delta data yet.
+            Complete at least {{ stats.min_samples }} valid system-assigned attempts to see skill impact.
+        </div>
+        {% endif %}
+
+    </div>
+
+    {# ── Footer ───────────────────────────────────────────────────────────── #}
+    <div class="vt-hf-footer">
+        <a href="/virtual-training">💻 All Games</a>
+        <a href="/virtual-training/history">📋 History</a>
+        <a href="/training">🎓 Training</a>
+    </div>
+
+</div>
+{% endblock %}

--- a/app/templates/virtual_training_history.html
+++ b/app/templates/virtual_training_history.html
@@ -174,7 +174,7 @@
                         {% else %}—{% endif %}
                     </td>
                     <td>
-                        {% if _hp and _hp.get("protocol_difficulty_multiplier", 1.0) | float > 1.0 %}
+                        {% if _hp and _hp.get("assignment_source") == "system" and _hp.get("hand") != "free" %}
                         <span class="vth-protocol-badge"
                               title="{{ _hp.get('label', '') }} · Self-declared · Not automatically verified">
                             🖐 {{ _hp.get("label", "—") }} ×{{ "%.2f"|format(_hp.get("protocol_difficulty_multiplier", 1.0) | float) }}

--- a/app/templates/virtual_training_history.html
+++ b/app/templates/virtual_training_history.html
@@ -200,6 +200,7 @@
 
     <div class="vth-footer">
         <a href="/virtual-training">💻 All Games</a>
+        <a href="/virtual-training/hand-finger-stats">🖐 Hand Stats</a>
         <a href="/virtual-training/color-reaction">⚡ Play Color Reaction</a>
         <a href="/training">🎓 Training</a>
     </div>

--- a/app/templates/virtual_training_hub.html
+++ b/app/templates/virtual_training_hub.html
@@ -268,7 +268,10 @@
     </div>
     {% endif %}
 
-    <div style="margin-top: 1.25rem; text-align: right;">
+    <div style="margin-top: 1.25rem; text-align: right; display: flex; gap: 1.25rem; justify-content: flex-end; flex-wrap: wrap;">
+        <a href="/virtual-training/hand-finger-stats" style="color: #667eea; font-size: 0.88rem; font-weight: 600; text-decoration: none;">
+            🖐 Hand &amp; Finger Stats
+        </a>
         <a href="/virtual-training/history" style="color: #667eea; font-size: 0.88rem; font-weight: 600; text-decoration: none;">
             📋 View my history →
         </a>

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -64116,6 +64116,51 @@
         ]
       }
     },
+    "/virtual-training/hand-finger-stats": {
+      "get": {
+        "description": "Hand/Finger performance aggregation \u2014 system-assigned v3 attempts only.",
+        "operationId": "virtual_training_hand_finger_stats_virtual_training_hand_finger_stats_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "game",
+            "required": false,
+            "schema": {
+              "default": "all",
+              "title": "Game",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Virtual Training Hand Finger Stats",
+        "tags": [
+          "web",
+          "virtual-training"
+        ]
+      }
+    },
     "/virtual-training/history": {
       "get": {
         "description": "Attempt history \u2014 last 20 valid attempts across all VT games.",

--- a/tests/unit/services/test_vt_hand_finger_stats.py
+++ b/tests/unit/services/test_vt_hand_finger_stats.py
@@ -1,25 +1,30 @@
-"""Hand/Finger Stats service tests — Phase 2.4 (PR #158).
+"""Hand/Finger Stats service tests — Phase 2.4 (PR #158, UX fix).
 
-HFS-01  0 attempts → all 4 finger_rows has_data=False, attempt_count=0
-HFS-02  < _MIN_SAMPLES (2 attempts RI) → has_data=False, attempt_count=2
-HFS-03  >= _MIN_SAMPLES (3 attempts RI) → has_data=True
-HFS-04  all 4 combos ≥3 attempts → 4 rows all has_data=True
+HFS-01  0 attempts → all 4 finger_rows state=no_data, attempt_count=0
+HFS-02  < _MIN_SAMPLES (2 attempts RI) → state=low_sample (not no_data)
+HFS-03  >= _MIN_SAMPLES (3 attempts RI) → state=ready
+HFS-04  all 4 combos ≥3 attempts → 4 rows all state=ready
 HFS-05  finger_rows canonical order: RI, RT, LI, LT
 HFS-06  return dict has all required keys
 HFS-07  min_samples == 3
 HFS-08  game_id=None → no gid param sent to SQL
 HFS-09  game_id=42 → gid=42 in SQL params
 HFS-10  SQL filters on is_valid + assignment_source (no v1/v2/free bleed)
-HFS-11  by_hand right has_data=True when cnt >= 3
-HFS-12  by_hand left has_data=False when cnt == 0
+HFS-11  by_hand right state=ready when cnt >= 3
+HFS-12  by_hand left state=no_data when cnt == 0
 HFS-13  skill_totals accumulated correctly across two rows
 HFS-14  skill_totals empty when no valid skill_deltas rows
 HFS-15  game_id filter is forwarded to all 3 SQL execute calls
+HFS-16  attempt_count=0 → state="no_data"
+HFS-17  attempt_count=1 → state="low_sample", real metrics present
+HFS-18  attempt_count=2 → state="low_sample", real metrics present
+HFS-19  skill_totals returned regardless of state (no has_data gate in service)
+HFS-20  by_hand left state=low_sample when 1 ≤ cnt < 3
 """
 from __future__ import annotations
 
 import pytest
-from unittest.mock import MagicMock, call
+from unittest.mock import MagicMock
 
 from app.services.virtual_training_service import VirtualTrainingService, _MIN_SAMPLES
 
@@ -63,11 +68,7 @@ def _dr(hand: str, finger: str, skill_deltas: dict | None) -> MagicMock:
     return r
 
 
-def _make_db(
-    finger_rows: list,
-    hand_rows: list,
-    delta_rows: list,
-) -> MagicMock:
+def _make_db(finger_rows: list, hand_rows: list, delta_rows: list) -> MagicMock:
     """Return a DB mock that cycles execute results: finger → hand → delta."""
     db = MagicMock()
     call_count = 0
@@ -97,20 +98,20 @@ def _call(finger_rows, hand_rows, delta_rows=None, game_id=None, user_id=202):
 
 class TestZeroAttempts:
 
-    def test_hfs01_zero_attempts_all_rows_no_data(self):
-        """HFS-01: 0 attempts → all 4 finger_rows has_data=False, attempt_count=0."""
+    def test_hfs01_zero_attempts_all_rows_no_data_state(self):
+        """HFS-01: 0 attempts → all 4 finger_rows state=no_data, attempt_count=0."""
         result = _call([], [], [])
         rows = result["finger_rows"]
         assert len(rows) == 4
         for row in rows:
-            assert row["has_data"] is False
+            assert row["state"] == "no_data"
             assert row["attempt_count"] == 0
 
-    def test_hfs01b_zero_attempts_by_hand_no_data(self):
-        """HFS-01b: 0 attempts → both hands has_data=False."""
+    def test_hfs01b_zero_attempts_by_hand_no_data_state(self):
+        """HFS-01b: 0 attempts → both hands state=no_data."""
         result = _call([], [], [])
-        assert result["by_hand"]["right"]["has_data"] is False
-        assert result["by_hand"]["left"]["has_data"] is False
+        assert result["by_hand"]["right"]["state"] == "no_data"
+        assert result["by_hand"]["left"]["state"] == "no_data"
 
     def test_hfs01c_zero_attempts_skill_totals_empty(self):
         """HFS-01c: 0 attempts → skill_totals == {}."""
@@ -118,46 +119,57 @@ class TestZeroAttempts:
         assert result["skill_totals"] == {}
 
 
-# ── HFS-02/03: _MIN_SAMPLES threshold ────────────────────────────────────────
+# ── HFS-02/03: state thresholds ──────────────────────────────────────────────
 
-class TestMinSamplesThreshold:
+class TestStateThresholds:
 
-    def test_hfs02_below_threshold_has_data_false(self):
-        """HFS-02: 2 RI attempts → has_data=False."""
+    def test_hfs02_below_threshold_is_low_sample(self):
+        """HFS-02: 2 RI attempts → state=low_sample (NOT no_data, NOT hidden)."""
         result = _call(
             [_fr("right", "index", 2)],
             [_hr("right", 2)],
         )
         ri = next(r for r in result["finger_rows"] if r["hand"] == "right" and r["finger"] == "index")
-        assert ri["has_data"] is False
+        assert ri["state"] == "low_sample"
         assert ri["attempt_count"] == 2
 
-    def test_hfs03_at_threshold_has_data_true(self):
-        """HFS-03: 3 RI attempts → has_data=True."""
+    def test_hfs02b_low_sample_metrics_are_present(self):
+        """HFS-02b: low_sample row contains real metric values (not hidden)."""
+        result = _call(
+            [_fr("right", "index", 2, avg_score=40.5, avg_rt_ms=1458)],
+            [_hr("right", 2)],
+        )
+        ri = next(r for r in result["finger_rows"] if r["hand"] == "right" and r["finger"] == "index")
+        assert ri["state"] == "low_sample"
+        assert ri["avg_score"] == 40.5
+        assert ri["avg_rt_ms"] == 1458
+
+    def test_hfs03_at_threshold_is_ready(self):
+        """HFS-03: 3 RI attempts → state=ready."""
         result = _call(
             [_fr("right", "index", 3)],
             [_hr("right", 3)],
         )
         ri = next(r for r in result["finger_rows"] if r["hand"] == "right" and r["finger"] == "index")
-        assert ri["has_data"] is True
+        assert ri["state"] == "ready"
         assert ri["attempt_count"] == 3
 
-    def test_hfs03b_above_threshold_has_data_true(self):
-        """HFS-03b: 10 LT attempts → has_data=True."""
+    def test_hfs03b_above_threshold_is_ready(self):
+        """HFS-03b: 10 LT attempts → state=ready."""
         result = _call(
             [_fr("left", "thumb", 10)],
             [_hr("left", 10)],
         )
         lt = next(r for r in result["finger_rows"] if r["hand"] == "left" and r["finger"] == "thumb")
-        assert lt["has_data"] is True
+        assert lt["state"] == "ready"
 
 
 # ── HFS-04: all 4 combos ─────────────────────────────────────────────────────
 
 class TestAllFourCombos:
 
-    def test_hfs04_all_combos_have_data(self):
-        """HFS-04: all 4 combos ≥3 attempts → 4 rows all has_data=True."""
+    def test_hfs04_all_combos_ready(self):
+        """HFS-04: all 4 combos ≥3 attempts → 4 rows all state=ready."""
         finger_rows = [
             _fr("right", "index", 5),
             _fr("right", "thumb", 4),
@@ -169,7 +181,7 @@ class TestAllFourCombos:
             [_hr("right", 9), _hr("left", 9)],
         )
         for row in result["finger_rows"]:
-            assert row["has_data"] is True, f"{row['label']} should have data"
+            assert row["state"] == "ready", f"{row['label']} should be ready"
 
 
 # ── HFS-05: canonical order ───────────────────────────────────────────────────
@@ -178,7 +190,6 @@ class TestCanonicalOrder:
 
     def test_hfs05_finger_rows_canonical_order(self):
         """HFS-05: finger_rows[0..3] = RI, RT, LI, LT regardless of DB return order."""
-        # DB returns in reverse order
         finger_rows = [
             _fr("left",  "thumb",  4),
             _fr("left",  "index",  3),
@@ -265,26 +276,26 @@ class TestSQLFilterContent:
             assert "assignment_source" in sql_str, "SQL must filter on assignment_source"
 
 
-# ── HFS-11/12: by_hand ────────────────────────────────────────────────────────
+# ── HFS-11/12: by_hand state ─────────────────────────────────────────────────
 
-class TestByHand:
+class TestByHandState:
 
-    def test_hfs11_right_hand_has_data_true(self):
-        """HFS-11: right 3 attempts → by_hand[right] has_data=True."""
+    def test_hfs11_right_hand_ready_at_threshold(self):
+        """HFS-11: right 3 attempts → by_hand[right] state=ready."""
         result = _call(
             [_fr("right", "index", 3)],
             [_hr("right", 3)],
         )
-        assert result["by_hand"]["right"]["has_data"] is True
+        assert result["by_hand"]["right"]["state"] == "ready"
         assert result["by_hand"]["right"]["attempt_count"] == 3
 
-    def test_hfs12_left_hand_has_data_false_when_zero(self):
-        """HFS-12: left 0 attempts → by_hand[left] has_data=False."""
+    def test_hfs12_left_hand_no_data_when_zero(self):
+        """HFS-12: left 0 attempts → by_hand[left] state=no_data."""
         result = _call(
             [_fr("right", "index", 5)],
             [_hr("right", 5)],
         )
-        assert result["by_hand"]["left"]["has_data"] is False
+        assert result["by_hand"]["left"]["state"] == "no_data"
         assert result["by_hand"]["left"]["attempt_count"] == 0
 
 
@@ -312,7 +323,6 @@ class TestSkillTotals:
         result = _call([], [], delta_rows)
         assert abs(result["skill_totals"]["right_index"]["reactions"] - 0.5) < 1e-6
         assert abs(result["skill_totals"]["left_thumb"]["composure"] - 0.3) < 1e-6
-        assert "right_index" not in result["skill_totals"].get("left_thumb", {})
 
     def test_hfs14_no_skill_deltas_returns_empty(self):
         """HFS-14: delta rows with None/empty skill_deltas → skill_totals == {}."""
@@ -346,3 +356,68 @@ class TestGameIdIsolation:
         for idx, params in enumerate(call_params):
             assert params.get("gid") == 7, f"gid missing from query {idx + 1}"
             assert params.get("uid") == 505
+
+
+# ── HFS-16..20: 3-state model correctness ────────────────────────────────────
+
+class TestThreeStateModel:
+
+    def test_hfs16_zero_attempts_state_no_data(self):
+        """HFS-16: attempt_count=0 (unseen combo) → state='no_data'."""
+        result = _call([], [], [])
+        for row in result["finger_rows"]:
+            assert row["state"] == "no_data"
+        for side in ("right", "left"):
+            assert result["by_hand"][side]["state"] == "no_data"
+
+    def test_hfs17_one_attempt_is_low_sample_with_metrics(self):
+        """HFS-17: attempt_count=1 → state=low_sample AND real metrics present."""
+        result = _call(
+            [_fr("right", "index", 1, avg_score=55.0, avg_rt_ms=900)],
+            [_hr("right", 1, avg_score=55.0, avg_rt_ms=900)],
+        )
+        ri = next(r for r in result["finger_rows"] if r["hand"] == "right" and r["finger"] == "index")
+        assert ri["state"] == "low_sample"
+        assert ri["avg_score"] == 55.0
+        assert ri["avg_rt_ms"] == 900
+
+        rh = result["by_hand"]["right"]
+        assert rh["state"] == "low_sample"
+        assert rh["avg_score"] == 55.0
+
+    def test_hfs18_two_attempts_is_low_sample_with_metrics(self):
+        """HFS-18: attempt_count=2 → state=low_sample AND real metrics present."""
+        result = _call(
+            [_fr("right", "index", 2, avg_score=40.5, avg_rt_ms=1458, accuracy_pct=41.0)],
+            [_hr("right", 2, avg_score=40.5, avg_rt_ms=1458)],
+        )
+        ri = next(r for r in result["finger_rows"] if r["hand"] == "right" and r["finger"] == "index")
+        assert ri["state"] == "low_sample"
+        assert ri["avg_score"] == 40.5
+        assert ri["avg_rt_ms"] == 1458
+        assert ri["accuracy_pct"] == 41.0
+
+    def test_hfs19_skill_totals_present_in_low_sample_state(self):
+        """HFS-19: skill_totals accumulate for low_sample combos (no state gate in service)."""
+        delta_rows = [
+            _dr("right", "index", {"reactions": 0.25}),
+        ]
+        # 2 attempts → low_sample; delta must still be in skill_totals
+        result = _call(
+            [_fr("right", "index", 2)],
+            [_hr("right", 2)],
+            delta_rows,
+        )
+        ri = next(r for r in result["finger_rows"] if r["hand"] == "right" and r["finger"] == "index")
+        assert ri["state"] == "low_sample"
+        assert "right_index" in result["skill_totals"]
+        assert abs(result["skill_totals"]["right_index"]["reactions"] - 0.25) < 1e-6
+
+    def test_hfs20_by_hand_low_sample_when_between_thresholds(self):
+        """HFS-20: by_hand left 1 ≤ cnt < 3 → state=low_sample."""
+        result = _call(
+            [_fr("left", "index", 2)],
+            [_hr("left", 2)],
+        )
+        assert result["by_hand"]["left"]["state"] == "low_sample"
+        assert result["by_hand"]["left"]["attempt_count"] == 2

--- a/tests/unit/services/test_vt_hand_finger_stats.py
+++ b/tests/unit/services/test_vt_hand_finger_stats.py
@@ -1,0 +1,348 @@
+"""Hand/Finger Stats service tests — Phase 2.4 (PR #158).
+
+HFS-01  0 attempts → all 4 finger_rows has_data=False, attempt_count=0
+HFS-02  < _MIN_SAMPLES (2 attempts RI) → has_data=False, attempt_count=2
+HFS-03  >= _MIN_SAMPLES (3 attempts RI) → has_data=True
+HFS-04  all 4 combos ≥3 attempts → 4 rows all has_data=True
+HFS-05  finger_rows canonical order: RI, RT, LI, LT
+HFS-06  return dict has all required keys
+HFS-07  min_samples == 3
+HFS-08  game_id=None → no gid param sent to SQL
+HFS-09  game_id=42 → gid=42 in SQL params
+HFS-10  SQL filters on is_valid + assignment_source (no v1/v2/free bleed)
+HFS-11  by_hand right has_data=True when cnt >= 3
+HFS-12  by_hand left has_data=False when cnt == 0
+HFS-13  skill_totals accumulated correctly across two rows
+HFS-14  skill_totals empty when no valid skill_deltas rows
+HFS-15  game_id filter is forwarded to all 3 SQL execute calls
+"""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import MagicMock, call
+
+from app.services.virtual_training_service import VirtualTrainingService, _MIN_SAMPLES
+
+
+# ── row factories ─────────────────────────────────────────────────────────────
+
+def _fr(hand: str, finger: str, count: int, label: str | None = None, **kw) -> MagicMock:
+    """Build a finger-aggregate row mock."""
+    r = MagicMock()
+    r.hand = hand
+    r.finger = finger
+    r.label = label or f"{hand.capitalize()} {finger.capitalize()}"
+    r.attempt_count = count
+    r.avg_score     = kw.get("avg_score", 85.0)
+    r.avg_rt_ms     = kw.get("avg_rt_ms", 420)
+    r.best_rt_ms    = kw.get("best_rt_ms", 310)
+    r.accuracy_pct  = kw.get("accuracy_pct", 90.0)
+    r.miss_pct      = kw.get("miss_pct", 5.0)
+    r.wrong_pct     = kw.get("wrong_pct", 5.0)
+    r.late_pct      = kw.get("late_pct", 3.0)
+    return r
+
+
+def _hr(hand: str, count: int, **kw) -> MagicMock:
+    """Build a hand-aggregate row mock."""
+    r = MagicMock()
+    r.hand = hand
+    r.attempt_count = count
+    r.avg_score     = kw.get("avg_score", 85.0)
+    r.avg_rt_ms     = kw.get("avg_rt_ms", 420)
+    r.accuracy_pct  = kw.get("accuracy_pct", 90.0)
+    return r
+
+
+def _dr(hand: str, finger: str, skill_deltas: dict | None) -> MagicMock:
+    """Build a delta row mock."""
+    r = MagicMock()
+    r.hand = hand
+    r.finger = finger
+    r.skill_deltas = skill_deltas
+    return r
+
+
+def _make_db(
+    finger_rows: list,
+    hand_rows: list,
+    delta_rows: list,
+) -> MagicMock:
+    """Return a DB mock that cycles execute results: finger → hand → delta."""
+    db = MagicMock()
+    call_count = 0
+
+    def _execute(sql, params):
+        nonlocal call_count
+        call_count += 1
+        m = MagicMock()
+        if call_count == 1:
+            m.fetchall.return_value = finger_rows
+        elif call_count == 2:
+            m.fetchall.return_value = hand_rows
+        else:
+            m.fetchall.return_value = delta_rows
+        return m
+
+    db.execute.side_effect = _execute
+    return db
+
+
+def _call(finger_rows, hand_rows, delta_rows=None, game_id=None, user_id=202):
+    db = _make_db(finger_rows, hand_rows, delta_rows or [])
+    return VirtualTrainingService.get_hand_finger_stats(db, user_id=user_id, game_id=game_id)
+
+
+# ── HFS-01: 0 attempts ───────────────────────────────────────────────────────
+
+class TestZeroAttempts:
+
+    def test_hfs01_zero_attempts_all_rows_no_data(self):
+        """HFS-01: 0 attempts → all 4 finger_rows has_data=False, attempt_count=0."""
+        result = _call([], [], [])
+        rows = result["finger_rows"]
+        assert len(rows) == 4
+        for row in rows:
+            assert row["has_data"] is False
+            assert row["attempt_count"] == 0
+
+    def test_hfs01b_zero_attempts_by_hand_no_data(self):
+        """HFS-01b: 0 attempts → both hands has_data=False."""
+        result = _call([], [], [])
+        assert result["by_hand"]["right"]["has_data"] is False
+        assert result["by_hand"]["left"]["has_data"] is False
+
+    def test_hfs01c_zero_attempts_skill_totals_empty(self):
+        """HFS-01c: 0 attempts → skill_totals == {}."""
+        result = _call([], [], [])
+        assert result["skill_totals"] == {}
+
+
+# ── HFS-02/03: _MIN_SAMPLES threshold ────────────────────────────────────────
+
+class TestMinSamplesThreshold:
+
+    def test_hfs02_below_threshold_has_data_false(self):
+        """HFS-02: 2 RI attempts → has_data=False."""
+        result = _call(
+            [_fr("right", "index", 2)],
+            [_hr("right", 2)],
+        )
+        ri = next(r for r in result["finger_rows"] if r["hand"] == "right" and r["finger"] == "index")
+        assert ri["has_data"] is False
+        assert ri["attempt_count"] == 2
+
+    def test_hfs03_at_threshold_has_data_true(self):
+        """HFS-03: 3 RI attempts → has_data=True."""
+        result = _call(
+            [_fr("right", "index", 3)],
+            [_hr("right", 3)],
+        )
+        ri = next(r for r in result["finger_rows"] if r["hand"] == "right" and r["finger"] == "index")
+        assert ri["has_data"] is True
+        assert ri["attempt_count"] == 3
+
+    def test_hfs03b_above_threshold_has_data_true(self):
+        """HFS-03b: 10 LT attempts → has_data=True."""
+        result = _call(
+            [_fr("left", "thumb", 10)],
+            [_hr("left", 10)],
+        )
+        lt = next(r for r in result["finger_rows"] if r["hand"] == "left" and r["finger"] == "thumb")
+        assert lt["has_data"] is True
+
+
+# ── HFS-04: all 4 combos ─────────────────────────────────────────────────────
+
+class TestAllFourCombos:
+
+    def test_hfs04_all_combos_have_data(self):
+        """HFS-04: all 4 combos ≥3 attempts → 4 rows all has_data=True."""
+        finger_rows = [
+            _fr("right", "index", 5),
+            _fr("right", "thumb", 4),
+            _fr("left",  "index", 3),
+            _fr("left",  "thumb", 6),
+        ]
+        result = _call(
+            finger_rows,
+            [_hr("right", 9), _hr("left", 9)],
+        )
+        for row in result["finger_rows"]:
+            assert row["has_data"] is True, f"{row['label']} should have data"
+
+
+# ── HFS-05: canonical order ───────────────────────────────────────────────────
+
+class TestCanonicalOrder:
+
+    def test_hfs05_finger_rows_canonical_order(self):
+        """HFS-05: finger_rows[0..3] = RI, RT, LI, LT regardless of DB return order."""
+        # DB returns in reverse order
+        finger_rows = [
+            _fr("left",  "thumb",  4),
+            _fr("left",  "index",  3),
+            _fr("right", "thumb",  5),
+            _fr("right", "index",  6),
+        ]
+        result = _call(finger_rows, [])
+        rows = result["finger_rows"]
+        assert rows[0]["hand"] == "right" and rows[0]["finger"] == "index"
+        assert rows[1]["hand"] == "right" and rows[1]["finger"] == "thumb"
+        assert rows[2]["hand"] == "left"  and rows[2]["finger"] == "index"
+        assert rows[3]["hand"] == "left"  and rows[3]["finger"] == "thumb"
+
+
+# ── HFS-06/07: structure ─────────────────────────────────────────────────────
+
+class TestReturnStructure:
+
+    def test_hfs06_all_required_keys_present(self):
+        """HFS-06: return dict has all required keys."""
+        result = _call([], [], [])
+        for key in ("min_samples", "finger_rows", "by_hand", "skill_totals"):
+            assert key in result, f"Missing key: {key}"
+
+    def test_hfs07_min_samples_equals_3(self):
+        """HFS-07: min_samples == 3 (matches _MIN_SAMPLES constant)."""
+        result = _call([], [], [])
+        assert result["min_samples"] == 3
+        assert result["min_samples"] == _MIN_SAMPLES
+
+
+# ── HFS-08/09: game_id param ─────────────────────────────────────────────────
+
+class TestGameIdParam:
+
+    def _capture_params(self, game_id):
+        db = MagicMock()
+        captured = []
+
+        def _execute(sql, params):
+            captured.append(params.copy())
+            m = MagicMock()
+            m.fetchall.return_value = []
+            return m
+
+        db.execute.side_effect = _execute
+        VirtualTrainingService.get_hand_finger_stats(db, user_id=303, game_id=game_id)
+        return captured
+
+    def test_hfs08_no_game_id_no_gid_in_params(self):
+        """HFS-08: game_id=None → no gid key in SQL params."""
+        params_list = self._capture_params(game_id=None)
+        for params in params_list:
+            assert "gid" not in params
+
+    def test_hfs09_game_id_forwarded_to_sql(self):
+        """HFS-09: game_id=42 → gid=42 in all 3 SQL execute calls."""
+        params_list = self._capture_params(game_id=42)
+        assert len(params_list) == 3
+        for params in params_list:
+            assert params.get("gid") == 42
+
+
+# ── HFS-10: SQL filter content ───────────────────────────────────────────────
+
+class TestSQLFilterContent:
+
+    def test_hfs10_sql_contains_is_valid_and_assignment_source(self):
+        """HFS-10: SQL filters on is_valid and assignment_source = system."""
+        db = MagicMock()
+        sql_strings: list[str] = []
+
+        def _execute(sql, params):
+            sql_strings.append(str(sql))
+            m = MagicMock()
+            m.fetchall.return_value = []
+            return m
+
+        db.execute.side_effect = _execute
+        VirtualTrainingService.get_hand_finger_stats(db, user_id=404, game_id=None)
+
+        for sql_str in sql_strings:
+            assert "is_valid" in sql_str, "SQL must filter on is_valid"
+            assert "assignment_source" in sql_str, "SQL must filter on assignment_source"
+
+
+# ── HFS-11/12: by_hand ────────────────────────────────────────────────────────
+
+class TestByHand:
+
+    def test_hfs11_right_hand_has_data_true(self):
+        """HFS-11: right 3 attempts → by_hand[right] has_data=True."""
+        result = _call(
+            [_fr("right", "index", 3)],
+            [_hr("right", 3)],
+        )
+        assert result["by_hand"]["right"]["has_data"] is True
+        assert result["by_hand"]["right"]["attempt_count"] == 3
+
+    def test_hfs12_left_hand_has_data_false_when_zero(self):
+        """HFS-12: left 0 attempts → by_hand[left] has_data=False."""
+        result = _call(
+            [_fr("right", "index", 5)],
+            [_hr("right", 5)],
+        )
+        assert result["by_hand"]["left"]["has_data"] is False
+        assert result["by_hand"]["left"]["attempt_count"] == 0
+
+
+# ── HFS-13/14: skill_totals ───────────────────────────────────────────────────
+
+class TestSkillTotals:
+
+    def test_hfs13_skill_totals_accumulated(self):
+        """HFS-13: two RI delta rows → reactions sums to 0.3 (0.1 + 0.2)."""
+        delta_rows = [
+            _dr("right", "index", {"reactions": 0.1, "decisions": 0.05}),
+            _dr("right", "index", {"reactions": 0.2, "decisions": 0.10}),
+        ]
+        result = _call([], [], delta_rows)
+        ri_totals = result["skill_totals"].get("right_index", {})
+        assert abs(ri_totals.get("reactions", 0) - 0.3) < 1e-6
+        assert abs(ri_totals.get("decisions", 0) - 0.15) < 1e-6
+
+    def test_hfs13b_multiple_combos_independent_accumulation(self):
+        """HFS-13b: RI and LT accumulate independently."""
+        delta_rows = [
+            _dr("right", "index", {"reactions": 0.5}),
+            _dr("left",  "thumb", {"composure": 0.3}),
+        ]
+        result = _call([], [], delta_rows)
+        assert abs(result["skill_totals"]["right_index"]["reactions"] - 0.5) < 1e-6
+        assert abs(result["skill_totals"]["left_thumb"]["composure"] - 0.3) < 1e-6
+        assert "right_index" not in result["skill_totals"].get("left_thumb", {})
+
+    def test_hfs14_no_skill_deltas_returns_empty(self):
+        """HFS-14: delta rows with None/empty skill_deltas → skill_totals == {}."""
+        delta_rows = [
+            _dr("right", "index", None),
+            _dr("right", "thumb", {}),
+        ]
+        result = _call([], [], delta_rows)
+        assert result["skill_totals"] == {}
+
+
+# ── HFS-15: game_id in all 3 queries ─────────────────────────────────────────
+
+class TestGameIdIsolation:
+
+    def test_hfs15_game_id_in_all_three_queries(self):
+        """HFS-15: game_id filter forwarded to all 3 SQL execute calls."""
+        db = MagicMock()
+        call_params: list[dict] = []
+
+        def _execute(sql, params):
+            call_params.append(dict(params))
+            m = MagicMock()
+            m.fetchall.return_value = []
+            return m
+
+        db.execute.side_effect = _execute
+        VirtualTrainingService.get_hand_finger_stats(db, user_id=505, game_id=7)
+
+        assert len(call_params) == 3, "Expected exactly 3 SQL execute calls"
+        for idx, params in enumerate(call_params):
+            assert params.get("gid") == 7, f"gid missing from query {idx + 1}"
+            assert params.get("uid") == 505


### PR DESCRIPTION
## Summary

- **Service** — `VirtualTrainingService.get_hand_finger_stats()`: 3-query aggregation from system-assigned v3 attempts (per-finger metrics, per-hand metrics, skill delta totals). `_MIN_SAMPLES=3` gate; `_FINGER_ORDER` canonical `RI→RT→LI→LT`; `game_id=None` → all games combined.
- **Route** — `GET /virtual-training/hand-finger-stats` with soft `?game=` filter (`all|color_reaction|go_no_go`); invalid values fall back to `"all"`.
- **Template** — `virtual_training_hand_finger_stats.html`: game filter tabs, disclaimer, By Hand 2-col grid, By Finger table, CSS delta bars — no JS, no charts.
- **Navigation** — hub + history footers link to `/virtual-training/hand-finger-stats`.
- **Tests** — 19 HFS-* unit tests (mocked DB): threshold, canonical order, game_id forwarding, SQL filter content, skill accumulation. OpenAPI snapshot refreshed.

## Constraints respected

- No DB model / migration changes
- No XP pipeline / scoring / skill delta calculation changes
- No scheduler logic changes
- Not wired into /skills, Player Card, dashboard widgets, or admin pages
- Aggregated UI / service / route / template only

## Test plan

- [ ] 19/19 HFS-* unit tests pass (`tests/unit/services/test_vt_hand_finger_stats.py`)
- [ ] Full unit suite passes (10245 tests, 0 failures)
- [ ] OpenAPI snapshot updated (775 routes)
- [ ] Manual: visit `/virtual-training/hand-finger-stats` as a student → tabs, disclaimer, by-hand cards, by-finger table all render
- [ ] Manual: `?game=color_reaction` and `?game=go_no_go` tabs activate correctly; `?game=invalid` falls back to All Games
- [ ] Manual: hub footer shows "🖐 Hand & Finger Stats" link; history footer shows "🖐 Hand Stats" link

🤖 Generated with [Claude Code](https://claude.com/claude-code)