### PR TITLE
feat(vt): Track B — concurrent flash, repeat flash, direction change

### DIFF
--- a/app/templates/virtual_training_target_tracking.html
+++ b/app/templates/virtual_training_target_tracking.html
@@ -336,8 +336,8 @@
                     <span class="tt-diff-mult">1.30×</span>
                     <div class="tt-diff-name">Medium</div>
                     <div class="tt-diff-meta">
-                        4–6 objects &nbsp;·&nbsp; 9 rounds<br>
-                        1 flash distractor (Phase 2–3)
+                        5–7 objects &nbsp;·&nbsp; 9 rounds<br>
+                        1–3 flashes per round
                     </div>
                 </div>
 
@@ -346,8 +346,8 @@
                     <span class="tt-diff-mult">1.70×</span>
                     <div class="tt-diff-name">Hard</div>
                     <div class="tt-diff-meta">
-                        5–7 objects &nbsp;·&nbsp; 12 rounds<br>
-                        1–3 flash distractors per round
+                        6–8 objects &nbsp;·&nbsp; 12 rounds<br>
+                        2 concurrent flashes · direction change
                     </div>
                 </div>
 
@@ -357,15 +357,15 @@
                     <span class="tt-diff-mult">2.20×</span>
                     <div class="tt-diff-name">Expert</div>
                     <div class="tt-diff-meta">
-                        6–9 objects &nbsp;·&nbsp; 12 rounds<br>
-                        2–5 flash distractors per round
+                        7–9 objects &nbsp;·&nbsp; 12 rounds<br>
+                        3 concurrent flashes · fast direction change
                     </div>
                 </div>
                 {% else %}
                 <div class="tt-diff-card tt-diff-disabled" id="tt-diff-expert">
                     <span class="tt-diff-mult">2.20×</span>
                     <div class="tt-diff-name">Expert 🔒</div>
-                    <div class="tt-diff-meta">6–9 objects · 12 rounds</div>
+                    <div class="tt-diff-meta">7–9 objects · 12 rounds</div>
                     <div class="tt-diff-locked">Unlock: 70%+ on 3 Hard attempts</div>
                 </div>
                 {% endif %}
@@ -380,7 +380,7 @@
 
         <!-- Flash warning (shown for Medium+) -->
         <div class="tt-flash-notice" id="tt-flash-notice">
-            ⚠ Distractor flashes may appear during tracking (amber colour). Ignore them — only follow the original target.
+            ⚠ Distractor flashes appear during tracking (amber colour). On Hard/Expert, multiple objects may flash simultaneously — ignore them and keep tracking your target.
         </div>
 
         {% if attempts_today >= max_daily_attempts %}
@@ -534,11 +534,13 @@ let roundResults = [];
 let startedAt    = null;
 
 /* Flash tracking per round */
-let activeFlashes   = [];  /* [{distractor_index, start_ms, duration_ms, color, t_offset_ms}] */
-let flashEventLog   = [];  /* all flashes in current round */
-let totalFlashShown = 0;
-let tapsDuringFlash = 0;
-let tapWasDuringFlash = false;
+let activeFlashes      = [];  /* [{distractor_index, start_ms, duration_ms, color, t_offset_ms}] */
+let flashEventLog      = [];  /* all flashes in current round */
+let totalFlashShown    = 0;
+let tapsDuringFlash    = 0;
+let tapWasDuringFlash  = false;
+let currentDirChangeCount = 0; /* direction changes in the current round */
+let totalDirChanges    = 0;    /* accumulates over all rounds */
 
 /* ── DOM helpers ──────────────────────────────────────────────────────────── */
 const arena      = document.getElementById('tt-arena');
@@ -600,7 +602,7 @@ function spawnObjects(count) {
         el.style.left = (x - radius) + 'px';
         el.style.top  = (y - radius) + 'px';
         arena.appendChild(el);
-        objects.push({ x: x, y: y, vx: 0, vy: 0, el: el });
+        objects.push({ x: x, y: y, vx: 0, vy: 0, el: el, _flashCount: 0 });
     }
 }
 
@@ -619,57 +621,88 @@ function moveObjects() {
 }
 
 /* ── Flash schedule generator ─────────────────────────────────────────────── */
