### PR TITLE
feat(vt): Phase 2.3 — Number-Color Conflict game

### DIFF
--- a/app/api/web_routes/virtual_training.py
+++ b/app/api/web_routes/virtual_training.py
@@ -1568,3 +1568,226 @@ async def virtual_training_direction_swipe_result(
             "is_admin":     is_admin,
         },
     )
+
+
+# ── Number-Color Conflict game page ──────────────────────────────────────────
+
+@router.get("/virtual-training/number-color-conflict", response_class=HTMLResponse)
+async def virtual_training_number_color_conflict(
+    request: Request,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user_web),
+):
+    """Number-Color Conflict game page — instructions + Vanilla JS game loop."""
+    guard = require_student_onboarding(user)
+    if guard:
+        return guard
+
+    game = VirtualTrainingService.get_game(db, "number_color_conflict")
+    if game is None or not game.is_active:
+        all_games = VirtualTrainingService.get_hub_games(db)
+        return templates.TemplateResponse(
+            "virtual_training_hub.html",
+            {
+                "request": request,
+                "user": user,
+                **_spec_ctx(user, db),
+                "all_games": all_games,
+                "error": "Number-Color Conflict is not available at this time.",
+            },
+        )
+
+    today_start = datetime.combine(
+        datetime.now(timezone.utc).date(),
+        datetime.min.time(),
+    ).replace(tzinfo=timezone.utc)
+    attempts_today = (
+        db.query(VirtualTrainingAttempt)
+        .filter(
+            VirtualTrainingAttempt.user_id == user.id,
+            VirtualTrainingAttempt.game_id == game.id,
+            VirtualTrainingAttempt.started_at >= today_start,
+            VirtualTrainingAttempt.is_valid == True,  # noqa: E712
+        )
+        .count()
+    )
+
+    assigned_protocol = VirtualTrainingService.assign_protocol(db, user.id, game.id)
+
+    return templates.TemplateResponse(
+        "virtual_training_number_color_conflict.html",
+        {
+            "request": request,
+            "user": user,
+            **_spec_ctx(user, db),
+            "game": game,
+            "attempts_today": attempts_today,
+            "max_daily_attempts": game.max_daily_attempts,
+            "attempts_remaining": max(0, game.max_daily_attempts - attempts_today),
+            "assigned_protocol": assigned_protocol,
+        },
+    )
+
+
+# ── Number-Color Conflict submit (JSON API) ───────────────────────────────────
+
+@router.post("/virtual-training/number-color-conflict/submit")
+async def virtual_training_number_color_conflict_submit(
+    request: Request,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user_web),
+):
+    """Record a Number-Color Conflict attempt. Returns attempt_id, xp_awarded, is_valid."""
+    guard = require_student_onboarding(user)
+    if guard:
+        return JSONResponse({"error": "onboarding required"}, status_code=403)
+
+    game = VirtualTrainingService.get_game(db, "number_color_conflict")
+    if game is None or not game.is_active:
+        return JSONResponse({"error": "game not available"}, status_code=404)
+
+    body = await request.json()
+
+    today_start = datetime.combine(
+        datetime.now(timezone.utc).date(),
+        datetime.min.time(),
+    ).replace(tzinfo=timezone.utc)
+    valid_today = (
+        db.query(VirtualTrainingAttempt)
+        .filter(
+            VirtualTrainingAttempt.user_id == user.id,
+            VirtualTrainingAttempt.game_id == game.id,
+            VirtualTrainingAttempt.started_at >= today_start,
+            VirtualTrainingAttempt.is_valid == True,  # noqa: E712
+        )
+        .count()
+    )
+    if valid_today >= game.max_daily_attempts:
+        return JSONResponse(
+            {"error": "daily_cap", "message": "Daily attempt limit reached for this game."},
+            status_code=429,
+        )
+
+    started_at_raw = body.get("started_at", "")
+    idem_key = f"vt_ncc_u{user.id}_{started_at_raw}"
+
+    attempt = VirtualTrainingService.record_attempt(
+        db=db,
+        user_id=user.id,
+        game=game,
+        data=body,
+        idempotency_key=idem_key,
+    )
+
+    db.commit()
+
+    return JSONResponse({
+        "attempt_id": attempt.id,
+        "is_valid": attempt.is_valid,
+        "invalid_reason": attempt.invalid_reason,
+        "xp_awarded": attempt.xp_awarded,
+        "skill_deltas": attempt.skill_deltas,
+        "attempt_index_today": attempt.attempt_index_today,
+        "score_normalized": attempt.score_normalized,
+    })
+
+
+# ── Number-Color Conflict result page ────────────────────────────────────────
+
+@router.get("/virtual-training/number-color-conflict/result/{attempt_id}",
+            response_class=HTMLResponse)
+async def virtual_training_number_color_conflict_result(
+    attempt_id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user_web),
+):
+    """Result screen for a completed Number-Color Conflict attempt."""
+    guard = require_student_onboarding(user)
+    if guard:
+        return guard
+
+    attempt = (
+        db.query(VirtualTrainingAttempt)
+        .filter(
+            VirtualTrainingAttempt.id == attempt_id,
+            VirtualTrainingAttempt.user_id == user.id,
+        )
+        .first()
+    )
+    if attempt is None:
+        all_games = VirtualTrainingService.get_hub_games(db)
+        return templates.TemplateResponse(
+            "virtual_training_hub.html",
+            {
+                "request": request,
+                "user": user,
+                **_spec_ctx(user, db),
+                "all_games": all_games,
+                "error": "Attempt not found.",
+            },
+        )
+
+    game = db.query(VirtualTrainingGame).filter(
+        VirtualTrainingGame.id == attempt.game_id
+    ).first()
+
+    skill_scores: dict = {}
+    signals_ctx: dict = {}
+    if attempt.skill_deltas and game is not None:
+        from ...services.virtual_training_metrics import VTSignalExtractor, VTSkillScorer
+        cfg          = game.config or {}
+        phase_config = cfg.get("phases", []) if isinstance(cfg, dict) else []
+        data_for_signals = {
+            "stimuli_count":     attempt.stimuli_count,
+            "correct_count":     attempt.correct_count,
+            "wrong_click_count": attempt.wrong_click_count,
+            "error_count":       attempt.error_count,
+            "avg_reaction_ms":   attempt.avg_reaction_ms,
+            "raw_metrics":       attempt.raw_metrics,
+        }
+        signals = VTSignalExtractor.extract(data_for_signals, phase_config)
+        skill_scores = VTSkillScorer.score_all(signals, game.skill_targets or {})
+        signals_ctx = {
+            "hit_rate":        round(signals.hit_rate * 100, 1),
+            "wrong_rate":      round(signals.wrong_rate * 100, 1),
+            "miss_rate":       round(signals.miss_rate * 100, 1),
+            "speed_score":     round(signals.speed_score * 100, 1),
+            "completion_rate": round(signals.completion_rate * 100, 1),
+            "avg_reaction_ms": signals.avg_reaction_ms,
+        }
+
+    per_phase: list = []
+    per_stimulus: list = []
+    late_summary: dict | None = None
+    raw = attempt.raw_metrics
+    if isinstance(raw, dict) and raw.get("v", 1) >= 1:
+        per_phase    = raw.get("per_phase")    or []
+        per_stimulus = raw.get("per_stimulus") or []
+    if isinstance(raw, dict) and raw.get("v", 1) >= 2:
+        late_summary = raw.get("late_summary") or None
+
+    hand_profile: dict | None = None
+    if isinstance(raw, dict) and int(raw.get("v", 1)) >= 3:
+        hand_profile = raw.get("hand_profile") or None
+
+    from ...models.user import UserRole
+    is_admin = user.role == UserRole.ADMIN
+
+    return templates.TemplateResponse(
+        "virtual_training_number_color_conflict_result.html",
+        {
+            "request": request,
+            "user": user,
+            **_spec_ctx(user, db),
+            "attempt": attempt,
+            "game": game,
+            "skill_scores": skill_scores,
+            "signals_ctx":  signals_ctx,
+            "per_phase":     per_phase,
+            "per_stimulus":  per_stimulus,
+            "late_summary":  late_summary,
+            "hand_profile":  hand_profile,
+            "is_admin":      is_admin,
+        },
+    )

