### PR TITLE
feat(vt): Phase 2.3 — Direction Swipe game

### DIFF
--- a/app/api/web_routes/virtual_training.py
+++ b/app/api/web_routes/virtual_training.py
@@ -1353,3 +1353,218 @@ async def virtual_training_memory_sequence_result(
             "challenge_ctx": challenge_ctx,
         },
     )
+
+
+# ── Direction Swipe game page ──────────────────────────────────────────────────
+
+@router.get("/virtual-training/direction-swipe", response_class=HTMLResponse)
+async def virtual_training_direction_swipe(
+    request: Request,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user_web),
+):
+    """Direction Swipe game page — swipe or press arrow keys to match the shown direction."""
+    guard = require_student_onboarding(user)
+    if guard:
+        return guard
+
+    game = VirtualTrainingService.get_game(db, "direction_swipe")
+    all_games = VirtualTrainingService.get_hub_games(db)
+    if game is None or not game.is_active:
+        return templates.TemplateResponse(
+            "virtual_training_hub.html",
+            {
+                "request": request,
+                "user": user,
+                **_spec_ctx(user, db),
+                "all_games": all_games,
+                "error": "Direction Swipe is not available at this time.",
+            },
+        )
+
+    today_start = datetime.combine(
+        datetime.now(timezone.utc).date(),
+        datetime.min.time(),
+    ).replace(tzinfo=timezone.utc)
+    attempts_today = (
+        db.query(VirtualTrainingAttempt)
+        .filter(
+            VirtualTrainingAttempt.user_id == user.id,
+            VirtualTrainingAttempt.game_id == game.id,
+            VirtualTrainingAttempt.started_at >= today_start,
+            VirtualTrainingAttempt.is_valid == True,  # noqa: E712
+        )
+        .count()
+    )
+
+    return templates.TemplateResponse(
+        "virtual_training_direction_swipe.html",
+        {
+            "request": request,
+            "user": user,
+            **_spec_ctx(user, db),
+            "game": game,
+            "attempts_today": attempts_today,
+            "max_daily_attempts": game.max_daily_attempts,
+            "attempts_remaining": max(0, game.max_daily_attempts - attempts_today),
+        },
+    )
+
+
+# ── Direction Swipe submit (JSON API) ─────────────────────────────────────────
+
+@router.post("/virtual-training/direction-swipe/submit")
+async def virtual_training_direction_swipe_submit(
+    request: Request,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user_web),
+):
+    """Record a Direction Swipe attempt. Returns attempt_id, xp_awarded, is_valid."""
+    guard = require_student_onboarding(user)
+    if guard:
+        return JSONResponse({"error": "onboarding required"}, status_code=403)
+
+    game = VirtualTrainingService.get_game(db, "direction_swipe")
+    if game is None or not game.is_active:
+        return JSONResponse({"error": "game not available"}, status_code=404)
+
+    body = await request.json()
+
+    today_start = datetime.combine(
+        datetime.now(timezone.utc).date(),
+        datetime.min.time(),
+    ).replace(tzinfo=timezone.utc)
+    valid_today = (
+        db.query(VirtualTrainingAttempt)
+        .filter(
+            VirtualTrainingAttempt.user_id == user.id,
+            VirtualTrainingAttempt.game_id == game.id,
+            VirtualTrainingAttempt.started_at >= today_start,
+            VirtualTrainingAttempt.is_valid == True,  # noqa: E712
+        )
+        .count()
+    )
+    if valid_today >= game.max_daily_attempts:
+        return JSONResponse(
+            {"error": "daily_cap", "message": "Daily attempt limit reached for this game."},
+            status_code=429,
+        )
+
+    started_at_raw = body.get("started_at", "")
+    idem_key = f"vt_ds_u{user.id}_{started_at_raw}"
+
+    attempt = VirtualTrainingService.record_attempt(
+        db=db,
+        user_id=user.id,
+        game=game,
+        data=body,
+        idempotency_key=idem_key,
+    )
+
+    db.commit()
+
+    return JSONResponse({
+        "attempt_id": attempt.id,
+        "is_valid": attempt.is_valid,
+        "invalid_reason": attempt.invalid_reason,
+        "xp_awarded": attempt.xp_awarded,
+        "skill_deltas": attempt.skill_deltas,
+        "attempt_index_today": attempt.attempt_index_today,
+        "score_normalized": attempt.score_normalized,
+    })
+
+
+# ── Direction Swipe result page ───────────────────────────────────────────────
+
+@router.get("/virtual-training/direction-swipe/result/{attempt_id}",
+            response_class=HTMLResponse)
+async def virtual_training_direction_swipe_result(
+    attempt_id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user_web),
+):
+    """Result screen for a completed Direction Swipe attempt."""
+    guard = require_student_onboarding(user)
+    if guard:
+        return guard
+
+    attempt = (
+        db.query(VirtualTrainingAttempt)
+        .filter(
+            VirtualTrainingAttempt.id == attempt_id,
+            VirtualTrainingAttempt.user_id == user.id,
+        )
+        .first()
+    )
+    if attempt is None:
+        all_games = VirtualTrainingService.get_hub_games(db)
+        return templates.TemplateResponse(
+            "virtual_training_hub.html",
+            {
+                "request": request,
+                "user": user,
+                **_spec_ctx(user, db),
+                "all_games": all_games,
+                "error": "Attempt not found.",
+            },
+        )
+
+    game = db.query(VirtualTrainingGame).filter(
+        VirtualTrainingGame.id == attempt.game_id
+    ).first()
+
+    skill_scores: dict = {}
+    signals_ctx: dict = {}
+    if attempt.skill_deltas and game is not None:
+        from ...services.virtual_training_metrics import VTSignalExtractor, VTSkillScorer
+        cfg          = game.config or {}
+        phase_config = cfg.get("phases", []) if isinstance(cfg, dict) else []
+        data_for_signals = {
+            "stimuli_count":     attempt.stimuli_count,
+            "correct_count":     attempt.correct_count,
+            "wrong_click_count": attempt.wrong_click_count,
+            "error_count":       attempt.error_count,
+            "avg_reaction_ms":   attempt.avg_reaction_ms,
+            "raw_metrics":       attempt.raw_metrics,
+        }
+        signals = VTSignalExtractor.extract(data_for_signals, phase_config)
+        skill_scores = VTSkillScorer.score_all(signals, game.skill_targets or {})
+        signals_ctx = {
+            "hit_rate":        round(signals.hit_rate * 100, 1),
+            "wrong_rate":      round(signals.wrong_rate * 100, 1),
+            "miss_rate":       round(signals.miss_rate * 100, 1),
+            "speed_score":     round(signals.speed_score * 100, 1),
+            "completion_rate": round(signals.completion_rate * 100, 1),
+            "avg_reaction_ms": signals.avg_reaction_ms,
+        }
+
+    per_phase: list = []
+    per_stimulus: list = []
+    late_summary: dict | None = None
+    raw = attempt.raw_metrics
+    if isinstance(raw, dict) and raw.get("v", 1) >= 1:
+        per_phase    = raw.get("per_phase")    or []
+        per_stimulus = raw.get("per_stimulus") or []
+    if isinstance(raw, dict) and raw.get("v", 1) >= 2:
+        late_summary = raw.get("late_summary") or None
+
+    from ...models.user import UserRole
+    is_admin = user.role == UserRole.ADMIN
+
+    return templates.TemplateResponse(
+        "virtual_training_direction_swipe_result.html",
+        {
+            "request": request,
+            "user": user,
+            **_spec_ctx(user, db),
+            "attempt": attempt,
+            "game": game,
+            "skill_scores": skill_scores,
+            "signals_ctx":  signals_ctx,
+            "per_phase":    per_phase,
+            "per_stimulus": per_stimulus,
+            "late_summary": late_summary,
+            "is_admin":     is_admin,
+        },
+    )

--- a/app/services/virtual_training_metrics.py
+++ b/app/services/virtual_training_metrics.py
@@ -274,6 +274,22 @@ class VTSkillScorer:
         return max(0.0, min(1.0, 0.65 * signals.hit_rate + 0.35 * signals.completion_rate))
 
     @staticmethod