-function generateFlashSchedule(flashCount, trackingMs, objectCount) {
-    /* Returns list of {distractor_index, t_offset_ms} ensuring:
-       - only non-target objects flash
-       - no two flashes on same distractor per round
-       - minimum FLASH_MIN_GAP_MS between flash starts
-       - earliest/latest pct constraints
+function generateFlashSchedule(flashCount, trackingMs, objectCount, flashConfig) {
+    /* Generates flash events supporting:
+       - concurrent flash (max_concurrent_flashes > 1): multiple objects flash simultaneously
+       - repeat flash (allow_repeat_flash): same distractor can flash again after repeat_gap_ms
+       - per-difficulty duration and gap (flash_duration_ms, flash_gap_ms)
+       - target never flashes (targetIdx excluded)
+       Each event: {distractor_index, t_offset_ms, duration_ms, color,
+                    concurrent_group_id, repeat, is_target}
     */
+    var flashDuration = (flashConfig && flashConfig.flash_duration_ms) || FLASH_DURATION_MS;
+    var flashGap      = (flashConfig && flashConfig.flash_gap_ms)      || FLASH_MIN_GAP_MS;
+    var maxConcurrent = (flashConfig && flashConfig.max_concurrent_flashes) || 1;
+    var allowRepeat   = !!(flashConfig && flashConfig.allow_repeat_flash);
+    var repeatGap     = (flashConfig && flashConfig.repeat_gap_ms) || 2000;
+
     if (flashCount <= 0 || objectCount <= 1) return [];
 
     var nonTargets = [];
     for (var i = 0; i < objectCount; i++) {
         if (i !== targetIdx) nonTargets.push(i);
     }
-
-    /* Shuffle non-targets */
-    for (var j = nonTargets.length - 1; j > 0; j--) {
-        var k = Math.floor(Math.random() * (j + 1));
-        var tmp = nonTargets[j]; nonTargets[j] = nonTargets[k]; nonTargets[k] = tmp;
-    }
+    if (nonTargets.length === 0) return [];
 
     var earliest = Math.floor(trackingMs * FLASH_EARLIEST_PCT);
-    var latest   = Math.floor(trackingMs * FLASH_LATEST_PCT - FLASH_DURATION_MS);
+    var latest   = Math.floor(trackingMs * FLASH_LATEST_PCT - flashDuration);
     if (latest <= earliest) return [];
 
-    var schedule = [];
-    var usedDistractors = new Set();
-    var lastStart = -FLASH_MIN_GAP_MS * 2;
+    var schedule  = [];
+    var usedOnce  = new Set();   /* non-repeat mode: exhausted distractors */
+    var lastEndMs = {};          /* distractor → last flash end ms (for repeat gap) */
+    var seenOnce  = new Set();   /* tracks `repeat` field: has this distractor appeared before? */
+    var groupId   = 0;
+    var tCursor   = earliest;
+    var placed    = 0;
+    var safeBreak = 0;
 
-    for (var f = 0; f < Math.min(flashCount, nonTargets.length); f++) {
-        /* Pick a non-target not used yet in this round */
-        var distIdx = -1;
-        for (var d = 0; d < nonTargets.length; d++) {
-            if (!usedDistractors.has(nonTargets[d])) {
-                distIdx = nonTargets[d];
-                break;
+    while (placed < flashCount && tCursor <= latest) {
+        if (++safeBreak > 500) break;
+
+        /* Build available pool at current tCursor */
+        var pool = nonTargets.filter(function (idx) {
+            if (!allowRepeat && usedOnce.has(idx)) return false;
+            if (allowRepeat && lastEndMs[idx] !== undefined) {
+                if (tCursor < lastEndMs[idx] + repeatGap) return false;
             }
+            return true;
+        });
+
+        if (pool.length === 0) {
+            if (!allowRepeat) break;
+            tCursor += Math.max(flashGap, 200);
+            continue;
         }
-        if (distIdx === -1) break;
 
-        /* Pick a time offset respecting gap constraint */
-        var attempts = 0, tOffset;
-        do {
-            tOffset = earliest + Math.floor(Math.random() * (latest - earliest));
-            attempts++;
-        } while (Math.abs(tOffset - lastStart) < FLASH_MIN_GAP_MS && attempts < 30);
+        /* Shuffle pool */
+        for (var j = pool.length - 1; j > 0; j--) {
+            var k = Math.floor(Math.random() * (j + 1));
+            var tmp = pool[j]; pool[j] = pool[k]; pool[k] = tmp;
+        }
 
-        if (Math.abs(tOffset - lastStart) < FLASH_MIN_GAP_MS) break;
+        var batchSize = Math.min(maxConcurrent, pool.length, flashCount - placed);
+        var batch     = pool.slice(0, batchSize);
+        var gid       = batch.length > 1 ? ++groupId : null;
 
-        usedDistractors.add(distIdx);
-        lastStart = tOffset;
-        schedule.push({ distractor_index: distIdx, t_offset_ms: tOffset });
+        batch.forEach(function (distIdx) {
+            var isRepeat = seenOnce.has(distIdx);
+            schedule.push({
+                distractor_index:    distIdx,
+                t_offset_ms:         tCursor,
+                duration_ms:         flashDuration,
+                color:               '#f59e0b',
+                concurrent_group_id: gid,
+                repeat:              isRepeat,
+                is_target:           false,
+            });
+            usedOnce.add(distIdx);
+            seenOnce.add(distIdx);
+            lastEndMs[distIdx] = tCursor + flashDuration;
+            placed++;
+        });
+
+        tCursor += flashDuration + flashGap;
     }
 
     return schedule;
@@ -695,6 +728,8 @@ function startGame() {
                 trackingMs:       p.tracking_ms,
                 windowMs:         p.window_ms,
                 distractorFlash:  p.distractor_flash || 0,
+                flashConfig:      diff.flash_config     || null,
+                directionChange:  diff.direction_change || null,
             });
         }
     });