--- a/app/templates/virtual_training_number_color_conflict.html
+++ b/app/templates/virtual_training_number_color_conflict.html
@@ -1,0 +1,877 @@
+{% extends "student_base.html" %}
+{% from "macros/vt_protocol_hand.html" import protocol_hand_diagram %}
+
+{% block title %}Number-Color Conflict - LFA{% endblock %}
+{% block active_page %}lfa-player{% endblock %}
+
+{% block student_header %}
+{% set _page_icon = '🔢' %}
+{% set _page_name = 'Number-Color Conflict' %}
+{% include "includes/spec_subpage_hdr.html" %}
+{% endblock %}
+
+{% block extra_styles %}
+<style>
+    .ncc-container {
+        max-width: 560px;
+        margin: 0 auto;
+        padding: 1.5rem 1rem 3rem;
+    }
+
+    /* ── Meta bar ───────────────────────────────────────────────────────── */
+    .ncc-meta {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        background: var(--app-card);
+        border-radius: 10px;
+        padding: 0.65rem 1rem;
+        margin-bottom: 1.25rem;
+        font-size: 0.85rem;
+        color: var(--app-text-muted);
+        box-shadow: 0 1px 6px rgba(0,0,0,0.06);
+    }
+    .ncc-meta span { font-weight: 600; color: var(--app-text); }
+
+    /* ── Instruction card ───────────────────────────────────────────────── */
+    .ncc-instruction {
+        background: var(--app-card);
+        border-radius: 14px;
+        padding: 1.5rem 1.5rem 1.75rem;
+        box-shadow: 0 2px 10px rgba(0,0,0,0.07);
+        text-align: center;
+        margin-bottom: 1.5rem;
+    }
+    .ncc-instruction h2 {
+        font-size: 1.3rem;
+        font-weight: 700;
+        margin: 0 0 0.6rem;
+        color: var(--app-text);
+    }
+    .ncc-instruction p {
+        font-size: 0.9rem;
+        color: var(--app-text-muted);
+        line-height: 1.6;
+        margin: 0 0 1.25rem;
+    }
+    .ncc-rule-examples {
+        display: flex;
+        justify-content: center;
+        gap: 1.5rem;
+        margin-bottom: 1.25rem;
+        flex-wrap: wrap;
+    }
+    .ncc-rule-item {
+        background: #f3f4f6;
+        border-radius: 10px;
+        padding: 0.6rem 1rem;
+        font-size: 0.82rem;
+        font-weight: 700;
+        color: var(--app-text);
+        text-align: center;
+    }
+    .ncc-rule-item .ncc-rule-label {
+        font-size: 0.7rem;
+        font-weight: 600;
+        color: var(--app-text-muted);
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        display: block;
+        margin-bottom: 0.25rem;
+    }
+    .ncc-skill-chips {
+        display: flex;
+        justify-content: center;
+        gap: 0.5rem;
+        flex-wrap: wrap;
+        margin-bottom: 1.25rem;
+    }
+    .ncc-skill-chip {
+        font-size: 0.75rem;
+        font-weight: 600;
+        background: #ede9fe;
+        color: #5b21b6;
+        padding: 0.2rem 0.65rem;
+        border-radius: 20px;
+    }
+    .ncc-btn-start {
+        display: inline-block;
+        background: #4f46e5;
+        color: #fff;
+        font-size: 1rem;
+        font-weight: 700;
+        padding: 0.8rem 2.5rem;
+        border-radius: 10px;
+        border: none;
+        cursor: pointer;
+        transition: background 0.15s;
+    }
+    .ncc-btn-start:hover { background: #4338ca; }
+    .ncc-btn-start:disabled {
+        background: #9ca3af;
+        cursor: not-allowed;
+    }
+
+    /* ── System-assigned protocol card ──────────────────────────────────── */
+    .ncc-protocol-card {
+        background: var(--app-card);
+        border: 1px solid #c7d2fe;
+        border-radius: 14px;
+        padding: 1.1rem 1.4rem;
+        box-shadow: 0 2px 10px rgba(0,0,0,0.06);
+        margin-bottom: 1.5rem;
+    }
+    .ncc-protocol-card-header {
+        display: flex;
+        align-items: center;
+        gap: 0.45rem;
+        margin-bottom: 0.55rem;
+    }
+    .ncc-protocol-card-title {
+        font-size: 0.78rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        color: var(--app-text-muted);
+    }
+    .ncc-protocol-card-combo {
+        font-size: 1.15rem;
+        font-weight: 800;
+        color: #3730a3;
+        letter-spacing: 0.02em;
+        margin-bottom: 0.15rem;
+    }
+    .ncc-protocol-card-mult {
+        font-size: 0.82rem;
+        font-weight: 600;
+        color: #4f46e5;
+        margin-bottom: 0.6rem;
+    }
+    .ncc-protocol-card-info {
+        font-size: 0.75rem;
+        color: var(--app-text-muted);
+        line-height: 1.5;
+        border-top: 1px solid #e0e7ff;
+        padding-top: 0.5rem;
+    }
+
+    /* ── Hand/finger diagram ────────────────────────────────────────────── */
+    .vt-hd-wrap {
+        display: flex;
+        justify-content: center;
+        align-items: flex-end;
+        gap: 4px;
+        margin: 0.4rem 0 0.85rem;
+    }
+    .vt-hd-svg { width: 60px; height: 88px; }
+
+    /* ── Game arena ─────────────────────────────────────────────────────── */
+    .ncc-arena { display: none; }
+    .ncc-arena.active { display: block; }
+
+    /* ── Progress + timer bar ───────────────────────────────────────────── */
+    .ncc-hud {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 0.75rem;
+        font-size: 0.82rem;
+        color: var(--app-text-muted);
+        font-weight: 600;
+    }
+    .ncc-progress-wrap {
+        background: #e5e7eb;
+        border-radius: 6px;
+        height: 6px;
+        margin-bottom: 1rem;
+        overflow: hidden;
+    }
+    .ncc-progress-bar {
+        height: 100%;
+        background: #4f46e5;
+        border-radius: 6px;
+        transition: width 0.2s ease;
+        width: 0%;
+    }
+
+    /* ── Counters row ───────────────────────────────────────────────────── */
+    .ncc-counters {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 0.5rem;
+        margin-bottom: 1rem;
+    }
+    .ncc-counter {
+        background: var(--app-card);
+        border-radius: 10px;
+        padding: 0.6rem 0.5rem;
+        text-align: center;
+        box-shadow: 0 1px 4px rgba(0,0,0,0.05);
+    }
+    .ncc-counter-label {
+        font-size: 0.65rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: var(--app-text-muted);
+        margin-bottom: 0.2rem;
+    }
+    .ncc-counter-value {
+        font-size: 1.1rem;
+        font-weight: 800;
+        color: var(--app-text);
+    }
+    .ncc-counter-value.hit-color   { color: #16a34a; }
+    .ncc-counter-value.miss-color  { color: #d97706; }
+    .ncc-counter-value.wrong-color { color: #dc2626; }
+    .ncc-counter-value.late-color  { color: #9333ea; }
+
+    /* ── Stimulus card ──────────────────────────────────────────────────── */
+    .ncc-field {
+        background: var(--app-card);
+        border-radius: 16px;
+        box-shadow: 0 2px 14px rgba(0,0,0,0.09);
+        min-height: 260px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        margin-bottom: 1rem;
+        position: relative;
+        overflow: hidden;
+        user-select: none;
+        -webkit-user-select: none;
+    }
+
+    /* ── Rule banner ────────────────────────────────────────────────────── */
+    .ncc-rule-banner {
+        font-size: 0.78rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--app-text-muted);
+        margin-bottom: 0.75rem;
+        padding: 0.25rem 0.75rem;
+        background: #f3f4f6;
+        border-radius: 20px;
+    }
+
+    /* ── Stimulus display ───────────────────────────────────────────────── */
+    .ncc-stimulus { display: none; text-align: center; }
+    .ncc-stimulus.visible { display: block; }
+
+    .ncc-stim-number {
+        font-size: 4rem;
+        font-weight: 900;
+        line-height: 1;
+        margin-bottom: 0.5rem;
+    }
+    .ncc-stim-color-patch {
+        width: 60px;
+        height: 60px;
+        border-radius: 50%;
+        margin: 0 auto 0.5rem;
+    }
+
+    .ncc-field-idle {
+        font-size: 0.9rem;
+        color: var(--app-text-muted);
+        font-weight: 600;
+    }
+
+    /* ── Answer buttons ─────────────────────────────────────────────────── */
+    .ncc-answers {
+        display: none;
+        gap: 0.5rem;
+        flex-wrap: wrap;
+        justify-content: center;
+        margin-bottom: 1rem;
+    }
+    .ncc-answers.visible { display: flex; }
+
+    .ncc-ans-btn {
+        min-width: 64px;
+        padding: 0.65rem 1rem;
+        border-radius: 10px;
+        border: 2px solid transparent;
+        font-size: 1rem;
+        font-weight: 700;
+        cursor: pointer;
+        transition: transform 0.08s ease, border-color 0.1s;
+        color: #fff;
+    }
+    .ncc-ans-btn:active { transform: scale(0.94); }
+
+    /* ── Feedback flash ─────────────────────────────────────────────────── */
+    .ncc-feedback {
+        position: absolute;
+        top: 12px;
+        left: 50%;
+        transform: translateX(-50%);
+        font-size: 0.82rem;
+        font-weight: 800;
+        padding: 0.25rem 0.85rem;
+        border-radius: 20px;
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.15s;
+        white-space: nowrap;
+    }
+    .ncc-feedback.show { opacity: 1; }
+    .ncc-feedback.fb-hit   { background: #dcfce7; color: #166534; }
+    .ncc-feedback.fb-miss  { background: #fef3c7; color: #92400e; }
+    .ncc-feedback.fb-wrong { background: #fee2e2; color: #991b1b; }
+    .ncc-feedback.fb-late  { background: #f3e8ff; color: #6b21a8; }
+
+    /* ── Submitting overlay ─────────────────────────────────────────────── */
+    .ncc-submitting {
+        display: none;
+        text-align: center;
+        padding: 3rem 1rem;
+        background: var(--app-card);
+        border-radius: 16px;
+        box-shadow: 0 2px 14px rgba(0,0,0,0.09);
+        color: var(--app-text-muted);
+        font-size: 0.95rem;
+        font-weight: 600;
+    }
+    .ncc-submitting.active { display: block; }
+    .ncc-submitting p { margin: 0.5rem 0 0; }
+</style>
+{% endblock %}
+
+{% block student_content %}
+<div class="ncc-container">
+
+    {# ── Meta bar ─────────────────────────────────────────────────────────── #}
+    <div class="ncc-meta">
+        <div>Today: <span>{{ attempts_today }} / {{ max_daily_attempts }}</span> attempts</div>
+        <div>Remaining: <span>{{ attempts_remaining }}</span></div>
+    </div>
+
+    {# ── Daily cap reached ────────────────────────────────────────────────── #}
+    {% if attempts_remaining == 0 %}
+    <div style="background:#fef3c7;border:1px solid #f59e0b;border-radius:12px;padding:1rem 1.25rem;text-align:center;margin-bottom:1.25rem;color:#92400e;font-weight:600;font-size:0.9rem;">
+        Daily limit reached. Come back tomorrow to earn XP again.
+    </div>
+    {% endif %}
+
+    {# ── Instruction screen (pre-game) ────────────────────────────────────── #}
+    <div class="ncc-instruction" id="nccInstruction">
+        <h2>🔢 Number-Color Conflict</h2>
+        <p>
+            Each round shows a <strong>number</strong> and a <strong>colour</strong>.<br>
+            The rule tells you <em>which dimension to answer on</em>.
+            Tap the correct answer button before time runs out.
+        </p>
+
+        <div class="ncc-rule-examples">
+            <div class="ncc-rule-item">
+                <span class="ncc-rule-label">Rule: NUMBER</span>
+                Answer with the <strong>number</strong> shown
+            </div>
+            <div class="ncc-rule-item">
+                <span class="ncc-rule-label">Rule: COLOUR</span>
+                Answer with the <strong>colour</strong> shown
+            </div>
+        </div>
+
+        <div class="ncc-skill-chips">
+            {% for skill in game.skill_targets %}
+            <span class="ncc-skill-chip">{{ skill }}</span>
+            {% endfor %}
+        </div>
+    </div>
+
+    {# ── System-assigned protocol card ────────────────────────────────────── #}
+    {% set _ap = assigned_protocol %}
+    <div class="ncc-protocol-card" id="nccProtocol">
+        <div class="ncc-protocol-card-header">
+            <span>🎯</span>
+            <span class="ncc-protocol-card-title">Today's Protocol</span>
+        </div>
+        {{ protocol_hand_diagram(_ap.hand, _ap.finger) }}
+        {% if _ap.hand == "free" %}
+        <div class="ncc-protocol-card-combo">Free — No Protocol Assigned</div>
+        <div class="ncc-protocol-card-mult">×1.00 (standard)</div>
+        {% else %}
+        <div class="ncc-protocol-card-combo">{{ _ap.hand | upper }} HAND — {{ _ap.finger | upper }}</div>
+        <div class="ncc-protocol-card-mult">Difficulty multiplier: ×{{ "%.2f" | format(_ap.protocol_difficulty_multiplier | float) }}</div>
+        {% endif %}
+        <div class="ncc-protocol-card-info">
+            System assigned · Self-declared · Not verified<br>
+            Skill deltas will reflect this protocol. XP and score are unaffected.
+        </div>
+    </div>
+
+    {# ── Start button ─────────────────────────────────────────────────────── #}
+    <div style="text-align:center;margin-bottom:1.5rem;">
+        <button class="ncc-btn-start" id="nccBtnStart"
+            {% if attempts_remaining == 0 %}disabled{% endif %}
+            onclick="nccStart()">
+            ▶ Start Game
+        </button>
+    </div>
+
+    {# ── Game arena ───────────────────────────────────────────────────────── #}
+    <div class="ncc-arena" id="nccArena">
+
+        <div class="ncc-hud">
+            <span id="nccProgress">0 / {{ game.config.phases | sum(attribute='stimuli') }}</span>
+            <span id="nccTimer">0s</span>
+        </div>
+        <div class="ncc-progress-wrap">
+            <div class="ncc-progress-bar" id="nccProgressBar"></div>
+        </div>
+
+        <div class="ncc-counters">
+            <div class="ncc-counter">
+                <div class="ncc-counter-label">Correct</div>
+                <div class="ncc-counter-value hit-color" id="nccHit">0</div>
+            </div>
+            <div class="ncc-counter">
+                <div class="ncc-counter-label">Wrong</div>
+                <div class="ncc-counter-value wrong-color" id="nccWrong">0</div>
+            </div>
+            <div class="ncc-counter">
+                <div class="ncc-counter-label">Late</div>
+                <div class="ncc-counter-value late-color" id="nccLate">0</div>
+            </div>
+            <div class="ncc-counter">
+                <div class="ncc-counter-label">Missed</div>
+                <div class="ncc-counter-value miss-color" id="nccMiss">0</div>
+            </div>
+        </div>
+
+        <div class="ncc-field" id="nccField">
+            <div class="ncc-feedback" id="nccFeedback"></div>
+            <div class="ncc-rule-banner" id="nccRuleBanner" style="display:none;"></div>
+            <div class="ncc-field-idle" id="nccFieldIdle">Get ready…</div>
+            <div class="ncc-stimulus" id="nccStimulus">
+                <div class="ncc-stim-number" id="nccStimNumber"></div>
+                <div class="ncc-stim-color-patch" id="nccStimPatch"></div>
+            </div>
+        </div>
+
+        {# ── Answer buttons (rendered by JS) ──────────────────────────────── #}
+        <div class="ncc-answers" id="nccAnswers"></div>
+
+    </div>
+
+    {# ── Submitting overlay ───────────────────────────────────────────────── #}
+    <div class="ncc-submitting" id="nccSubmitting">
+        <div style="font-size:2rem;margin-bottom:0.5rem;">⏳</div>
+        <p>Saving your result…</p>
+    </div>
+
+</div>
+
+<script>
+(function () {
+    // ── Server-injected config ─────────────────────────────────────────────
+    var PHASES        = {{ game.config.phases | tojson }};
+    var NUMBERS       = {{ game.config.numbers | tojson }};
+    var COLORS        = {{ game.config.colors | tojson }};
+    var LATE_GRACE_MS = {{ game.config.late_grace_ms | default(350) }};
+    var CSRF_TOKEN    = "{{ request.cookies.get('csrf_token', '') }}";
+    var SUBMIT_URL    = "/virtual-training/number-color-conflict/submit";
+
+    // Derived total stimuli
+    var TOTAL_STIM = PHASES.reduce(function(s, p) { return s + p.stimuli; }, 0); // 36
+
+    // Color name → hex map for button rendering
+    var COLOR_HEX = COLORS; // {"RED": "#ef4444", ...}
+    var COLOR_NAMES = Object.keys(COLOR_HEX);
+
+    // ── Game state ─────────────────────────────────────────────────────────
+    var started        = false;
+    var startedAt      = null;
+    var globalStimIdx  = 0;
+    var hitCount       = 0;
+    var wrongCount     = 0;
+    var lateCount      = 0;
+    var missCount      = 0;
+    var reactionTimes  = [];
+    var stimTimestamp  = null;
+    var stimTimeout    = null;
+    var isiTimeout     = null;
+    var elapsedInterval = null;
+    var elapsedSeconds = 0;
+    var clickHandled   = false;
+    var lateHandled    = false;
+    var windowExpiredAt = null;
+
+    // Current stimulus state
+    var currentNumber  = null;   // integer
+    var currentColor   = null;   // color name string e.g. "RED"
+    var currentRule    = null;   // "number" | "color"
+    var correctAnswer  = null;   // string — what player must click
+    var currentPhaseIdx = 0;
+
+    // Late-click tracking
+    var lateClickTimes = [];
+
+    // Protocol difficulty (system-assigned, v3)
+    var handProfile = {{ assigned_protocol | tojson }};
+
+    // raw_metrics tracking
+    var stimulusLog = [];
+
+    // Rule switch state for alternating
+    var lastRule = null;
+
+    // ── DOM refs ───────────────────────────────────────────────────────────
+    var elInstruction  = document.getElementById("nccInstruction");
+    var elArena        = document.getElementById("nccArena");
+    var elBtnStart     = document.getElementById("nccBtnStart");
+    var elField        = document.getElementById("nccField");
+    var elFieldIdle    = document.getElementById("nccFieldIdle");
+    var elStimulus     = document.getElementById("nccStimulus");
+    var elStimNumber   = document.getElementById("nccStimNumber");
+    var elStimPatch    = document.getElementById("nccStimPatch");
+    var elRuleBanner   = document.getElementById("nccRuleBanner");
+    var elFeedback     = document.getElementById("nccFeedback");
+    var elAnswers      = document.getElementById("nccAnswers");
+    var elProgress     = document.getElementById("nccProgress");
+    var elProgressBar  = document.getElementById("nccProgressBar");
+    var elTimer        = document.getElementById("nccTimer");
+    var elHit          = document.getElementById("nccHit");
+    var elWrong        = document.getElementById("nccWrong");
+    var elLate         = document.getElementById("nccLate");
+    var elMiss         = document.getElementById("nccMiss");
+    var elSubmitting   = document.getElementById("nccSubmitting");
+
+    // ── Build stimulus sequence ────────────────────────────────────────────
+    function pickRule(phase, phaseStimIdx) {
+        var rs = phase.rule_switch;
+        if (rs === "alternating") {
+            return phaseStimIdx % 2 === 0 ? "number" : "color";
+        }
+        // random and random_high both randomise; random_high favours rule switches
+        // Simple 50/50 random for both variants (server-side label is for analytics)
+        return Math.random() < 0.5 ? "number" : "color";
+    }
+
+    function buildStimSequence() {
+        var seq = [];
+        for (var pi = 0; pi < PHASES.length; pi++) {
+            var p = PHASES[pi];
+            for (var si = 0; si < p.stimuli; si++) {
+                var num   = NUMBERS[Math.floor(Math.random() * NUMBERS.length)];
+                var color = COLOR_NAMES[Math.floor(Math.random() * COLOR_NAMES.length)];
+                var rule  = pickRule(p, si);
+                seq.push({ num: num, color: color, rule: rule, phase: pi, cfg: p });
+            }
+        }
+        return seq;
+    }
+
+    var SEQUENCE = buildStimSequence();
+
+    // ── Build answer buttons ───────────────────────────────────────────────
+    // Numbers → rendered as text, Colors → colored patch buttons
+    function renderAnswerButtons(rule) {
+        elAnswers.innerHTML = "";
+        if (rule === "number") {
+            NUMBERS.forEach(function(n) {
+                var btn = document.createElement("button");
+                btn.className   = "ncc-ans-btn";
+                btn.style.background = "#4f46e5";
+                btn.textContent = String(n);
+                btn.dataset.value = String(n);
+                btn.addEventListener("click", function() { handleAnswer(String(n)); });
+                elAnswers.appendChild(btn);
+            });
+        } else {
+            COLOR_NAMES.forEach(function(cname) {
+                var btn = document.createElement("button");
+                btn.className   = "ncc-ans-btn";
+                btn.style.background = COLOR_HEX[cname];
+                btn.textContent = cname;
+                btn.dataset.value = cname;
+                btn.addEventListener("click", function() { handleAnswer(cname); });
+                elAnswers.appendChild(btn);
+            });
+        }
+        elAnswers.classList.add("visible");
+    }
+
+    // ── Start game ─────────────────────────────────────────────────────────
+    function nccStart() {
+        if (started) { return; }
+        started   = true;
+        startedAt = new Date().toISOString();
+
+        elInstruction.style.display = "none";
+        var protocolEl = document.getElementById("nccProtocol");
+        if (protocolEl) { protocolEl.style.display = "none"; }
+        elArena.classList.add("active");
+
+        elapsedInterval = setInterval(function() {
+            elapsedSeconds++;
+            elTimer.textContent = elapsedSeconds + "s";
+        }, 1000);
+
+        isiTimeout = setTimeout(showStimulus, 800);
+    }
+    window.nccStart = nccStart;
+
+    // ── Show next stimulus ─────────────────────────────────────────────────
+    function showStimulus() {
+        if (globalStimIdx >= SEQUENCE.length) { finishGame(); return; }
+
+        var stim = SEQUENCE[globalStimIdx];
+        currentNumber  = stim.num;
+        currentColor   = stim.color;
+        currentRule    = stim.rule;
+        correctAnswer  = stim.rule === "number" ? String(stim.num) : stim.color;
+        currentPhaseIdx = stim.phase;
+        clickHandled   = false;
+        lateHandled    = false;
+        windowExpiredAt = null;
+
+        // Update UI
+        elFieldIdle.style.display = "none";
+        elRuleBanner.style.display = "block";
+        elRuleBanner.textContent  = "Rule: " + stim.rule.toUpperCase();
+        elStimNumber.textContent  = stim.num;
+        elStimPatch.style.background = COLOR_HEX[stim.color];
+        elStimulus.classList.add("visible");
+
+        renderAnswerButtons(stim.rule);
+
+        stimTimestamp = Date.now();
+
+        // Window timeout
+        stimTimeout = setTimeout(function() {
+            windowExpiredAt = Date.now();
+            expiredStimIdx  = globalStimIdx;
+
+            // Late grace window — listen for late taps
+            setTimeout(function() {
+                if (!clickHandled && !lateHandled) {
+                    // True miss
+                    recordOutcome("missed", null);
+                }
+                lateHandled = true;
+            }, LATE_GRACE_MS);
+        }, stim.cfg.window_ms);
+    }
+
+    // ── Handle answer button click ─────────────────────────────────────────
+    function handleAnswer(value) {
+        if (!started || clickHandled) { return; }
+
+        var now = Date.now();
+        var rt  = now - stimTimestamp;
+
+        // Was the window already expired? → late click
+        if (windowExpiredAt !== null && !lateHandled) {
+            lateHandled = true;
+            lateCount++;
+            elLate.textContent = lateCount;
+            lateClickTimes.push(rt);
+
+            var lateCorrect = (value === correctAnswer);
+            recordStimulusLog({
+                stim_idx:  globalStimIdx,
+                phase:     currentPhaseIdx,
+                rule:      currentRule,
+                number:    currentNumber,
+                color:     currentColor,
+                answer:    value,
+                correct:   correctAnswer,
+                outcome:   "late",
+                rt_ms:     rt,
+            });
+
+            showFeedback("fb-late", "Late!");
+            clearTimeout(stimTimeout);
+            nextStimulus();
+            return;
+        }
+
+        if (windowExpiredAt !== null) { return; }  // after grace window, ignore
+        clickHandled = true;
+        clearTimeout(stimTimeout);
+
+        var isCorrect = (value === correctAnswer);
+        var outcome;
+        if (isCorrect) {
+            outcome = "correct";
+        } else {
+            // Distinguish wrong_value vs wrong_dimension
+            if (currentRule === "number" && COLOR_NAMES.indexOf(value) >= 0) {
+                outcome = "wrong_dimension";
+            } else if (currentRule === "color" && NUMBERS.indexOf(parseInt(value)) >= 0) {
+                outcome = "wrong_dimension";
+            } else {
+                outcome = "wrong_value";
+            }
+        }
+
+        recordOutcome(outcome, rt);
+    }
+
+    function recordOutcome(outcome, rt) {
+        if (outcome === "correct") {
+            hitCount++;
+            reactionTimes.push(rt);
+            elHit.textContent = hitCount;
+            showFeedback("fb-hit", "Correct!");
+        } else if (outcome === "wrong_value" || outcome === "wrong_dimension") {
+            wrongCount++;
+            elWrong.textContent = wrongCount;
+            showFeedback("fb-wrong", outcome === "wrong_dimension" ? "Wrong dimension!" : "Wrong!");
+        } else {
+            // missed
+            missCount++;
+            elMiss.textContent = missCount;
+            showFeedback("fb-miss", "Missed!");
+        }
+
+        recordStimulusLog({
+            stim_idx:  globalStimIdx,
+            phase:     currentPhaseIdx,
+            rule:      currentRule,
+            number:    currentNumber,
+            color:     currentColor,
+            answer:    outcome !== "missed" ? correctAnswer : null,
+            correct:   correctAnswer,
+            outcome:   outcome,
+            rt_ms:     rt,
+        });
+
+        nextStimulus();
+    }
+
+    function recordStimulusLog(entry) {
+        stimulusLog.push(entry);
+    }
+
+    // ── Advance to next stimulus ───────────────────────────────────────────
+    function nextStimulus() {
+        elStimulus.classList.remove("visible");
+        elAnswers.classList.remove("visible");
+        elAnswers.innerHTML = "";
+        elRuleBanner.style.display = "none";
+
+        globalStimIdx++;
+        elProgress.textContent = globalStimIdx + " / " + TOTAL_STIM;
+        elProgressBar.style.width = ((globalStimIdx / TOTAL_STIM) * 100) + "%";
+
+        if (globalStimIdx >= SEQUENCE.length) {
+            finishGame();
+            return;
+        }
+
+        var isi = SEQUENCE[globalStimIdx].cfg.isi_ms;
+        elFieldIdle.style.display = "block";
+        isiTimeout = setTimeout(showStimulus, isi);
+    }
+
+    // ── Feedback flash ─────────────────────────────────────────────────────
+    var fbTimeout = null;
+    function showFeedback(cls, msg) {
+        elFeedback.className = "ncc-feedback " + cls + " show";
+        elFeedback.textContent = msg;
+        clearTimeout(fbTimeout);
+        fbTimeout = setTimeout(function() {
+            elFeedback.classList.remove("show");
+        }, 650);
+    }
+
+    // ── Finish — build payload and submit ──────────────────────────────────
+    function finishGame() {
+        clearInterval(elapsedInterval);
+        clearTimeout(isiTimeout);
+        clearTimeout(stimTimeout);
+
+        elArena.classList.remove("active");
+        elSubmitting.classList.add("active");
+
+        var totalStim = SEQUENCE.length;
+        var avgRt = reactionTimes.length > 0
+            ? reactionTimes.reduce(function(a, b) { return a + b; }, 0) / reactionTimes.length
+            : null;
+
+        // Per-phase aggregation
+        var phaseData = PHASES.map(function(p, pi) {
+            var logs = stimulusLog.filter(function(e) { return e.phase === pi; });
+            var ph_correct = logs.filter(function(e) { return e.outcome === "correct"; }).length;
+            var ph_wrong   = logs.filter(function(e) { return e.outcome === "wrong_value" || e.outcome === "wrong_dimension"; }).length;
+            var ph_missed  = logs.filter(function(e) { return e.outcome === "missed"; }).length;
+            var ph_late    = logs.filter(function(e) { return e.outcome === "late"; }).length;
+            var ph_rts     = logs.filter(function(e) { return e.outcome === "correct" && e.rt_ms != null; }).map(function(e) { return e.rt_ms; });
+            var ph_avg_rt  = ph_rts.length > 0 ? ph_rts.reduce(function(a,b){return a+b;},0)/ph_rts.length : null;
+            return {
+                phase:   pi,
+                stimuli: p.stimuli,
+                rule_switch: p.rule_switch,
+                correct: ph_correct,
+                wrong:   ph_wrong,
+                missed:  ph_missed,
+                late:    ph_late,
+                avg_rt_ms: ph_avg_rt != null ? Math.round(ph_avg_rt) : null,
+            };
+        });
+
+        var speedFactor = avgRt != null ? Math.max(0, 1.0 - avgRt / 1600.0) : 0.5;
+        var hitRate     = hitCount / Math.max(totalStim, 1);
+        var wrongRate   = wrongCount / Math.max(totalStim, 1);
+        var scoreRaw    = 0.55 * hitRate + 0.25 * (1.0 - wrongRate) + 0.20 * speedFactor;
+        var scoreNorm   = Math.round(scoreRaw * 100);
+
+        var payload = {
+            started_at:       startedAt,
+            stimuli_count:    totalStim,
+            correct_count:    hitCount,
+            wrong_click_count: wrongCount,
+            error_count:      missCount,
+            avg_reaction_ms:  avgRt != null ? Math.round(avgRt) : null,
+            duration_seconds: elapsedSeconds,
+            score_normalized: scoreNorm,
+            raw_metrics: {
+                v:          3,
+                per_phase:  phaseData,
+                per_stimulus: stimulusLog,
+                late_summary: {
+                    late_click_count:  lateCount,
+                    late_go_count:     0,
+                    late_no_go_count:  0,
+                },
+                hand_profile: {
+                    hand:   handProfile.hand,
+                    finger: handProfile.finger,
+                    label:  handProfile.label || "",
+                    protocol_difficulty_multiplier: handProfile.protocol_difficulty_multiplier || 1.0,
+                    assignment_source: handProfile.assignment_source || "system",
+                },
+            },
+        };
+
+        fetch(SUBMIT_URL, {
+            method: "POST",
+            headers: {
+                "Content-Type":   "application/json",
+                "X-CSRF-Token":   CSRF_TOKEN,
+            },
+            credentials: "same-origin",
+            body: JSON.stringify(payload),
+        })
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+            if (data.attempt_id) {
+                window.location.href = "/virtual-training/number-color-conflict/result/" + data.attempt_id;
+            } else {
+                window.location.href = "/virtual-training";
+            }
+        })
+        .catch(function() {
+            window.location.href = "/virtual-training";
+        });
+    }
+
+})();
+</script>
+{% endblock %}

--- a/app/templates/virtual_training_number_color_conflict_result.html
+++ b/app/templates/virtual_training_number_color_conflict_result.html
@@ -1,0 +1,530 @@
+{% extends "student_base.html" %}
+
+{% block title %}Number-Color Conflict Result - LFA{% endblock %}
+{% block active_page %}lfa-player{% endblock %}
+
+{% block student_header %}
+{% set _page_icon = '🔢' %}
+{% set _page_name = 'Result' %}
+{% include "includes/spec_subpage_hdr.html" %}
+{% endblock %}
+
+{% block extra_styles %}
+<style>
+    .nccr-container {
+        max-width: 560px;
+        margin: 0 auto;
+        padding: 1.5rem 1rem 3rem;
+    }
+
+    .nccr-card {
+        background: var(--app-card);
+        border-radius: 16px;
+        padding: 2rem 1.75rem;
+        box-shadow: 0 2px 14px rgba(0,0,0,0.09);
+        text-align: center;
+        margin-bottom: 1.25rem;
+    }
+
+    .nccr-status-icon {
+        font-size: 3rem;
+        margin-bottom: 0.5rem;
+        line-height: 1;
+    }
+
+    .nccr-title {
+        font-size: 1.45rem;
+        font-weight: 800;
+        color: var(--app-text);
+        margin: 0 0 0.3rem;
+    }
+
+    .nccr-subtitle {
+        font-size: 0.9rem;
+        color: var(--app-text-muted);
+        margin: 0 0 1.5rem;
+    }
+
+    /* ── Stats grid ──────────────────────────────────────────────────── */
+    .nccr-stats-grid {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        gap: 0.85rem;
+        margin-bottom: 1.5rem;
+    }
+
+    .nccr-stat {
+        background: #f9fafb;
+        border-radius: 10px;
+        padding: 0.85rem 0.75rem;
+    }
+
+    .nccr-stat-label {
+        font-size: 0.75rem;
+        color: var(--app-text-muted);
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        margin-bottom: 0.3rem;
+    }
+
+    .nccr-stat-value {
+        font-size: 1.35rem;
+        font-weight: 800;
+        color: var(--app-text);
+    }
+
+    .nccr-stat-value.good   { color: #16a34a; }
+    .nccr-stat-value.danger { color: #ef4444; }
+    .nccr-stat-value.warn   { color: #d97706; }
+
+    /* ── XP badge ────────────────────────────────────────────────────── */
+    .nccr-xp-badge {
+        display: inline-block;
+        background: #ede9fe;
+        color: #5b21b6;
+        font-size: 1.1rem;
+        font-weight: 800;
+        padding: 0.5rem 1.5rem;
+        border-radius: 20px;
+        margin-bottom: 1.5rem;
+    }
+
+    /* ── Invalid banner ──────────────────────────────────────────────── */
+    .nccr-invalid-banner {
+        background: #fef3c7;
+        border: 1px solid #f59e0b;
+        border-radius: 10px;
+        padding: 0.85rem 1rem;
+        color: #92400e;
+        font-size: 0.88rem;
+        font-weight: 600;
+        margin-bottom: 1.25rem;
+        text-align: center;
+    }
+
+    /* ── Skill deltas summary ────────────────────────────────────────── */
+    .nccr-skill-deltas {
+        background: #f0fdf4;
+        border: 1px solid #bbf7d0;
+        border-radius: 10px;
+        padding: 0.85rem 1rem;
+        margin-bottom: 1.5rem;
+        text-align: left;
+    }
+
+    .nccr-skill-deltas h4 {
+        font-size: 0.78rem;
+        font-weight: 700;
+        color: #166534;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        margin: 0 0 0.6rem;
+    }
+
+    .nccr-skill-row {
+        display: flex;
+        justify-content: space-between;
+        font-size: 0.875rem;
+        color: #14532d;
+        padding: 0.2rem 0;
+    }
+
+    .nccr-skill-row.neg { color: #dc2626; }
+
+    /* ── Play again button ───────────────────────────────────────────── */
+    .nccr-btn-play {
+        display: inline-block;
+        background: #4f46e5;
+        color: #fff;
+        font-size: 0.95rem;
+        font-weight: 700;
+        padding: 0.7rem 2rem;
+        border-radius: 10px;
+        text-decoration: none;
+        transition: background 0.15s;
+        margin-bottom: 0.5rem;
+    }
+    .nccr-btn-play:hover { background: #4338ca; }
+
+    /* ── Skill breakdown ─────────────────────────────────────────────── */
+    .nccr-breakdown {
+        background: #f0fdf4;
+        border: 1px solid #bbf7d0;
+        border-radius: 12px;
+        padding: 1rem 1.1rem;
+        margin-bottom: 1.25rem;
+        text-align: left;
+    }
+
+    .nccr-breakdown h4 {
+        font-size: 0.78rem;
+        font-weight: 700;
+        color: #166534;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        margin: 0 0 0.75rem;
+    }
+
+    .nccr-breakdown-row {
+        display: grid;
+        grid-template-columns: 1fr auto auto;
+        align-items: start;
+        gap: 0.5rem 1rem;
+        padding: 0.45rem 0;
+        border-bottom: 1px solid #d1fae5;
+        font-size: 0.875rem;
+    }
+    .nccr-breakdown-row:last-child { border-bottom: none; }
+
+    .nccr-breakdown-skill        { font-weight: 700; color: #14532d; }
+    .nccr-breakdown-delta        { font-weight: 800; color: #166534; white-space: nowrap; }
+    .nccr-breakdown-delta.neg    { color: #dc2626; }
+    .nccr-breakdown-factors {
+        font-size: 0.78rem;
+        color: #6b7280;
+        grid-column: 1 / -1;
+        padding-top: 0.1rem;
+        padding-left: 0.1rem;
+    }
+
+    /* ── Per-phase table ─────────────────────────────────────────────── */
+    .nccr-detail-section {
+        background: white;
+        border: 1px solid #e5e7eb;
+        border-radius: 12px;
+        padding: 1rem 1.1rem;
+        margin-bottom: 1.25rem;
+        text-align: left;
+    }
+
+    .nccr-detail-section h4 {
+        font-size: 0.78rem;
+        font-weight: 700;
+        color: #374151;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        margin: 0 0 0.75rem;
+    }
+
+    .nccr-detail-table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.8rem;
+    }
+
+    .nccr-detail-table th {
+        background: #f9fafb;
+        color: #6b7280;
+        font-weight: 700;
+        font-size: 0.72rem;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        padding: 0.45rem 0.6rem;
+        text-align: left;
+        border-bottom: 1px solid #e5e7eb;
+        white-space: nowrap;
+    }
+
+    .nccr-detail-table td {
+        padding: 0.45rem 0.6rem;
+        border-bottom: 1px solid #f3f4f6;
+        color: #374151;
+        vertical-align: middle;
+    }
+
+    .nccr-detail-table tr:last-child td { border-bottom: none; }
+
+    .nccr-acc-good { color: #16a34a; font-weight: 700; }
+    .nccr-acc-ok   { color: #d97706; font-weight: 700; }
+    .nccr-acc-poor { color: #dc2626; font-weight: 700; }
+
+    /* ── Admin debug ─────────────────────────────────────────────────── */
+    .nccr-admin-debug {
+        background: #1e293b;
+        border-radius: 10px;
+        padding: 0.85rem 1rem;
+        margin-bottom: 1.25rem;
+        text-align: left;
+    }
+    .nccr-admin-debug summary {
+        color: #94a3b8;
+        font-size: 0.78rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        cursor: pointer;
+    }
+    .nccr-admin-debug pre {
+        color: #e2e8f0;
+        font-size: 0.72rem;
+        overflow-x: auto;
+        margin: 0.75rem 0 0;
+        white-space: pre-wrap;
+        word-break: break-all;
+        max-height: 300px;
+        overflow-y: auto;
+    }
+
+    /* ── Footer ──────────────────────────────────────────────────────── */
+    .nccr-footer {
+        text-align: center;
+        margin-top: 1.25rem;
+        padding-top: 1.25rem;
+        border-top: 1px solid #e2e8f0;
+    }
+    .nccr-footer a {
+        color: #667eea;
+        text-decoration: none;
+        margin: 0 0.75rem;
+        font-weight: 600;
+        font-size: 0.88rem;
+    }
+    .nccr-footer a:hover { text-decoration: underline; }
+</style>
+{% endblock %}
+
+{% block student_content %}
+<div class="nccr-container">
+
+    {% if attempt.is_valid %}
+    {# ── Valid result ──────────────────────────────────────────────────── #}
+    <div class="nccr-card">
+        <div class="nccr-status-icon">
+            {% if attempt.score_normalized >= 85 %}🏆
+            {% elif attempt.score_normalized >= 65 %}⚡
+            {% elif attempt.score_normalized >= 45 %}💪
+            {% else %}🎯{% endif %}
+        </div>
+        <h2 class="nccr-title">
+            {% if attempt.score_normalized >= 85 %}Sharp decision-making!
+            {% elif attempt.score_normalized >= 65 %}Good conflict resolution!
+            {% elif attempt.score_normalized >= 45 %}Keep training!
+            {% else %}Keep practicing!{% endif %}
+        </h2>
+        <p class="nccr-subtitle">Number-Color Conflict</p>
+
+        {% set _total_stim = attempt.stimuli_count if attempt.stimuli_count else 36 %}
+
+        <div class="nccr-stats-grid">
+            <div class="nccr-stat">
+                <div class="nccr-stat-label">Score</div>
+                <div class="nccr-stat-value">
+                    {% if attempt.score_normalized is not none %}{{ attempt.score_normalized | round(0) | int }}%
+                    {% else %}—{% endif %}
+                </div>
+            </div>
+            <div class="nccr-stat">
+                <div class="nccr-stat-label">Accuracy</div>
+                {% set _acc = ((attempt.correct_count / _total_stim) * 100) | round(0) | int if attempt.correct_count is not none else none %}
+                <div class="nccr-stat-value {% if _acc is not none %}{% if _acc >= 80 %}good{% elif _acc >= 60 %}warn{% else %}danger{% endif %}{% endif %}">
+                    {% if _acc is not none %}{{ _acc }}%{% else %}—{% endif %}
+                    <small style="font-size:0.65rem;font-weight:600;color:var(--app-text-muted);">{{ attempt.correct_count if attempt.correct_count is not none else "—" }}/{{ _total_stim }}</small>
+                </div>
+            </div>
+            <div class="nccr-stat">
+                <div class="nccr-stat-label">Wrong</div>
+                {% set _wrong = attempt.wrong_click_count if attempt.wrong_click_count is not none else 0 %}
+                <div class="nccr-stat-value{% if _wrong > 0 %} danger{% endif %}">
+                    {{ _wrong }}
+                    <small style="font-size:0.65rem;font-weight:600;color:var(--app-text-muted);">/ {{ _total_stim }}</small>
+                </div>
+            </div>
+            <div class="nccr-stat">
+                <div class="nccr-stat-label">Missed</div>
+                {% set _miss = attempt.error_count if attempt.error_count is not none else 0 %}
+                <div class="nccr-stat-value{% if _miss > 0 %} warn{% endif %}">
+                    {{ _miss }}
+                    <small style="font-size:0.65rem;font-weight:600;color:var(--app-text-muted);">/ {{ _total_stim }}</small>
+                </div>
+            </div>
+            <div class="nccr-stat">
+                <div class="nccr-stat-label">Avg Reaction</div>
+                <div class="nccr-stat-value">
+                    {% if attempt.avg_reaction_ms is not none %}{{ attempt.avg_reaction_ms | round(0) | int }} ms
+                    {% else %}—{% endif %}
+                </div>
+            </div>
+            <div class="nccr-stat">
+                <div class="nccr-stat-label">Duration</div>
+                <div class="nccr-stat-value">
+                    {% if attempt.duration_seconds is not none %}{{ attempt.duration_seconds | round(1) }} s
+                    {% else %}—{% endif %}
+                </div>
+            </div>
+            <div class="nccr-stat">
+                <div class="nccr-stat-label">Attempt</div>
+                <div class="nccr-stat-value">
+                    #{{ attempt.attempt_index_today }} today
+                </div>
+            </div>
+            {# Late count from raw_metrics #}
+            {% if late_summary and late_summary.late_click_count %}
+            <div class="nccr-stat">
+                <div class="nccr-stat-label">Late Taps</div>
+                <div class="nccr-stat-value warn">{{ late_summary.late_click_count }}</div>
+            </div>
+            {% endif %}
+        </div>
+
+        {% if attempt.xp_awarded > 0 %}
+        <div class="nccr-xp-badge">+{{ attempt.xp_awarded }} XP earned</div>
+        {% elif attempt.attempt_index_today > game.max_daily_attempts %}
+        <div class="nccr-xp-badge" style="background:#f3f4f6;color:#6b7280;">
+            No XP — daily limit reached
+        </div>
+        {% endif %}
+
+        {# ── Protocol badge (v3 hand_profile) ─────────────────────────────── #}
+        {% set _hp = hand_profile %}
+        {% if _hp and _hp.get("protocol_difficulty_multiplier", 1.0) | float > 1.0 %}
+        <div style="background:#eef2ff;border:1px solid #c7d2fe;border-radius:10px;padding:0.65rem 1rem;margin-bottom:0.85rem;font-size:0.85rem;">
+            <div style="font-weight:700;color:#3730a3;margin-bottom:0.15rem;">
+                🖐 Protocol: {{ _hp.get("label", "—") }} &nbsp;·&nbsp;
+                ×{{ "%.2f"|format(_hp.get("protocol_difficulty_multiplier", 1.0) | float) }}
+            </div>
+            <div style="color:#4f46e5;font-size:0.78rem;">
+                {% if _hp.get("assignment_source") == "system" %}System assigned · {% endif %}Self-declared · Not verified
+            </div>
+        </div>
+        {% endif %}
+
+        {% if attempt.skill_deltas %}
+        <div class="nccr-skill-deltas">
+            <h4>Skill deltas</h4>
+            {% for skill, delta in attempt.skill_deltas.items() %}
+            <div class="nccr-skill-row {% if delta < 0 %}neg{% endif %}">
+                <span>{{ skill }}</span>
+                <span>{{ "%+.2f"|format(delta) }}</span>
+            </div>
+            {% endfor %}
+        </div>
+        {% endif %}
+
+        {# ── Skill Delta Breakdown ──────────────────────────────────────────── #}
+        {% if skill_scores %}
+        <div class="nccr-breakdown" id="nccr-breakdown">
+            <h4>Skill Delta Breakdown</h4>
+            {% if _hp and _hp.get("protocol_difficulty_multiplier", 1.0) | float > 1.0 %}
+            <p style="font-size:0.78rem;color:#4f46e5;margin:0 0 0.6rem;font-style:italic;">
+                Skill deltas include ×{{ "%.2f"|format(_hp.get("protocol_difficulty_multiplier", 1.0) | float) }} protocol difficulty multiplier.
+                Applied to skill deltas only · XP and score unaffected.
+            </p>
+            {% endif %}
+            {% for skill, score in skill_scores.items() %}
+            {% set delta = attempt.skill_deltas.get(skill, 0) if attempt.skill_deltas else 0 %}
+            <div class="nccr-breakdown-row">
+                <span class="nccr-breakdown-skill">{{ skill|capitalize }}</span>
+                <span class="nccr-breakdown-delta {% if delta < 0 %}neg{% endif %}">{{ "%+.3f"|format(delta) }}</span>
+                <span class="nccr-breakdown-factors">
+                    {% if skill == "decisions" %}
+                        Accuracy: {{ signals_ctx.hit_rate }}% · Wrong penalty ({{ signals_ctx.wrong_rate }}% × 1.5×) · Score: {{ "%.0f"|format(score * 100) }}%
+                        <br><span style="font-style:italic;color:#9ca3af;">Rule-based decision accuracy — penalised for wrong dimension or wrong value</span>
+                    {% elif skill == "concentration" %}
+                        Missed: {{ signals_ctx.miss_rate }}% · Sustained attention score: {{ "%.0f"|format(score * 100) }}%
+                        <br><span style="font-style:italic;color:#9ca3af;">Measures ability to stay focused and respond before the window closes</span>
+                    {% elif skill == "composure" %}
+                        Wrong rate: {{ signals_ctx.wrong_rate }}% (× 1.5× penalty) · Score: {{ "%.0f"|format(score * 100) }}%
+                        <br><span style="font-style:italic;color:#9ca3af;">Measures impulse control — not acting on the wrong dimension under pressure</span>
+                    {% elif skill == "reactions" %}
+                        Speed: {{ signals_ctx.speed_score }}% · Accuracy: {{ signals_ctx.hit_rate }}% · Score: {{ "%.0f"|format(score * 100) }}%
+                        <br><span style="font-style:italic;color:#9ca3af;">Reaction speed to conflicting stimuli (secondary skill)</span>
+                    {% else %}
+                        Score: {{ "%.0f"|format(score * 100) }}%
+                    {% endif %}
+                    {% if delta < 0 %}
+                    <br><span style="color:#dc2626;font-style:italic;">Performance below training threshold — skill decreased this attempt.</span>
+                    {% endif %}
+                </span>
+            </div>
+            {% endfor %}
+        </div>
+        {% endif %}
+
+        <a href="/virtual-training/number-color-conflict" class="nccr-btn-play">Play again</a>
+    </div>
+
+    {# ── Per-phase summary ─────────────────────────────────────────────── #}
+    {% if per_phase %}
+    <div class="nccr-detail-section" id="nccr-per-phase">
+        <h4>Phase Performance</h4>
+        <table class="nccr-detail-table">
+            <thead>
+                <tr>
+                    <th>Phase</th>
+                    <th>Stimuli</th>
+                    <th>Correct</th>
+                    <th>Accuracy</th>
+                    <th>Wrong</th>
+                    <th>Avg RT</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for p in per_phase %}
+                {% set ph_total = p.stimuli if p.stimuli else 1 %}
+                {% set ph_acc   = ((p.correct / ph_total) * 100) | round(1) %}
+                <tr>
+                    <td>Phase {{ loop.index }}</td>
+                    <td>{{ p.stimuli }}</td>
+                    <td>{{ p.correct }}</td>
+                    <td class="{% if ph_acc >= 85 %}nccr-acc-good{% elif ph_acc >= 65 %}nccr-acc-ok{% else %}nccr-acc-poor{% endif %}">{{ ph_acc }}%</td>
+                    <td class="{% if p.wrong > 0 %}nccr-acc-poor{% else %}nccr-acc-good{% endif %}">{{ p.wrong }}</td>
+                    <td>{% if p.avg_rt_ms is not none %}{{ p.avg_rt_ms | round(0) | int }} ms{% else %}—{% endif %}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    {% endif %}
+
+    {# ── Late tap summary ────────────────────────────────────────────────── #}
+    {% if late_summary and late_summary.late_click_count %}
+    <div class="nccr-detail-section" id="nccr-late-clicks">
+        <h4>Late Taps</h4>
+        <p style="font-size:0.82rem;color:var(--app-text-muted);margin:0 0 0.5rem;">
+            Taps detected within {{ game.config.late_grace_ms if game and game.config else 350 }} ms after the stimulus window expired.
+        </p>
+        <table class="nccr-detail-table">
+            <thead>
+                <tr><th>Late taps</th></tr>
+            </thead>
+            <tbody>
+                <tr><td>{{ late_summary.late_click_count }}</td></tr>
+            </tbody>
+        </table>
+    </div>
+    {% endif %}
+
+    {# ── Admin raw_metrics ───────────────────────────────────────────────── #}
+    {% if is_admin and attempt.raw_metrics %}
+    <details class="nccr-admin-debug">
+        <summary>Admin — raw_metrics</summary>
+        <pre>{{ attempt.raw_metrics | tojson(indent=2) }}</pre>
+    </details>
+    {% endif %}
+
+    <a href="/virtual-training/number-color-conflict" class="nccr-btn-play" style="display:block;text-align:center;margin-bottom:0.5rem;">
+        ▶ Play again
+    </a>
+
+    {% else %}
+    {# ── Invalid attempt ───────────────────────────────────────────────── #}
+    <div class="nccr-card">
+        <div class="nccr-status-icon">⚠️</div>
+        <h2 class="nccr-title">Attempt not counted</h2>
+        <p class="nccr-subtitle">Number-Color Conflict</p>
+        <div class="nccr-invalid-banner">
+            {{ attempt.invalid_reason or "This attempt was flagged as invalid." }}
+        </div>
+        <a href="/virtual-training/number-color-conflict" class="nccr-btn-play">Try again</a>
+    </div>
+    {% endif %}
+
+    <div class="nccr-footer">
+        <a href="/virtual-training">🎮 Virtual Games</a>
+        <a href="/virtual-training/history">📋 History</a>
+        <a href="/dashboard/lfa-football-player">⚽ Dashboard</a>
+    </div>
+
+</div>
+{% endblock %}

--- a/scripts/seed_virtual_training_games.py
+++ b/scripts/seed_virtual_training_games.py
@@ -189,7 +189,7 @@ _GAMES = [
             "whether to respond to the number or the colour. Rule-switching tested each round."
         ),
         "game_type": "cognitive_inhibition",
-        "is_active": False,
+        "is_active": True,
         "base_xp": 12,
         "max_daily_attempts": 5,
         "skill_targets": {
@@ -199,6 +199,33 @@ _GAMES = [
             "reactions":     0.10,
         },
         "config": {
+            # ── runtime gameplay keys ──────────────────────────────────────
+            # 3-phase session: 10 + 12 + 14 = 36 stimuli total
+            # rule_switch: "alternating" | "random" | "random_high"
+            "phases": [
+                {"stimuli": 10, "window_ms": 2000, "isi_ms": 900,  "rule_switch": "alternating"},
+                {"stimuli": 12, "window_ms": 1600, "isi_ms": 700,  "rule_switch": "random"},
+                {"stimuli": 14, "window_ms": 1200, "isi_ms": 550,  "rule_switch": "random_high"},
+            ],
+            "numbers": [1, 2, 3, 4],
+            "colors": {
+                "RED":    "#ef4444",
+                "GREEN":  "#22c55e",
+                "BLUE":   "#3b82f6",
+                "YELLOW": "#eab308",
+            },
+            "late_grace_ms": 350,
+            # Score formula (documented for transparency):
+            #   score_raw = 0.55 × hit_rate + 0.25 × (1 − wrong_rate) + 0.20 × speed_factor
+            #   speed_factor = max(0, 1 − avg_rt / 1600)
+            #   score_normalized = round(score_raw × 100)
+            # Outcome mapping:
+            #   correct        → correct_count
+            #   wrong_value    → wrong_click_count (wrong number/color answer)
+            #   wrong_dimension → wrong_click_count (answered wrong dimension)
+            #   missed         → error_count
+            #   late           → late_summary.late_click_count
+            # ── display keys ──────────────────────────────────────────────
             "show_in_hub":      True,
             "icon":             "🔢",
             "football_benefit": (

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "G\u0101nCuju\u2122\u00a9 Education Center",
+    "title": "GānCuju™© Education Center",
     "description": "LFA Education Center - Comprehensive Football Education Platform featuring LFA Player Development, Coach Training, Internship Programs, and Gamification with Parallel Specialization Tracks",
     "version": "2.0.0"
   },
@@ -1542,7 +1542,7 @@
           "scheduling"
         ],
         "summary": "Generate Sessions",
-        "description": "Generate weekly training sessions for a MINI_SEASON or ACADEMY_SEASON semester.\n\nValidations (in order):\n  1. Semester exists \u2192 404\n  2. semester_category in (MINI_SEASON, ACADEMY_SEASON) \u2192 400\n  3. start_date + end_date set \u2192 400\n  4. sessions already generated \u2192 409\n  5. campus_id belongs to semester's location \u2192 400\n  6. pitch_id belongs to resolved campus \u2192 400",
+        "description": "Generate weekly training sessions for a MINI_SEASON or ACADEMY_SEASON semester.\n\nValidations (in order):\n  1. Semester exists → 404\n  2. semester_category in (MINI_SEASON, ACADEMY_SEASON) → 400\n  3. start_date + end_date set → 400\n  4. sessions already generated → 409\n  5. campus_id belongs to semester's location → 400\n  6. pitch_id belongs to resolved campus → 400",
         "operationId": "generate_sessions_api_v1_semesters__semester_id__generate_sessions_post",
         "security": [
           {
@@ -2612,7 +2612,7 @@
           "sessions"
         ],
         "summary": "Check In To Session",
-        "description": "Instructor checks in to session (marks PENDING \u2192 STARTED).\n\n**Authorization:** Instructor only, must be assigned to session\n**Performance Target:** p95 < 200ms\n\n**Business Logic:**\n1. Verify session exists\n2. Verify current user is assigned instructor\n3. Verify session status is 'scheduled' or 'pending'\n4. Update session status to 'in_progress'\n\n**Returns:**\n- Success status\n- Session ID\n- Updated session status ('in_progress')\n- Check-in timestamp\n\n**Raises:**\n- 403: User is not an instructor OR not assigned to session\n- 404: Session not found\n- 400: Session already in_progress or completed",
+        "description": "Instructor checks in to session (marks PENDING → STARTED).\n\n**Authorization:** Instructor only, must be assigned to session\n**Performance Target:** p95 < 200ms\n\n**Business Logic:**\n1. Verify session exists\n2. Verify current user is assigned instructor\n3. Verify session status is 'scheduled' or 'pending'\n4. Update session status to 'in_progress'\n\n**Returns:**\n- Success status\n- Session ID\n- Updated session status ('in_progress')\n- Check-in timestamp\n\n**Raises:**\n- 403: User is not an instructor OR not assigned to session\n- 404: Session not found\n- 400: Session already in_progress or completed",
         "operationId": "check_in_to_session_api_v1_sessions__session_id__check_in_post",
         "security": [
           {
@@ -2786,7 +2786,7 @@
           "session-segments"
         ],
         "summary": "Soft-delete a session segment",
-        "description": "Soft-delete a segment by setting ``is_active=False``.\n\n- **Admin**: may delete segments on any session.\n- **Instructor**: may only delete segments on sessions they own.\n- Idempotent: deleting an already-inactive segment returns 200 with no error.\n- Segment results (``session_segment_results``) are preserved \u2014 no cascade delete.",
+        "description": "Soft-delete a segment by setting ``is_active=False``.\n\n- **Admin**: may delete segments on any session.\n- **Instructor**: may only delete segments on sessions they own.\n- Idempotent: deleting an already-inactive segment returns 200 with no error.\n- Segment results (``session_segment_results``) are preserved — no cascade delete.",
         "operationId": "delete_session_segment_api_v1_sessions__session_id__segments__segment_id__delete",
         "security": [
           {
@@ -3209,7 +3209,7 @@
           "bookings"
         ],
         "summary": "Create Booking",
-        "description": "Create new booking - STUDENTS ONLY\n\n\ud83c\udfaf REFACTORED: Uses spec services for validation\n- Session-based (LFA Player): Requires only UserLicense\n- Semester-based (Coach/Internship): Requires UserLicense + SemesterEnrollment + payment",
+        "description": "Create new booking - STUDENTS ONLY\n\n🎯 REFACTORED: Uses spec services for validation\n- Session-based (LFA Player): Requires only UserLicense\n- Semester-based (Coach/Internship): Requires UserLicense + SemesterEnrollment + payment",
         "operationId": "create_booking_api_v1_bookings__post",
         "security": [
           {
@@ -4121,7 +4121,7 @@
           "feedback"
         ],
         "summary": "Create Feedback",
-        "description": "Create feedback for a session\n\n\ud83d\udd12 RULE #4: Feedback can only be submitted within 24 hours after session ends",
+        "description": "Create feedback for a session\n\n🔒 RULE #4: Feedback can only be submitted within 24 hours after session ends",
         "operationId": "create_feedback_api_v1_feedback__post",
         "security": [
           {
@@ -5501,7 +5501,7 @@
           "quizzes"
         ],
         "summary": "Get Quiz For Taking",
-        "description": "Get quiz details for taking (without correct answers)\n\n\ud83d\udd12 RULE #5: For hybrid/virtual sessions, quiz is only available during session time",
+        "description": "Get quiz details for taking (without correct answers)\n\n🔒 RULE #5: For hybrid/virtual sessions, quiz is only available during session time",
         "operationId": "get_quiz_for_taking_api_v1_quizzes__quiz_id__get",
         "security": [
           {
@@ -6418,7 +6418,7 @@
           "enrollment"
         ],
         "summary": "Complete Enrollment Quiz",
-        "description": "\u00c9rt\u00e9keli a jelentkez\u00e9si quiz eredm\u00e9ny\u00e9t \u00e9s meghat\u00e1rozza a rangsorol\u00e1si poz\u00edci\u00f3t",
+        "description": "Értékeli a jelentkezési quiz eredményét és meghatározza a rangsorolási pozíciót",
         "operationId": "complete_enrollment_quiz_api_v1_projects__project_id__enrollment_quiz_post",
         "security": [
           {
@@ -6474,7 +6474,7 @@
           "projects"
         ],
         "summary": "Get Enrollment Quiz Info",
-        "description": "Lek\u00e9ri a projekt enrollment quiz inform\u00e1ci\u00f3it",
+        "description": "Lekéri a projekt enrollment quiz információit",
         "operationId": "get_enrollment_quiz_info_api_v1_projects__project_id__enrollment_quiz_get",
         "security": [
           {
@@ -6524,7 +6524,7 @@
           "enrollment"
         ],
         "summary": "Confirm Project Enrollment",
-        "description": "Meger\u0151s\u00edti a projekt jelentkez\u00e9st",
+        "description": "Megerősíti a projekt jelentkezést",
         "operationId": "confirm_project_enrollment_api_v1_projects__project_id__confirm_enrollment_post",
         "security": [
           {
@@ -6750,7 +6750,7 @@
           "projects"
         ],
         "summary": "Add Quiz To Project",
-        "description": "Hozz\u00e1ad egy quiz-t a projekthez (Admin/Instructor only)",
+        "description": "Hozzáad egy quiz-t a projekthez (Admin/Instructor only)",
         "operationId": "add_quiz_to_project_api_v1_projects__project_id__quizzes_post",
         "security": [
           {
@@ -6807,7 +6807,7 @@
           "projects"
         ],
         "summary": "Get Project Quizzes",
-        "description": "Lek\u00e9ri a projekthez kapcsol\u00f3d\u00f3 quiz-eket",
+        "description": "Lekéri a projekthez kapcsolódó quiz-eket",
         "operationId": "get_project_quizzes_api_v1_projects__project_id__quizzes_get",
         "security": [
           {
@@ -6860,7 +6860,7 @@
           "projects"
         ],
         "summary": "Remove Quiz From Project",
-        "description": "Elt\u00e1vol\u00edt egy quiz-t a projektb\u0151l",
+        "description": "Eltávolít egy quiz-t a projektből",
         "operationId": "remove_quiz_from_project_api_v1_projects__project_id__quizzes__quiz_connection_id__delete",
         "security": [
           {
@@ -8302,7 +8302,7 @@
           "specializations"
         ],
         "summary": "List Specializations",
-        "description": "Get available specializations with descriptions (HYBRID: DB + JSON)\n\ud83c\udf93 PUBLIC ENDPOINT - no authentication required for onboarding\n\nProcess:\n1. Load active specializations from DB\n2. Load full content from JSON configs\n3. Return merged data",
+        "description": "Get available specializations with descriptions (HYBRID: DB + JSON)\n🎓 PUBLIC ENDPOINT - no authentication required for onboarding\n\nProcess:\n1. Load active specializations from DB\n2. Load full content from JSON configs\n3. Return merged data",
         "operationId": "list_specializations_api_v1_specializations__get",
         "responses": {
           "200": {
@@ -8354,7 +8354,7 @@
           "specializations"
         ],
         "summary": "Set User Specialization",
-        "description": "Set current user's specialization (HYBRID: with age/consent validation)\n\ud83c\udf93 CRITICAL: This is used during onboarding and profile updates\n\nProcess:\n1. Validate specialization enum\n2. Check DB existence + is_active\n3. Validate age requirements (JSON)\n4. Validate parental consent (for LFA_COACH under 18)\n5. Update user specialization",
+        "description": "Set current user's specialization (HYBRID: with age/consent validation)\n🎓 CRITICAL: This is used during onboarding and profile updates\n\nProcess:\n1. Validate specialization enum\n2. Check DB existence + is_active\n3. Validate age requirements (JSON)\n4. Validate parental consent (for LFA_COACH under 18)\n5. Update user specialization",
         "operationId": "set_user_specialization_api_v1_specializations_me_post",
         "requestBody": {
           "content": {
@@ -10105,7 +10105,7 @@
           "licenses"
         ],
         "summary": "Get Football Skills",
-        "description": "Get football skills for a specific license (LFA Player specializations only).\n\nReturns the raw football_skills JSONB for the license. Each skill entry contains:\n- `current_level`   \u2014 EMA-updated visible skill level (starts at SYSTEM_BASELINE = 60.0)\n- `system_baseline` \u2014 fixed EMA anchor, always 60.0 for post-onboarding players\n- `baseline`        \u2014 backward-compatible alias for system_baseline (60.0)\n- `self_assessment` \u2014 onboarding self-evaluation entered by the player (0-100 scale).\n                      **Motivational reference only. Not a skill level. Never used\n                      as input by EMA, baseline extraction, or any calculation service.**\n- `assessment_delta`\u2014 computed from FootballSkillAssessment rows (coach evaluations),\n                      NOT from self_assessment\n- `tournament_delta`\u2014 cumulative EMA delta from tournament placements\n\n- **license_id**: UserLicense ID",
+        "description": "Get football skills for a specific license (LFA Player specializations only).\n\nReturns the raw football_skills JSONB for the license. Each skill entry contains:\n- `current_level`   — EMA-updated visible skill level (starts at SYSTEM_BASELINE = 60.0)\n- `system_baseline` — fixed EMA anchor, always 60.0 for post-onboarding players\n- `baseline`        — backward-compatible alias for system_baseline (60.0)\n- `self_assessment` — onboarding self-evaluation entered by the player (0-100 scale).\n                      **Motivational reference only. Not a skill level. Never used\n                      as input by EMA, baseline extraction, or any calculation service.**\n- `assessment_delta`— computed from FootballSkillAssessment rows (coach evaluations),\n                      NOT from self_assessment\n- `tournament_delta`— cumulative EMA delta from tournament placements\n\n- **license_id**: UserLicense ID",
         "operationId": "get_football_skills_api_v1_licenses__license_id__football_skills_get",
         "security": [
           {
@@ -10264,7 +10264,7 @@
           "licenses"
         ],
         "summary": "Create Skill Assessment",
-        "description": "Create individual skill assessment (INSTRUCTOR ONLY)\n\nCreates new assessment with state=ASSESSED. If identical assessment exists,\nreturns existing (idempotent). If different assessment exists, archives old\nand creates new.\n\n**State transition:** NOT_ASSESSED \u2192 ASSESSED\n\n**Permissions:** INSTRUCTOR or ADMIN only\n\n**Idempotency:**\n- Identical data (same points) \u2192 returns existing (created=False)\n- Different data \u2192 archives old + creates new (created=True)\n\n**Business Rules:**\n- `requires_validation` auto-determined by:\n  - License level 5+ \u2192 requires validation\n  - Instructor tenure < 6 months \u2192 requires validation\n  - Critical skills (mental, set_pieces) \u2192 requires validation\n\n**Args:**\n- license_id: UserLicense ID\n- skill_name: Skill identifier (e.g., 'ball_control', 'passing')\n- points_earned: Points scored (0-N)\n- points_total: Total possible points (must be > 0)\n- notes: Optional instructor notes\n\n**Returns:**\n- success: True if operation succeeded\n- created: True if new assessment created, False if existing returned\n- message: Human-readable status message\n- assessment: Full assessment object",
+        "description": "Create individual skill assessment (INSTRUCTOR ONLY)\n\nCreates new assessment with state=ASSESSED. If identical assessment exists,\nreturns existing (idempotent). If different assessment exists, archives old\nand creates new.\n\n**State transition:** NOT_ASSESSED → ASSESSED\n\n**Permissions:** INSTRUCTOR or ADMIN only\n\n**Idempotency:**\n- Identical data (same points) → returns existing (created=False)\n- Different data → archives old + creates new (created=True)\n\n**Business Rules:**\n- `requires_validation` auto-determined by:\n  - License level 5+ → requires validation\n  - Instructor tenure < 6 months → requires validation\n  - Critical skills (mental, set_pieces) → requires validation\n\n**Args:**\n- license_id: UserLicense ID\n- skill_name: Skill identifier (e.g., 'ball_control', 'passing')\n- points_earned: Points scored (0-N)\n- points_total: Total possible points (must be > 0)\n- notes: Optional instructor notes\n\n**Returns:**\n- success: True if operation succeeded\n- created: True if new assessment created, False if existing returned\n- message: Human-readable status message\n- assessment: Full assessment object",
         "operationId": "create_skill_assessment_api_v1_licenses__license_id__skills__skill_name__assess_post",
         "security": [
           {
@@ -10450,7 +10450,7 @@
           "licenses"
         ],
         "summary": "Validate Assessment",
-        "description": "Validate skill assessment (ADMIN/INSTRUCTOR ONLY)\n\nTransitions assessment from ASSESSED \u2192 VALIDATED.\n\n**State transition:** ASSESSED \u2192 VALIDATED\n\n**Permissions:** ADMIN or INSTRUCTOR only\n\n**Idempotency:**\n- If already VALIDATED \u2192 returns existing (no error)\n\n**Invalid transitions:**\n- NOT_ASSESSED \u2192 VALIDATED (must assess first)\n- ARCHIVED \u2192 VALIDATED (cannot restore archived)\n\n**Args:**\n- assessment_id: Assessment ID\n\n**Returns:**\n- success: True\n- message: Status message\n- assessment: Updated assessment object",
+        "description": "Validate skill assessment (ADMIN/INSTRUCTOR ONLY)\n\nTransitions assessment from ASSESSED → VALIDATED.\n\n**State transition:** ASSESSED → VALIDATED\n\n**Permissions:** ADMIN or INSTRUCTOR only\n\n**Idempotency:**\n- If already VALIDATED → returns existing (no error)\n\n**Invalid transitions:**\n- NOT_ASSESSED → VALIDATED (must assess first)\n- ARCHIVED → VALIDATED (cannot restore archived)\n\n**Args:**\n- assessment_id: Assessment ID\n\n**Returns:**\n- success: True\n- message: Status message\n- assessment: Updated assessment object",
         "operationId": "validate_assessment_api_v1_licenses_assessments__assessment_id__validate_post",
         "security": [
           {
@@ -10498,7 +10498,7 @@
           "licenses"
         ],
         "summary": "Archive Assessment",
-        "description": "Archive skill assessment (ADMIN/INSTRUCTOR ONLY)\n\nTransitions assessment from ASSESSED/VALIDATED \u2192 ARCHIVED.\n\n**State transition:** ASSESSED/VALIDATED \u2192 ARCHIVED\n\n**Permissions:** ADMIN or INSTRUCTOR only\n\n**Idempotency:**\n- If already ARCHIVED \u2192 returns existing (no error)\n\n**Invalid transitions:**\n- NOT_ASSESSED \u2192 ARCHIVED (must assess first)\n- ARCHIVED \u2192 ARCHIVED (already archived - idempotent)\n\n**Query Parameters:**\n- reason: Optional reason for archiving (default: \"Manually archived by instructor\")\n\n**Args:**\n- assessment_id: Assessment ID\n\n**Returns:**\n- success: True\n- message: Status message\n- assessment: Updated assessment object",
+        "description": "Archive skill assessment (ADMIN/INSTRUCTOR ONLY)\n\nTransitions assessment from ASSESSED/VALIDATED → ARCHIVED.\n\n**State transition:** ASSESSED/VALIDATED → ARCHIVED\n\n**Permissions:** ADMIN or INSTRUCTOR only\n\n**Idempotency:**\n- If already ARCHIVED → returns existing (no error)\n\n**Invalid transitions:**\n- NOT_ASSESSED → ARCHIVED (must assess first)\n- ARCHIVED → ARCHIVED (already archived - idempotent)\n\n**Query Parameters:**\n- reason: Optional reason for archiving (default: \"Manually archived by instructor\")\n\n**Args:**\n- assessment_id: Assessment ID\n\n**Returns:**\n- success: True\n- message: Status message\n- assessment: Updated assessment object",
         "operationId": "archive_assessment_api_v1_licenses_assessments__assessment_id__archive_post",
         "security": [
           {
@@ -10943,7 +10943,7 @@
           "progression"
         ],
         "summary": "Get Skill Profile",
-        "description": "Get player's dynamic skill profile with placement-based calculation\n\nNEW V2 System:\n    - Skills calculated from tournament placement (not points)\n    - Can both INCREASE and DECREASE based on performance\n    - 1st place \u2192 ~95-100, Last place \u2192 ~40-50\n    - Weighted average: baseline + placement-based value\n\nReturns:\n    - Current skill levels (baseline + tournament deltas)\n    - Baseline values from onboarding\n    - Tournament participation count per skill\n    - Assessment count per skill\n    - Average skill level (dynamically calculated)\n    - Skill tiers (BEGINNER, DEVELOPING, INTERMEDIATE, ADVANCED, MASTER)",
+        "description": "Get player's dynamic skill profile with placement-based calculation\n\nNEW V2 System:\n    - Skills calculated from tournament placement (not points)\n    - Can both INCREASE and DECREASE based on performance\n    - 1st place → ~95-100, Last place → ~40-50\n    - Weighted average: baseline + placement-based value\n\nReturns:\n    - Current skill levels (baseline + tournament deltas)\n    - Baseline values from onboarding\n    - Tournament participation count per skill\n    - Assessment count per skill\n    - Average skill level (dynamically calculated)\n    - Skill tiers (BEGINNER, DEVELOPING, INTERMEDIATE, ADVANCED, MASTER)",
         "operationId": "get_skill_profile_api_v1_progression_skill_profile_get",
         "responses": {
           "200": {
@@ -14510,7 +14510,7 @@
           "semester-enrollments"
         ],
         "summary": "Get Payment Info",
-        "description": "\ud83d\udcc4 Get payment information for an enrollment (payment code, instructions, etc.)\n\nReturns:\n- payment_reference_code: Unique code for bank transfer\n- bank_details: Bank account information\n- amount: Payment amount\n- enrollment_details: Specialization, semester info",
+        "description": "📄 Get payment information for an enrollment (payment code, instructions, etc.)\n\nReturns:\n- payment_reference_code: Unique code for bank transfer\n- bank_details: Bank account information\n- amount: Payment amount\n- enrollment_details: Specialization, semester info",
         "operationId": "get_payment_info_api_v1_semester_enrollments__enrollment_id__payment_info_get",
         "parameters": [
           {
@@ -14552,7 +14552,7 @@
           "semester-enrollments"
         ],
         "summary": "Verify Payment By Code",
-        "description": "\u2705 Admin verifies payment using the payment reference code\n\nFlow:\n1. Admin receives bank transfer with payment code in comment\n2. Admin enters the code here\n3. System finds the enrollment and marks payment as verified",
+        "description": "✅ Admin verifies payment using the payment reference code\n\nFlow:\n1. Admin receives bank transfer with payment code in comment\n2. Admin enters the code here\n3. System finds the enrollment and marks payment as verified",
         "operationId": "verify_payment_by_code_api_v1_semester_enrollments_verify_by_code_post",
         "parameters": [
           {
@@ -14594,7 +14594,7 @@
           "semester-enrollments"
         ],
         "summary": "Approve Enrollment Request",
-        "description": "\u2705 Admin or Master Instructor approves a PENDING enrollment request\n\n**Who can approve:**\n- \ud83e\udd4b Master Instructor of the semester\n- \ud83d\udc51 Admin (can override)\n\nChanges:\n- request_status: PENDING \u2192 APPROVED\n- is_active: False \u2192 True\n- approved_at: set to now\n- approved_by: set to current_user.id",
+        "description": "✅ Admin or Master Instructor approves a PENDING enrollment request\n\n**Who can approve:**\n- 🥋 Master Instructor of the semester\n- 👑 Admin (can override)\n\nChanges:\n- request_status: PENDING → APPROVED\n- is_active: False → True\n- approved_at: set to now\n- approved_by: set to current_user.id",
         "operationId": "approve_enrollment_request_api_v1_semester_enrollments__enrollment_id__approve_post",
         "parameters": [
           {
@@ -14636,7 +14636,7 @@
           "semester-enrollments"
         ],
         "summary": "Reject Enrollment Request",
-        "description": "\u274c Admin or Master Instructor rejects a PENDING enrollment request\n\n**Who can reject:**\n- \ud83e\udd4b Master Instructor of the semester\n- \ud83d\udc51 Admin (can override)\n\nChanges:\n- request_status: PENDING \u2192 REJECTED\n- is_active: False (remains)\n- approved_at: set to now\n- approved_by: set to current_user.id\n- rejection_reason: set to provided reason",
+        "description": "❌ Admin or Master Instructor rejects a PENDING enrollment request\n\n**Who can reject:**\n- 🥋 Master Instructor of the semester\n- 👑 Admin (can override)\n\nChanges:\n- request_status: PENDING → REJECTED\n- is_active: False (remains)\n- approved_at: set to now\n- approved_by: set to current_user.id\n- rejection_reason: set to provided reason",
         "operationId": "reject_enrollment_request_api_v1_semester_enrollments__enrollment_id__reject_post",
         "parameters": [
           {
@@ -14688,7 +14688,7 @@
           "semester-enrollments"
         ],
         "summary": "Override Age Category",
-        "description": "\ud83c\udfaf Override age category for a student enrollment.\n\n**Permissions**:\n- \ud83e\udd4b Instructor (any instructor)\n- \ud83d\udc51 Admin (can override any, with warnings)\n\n**Business Rules**:\n- \u2705 14+ year-olds can be moved between YOUTH/AMATEUR/PRO anytime (even mid-season)\n- \u274c 5-13 year-olds MUST stay in PRE (cannot override)\n- \ud83d\udd12 Season lock: Category is determined at July 1 and stays fixed\n- \ud83d\udcdd Override is audited (who, when)\n\n**Example**:\n- Student born 2007-12-06, season 2025/26 (July 1, 2025)\n- Age at season start: 17 years\n- Default: YOUTH\n- Instructor can override to: AMATEUR or PRO",
+        "description": "🎯 Override age category for a student enrollment.\n\n**Permissions**:\n- 🥋 Instructor (any instructor)\n- 👑 Admin (can override any, with warnings)\n\n**Business Rules**:\n- ✅ 14+ year-olds can be moved between YOUTH/AMATEUR/PRO anytime (even mid-season)\n- ❌ 5-13 year-olds MUST stay in PRE (cannot override)\n- 🔒 Season lock: Category is determined at July 1 and stays fixed\n- 📝 Override is audited (who, when)\n\n**Example**:\n- Student born 2007-12-06, season 2025/26 (July 1, 2025)\n- Age at season start: 17 years\n- Default: YOUTH\n- Instructor can override to: AMATEUR or PRO",
         "operationId": "override_age_category_api_v1_semester_enrollments__enrollment_id__override_category_post",
         "parameters": [
           {
@@ -15416,7 +15416,7 @@
           "coupons"
         ],
         "summary": "Apply Coupon",
-        "description": "Apply a coupon code to the current user's account.\n\n**Coupon Types:**\n- BONUS_CREDITS: Instant free credits (no purchase required)\n- PURCHASE_DISCOUNT_PERCENT: Percentage discount on credit purchase (requires invoice + admin approval)\n- PURCHASE_BONUS_CREDITS: Bonus credits after credit purchase (requires invoice + admin approval)\n\n**Legacy types (auto-migrated to BONUS_CREDITS):**\n- PERCENT, FIXED, CREDITS \u2192 All treated as instant bonus credits\n\n**Authorization:** Authenticated user\n\n**Validations:**\n- Coupon exists\n- Coupon is valid (active, not expired, not at max uses)\n- User has not already used this coupon\n- Coupon type allows instant redemption (not purchase-only)\n\n**Actions:**\n- For BONUS_CREDITS: Adds credits immediately to user's balance\n- For PURCHASE_* types: Rejects with error (can only be used during purchase)\n- Creates CouponUsage record\n- Increments coupon usage count\n\n**Returns:**\n- Success message\n- Credits awarded (if applicable)\n- User's new credit balance",
+        "description": "Apply a coupon code to the current user's account.\n\n**Coupon Types:**\n- BONUS_CREDITS: Instant free credits (no purchase required)\n- PURCHASE_DISCOUNT_PERCENT: Percentage discount on credit purchase (requires invoice + admin approval)\n- PURCHASE_BONUS_CREDITS: Bonus credits after credit purchase (requires invoice + admin approval)\n\n**Legacy types (auto-migrated to BONUS_CREDITS):**\n- PERCENT, FIXED, CREDITS → All treated as instant bonus credits\n\n**Authorization:** Authenticated user\n\n**Validations:**\n- Coupon exists\n- Coupon is valid (active, not expired, not at max uses)\n- User has not already used this coupon\n- Coupon type allows instant redemption (not purchase-only)\n\n**Actions:**\n- For BONUS_CREDITS: Adds credits immediately to user's balance\n- For PURCHASE_* types: Rejects with error (can only be used during purchase)\n- Creates CouponUsage record\n- Increments coupon usage count\n\n**Returns:**\n- Success message\n- Credits awarded (if applicable)\n- User's new credit balance",
         "operationId": "apply_coupon_api_v1_coupons_apply_post",
         "requestBody": {
           "content": {
@@ -15700,7 +15700,7 @@
           "lfa-player"
         ],
         "summary": "Create License",
-        "description": "Create a new LFA Player license \u2014 **DEPRECATED (410 Gone)**\n\nLicense creation is now handled via the specialization unlock flow.\nUse POST /onboarding/specialization to unlock LFA Football Player.",
+        "description": "Create a new LFA Player license — **DEPRECATED (410 Gone)**\n\nLicense creation is now handled via the specialization unlock flow.\nUse POST /onboarding/specialization to unlock LFA Football Player.",
         "operationId": "create_license_api_v1_lfa_player_licenses_post",
         "requestBody": {
           "content": {
@@ -15772,7 +15772,7 @@
           "lfa-player"
         ],
         "summary": "Update Skill",
-        "description": "Update a skill average \u2014 **DEPRECATED (410 Gone)**\n\nSkill updates are now handled via the 44-skill system.\nUse PUT /licenses/{license_id}/football-skills instead.",
+        "description": "Update a skill average — **DEPRECATED (410 Gone)**\n\nSkill updates are now handled via the 44-skill system.\nUse PUT /licenses/{license_id}/football-skills instead.",
         "operationId": "update_skill_api_v1_lfa_player_licenses__license_id__skills_put",
         "security": [
           {
@@ -15993,7 +15993,7 @@
           "gancuju"
         ],
         "summary": "List All Licenses",
-        "description": "Get all G\u0101nCuju licenses (Admin only)",
+        "description": "Get all GānCuju licenses (Admin only)",
         "operationId": "list_all_licenses_api_v1_gancuju_licenses_get",
         "responses": {
           "200": {
@@ -16016,7 +16016,7 @@
           "gancuju"
         ],
         "summary": "Create License",
-        "description": "Create a new G\u0101nCuju license for the current user.\n\n**Cost:** 100 credits (deducted from user's credit_balance)\n\n- **starting_level**: Initial level (1-8), defaults to 1\n\nReturns the created license with all fields.",
+        "description": "Create a new GānCuju license for the current user.\n\n**Cost:** 100 credits (deducted from user's credit_balance)\n\n- **starting_level**: Initial level (1-8), defaults to 1\n\nReturns the created license with all fields.",
         "operationId": "create_license_api_v1_gancuju_licenses_post",
         "requestBody": {
           "content": {
@@ -16063,7 +16063,7 @@
           "gancuju"
         ],
         "summary": "Get My License",
-        "description": "Get the current user's active G\u0101nCuju license.\n\nReturns 404 if no active license is found.",
+        "description": "Get the current user's active GānCuju license.\n\nReturns 404 if no active license is found.",
         "operationId": "get_my_license_api_v1_gancuju_licenses_me_get",
         "responses": {
           "200": {
@@ -17149,7 +17149,7 @@
           "motivation-assessment"
         ],
         "summary": "Submit Motivation Assessment",
-        "description": "Submit motivation/preference assessment after specialization unlock\n\n**Workflow:**\n1. User unlocks specialization (100 credits)\n2. User completes THIS motivation assessment (ONCE per specialization)\n3. User can start semester enrollments\n\n**Specialization-specific assessments:**\n- **LFA Player:** 7 skill self-ratings (1-10 scale)\n- **G\u0101nCuju:** Character type selection (Warrior/Teacher)\n- **Coach:** Age group + Role + Specialization preferences\n- **Internship:** Position selection (45 positions)\n\n**Storage:** Saved to `user_licenses.motivation_scores` (JSON field)",
+        "description": "Submit motivation/preference assessment after specialization unlock\n\n**Workflow:**\n1. User unlocks specialization (100 credits)\n2. User completes THIS motivation assessment (ONCE per specialization)\n3. User can start semester enrollments\n\n**Specialization-specific assessments:**\n- **LFA Player:** 7 skill self-ratings (1-10 scale)\n- **GānCuju:** Character type selection (Warrior/Teacher)\n- **Coach:** Age group + Role + Specialization preferences\n- **Internship:** Position selection (45 positions)\n\n**Storage:** Saved to `user_licenses.motivation_scores` (JSON field)",
         "operationId": "submit_motivation_assessment_api_v1_licenses_motivation_assessment_post",
         "requestBody": {
           "content": {
@@ -17237,7 +17237,7 @@
           "public-profile"
         ],
         "summary": "Get Basic Profile",
-        "description": "Get basic profile for OTHER specializations (G\u0101nCuju, Coach, Internship)\n\nReturns:\n- User basic info\n- Active licenses list\n- Simple stats (no detailed skills)",
+        "description": "Get basic profile for OTHER specializations (GānCuju, Coach, Internship)\n\nReturns:\n- User basic info\n- Active licenses list\n- Simple stats (no detailed skills)",
         "operationId": "get_basic_profile_api_v1_public_users__user_id__profile_basic_get",
         "parameters": [
           {
@@ -17319,7 +17319,7 @@
           "semester-generator"
         ],
         "summary": "Generate Semesters",
-        "description": "Generate semesters for a specific year, specialization, and age group.\n\n**Admin only** - Automatically creates all semesters based on templates.\n\nExamples:\n- LFA_PLAYER + PRE \u2192 12 monthly semesters (M01-M12)\n- LFA_PLAYER + YOUTH \u2192 4 quarterly semesters (Q1-Q4)\n- LFA_PLAYER + AMATEUR \u2192 2 semi-annual semesters (Fall, Spring)\n- LFA_PLAYER + PRO \u2192 1 annual semester (Season)",
+        "description": "Generate semesters for a specific year, specialization, and age group.\n\n**Admin only** - Automatically creates all semesters based on templates.\n\nExamples:\n- LFA_PLAYER + PRE → 12 monthly semesters (M01-M12)\n- LFA_PLAYER + YOUTH → 4 quarterly semesters (Q1-Q4)\n- LFA_PLAYER + AMATEUR → 2 semi-annual semesters (Fall, Spring)\n- LFA_PLAYER + PRO → 1 annual semester (Season)",
         "operationId": "generate_semesters_api_v1_admin_semesters_generate_post",
         "requestBody": {
           "content": {
@@ -17634,7 +17634,7 @@
           "locations"
         ],
         "summary": "Create Location",
-        "description": "Create a new LFA Education Center location.\n\n**Admin only**\n\nExample:\n```json\n{\n    \"name\": \"LFA Education Center - Budapest\",\n    \"city\": \"Budapest\",\n    \"country\": \"Hungary\",\n    \"address\": \"1011 Budapest, F\u0151 utca 1.\",\n    \"notes\": \"Main campus in Hungary\",\n    \"is_active\": true\n}\n```",
+        "description": "Create a new LFA Education Center location.\n\n**Admin only**\n\nExample:\n```json\n{\n    \"name\": \"LFA Education Center - Budapest\",\n    \"city\": \"Budapest\",\n    \"country\": \"Hungary\",\n    \"address\": \"1011 Budapest, Fő utca 1.\",\n    \"notes\": \"Main campus in Hungary\",\n    \"is_active\": true\n}\n```",
         "operationId": "create_location_api_v1_admin_locations__post",
         "security": [
           {
@@ -18501,7 +18501,7 @@
           "instructor-assignments"
         ],
         "summary": "Get Instructor Assignment Requests",
-        "description": "Get all assignment requests for a specific instructor with advanced filtering.\n\nInstructors can only see their own requests, admins can see all.\n\nFilters available:\n- status_filter: PENDING, ACCEPTED, DECLINED, CANCELLED\n- specialization_type: LFA_PLAYER, GANCUJU, INTERNSHIP, COACH\n- age_group: PRE, YOUTH, ADULT, etc.\n- location_city: Budapest, Buda\u00f6rs, etc.\n- priority_min: Only show requests with priority >= this value (1-10)",
+        "description": "Get all assignment requests for a specific instructor with advanced filtering.\n\nInstructors can only see their own requests, admins can see all.\n\nFilters available:\n- status_filter: PENDING, ACCEPTED, DECLINED, CANCELLED\n- specialization_type: LFA_PLAYER, GANCUJU, INTERNSHIP, COACH\n- age_group: PRE, YOUTH, ADULT, etc.\n- location_city: Budapest, Budaörs, etc.\n- priority_min: Only show requests with priority >= this value (1-10)",
         "operationId": "get_instructor_assignment_requests_api_v1_instructor_assignments_requests_instructor__instructor_id__get",
         "security": [
           {
@@ -18585,10 +18585,10 @@
                   "type": "null"
                 }
               ],
-              "description": "Filter by city: Budapest, Buda\u00f6rs, etc.",
+              "description": "Filter by city: Budapest, Budaörs, etc.",
               "title": "Location City"
             },
-            "description": "Filter by city: Budapest, Buda\u00f6rs, etc."
+            "description": "Filter by city: Budapest, Budaörs, etc."
           },
           {
             "name": "priority_min",
@@ -18697,7 +18697,7 @@
           "instructor-assignments"
         ],
         "summary": "Accept Assignment Request",
-        "description": "Instructor accepts an assignment request.\n\nWhen accepted:\n1. Request status \u2192 ACCEPTED\n2. semester.master_instructor_id = instructor.id",
+        "description": "Instructor accepts an assignment request.\n\nWhen accepted:\n1. Request status → ACCEPTED\n2. semester.master_instructor_id = instructor.id",
         "operationId": "accept_assignment_request_api_v1_instructor_assignments_requests__request_id__accept_patch",
         "security": [
           {
@@ -19618,7 +19618,7 @@
           "spec-info"
         ],
         "summary": "Check Age Eligibility",
-        "description": "Check if current user's age meets requirements for a specialization.\n\n**Examples:**\n- `specialization_type=LFA_PLAYER_PRE` \u2192 Check if age 6-11\n- `specialization_type=LFA_COACH&target_group=PRO_HEAD` \u2192 Check if age 23+\n- `specialization_type=INTERNSHIP` \u2192 Check if age 18+\n- `specialization_type=GANCUJU_PLAYER` \u2192 Check if age 5+\n\n**Example Response:**\n```json\n{\n    \"specialization_type\": \"LFA_COACH\",\n    \"target_group\": \"PRO_HEAD\",\n    \"user_age\": 25,\n    \"is_eligible\": true,\n    \"reason\": \"Eligible for LFA Coach (age 25)\"\n}\n```",
+        "description": "Check if current user's age meets requirements for a specialization.\n\n**Examples:**\n- `specialization_type=LFA_PLAYER_PRE` → Check if age 6-11\n- `specialization_type=LFA_COACH&target_group=PRO_HEAD` → Check if age 23+\n- `specialization_type=INTERNSHIP` → Check if age 18+\n- `specialization_type=GANCUJU_PLAYER` → Check if age 5+\n\n**Example Response:**\n```json\n{\n    \"specialization_type\": \"LFA_COACH\",\n    \"target_group\": \"PRO_HEAD\",\n    \"user_age\": 25,\n    \"is_eligible\": true,\n    \"reason\": \"Eligible for LFA Coach (age 25)\"\n}\n```",
         "operationId": "check_age_eligibility_api_v1_spec_info_age_eligibility_get",
         "security": [
           {
@@ -19712,7 +19712,7 @@
           "Master Hiring - Direct"
         ],
         "summary": "Create Direct Hire Offer",
-        "description": "Admin: Create direct hire offer (Pathway A)\n\nSends offer to instructor \u2192 Instructor must accept/decline\n\nBusiness Rules:\n- Only one active master per location\n- Instructor cannot have active master position elsewhere\n- Availability validation is ADVISORY only (admin can override)\n- Offer has deadline (default 14 days)",
+        "description": "Admin: Create direct hire offer (Pathway A)\n\nSends offer to instructor → Instructor must accept/decline\n\nBusiness Rules:\n- Only one active master per location\n- Instructor cannot have active master position elsewhere\n- Availability validation is ADVISORY only (admin can override)\n- Offer has deadline (default 14 days)",
         "operationId": "create_direct_hire_offer_api_v1_instructor_management_masters_direct_hire_post",
         "requestBody": {
           "content": {
@@ -19761,7 +19761,7 @@
           "Master Hiring - Applications"
         ],
         "summary": "Hire From Application",
-        "description": "Admin: Accept application and create master offer (Pathway B)\n\nWorkflow:\n1. Admin accepts application\n2. Creates OFFERED contract (instructor still must accept!)\n3. Auto-declines other PENDING applications for position\n4. Marks position as FILLED\n\nBusiness Rule: Application acceptance \u2260 contract acceptance!\nInstructor applied = intent, but still must formally accept contract.",
+        "description": "Admin: Accept application and create master offer (Pathway B)\n\nWorkflow:\n1. Admin accepts application\n2. Creates OFFERED contract (instructor still must accept!)\n3. Auto-declines other PENDING applications for position\n4. Marks position as FILLED\n\nBusiness Rule: Application acceptance ≠ contract acceptance!\nInstructor applied = intent, but still must formally accept contract.",
         "operationId": "hire_from_application_api_v1_instructor_management_masters_hire_from_application_post",
         "requestBody": {
           "content": {
@@ -19810,7 +19810,7 @@
           "Master Hiring - Offers"
         ],
         "summary": "Respond To Offer",
-        "description": "Instructor: Accept or decline master instructor offer\n\nBusiness Rules:\n- Offer must belong to current user\n- Offer must be in OFFERED status\n- Offer deadline must not have passed\n- When accepting:\n  - Instructor cannot have another active master position\n  - All other OFFERED contracts for this instructor auto-decline\n  - Semesters transition: DRAFT \u2192 INSTRUCTOR_ASSIGNED",
+        "description": "Instructor: Accept or decline master instructor offer\n\nBusiness Rules:\n- Offer must belong to current user\n- Offer must be in OFFERED status\n- Offer deadline must not have passed\n- When accepting:\n  - Instructor cannot have another active master position\n  - All other OFFERED contracts for this instructor auto-decline\n  - Semesters transition: DRAFT → INSTRUCTOR_ASSIGNED",
         "operationId": "respond_to_offer_api_v1_instructor_management_masters_offers__offer_id__respond_patch",
         "security": [
           {
@@ -21220,7 +21220,7 @@
           "session-groups"
         ],
         "summary": "Auto Assign Groups",
-        "description": "Auto-assign present students to groups\n\nAlgorithm:\n- Gets all students marked PRESENT\n- Gets available instructors\n- Distributes students evenly\n\nExample:\n- 2 instructors, 6 students \u2192 2 groups of 3\n- 2 instructors, 7 students \u2192 1 group of 4, 1 group of 3\n\nAuthorization: Head coach or instructor for this session",
+        "description": "Auto-assign present students to groups\n\nAlgorithm:\n- Gets all students marked PRESENT\n- Gets available instructors\n- Distributes students evenly\n\nExample:\n- 2 instructors, 6 students → 2 groups of 3\n- 2 instructors, 7 students → 1 group of 4, 1 group of 3\n\nAuthorization: Head coach or instructor for this session",
         "operationId": "auto_assign_groups_api_v1_session_groups_auto_assign_post",
         "requestBody": {
           "content": {
@@ -21531,7 +21531,7 @@
           "tournaments"
         ],
         "summary": "Update Tournament",
-        "description": "Update tournament fields (Admin only)\n\n**Authorization:** Admin only\n\n**Allowed updates:**\n- name: Tournament name\n- enrollment_cost: Credits required to enroll\n- max_players: Maximum participant capacity (cannot be reduced below current enrollment count)\n- age_group: Age group classification\n- description: Tournament description\n- start_date: Tournament start date (ISO format)\n- end_date: Tournament end date (ISO format)\n- specialization_type: Specialization type\n- assignment_type: OPEN_ASSIGNMENT or APPLICATION_BASED\n- participant_type: INDIVIDUAL, TEAM, or MIXED\n- tournament_type_id: Tournament type (\u26a0\ufe0f Auto-deletes sessions if changed)\n- tournament_status: Tournament status (\u26a0\ufe0f ADMIN OVERRIDE: Bypasses state machine validation)\n\n**Important Notes:**\n- max_players cannot be reduced below current enrollment count\n- tournament_type_id: Automatically deletes existing sessions if changed\n- tournament_status: Admin can set ANY status (state machine validation bypassed)",
+        "description": "Update tournament fields (Admin only)\n\n**Authorization:** Admin only\n\n**Allowed updates:**\n- name: Tournament name\n- enrollment_cost: Credits required to enroll\n- max_players: Maximum participant capacity (cannot be reduced below current enrollment count)\n- age_group: Age group classification\n- description: Tournament description\n- start_date: Tournament start date (ISO format)\n- end_date: Tournament end date (ISO format)\n- specialization_type: Specialization type\n- assignment_type: OPEN_ASSIGNMENT or APPLICATION_BASED\n- participant_type: INDIVIDUAL, TEAM, or MIXED\n- tournament_type_id: Tournament type (⚠️ Auto-deletes sessions if changed)\n- tournament_status: Tournament status (⚠️ ADMIN OVERRIDE: Bypasses state machine validation)\n\n**Important Notes:**\n- max_players cannot be reduced below current enrollment count\n- tournament_type_id: Automatically deletes existing sessions if changed\n- tournament_status: Admin can set ANY status (state machine validation bypassed)",
         "operationId": "update_tournament_api_v1_tournaments__tournament_id__patch",
         "security": [
           {
@@ -21862,7 +21862,7 @@
           "tournaments"
         ],
         "summary": "Send Instructor Request",
-        "description": "Send instructor assignment request for tournament (Admin only)\n\n**Authorization:** Admin only\n\n**IMPORTANT:** This sends a PENDING request to the instructor (grandmaster).\nTournament activates only when instructor ACCEPTS the request.\n\nWorkflow:\n1. Admin sends request \u2192 Status: PENDING\n2. Instructor sees request in their dashboard\n3. Instructor accepts \u2192 Tournament status: READY_FOR_ENROLLMENT\n4. Instructor declines \u2192 Tournament status: SEEKING_INSTRUCTOR (can send new request)\n\n**Example:**\n```json\n{\n  \"instructor_id\": 2,\n  \"message\": \"Would you like to lead the Winter Cup tournament?\"\n}\n```",
+        "description": "Send instructor assignment request for tournament (Admin only)\n\n**Authorization:** Admin only\n\n**IMPORTANT:** This sends a PENDING request to the instructor (grandmaster).\nTournament activates only when instructor ACCEPTS the request.\n\nWorkflow:\n1. Admin sends request → Status: PENDING\n2. Instructor sees request in their dashboard\n3. Instructor accepts → Tournament status: READY_FOR_ENROLLMENT\n4. Instructor declines → Tournament status: SEEKING_INSTRUCTOR (can send new request)\n\n**Example:**\n```json\n{\n  \"instructor_id\": 2,\n  \"message\": \"Would you like to lead the Winter Cup tournament?\"\n}\n```",
         "operationId": "send_instructor_request_api_v1_tournaments__tournament_id__send_instructor_request_post",
         "security": [
           {
@@ -22020,7 +22020,7 @@
           "tournaments"
         ],
         "summary": "Get Tournament Summary",
-        "description": "Get tournament summary\n\n**Authorization:** Any authenticated user\n\n# TICKET-UI-01: Extend response with seeding metrics post-generation\n# Add to TournamentSummaryResponse (and get_tournament_summary service):\n#   seeded_count    : int | None  \u2014 number of players in the bracket pool\n#   checked_in_count: int | None  \u2014 confirmed check-ins at generation time\n#   pool_label      : str | None  \u2014 \"check-in confirmed\" | \"fallback: all approved\"\n# These fields are available in session_generator.py after generate_sessions() runs.\n# Consumer: Tournament Monitor header (Enrolled / Confirmed / Seeded display).\n# Priority: UX improvement, not a correctness fix. Does NOT block current release.",
+        "description": "Get tournament summary\n\n**Authorization:** Any authenticated user\n\n# TICKET-UI-01: Extend response with seeding metrics post-generation\n# Add to TournamentSummaryResponse (and get_tournament_summary service):\n#   seeded_count    : int | None  — number of players in the bracket pool\n#   checked_in_count: int | None  — confirmed check-ins at generation time\n#   pool_label      : str | None  — \"check-in confirmed\" | \"fallback: all approved\"\n# These fields are available in session_generator.py after generate_sessions() runs.\n# Consumer: Tournament Monitor header (Enrolled / Confirmed / Seeded display).\n# Priority: UX improvement, not a correctness fix. Does NOT block current release.",
         "operationId": "get_tournament_summary_api_v1_tournaments__tournament_id__summary_get",
         "security": [
           {
@@ -22548,7 +22548,7 @@
           "tournaments"
         ],
         "summary": "Accept Instructor Assignment",
-        "description": "Instructor accepts tournament assignment.\n\nThis endpoint transitions a tournament to INSTRUCTOR_CONFIRMED status.\nSupports two scenarios:\n1. APPLICATION_BASED: Tournament status SEEKING_INSTRUCTOR \u2192 INSTRUCTOR_CONFIRMED\n2. OPEN_ASSIGNMENT: Tournament status PENDING_INSTRUCTOR_ACCEPTANCE \u2192 INSTRUCTOR_CONFIRMED\n\n**Authorization:** INSTRUCTOR role only\n\n**Validations:**\n- Current user is INSTRUCTOR\n- Current user has active LFA_COACH license\n- Tournament exists\n- Tournament status is SEEKING_INSTRUCTOR or PENDING_INSTRUCTOR_ACCEPTANCE\n\n**Actions Performed:**\n- Updates semester.master_instructor_id = current_user.id\n- Updates semester.tournament_status = INSTRUCTOR_CONFIRMED\n- Updates all associated sessions.instructor_id = current_user.id\n\n**Returns:**\n- Tournament details\n- Number of sessions updated\n- Confirmation message\n\n**Example Response:**\n```json\n{\n    \"message\": \"Tournament assignment accepted successfully\",\n    \"tournament_id\": 123,\n    \"tournament_name\": \"Youth Football Tournament 2026\",\n    \"tournament_status\": \"INSTRUCTOR_CONFIRMED\",\n    \"instructor_id\": 5,\n    \"instructor_name\": \"Coach Smith\",\n    \"sessions_updated\": 3\n}\n```\n\n**Raises:**\n- 403 FORBIDDEN: User is not an instructor or lacks LFA_COACH license\n- 404 NOT FOUND: Tournament not found\n- 400 BAD REQUEST: Tournament is not in valid status for acceptance",
+        "description": "Instructor accepts tournament assignment.\n\nThis endpoint transitions a tournament to INSTRUCTOR_CONFIRMED status.\nSupports two scenarios:\n1. APPLICATION_BASED: Tournament status SEEKING_INSTRUCTOR → INSTRUCTOR_CONFIRMED\n2. OPEN_ASSIGNMENT: Tournament status PENDING_INSTRUCTOR_ACCEPTANCE → INSTRUCTOR_CONFIRMED\n\n**Authorization:** INSTRUCTOR role only\n\n**Validations:**\n- Current user is INSTRUCTOR\n- Current user has active LFA_COACH license\n- Tournament exists\n- Tournament status is SEEKING_INSTRUCTOR or PENDING_INSTRUCTOR_ACCEPTANCE\n\n**Actions Performed:**\n- Updates semester.master_instructor_id = current_user.id\n- Updates semester.tournament_status = INSTRUCTOR_CONFIRMED\n- Updates all associated sessions.instructor_id = current_user.id\n\n**Returns:**\n- Tournament details\n- Number of sessions updated\n- Confirmation message\n\n**Example Response:**\n```json\n{\n    \"message\": \"Tournament assignment accepted successfully\",\n    \"tournament_id\": 123,\n    \"tournament_name\": \"Youth Football Tournament 2026\",\n    \"tournament_status\": \"INSTRUCTOR_CONFIRMED\",\n    \"instructor_id\": 5,\n    \"instructor_name\": \"Coach Smith\",\n    \"sessions_updated\": 3\n}\n```\n\n**Raises:**\n- 403 FORBIDDEN: User is not an instructor or lacks LFA_COACH license\n- 404 NOT FOUND: Tournament not found\n- 400 BAD REQUEST: Tournament is not in valid status for acceptance",
         "operationId": "accept_instructor_assignment_api_v1_tournaments__tournament_id__instructor_assignment_accept_post",
         "security": [
           {
@@ -23661,7 +23661,7 @@
           "tournaments"
         ],
         "summary": "Distribute Tournament Rewards",
-        "description": "DEPRECATED \u2014 use POST /{tournament_id}/distribute-rewards-v2\n\nReturns HTTP 410 Gone. The V2 endpoint runs the full EMA skill\npropagation pipeline (Phase 3) and issues idempotent credit/XP grants.",
+        "description": "DEPRECATED — use POST /{tournament_id}/distribute-rewards-v2\n\nReturns HTTP 410 Gone. The V2 endpoint runs the full EMA skill\npropagation pipeline (Phase 3) and issues idempotent credit/XP grants.",
         "operationId": "distribute_tournament_rewards_api_v1_tournaments__tournament_id__distribute_rewards_post",
         "security": [
           {
@@ -24248,7 +24248,7 @@
           "tournaments"
         ],
         "summary": "Save Tournament Reward Config",
-        "description": "Save reward configuration for a tournament.\n\n\u26a0\ufe0f VALIDATION: At least 1 skill must be enabled.\n\nArgs:\n    tournament_id: Tournament (semester) ID\n    reward_config: Reward configuration to save\n\nReturns:\n    Saved reward configuration\n\nRaises:\n    403: If user is not admin\n    404: If tournament not found\n    400: If validation fails (no enabled skills, invalid config, etc.)",
+        "description": "Save reward configuration for a tournament.\n\n⚠️ VALIDATION: At least 1 skill must be enabled.\n\nArgs:\n    tournament_id: Tournament (semester) ID\n    reward_config: Reward configuration to save\n\nReturns:\n    Saved reward configuration\n\nRaises:\n    403: If user is not admin\n    404: If tournament not found\n    400: If validation fails (no enabled skills, invalid config, etc.)",
         "operationId": "save_tournament_reward_config_api_v1_tournaments__tournament_id__reward_config_post",
         "security": [
           {
@@ -24671,7 +24671,7 @@
           "tournaments"
         ],
         "summary": "Update Schedule Config",
-        "description": "Update the global schedule configuration for a tournament.\n\nOnly provided fields are updated (PATCH semantics \u2014 NULL fields are ignored).\nTo clear a value back to type defaults, set it to null in the request.\n\n**Authorization:** Admin only\n\n**Effect:** Values are persisted to `tournament_configurations` table\nand will be used as defaults in all subsequent session generation calls.\nPer-campus overrides (set via PUT /campus-schedules) take precedence.",
+        "description": "Update the global schedule configuration for a tournament.\n\nOnly provided fields are updated (PATCH semantics — NULL fields are ignored).\nTo clear a value back to type defaults, set it to null in the request.\n\n**Authorization:** Admin only\n\n**Effect:** Values are persisted to `tournament_configurations` table\nand will be used as defaults in all subsequent session generation calls.\nPer-campus overrides (set via PUT /campus-schedules) take precedence.",
         "operationId": "update_schedule_config_api_v1_tournaments__tournament_id__schedule_config_patch",
         "security": [
           {
@@ -24731,7 +24731,7 @@
           "session-generation"
         ],
         "summary": "Preview Tournament Sessions",
-        "description": "Preview tournament session structure WITHOUT creating sessions in database\n\n**Authorization:** Admin only\n\n**Parameters:**\n- `tournament_id`: Tournament (Semester) ID\n- `parallel_fields`: Number of fields for parallel matches (default: 1)\n- `session_duration_minutes`: Session duration (default: 90)\n- `break_minutes`: Break between sessions (default: 15)\n\n**Returns:**\n- Tournament info\n- Tournament type config\n- Player count (enrolled)\n- Estimated sessions (preview)\n\n**Response Example:**\n```json\n{\n    \"tournament_id\": 121,\n    \"tournament_name\": \"\ud83c\udded\ud83c\uddfa HU - Winter Cup - Budapest\",\n    \"tournament_type\": \"League (Round Robin)\",\n    \"player_count\": 8,\n    \"parallel_fields\": 1,\n    \"estimated_sessions\": [\n        {\n            \"title\": \"Winter Cup - Round 1 - Match 1\",\n            \"date_start\": \"2026-01-20T09:00:00\",\n            \"date_end\": \"2026-01-20T10:30:00\",\n            \"game_type\": \"Round 1\",\n            \"tournament_phase\": \"League\",\n            \"tournament_round\": 1,\n            \"tournament_match_number\": 1\n        }\n    ],\n    \"total_matches\": 28,\n    \"total_rounds\": 7,\n    \"estimated_duration_minutes\": 1260\n}\n```",
+        "description": "Preview tournament session structure WITHOUT creating sessions in database\n\n**Authorization:** Admin only\n\n**Parameters:**\n- `tournament_id`: Tournament (Semester) ID\n- `parallel_fields`: Number of fields for parallel matches (default: 1)\n- `session_duration_minutes`: Session duration (default: 90)\n- `break_minutes`: Break between sessions (default: 15)\n\n**Returns:**\n- Tournament info\n- Tournament type config\n- Player count (enrolled)\n- Estimated sessions (preview)\n\n**Response Example:**\n```json\n{\n    \"tournament_id\": 121,\n    \"tournament_name\": \"🇭🇺 HU - Winter Cup - Budapest\",\n    \"tournament_type\": \"League (Round Robin)\",\n    \"player_count\": 8,\n    \"parallel_fields\": 1,\n    \"estimated_sessions\": [\n        {\n            \"title\": \"Winter Cup - Round 1 - Match 1\",\n            \"date_start\": \"2026-01-20T09:00:00\",\n            \"date_end\": \"2026-01-20T10:30:00\",\n            \"game_type\": \"Round 1\",\n            \"tournament_phase\": \"League\",\n            \"tournament_round\": 1,\n            \"tournament_match_number\": 1\n        }\n    ],\n    \"total_matches\": 28,\n    \"total_rounds\": 7,\n    \"estimated_duration_minutes\": 1260\n}\n```",
         "operationId": "preview_tournament_sessions_api_v1_tournaments__tournament_id__preview_sessions_get",
         "security": [
           {
@@ -24871,7 +24871,7 @@
           "session-generation"
         ],
         "summary": "Get Generation Status",
-        "description": "Poll the status of a background session-generation task.\n\nWorks for both Celery tasks (when Redis is running) and in-process thread tasks.\n\n**Authorization:** Admin only\n\nReturns one of:\n- `{\"status\": \"pending\"}` \u2014 queued, not yet started\n- `{\"status\": \"running\"}` \u2014 generation in progress\n- `{\"status\": \"done\", \"sessions_count\": N, \"message\": \"...\"}` \u2014 completed successfully\n- `{\"status\": \"error\", \"message\": \"...\"}` \u2014 generation failed\n- `{\"status\": \"retrying\"}` \u2014 Celery is retrying after a transient error\n\nThe task_id is returned by `POST /tournaments/{id}/generate-sessions` when\nplayer_count >= 128 and async generation is used.",
+        "description": "Poll the status of a background session-generation task.\n\nWorks for both Celery tasks (when Redis is running) and in-process thread tasks.\n\n**Authorization:** Admin only\n\nReturns one of:\n- `{\"status\": \"pending\"}` — queued, not yet started\n- `{\"status\": \"running\"}` — generation in progress\n- `{\"status\": \"done\", \"sessions_count\": N, \"message\": \"...\"}` — completed successfully\n- `{\"status\": \"error\", \"message\": \"...\"}` — generation failed\n- `{\"status\": \"retrying\"}` — Celery is retrying after a transient error\n\nThe task_id is returned by `POST /tournaments/{id}/generate-sessions` when\nplayer_count >= 128 and async generation is used.",
         "operationId": "get_generation_status_api_v1_tournaments__tournament_id__generation_status__task_id__get",
         "security": [
           {
@@ -27380,7 +27380,7 @@
           "web"
         ],
         "summary": "Lfa Player Onboarding Web Submit",
-        "description": "Web-compatible LFA Player onboarding submit.\nCalled via AJAX fetch from lfa_player_onboarding.html (cookie session auth).\n\nAccepts the same JSON body as /specialization/lfa-player/onboarding-submit\n(Bearer JWT endpoint for Streamlit) but uses get_current_user_web so that\nbrowser-session users can submit the 6-step onboarding form.\n\nRequest body (JSON):\n    position   : str  \u2014 STRIKER | MIDFIELDER | DEFENDER | GOALKEEPER\n    goals      : str  \u2014 dropdown value\n    motivation : str  \u2014 free text\n    skills     : dict \u2014 all 44 skill keys (0-99 scale, step=1)\n\nReturns JSON {\"success\": true} on success; {\"error\": \"...\"} on failure.",
+        "description": "Web-compatible LFA Player onboarding submit.\nCalled via AJAX fetch from lfa_player_onboarding.html (cookie session auth).\n\nAccepts the same JSON body as /specialization/lfa-player/onboarding-submit\n(Bearer JWT endpoint for Streamlit) but uses get_current_user_web so that\nbrowser-session users can submit the 6-step onboarding form.\n\nRequest body (JSON):\n    position   : str  — STRIKER | MIDFIELDER | DEFENDER | GOALKEEPER\n    goals      : str  — dropdown value\n    motivation : str  — free text\n    skills     : dict — all 44 skill keys (0-99 scale, step=1)\n\nReturns JSON {\"success\": true} on success; {\"error\": \"...\"} on failure.",
         "operationId": "lfa_player_onboarding_web_submit_specialization_lfa_player_onboarding_web_post",
         "responses": {
           "200": {
@@ -27551,7 +27551,7 @@
           "web"
         ],
         "summary": "Lfa Player Profile Positions Submit",
-        "description": "Update only the player's positions (primary + secondaries, max 4 total).\n\nAccepts:\n  position      \u2014 canonical primary position (snake_case)\n  positions_raw \u2014 JSON array of all positions including primary, e.g. '[\"striker\",\"left_wing\"]'\n\nValidates: canonical values, 1\u20134 count, primary is first element.\nNever touches foot scores, goals, height, weight, or any other field.",
+        "description": "Update only the player's positions (primary + secondaries, max 4 total).\n\nAccepts:\n  position      — canonical primary position (snake_case)\n  positions_raw — JSON array of all positions including primary, e.g. '[\"striker\",\"left_wing\"]'\n\nValidates: canonical values, 1–4 count, primary is first element.\nNever touches foot scores, goals, height, weight, or any other field.",
         "operationId": "lfa_player_profile_positions_submit_profile_lfa_football_player_positions_post",
         "requestBody": {
           "content": {
@@ -27712,7 +27712,7 @@
           "web"
         ],
         "summary": "Onboarding Welcome Card",
-        "description": "Welcome Card preview \u2014 private self-assessment view.\n\nData source: football_skills[*].self_assessment ONLY.\nNEVER reads current_level, baseline, system_baseline, tournament_delta,\nassessment_delta, or any EMA output.\n\nWithout ?platform=: renders the gallery hub (iframe + download buttons).\nWith ?platform=X:   renders the FIFA Classic card for that platform size.\nWith ?export=1:     switches the FIFA template to export-mode (Playwright use).\n\nAuth: cookie session (browser) OR short-lived render JWT (Playwright export).\nrender_token is generated by export_onboarding_welcome_card, expires in 60 s,\nand is only accepted when purpose==\"wc_render\".\nVisibility: private, no-index (meta tag in template).",
+        "description": "Welcome Card preview — private self-assessment view.\n\nData source: football_skills[*].self_assessment ONLY.\nNEVER reads current_level, baseline, system_baseline, tournament_delta,\nassessment_delta, or any EMA output.\n\nWithout ?platform=: renders the gallery hub (iframe + download buttons).\nWith ?platform=X:   renders the FIFA Classic card for that platform size.\nWith ?export=1:     switches the FIFA template to export-mode (Playwright use).\n\nAuth: cookie session (browser) OR short-lived render JWT (Playwright export).\nrender_token is generated by export_onboarding_welcome_card, expires in 60 s,\nand is only accepted when purpose==\"wc_render\".\nVisibility: private, no-index (meta tag in template).",
         "operationId": "onboarding_welcome_card_profile_onboarding_card_get",
         "parameters": [
           {
@@ -27938,7 +27938,7 @@
           "web"
         ],
         "summary": "Skills Data Endpoint",
-        "description": "JSON endpoint \u2014 returns full skill profile for lazy-load widgets.",
+        "description": "JSON endpoint — returns full skill profile for lazy-load widgets.",
         "operationId": "skills_data_endpoint_skills_data_get",
         "responses": {
           "200": {
@@ -27958,7 +27958,7 @@
           "web"
         ],
         "summary": "Skills Page",
-        "description": "Student skill progression page \u2014 all 44 skills, lazy-loaded.",
+        "description": "Student skill progression page — all 44 skills, lazy-loaded.",
         "operationId": "skills_page_skills_get",
         "responses": {
           "200": {
@@ -27980,7 +27980,7 @@
           "web"
         ],
         "summary": "Skills History Data Endpoint",
-        "description": "JSON endpoint \u2014 EMA timeline for a single skill, used by the skill history chart.",
+        "description": "JSON endpoint — EMA timeline for a single skill, used by the skill history chart.",
         "operationId": "skills_history_data_endpoint_skills_history_data_get",
         "parameters": [
           {
@@ -28024,7 +28024,7 @@
           "web"
         ],
         "summary": "Skills History Page",
-        "description": "Student skill history page \u2014 per-skill EMA timeline chart.",
+        "description": "Student skill history page — per-skill EMA timeline chart.",
         "operationId": "skills_history_page_skills_history_get",
         "parameters": [
           {
@@ -30758,7 +30758,7 @@
           "web"
         ],
         "summary": "Admin Renew License",
-        "description": "Admin: renew a license \u2014 set new expires_at + record LicenseProgression('RENEWED').",
+        "description": "Admin: renew a license — set new expires_at + record LicenseProgression('RENEWED').",
         "operationId": "admin_renew_license_admin_users__user_id__renew_license__license_id__post",
         "parameters": [
           {
@@ -31110,7 +31110,7 @@
           "web"
         ],
         "summary": "Admin Patch Session Instructor",
-        "description": "Override the instructor on a single auto-generated session.\n\nBody: {\"instructor_id\": <int>}   \u2014 set to specific instructor\n      {\"instructor_id\": null}    \u2014 clear override (reverts to semester default)",
+        "description": "Override the instructor on a single auto-generated session.\n\nBody: {\"instructor_id\": <int>}   — set to specific instructor\n      {\"instructor_id\": null}    — clear override (reverts to semester default)",
         "operationId": "admin_patch_session_instructor_admin_semesters__semester_id__sessions__session_id__instructor_patch",
         "parameters": [
           {
@@ -31261,7 +31261,7 @@
           "web"
         ],
         "summary": "Admin Location Detail Page",
-        "description": "Admin-only: Location detail \u2014 hierarchical view of campus, programs, sessions, instructors.",
+        "description": "Admin-only: Location detail — hierarchical view of campus, programs, sessions, instructors.",
         "operationId": "admin_location_detail_page_admin_locations__location_id__get",
         "parameters": [
           {
@@ -31474,7 +31474,7 @@
           "web"
         ],
         "summary": "Admin Location Events Page",
-        "description": "Admin-only: Per-location event management \u2014 all event types CRUD in one place.",
+        "description": "Admin-only: Per-location event management — all event types CRUD in one place.",
         "operationId": "admin_location_events_page_admin_events_locations__location_id__get",
         "parameters": [
           {
@@ -31567,7 +31567,7 @@
           "web"
         ],
         "summary": "Admin Campus Detail Page",
-        "description": "Admin-only: Campus detail \u2014 programs, upcoming sessions, location instructors.",
+        "description": "Admin-only: Campus detail — programs, upcoming sessions, location instructors.",
         "operationId": "admin_campus_detail_page_admin_campuses__campus_id__get",
         "parameters": [
           {
@@ -31986,7 +31986,7 @@
           "web"
         ],
         "summary": "Admin Sessions Page",
-        "description": "Admin-only: Session management \u2014 hierarchical view (Location \u2192 Spec \u2192 Semester \u2192 Session)",
+        "description": "Admin-only: Session management — hierarchical view (Location → Spec → Semester → Session)",
         "operationId": "admin_sessions_page_admin_sessions_get",
         "parameters": [
           {
@@ -32389,7 +32389,7 @@
           "web"
         ],
         "summary": "Admin Invoice Unverify",
-        "description": "Unverify invoice (reverts credits) \u2014 cookie auth.",
+        "description": "Unverify invoice (reverts credits) — cookie auth.",
         "operationId": "admin_invoice_unverify_admin_invoices__invoice_id__unverify_post",
         "parameters": [
           {
@@ -33590,7 +33590,7 @@
           "web"
         ],
         "summary": "Admin Events Hub Page",
-        "description": "Admin-only: Event Management hub \u2014 tournaments, camps, training sessions, match sessions.",
+        "description": "Admin-only: Event Management hub — tournaments, camps, training sessions, match sessions.",
         "operationId": "admin_events_hub_page_admin_events_get",
         "responses": {
           "200": {
@@ -33812,7 +33812,7 @@
           "web"
         ],
         "summary": "Admin Camps Page",
-        "description": "Admin-only: Camp management \u2014 list of CAMP-category semesters.",
+        "description": "Admin-only: Camp management — list of CAMP-category semesters.",
         "operationId": "admin_camps_page_admin_camps_get",
         "parameters": [
           {
@@ -34310,7 +34310,7 @@
           "web"
         ],
         "summary": "Admin Sponsor Promotion Create",
-        "description": "Admin: create one INDIVIDUAL promotion event per selected age category for a sponsor.\n\nSponsor-only flow \u2014 no Club, no Team, no TournamentTeamEnrollment.\nEach age group produces one Semester record with:\n  organizer_sponsor_id    = sponsor.id\n  organizer_campaign_id   = campaign.id  (required \u2014 campaign audience feeds the event)\n  organizer_club_id       = NULL  (explicit)\n  participant_type        = INDIVIDUAL",
+        "description": "Admin: create one INDIVIDUAL promotion event per selected age category for a sponsor.\n\nSponsor-only flow — no Club, no Team, no TournamentTeamEnrollment.\nEach age group produces one Semester record with:\n  organizer_sponsor_id    = sponsor.id\n  organizer_campaign_id   = campaign.id  (required — campaign audience feeds the event)\n  organizer_club_id       = NULL  (explicit)\n  participant_type        = INDIVIDUAL",
         "operationId": "admin_sponsor_promotion_create_admin_sponsors__sponsor_id__promotion_post",
         "parameters": [
           {
@@ -35014,7 +35014,7 @@
           "web"
         ],
         "summary": " Redirect Audience To Campaigns",
-        "description": "Legacy URL \u2014 redirects to campaign list on sponsor detail.",
+        "description": "Legacy URL — redirects to campaign list on sponsor detail.",
         "operationId": "_redirect_audience_to_campaigns_admin_sponsors__sponsor_id__audience_get",
         "parameters": [
           {
@@ -35057,7 +35057,7 @@
           "web"
         ],
         "summary": " Redirect Csv Import To Campaigns",
-        "description": "Legacy URL \u2014 redirects to sponsor detail (create a campaign there first).",
+        "description": "Legacy URL — redirects to sponsor detail (create a campaign there first).",
         "operationId": "_redirect_csv_import_to_campaigns_admin_sponsors__sponsor_id__csv_import_get",
         "parameters": [
           {
@@ -35100,7 +35100,7 @@
           "web"
         ],
         "summary": " Legacy Rollback Redirect",
-        "description": "Legacy rollback URL \u2014 redirects to sponsor detail with guidance.",
+        "description": "Legacy rollback URL — redirects to sponsor detail with guidance.",
         "operationId": "_legacy_rollback_redirect_admin_sponsors__sponsor_id__csv_import__log_id__rollback_post",
         "parameters": [
           {
@@ -36714,7 +36714,7 @@
           "web"
         ],
         "summary": "Admin Start Tournament",
-        "description": "Admin: advance ENROLLMENT_CLOSED \u2192 IN_PROGRESS.",
+        "description": "Admin: advance ENROLLMENT_CLOSED → IN_PROGRESS.",
         "operationId": "admin_start_tournament_admin_tournaments__tournament_id__start_post",
         "parameters": [
           {
@@ -36822,7 +36822,7 @@
           "web"
         ],
         "summary": "Admin Rollback Tournament",
-        "description": "Admin: rollback stuck IN_PROGRESS \u2192 ENROLLMENT_CLOSED for re-generation.",
+        "description": "Admin: rollback stuck IN_PROGRESS → ENROLLMENT_CLOSED for re-generation.",
         "operationId": "admin_rollback_tournament_admin_tournaments__tournament_id__rollback_post",
         "parameters": [
           {
@@ -36858,7 +36858,7 @@
           "web"
         ],
         "summary": "Admin Tournament Edit Page",
-        "description": "Admin: tournament edit page \u2014 all lifecycle management in one place.",
+        "description": "Admin: tournament edit page — all lifecycle management in one place.",
         "operationId": "admin_tournament_edit_page_admin_tournaments__tournament_id__edit_get",
         "parameters": [
           {
@@ -36901,7 +36901,7 @@
           "web"
         ],
         "summary": "Admin Instructors Page",
-        "description": "Admin instructor list \u2014 all users with role=INSTRUCTOR.",
+        "description": "Admin instructor list — all users with role=INSTRUCTOR.",
         "operationId": "admin_instructors_page_admin_instructors_get",
         "responses": {
           "200": {
@@ -36923,7 +36923,7 @@
           "web"
         ],
         "summary": "Admin Instructor Detail Page",
-        "description": "Admin instructor detail \u2014 licenses, assignments, availability, requests.",
+        "description": "Admin instructor detail — licenses, assignments, availability, requests.",
         "operationId": "admin_instructor_detail_page_admin_instructors__instructor_id__get",
         "parameters": [
           {
@@ -37591,7 +37591,7 @@
           "web"
         ],
         "summary": "Admin Enroll Player",
-        "description": "Bulk-enroll one or more players (admin bypass \u2014 no credit deduction).",
+        "description": "Bulk-enroll one or more players (admin bypass — no credit deduction).",
         "operationId": "admin_enroll_player_admin_tournaments__tournament_id__enroll_player_post",
         "security": [
           {
@@ -37964,7 +37964,7 @@
           "web"
         ],
         "summary": "Admin Apply Fallback",
-        "description": "Apply the fallback plan \u2014 reassign sessions + update parallel_fields.",
+        "description": "Apply the fallback plan — reassign sessions + update parallel_fields.",
         "operationId": "admin_apply_fallback_admin_tournaments__tournament_id__apply_fallback_post",
         "parameters": [
           {
@@ -38315,7 +38315,7 @@
           "events"
         ],
         "summary": "Events Hub",
-        "description": "Events hub \u2014 navigation hub for Camps, Tournaments, Academy Season, Mini Season.",
+        "description": "Events hub — navigation hub for Camps, Tournaments, Academy Season, Mini Season.",
         "operationId": "events_hub_events_get",
         "responses": {
           "200": {
@@ -38338,7 +38338,7 @@
           "adaptive-learning"
         ],
         "summary": "Adaptive Learning Page",
-        "description": "Adaptive Learning entry point \u2014 XP summary + disabled CTA until full engine lands.",
+        "description": "Adaptive Learning entry point — XP summary + disabled CTA until full engine lands.",
         "operationId": "adaptive_learning_page_adaptive_learning_get",
         "responses": {
           "200": {
@@ -38510,7 +38510,7 @@
           "adaptive-learning"
         ],
         "summary": "Al Session Start",
-        "description": "Start a new adaptive learning session scoped to a specific module.\n\nDecision matrix:\n  - No active session                                      \u2192 CREATE  (resumed=false)\n  - Active session, expired                               \u2192 retire  \u2192 CREATE\n  - Active session, force_new=true                        \u2192 retire  \u2192 CREATE  (previous_session_retired=true)\n  - Active session, any of lang/cat/module differs        \u2192 retire  \u2192 CREATE  (previous_session_retired=true)\n  - Active session, exact lang+cat+module match           \u2192 RESUME             (resumed=true)",
+        "description": "Start a new adaptive learning session scoped to a specific module.\n\nDecision matrix:\n  - No active session                                      → CREATE  (resumed=false)\n  - Active session, expired                               → retire  → CREATE\n  - Active session, force_new=true                        → retire  → CREATE  (previous_session_retired=true)\n  - Active session, any of lang/cat/module differs        → retire  → CREATE  (previous_session_retired=true)\n  - Active session, exact lang+cat+module match           → RESUME             (resumed=true)",
         "operationId": "al_session_start_adaptive_learning_session_start_post",
         "parameters": [
           {
@@ -38782,7 +38782,7 @@
           "training"
         ],
         "summary": "Training Hub Page",
-        "description": "Training hub \u2014 top-level entry point for all training modes.",
+        "description": "Training hub — top-level entry point for all training modes.",
         "operationId": "training_hub_page_training_get",
         "responses": {
           "200": {
@@ -38805,7 +38805,7 @@
           "virtual-training"
         ],
         "summary": "Virtual Training Hub",
-        "description": "Virtual Games hub \u2014 lists all hub-visible games (active + planned).",
+        "description": "Virtual Games hub — lists all hub-visible games (active + planned).",
         "operationId": "virtual_training_hub_virtual_training_get",
         "responses": {
           "200": {
@@ -38828,7 +38828,7 @@
           "virtual-training"
         ],
         "summary": "Virtual Training Color Reaction",
-        "description": "Color Reaction game page \u2014 instructions + Vanilla JS game loop.",
+        "description": "Color Reaction game page — instructions + Vanilla JS game loop.",
         "operationId": "virtual_training_color_reaction_virtual_training_color_reaction_get",
         "responses": {
           "200": {
@@ -39004,7 +39004,7 @@
           "virtual-training"
         ],
         "summary": "Virtual Training Go No Go",
-        "description": "Go / No-Go Reaction game page \u2014 instructions + Vanilla JS game loop.",
+        "description": "Go / No-Go Reaction game page — instructions + Vanilla JS game loop.",
         "operationId": "virtual_training_go_no_go_virtual_training_go_no_go_get",
         "responses": {
           "200": {
@@ -39092,7 +39092,7 @@
           "virtual-training"
         ],
         "summary": "Virtual Training Target Tracking",
-        "description": "Target Tracking game page \u2014 instruction + MOT arena (moving objects).",
+        "description": "Target Tracking game page — instruction + MOT arena (moving objects).",
         "operationId": "virtual_training_target_tracking_virtual_training_target_tracking_get",
         "responses": {
           "200": {
@@ -39196,7 +39196,7 @@
           "virtual-training"
         ],
         "summary": "Virtual Training History",
-        "description": "Attempt history \u2014 last 20 valid attempts across all VT games.",
+        "description": "Attempt history — last 20 valid attempts across all VT games.",
         "operationId": "virtual_training_history_virtual_training_history_get",
         "responses": {
           "200": {
@@ -39219,7 +39219,7 @@
           "virtual-training"
         ],
         "summary": "Virtual Training Memory Sequence",
-        "description": "Memory Sequence game page \u2014 instruction + 3\u00d74 grid recall game loop.",
+        "description": "Memory Sequence game page — instruction + 3×4 grid recall game loop.",
         "operationId": "virtual_training_memory_sequence_virtual_training_memory_sequence_get",
         "responses": {
           "200": {
@@ -39314,6 +39314,94 @@
             }
           }
         }
+      }
+    },
+    "/virtual-training/number-color-conflict": {
+      "get": {
+        "description": "Number-Color Conflict game page — instructions + Vanilla JS game loop.",
+        "operationId": "virtual_training_number_color_conflict_virtual_training_number_color_conflict_get",
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Virtual Training Number Color Conflict",
+        "tags": [
+          "web",
+          "virtual-training"
+        ]
+      }
+    },
+    "/virtual-training/number-color-conflict/result/{attempt_id}": {
+      "get": {
+        "description": "Result screen for a completed Number-Color Conflict attempt.",
+        "operationId": "virtual_training_number_color_conflict_result_virtual_training_number_color_conflict_result__attempt_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "attempt_id",
+            "required": true,
+            "schema": {
+              "title": "Attempt Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Virtual Training Number Color Conflict Result",
+        "tags": [
+          "web",
+          "virtual-training"
+        ]
+      }
+    },
+    "/virtual-training/number-color-conflict/submit": {
+      "post": {
+        "description": "Record a Number-Color Conflict attempt. Returns attempt_id, xp_awarded, is_valid.",
+        "operationId": "virtual_training_number_color_conflict_submit_virtual_training_number_color_conflict_submit_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Virtual Training Number Color Conflict Submit",
+        "tags": [
+          "web",
+          "virtual-training"
+        ]
       }
     },
     "/notifications": {
@@ -40204,7 +40292,7 @@
           "web"
         ],
         "summary": "Public Player Profile",
-        "description": "Public player profile page \u2014 auth-optional, social panel, card preview.",
+        "description": "Public player profile page — auth-optional, social panel, card preview.",
         "operationId": "public_player_profile_players__user_id__get",
         "parameters": [
           {
@@ -40651,7 +40739,7 @@
           "web"
         ],
         "summary": "Sd Enroll Team",
-        "description": "Enroll a club team in the tournament (SD/admin bypass \u2014 no credit cost).",
+        "description": "Enroll a club team in the tournament (SD/admin bypass — no credit cost).",
         "operationId": "sd_enroll_team_sport_director_tournaments__tournament_id__teams__team_id__enroll_post",
         "parameters": [
           {
@@ -40752,7 +40840,7 @@
           "my-cards"
         ],
         "summary": "My Cards Hub",
-        "description": "Hub page listing all card types \u2014 active (v\u22651) and coming-soon (v0).",
+        "description": "Hub page listing all card types — active (v≥1) and coming-soon (v0).",
         "operationId": "my_cards_hub_my_cards_get",
         "responses": {
           "200": {
@@ -40775,7 +40863,7 @@
           "my-cards"
         ],
         "summary": "My Cards Player Card",
-        "description": "Detail entry point for Player Card \u2014 redirects to the card editor.",
+        "description": "Detail entry point for Player Card — redirects to the card editor.",
         "operationId": "my_cards_player_card_my_cards_player_card_get",
         "responses": {
           "200": {
@@ -40796,7 +40884,7 @@
           "my-cards"
         ],
         "summary": "My Cards Welcome Card",
-        "description": "Detail entry point for Welcome Card \u2014 redirects to the onboarding card.",
+        "description": "Detail entry point for Welcome Card — redirects to the onboarding card.",
         "operationId": "my_cards_welcome_card_my_cards_welcome_card_get",
         "responses": {
           "200": {
@@ -40858,7 +40946,7 @@
           "web"
         ],
         "summary": "Send Friend Request By Identifier",
-        "description": "Add Friend form \u2014 looks up target by email or nickname, then delegates.",
+        "description": "Add Friend form — looks up target by email or nickname, then delegates.",
         "operationId": "send_friend_request_by_identifier_friends_send_post",
         "requestBody": {
           "content": {
@@ -43330,7 +43418,7 @@
             "type": "string",
             "title": "Icon",
             "description": "Badge emoji icon",
-            "default": "\ud83c\udfc6"
+            "default": "🏆"
           },
           "title": {
             "type": "string",
@@ -43393,7 +43481,7 @@
           },
           "description": "Won 1st place in {tournament_name}",
           "enabled": true,
-          "icon": "\ud83e\udd47",
+          "icon": "🥇",
           "rarity": "EPIC",
           "title": "Champion"
         }
@@ -43408,7 +43496,7 @@
             "maxItems": 1024,
             "minItems": 1,
             "title": "Players",
-            "description": "List of players to create (1\u20131024 per call)"
+            "description": "List of players to create (1–1024 per call)"
           },
           "specialization": {
             "type": "string",
@@ -47470,7 +47558,7 @@
         "title": "CompetitionRecord",
         "description": "Request body for recording a competition result",
         "example": {
-          "competition_name": "Budapest G\u0101nCuju Championship",
+          "competition_name": "Budapest GānCuju Championship",
           "notes": "Final score: 3-1",
           "opponent": "Team Alpha",
           "won": true
@@ -48198,7 +48286,7 @@
           "can_confirm"
         ],
         "title": "EnrollmentPriorityResponse",
-        "description": "Rangsorol\u00e1si inform\u00e1ci\u00f3k"
+        "description": "Rangsorolási információk"
       },
       "EnrollmentRejection": {
         "properties": {
@@ -49085,7 +49173,7 @@
           "teacher"
         ],
         "title": "GanCujuCharacterType",
-        "description": "Character path selection for G\u0101nCuju specialization"
+        "description": "Character path selection for GānCuju specialization"
       },
       "GanCujuMotivation": {
         "properties": {
@@ -49099,7 +49187,7 @@
           "character_type"
         ],
         "title": "GanCujuMotivation",
-        "description": "G\u0101nCuju character type selection\n\nDetermines student's focus:\n- Warrior: Competition-focused, winning mindset\n- Teacher: Knowledge transfer, teaching others"
+        "description": "GānCuju character type selection\n\nDetermines student's focus:\n- Warrior: Competition-focused, winning mindset\n- Teacher: Knowledge transfer, teaching others"
       },
       "GeneratedSemesterInfo": {
         "properties": {
@@ -53008,7 +53096,7 @@
             "maximum": 1024.0,
             "minimum": 0.0,
             "title": "Player Count",
-            "description": "Number of players to seed + enroll (0\u20131024). Use 0 for testing enrollment workflows.",
+            "description": "Number of players to seed + enroll (0–1024). Use 0 for testing enrollment workflows.",
             "default": 1024
           },
           "max_players": {
@@ -53141,7 +53229,7 @@
               "accelerated"
             ],
             "title": "Simulation Mode",
-            "description": "Controls result auto-simulation: 'manual' \u2014 sessions created, no auto-simulation (observe live); 'auto_immediate' \u2014 results simulated but lifecycle not completed; 'accelerated' \u2014 full lifecycle completed synchronously (default).",
+            "description": "Controls result auto-simulation: 'manual' — sessions created, no auto-simulation (observe live); 'auto_immediate' — results simulated but lifecycle not completed; 'accelerated' — full lifecycle completed synchronously (default).",
             "default": "accelerated"
           },
           "game_preset_id": {
@@ -53154,7 +53242,7 @@
               }
             ],
             "title": "Game Preset Id",
-            "description": "Game preset ID (e.g., G\u0101nFootvolley=1). When provided, skills and game config are auto-synced from the preset. Overrides the default hardcoded skill list."
+            "description": "Game preset ID (e.g., GānFootvolley=1). When provided, skills and game config are auto-synced from the preset. Overrides the default hardcoded skill list."
           },
           "reward_config": {
             "anyOf": [
@@ -53180,7 +53268,7 @@
               }
             ],
             "title": "Number Of Rounds",
-            "description": "Number of rounds for INDIVIDUAL_RANKING tournaments (1\u201320). Defaults to 1 if omitted."
+            "description": "Number of rounds for INDIVIDUAL_RANKING tournaments (1–20). Defaults to 1 if omitted."
           },
           "player_ids": {
             "anyOf": [
@@ -53195,7 +53283,7 @@
               }
             ],
             "title": "Player Ids",
-            "description": "Explicit list of user IDs to enroll. When provided, overrides player_count and skips the @lfa-seed.hu pool lookup \u2014 any active users can be selected. player_count is ignored when player_ids is set."
+            "description": "Explicit list of user IDs to enroll. When provided, overrides player_count and skips the @lfa-seed.hu pool lookup — any active users can be selected. player_count is ignored when player_ids is set."
           },
           "campus_ids": {
             "items": {
@@ -53204,7 +53292,7 @@
             "type": "array",
             "minItems": 1,
             "title": "Campus Ids",
-            "description": "Explicit campus IDs for session distribution (required, min 1). Sessions are assigned round-robin across the provided campus IDs. Auto-discovery is disabled \u2014 campuses must be specified explicitly."
+            "description": "Explicit campus IDs for session distribution (required, min 1). Sessions are assigned round-robin across the provided campus IDs. Auto-discovery is disabled — campuses must be specified explicitly."
           },
           "participant_type": {
             "type": "string",
@@ -53213,7 +53301,7 @@
               "TEAM"
             ],
             "title": "Participant Type",
-            "description": "Participant type for the tournament. 'INDIVIDUAL' (default): players enroll and compete as individuals. 'TEAM': teams enroll as units \u2014 requires tournament_format='HEAD_TO_HEAD' and simulation_mode='manual' (TEAM auto-simulation is not implemented). 'MIXED' is not supported via the ops endpoint.",
+            "description": "Participant type for the tournament. 'INDIVIDUAL' (default): players enroll and compete as individuals. 'TEAM': teams enroll as units — requires tournament_format='HEAD_TO_HEAD' and simulation_mode='manual' (TEAM auto-simulation is not implemented). 'MIXED' is not supported via the ops endpoint.",
             "default": "INDIVIDUAL"
           },
           "auto_generate_sessions": {
@@ -53622,7 +53710,7 @@
             {
               "badge_type": "CHAMPION",
               "enabled": true,
-              "icon": "\ud83e\udd47",
+              "icon": "🥇",
               "rarity": "EPIC",
               "title": "Champion"
             }
@@ -58413,7 +58501,7 @@
               }
             ],
             "title": "Campus Ids",
-            "description": "Explicit list of campus IDs for multi-venue group_knockout tournaments. Admin: multiple campuses allowed. Instructor: exactly 1 campus allowed \u2014 request is rejected if more than 1 ID is provided."
+            "description": "Explicit list of campus IDs for multi-venue group_knockout tournaments. Admin: multiple campuses allowed. Instructor: exactly 1 campus allowed — request is rejected if more than 1 ID is provided."
           },
           "campus_schedule_overrides": {
             "anyOf": [
@@ -58522,7 +58610,7 @@
               }
             ],
             "title": "Skill Targets",
-            "description": "Map of skill_key \u2192 weight. NULL = inherit from session game_preset at result time. All weights must be > 0."
+            "description": "Map of skill_key → weight. NULL = inherit from session game_preset at result time. All weights must be > 0."
           }
         },
         "type": "object",
@@ -58678,7 +58766,7 @@
         },
         "type": "object",
         "title": "SessionSegmentUpdate",
-        "description": "Partial update schema for a session segment.\n\nAll fields are optional \u2014 omit a field to leave it unchanged.\n``null`` is valid only for ``duration_minutes`` and ``skill_targets``\n(it clears the field); ``label``, ``position``, and ``is_active``\nreject explicit null.  An empty body ``{}`` is rejected with 422."
+        "description": "Partial update schema for a session segment.\n\nAll fields are optional — omit a field to leave it unchanged.\n``null`` is valid only for ``duration_minutes`` and ``skill_targets``\n(it clears the field); ``label``, ``position``, and ``is_active``\nreject explicit null.  An empty body ``{}`` is rejected with 422."
       },
       "SessionSummaryResponse": {
         "properties": {
@@ -59315,7 +59403,7 @@
           "ema_path"
         ],
         "title": "SkillAuditRow",
-        "description": "One audit row: one tournament \u00d7 one mapped skill"
+        "description": "One audit row: one tournament × one mapped skill"
       },
       "SkillData": {
         "properties": {
@@ -59654,7 +59742,7 @@
           "LFA_PLAYER_PRO_ACADEMY"
         ],
         "title": "SpecializationType",
-        "description": "Specialization types for users and semesters/seasons\n\n\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n4 USER LICENSE TYPES (what users can BE in user_licenses table):\n\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n- LFA_COACH: Coach license (8 levels, teaches players/coaches)\n- LFA_FOOTBALL_PLAYER: Player license (8 levels, ONE unified specialization)\n- GANCUJU_PLAYER: G\u0101nCuju player (8 belt system)\n- INTERNSHIP: Internship program (3 levels)\n\n\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n11 SEMESTER/SEASON TYPES (what semesters teach - semesters table ONLY):\n\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n- LFA_PLAYER_PRE: Mini Seasons for PRE age group (5-13 years, monthly M01-M12) - SEASON TYPE ONLY\n- LFA_PLAYER_YOUTH: Mini Seasons for YOUTH age group (14-18 years, quarterly Q1-Q4) - SEASON TYPE ONLY\n- LFA_PLAYER_AMATEUR: Mini Seasons for AMATEUR age group (14+ years, quarterly Q1-Q4) - SEASON TYPE ONLY\n- LFA_PLAYER_PRO: Mini Seasons for PRO age group (14+ years, quarterly Q1-Q4) - SEASON TYPE ONLY\n- LFA_PLAYER_PRE_ACADEMY: Academy Season for PRE (5-13 years, full year Jul-Jun) - SEASON TYPE ONLY\n- LFA_PLAYER_YOUTH_ACADEMY: Academy Season for YOUTH (14-18 years, full year Jul-Jun) - SEASON TYPE ONLY\n- LFA_PLAYER_AMATEUR_ACADEMY: Academy Season for AMATEUR (14+ years, full year Jul-Jun) - SEASON TYPE ONLY\n- LFA_PLAYER_PRO_ACADEMY: Academy Season for PRO (14+ years, full year Jul-Jun) - SEASON TYPE ONLY\n- GANCUJU_PLAYER: Also used for seasons\n- LFA_COACH: Also used for seasons\n- INTERNSHIP: Also used for seasons\n\n\u26a0\ufe0f CRITICAL RULES:\n\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n1. Users can ONLY have these in user_licenses.specialization_type:\n   - LFA_COACH\n   - LFA_FOOTBALL_PLAYER (NOT PRE/YOUTH/AMATEUR/PRO!)\n   - GANCUJU_PLAYER\n   - INTERNSHIP\n\n2. Semesters can have these in semesters.specialization_type:\n   - LFA_PLAYER_PRE/YOUTH/AMATEUR/PRO (for age-specific semesters)\n   - LFA_FOOTBALL_PLAYER (for tournaments/general sessions)\n   - LFA_COACH, GANCUJU_PLAYER, INTERNSHIP\n\n3. Age groups (PRE/YOUTH/AMATEUR/PRO) are determined by:\n   - User's age AT SEASON START (July 1)\n   - Season lock: stays fixed for entire season (July 1 - June 30)\n   - Follows international football practice"
+        "description": "Specialization types for users and semesters/seasons\n\n═══════════════════════════════════════════════════════════════════════════\n4 USER LICENSE TYPES (what users can BE in user_licenses table):\n═══════════════════════════════════════════════════════════════════════════\n- LFA_COACH: Coach license (8 levels, teaches players/coaches)\n- LFA_FOOTBALL_PLAYER: Player license (8 levels, ONE unified specialization)\n- GANCUJU_PLAYER: GānCuju player (8 belt system)\n- INTERNSHIP: Internship program (3 levels)\n\n═══════════════════════════════════════════════════════════════════════════\n11 SEMESTER/SEASON TYPES (what semesters teach - semesters table ONLY):\n═══════════════════════════════════════════════════════════════════════════\n- LFA_PLAYER_PRE: Mini Seasons for PRE age group (5-13 years, monthly M01-M12) - SEASON TYPE ONLY\n- LFA_PLAYER_YOUTH: Mini Seasons for YOUTH age group (14-18 years, quarterly Q1-Q4) - SEASON TYPE ONLY\n- LFA_PLAYER_AMATEUR: Mini Seasons for AMATEUR age group (14+ years, quarterly Q1-Q4) - SEASON TYPE ONLY\n- LFA_PLAYER_PRO: Mini Seasons for PRO age group (14+ years, quarterly Q1-Q4) - SEASON TYPE ONLY\n- LFA_PLAYER_PRE_ACADEMY: Academy Season for PRE (5-13 years, full year Jul-Jun) - SEASON TYPE ONLY\n- LFA_PLAYER_YOUTH_ACADEMY: Academy Season for YOUTH (14-18 years, full year Jul-Jun) - SEASON TYPE ONLY\n- LFA_PLAYER_AMATEUR_ACADEMY: Academy Season for AMATEUR (14+ years, full year Jul-Jun) - SEASON TYPE ONLY\n- LFA_PLAYER_PRO_ACADEMY: Academy Season for PRO (14+ years, full year Jul-Jun) - SEASON TYPE ONLY\n- GANCUJU_PLAYER: Also used for seasons\n- LFA_COACH: Also used for seasons\n- INTERNSHIP: Also used for seasons\n\n⚠️ CRITICAL RULES:\n═══════════════════════════════════════════════════════════════════════════\n1. Users can ONLY have these in user_licenses.specialization_type:\n   - LFA_COACH\n   - LFA_FOOTBALL_PLAYER (NOT PRE/YOUTH/AMATEUR/PRO!)\n   - GANCUJU_PLAYER\n   - INTERNSHIP\n\n2. Semesters can have these in semesters.specialization_type:\n   - LFA_PLAYER_PRE/YOUTH/AMATEUR/PRO (for age-specific semesters)\n   - LFA_FOOTBALL_PLAYER (for tournaments/general sessions)\n   - LFA_COACH, GANCUJU_PLAYER, INTERNSHIP\n\n3. Age groups (PRE/YOUTH/AMATEUR/PRO) are determined by:\n   - User's age AT SEASON START (July 1)\n   - Season lock: stays fixed for entire season (July 1 - June 30)\n   - Follows international football practice"
       },
       "StartSessionRequest": {
         "properties": {
@@ -60172,7 +60260,7 @@
         "description": "Request body for recording teaching hours",
         "example": {
           "hours": 3,
-          "session_description": "Taught beginner class on basic G\u0101nCuju techniques"
+          "session_description": "Taught beginner class on basic GānCuju techniques"
         }
       },
       "TeachingHoursResponse": {
@@ -60744,7 +60832,7 @@
         },
         "type": "object",
         "title": "TournamentRewardConfig",
-        "description": "Complete reward configuration for a tournament.\n\nThis schema defines:\n- Skill mappings (which skills earn points)\n- Badge configurations (placement-based and conditional)\n- Credit bonuses per placement\n- XP multipliers\n\n\u26a0\ufe0f IMPORTANT: Skills must be explicitly enabled per tournament.\nAt least 1 skill must be enabled, or validation fails.",
+        "description": "Complete reward configuration for a tournament.\n\nThis schema defines:\n- Skill mappings (which skills earn points)\n- Badge configurations (placement-based and conditional)\n- Credit bonuses per placement\n- XP multipliers\n\n⚠️ IMPORTANT: Skills must be explicitly enabled per tournament.\nAt least 1 skill must be enabled, or validation fails.",
         "example": {
           "custom_config": false,
           "first_place": {
@@ -60752,7 +60840,7 @@
               {
                 "badge_type": "CHAMPION",
                 "enabled": true,
-                "icon": "\ud83e\udd47",
+                "icon": "🥇",
                 "rarity": "EPIC",
                 "title": "Champion"
               }
@@ -61114,7 +61202,7 @@
               }
             ],
             "title": "Tournament Type Id",
-            "description": "Tournament type ID (\u26a0\ufe0f WARNING: Can only change if no sessions generated)"
+            "description": "Tournament type ID (⚠️ WARNING: Can only change if no sessions generated)"
           },
           "tournament_status": {
             "anyOf": [
@@ -61126,7 +61214,7 @@
               }
             ],
             "title": "Tournament Status",
-            "description": "Tournament status (\u26a0\ufe0f ADMIN OVERRIDE: Bypasses state machine validation)"
+            "description": "Tournament status (⚠️ ADMIN OVERRIDE: Bypasses state machine validation)"
           },
           "format": {
             "anyOf": [
@@ -61188,7 +61276,7 @@
               }
             ],
             "title": "Number Of Rounds",
-            "description": "Number of rounds for INDIVIDUAL_RANKING tournaments (\u26a0\ufe0f WARNING: Triggers session regeneration if changed)"
+            "description": "Number of rounds for INDIVIDUAL_RANKING tournaments (⚠️ WARNING: Triggers session regeneration if changed)"
           },
           "campus_id": {
             "anyOf": [
@@ -64010,7 +64098,7 @@
         },
         "type": "object",
         "title": "LicenseCreate",
-        "description": "Request body for creating a new G\u0101nCuju license",
+        "description": "Request body for creating a new GānCuju license",
         "example": {
           "starting_level": 1
         }
@@ -64091,7 +64179,7 @@
           "updated_at"
         ],
         "title": "LicenseResponse",
-        "description": "Response model for G\u0101nCuju license data",
+        "description": "Response model for GānCuju license data",
         "example": {
           "competitions_entered": 10,
           "competitions_won": 7,
@@ -64647,7 +64735,7 @@
           "age_group"
         ],
         "title": "LicenseCreate",
-        "description": "Request to create LFA Player license \u2014 kept for schema compat, endpoint is deprecated"
+        "description": "Request to create LFA Player license — kept for schema compat, endpoint is deprecated"
       },
       "app__api__api_v1__endpoints__lfa_player__licenses__LicenseResponse": {
         "properties": {
@@ -64882,7 +64970,7 @@
             "type": "array",
             "maxItems": 20,
             "title": "Skills To Test",
-            "description": "Skills to develop in this tournament (weight=1.0 each). Optional if game_preset_id is provided \u2014 the preset's skills_tested and weights are used automatically."
+            "description": "Skills to develop in this tournament (weight=1.0 each). Optional if game_preset_id is provided — the preset's skills_tested and weights are used automatically."
           },
           "reward_config": {
             "items": {
@@ -64903,7 +64991,7 @@
               }
             ],
             "title": "Game Preset Id",
-            "description": "Game preset ID (e.g., G\u0101nFootvolley=1, G\u0101nFoottennis=2). When provided, the preset's skills_tested and skill_weights are automatically synced to tournament_skill_mappings with converted reactivity multipliers. Takes priority over skills_to_test."
+            "description": "Game preset ID (e.g., GānFootvolley=1, GānFoottennis=2). When provided, the preset's skills_tested and skill_weights are automatically synced to tournament_skill_mappings with converted reactivity multipliers. Takes priority over skills_to_test."
           },
           "game_config": {
             "anyOf": [
@@ -65201,6 +65289,94 @@
       "HTTPBearer": {
         "type": "http",
         "scheme": "bearer"
+      }
+    },
+    "/virtual-training/number-color-conflict": {
+      "get": {
+        "description": "Number-Color Conflict game page — instructions + Vanilla JS game loop.",
+        "operationId": "virtual_training_number_color_conflict_virtual_training_number_color_conflict_get",
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Virtual Training Number Color Conflict",
+        "tags": [
+          "web",
+          "virtual-training"
+        ]
+      }
+    },
+    "/virtual-training/number-color-conflict/result/{attempt_id}": {
+      "get": {
+        "description": "Result screen for a completed Number-Color Conflict attempt.",
+        "operationId": "virtual_training_number_color_conflict_result_virtual_training_number_color_conflict_result__attempt_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "attempt_id",
+            "required": true,
+            "schema": {
+              "title": "Attempt Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Virtual Training Number Color Conflict Result",
+        "tags": [
+          "web",
+          "virtual-training"
+        ]
+      }
+    },
+    "/virtual-training/number-color-conflict/submit": {
+      "post": {
+        "description": "Record a Number-Color Conflict attempt. Returns attempt_id, xp_awarded, is_valid.",
+        "operationId": "virtual_training_number_color_conflict_submit_virtual_training_number_color_conflict_submit_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Virtual Training Number Color Conflict Submit",
+        "tags": [
+          "web",
+          "virtual-training"
+        ]
       }
     }
   }

--- a/tests/unit/api/web_routes/test_number_color_conflict.py
+++ b/tests/unit/api/web_routes/test_number_color_conflict.py
@@ -1,0 +1,729 @@
+"""Unit tests for Number-Color Conflict — Phase 2.3.
+
+Route tests:
+NCC-01   GET /virtual-training/number-color-conflict → 200 active game
+NCC-02   GET /virtual-training/number-color-conflict → hub redirect when game inactive
+NCC-03   GET /virtual-training/number-color-conflict → 303 non-student / non-onboarded
+NCC-04   POST /virtual-training/number-color-conflict/submit → 200 valid data
+NCC-05   POST submit → is_valid=False + 0 XP too_short
+NCC-06   POST submit → is_valid=False + 0 XP bot_suspected
+NCC-07   POST submit → 429 daily cap
+NCC-08   POST submit → 404 inactive game
+NCC-09   POST submit → 403 not onboarded
+NCC-10   GET /virtual-training/number-color-conflict/result/{id} → 200 owner
+NCC-11   GET result → hub redirect wrong user (attempt not found)
+NCC-12   POST submit → idempotency key includes 'ncc'
+
+Skill scorer tests (reuses existing scorers — no new scorer):
+NCC-13   score_decisions(hit=1.0, wrong=0.0) → 1.0
+NCC-14   score_decisions(hit=0.5, wrong=0.2) → 0.5 - 0.3 = 0.2
+NCC-15   score_concentration(miss=0.0) → 1.0
+NCC-16   score_composure(wrong=0.0) → 1.0
+NCC-17   score_all() for NCC skill_targets covers all 4 skills
+
+Performance delta tests:
+NCC-18   Perfect NCC run → all four deltas positive
+NCC-19   Wrong-heavy run → decisions and composure delta near zero or negative
+NCC-20   Missed-heavy run → concentration delta near zero or negative
+
+raw_metrics v3 tests:
+NCC-21   Payload with v=3 hand_profile → protocol_difficulty_multiplier extracted
+NCC-22   v3 late_summary.late_click_count → late_click_rate in signals
+NCC-23   v1 payload (no hand_profile) → PDM defaults to 1.0
+
+Template / link tests:
+NCC-24   virtual_training_number_color_conflict.html exists in templates dir
+NCC-25   virtual_training_number_color_conflict_result.html exists in templates dir
+NCC-26   Result template references 'nccr-breakdown' (skill breakdown present)
+NCC-27   Result template references 'decisions' formula note
+NCC-28   Game template references 'ncc-protocol-card' (Today's Protocol card)
+
+Seed:
+NCC-SEED-01  number_color_conflict is_active=True in seed data
+NCC-SEED-02  number_color_conflict config includes phases, numbers, colors, late_grace_ms
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+_ROUTES = "app.api.web_routes.virtual_training"
+_METRICS = "app.services.virtual_training_metrics"
+_TEMPLATES_DIR = Path(__file__).resolve().parents[4] / "app" / "templates"
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+_NCC_SKILL_TARGETS = {
+    "decisions":     0.40,
+    "concentration": 0.30,
+    "composure":     0.20,
+    "reactions":     0.10,
+}
+
+_NCC_CONFIG = {
+    "phases": [
+        {"stimuli": 10, "window_ms": 2000, "isi_ms": 900,  "rule_switch": "alternating"},
+        {"stimuli": 12, "window_ms": 1600, "isi_ms": 700,  "rule_switch": "random"},
+        {"stimuli": 14, "window_ms": 1200, "isi_ms": 550,  "rule_switch": "random_high"},
+    ],
+    "numbers": [1, 2, 3, 4],
+    "colors": {
+        "RED":    "#ef4444",
+        "GREEN":  "#22c55e",
+        "BLUE":   "#3b82f6",
+        "YELLOW": "#eab308",
+    },
+    "late_grace_ms": 350,
+    "show_in_hub": True,
+    "icon": "🔢",
+    "football_benefit": "Filtering conflicting information.",
+}
+
+
+def _mock_ncc_game(*, is_active: bool = True) -> MagicMock:
+    g = MagicMock()
+    g.id                 = 5
+    g.code               = "number_color_conflict"
+    g.name               = "Number-Color Conflict"
+    g.is_active          = is_active
+    g.base_xp            = 12
+    g.max_daily_attempts = 5
+    g.skill_targets      = _NCC_SKILL_TARGETS
+    g.config             = _NCC_CONFIG
+    return g
+
+
+def _mock_attempt(
+    *,
+    id: int = 55,
+    user_id: int = 42,
+    game_id: int = 5,
+    is_valid: bool = True,
+    xp_awarded: int = 12,
+    score_normalized: float = 72.0,
+    attempt_index_today: int = 1,
+    invalid_reason: str | None = None,
+    skill_deltas: dict | None = None,
+    correct_count: int = 28,
+    wrong_click_count: int = 4,
+    error_count: int = 4,
+    avg_reaction_ms: float = 620.0,
+    stimuli_count: int = 36,
+    duration_seconds: float = 55.0,
+    raw_metrics: dict | None = None,
+) -> MagicMock:
+    a = MagicMock()
+    a.id                  = id
+    a.user_id             = user_id
+    a.game_id             = game_id
+    a.is_valid            = is_valid
+    a.xp_awarded          = xp_awarded
+    a.score_normalized    = score_normalized
+    a.attempt_index_today = attempt_index_today
+    a.invalid_reason      = invalid_reason
+    a.skill_deltas        = skill_deltas or {
+        "decisions": 0.18, "concentration": 0.14,
+        "composure": 0.09, "reactions": 0.04,
+    }
+    a.correct_count       = correct_count
+    a.wrong_click_count   = wrong_click_count
+    a.error_count         = error_count
+    a.avg_reaction_ms     = avg_reaction_ms
+    a.stimuli_count       = stimuli_count
+    a.duration_seconds    = duration_seconds
+    a.raw_metrics         = raw_metrics
+    return a
+
+
+def _mock_db(*, count: int = 0) -> MagicMock:
+    db = MagicMock()
+    q = MagicMock()
+    q.filter.return_value  = q
+    q.count.return_value   = count
+    q.first.return_value   = None
+    q.all.return_value     = []
+    db.query.return_value  = q
+    return db
+
+
+def _make_student(user_id: int = 42) -> MagicMock:
+    from app.models.user import UserRole
+    u = MagicMock()
+    u.id = user_id
+    u.role = UserRole.STUDENT
+    u.onboarding_completed = True
+    u.credit_balance = 0
+    u.specialization = MagicMock()
+    u.specialization.value = "LFA_FOOTBALL_PLAYER"
+    return u
+
+
+def _make_request(path: str = "/virtual-training/number-color-conflict") -> MagicMock:
+    r = MagicMock()
+    r.url.path = path
+    r.cookies  = {}
+    return r
+
+
+def _valid_payload() -> dict:
+    return {
+        "started_at":        "2026-05-23T10:00:00.000Z",
+        "duration_seconds":  56.0,
+        "stimuli_count":     36,
+        "correct_count":     28,
+        "wrong_click_count": 4,
+        "error_count":       4,
+        "avg_reaction_ms":   620.0,
+        "score_normalized":  72.0,
+        "raw_metrics": {
+            "v": 3,
+            "per_phase": [],
+            "per_stimulus": [],
+            "late_summary": {"late_click_count": 2, "late_go_count": 0, "late_no_go_count": 0},
+            "hand_profile": {
+                "hand":   "right",
+                "finger": "index",
+                "label":  "Right Index",
+                "protocol_difficulty_multiplier": 1.05,
+                "assignment_source": "system",
+            },
+        },
+    }
+
+
+# ── NCC-01..03: GET game page ─────────────────────────────────────────────────
+
+class TestNCCPage:
+
+    def test_ncc01_active_game_returns_200(self):
+        """NCC-01: GET /virtual-training/number-color-conflict → 200 for active game."""
+        from app.api.web_routes.virtual_training import virtual_training_number_color_conflict
+
+        user    = _make_student()
+        request = _make_request()
+        db      = _mock_db()
+        game    = _mock_ncc_game()
+        fake_protocol = MagicMock()
+        fake_protocol.hand   = "free"
+        fake_protocol.finger = "free"
+        fake_protocol.protocol_difficulty_multiplier = 1.0
+        fake_protocol.label  = ""
+        fake_protocol.assignment_source = "system"
+
+        fake_resp = MagicMock(spec=HTMLResponse)
+        fake_resp.status_code = 200
+
+        with patch(f"{_ROUTES}.require_student_onboarding", return_value=None), \
+             patch(f"{_ROUTES}._spec_ctx", return_value={}), \
+             patch(f"{_ROUTES}.VirtualTrainingService.get_game", return_value=game), \
+             patch(f"{_ROUTES}.VirtualTrainingService.assign_protocol", return_value=fake_protocol), \
+             patch(f"{_ROUTES}.templates") as mock_tmpl:
+            mock_tmpl.TemplateResponse.return_value = fake_resp
+            result = _run(virtual_training_number_color_conflict(request=request, db=db, user=user))
+
+        assert result is fake_resp
+        call_args = mock_tmpl.TemplateResponse.call_args
+        assert call_args[0][0] == "virtual_training_number_color_conflict.html"
+        ctx = call_args[0][1]
+        assert ctx["game"] is game
+
+    def test_ncc02_inactive_game_returns_hub(self):
+        """NCC-02: GET → renders hub with error when game inactive."""
+        from app.api.web_routes.virtual_training import virtual_training_number_color_conflict
+
+        user    = _make_student()
+        request = _make_request()
+        db      = _mock_db()
+        game    = _mock_ncc_game(is_active=False)
+
+        fake_hub = MagicMock(spec=HTMLResponse)
+
+        with patch(f"{_ROUTES}.require_student_onboarding", return_value=None), \
+             patch(f"{_ROUTES}._spec_ctx", return_value={}), \
+             patch(f"{_ROUTES}.VirtualTrainingService.get_game", return_value=game), \
+             patch(f"{_ROUTES}.VirtualTrainingService.get_hub_games", return_value=[]), \
+             patch(f"{_ROUTES}.templates") as mock_tmpl:
+            mock_tmpl.TemplateResponse.return_value = fake_hub
+            result = _run(virtual_training_number_color_conflict(request=request, db=db, user=user))
+
+        assert result is fake_hub
+        call_args = mock_tmpl.TemplateResponse.call_args
+        assert call_args[0][0] == "virtual_training_hub.html"
+        assert "error" in call_args[0][1]
+
+    def test_ncc03_non_onboarded_redirected(self):
+        """NCC-03: GET → guard redirect for non-onboarded user."""
+        from app.api.web_routes.virtual_training import virtual_training_number_color_conflict
+
+        user = _make_student()
+        user.onboarding_completed = False
+        request = _make_request()
+        db = _mock_db()
+        redirect = RedirectResponse(url="/dashboard", status_code=303)
+
+        with patch(f"{_ROUTES}.require_student_onboarding", return_value=redirect), \
+             patch(f"{_ROUTES}.templates") as mock_tmpl:
+            result = _run(virtual_training_number_color_conflict(request=request, db=db, user=user))
+
+        assert isinstance(result, RedirectResponse)
+        mock_tmpl.TemplateResponse.assert_not_called()
+
+
+# ── NCC-04..09: POST submit ───────────────────────────────────────────────────
+
+class TestNCCSubmit:
+
+    def test_ncc04_valid_submit_returns_200(self):
+        """NCC-04: POST submit with valid data returns attempt_id, xp_awarded."""
+        from app.api.web_routes.virtual_training import virtual_training_number_color_conflict_submit
+
+        user    = _make_student()
+        request = _make_request(path="/virtual-training/number-color-conflict/submit")
+
+        async def _fake_json():
+            return _valid_payload()
+        request.json = _fake_json
+
+        db      = _mock_db(count=0)
+        game    = _mock_ncc_game()
+        attempt = _mock_attempt()
+
+        with patch(f"{_ROUTES}.require_student_onboarding", return_value=None), \
+             patch(f"{_ROUTES}.VirtualTrainingService.get_game", return_value=game), \
+             patch(f"{_ROUTES}.VirtualTrainingService.record_attempt", return_value=attempt):
+            result = _run(virtual_training_number_color_conflict_submit(request=request, db=db, user=user))
+
+        assert result.status_code == 200
+        body = json.loads(result.body)
+        assert body["attempt_id"] == attempt.id
+        assert body["xp_awarded"] == attempt.xp_awarded
+        assert body["is_valid"] is True
+
+    def test_ncc05_too_short_returns_invalid(self):
+        """NCC-05: POST submit → is_valid=False, xp=0, invalid_reason='too_short'."""
+        from app.api.web_routes.virtual_training import virtual_training_number_color_conflict_submit
+
+        user = _make_student()
+        request = _make_request()
+        payload = _valid_payload()
+        payload["duration_seconds"] = 5.0
+
+        async def _fake_json():
+            return payload
+        request.json = _fake_json
+
+        db      = _mock_db(count=0)
+        game    = _mock_ncc_game()
+        attempt = _mock_attempt(is_valid=False, xp_awarded=0, invalid_reason="too_short")
+
+        with patch(f"{_ROUTES}.require_student_onboarding", return_value=None), \
+             patch(f"{_ROUTES}.VirtualTrainingService.get_game", return_value=game), \
+             patch(f"{_ROUTES}.VirtualTrainingService.record_attempt", return_value=attempt):
+            result = _run(virtual_training_number_color_conflict_submit(request=request, db=db, user=user))
+
+        body = json.loads(result.body)
+        assert body["is_valid"] is False
+        assert body["xp_awarded"] == 0
+        assert body["invalid_reason"] == "too_short"
+
+    def test_ncc06_bot_suspected_returns_invalid(self):
+        """NCC-06: POST submit avg_reaction_ms < 80 → bot_suspected."""
+        from app.api.web_routes.virtual_training import virtual_training_number_color_conflict_submit
+
+        user = _make_student()
+        request = _make_request()
+        payload = _valid_payload()
+        payload["avg_reaction_ms"] = 50.0
+
+        async def _fake_json():
+            return payload
+        request.json = _fake_json
+
+        db      = _mock_db(count=0)
+        game    = _mock_ncc_game()
+        attempt = _mock_attempt(is_valid=False, xp_awarded=0, invalid_reason="bot_suspected")
+
+        with patch(f"{_ROUTES}.require_student_onboarding", return_value=None), \
+             patch(f"{_ROUTES}.VirtualTrainingService.get_game", return_value=game), \
+             patch(f"{_ROUTES}.VirtualTrainingService.record_attempt", return_value=attempt):
+            result = _run(virtual_training_number_color_conflict_submit(request=request, db=db, user=user))
+
+        body = json.loads(result.body)
+        assert body["is_valid"] is False
+        assert body["invalid_reason"] == "bot_suspected"
+
+    def test_ncc07_daily_cap_returns_429(self):
+        """NCC-07: POST submit → 429 when valid_today >= max_daily_attempts."""
+        from app.api.web_routes.virtual_training import virtual_training_number_color_conflict_submit
+
+        user = _make_student()
+        request = _make_request()
+
+        async def _fake_json():
+            return _valid_payload()
+        request.json = _fake_json
+
+        db   = _mock_db(count=5)
+        game = _mock_ncc_game()
+        game.max_daily_attempts = 5
+
+        with patch(f"{_ROUTES}.require_student_onboarding", return_value=None), \
+             patch(f"{_ROUTES}.VirtualTrainingService.get_game", return_value=game):
+            result = _run(virtual_training_number_color_conflict_submit(request=request, db=db, user=user))
+
+        assert result.status_code == 429
+
+    def test_ncc08_inactive_game_returns_404(self):
+        """NCC-08: POST submit → 404 when game is inactive."""
+        from app.api.web_routes.virtual_training import virtual_training_number_color_conflict_submit
+
+        user = _make_student()
+        request = _make_request()
+
+        async def _fake_json():
+            return _valid_payload()
+        request.json = _fake_json
+
+        db   = _mock_db()
+        game = _mock_ncc_game(is_active=False)
+
+        with patch(f"{_ROUTES}.require_student_onboarding", return_value=None), \
+             patch(f"{_ROUTES}.VirtualTrainingService.get_game", return_value=game):
+            result = _run(virtual_training_number_color_conflict_submit(request=request, db=db, user=user))
+
+        assert result.status_code == 404
+
+    def test_ncc09_not_onboarded_returns_403(self):
+        """NCC-09: POST submit → 403 when user not onboarded."""
+        from app.api.web_routes.virtual_training import virtual_training_number_color_conflict_submit
+
+        user = _make_student()
+        user.onboarding_completed = False
+        request = _make_request()
+
+        async def _fake_json():
+            return _valid_payload()
+        request.json = _fake_json
+
+        db = _mock_db()
+        redirect = RedirectResponse(url="/onboarding", status_code=303)
+
+        with patch(f"{_ROUTES}.require_student_onboarding", return_value=redirect):
+            result = _run(virtual_training_number_color_conflict_submit(request=request, db=_mock_db(), user=user))
+
+        assert result.status_code == 403
+
+
+# ── NCC-10..12: GET result + idempotency ─────────────────────────────────────
+
+class TestNCCResult:
+
+    def test_ncc10_result_page_returns_200(self):
+        """NCC-10: GET /result/{id} → 200 for attempt owner."""
+        from app.api.web_routes.virtual_training import virtual_training_number_color_conflict_result
+
+        user    = _make_student()
+        request = _make_request(path="/virtual-training/number-color-conflict/result/55")
+        db      = _mock_db()
+        attempt = _mock_attempt()
+        game    = _mock_ncc_game()
+
+        # db.query().filter().first() returns attempt then game
+        q = MagicMock()
+        q.filter.return_value = q
+        q.first.side_effect   = [attempt, game]
+        db.query.return_value = q
+
+        fake_resp = MagicMock(spec=HTMLResponse)
+        fake_resp.status_code = 200
+
+        with patch(f"{_ROUTES}.require_student_onboarding", return_value=None), \
+             patch(f"{_ROUTES}._spec_ctx", return_value={}), \
+             patch(f"{_ROUTES}.templates") as mock_tmpl:
+            mock_tmpl.TemplateResponse.return_value = fake_resp
+            result = _run(virtual_training_number_color_conflict_result(
+                attempt_id=55, request=request, db=db, user=user
+            ))
+
+        assert result is fake_resp
+        call_args = mock_tmpl.TemplateResponse.call_args
+        assert call_args[0][0] == "virtual_training_number_color_conflict_result.html"
+
+    def test_ncc11_result_not_found_returns_hub(self):
+        """NCC-11: GET /result/{id} → hub when attempt not found."""
+        from app.api.web_routes.virtual_training import virtual_training_number_color_conflict_result
+
+        user    = _make_student()
+        request = _make_request()
+        db      = _mock_db()  # q.first() returns None
+
+        fake_hub = MagicMock(spec=HTMLResponse)
+
+        with patch(f"{_ROUTES}.require_student_onboarding", return_value=None), \
+             patch(f"{_ROUTES}._spec_ctx", return_value={}), \
+             patch(f"{_ROUTES}.VirtualTrainingService.get_hub_games", return_value=[]), \
+             patch(f"{_ROUTES}.templates") as mock_tmpl:
+            mock_tmpl.TemplateResponse.return_value = fake_hub
+            result = _run(virtual_training_number_color_conflict_result(
+                attempt_id=9999, request=request, db=db, user=user
+            ))
+
+        call_args = mock_tmpl.TemplateResponse.call_args
+        assert call_args[0][0] == "virtual_training_hub.html"
+        assert "error" in call_args[0][1]
+
+    def test_ncc12_idempotency_key_contains_ncc(self):
+        """NCC-12: Idempotency key uses 'vt_ncc_u{id}_{started_at}' prefix."""
+        from app.api.web_routes.virtual_training import virtual_training_number_color_conflict_submit
+
+        user = _make_student()
+        user.id = 42
+        request = _make_request()
+
+        payload = _valid_payload()
+        payload["started_at"] = "2026-05-23T10:00:00.000Z"
+
+        async def _fake_json():
+            return payload
+        request.json = _fake_json
+
+        db   = _mock_db(count=0)
+        game = _mock_ncc_game()
+        attempt = _mock_attempt()
+
+        captured = {}
+
+        def capture_record(**kwargs):
+            captured["idem_key"] = kwargs.get("idempotency_key", "")
+            return attempt
+
+        with patch(f"{_ROUTES}.require_student_onboarding", return_value=None), \
+             patch(f"{_ROUTES}.VirtualTrainingService.get_game", return_value=game), \
+             patch(f"{_ROUTES}.VirtualTrainingService.record_attempt", side_effect=lambda **kw: capture_record(**kw)):
+            _run(virtual_training_number_color_conflict_submit(request=request, db=db, user=user))
+
+        assert "ncc" in captured.get("idem_key", ""), (
+            f"Expected 'ncc' in idempotency key, got: {captured.get('idem_key')}"
+        )
+
+
+# ── NCC-13..17: Skill scorers ─────────────────────────────────────────────────
+
+class TestNCCScorerReuse:
+
+    def _signals(self, **kwargs):
+        from app.services.virtual_training_metrics import VTSignals
+        defaults = dict(
+            hit_rate=1.0, wrong_rate=0.0, miss_rate=0.0,
+            speed_score=1.0, completion_rate=1.0,
+            avg_reaction_ms=400.0, per_phase=None,
+            late_click_rate=0.0, late_go_rate=0.0, late_nogo_rate=0.0,
+            protocol_difficulty_multiplier=1.0,
+        )
+        defaults.update(kwargs)
+        return VTSignals(**defaults)
+
+    def test_ncc13_decisions_perfect(self):
+        """NCC-13: score_decisions at hit=1.0, wrong=0.0 → 1.0."""
+        from app.services.virtual_training_metrics import VTSkillScorer
+        sig = self._signals(hit_rate=1.0, wrong_rate=0.0)
+        assert VTSkillScorer.score_decisions(sig) == 1.0
+
+    def test_ncc14_decisions_with_wrong(self):
+        """NCC-14: score_decisions(hit=0.5, wrong=0.2) → 0.5 - 0.3 = 0.2."""
+        from app.services.virtual_training_metrics import VTSkillScorer
+        sig = self._signals(hit_rate=0.5, wrong_rate=0.2)
+        score = VTSkillScorer.score_decisions(sig)
+        assert abs(score - 0.2) < 1e-9
+
+    def test_ncc15_concentration_perfect(self):
+        """NCC-15: score_concentration at miss=0.0 → 1.0."""
+        from app.services.virtual_training_metrics import VTSkillScorer
+        sig = self._signals(miss_rate=0.0)
+        assert VTSkillScorer.score_concentration(sig) == 1.0
+
+    def test_ncc16_composure_perfect(self):
+        """NCC-16: score_composure(wrong=0.0) → 1.0 (no false alarms in NCC context)."""
+        from app.services.virtual_training_metrics import VTSkillScorer
+        sig = self._signals(wrong_rate=0.0)
+        assert VTSkillScorer.score_composure(sig) == 1.0
+
+    def test_ncc17_score_all_covers_ncc_skills(self):
+        """NCC-17: score_all() with NCC skill_targets returns all 4 skills."""
+        from app.services.virtual_training_metrics import VTSkillScorer
+        sig = self._signals()
+        scores = VTSkillScorer.score_all(sig, _NCC_SKILL_TARGETS)
+        assert set(scores.keys()) == {"decisions", "concentration", "composure", "reactions"}
+
+
+# ── NCC-18..20: Performance delta direction ───────────────────────────────────
+
+class TestNCCDeltaDirection:
+
+    def _signals_from_data(self, data: dict):
+        from app.services.virtual_training_metrics import VTSignalExtractor
+        return VTSignalExtractor.extract(data, _NCC_CONFIG["phases"])
+
+    def test_ncc18_perfect_run_all_positive(self):
+        """NCC-18: Perfect NCC run → all four skill deltas positive."""
+        from app.services.virtual_training_metrics import VTSkillScorer, VTDeltaComputer
+        data = {
+            "stimuli_count": 36, "correct_count": 36,
+            "wrong_click_count": 0, "error_count": 0,
+            "avg_reaction_ms": 400.0,
+        }
+        from app.services.virtual_training_metrics import VTSignalExtractor
+        signals = VTSignalExtractor.extract(data, _NCC_CONFIG["phases"])
+        scores  = VTSkillScorer.score_all(signals, _NCC_SKILL_TARGETS)
+        deltas  = VTDeltaComputer.compute(scores, _NCC_SKILL_TARGETS, 12, 1.0)
+        assert all(v > 0 for v in deltas.values()), f"Expected all positive, got: {deltas}"
+
+    def test_ncc19_wrong_heavy_reduces_decisions_composure(self):
+        """NCC-19: High wrong rate → decisions and composure scores low."""
+        from app.services.virtual_training_metrics import VTSkillScorer, VTSignalExtractor
+        data = {
+            "stimuli_count": 36, "correct_count": 10,
+            "wrong_click_count": 25, "error_count": 1,
+            "avg_reaction_ms": 600.0,
+        }
+        signals = VTSignalExtractor.extract(data, _NCC_CONFIG["phases"])
+        scores  = VTSkillScorer.score_all(signals, _NCC_SKILL_TARGETS)
+        assert scores["decisions"]  < 0.45, f"decisions={scores['decisions']}"
+        assert scores["composure"]  < 0.45, f"composure={scores['composure']}"
+
+    def test_ncc20_missed_heavy_reduces_concentration(self):
+        """NCC-20: High miss rate → concentration score low."""
+        from app.services.virtual_training_metrics import VTSkillScorer, VTSignalExtractor
+        data = {
+            "stimuli_count": 36, "correct_count": 8,
+            "wrong_click_count": 0, "error_count": 28,
+            "avg_reaction_ms": 900.0,
+        }
+        signals = VTSignalExtractor.extract(data, _NCC_CONFIG["phases"])
+        scores  = VTSkillScorer.score_all(signals, _NCC_SKILL_TARGETS)
+        assert scores["concentration"] < 0.45, f"concentration={scores['concentration']}"
+
+
+# ── NCC-21..23: raw_metrics v3 / hand_profile ────────────────────────────────
+
+class TestNCCRawMetricsV3:
+
+    def test_ncc21_v3_hand_profile_extracts_pdm(self):
+        """NCC-21: v3 payload with hand_profile → PDM extracted correctly."""
+        from app.services.virtual_training_metrics import VTSignalExtractor
+        data = {
+            "stimuli_count": 36, "correct_count": 28,
+            "wrong_click_count": 4, "error_count": 4,
+            "avg_reaction_ms": 620.0,
+            "raw_metrics": {
+                "v": 3,
+                "hand_profile": {
+                    "protocol_difficulty_multiplier": 1.10,
+                },
+            },
+        }
+        signals = VTSignalExtractor.extract(data, _NCC_CONFIG["phases"])
+        assert abs(signals.protocol_difficulty_multiplier - 1.10) < 1e-9
+
+    def test_ncc22_v3_late_summary_sets_late_click_rate(self):
+        """NCC-22: v3 late_summary.late_click_count → late_click_rate in signals."""
+        from app.services.virtual_training_metrics import VTSignalExtractor
+        data = {
+            "stimuli_count": 36, "correct_count": 30,
+            "wrong_click_count": 2, "error_count": 0,
+            "avg_reaction_ms": 550.0,
+            "raw_metrics": {
+                "v": 3,
+                "late_summary": {
+                    "late_click_count": 4,
+                    "late_go_count": 0,
+                    "late_no_go_count": 0,
+                },
+                "hand_profile": {"protocol_difficulty_multiplier": 1.0},
+            },
+        }
+        signals = VTSignalExtractor.extract(data, _NCC_CONFIG["phases"])
+        expected = 4 / 36
+        assert abs(signals.late_click_rate - expected) < 1e-6
+
+    def test_ncc23_v1_payload_pdm_defaults_to_1(self):
+        """NCC-23: v1 payload (no hand_profile) → PDM defaults to 1.0."""
+        from app.services.virtual_training_metrics import VTSignalExtractor
+        data = {
+            "stimuli_count": 36, "correct_count": 28,
+            "wrong_click_count": 4, "error_count": 4,
+            "avg_reaction_ms": 620.0,
+            "raw_metrics": {"v": 1, "per_stimulus": [], "per_phase": []},
+        }
+        signals = VTSignalExtractor.extract(data, _NCC_CONFIG["phases"])
+        assert signals.protocol_difficulty_multiplier == 1.0
+
+
+# ── NCC-24..28: Template / link tests ────────────────────────────────────────
+
+class TestNCCTemplates:
+
+    def test_ncc24_game_template_exists(self):
+        """NCC-24: virtual_training_number_color_conflict.html present in templates."""
+        tmpl = _TEMPLATES_DIR / "virtual_training_number_color_conflict.html"
+        assert tmpl.exists(), f"Missing: {tmpl}"
+
+    def test_ncc25_result_template_exists(self):
+        """NCC-25: virtual_training_number_color_conflict_result.html present."""
+        tmpl = _TEMPLATES_DIR / "virtual_training_number_color_conflict_result.html"
+        assert tmpl.exists(), f"Missing: {tmpl}"
+
+    def test_ncc26_result_template_has_skill_breakdown(self):
+        """NCC-26: Result template references 'nccr-breakdown' (skill breakdown)."""
+        tmpl = _TEMPLATES_DIR / "virtual_training_number_color_conflict_result.html"
+        content = tmpl.read_text()
+        assert "nccr-breakdown" in content
+
+    def test_ncc27_result_template_has_decisions_formula(self):
+        """NCC-27: Result template shows decisions formula note for players."""
+        tmpl = _TEMPLATES_DIR / "virtual_training_number_color_conflict_result.html"
+        content = tmpl.read_text()
+        assert "decisions" in content
+        assert "wrong" in content.lower()
+
+    def test_ncc28_game_template_has_protocol_card(self):
+        """NCC-28: Game template has Today's Protocol card (ncc-protocol-card)."""
+        tmpl = _TEMPLATES_DIR / "virtual_training_number_color_conflict.html"
+        content = tmpl.read_text()
+        assert "ncc-protocol-card" in content
+
+
+# ── NCC-SEED-01..02: Seed tests ───────────────────────────────────────────────
+
+class TestNCCSeed:
+
+    def _get_ncc_seed(self):
+        from scripts.seed_virtual_training_games import _GAMES
+        return next((g for g in _GAMES if g["code"] == "number_color_conflict"), None)
+
+    def test_ncc_seed01_is_active_true(self):
+        """NCC-SEED-01: number_color_conflict is_active=True in seed data."""
+        entry = self._get_ncc_seed()
+        assert entry is not None, "number_color_conflict not found in _GAMES"
+        assert entry["is_active"] is True, "number_color_conflict must be active"
+
+    def test_ncc_seed02_config_has_gameplay_keys(self):
+        """NCC-SEED-02: seed config includes phases, numbers, colors, late_grace_ms."""
+        entry = self._get_ncc_seed()
+        assert entry is not None
+        cfg = entry["config"]
+        assert "phases" in cfg, "seed config missing 'phases'"
+        assert "numbers" in cfg, "seed config missing 'numbers'"
+        assert "colors" in cfg, "seed config missing 'colors'"
+        assert "late_grace_ms" in cfg, "seed config missing 'late_grace_ms'"
+        assert len(cfg["phases"]) == 3, f"expected 3 phases, got {len(cfg['phases'])}"
+        total = sum(p["stimuli"] for p in cfg["phases"])
+        assert total == 36, f"expected 36 total stimuli, got {total}"

--- a/tests/unit/services/test_virtual_training_service.py
+++ b/tests/unit/services/test_virtual_training_service.py
@@ -24,7 +24,7 @@ VT-25   attempt 4 below-neutral performance → negative skill delta (Phase 2.4)
 VT-26   attempt 6 → empty skill delta regardless of performance
 VT-14   calculate_skill_deltas() produces correct per-skill deltas
 VT-15   calculate_skill_deltas() returns empty dict when xp_awarded=0
-VT-16   seed data: 12 games present; color_reaction active; stroop_challenge show_in_hub=False
+VT-16   seed data: 12 games present; color_reaction+go_no_go+number_color_conflict active; stroop_challenge hidden
 VT-17   get_training_skill_deltas_for_user() merges VT attempt deltas with segment deltas
 """
 from __future__ import annotations
@@ -259,10 +259,10 @@ class TestSkillDeltas:
 class TestSeedData:
 
     def test_vt16_seed_presets_present_and_correct_active_state(self):
-        """VT-16: Seed contains 12 games; color_reaction+go_no_go+memory_sequence+target_tracking+direction_swipe active; stroop_challenge hidden; rest planned."""
+        """VT-16: Seed contains 12 games; color_reaction+go_no_go+memory_sequence+target_tracking+direction_swipe+number_color_conflict active; stroop_challenge hidden; rest planned."""
         from scripts.seed_virtual_training_games import _GAMES
 
-        # 5 active + 1 hidden + 6 planned = 12 total
+        # 6 active + 1 hidden + 5 planned = 12 total
         assert len(_GAMES) == 12
 
         codes = {g["code"] for g in _GAMES}
@@ -283,8 +283,8 @@ class TestSeedData:
 
         game_map = {g["code"]: g for g in _GAMES}
 
-        # Active state — 5 active games
-        _active_games = {"color_reaction", "go_no_go", "memory_sequence", "target_tracking", "direction_swipe"}
+        # Active state — 6 active games
+        _active_games = {"color_reaction", "go_no_go", "memory_sequence", "target_tracking", "direction_swipe", "number_color_conflict"}
         for code in _active_games:
             assert game_map[code]["is_active"] is True, f"{code} must be active"
         for code in codes - _active_games:
@@ -292,6 +292,13 @@ class TestSeedData:
 
         # stroop_challenge hidden from hub
         assert game_map["stroop_challenge"]["config"].get("show_in_hub") is False
+
+        # number_color_conflict has full gameplay config
+        ncc_cfg = game_map["number_color_conflict"]["config"]
+        assert "phases" in ncc_cfg, "number_color_conflict seed missing phases"
+        assert "numbers" in ncc_cfg, "number_color_conflict seed missing numbers"
+        assert "colors" in ncc_cfg, "number_color_conflict seed missing colors"
+        assert "late_grace_ms" in ncc_cfg, "number_color_conflict seed missing late_grace_ms"
 
         # All hub-visible games have football_benefit in config
         hub_games = [g for g in _GAMES if g["config"].get("show_in_hub", True) is not False]


### PR DESCRIPTION
## Summary

- 3 routes: GET/POST `/virtual-training/number-color-conflict`, GET `/result/{attempt_id}`
- 2 templates: game page (instruction + Today's Protocol card + JS game loop) + result page (stats, skill breakdown, per-phase table)
- 30 NCC-* tests: routes, skill scorers, delta direction, raw_metrics v3, templates, seed
- Seed updated: `is_active=True`, full 3-phase gameplay config (10+12+14=36 stimuli, window 2000/1600/1200ms, ISI 900/700/550ms, late_grace_ms=350)
- VT-16 updated: 3 active games (color_reaction + go_no_go + number_color_conflict)
- OpenAPI snapshot: 774 → 777 routes

## Technical details

- `raw_metrics v=3` with `hand_profile` (same as CR/GNG) — system-assigned protocol scheduler, PDM affects skill deltas only
- Score formula: `0.55×hit_rate + 0.25×(1−wrong_rate) + 0.20×speed_factor`
- Outcome mapping: `correct→correct_count`, `wrong_value/wrong_dimension→wrong_click_count`, `missed→error_count`, `late→late_summary.late_click_count`
- No new scorer: decisions/concentration/composure/reactions existing scorers cover all 4 skill targets
- Idempotency key: `vt_ncc_u{user.id}_{started_at}`

## Scope boundary (as specified)

No changes to: DB model, migration, XP pipeline, daily cap logic, Player Card, /skills dashboard, Hand/Finger Performance UI.

## Test plan

- [ ] 30/30 NCC-* tests pass locally
- [ ] VT-16 passes (3 active games)
- [ ] OpenAPI snapshot test passes (777 routes)
- [ ] CI green
- [ ] Manual: open `/virtual-training`, click Number-Color Conflict card, play through 3 phases, verify result page shows score + skill deltas + per-phase table

🤖 Generated with [Claude Code](https://claude.com/claude-code)