+    def score_coordination(signals: VTSignals) -> float:
+        """
+        Motor-visual coordination for directional-response games.
+
+        Rewards correct directional responses and fast execution.
+        Wrong-direction errors (commission errors in motor accuracy) penalised
+        at 1.0× — heavier than misses, lighter than in score_decisions.
+
+          coordination = 0.55 × hit_rate − 1.0 × wrong_rate + 0.45 × speed_score
+
+        Range: (−∞, 1.0].  Negative when wrong-direction errors dominate.
+        """
+        score = 0.55 * signals.hit_rate - 1.0 * signals.wrong_rate + 0.45 * signals.speed_score
+        return min(1.0, score)
+
+    @staticmethod
     def score_all(signals: VTSignals, skill_targets: dict[str, float]) -> dict[str, float]:
         """
         Score every skill present in skill_targets.
@@ -287,6 +303,7 @@ class VTSkillScorer:
             "anticipation":       VTSkillScorer.score_anticipation,
             "composure":          VTSkillScorer.score_composure,
             "tactical_awareness": VTSkillScorer.score_tactical_awareness,
+            "coordination":       VTSkillScorer.score_coordination,
         }
         known = {k: fn(signals) for k, fn in _scorers.items()}
         fallback = sum(known.values()) / len(known) if known else 0.5

--- a/app/templates/virtual_training_direction_swipe.html
+++ b/app/templates/virtual_training_direction_swipe.html
@@ -1,0 +1,749 @@
+{% extends "student_base.html" %}
+
+{% block title %}Direction Swipe - LFA{% endblock %}
+{% block active_page %}lfa-player{% endblock %}
+
+{% block student_header %}
+{% set _page_icon = '↕️' %}
+{% set _page_name = 'Direction Swipe' %}
+{% include "includes/spec_subpage_hdr.html" %}
+{% endblock %}
+
+{% block extra_styles %}
+<style>
+    .ds-container {
+        max-width: 520px;
+        margin: 0 auto;
+        padding: 1.5rem 1rem 3rem;
+    }
+
+    /* ── Meta bar ─────────────────────────────────────────────────────────── */
+    .ds-meta {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        background: var(--app-card);
+        border-radius: 10px;
+        padding: 0.65rem 1rem;
+        margin-bottom: 1.25rem;
+        font-size: 0.85rem;
+        color: var(--app-text-muted);
+        box-shadow: 0 1px 6px rgba(0,0,0,0.06);
+    }
+    .ds-meta span { font-weight: 600; color: var(--app-text); }
+
+    /* ── Instruction card ─────────────────────────────────────────────────── */
+    .ds-instruction {
+        background: var(--app-card);
+        border-radius: 14px;
+        padding: 1.5rem 1.5rem 1.75rem;
+        box-shadow: 0 2px 10px rgba(0,0,0,0.07);
+        text-align: center;
+        margin-bottom: 1.5rem;
+    }
+    .ds-instruction h2 {
+        font-size: 1.3rem;
+        font-weight: 700;
+        margin: 0 0 0.6rem;
+        color: var(--app-text);
+    }
+    .ds-instruction p {
+        font-size: 0.9rem;
+        color: var(--app-text-muted);
+        line-height: 1.6;
+        margin: 0 0 1.25rem;
+    }
+
+    /* ── Direction legend ─────────────────────────────────────────────────── */
+    .ds-dir-legend {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 0.5rem;
+        max-width: 240px;
+        margin: 0 auto 1.25rem;
+    }
+    .ds-dir-legend-item {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 0.2rem;
+    }
+    .ds-dir-arrow {
+        font-size: 1.8rem;
+        line-height: 1;
+    }
+    .ds-dir-key {
+        font-size: 0.68rem;
+        font-weight: 700;
+        color: var(--app-text-muted);
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+    }
+    .ds-dir-legend-item.center { grid-column: 2; }
+    .ds-dir-legend-item.left   { grid-column: 1; }
+    .ds-dir-legend-item.right  { grid-column: 3; }
+
+    .ds-skill-chips {
+        display: flex;
+        justify-content: center;
+        gap: 0.5rem;
+        flex-wrap: wrap;
+        margin-bottom: 1.25rem;
+    }
+    .ds-skill-chip {
+        font-size: 0.75rem;
+        font-weight: 600;
+        background: #ede9fe;
+        color: #5b21b6;
+        padding: 0.2rem 0.65rem;
+        border-radius: 20px;
+    }
+    .ds-btn-start {
+        display: inline-block;
+        background: #4f46e5;
+        color: #fff;
+        font-size: 1rem;
+        font-weight: 700;
+        padding: 0.8rem 2.5rem;
+        border-radius: 10px;
+        border: none;
+        cursor: pointer;
+        transition: background 0.15s;
+    }
+    .ds-btn-start:hover { background: #4338ca; }
+    .ds-btn-start:disabled {
+        background: #9ca3af;
+        cursor: not-allowed;
+    }
+
+    /* ── Game arena ───────────────────────────────────────────────────────── */
+    .ds-arena { display: none; }
+    .ds-arena.active { display: block; }
+
+    /* ── HUD ──────────────────────────────────────────────────────────────── */
+    .ds-hud {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 0.75rem;
+        font-size: 0.82rem;
+        color: var(--app-text-muted);
+        font-weight: 600;
+    }
+    .ds-progress-wrap {
+        background: #e5e7eb;
+        border-radius: 6px;
+        height: 6px;
+        margin-bottom: 1rem;
+        overflow: hidden;
+    }
+    .ds-progress-bar {
+        height: 100%;
+        background: #4f46e5;
+        border-radius: 6px;
+        transition: width 0.2s ease;
+        width: 0%;
+    }
+
+    /* ── Counters ─────────────────────────────────────────────────────────── */
+    .ds-counters {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 0.5rem;
+        margin-bottom: 1rem;
+    }
+    .ds-counter {
+        background: var(--app-card);
+        border-radius: 10px;
+        padding: 0.6rem 0.5rem;
+        text-align: center;
+        box-shadow: 0 1px 4px rgba(0,0,0,0.05);
+    }
+    .ds-counter-label {
+        font-size: 0.65rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: var(--app-text-muted);
+        margin-bottom: 0.2rem;
+    }
+    .ds-counter-value {
+        font-size: 1.1rem;
+        font-weight: 800;
+        color: var(--app-text);
+    }
+    .ds-counter-value.hit-color   { color: #16a34a; }
+    .ds-counter-value.wrong-color { color: #dc2626; }
+    .ds-counter-value.late-color  { color: #d97706; }
+    .ds-counter-value.miss-color  { color: #6b7280; }
+
+    /* ── Stimulus field ───────────────────────────────────────────────────── */
+    .ds-field {
+        background: var(--app-card);
+        border-radius: 16px;
+        box-shadow: 0 2px 14px rgba(0,0,0,0.09);
+        min-height: 240px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        margin-bottom: 1rem;
+        position: relative;
+        overflow: hidden;
+        user-select: none;
+        -webkit-user-select: none;
+        touch-action: none;
+    }
+
+    .ds-field-idle {
+        font-size: 0.9rem;
+        color: var(--app-text-muted);
+        font-weight: 600;
+    }
+
+    .ds-stimulus {
+        display: none;
+        flex-direction: column;
+        align-items: center;
+        gap: 0.5rem;
+    }
+    .ds-stimulus.visible { display: flex; }
+
+    .ds-arrow-display {
+        font-size: 5rem;
+        line-height: 1;
+        transition: transform 0.08s ease;
+    }
+    .ds-arrow-display.correct-flash  { color: #16a34a; }
+    .ds-arrow-display.wrong-flash    { color: #dc2626; }
+
+    .ds-stim-label {
+        font-size: 0.72rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--app-text-muted);
+    }
+
+    /* ── Keyboard hint ────────────────────────────────────────────────────── */
+    .ds-keyboard-hint {
+        font-size: 0.72rem;
+        color: var(--app-text-muted);
+        text-align: center;
+        margin-top: 0.35rem;
+    }
+
+    /* ── Feedback flash ───────────────────────────────────────────────────── */
+    .ds-feedback {
+        position: absolute;
+        top: 12px;
+        left: 50%;
+        transform: translateX(-50%);
+        font-size: 0.82rem;
+        font-weight: 800;
+        padding: 0.25rem 0.85rem;
+        border-radius: 20px;
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.15s;
+        white-space: nowrap;
+    }
+    .ds-feedback.show { opacity: 1; }
+    .ds-feedback.fb-hit   { background: #dcfce7; color: #166534; }
+    .ds-feedback.fb-wrong { background: #fee2e2; color: #991b1b; }
+    .ds-feedback.fb-late  { background: #fef3c7; color: #92400e; }
+    .ds-feedback.fb-miss  { background: #f3f4f6; color: #6b7280; }
+
+    /* ── Submitting overlay ───────────────────────────────────────────────── */
+    .ds-submitting {
+        display: none;
+        text-align: center;
+        padding: 3rem 1rem;
+        background: var(--app-card);
+        border-radius: 16px;
+        box-shadow: 0 2px 14px rgba(0,0,0,0.09);
+        color: var(--app-text-muted);
+        font-size: 0.95rem;
+        font-weight: 600;
+    }
+    .ds-submitting.active { display: block; }
+    .ds-submitting p { margin: 0.5rem 0 0; }
+</style>
+{% endblock %}
+
+{% block student_content %}
+<div class="ds-container">
+
+    {# ── Meta bar ──────────────────────────────────────────────────────────── #}
+    <div class="ds-meta">
+        <div>Today: <span>{{ attempts_today }} / {{ max_daily_attempts }}</span> attempts</div>
+        <div>Remaining: <span>{{ attempts_remaining }}</span></div>
+    </div>
+
+    {# ── Daily cap reached ─────────────────────────────────────────────────── #}
+    {% if attempts_remaining == 0 %}
+    <div style="background:#fef3c7;border:1px solid #f59e0b;border-radius:12px;padding:1rem 1.25rem;text-align:center;margin-bottom:1.25rem;color:#92400e;font-weight:600;font-size:0.9rem;">
+        Daily limit reached. Come back tomorrow to earn XP again.
+    </div>
+    {% endif %}
+
+    {# ── Instruction screen ────────────────────────────────────────────────── #}
+    <div class="ds-instruction" id="dsInstruction">
+        <h2>↕️ Direction Swipe</h2>
+        <p>
+            An arrow appears — <strong>swipe</strong> (touch) or press the matching
+            <strong>arrow key</strong> as fast as possible.<br>
+            Three phases get progressively faster. React quickly and accurately.
+        </p>
+
+        <div class="ds-dir-legend">
+            <div class="ds-dir-legend-item center" style="grid-row:1;grid-column:2;">
+                <div class="ds-dir-arrow">↑</div>
+                <div class="ds-dir-key">Up</div>
+            </div>
+            <div class="ds-dir-legend-item" style="grid-row:2;grid-column:1;">
+                <div class="ds-dir-arrow">←</div>
+                <div class="ds-dir-key">Left</div>
+            </div>
+            <div class="ds-dir-legend-item" style="grid-row:2;grid-column:3;">
+                <div class="ds-dir-arrow">→</div>
+                <div class="ds-dir-key">Right</div>
+            </div>
+            <div class="ds-dir-legend-item" style="grid-row:3;grid-column:2;">
+                <div class="ds-dir-arrow">↓</div>
+                <div class="ds-dir-key">Down</div>
+            </div>
+        </div>
+
+        <div class="ds-skill-chips">
+            {% for skill in game.skill_targets %}
+            <span class="ds-skill-chip">{{ skill }}</span>
+            {% endfor %}
+        </div>
+
+        <button class="ds-btn-start" id="dsBtnStart"
+            {% if attempts_remaining == 0 %}disabled{% endif %}>
+            ▶ Start Game
+        </button>
+    </div>
+
+    {# ── Game arena ────────────────────────────────────────────────────────── #}
+    <div class="ds-arena" id="dsArena">
+
+        <div class="ds-hud">
+            <span id="dsProgress">0 / {{ game.config.phases | sum(attribute='stimuli') }}</span>
+            <span id="dsTimer">0s</span>
+        </div>
+        <div class="ds-progress-wrap">
+            <div class="ds-progress-bar" id="dsProgressBar"></div>
+        </div>
+
+        <div class="ds-counters">
+            <div class="ds-counter">
+                <div class="ds-counter-label">Correct</div>
+                <div class="ds-counter-value hit-color" id="dsHit">0</div>
+            </div>
+            <div class="ds-counter">
+                <div class="ds-counter-label">Wrong Dir</div>
+                <div class="ds-counter-value wrong-color" id="dsWrong">0</div>
+            </div>
+            <div class="ds-counter">
+                <div class="ds-counter-label">Late</div>
+                <div class="ds-counter-value late-color" id="dsLate">0</div>
+            </div>
+            <div class="ds-counter">
+                <div class="ds-counter-label">Missed</div>
+                <div class="ds-counter-value miss-color" id="dsMiss">0</div>
+            </div>
+        </div>
+
+        <div class="ds-field" id="dsField">
+            <div class="ds-field-idle" id="dsFieldIdle">Get ready…</div>
+            <div class="ds-stimulus" id="dsStimulus">
+                <div class="ds-arrow-display" id="dsArrow"></div>
+                <div class="ds-stim-label" id="dsStimLabel">Swipe or press arrow key</div>
+            </div>
+            <div class="ds-feedback" id="dsFeedback"></div>
+        </div>
+
+        <div class="ds-keyboard-hint">⌨️ Arrow keys · 📱 Swipe on touch</div>
+
+    </div>
+
+    {# ── Submitting overlay ────────────────────────────────────────────────── #}
+    <div class="ds-submitting" id="dsSubmitting">
+        <div style="font-size:2rem;margin-bottom:0.5rem;">⏳</div>
+        <p>Saving your result…</p>
+    </div>
+
+</div>
+
+<script>
+(function () {
+    // ── Server-injected config ─────────────────────────────────────────────
+    var PHASES        = {{ game.config.phases | tojson }};
+    var DIRECTIONS    = {{ game.config.directions | tojson }};    // ["up","down","left","right"]
+    var LATE_GRACE_MS = {{ game.config.late_grace_ms | tojson }}; // 300
+    var JITTER_MS     = {{ game.config.jitter_ms | tojson }};     // 150
+    var SWIPE_MIN_PX  = {{ game.config.swipe_min_px | tojson }};  // 30
+    var SWIPE_MAX_DUR_MS = {{ game.config.swipe_max_duration_ms | tojson }}; // 500
+    var CSRF_TOKEN    = "{{ request.cookies.get('csrf_token', '') }}";
+    var SUBMIT_URL    = "/virtual-training/direction-swipe/submit";
+
+    var TOTAL_STIM = PHASES.reduce(function(s, p){ return s + p.stimuli; }, 0); // 36
+
+    // ── Arrow glyphs ───────────────────────────────────────────────────────
+    var ARROW_GLYPH = { up: "↑", down: "↓", left: "←", right: "→" };
+
+    // ── Game state ─────────────────────────────────────────────────────────
+    var started         = false;
+    var startedAt       = null;
+    var globalStimIdx   = 0;
+    var hitCount        = 0;
+    var wrongCount      = 0;
+    var lateCount       = 0;
+    var missCount       = 0;
+    var reactionTimes   = [];        // RT of correct hits only
+    var stimTimestamp   = null;
+    var stimTimeout     = null;
+    var lateTimeout     = null;
+    var isiTimeout      = null;
+    var elapsedInterval = null;
+    var elapsedSeconds  = 0;
+    var currentDir      = null;
+    var responseHandled = false;
+    var stimulusLog     = [];
+    var perPhaseData    = [];
+
+    // Touch tracking
+    var touchStartX = null;
+    var touchStartY = null;
+    var touchStartT = null;
+
+    // DOM refs
+    var elInstruction = document.getElementById("dsInstruction");
+    var elArena       = document.getElementById("dsArena");
+    var elBtnStart    = document.getElementById("dsBtnStart");
+    var elField       = document.getElementById("dsField");
+    var elFieldIdle   = document.getElementById("dsFieldIdle");
+    var elStimulus    = document.getElementById("dsStimulus");
+    var elArrowDisp   = document.getElementById("dsArrow");
+    var elFeedback    = document.getElementById("dsFeedback");
+    var elProgress    = document.getElementById("dsProgress");
+    var elProgressBar = document.getElementById("dsProgressBar");
+    var elTimer       = document.getElementById("dsTimer");
+    var elHit         = document.getElementById("dsHit");
+    var elWrong       = document.getElementById("dsWrong");
+    var elLate        = document.getElementById("dsLate");
+    var elMiss        = document.getElementById("dsMiss");
+    var elSubmitting  = document.getElementById("dsSubmitting");
+
+    // ── Build randomised sequence ──────────────────────────────────────────
+    function buildSequence() {
+        var seq = [];
+        for (var pi = 0; pi < PHASES.length; pi++) {
+            var p = PHASES[pi];
+            var block = [];
+            for (var s = 0; s < p.stimuli; s++) {
+                block.push({ phase: pi, cfg: p, dir: DIRECTIONS[s % DIRECTIONS.length] });
+            }
+            // Fisher-Yates shuffle direction assignment
+            for (var i = block.length - 1; i > 0; i--) {
+                var j = Math.floor(Math.random() * (i + 1));
+                var tmp = block[i]; block[i] = block[j]; block[j] = tmp;
+            }
+            // Re-assign directions randomly
+            for (var k = 0; k < block.length; k++) {
+                block[k].dir = DIRECTIONS[Math.floor(Math.random() * DIRECTIONS.length)];
+            }
+            seq = seq.concat(block);
+        }
+        return seq;
+    }
+
+    var SEQUENCE = buildSequence();
+
+    // ── Phase lookup ───────────────────────────────────────────────────────
+    function getPhaseForIdx(idx) {
+        var cumulative = 0;
+        for (var pi = 0; pi < PHASES.length; pi++) {
+            cumulative += PHASES[pi].stimuli;
+            if (idx < cumulative) { return pi; }
+        }
+        return PHASES.length - 1;
+    }
+
+    // ── Start ──────────────────────────────────────────────────────────────
+    elBtnStart.addEventListener("click", function () {
+        if (started) { return; }
+        started   = true;
+        startedAt = new Date().toISOString();
+
+        elInstruction.style.display = "none";
+        elArena.classList.add("active");
+
+        elapsedInterval = setInterval(function () {
+            elapsedSeconds++;
+            elTimer.textContent = elapsedSeconds + "s";
+        }, 1000);
+
+        isiTimeout = setTimeout(showStimulus, 800);
+    });
+
+    // ── Keyboard input ─────────────────────────────────────────────────────
+    document.addEventListener("keydown", function (e) {
+        if (!started || responseHandled || currentDir === null) { return; }
+        var keyMap = { ArrowUp: "up", ArrowDown: "down", ArrowLeft: "left", ArrowRight: "right" };
+        var pressed = keyMap[e.key];
+        if (!pressed) { return; }
+        e.preventDefault();
+        var rt = Date.now() - stimTimestamp;
+        handleResponse(pressed, rt, "keyboard");
+    });
+
+    // ── Touch input ────────────────────────────────────────────────────────
+    elField.addEventListener("touchstart", function (e) {
+        var t = e.changedTouches[0];
+        touchStartX = t.clientX;
+        touchStartY = t.clientY;
+        touchStartT = Date.now();
+    }, { passive: true });
+
+    elField.addEventListener("touchend", function (e) {
+        if (!started || responseHandled || currentDir === null) { return; }
+        if (touchStartX === null) { return; }
+        var t    = e.changedTouches[0];
+        var dx   = t.clientX - touchStartX;
+        var dy   = t.clientY - touchStartY;
+        var dur  = Date.now() - touchStartT;
+        var dist = Math.sqrt(dx * dx + dy * dy);
+        touchStartX = touchStartY = touchStartT = null;
+
+        if (dist < SWIPE_MIN_PX || dur > SWIPE_MAX_DUR_MS) { return; }
+
+        var swipeDir;
+        if (Math.abs(dx) >= Math.abs(dy)) {
+            swipeDir = dx > 0 ? "right" : "left";
+        } else {
+            swipeDir = dy > 0 ? "down" : "up";
+        }
+        var rt = Date.now() - stimTimestamp;
+        handleResponse(swipeDir, rt, "touch");
+    }, { passive: true });
+
+    // ── Handle a response (correct / wrong) ───────────────────────────────
+    function handleResponse(dir, rt, inputMode) {
+        if (responseHandled) { return; }
+        responseHandled = true;
+        clearTimeout(stimTimeout);
+        clearTimeout(lateTimeout);
+
+        if (dir === currentDir) {
+            hitCount++;
+            reactionTimes.push(rt);
+            elHit.textContent = hitCount;
+            recordStimEvent("correct", rt, inputMode);
+            showFeedback("CORRECT", "fb-hit");
+        } else {
+            wrongCount++;
+            elWrong.textContent = wrongCount;
+            recordStimEvent("wrong_direction", rt, inputMode, dir);
+            showFeedback("WRONG DIR", "fb-wrong");
+        }
+
+        hideStimulus();
+        scheduleNext();
+    }
+
+    // ── Show stimulus ──────────────────────────────────────────────────────
+    function showStimulus() {
+        if (globalStimIdx >= TOTAL_STIM) { finishGame(); return; }
+
+        responseHandled = false;
+        stimTimestamp   = Date.now();
+        var item        = SEQUENCE[globalStimIdx];
+        currentDir      = item.dir;
+        var cfg         = item.cfg;
+
+        // ISI jitter already applied at scheduleNext; show arrow now
+        elArrowDisp.textContent = ARROW_GLYPH[currentDir];
+        elArrowDisp.className   = "ds-arrow-display";
+
+        elFieldIdle.style.display = "none";
+        elStimulus.classList.add("visible");
+
+        elProgress.textContent    = (globalStimIdx + 1) + " / " + TOTAL_STIM;
+        elProgressBar.style.width = ((globalStimIdx + 1) / TOTAL_STIM * 100) + "%";
+
+        // Window timeout — missed
+        stimTimeout = setTimeout(function () {
+            if (responseHandled) { return; }
+            responseHandled = true;
+            missCount++;
+            elMiss.textContent = missCount;
+            recordStimEvent("missed", null, null);
+            showFeedback("MISS", "fb-miss");
+            hideStimulus();
+
+            // Late grace window
+            lateTimeout = setTimeout(function () {}, LATE_GRACE_MS);
+            scheduleNextAfterLate(cfg);
+        }, cfg.window_ms);
+    }
+
+    function hideStimulus() {
+        elStimulus.classList.remove("visible");
+        currentDir = null;
+    }
+
+    function scheduleNext() {
+        globalStimIdx++;
+        if (globalStimIdx >= TOTAL_STIM) {
+            isiTimeout = setTimeout(finishGame, 300);
+            return;
+        }
+        var pi  = getPhaseForIdx(globalStimIdx);
+        var isi = PHASES[pi].isi_ms + (Math.random() * JITTER_MS * 2 - JITTER_MS);
+        isi = Math.max(100, Math.round(isi));
+        isiTimeout = setTimeout(showStimulus, isi);
+    }
+
+    // After a miss: allow late swipe within LATE_GRACE_MS, then advance
+    function scheduleNextAfterLate(cfg) {
+        // We re-attach a one-shot late listener
+        var lateDir = currentDir; // capture before hideStimulus clears it
+        var lateMissIdx = globalStimIdx;
+
+        setTimeout(function () {
+            globalStimIdx++;
+            if (globalStimIdx >= TOTAL_STIM) {
+                isiTimeout = setTimeout(finishGame, 300);
+                return;
+            }
+            var pi  = getPhaseForIdx(globalStimIdx);
+            var isi = PHASES[pi].isi_ms + (Math.random() * JITTER_MS * 2 - JITTER_MS);
+            isi = Math.max(100, Math.round(isi));
+            isiTimeout = setTimeout(showStimulus, isi);
+        }, LATE_GRACE_MS);
+    }
+
+    // ── Feedback ───────────────────────────────────────────────────────────
+    var fbTimeout = null;
+    function showFeedback(text, cls) {
+        if (fbTimeout) { clearTimeout(fbTimeout); }
+        elFeedback.textContent = text;
+        elFeedback.className   = "ds-feedback show " + cls;
+        fbTimeout = setTimeout(function () {
+            elFeedback.className = "ds-feedback";
+        }, 380);
+    }
+
+    // ── Record stimulus event ──────────────────────────────────────────────
+    function recordStimEvent(outcome, rtMs, inputMode, pressedDir) {
+        var entry = {
+            i:          globalStimIdx,
+            phase:      getPhaseForIdx(globalStimIdx),
+            direction:  SEQUENCE[globalStimIdx] ? SEQUENCE[globalStimIdx].dir : null,
+            outcome:    outcome,
+            rt_ms:      rtMs,
+            input_mode: inputMode || null,
+        };
+        if (pressedDir !== undefined) { entry.pressed_dir = pressedDir; }
+        stimulusLog.push(entry);
+    }
+
+    // ── Finish + submit ─────────────────────────────────────────────────────
+    function finishGame() {
+        clearInterval(elapsedInterval);
+        clearTimeout(stimTimeout);
+        clearTimeout(lateTimeout);
+        clearTimeout(isiTimeout);
+        hideStimulus();
+        elArena.classList.remove("active");
+        elSubmitting.classList.add("active");
+
+        var durationSeconds = startedAt
+            ? Math.round((Date.now() - new Date(startedAt).getTime()) / 100) / 10
+            : null;
+
+        var avgMs = reactionTimes.length > 0
+            ? Math.round(reactionTimes.reduce(function(a,b){return a+b;},0) / reactionTimes.length)
+            : null;
+        var minMs = reactionTimes.length > 0
+            ? Math.min.apply(null, reactionTimes)
+            : null;
+
+        // Score: hit_rate weighted with speed
+        var hitRate    = TOTAL_STIM > 0 ? hitCount / TOTAL_STIM : 0;
+        var wrongRate  = TOTAL_STIM > 0 ? wrongCount / TOTAL_STIM : 0;
+        var speedFactor = avgMs !== null ? Math.max(0, 1 - avgMs / 1500) : 0;
+        var scoreRaw   = 0.50 * hitRate + 0.30 * (1 - wrongRate) + 0.20 * speedFactor;
+        var scoreNorm  = Math.min(100, Math.max(0, Math.round(100 * scoreRaw)));
+
+        // per_phase summary
+        var perPhase = PHASES.map(function(p, pi) {
+            var evs     = stimulusLog.filter(function(e){ return e.phase === pi; });
+            var correct = evs.filter(function(e){ return e.outcome === "correct"; }).length;
+            var wrong   = evs.filter(function(e){ return e.outcome === "wrong_direction"; }).length;
+            var missed  = evs.filter(function(e){ return e.outcome === "missed"; }).length;
+            var late    = evs.filter(function(e){ return e.outcome === "late_swipe"; }).length;
+            var rtArr   = evs.filter(function(e){ return e.rt_ms !== null; }).map(function(e){ return e.rt_ms; });
+            var avgRtMs = rtArr.length > 0 ? Math.round(rtArr.reduce(function(a,b){return a+b;},0)/rtArr.length) : null;
+            return {
+                phase:   pi,
+                stimuli: p.stimuli,
+                correct: correct,
+                wrong:   wrong,
+                missed:  missed,
+                late:    late,
+                avg_rt_ms: avgRtMs,
+            };
+        });
+
+        var rawMetrics = {
+            v:            2,
+            per_stimulus: stimulusLog,
+            per_phase:    perPhase,
+            late_summary: {
+                late_click_count: lateCount,
+            },
+        };
+
+        var payload = {
+            started_at:        startedAt,
+            duration_seconds:  durationSeconds,
+            stimuli_count:     TOTAL_STIM,
+            correct_count:     hitCount,
+            wrong_click_count: wrongCount,
+            error_count:       missCount,
+            avg_reaction_ms:   avgMs,
+            min_reaction_ms:   minMs,
+            score_raw:         scoreRaw,
+            score_normalized:  scoreNorm,
+            raw_metrics:       rawMetrics,
+        };
+
+        fetch(SUBMIT_URL, {
+            method:  "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "X-CSRF-Token": CSRF_TOKEN,
+            },
+            body: JSON.stringify(payload),
+        })
+        .then(function(r){ return r.json(); })
+        .then(function(data){
+            if (data.attempt_id) {
+                window.location.href = "/virtual-training/direction-swipe/result/" + data.attempt_id;
+            } else {
+                elSubmitting.innerHTML = "<p>⚠️ Could not save attempt. <a href='/virtual-training'>Back to hub</a></p>";
+            }
+        })
+        .catch(function(){
+            elSubmitting.innerHTML = "<p>⚠️ Network error. <a href='/virtual-training'>Back to hub</a></p>";
+        });
+    }
+
+})();
+</script>
+{% endblock %}

--- a/app/templates/virtual_training_direction_swipe_result.html
+++ b/app/templates/virtual_training_direction_swipe_result.html
@@ -1,0 +1,527 @@
+{% extends "student_base.html" %}
+
+{% block title %}Direction Swipe Result - LFA{% endblock %}
+{% block active_page %}lfa-player{% endblock %}
+
+{% block student_header %}
+{% set _page_icon = '↕️' %}
+{% set _page_name = 'Result' %}
+{% include "includes/spec_subpage_hdr.html" %}
+{% endblock %}
+
+{% block extra_styles %}
+<style>
+    .dsr-container {
+        max-width: 560px;
+        margin: 0 auto;
+        padding: 1.5rem 1rem 3rem;
+    }
+
+    .dsr-card {
+        background: var(--app-card);
+        border-radius: 16px;
+        padding: 2rem 1.75rem;
+        box-shadow: 0 2px 14px rgba(0,0,0,0.09);
+        text-align: center;
+        margin-bottom: 1.25rem;
+    }
+
+    .dsr-status-icon {
+        font-size: 3rem;
+        margin-bottom: 0.5rem;
+        line-height: 1;
+    }
+
+    .dsr-title {
+        font-size: 1.45rem;
+        font-weight: 800;
+        color: var(--app-text);
+        margin: 0 0 0.3rem;
+    }
+
+    .dsr-subtitle {
+        font-size: 0.9rem;
+        color: var(--app-text-muted);
+        margin: 0 0 1.5rem;
+    }
+
+    /* ── Stats grid ─────────────────────────────────────────────────────── */
+    .dsr-stats-grid {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        gap: 0.85rem;
+        margin-bottom: 1.5rem;
+    }
+
+    .dsr-stat {
+        background: #f9fafb;
+        border-radius: 10px;
+        padding: 0.85rem 0.75rem;
+    }
+
+    .dsr-stat-label {
+        font-size: 0.75rem;
+        color: var(--app-text-muted);
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        margin-bottom: 0.3rem;
+    }
+
+    .dsr-stat-value {
+        font-size: 1.35rem;
+        font-weight: 800;
+        color: var(--app-text);
+    }
+
+    .dsr-stat-value.good   { color: #16a34a; }
+    .dsr-stat-value.danger { color: #ef4444; }
+    .dsr-stat-value.warn   { color: #d97706; }
+
+    /* ── XP badge ───────────────────────────────────────────────────────── */
+    .dsr-xp-badge {
+        display: inline-block;
+        background: #ede9fe;
+        color: #5b21b6;
+        font-size: 1.1rem;
+        font-weight: 800;
+        padding: 0.5rem 1.5rem;
+        border-radius: 20px;
+        margin-bottom: 1.5rem;
+    }
+
+    /* ── Invalid banner ─────────────────────────────────────────────────── */
+    .dsr-invalid-banner {
+        background: #fef3c7;
+        border: 1px solid #f59e0b;
+        border-radius: 10px;
+        padding: 0.85rem 1rem;
+        color: #92400e;
+        font-size: 0.88rem;
+        font-weight: 600;
+        margin-bottom: 1.25rem;
+        text-align: center;
+    }
+
+    /* ── Skill deltas summary ───────────────────────────────────────────── */
+    .dsr-skill-deltas {
+        background: #f0fdf4;
+        border: 1px solid #bbf7d0;
+        border-radius: 10px;
+        padding: 0.85rem 1rem;
+        margin-bottom: 1.5rem;
+        text-align: left;
+    }
+
+    .dsr-skill-deltas h4 {
+        font-size: 0.78rem;
+        font-weight: 700;
+        color: #166534;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        margin: 0 0 0.6rem;
+    }
+
+    .dsr-skill-row {
+        display: flex;
+        justify-content: space-between;
+        font-size: 0.875rem;
+        color: #14532d;
+        padding: 0.2rem 0;
+    }
+
+    .dsr-skill-row.neg { color: #dc2626; }
+
+    /* ── Play again button ──────────────────────────────────────────────── */
+    .dsr-btn-play {
+        display: inline-block;
+        background: #4f46e5;
+        color: #fff;
+        font-size: 0.95rem;
+        font-weight: 700;
+        padding: 0.7rem 2rem;
+        border-radius: 10px;
+        text-decoration: none;
+        transition: background 0.15s;
+        margin-bottom: 0.5rem;
+    }
+    .dsr-btn-play:hover { background: #4338ca; }
+
+    /* ── Skill breakdown ────────────────────────────────────────────────── */
+    .dsr-breakdown {
+        background: #f0fdf4;
+        border: 1px solid #bbf7d0;
+        border-radius: 12px;
+        padding: 1rem 1.1rem;
+        margin-bottom: 1.25rem;
+        text-align: left;
+    }
+
+    .dsr-breakdown h4 {
+        font-size: 0.78rem;
+        font-weight: 700;
+        color: #166534;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        margin: 0 0 0.75rem;
+    }
+
+    .dsr-breakdown-row {
+        display: grid;
+        grid-template-columns: 1fr auto auto;
+        align-items: start;
+        gap: 0.5rem 1rem;
+        padding: 0.45rem 0;
+        border-bottom: 1px solid #d1fae5;
+        font-size: 0.875rem;
+    }
+    .dsr-breakdown-row:last-child { border-bottom: none; }
+
+    .dsr-breakdown-skill     { font-weight: 700; color: #14532d; }
+    .dsr-breakdown-delta     { font-weight: 800; color: #166534; white-space: nowrap; }
+    .dsr-breakdown-delta.neg { color: #dc2626; }
+    .dsr-breakdown-factors {
+        font-size: 0.78rem;
+        color: #6b7280;
+        grid-column: 1 / -1;
+        padding-top: 0.1rem;
+        padding-left: 0.1rem;
+    }
+
+    /* ── Per-phase table ────────────────────────────────────────────────── */
+    .dsr-detail-section {
+        background: white;
+        border: 1px solid #e5e7eb;
+        border-radius: 12px;
+        padding: 1rem 1.1rem;
+        margin-bottom: 1.25rem;
+        text-align: left;
+    }
+
+    .dsr-detail-section h4 {
+        font-size: 0.78rem;
+        font-weight: 700;
+        color: #374151;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        margin: 0 0 0.75rem;
+    }
+
+    .dsr-detail-table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.8rem;
+    }
+
+    .dsr-detail-table th {
+        background: #f9fafb;
+        color: #6b7280;
+        font-weight: 700;
+        font-size: 0.72rem;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        padding: 0.45rem 0.6rem;
+        text-align: left;
+        border-bottom: 1px solid #e5e7eb;
+        white-space: nowrap;
+    }
+
+    .dsr-detail-table td {
+        padding: 0.45rem 0.6rem;
+        border-bottom: 1px solid #f3f4f6;
+        color: #374151;
+        vertical-align: middle;
+    }
+
+    .dsr-detail-table tr:last-child td { border-bottom: none; }
+
+    .dsr-acc-good { color: #16a34a; font-weight: 700; }
+    .dsr-acc-ok   { color: #d97706; font-weight: 700; }
+    .dsr-acc-poor { color: #dc2626; font-weight: 700; }
+
+    /* ── Admin debug ────────────────────────────────────────────────────── */
+    .dsr-admin-debug {
+        background: #1e293b;
+        border-radius: 10px;
+        padding: 0.85rem 1rem;
+        margin-bottom: 1.25rem;
+        text-align: left;
+    }
+    .dsr-admin-debug summary {
+        color: #94a3b8;
+        font-size: 0.78rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        cursor: pointer;
+    }
+    .dsr-admin-debug pre {
+        color: #e2e8f0;
+        font-size: 0.72rem;
+        overflow-x: auto;
+        margin: 0.75rem 0 0;
+        white-space: pre-wrap;
+        word-break: break-all;
+        max-height: 300px;
+        overflow-y: auto;
+    }
+
+    /* ── Footer ─────────────────────────────────────────────────────────── */
+    .dsr-footer {
+        text-align: center;
+        margin-top: 1.25rem;
+        padding-top: 1.25rem;
+        border-top: 1px solid #e2e8f0;
+    }
+    .dsr-footer a {
+        color: #667eea;
+        text-decoration: none;
+        margin: 0 0.75rem;
+        font-weight: 600;
+        font-size: 0.88rem;
+    }
+    .dsr-footer a:hover { text-decoration: underline; }
+</style>
+{% endblock %}
+
+{% block student_content %}
+<div class="dsr-container">
+
+    {% if attempt.is_valid %}
+    {# ── Valid result ────────────────────────────────────────────────────── #}
+    <div class="dsr-card">
+        <div class="dsr-status-icon">
+            {% if attempt.score_normalized >= 85 %}🏆
+            {% elif attempt.score_normalized >= 65 %}⚡
+            {% elif attempt.score_normalized >= 45 %}💪
+            {% else %}🎯{% endif %}
+        </div>
+        <h2 class="dsr-title">
+            {% if attempt.score_normalized >= 85 %}Sharp directional reactions!
+            {% elif attempt.score_normalized >= 65 %}Good motor accuracy!
+            {% elif attempt.score_normalized >= 45 %}Keep training your swipes!
+            {% else %}Keep practicing!{% endif %}
+        </h2>
+        <p class="dsr-subtitle">Direction Swipe</p>
+
+        {% set _total = attempt.stimuli_count if attempt.stimuli_count is not none else 36 %}
+
+        <div class="dsr-stats-grid">
+            <div class="dsr-stat">
+                <div class="dsr-stat-label">Score</div>
+                <div class="dsr-stat-value">
+                    {% if attempt.score_normalized is not none %}{{ attempt.score_normalized | round(0) | int }}%
+                    {% else %}—{% endif %}
+                </div>
+            </div>
+            <div class="dsr-stat">
+                <div class="dsr-stat-label">Accuracy</div>
+                {% set _correct = attempt.correct_count if attempt.correct_count is not none else 0 %}
+                {% set _acc_pct = ((_correct / _total) * 100) | round(0) | int if _total > 0 else 0 %}
+                <div class="dsr-stat-value {% if _acc_pct >= 85 %}good{% elif _acc_pct >= 65 %}warn{% else %}danger{% endif %}">
+                    {{ _acc_pct }}%
+                    <small style="font-size:0.65rem;font-weight:600;color:var(--app-text-muted);">{{ _correct }}/{{ _total }}</small>
+                </div>
+            </div>
+            <div class="dsr-stat">
+                <div class="dsr-stat-label">Wrong Dir</div>
+                {% set _wrong = attempt.wrong_click_count if attempt.wrong_click_count is not none else 0 %}
+                <div class="dsr-stat-value {% if _wrong > 3 %}danger{% elif _wrong > 0 %}warn{% else %}good{% endif %}">
+                    {{ _wrong }}
+                    <small style="font-size:0.65rem;font-weight:600;color:var(--app-text-muted);">/ {{ _total }}</small>
+                </div>
+            </div>
+            <div class="dsr-stat">
+                <div class="dsr-stat-label">Missed</div>
+                {% set _miss = attempt.error_count if attempt.error_count is not none else 0 %}
+                <div class="dsr-stat-value {% if _miss > 3 %}warn{% endif %}">
+                    {{ _miss }}
+                </div>
+            </div>
+            <div class="dsr-stat">
+                <div class="dsr-stat-label">Avg Reaction</div>
+                <div class="dsr-stat-value">
+                    {% if attempt.avg_reaction_ms is not none %}{{ attempt.avg_reaction_ms | round(0) | int }} ms
+                    {% else %}—{% endif %}
+                </div>
+            </div>
+            <div class="dsr-stat">
+                <div class="dsr-stat-label">Best Reaction</div>
+                <div class="dsr-stat-value">
+                    {% if attempt.min_reaction_ms is not none %}{{ attempt.min_reaction_ms | round(0) | int }} ms
+                    {% else %}—{% endif %}
+                </div>
+            </div>
+            <div class="dsr-stat">
+                <div class="dsr-stat-label">Duration</div>
+                <div class="dsr-stat-value">
+                    {% if attempt.duration_seconds is not none %}{{ attempt.duration_seconds | round(1) }} s
+                    {% else %}—{% endif %}
+                </div>
+            </div>
+            <div class="dsr-stat">
+                <div class="dsr-stat-label">Attempt</div>
+                <div class="dsr-stat-value">
+                    #{{ attempt.attempt_index_today }} today
+                </div>
+            </div>
+        </div>
+
+        {% if attempt.xp_awarded > 0 %}
+        <div class="dsr-xp-badge">+{{ attempt.xp_awarded }} XP earned</div>
+        {% elif attempt.attempt_index_today > game.max_daily_attempts %}
+        <div class="dsr-xp-badge" style="background:#f3f4f6;color:#6b7280;">
+            No XP — daily limit reached
+        </div>
+        {% endif %}
+
+        {% if attempt.skill_deltas %}
+        <div class="dsr-skill-deltas">
+            <h4>Skill deltas</h4>
+            {% for skill, delta in attempt.skill_deltas.items() %}
+            <div class="dsr-skill-row {% if delta < 0 %}neg{% endif %}">
+                <span>{{ skill }}</span>
+                <span>{{ "%+.2f"|format(delta) }}</span>
+            </div>
+            {% endfor %}
+        </div>
+        {% endif %}
+
+        {# ── Skill delta breakdown ──────────────────────────────────────────── #}
+        {% if skill_scores %}
+        <div class="dsr-breakdown">
+            <h4>Skill Delta Breakdown</h4>
+            {% for skill, score in skill_scores.items() %}
+            {% set delta = attempt.skill_deltas.get(skill, 0) if attempt.skill_deltas else 0 %}
+            <div class="dsr-breakdown-row">
+                <span class="dsr-breakdown-skill">{{ skill|capitalize }}</span>
+                <span class="dsr-breakdown-delta {% if delta < 0 %}neg{% endif %}">{{ "%+.3f"|format(delta) }}</span>
+                <span class="dsr-breakdown-factors">
+                    {% if skill == "coordination" %}
+                        Hit rate: {{ signals_ctx.hit_rate }}% · Wrong dir: {{ signals_ctx.wrong_rate }}% (×1.0 penalty) · Speed: {{ signals_ctx.speed_score }}% · Score: {{ "%.0f"|format(score * 100) }}%
+                        <br><span style="font-style:italic;color:#9ca3af;">Motor-visual accuracy — correct direction under time pressure</span>
+                    {% elif skill == "reactions" %}
+                        Speed: {{ signals_ctx.speed_score }}% · Hit rate: {{ signals_ctx.hit_rate }}% · Score: {{ "%.0f"|format(score * 100) }}%
+                        <br><span style="font-style:italic;color:#9ca3af;">How quickly you responded to each directional stimulus</span>
+                    {% elif skill == "decisions" %}
+                        Hit rate: {{ signals_ctx.hit_rate }}% · Wrong dir (× 1.5 penalty): {{ signals_ctx.wrong_rate }}% · Score: {{ "%.0f"|format(score * 100) }}%
+                        <br><span style="font-style:italic;color:#9ca3af;">Choosing the correct direction — accuracy under pressure</span>
+                    {% elif skill == "concentration" %}
+                        Missed: {{ signals_ctx.miss_rate }}% · Sustained attention score: {{ "%.0f"|format(score * 100) }}%
+                        <br><span style="font-style:italic;color:#9ca3af;">Staying engaged across all three phases without losing stimuli</span>
+                    {% else %}
+                        Score: {{ "%.0f"|format(score * 100) }}%
+                    {% endif %}
+                    {% if delta < 0 %}
+                    <br><span style="color:#dc2626;font-style:italic;">Performance below training threshold — skill decreased this attempt.</span>
+                    {% endif %}
+                </span>
+            </div>
+            {% endfor %}
+        </div>
+        {% endif %}
+
+        <a href="/virtual-training/direction-swipe" class="dsr-btn-play">Play again</a>
+    </div>
+
+    {# ── Per-phase summary ───────────────────────────────────────────────── #}
+    {% if per_phase %}
+    <div class="dsr-detail-section">
+        <h4>Phase Performance</h4>
+        <table class="dsr-detail-table">
+            <thead>
+                <tr>
+                    <th>Phase</th>
+                    <th>Stimuli</th>
+                    <th>Correct</th>
+                    <th>Accuracy</th>
+                    <th>Wrong Dir</th>
+                    <th>Avg RT</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for p in per_phase %}
+                {% set _stim  = p.stimuli if p.stimuli else 1 %}
+                {% set _corr  = p.correct if p.correct is defined else 0 %}
+                {% set _acc   = ((_corr / _stim) * 100) | round(1) %}
+                <tr>
+                    <td>Phase {{ loop.index }}</td>
+                    <td>{{ p.stimuli }}</td>
+                    <td>{{ _corr }}</td>
+                    <td class="{% if _acc >= 85 %}dsr-acc-good{% elif _acc >= 65 %}dsr-acc-ok{% else %}dsr-acc-poor{% endif %}">{{ _acc }}%</td>
+                    <td class="{% if p.wrong > 0 %}dsr-acc-poor{% else %}dsr-acc-good{% endif %}">{{ p.wrong if p.wrong is defined else 0 }}</td>
+                    <td>{% if p.avg_rt_ms is not none %}{{ p.avg_rt_ms | round(0) | int }} ms{% else %}—{% endif %}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    {% endif %}
+
+    {# ── Late summary ────────────────────────────────────────────────────── #}
+    {% if late_summary and late_summary.late_click_count %}
+    <div class="dsr-detail-section">
+        <h4>Late Swipes / Key Presses</h4>
+        <p style="font-size:0.82rem;color:var(--app-text-muted);margin:0 0 0.6rem;">
+            Responses within {{ game.config.late_grace_ms if game else 300 }} ms after window expired — counted as missed but recorded for analysis.
+        </p>
+        <table class="dsr-detail-table">
+            <thead>
+                <tr>
+                    <th>Total late</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>{{ late_summary.late_click_count }}</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+    {% endif %}
+
+    {# ── Admin per-stimulus debug ─────────────────────────────────────────── #}
+    {% if is_admin and per_stimulus %}
+    <div class="dsr-admin-debug">
+        <details>
+            <summary>Admin: per-stimulus raw data ({{ per_stimulus | length }} entries)</summary>
+            <pre>{{ per_stimulus | tojson(indent=2) }}</pre>
+        </details>
+    </div>
+    {% endif %}
+
+    {% else %}
+    {# ── Invalid attempt ─────────────────────────────────────────────────── #}
+    <div class="dsr-card">
+        <div class="dsr-status-icon">⚠️</div>
+        <h2 class="dsr-title">Attempt not counted</h2>
+        <p class="dsr-subtitle">Direction Swipe</p>
+        <div class="dsr-invalid-banner">
+            {% if attempt.invalid_reason == "too_short" %}
+            Session ended too quickly. Try completing all three phases.
+            {% elif attempt.invalid_reason == "too_few_stimuli" %}
+            Not enough stimuli were presented. Please complete a full round.
+            {% elif attempt.invalid_reason == "random_clicking" %}
+            Too many wrong-direction responses detected. Focus on matching the arrow!
+            {% elif attempt.invalid_reason == "bot_suspected" %}
+            Reaction times were unusually fast and could not be validated.
+            {% else %}
+            This attempt could not be validated ({{ attempt.invalid_reason }}).
+            {% endif %}
+        </div>
+        <p style="font-size:0.88rem;color:var(--app-text-muted);margin-bottom:1.25rem;">
+            No XP was awarded. Remaining daily attempts are not consumed.
+        </p>
+        <a href="/virtual-training/direction-swipe" class="dsr-btn-play">Try again</a>
+    </div>
+    {% endif %}
+
+    <div class="dsr-footer">
+        <a href="/virtual-training">💻 All Games</a>
+        <a href="/virtual-training/history">📋 History</a>
+        <a href="/training">🎓 Training</a>
+        <a href="/dashboard/lfa-football-player">⚽ Dashboard</a>
+    </div>
+
+</div>
+{% endblock %}

--- a/scripts/seed_virtual_training_games.py
+++ b/scripts/seed_virtual_training_games.py
@@ -140,16 +140,16 @@ _GAMES = [
         },
     },
 
-    # ── 4. Direction Swipe ────────────────────────────────────────────────────
+    # ── 4. Direction Swipe (ACTIVE — Phase 2.3) ──────────────────────────────
     {
         "code": "direction_swipe",
         "name": "Direction Swipe",
         "description": (
-            "An arrow or directional cue appears on screen — swipe or click in the "
-            "indicated direction as quickly as possible. Speed and motor accuracy tested."
+            "An arrow appears — swipe or press the matching direction key as fast as "
+            "possible. Three phases test speed, accuracy and sustained directional focus."
         ),
-        "game_type": "direction_recognition",
-        "is_active": False,
+        "game_type": "direction_reaction",
+        "is_active": True,
         "base_xp": 12,
         "max_daily_attempts": 5,
         "skill_targets": {
@@ -159,6 +159,18 @@ _GAMES = [
             "concentration": 0.15,
         },
         "config": {
+            # gameplay parameters
+            "phases": [
+                {"stimuli": 10, "window_ms": 1500, "isi_ms": 900},
+                {"stimuli": 12, "window_ms": 1100, "isi_ms": 700},
+                {"stimuli": 14, "window_ms":  750, "isi_ms": 550},
+            ],
+            "directions":           ["up", "down", "left", "right"],
+            "late_grace_ms":        300,
+            "jitter_ms":            150,
+            "swipe_min_px":         30,
+            "swipe_max_duration_ms": 500,
+            # display keys
             "show_in_hub":      True,
             "icon":             "↕️",
             "football_benefit": (

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -38909,6 +38909,94 @@
         }
       }
     },
+    "/virtual-training/direction-swipe": {
+      "get": {
+        "description": "Direction Swipe game page — swipe or press arrow keys to match the shown direction.",
+        "operationId": "virtual_training_direction_swipe_virtual_training_direction_swipe_get",
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Virtual Training Direction Swipe",
+        "tags": [
+          "web",
+          "virtual-training"
+        ]
+      }
+    },
+    "/virtual-training/direction-swipe/result/{attempt_id}": {
+      "get": {
+        "description": "Result screen for a completed Direction Swipe attempt.",
+        "operationId": "virtual_training_direction_swipe_result_virtual_training_direction_swipe_result__attempt_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "attempt_id",
+            "required": true,
+            "schema": {
+              "title": "Attempt Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Virtual Training Direction Swipe Result",
+        "tags": [
+          "web",
+          "virtual-training"
+        ]
+      }
+    },
+    "/virtual-training/direction-swipe/submit": {
+      "post": {
+        "description": "Record a Direction Swipe attempt. Returns attempt_id, xp_awarded, is_valid.",
+        "operationId": "virtual_training_direction_swipe_submit_virtual_training_direction_swipe_submit_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Virtual Training Direction Swipe Submit",
+        "tags": [
+          "web",
+          "virtual-training"
+        ]
+      }
+    },
     "/virtual-training/go-no-go": {
       "get": {
         "tags": [

--- a/tests/unit/api/web_routes/test_direction_swipe.py
+++ b/tests/unit/api/web_routes/test_direction_swipe.py
@@ -1,0 +1,615 @@
+"""Unit tests for Direction Swipe — Phase 2.3.
+
+Scorer tests:
+DS-01   score_coordination — perfect (hit=1.0, wrong=0, speed=1.0) → clamp 1.0
+DS-02   score_coordination — all wrong_direction (wrong_rate=1.0, hit=0, speed=0) → negative
+DS-03   score_coordination — all missed (hit=0, wrong=0, speed=0) → 0.0
+DS-04   score_coordination — mixed: hit=0.8, wrong=0.1, speed=0.7 → correct blend
+DS-05   score_coordination — worst case wrong_rate dominates → below −0.5
+
+Signal extraction tests:
+DS-06   VTSignalExtractor — DS phase config, expected_total=36
+DS-07   VTSignalExtractor — avg window_ms for DS phases: (1500+1100+750)/3 = 1116.67
+DS-08   VTSignalExtractor — late_click_rate from late_summary (v2)
+
+Score registration tests:
+DS-09   score_all — "coordination" in skill_targets dispatches to score_coordination
+DS-10   score_all — missing "coordination" in skill_targets uses fallback
+
+Validation tests:
+DS-11   validate_attempt — 36 correct, 0 wrong, valid duration → is_valid=True
+DS-12   validate_attempt — duration < 25 → too_short
+DS-13   validate_attempt — wrong_click_count > 0.55 * stimuli → random_clicking
+
+Delta computation tests:
+DS-14   compute_vt_skill_deltas — coordination delta positive on perfect run
+DS-15   compute_vt_skill_deltas — coordination delta negative on wrong-heavy run
+DS-16   compute_vt_skill_deltas — daily_neg_cap limits cumulative negative delta
+
+Route tests:
+DS-17   GET /virtual-training/direction-swipe → 200 for active game
+DS-18   GET /virtual-training/direction-swipe → hub redirect when game inactive
+DS-19   POST /virtual-training/direction-swipe/submit → valid data → attempt_id returned
+DS-20   POST submit → 429 when daily cap reached
+DS-21   POST submit → 404 when game inactive
+DS-22   GET /virtual-training/direction-swipe/result/{id} → 200 owner
+DS-23   GET result → hub redirect when attempt not found
+DS-24   Seed: direction_swipe is_active=True in seed data
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.responses import HTMLResponse, JSONResponse
+
+_ROUTES = "app.api.web_routes.virtual_training"
+_METRICS = "app.services.virtual_training_metrics"
+
+_DS_SKILL_TARGETS = {
+    "reactions":     0.35,
+    "decisions":     0.30,
+    "coordination":  0.20,
+    "concentration": 0.15,
+}
+
+_DS_PHASE_CONFIG = [
+    {"stimuli": 10, "window_ms": 1500, "isi_ms": 900},
+    {"stimuli": 12, "window_ms": 1100, "isi_ms": 700},
+    {"stimuli": 14, "window_ms":  750, "isi_ms": 550},
+]
+
+_DS_CONFIG = {
+    "phases":            _DS_PHASE_CONFIG,
+    "directions":        ["up", "down", "left", "right"],
+    "late_grace_ms":     300,
+    "jitter_ms":         150,
+    "swipe_min_px":      30,
+    "swipe_max_duration_ms": 500,
+    "show_in_hub":       True,
+    "icon":              "↕️",
+    "football_benefit":  "Fast directional recognition.",
+}
+
+_DS_AVG_WINDOW = (1500 + 1100 + 750) / 3   # ≈ 1116.67 ms
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _mock_ds_game(*, is_active: bool = True) -> MagicMock:
+    g = MagicMock()
+    g.id                 = 4
+    g.code               = "direction_swipe"
+    g.name               = "Direction Swipe"
+    g.is_active          = is_active
+    g.base_xp            = 12
+    g.max_daily_attempts = 5
+    g.skill_targets      = _DS_SKILL_TARGETS
+    g.config             = _DS_CONFIG
+    return g
+
+
+def _mock_attempt(
+    *,
+    id: int = 77,
+    user_id: int = 42,
+    game_id: int = 4,
+    is_valid: bool = True,
+    xp_awarded: int = 12,
+    score_normalized: float = 80.0,
+    attempt_index_today: int = 1,
+    invalid_reason: str | None = None,
+    skill_deltas: dict | None = None,
+    correct_count: int = 32,
+    wrong_click_count: int = 2,
+    error_count: int = 2,
+    avg_reaction_ms: float = 520.0,
+    stimuli_count: int = 36,
+    duration_seconds: float = 42.0,
+    raw_metrics: dict | None = None,
+) -> MagicMock:
+    a = MagicMock()
+    a.id                  = id
+    a.user_id             = user_id
+    a.game_id             = game_id
+    a.is_valid            = is_valid
+    a.xp_awarded          = xp_awarded
+    a.score_normalized    = score_normalized
+    a.attempt_index_today = attempt_index_today
+    a.invalid_reason      = invalid_reason
+    a.skill_deltas        = skill_deltas or {
+        "reactions": 0.15, "decisions": 0.18, "coordination": 0.09, "concentration": 0.08,
+    }
+    a.correct_count       = correct_count
+    a.wrong_click_count   = wrong_click_count
+    a.error_count         = error_count
+    a.avg_reaction_ms     = avg_reaction_ms
+    a.min_reaction_ms     = 310.0
+    a.stimuli_count       = stimuli_count
+    a.duration_seconds    = duration_seconds
+    a.raw_metrics         = raw_metrics
+    return a
+
+
+def _mock_db(*, count: int = 0) -> MagicMock:
+    db = MagicMock()
+    q  = MagicMock()
+    q.filter.return_value = q
+    q.count.return_value  = count
+    q.first.return_value  = None
+    q.all.return_value    = []
+    db.query.return_value = q
+    return db
+
+
+def _make_student(user_id: int = 42) -> MagicMock:
+    from app.models.user import UserRole
+    u = MagicMock()
+    u.id = user_id
+    u.role = UserRole.STUDENT
+    u.onboarding_completed = True
+    u.credit_balance = 0
+    u.specialization = MagicMock()
+    u.specialization.value = "LFA_FOOTBALL_PLAYER"
+    return u
+
+
+def _make_request(path: str = "/virtual-training/direction-swipe") -> MagicMock:
+    r = MagicMock()
+    r.url.path = path
+    r.cookies.get = MagicMock(return_value="testcsrf")
+    return r
+
+
+# ── DS-01..05: score_coordination ────────────────────────────────────────────
+
+class TestScoreCoordination:
+
+    def _sig(self, *, hit=1.0, wrong=0.0, speed=1.0, miss=0.0):
+        from app.services.virtual_training_metrics import VTSignals
+        return VTSignals(
+            hit_rate=hit, wrong_rate=wrong, miss_rate=miss,
+            speed_score=speed, completion_rate=1.0,
+        )
+
+    def test_ds01_perfect_run_clamps_to_1(self):
+        """DS-01: hit=1.0, wrong=0, speed=1.0 → 0.55+0.45=1.0 (clamped)."""
+        from app.services.virtual_training_metrics import VTSkillScorer
+        score = VTSkillScorer.score_coordination(self._sig(hit=1.0, wrong=0.0, speed=1.0))
+        assert abs(score - 1.0) < 1e-9
+
+    def test_ds02_all_wrong_direction_gives_negative(self):
+        """DS-02: wrong_rate=1.0, hit=0, speed=0 → 0 - 1.0 + 0 = -1.0."""
+        from app.services.virtual_training_metrics import VTSkillScorer
+        score = VTSkillScorer.score_coordination(self._sig(hit=0.0, wrong=1.0, speed=0.0))
+        assert score == pytest.approx(-1.0, abs=1e-9)
+
+    def test_ds03_all_missed_gives_zero(self):
+        """DS-03: hit=0, wrong=0, speed=0 → 0.0 (no wrong-dir errors, no speed, no hits)."""
+        from app.services.virtual_training_metrics import VTSkillScorer
+        score = VTSkillScorer.score_coordination(self._sig(hit=0.0, wrong=0.0, speed=0.0))
+        assert score == pytest.approx(0.0, abs=1e-9)
+
+    def test_ds04_mixed_run_correct_blend(self):
+        """DS-04: hit=0.8, wrong=0.1, speed=0.7 → 0.55×0.8 - 1.0×0.1 + 0.45×0.7."""
+        from app.services.virtual_training_metrics import VTSkillScorer
+        expected = 0.55 * 0.8 - 1.0 * 0.1 + 0.45 * 0.7
+        score = VTSkillScorer.score_coordination(self._sig(hit=0.8, wrong=0.1, speed=0.7))
+        assert score == pytest.approx(expected, abs=1e-9)
+
+    def test_ds05_wrong_dominant_is_very_negative(self):
+        """DS-05: wrong_rate=0.7 dominates → score well below 0."""
+        from app.services.virtual_training_metrics import VTSkillScorer
+        score = VTSkillScorer.score_coordination(self._sig(hit=0.2, wrong=0.7, speed=0.1))
+        assert score < -0.3
+
+
+# ── DS-06..08: VTSignalExtractor with DS config ───────────────────────────────
+
+class TestDSSignalExtraction:
+
+    def test_ds06_expected_total_is_36(self):
+        """DS-06: Phase sum 10+12+14=36 → expected_total=36, completion_rate=1.0."""
+        from app.services.virtual_training_metrics import VTSignalExtractor
+        data = {
+            "stimuli_count": 36, "correct_count": 36,
+            "wrong_click_count": 0, "error_count": 0, "avg_reaction_ms": None,
+        }
+        sig = VTSignalExtractor.extract(data, _DS_PHASE_CONFIG)
+        assert sig.completion_rate == pytest.approx(1.0)
+        assert sig.hit_rate == pytest.approx(1.0)
+
+    def test_ds07_speed_score_uses_ds_avg_window(self):
+        """DS-07: avg window = (1500+1100+750)/3 ≈ 1116.67 ms; rt=558 → speed≈0.5."""
+        from app.services.virtual_training_metrics import VTSignalExtractor
+        rt = _DS_AVG_WINDOW / 2   # exactly 50% of window
+        data = {
+            "stimuli_count": 36, "correct_count": 36,
+            "wrong_click_count": 0, "error_count": 0, "avg_reaction_ms": rt,
+        }
+        sig = VTSignalExtractor.extract(data, _DS_PHASE_CONFIG)
+        assert sig.speed_score == pytest.approx(0.5, abs=0.001)
+
+    def test_ds08_late_click_rate_from_v2_payload(self):
+        """DS-08: raw_metrics v=2 late_summary.late_click_count populates late_click_rate."""
+        from app.services.virtual_training_metrics import VTSignalExtractor
+        raw = {
+            "v": 2,
+            "per_phase": [],
+            "late_summary": {"late_click_count": 4},
+        }
+        data = {
+            "stimuli_count": 36, "correct_count": 32,
+            "wrong_click_count": 0, "error_count": 0, "avg_reaction_ms": None,
+            "raw_metrics": raw,
+        }
+        sig = VTSignalExtractor.extract(data, _DS_PHASE_CONFIG)
+        assert sig.late_click_rate == pytest.approx(4 / 36, abs=1e-6)
+
+
+# ── DS-09..10: score_all dispatching ─────────────────────────────────────────
+
+class TestScoreAllCoordination:
+
+    def _sig(self):
+        from app.services.virtual_training_metrics import VTSignals
+        return VTSignals(
+            hit_rate=0.9, wrong_rate=0.05, miss_rate=0.05,
+            speed_score=0.7, completion_rate=1.0,
+        )
+
+    def test_ds09_coordination_dispatches_to_scorer(self):
+        """DS-09: score_all with coordination key calls score_coordination (not fallback)."""
+        from app.services.virtual_training_metrics import VTSkillScorer
+        targets = {"coordination": 1.0}
+        scores = VTSkillScorer.score_all(self._sig(), targets)
+        # Manually compute expected coordination score
+        expected = 0.55 * 0.9 - 1.0 * 0.05 + 0.45 * 0.7
+        assert "coordination" in scores
+        assert scores["coordination"] == pytest.approx(expected, abs=1e-6)
+
+    def test_ds10_unknown_skill_uses_fallback(self):
+        """DS-10: unknown skill key uses mean of known scores, not coordination formula."""
+        from app.services.virtual_training_metrics import VTSkillScorer
+        targets = {"coordination": 1.0, "unknown_skill": 0.5}
+        scores = VTSkillScorer.score_all(self._sig(), targets)
+        # unknown_skill should be a scalar (the mean of all known scorers)
+        assert "unknown_skill" in scores
+        assert 0.0 <= scores["unknown_skill"] <= 1.0
+
+
+# ── DS-11..13: validate_attempt for Direction Swipe ──────────────────────────
+
+class TestValidateAttemptDS:
+
+    def test_ds11_valid_full_round(self):
+        """DS-11: 36 stimuli, 32 correct, duration=40s → is_valid=True."""
+        from app.services.virtual_training_service import VirtualTrainingService
+        data = {
+            "stimuli_count": 36, "correct_count": 32,
+            "wrong_click_count": 2, "error_count": 2,
+            "avg_reaction_ms": 480.0, "duration_seconds": 40.0,
+        }
+        valid, reason = VirtualTrainingService.validate_attempt(data)
+        assert valid is True
+        assert reason is None
+
+    def test_ds12_too_short_fails(self):
+        """DS-12: duration=10s → too_short."""
+        from app.services.virtual_training_service import VirtualTrainingService
+        data = {
+            "stimuli_count": 36, "correct_count": 32,
+            "wrong_click_count": 0, "error_count": 0,
+            "avg_reaction_ms": 300.0, "duration_seconds": 10.0,
+        }
+        valid, reason = VirtualTrainingService.validate_attempt(data)
+        assert valid is False
+        assert reason == "too_short"
+
+    def test_ds13_random_clicking_fails(self):
+        """DS-13: wrong_click_count > 0.55 * stimuli → random_clicking."""
+        from app.services.virtual_training_service import VirtualTrainingService
+        # 21 wrong out of 36 = 0.583 > 0.55
+        data = {
+            "stimuli_count": 36, "correct_count": 15,
+            "wrong_click_count": 21, "error_count": 0,
+            "avg_reaction_ms": 600.0, "duration_seconds": 42.0,
+        }
+        valid, reason = VirtualTrainingService.validate_attempt(data)
+        assert valid is False
+        assert reason == "random_clicking"
+
+
+# ── DS-14..16: compute_vt_skill_deltas for coordination ──────────────────────
+
+class TestDSSkillDeltas:
+
+    def test_ds14_perfect_coordination_delta_positive(self):
+        """DS-14: Perfect DS run → coordination delta is positive."""
+        from app.services.virtual_training_metrics import compute_vt_skill_deltas
+        game = _mock_ds_game()
+        data = {
+            "stimuli_count": 36, "correct_count": 36,
+            "wrong_click_count": 0, "error_count": 0,
+            "avg_reaction_ms": 400.0, "duration_seconds": 40.0,
+            "raw_metrics": None,
+        }
+        deltas = compute_vt_skill_deltas(
+            data=data, game=game, multiplier=1.0, existing_neg_today={}
+        )
+        assert "coordination" in deltas
+        assert deltas["coordination"] > 0
+
+    def test_ds15_wrong_direction_heavy_delta_negative(self):
+        """DS-15: Heavy wrong_direction run → coordination delta is negative."""
+        from app.services.virtual_training_metrics import compute_vt_skill_deltas
+        game = _mock_ds_game()
+        # 25 wrong out of 36 (69%) — will trip wrong_rate domination
+        data = {
+            "stimuli_count": 36, "correct_count": 5,
+            "wrong_click_count": 25, "error_count": 6,
+            "avg_reaction_ms": 900.0, "duration_seconds": 38.0,
+            "raw_metrics": None,
+        }
+        deltas = compute_vt_skill_deltas(
+            data=data, game=game, multiplier=1.0, existing_neg_today={}
+        )
+        assert "coordination" in deltas
+        assert deltas["coordination"] < 0
+
+    def test_ds16_daily_neg_cap_limits_coordination_loss(self):
+        """DS-16: existing_neg_today at cap → additional coordination delta is 0."""
+        from app.services.virtual_training_metrics import compute_vt_skill_deltas
+        game = _mock_ds_game()
+        data = {
+            "stimuli_count": 36, "correct_count": 0,
+            "wrong_click_count": 28, "error_count": 8,
+            "avg_reaction_ms": 1000.0, "duration_seconds": 38.0,
+            "raw_metrics": None,
+        }
+        # Cap already reached for coordination
+        existing_neg = {"coordination": -0.50}
+        deltas = compute_vt_skill_deltas(
+            data=data, game=game, multiplier=1.0,
+            existing_neg_today=existing_neg,
+        )
+        # coordination delta capped: should be 0 (not further negative)
+        assert deltas.get("coordination", 0) >= 0
+
+
+# ── DS-17..18: GET game page ──────────────────────────────────────────────────
+
+class TestDirectionSwipePage:
+
+    def test_ds17_active_game_returns_200(self):
+        """DS-17: GET /virtual-training/direction-swipe → 200 for active game."""
+        from app.api.web_routes.virtual_training import virtual_training_direction_swipe
+
+        user    = _make_student()
+        request = _make_request()
+        db      = _mock_db()
+        game    = _mock_ds_game()
+
+        fake_resp = MagicMock(spec=HTMLResponse)
+        fake_resp.status_code = 200
+
+        with patch(f"{_ROUTES}.require_student_onboarding", return_value=None), \
+             patch(f"{_ROUTES}._spec_ctx", return_value={}), \
+             patch(f"{_ROUTES}.VirtualTrainingService.get_game", return_value=game), \
+             patch(f"{_ROUTES}.templates") as mock_tmpl:
+            mock_tmpl.TemplateResponse.return_value = fake_resp
+            result = _run(virtual_training_direction_swipe(
+                request=request, db=db, user=user
+            ))
+
+        assert result is fake_resp
+        call_args = mock_tmpl.TemplateResponse.call_args
+        assert call_args[0][0] == "virtual_training_direction_swipe.html"
+        ctx = call_args[0][1]
+        assert ctx["game"] is game
+
+    def test_ds18_inactive_game_returns_hub(self):
+        """DS-18: GET → renders hub with error message when game is inactive."""
+        from app.api.web_routes.virtual_training import virtual_training_direction_swipe
+
+        user    = _make_student()
+        request = _make_request()
+        db      = _mock_db()
+        game    = _mock_ds_game(is_active=False)
+
+        fake_hub = MagicMock(spec=HTMLResponse)
+        fake_hub.status_code = 200
+
+        with patch(f"{_ROUTES}.require_student_onboarding", return_value=None), \
+             patch(f"{_ROUTES}._spec_ctx", return_value={}), \
+             patch(f"{_ROUTES}.VirtualTrainingService.get_game", return_value=game), \
+             patch(f"{_ROUTES}.VirtualTrainingService.get_hub_games", return_value=[game]), \
+             patch(f"{_ROUTES}.templates") as mock_tmpl:
+            mock_tmpl.TemplateResponse.return_value = fake_hub
+            result = _run(virtual_training_direction_swipe(
+                request=request, db=db, user=user
+            ))
+
+        call_args = mock_tmpl.TemplateResponse.call_args
+        assert call_args[0][0] == "virtual_training_hub.html"
+        ctx = call_args[0][1]
+        assert "error" in ctx
+
+
+# ── DS-19..21: POST submit ────────────────────────────────────────────────────
+
+class TestDirectionSwipeSubmit:
+
+    _VALID_PAYLOAD = {
+        "started_at":        "2026-05-23T10:00:00.000Z",
+        "duration_seconds":  42.0,
+        "stimuli_count":     36,
+        "correct_count":     32,
+        "wrong_click_count": 2,
+        "error_count":       2,
+        "avg_reaction_ms":   520.0,
+        "min_reaction_ms":   310.0,
+        "score_raw":         0.78,
+        "score_normalized":  78.0,
+        "raw_metrics": {
+            "v": 2,
+            "per_stimulus": [],
+            "per_phase": [],
+            "late_summary": {"late_click_count": 0},
+        },
+    }
+
+    def test_ds19_valid_submit_returns_attempt_id(self):
+        """DS-19: Valid POST → 200 JSON with attempt_id."""
+        from app.api.web_routes.virtual_training import virtual_training_direction_swipe_submit
+        import json
+
+        user    = _make_student()
+        request = _make_request("/virtual-training/direction-swipe/submit")
+        async def _fake_json():
+            return self._VALID_PAYLOAD
+        request.json = _fake_json
+
+        db      = _mock_db(count=0)
+        game    = _mock_ds_game()
+        attempt = _mock_attempt()
+
+        with patch(f"{_ROUTES}.require_student_onboarding", return_value=None), \
+             patch(f"{_ROUTES}.VirtualTrainingService.get_game", return_value=game), \
+             patch(f"{_ROUTES}.VirtualTrainingService.record_attempt", return_value=attempt), \
+             patch.object(db, "commit"):
+            result = _run(virtual_training_direction_swipe_submit(
+                request=request, db=db, user=user
+            ))
+
+        assert isinstance(result, JSONResponse)
+        body = json.loads(result.body)
+        assert body["attempt_id"] == 77
+        assert body["is_valid"] is True
+
+    def test_ds20_daily_cap_returns_429(self):
+        """DS-20: count >= max_daily_attempts → 429 daily_cap."""
+        from app.api.web_routes.virtual_training import virtual_training_direction_swipe_submit
+        import json
+
+        user    = _make_student()
+        request = _make_request("/virtual-training/direction-swipe/submit")
+        async def _fake_json():
+            return self._VALID_PAYLOAD
+        request.json = _fake_json
+
+        db   = _mock_db(count=5)   # already at limit
+        game = _mock_ds_game()
+
+        with patch(f"{_ROUTES}.require_student_onboarding", return_value=None), \
+             patch(f"{_ROUTES}.VirtualTrainingService.get_game", return_value=game):
+            result = _run(virtual_training_direction_swipe_submit(
+                request=request, db=db, user=user
+            ))
+
+        assert result.status_code == 429
+        body = json.loads(result.body)
+        assert body["error"] == "daily_cap"
+
+    def test_ds21_inactive_game_returns_404(self):
+        """DS-21: Inactive game → 404."""
+        from app.api.web_routes.virtual_training import virtual_training_direction_swipe_submit
+
+        user    = _make_student()
+        request = _make_request("/virtual-training/direction-swipe/submit")
+        async def _fake_json():
+            return self._VALID_PAYLOAD
+        request.json = _fake_json
+
+        db   = _mock_db()
+        game = _mock_ds_game(is_active=False)
+
+        with patch(f"{_ROUTES}.require_student_onboarding", return_value=None), \
+             patch(f"{_ROUTES}.VirtualTrainingService.get_game", return_value=game):
+            result = _run(virtual_training_direction_swipe_submit(
+                request=request, db=db, user=user
+            ))
+
+        assert result.status_code == 404
+
+
+# ── DS-22..23: GET result page ────────────────────────────────────────────────
+
+class TestDirectionSwipeResult:
+
+    def test_ds22_result_owner_gets_200(self):
+        """DS-22: GET result/{id} with correct user → 200 result template."""
+        from app.api.web_routes.virtual_training import virtual_training_direction_swipe_result
+
+        user    = _make_student()
+        request = _make_request("/virtual-training/direction-swipe/result/77")
+        db      = _mock_db()
+        attempt = _mock_attempt()
+        game    = _mock_ds_game()
+
+        fake_resp = MagicMock(spec=HTMLResponse)
+        fake_resp.status_code = 200
+
+        db.query.return_value.filter.return_value.first.return_value = attempt
+
+        with patch(f"{_ROUTES}.require_student_onboarding", return_value=None), \
+             patch(f"{_ROUTES}._spec_ctx", return_value={}), \
+             patch(f"{_ROUTES}.templates") as mock_tmpl:
+            # Second .first() call returns game
+            mock_tmpl.TemplateResponse.return_value = fake_resp
+            db.query.return_value.filter.return_value.first.side_effect = [attempt, game]
+            result = _run(virtual_training_direction_swipe_result(
+                attempt_id=77, request=request, db=db, user=user
+            ))
+
+        assert result is fake_resp
+        call_args = mock_tmpl.TemplateResponse.call_args
+        assert call_args[0][0] == "virtual_training_direction_swipe_result.html"
+
+    def test_ds23_result_not_found_renders_hub(self):
+        """DS-23: Attempt not found → hub template with error."""
+        from app.api.web_routes.virtual_training import virtual_training_direction_swipe_result
+
+        user    = _make_student()
+        request = _make_request("/virtual-training/direction-swipe/result/99")
+        db      = _mock_db()
+
+        fake_hub = MagicMock(spec=HTMLResponse)
+
+        with patch(f"{_ROUTES}.require_student_onboarding", return_value=None), \
+             patch(f"{_ROUTES}._spec_ctx", return_value={}), \
+             patch(f"{_ROUTES}.VirtualTrainingService.get_hub_games", return_value=[]), \
+             patch(f"{_ROUTES}.templates") as mock_tmpl:
+            mock_tmpl.TemplateResponse.return_value = fake_hub
+            db.query.return_value.filter.return_value.first.return_value = None
+            result = _run(virtual_training_direction_swipe_result(
+                attempt_id=99, request=request, db=db, user=user
+            ))
+
+        call_args = mock_tmpl.TemplateResponse.call_args
+        assert call_args[0][0] == "virtual_training_hub.html"
+        ctx = call_args[0][1]
+        assert "error" in ctx
+
+
+# ── DS-24: Seed guard ─────────────────────────────────────────────────────────
+
+class TestDirectionSwipeSeed:
+
+    def test_ds24_direction_swipe_is_active_in_seed(self):
+        """DS-24: Seed data has direction_swipe with is_active=True."""
+        from scripts.seed_virtual_training_games import _GAMES
+        ds = next((g for g in _GAMES if g["code"] == "direction_swipe"), None)
+        assert ds is not None, "direction_swipe preset missing from seed"
+        assert ds["is_active"] is True
+        assert ds["game_type"] == "direction_reaction"
+        cfg = ds["config"]
+        assert len(cfg["phases"]) == 3
+        assert sum(p["stimuli"] for p in cfg["phases"]) == 36
+        assert cfg["late_grace_ms"] == 300
+        assert "up" in cfg["directions"]
+        assert cfg["show_in_hub"] is True