@@ -705,6 +740,7 @@ function startGame() {
     roundResults = [];
     totalFlashShown = 0;
     tapsDuringFlash = 0;
+    totalDirChanges = 0;
 
     document.getElementById('tt-intro').style.display    = 'none';
     document.getElementById('tt-game-wrap').style.display = 'block';
@@ -722,9 +758,10 @@ function startRound() {
     setDot(roundIdx, 'active');
     setStatus('Get ready…');
     clearObjects();
-    activeFlashes  = [];
-    flashEventLog  = [];
-    tapWasDuringFlash = false;
+    activeFlashes         = [];
+    flashEventLog         = [];
+    tapWasDuringFlash     = false;
+    currentDirChangeCount = 0;
 
     targetIdx = Math.floor(Math.random() * round.objectCount);
     spawnObjects(round.objectCount);
@@ -751,8 +788,14 @@ function trackingPhase(round) {
         o.vy = Math.sin(angle) * spd;
     });
 
-    /* Build flash schedule for this round */
-    var schedule = generateFlashSchedule(round.distractorFlash, round.trackingMs, round.objectCount);
+    /* Direction change config */
+    var dirEnabled  = !!(round.directionChange && round.directionChange.enabled);
+    var dirInterval = dirEnabled ? (round.directionChange.interval_ms || 2000) : 0;
+    var lastDirChange = 0;
+    currentDirChangeCount = 0;
+
+    /* Build flash schedule — supports concurrent + repeat flash */
+    var schedule = generateFlashSchedule(round.distractorFlash, round.trackingMs, round.objectCount, round.flashConfig);
 
     var trackingStart = Date.now();
     var deadline      = trackingStart + round.trackingMs;
@@ -763,34 +806,44 @@ function trackingPhase(round) {
 
         moveObjects();
 
-        /* Process flash schedule */
+        /* Direction change — velocity direction only, speed preserved */
+        if (dirEnabled && elapsed > 0 && elapsed - lastDirChange >= dirInterval) {
+            lastDirChange = elapsed;
+            currentDirChangeCount++;
+            objects.forEach(function (o) {
+                var angle = Math.random() * Math.PI * 2;
+                o.vx = Math.cos(angle) * spd;
+                o.vy = Math.sin(angle) * spd;
+            });
+        }
+
+        /* Process flash schedule — ref-counted _flashCount, per-event start/end flags */
         schedule.forEach(function (ev) {
-            var isActive = (elapsed >= ev.t_offset_ms && elapsed < ev.t_offset_ms + FLASH_DURATION_MS);
+            var isActive = (elapsed >= ev.t_offset_ms && elapsed < ev.t_offset_ms + ev.duration_ms);
             var obj      = objects[ev.distractor_index];
             if (!obj) return;
             if (isActive) {
-                if (!obj._flashing) {
-                    obj._flashing = true;
-                    obj.el.classList.add('tt-flash');
-                    /* Log the flash event once */
-                    var alreadyLogged = flashEventLog.some(function (e) {
-                        return e.distractor_index === ev.distractor_index;
+                if (!ev._started) {
+                    ev._started = true;
+                    obj._flashCount = (obj._flashCount || 0) + 1;
+                    if (obj._flashCount === 1) obj.el.classList.add('tt-flash');
+                    flashEventLog.push({
+                        t_offset_ms:         ev.t_offset_ms,
+                        distractor_index:    ev.distractor_index,
+                        target_index:        targetIdx,
+                        is_target:           false,
+                        duration_ms:         ev.duration_ms,
+                        color:               ev.color || '#f59e0b',
+                        concurrent_group_id: ev.concurrent_group_id || null,
+                        repeat:              ev.repeat || false,
                     });
-                    if (!alreadyLogged) {
-                        flashEventLog.push({
-                            t_offset_ms:      ev.t_offset_ms,
-                            distractor_index: ev.distractor_index,
-                            target_index:     targetIdx,
-                            duration_ms:      FLASH_DURATION_MS,
-                            color:            '#f59e0b',
-                        });
-                        totalFlashShown++;
-                    }
+                    totalFlashShown++;
                 }
             } else {
-                if (obj._flashing) {
-                    obj._flashing = false;
-                    obj.el.classList.remove('tt-flash');
+                if (ev._started && !ev._ended) {
+                    ev._ended = true;
+                    obj._flashCount = Math.max(0, (obj._flashCount || 0) - 1);
+                    if (obj._flashCount === 0) obj.el.classList.remove('tt-flash');
                 }
             }
         });
@@ -799,9 +852,8 @@ function trackingPhase(round) {
             rafId = requestAnimationFrame(loop);
         } else {
             cancelAnimationFrame(rafId);
-            /* Clear any active flashes */
             objects.forEach(function (o) {
-                o._flashing = false;
+                o._flashCount = 0;
                 o.el.classList.remove('tt-flash');
             });
             responsePhase(round);
@@ -834,27 +886,29 @@ function handleTap(tappedIdx, round) {
     var responseMs = Date.now() - roundStartMs;
     var correct    = tappedIdx === targetIdx;
 
-    /* Check if tap coincided with any active flash */
-    var duringFlash = objects.some(function (o) { return o._flashing; });
+    var duringFlash = objects.some(function (o) { return (o._flashCount || 0) > 0; });
     if (duringFlash) tapsDuringFlash++;
 
-    objects.forEach(function (o) { o.el.onclick = null; o._flashing = false; o.el.classList.remove('tt-flash'); });
+    objects.forEach(function (o) { o.el.onclick = null; o._flashCount = 0; o.el.classList.remove('tt-flash'); });
     objects[targetIdx].el.classList.add('tt-reveal');
     objects[tappedIdx].el.classList.add(correct ? 'tt-correct' : 'tt-wrong');
 
     setStatus(correct ? '✓ Correct!' : '✗ Wrong object');
     setDot(roundIdx, correct ? 'done' : 'wrong');
 
+    totalDirChanges += currentDirChangeCount;
+
     roundResults.push({
-        round:             roundIdx,
-        phase:             round.phase,
-        object_count:      round.objectCount,
-        outcome:           correct ? 'correct' : 'wrong',
-        response_ms:       responseMs,
-        tapped_index:      tappedIdx,
-        target_index:      targetIdx,
-        flash_events:      flashEventLog.slice(),
-        tapped_during_flash: duringFlash,
+        round:                  roundIdx,
+        phase:                  round.phase,
+        object_count:           round.objectCount,
+        outcome:                correct ? 'correct' : 'wrong',
+        response_ms:            responseMs,
+        tapped_index:           tappedIdx,
+        target_index:           targetIdx,
+        flash_events:           flashEventLog.slice(),
+        tapped_during_flash:    duringFlash,
+        direction_change_count: currentDirChangeCount,
     });
 
     setTimeout(function () { roundIdx++; startRound(); }, 900);
@@ -864,22 +918,25 @@ function handleTimeout(round) {
     if (responded) return;
     responded = true;
 
-    objects.forEach(function (o) { o.el.onclick = null; o._flashing = false; o.el.classList.remove('tt-flash'); });
+    objects.forEach(function (o) { o.el.onclick = null; o._flashCount = 0; o.el.classList.remove('tt-flash'); });
     objects[targetIdx].el.classList.add('tt-reveal');
 
     setStatus('⏱ Time up!');
     setDot(roundIdx, 'timeout');
 
+    totalDirChanges += currentDirChangeCount;
+
     roundResults.push({
-        round:             roundIdx,
-        phase:             round.phase,
-        object_count:      round.objectCount,
-        outcome:           'timeout',
-        response_ms:       null,
-        tapped_index:      null,
-        target_index:      targetIdx,
-        flash_events:      flashEventLog.slice(),
-        tapped_during_flash: false,
+        round:                  roundIdx,
+        phase:                  round.phase,
+        object_count:           round.objectCount,
+        outcome:                'timeout',
+        response_ms:            null,
+        tapped_index:           null,
+        target_index:           targetIdx,
+        flash_events:           flashEventLog.slice(),
+        tapped_during_flash:    false,
+        direction_change_count: currentDirChangeCount,
     });
 
     setTimeout(function () { roundIdx++; startRound(); }, 900);
@@ -949,9 +1006,10 @@ function finishGame() {
             per_round:            roundResults,
             per_phase:            per_phase,
             late_summary: {
-                total_flashes_shown:   totalFlashShown,
-                taps_during_flash:     tapsDuringFlash,
-                flash_distraction_rate: flashRate,
+                total_flashes_shown:     totalFlashShown,
+                taps_during_flash:       tapsDuringFlash,
+                flash_distraction_rate:  flashRate,
+                total_direction_changes: totalDirChanges,
             },
         },
     };

--- a/scripts/seed_virtual_training_games.py
+++ b/scripts/seed_virtual_training_games.py
@@ -354,6 +354,17 @@ _GAMES = [
                          "distractor_flash": 0},
                     ],
                     "difficulty_multiplier": 1.00,
+                    "flash_config": {
+                        "flash_duration_ms":      400,
+                        "flash_gap_ms":           500,
+                        "max_concurrent_flashes": 1,
+                        "allow_repeat_flash":     False,
+                        "repeat_gap_ms":          None,
+                    },
+                    "direction_change": {
+                        "enabled":    False,
+                        "interval_ms": None,
+                    },
                     "validation_overrides": {
                         "min_stimuli_count":         3,
                         "min_duration_seconds":      20.0,
@@ -374,6 +385,17 @@ _GAMES = [
                          "distractor_flash": 3},
                     ],
                     "difficulty_multiplier": 1.30,
+                    "flash_config": {
+                        "flash_duration_ms":      400,
+                        "flash_gap_ms":           450,
+                        "max_concurrent_flashes": 1,
+                        "allow_repeat_flash":     False,
+                        "repeat_gap_ms":          None,
+                    },
+                    "direction_change": {
+                        "enabled":    False,
+                        "interval_ms": None,
+                    },
                     "validation_overrides": {
                         "min_stimuli_count":         3,
                         "min_duration_seconds":      25.0,
@@ -394,6 +416,17 @@ _GAMES = [
                          "distractor_flash": 5},
                     ],
                     "difficulty_multiplier": 1.70,
+                    "flash_config": {
+                        "flash_duration_ms":      350,
+                        "flash_gap_ms":           350,
+                        "max_concurrent_flashes": 2,
+                        "allow_repeat_flash":     True,
+                        "repeat_gap_ms":          2000,
+                    },
+                    "direction_change": {
+                        "enabled":    True,
+                        "interval_ms": 1800,
+                    },
                     "validation_overrides": {
                         "min_stimuli_count":         4,
                         "min_duration_seconds":      30.0,
@@ -417,6 +450,17 @@ _GAMES = [
                          "distractor_flash": 6},
                     ],
                     "difficulty_multiplier": 2.20,
+                    "flash_config": {
+                        "flash_duration_ms":      300,
+                        "flash_gap_ms":           250,
+                        "max_concurrent_flashes": 3,
+                        "allow_repeat_flash":     True,
+                        "repeat_gap_ms":          1500,
+                    },
+                    "direction_change": {
+                        "enabled":    True,
+                        "interval_ms": 1200,
+                    },
                     "unlock_threshold": {
                         "min_hard_attempts": 3,
                         "min_hard_score":    70,

--- a/tests/unit/api/web_routes/test_target_tracking.py
+++ b/tests/unit/api/web_routes/test_target_tracking.py
@@ -1340,3 +1340,154 @@ class TestTTDifficultyScaleGuards:
         assert d["medium"]["difficulty_multiplier"] == pytest.approx(1.30)
         assert d["hard"]["difficulty_multiplier"]   == pytest.approx(1.70)
         assert d["expert"]["difficulty_multiplier"] == pytest.approx(2.20)
+
+
+# ── TT-B01..TT-B17: Track B — concurrent flash + direction change ─────────────
+
+class TestTTTrackBFlashMotion:
+    """Track B: concurrent flash, repeat flash, per-difficulty flash config, direction change."""
+
+    def _difficulties(self):
+        from scripts.seed_virtual_training_games import _GAMES
+        for g in _GAMES:
+            if g["code"] == "target_tracking":
+                return g["config"]["difficulties"]
+        raise AssertionError("target_tracking seed entry not found")
+
+    @staticmethod
+    def _src() -> str:
+        with open(_TT_TEMPLATE_PATH, encoding="utf-8") as f:
+            return f.read()
+
+    # ── Seed pin tests ────────────────────────────────────────────────────────
+
+    def test_ttb01_hard_max_concurrent_flashes(self):
+        """TT-B01: Seed: hard flash_config.max_concurrent_flashes == 2."""
+        d = self._difficulties()
+        assert d["hard"]["flash_config"]["max_concurrent_flashes"] == 2
+
+    def test_ttb02_expert_max_concurrent_flashes(self):
+        """TT-B02: Seed: expert flash_config.max_concurrent_flashes == 3."""
+        d = self._difficulties()
+        assert d["expert"]["flash_config"]["max_concurrent_flashes"] == 3
+
+    def test_ttb03_hard_allow_repeat_flash(self):
+        """TT-B03: Seed: hard flash_config.allow_repeat_flash == True."""
+        d = self._difficulties()
+        assert d["hard"]["flash_config"]["allow_repeat_flash"] is True
+
+    def test_ttb04_expert_allow_repeat_flash(self):
+        """TT-B04: Seed: expert flash_config.allow_repeat_flash == True."""
+        d = self._difficulties()
+        assert d["expert"]["flash_config"]["allow_repeat_flash"] is True
+
+    def test_ttb05_easy_medium_no_repeat_flash(self):
+        """TT-B05: Seed: easy and medium allow_repeat_flash == False."""
+        d = self._difficulties()
+        assert d["easy"]["flash_config"]["allow_repeat_flash"]   is False
+        assert d["medium"]["flash_config"]["allow_repeat_flash"] is False
+
+    def test_ttb06_hard_direction_change_enabled(self):
+        """TT-B06: Seed: hard direction_change.enabled == True."""
+        d = self._difficulties()
+        assert d["hard"]["direction_change"]["enabled"] is True
+
+    def test_ttb07_expert_direction_change_enabled(self):
+        """TT-B07: Seed: expert direction_change.enabled == True."""
+        d = self._difficulties()
+        assert d["expert"]["direction_change"]["enabled"] is True
+
+    def test_ttb08_easy_medium_direction_change_disabled(self):
+        """TT-B08: Seed: easy and medium direction_change.enabled == False."""
+        d = self._difficulties()
+        assert d["easy"]["direction_change"]["enabled"]   is False
+        assert d["medium"]["direction_change"]["enabled"] is False
+
+    # ── Template static guards ────────────────────────────────────────────────
+
+    def test_ttb09_template_uses_flash_count_ref_counter(self):
+        """TT-B09: Template uses _flashCount ref-counter (not boolean _flashing) for flash state."""
+        src = self._src()
+        assert "_flashCount" in src
+        assert "obj._flashCount" in src or "o._flashCount" in src
+
+    def test_ttb10_template_logs_concurrent_group_id(self):
+        """TT-B10: Template flash event log contains concurrent_group_id field."""
+        src = self._src()
+        assert "concurrent_group_id" in src
+
+    def test_ttb11_template_logs_repeat_field(self):
+        """TT-B11: Template flash event log contains repeat field."""
+        src = self._src()
+        assert "repeat:" in src or '"repeat"' in src
+
+    def test_ttb12_template_logs_is_target_false(self):
+        """TT-B12: Template flash event log contains is_target: false."""
+        src = self._src()
+        assert "is_target" in src
+
+    def test_ttb13_template_logs_direction_change_count(self):
+        """TT-B13: Template logs direction_change_count per round in roundResults."""
+        src = self._src()
+        assert "direction_change_count" in src
+
+    def test_ttb14_flash_duration_comes_from_config(self):
+        """TT-B14: Flash duration reads from flashConfig, not only from hardcoded constant."""
+        src = self._src()
+        assert "flash_duration_ms" in src
+        assert "flashDuration" in src
+
+    def test_ttb15_flash_gap_comes_from_config(self):
+        """TT-B15: Flash gap reads from flashConfig, not only from hardcoded constant."""
+        src = self._src()
+        assert "flash_gap_ms" in src
+        assert "flashGap" in src
+
+    def test_ttb16_total_direction_changes_in_late_summary(self):
+        """TT-B16: total_direction_changes field present in late_summary payload."""
+        src = self._src()
+        assert "total_direction_changes" in src
+
+    def test_ttb17_result_page_backward_compat_v3_missing_new_fields(self):
+        """TT-B17: Result page renders without error when v=3 raw_metrics lacks Track B fields."""
+        from datetime import datetime, timezone
+        from unittest.mock import MagicMock
+
+        user    = _onboarded_student(user_id=42)
+        game    = _mock_tt_game(is_active=True)
+        # Pre-Track-B v=3 payload: no concurrent_group_id, no direction_change_count
+        old_v3_raw = {
+            "v": 3,
+            "difficulty_level":      "hard",
+            "difficulty_multiplier": 1.70,
+            "per_round": [
+                {"round": 0, "phase": 0, "object_count": 6, "outcome": "correct",
+                 "response_ms": 900, "tapped_index": 2, "target_index": 2,
+                 "flash_events": [
+                     {"t_offset_ms": 1200, "distractor_index": 4, "target_index": 2,
+                      "duration_ms": 350, "color": "#f59e0b"}
+                 ],
+                 "tapped_during_flash": False},
+            ],
+            "per_phase": [{"phase": 0, "rounds": 1, "correct": 1, "wrong": 0, "timeout": 0, "object_count": 6}],
+            "late_summary": {
+                "total_flashes_shown": 1,
+                "taps_during_flash": 0,
+                "flash_distraction_rate": 0.0,
+            },
+        }
+        attempt = _mock_tt_attempt(user_id=42, raw_metrics=old_v3_raw, skill_deltas=None)
+        attempt.skill_deltas = None
+
+        db = MagicMock()
+        q  = MagicMock()
+        q.filter.return_value = q
+        q.first.return_value  = attempt
+        db.query.return_value = q
+
+        with patch(f"{_ROUTE_BASE}.VirtualTrainingService.get_hub_games", return_value=[game]), \
+             patch(f"{_ROUTE_BASE}._spec_ctx", return_value={}):
+            client = _make_client(user, db)
+            resp   = client.get("/virtual-training/target-tracking/result/201")
+
+        assert resp.status_code == 200, f"Expected 200, got {resp.status_code}"


### PR DESCRIPTION
## Summary

- **Concurrent flash:** up to 3 objects flash simultaneously on Hard/Expert; shared `concurrent_group_id` in raw_metrics
- **Repeat flash:** same distractor can re-flash after cooldown (`repeat_gap_ms`); `repeat: true/false` field logged
- **Direction change:** all objects get new random angle every `interval_ms` during tracking phase (Hard: 1800ms, Expert: 1200ms); `direction_change_count` per round + `total_direction_changes` in late_summary
- **`_flashCount` ref-counter:** replaces boolean `_flashing` — handles concurrent events targeting same object correctly
- **raw_metrics v=3 extended:** backward compat — pre-Track-B attempts still accepted
- **Seed:** `flash_config` + `direction_change` added to all 4 TT difficulty levels (Easy/Medium: single flash, no direction change; Hard/Expert: concurrent + repeat + direction change)

## Test plan

- [x] TT tests: 89/89 pass (72 original + 17 new TT-B01..TT-B17)
- [x] Full unit regression: 10345/10345 pass, 0 failures
- [x] Manual validation: concurrent flash ✅ repeat flash ✅ direction change ✅ Hard/Expert harder ✅ mobile playable ✅ result page intact ✅ raw_metrics correct ✅
- [ ] CI: Unit Tests + API Smoke Tests (expected green — awaiting run)

## Scope boundary

Score formula, XP pipeline, daily cap, DB model, migration, Player Card, /skills dashboard, Track C football visual — **not touched**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)