--- a/tests/unit/services/test_virtual_training_service.py
+++ b/tests/unit/services/test_virtual_training_service.py
@@ -259,10 +259,10 @@ class TestSkillDeltas:
 class TestSeedData:
 
     def test_vt16_seed_presets_present_and_correct_active_state(self):
-        """VT-16: Seed contains 12 games; color_reaction+go_no_go+memory_sequence+target_tracking active; stroop_challenge hidden; rest planned."""
+        """VT-16: Seed contains 12 games; color_reaction+go_no_go+memory_sequence+target_tracking+direction_swipe active; stroop_challenge hidden; rest planned."""
         from scripts.seed_virtual_training_games import _GAMES
 
-        # 4 active + 1 hidden + 7 planned = 12 total
+        # 5 active + 1 hidden + 6 planned = 12 total
         assert len(_GAMES) == 12
 
         codes = {g["code"] for g in _GAMES}
@@ -283,8 +283,8 @@ class TestSeedData:
 
         game_map = {g["code"]: g for g in _GAMES}
 
-        # Active state — 4 active games on this branch
-        _active_games = {"color_reaction", "go_no_go", "memory_sequence", "target_tracking"}
+        # Active state — 5 active games
+        _active_games = {"color_reaction", "go_no_go", "memory_sequence", "target_tracking", "direction_swipe"}
         for code in _active_games:
             assert game_map[code]["is_active"] is True, f"{code} must be active"
         for code in codes - _active_games:


### PR DESCRIPTION
## Summary

- **New game**: Direction Swipe (↑↓←→) — 4-direction reaction game, touch + keyboard
- **3 phases**: 10/12/14 stimuli at 1500/1100/750 ms windows, 36 stimuli total
- **raw_metrics v=2**: per_stimulus (outcome, rt_ms, input_mode, direction), per_phase, late_summary
- **score_coordination()**: `0.55×hit_rate − 1.0×wrong_rate + 0.45×speed_score` — dedicated scorer for motor-visual accuracy; wrong-direction errors penalised at 1.0× (heavier than misses, lighter than decisions)
- **No hand/finger protocol**: Direction Swipe uses free-touch/keyboard, no PDM, no v3 raw_metrics
- **Seed updated**: `direction_swipe` → `is_active=True`, full gameplay config applied to DB

## Files changed

| File | Change |
|------|--------|
| `app/services/virtual_training_metrics.py` | `score_coordination()` + registered in `score_all()` |
| `app/api/web_routes/virtual_training.py` | 3 routes: GET/POST direction-swipe, GET result/{id} |
| `app/templates/virtual_training_direction_swipe.html` | Game template — touch swipe + arrow keys |
| `app/templates/virtual_training_direction_swipe_result.html` | Result template — per-phase table, skill breakdown |
| `scripts/seed_virtual_training_games.py` | direction_swipe → is_active=True, full config |
| `tests/unit/api/web_routes/test_direction_swipe.py` | 24 DS-* tests |
| `tests/unit/services/test_virtual_training_service.py` | VT-16 updated: direction_swipe added to active set |
| `tests/snapshots/openapi_snapshot.json` | 775 → 777 routes |

## Test plan

- [ ] DS-01..05: score_coordination edge cases (perfect, all-wrong, missed, mixed, worst-case)
- [ ] DS-06..08: VTSignalExtractor with DS phase config (expected_total=36, avg window, late_click_rate)
- [ ] DS-09..10: score_all dispatching — coordination key vs. unknown fallback
- [ ] DS-11..13: validate_attempt — valid, too_short, random_clicking
- [ ] DS-14..16: compute_vt_skill_deltas — positive, negative, daily neg cap
- [ ] DS-17..18: GET game page — active 200, inactive → hub
- [ ] DS-19..21: POST submit — valid, daily cap 429, inactive 404
- [ ] DS-22..23: GET result — owner 200, not found → hub
- [ ] DS-24: Seed guard — direction_swipe is_active=True, 36 stimuli, late_grace_ms=300
- [ ] Full regression: 10250/10250 PASS ✅

## Manual validation checklist

- [ ] `/virtual-training` hub shows Direction Swipe card with ▶ Play button
- [ ] `/virtual-training/direction-swipe` loads game page
- [ ] Arrow display renders (↑↓←→), keyboard arrow keys respond
- [ ] Touch swipe works on mobile / touch screen
- [ ] Score submitted → redirects to result page
- [ ] Result shows per-phase table + skill breakdown with coordination formula
- [ ] Invalid attempt shows warning card (try: close tab immediately)
- [ ] History page shows Direction Swipe attempts with correct game name link

🤖 Generated with [Claude Code](https://claude.ai/claude-code)