### PR TITLE
feat(vt): PR-C1 — VT Challenge lifecycle (model + routes + migration)

### DIFF
--- a/alembic/versions/2026_05_24_1000_vt_challenge_schema.py
+++ b/alembic/versions/2026_05_24_1000_vt_challenge_schema.py
@@ -1,0 +1,90 @@
+"""Add vt_challenges table and challenge notification types
+
+Creates the async friend-vs-friend VT challenge model.
+
+Tables:
+  vt_challenges — pending/accepted/declined/cancelled/expired/completed lifecycle
+
+Enum additions:
+  challengestatus      — new enum (DO $$ idempotent block, lesson from PR-F1)
+  notificationtype     — 6 new VT_CHALLENGE_* values
+
+Revision ID: 2026_05_24_1000
+Revises:     2026_05_24_0900
+Create Date: 2026-05-24 10:00:00
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision      = "2026_05_24_1000"
+down_revision = "2026_05_24_0900"
+branch_labels = None
+depends_on    = None
+
+
+def upgrade() -> None:
+    # ── 1. Extend notificationtype enum ──────────────────────────────────────
+    for value in [
+        "VT_CHALLENGE_RECEIVED",
+        "VT_CHALLENGE_ACCEPTED",
+        "VT_CHALLENGE_DECLINED",
+        "VT_CHALLENGE_CANCELLED",
+        "VT_CHALLENGE_EXPIRED",
+        "VT_CHALLENGE_COMPLETED",
+    ]:
+        op.execute(
+            f"ALTER TYPE notificationtype ADD VALUE IF NOT EXISTS '{value}'"
+        )
+
+    # ── 2. Create challengestatus enum (idempotent PL/pgSQL block) ───────────
+    op.execute("""
+        DO $$ BEGIN
+            CREATE TYPE challengestatus AS ENUM
+                ('pending', 'accepted', 'declined', 'expired', 'cancelled', 'completed');
+        EXCEPTION WHEN duplicate_object THEN null;
+        END $$;
+    """)
+
+    # ── 3. Create vt_challenges table (raw SQL — avoids double CREATE TYPE) ──
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS vt_challenges (
+            id                    SERIAL PRIMARY KEY,
+            challenger_id         INTEGER NOT NULL
+                                    REFERENCES users(id) ON DELETE CASCADE,
+            challenged_id         INTEGER NOT NULL
+                                    REFERENCES users(id) ON DELETE CASCADE,
+            game_id               INTEGER NOT NULL
+                                    REFERENCES virtual_training_games(id) ON DELETE CASCADE,
+            status                challengestatus NOT NULL DEFAULT 'pending',
+            message               TEXT,
+            challenger_attempt_id INTEGER
+                                    REFERENCES virtual_training_attempts(id) ON DELETE SET NULL,
+            challenged_attempt_id INTEGER
+                                    REFERENCES virtual_training_attempts(id) ON DELETE SET NULL,
+            winner_id             INTEGER
+                                    REFERENCES users(id) ON DELETE SET NULL,
+            is_draw               BOOLEAN NOT NULL DEFAULT FALSE,
+            completed_at          TIMESTAMPTZ,
+            expires_at            TIMESTAMPTZ NOT NULL,
+            created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at            TIMESTAMPTZ,
+            CONSTRAINT ck_challenge_no_self
+                CHECK (challenger_id != challenged_id)
+        )
+    """)
+
+    op.create_index("ix_vt_challenges_challenger_id", "vt_challenges", ["challenger_id"])
+    op.create_index("ix_vt_challenges_challenged_id", "vt_challenges", ["challenged_id"])
+    op.create_index("ix_vt_challenges_game_id",       "vt_challenges", ["game_id"])
+    op.create_index("ix_vt_challenges_status",        "vt_challenges", ["status"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_vt_challenges_status",        table_name="vt_challenges")
+    op.drop_index("ix_vt_challenges_game_id",       table_name="vt_challenges")
+    op.drop_index("ix_vt_challenges_challenged_id", table_name="vt_challenges")
+    op.drop_index("ix_vt_challenges_challenger_id", table_name="vt_challenges")
+    op.drop_table("vt_challenges")
+    op.execute("DROP TYPE IF EXISTS challengestatus")
+    # notificationtype VT_CHALLENGE_* values cannot be removed without
+    # recreating the type — leave in place on downgrade.

--- a/app/api/web_routes/__init__.py
+++ b/app/api/web_routes/__init__.py
@@ -29,6 +29,7 @@ from . import (
     sport_director,
     my_cards,
     friends,
+    vt_challenges,
 )
 from .admin import router as admin_router
 from .tournaments import router as tournaments_router
@@ -63,3 +64,4 @@ router.include_router(public_tournament.router)  # 🌐 Public event detail page
 router.include_router(sport_director.router)     # 🏅 Sport Director team enrollment
 router.include_router(my_cards.router)           # 🃏 My Cards hub (/my-cards)
 router.include_router(friends.router)            # 👥 Friendship system (/friends)
+router.include_router(vt_challenges.router)      # 🎮 VT Challenges (/challenges)

--- a/app/api/web_routes/vt_challenges.py
+++ b/app/api/web_routes/vt_challenges.py
@@ -1,0 +1,242 @@
+"""
+VT Challenge web routes — async friend-vs-friend challenge lifecycle (PR-C1).
+
+Routes:
+  POST /challenges/send               → send challenge to a friend
+  POST /challenges/{id}/accept        → accept incoming challenge (challenged only)
+  POST /challenges/{id}/decline       → decline incoming challenge (challenged only)
+  POST /challenges/{id}/cancel        → cancel pending/accepted challenge (challenger only)
+
+Guards (send):
+  - self-challenge blocked
+  - target must be active user
+  - must be friends (is_friends)
+  - game must exist
+  - game must be in CHALLENGE_COMPATIBLE_GAMES
+  - no duplicate active challenge between the pair on the same game
+
+Guards (accept):
+  - challenge must exist, current user must be challenged_id
+  - challenge must not be expired (auto-marks EXPIRED if so)
+
+Guards (decline/cancel):
+  - challenge must exist, correct ownership
+  - cancel allowed only for PENDING or ACCEPTED status
+
+Notifications:
+  - send   → VT_CHALLENGE_RECEIVED  to challenged_id
+  - accept → VT_CHALLENGE_ACCEPTED  to challenger_id
+  - decline→ VT_CHALLENGE_DECLINED  to challenger_id
+  - cancel → VT_CHALLENGE_CANCELLED to challenged_id
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, Form
+from fastapi.responses import RedirectResponse
+from sqlalchemy.orm import Session
+
+from ...database import get_db
+from ...dependencies import get_current_user_web
+from ...models.friendship import is_friends
+from ...models.notification import NotificationType
+from ...models.user import User
+from ...models.virtual_training import VirtualTrainingGame
+from ...models.vt_challenge import (
+    CHALLENGE_COMPATIBLE_GAMES,
+    ChallengeStatus,
+    VirtualTrainingChallenge,
+    get_active_challenge,
+    make_expires_at,
+)
+from ...services import notification_service
+
+router = APIRouter()
+
+_MAX_MSG = 500
+
+
+def _trim_message(raw: str | None) -> str | None:
+    if not raw:
+        return None
+    trimmed = raw.strip()[:_MAX_MSG]
+    return trimmed or None
+
+
+# ── Send ───────────────────────────────────────────────────────────────────────
+
+@router.post("/challenges/send")
+async def send_challenge(
+    challenged_user_id: int = Form(...),
+    game_id: int = Form(...),
+    message: str | None = Form(default=None),
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user_web),
+):
+    # Self-challenge guard
+    if challenged_user_id == user.id:
+        return RedirectResponse(url="/friends?error=self_challenge", status_code=303)
+
+    # Target must be active
+    target = db.query(User).filter(
+        User.id == challenged_user_id, User.is_active == True
+    ).first()
+    if not target:
+        return RedirectResponse(url="/friends?error=user_not_found", status_code=303)
+
+    # Friendship guard
+    if not is_friends(db, user.id, challenged_user_id):
+        return RedirectResponse(url="/friends?error=not_friends", status_code=303)
+
+    # Game existence guard
+    game = db.query(VirtualTrainingGame).filter(
+        VirtualTrainingGame.id == game_id
+    ).first()
+    if not game:
+        return RedirectResponse(url="/friends?error=game_not_found", status_code=303)
+
+    # Compatible game guard
+    if game.code not in CHALLENGE_COMPATIBLE_GAMES:
+        return RedirectResponse(url="/friends?error=game_not_compatible", status_code=303)
+
+    # Duplicate active challenge guard (bidirectional)
+    if get_active_challenge(db, user.id, challenged_user_id, game_id):
+        return RedirectResponse(url="/friends?error=challenge_active", status_code=303)
+
+    now = datetime.now(timezone.utc)
+    challenge = VirtualTrainingChallenge(
+        challenger_id=user.id,
+        challenged_id=challenged_user_id,
+        game_id=game_id,
+        status=ChallengeStatus.PENDING,
+        message=_trim_message(message),
+        expires_at=make_expires_at(now),
+        created_at=now,
+    )
+    db.add(challenge)
+    db.flush()
+
+    notification_service.create_notification(
+        db=db,
+        user_id=challenged_user_id,
+        title="Challenge Received",
+        message=f"{user.nickname or user.email} challenged you to a VT game.",
+        notification_type=NotificationType.VT_CHALLENGE_RECEIVED,
+        link="/friends",
+    )
+
+    db.commit()
+    return RedirectResponse(url="/friends?success=challenge_sent", status_code=303)
+
+
+# ── Accept ─────────────────────────────────────────────────────────────────────
+
+@router.post("/challenges/{challenge_id}/accept")
+async def accept_challenge(
+    challenge_id: int,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user_web),
+):
+    challenge = db.query(VirtualTrainingChallenge).filter(
+        VirtualTrainingChallenge.id == challenge_id
+    ).first()
+
+    if not challenge or challenge.challenged_id != user.id:
+        return RedirectResponse(url="/friends?error=not_found", status_code=303)
+
+    if challenge.status != ChallengeStatus.PENDING:
+        return RedirectResponse(url="/friends?error=not_pending", status_code=303)
+
+    # Expiry guard — auto-mark expired
+    now = datetime.now(timezone.utc)
+    if challenge.expires_at <= now:
+        challenge.status     = ChallengeStatus.EXPIRED
+        challenge.updated_at = now
+        db.commit()
+        return RedirectResponse(url="/friends?error=challenge_expired", status_code=303)
+
+    challenge.status     = ChallengeStatus.ACCEPTED
+    challenge.updated_at = now
+
+    notification_service.create_notification(
+        db=db,
+        user_id=challenge.challenger_id,
+        title="Challenge Accepted",
+        message=f"{user.nickname or user.email} accepted your VT challenge.",
+        notification_type=NotificationType.VT_CHALLENGE_ACCEPTED,
+        link="/friends",
+    )
+
+    db.commit()
+    return RedirectResponse(url="/friends?success=challenge_accepted", status_code=303)
+
+
+# ── Decline ────────────────────────────────────────────────────────────────────
+
+@router.post("/challenges/{challenge_id}/decline")
+async def decline_challenge(
+    challenge_id: int,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user_web),
+):
+    challenge = db.query(VirtualTrainingChallenge).filter(
+        VirtualTrainingChallenge.id == challenge_id
+    ).first()
+
+    if not challenge or challenge.challenged_id != user.id:
+        return RedirectResponse(url="/friends?error=not_found", status_code=303)
+
+    if challenge.status != ChallengeStatus.PENDING:
+        return RedirectResponse(url="/friends?error=not_pending", status_code=303)
+
+    now = datetime.now(timezone.utc)
+    challenge.status     = ChallengeStatus.DECLINED
+    challenge.updated_at = now
+
+    notification_service.create_notification(
+        db=db,
+        user_id=challenge.challenger_id,
+        title="Challenge Declined",
+        message=f"{user.nickname or user.email} declined your VT challenge.",
+        notification_type=NotificationType.VT_CHALLENGE_DECLINED,
+        link="/friends",
+    )
+
+    db.commit()
+    return RedirectResponse(url="/friends?success=challenge_declined", status_code=303)
+
+
+# ── Cancel ─────────────────────────────────────────────────────────────────────
+
+@router.post("/challenges/{challenge_id}/cancel")
+async def cancel_challenge(
+    challenge_id: int,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user_web),
+):
+    challenge = db.query(VirtualTrainingChallenge).filter(
+        VirtualTrainingChallenge.id == challenge_id
+    ).first()
+
+    if not challenge or challenge.challenger_id != user.id:
+        return RedirectResponse(url="/friends?error=not_found", status_code=303)
+
+    if challenge.status not in (ChallengeStatus.PENDING, ChallengeStatus.ACCEPTED):
+        return RedirectResponse(url="/friends?error=cannot_cancel", status_code=303)
+
+    now = datetime.now(timezone.utc)
+    challenge.status     = ChallengeStatus.CANCELLED
+    challenge.updated_at = now
+
+    notification_service.create_notification(
+        db=db,
+        user_id=challenge.challenged_id,
+        title="Challenge Cancelled",
+        message=f"{user.nickname or user.email} cancelled their VT challenge.",
+        notification_type=NotificationType.VT_CHALLENGE_CANCELLED,
+        link="/friends",
+    )
+
+    db.commit()
+    return RedirectResponse(url="/friends?success=challenge_cancelled", status_code=303)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -60,6 +60,10 @@ from .card_theme import CardTheme
 from .card_design import CardDesign
 from .virtual_training import VirtualTrainingGame, VirtualTrainingAttempt
 from .friendship import Friendship, FriendshipStatus, is_friends, get_friendship
+from .vt_challenge import (
+    VirtualTrainingChallenge, ChallengeStatus,
+    CHALLENGE_COMPATIBLE_GAMES, make_expires_at, get_active_challenge,
+)
 
 # 🎓 New Track-Based Modular Education System
 from .track import Track, Module, ModuleComponent

--- a/app/models/notification.py
+++ b/app/models/notification.py
@@ -31,6 +31,14 @@ class NotificationType(enum.Enum):
     FRIEND_REQUEST_RECEIVED = "friend_request_received"
     FRIEND_REQUEST_ACCEPTED = "friend_request_accepted"
 
+    # Virtual Training challenge notifications
+    VT_CHALLENGE_RECEIVED  = "vt_challenge_received"
+    VT_CHALLENGE_ACCEPTED  = "vt_challenge_accepted"
+    VT_CHALLENGE_DECLINED  = "vt_challenge_declined"
+    VT_CHALLENGE_CANCELLED = "vt_challenge_cancelled"
+    VT_CHALLENGE_EXPIRED   = "vt_challenge_expired"
+    VT_CHALLENGE_COMPLETED = "vt_challenge_completed"
+
 
 class Notification(Base):
     __tablename__ = "notifications"

--- a/app/models/vt_challenge.py
+++ b/app/models/vt_challenge.py
@@ -1,0 +1,128 @@
+"""VirtualTrainingChallenge model — async friend-vs-friend VT challenge.
+
+Lifecycle (PR-C1):
+  PENDING  → ACCEPTED   (challenged_id accepts, expires_at not passed)
+  PENDING  → DECLINED   (challenged_id declines)
+  PENDING  → CANCELLED  (challenger_id cancels)
+  ACCEPTED → CANCELLED  (challenger_id cancels)
+
+PR-C2 adds:
+  ACCEPTED → COMPLETED  (both attempts submitted, winner_id / is_draw set)
+
+Expiry:
+  expires_at = created_at + 7 days (set at creation).
+  Accept guard checks expires_at <= now() → rejects with EXPIRED status.
+
+Game compatibility:
+  Only games in CHALLENGE_COMPATIBLE_GAMES (by game.code) are allowed.
+  Expandable to a DB config field later.
+"""
+from __future__ import annotations
+
+import enum
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import (
+    Boolean, CheckConstraint, Column, DateTime, Enum,
+    ForeignKey, Integer, Text, UniqueConstraint,
+)
+from sqlalchemy.orm import Session, relationship
+
+from ..database import Base
+
+# ── Game allowlist ─────────────────────────────────────────────────────────────
+CHALLENGE_COMPATIBLE_GAMES: frozenset[str] = frozenset({
+    "memory_sequence",
+    "target_tracking",
+})
+
+
+# ── Enum ───────────────────────────────────────────────────────────────────────
+
+class ChallengeStatus(enum.Enum):
+    PENDING   = "pending"
+    ACCEPTED  = "accepted"
+    DECLINED  = "declined"
+    EXPIRED   = "expired"
+    CANCELLED = "cancelled"
+    COMPLETED = "completed"   # set by PR-C2 submit hook
+
+
+# ── Model ──────────────────────────────────────────────────────────────────────
+
+class VirtualTrainingChallenge(Base):
+    __tablename__ = "vt_challenges"
+    __table_args__ = (
+        CheckConstraint(
+            "challenger_id != challenged_id",
+            name="ck_challenge_no_self",
+        ),
+    )
+
+    id                    = Column(Integer, primary_key=True, index=True)
+    challenger_id         = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"),
+                                   nullable=False, index=True)
+    challenged_id         = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"),
+                                   nullable=False, index=True)
+    game_id               = Column(Integer,
+                                   ForeignKey("virtual_training_games.id", ondelete="CASCADE"),
+                                   nullable=False, index=True)
+    status                = Column(
+                                Enum(ChallengeStatus,
+                                     values_callable=lambda obj: [e.value for e in obj]),
+                                nullable=False,
+                                default=ChallengeStatus.PENDING,
+                            )
+    message               = Column(Text, nullable=True)
+    challenger_attempt_id = Column(Integer,
+                                   ForeignKey("virtual_training_attempts.id", ondelete="SET NULL"),
+                                   nullable=True)
+    challenged_attempt_id = Column(Integer,
+                                   ForeignKey("virtual_training_attempts.id", ondelete="SET NULL"),
+                                   nullable=True)
+    winner_id             = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"),
+                                   nullable=True)
+    is_draw               = Column(Boolean, nullable=False, default=False)
+    completed_at          = Column(DateTime(timezone=True), nullable=True)
+    expires_at            = Column(DateTime(timezone=True), nullable=False)
+    created_at            = Column(DateTime(timezone=True), nullable=False,
+                                   default=lambda: datetime.now(timezone.utc))
+    updated_at            = Column(DateTime(timezone=True), nullable=True)
+
+    challenger = relationship("User", foreign_keys=[challenger_id])
+    challenged = relationship("User", foreign_keys=[challenged_id])
+    winner     = relationship("User", foreign_keys=[winner_id])
+    game       = relationship("VirtualTrainingGame")
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def make_expires_at(created_at: datetime | None = None) -> datetime:
+    base = created_at or datetime.now(timezone.utc)
+    return base + timedelta(days=7)
+
+
+def get_active_challenge(
+    db: Session,
+    user_a_id: int,
+    user_b_id: int,
+    game_id: int,
+) -> VirtualTrainingChallenge | None:
+    """Return PENDING or ACCEPTED challenge between two users on a game (either direction)."""
+    return (
+        db.query(VirtualTrainingChallenge)
+        .filter(
+            VirtualTrainingChallenge.game_id == game_id,
+            VirtualTrainingChallenge.status.in_(
+                [ChallengeStatus.PENDING, ChallengeStatus.ACCEPTED]
+            ),
+            (
+                (VirtualTrainingChallenge.challenger_id == user_a_id) &
+                (VirtualTrainingChallenge.challenged_id == user_b_id)
+            ) | (
+                (VirtualTrainingChallenge.challenger_id == user_b_id) &
+                (VirtualTrainingChallenge.challenged_id == user_a_id)
+            ),
+        )
+        .first()
+    )

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -4149,6 +4149,35 @@
         "title": "Body_register_submit_register_post",
         "type": "object"
       },
+      "Body_send_challenge_challenges_send_post": {
+        "properties": {
+          "challenged_user_id": {
+            "title": "Challenged User Id",
+            "type": "integer"
+          },
+          "game_id": {
+            "title": "Game Id",
+            "type": "integer"
+          },
+          "message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Message"
+          }
+        },
+        "required": [
+          "challenged_user_id",
+          "game_id"
+        ],
+        "title": "Body_send_challenge_challenges_send_post",
+        "type": "object"
+      },
       "Body_send_friend_request_by_identifier_friends_send_post": {
         "properties": {
           "identifier": {
@@ -11302,7 +11331,13 @@
           "tournament_instructor_declined",
           "skill_tier_reached",
           "friend_request_received",
-          "friend_request_accepted"
+          "friend_request_accepted",
+          "vt_challenge_received",
+          "vt_challenge_accepted",
+          "vt_challenge_declined",
+          "vt_challenge_cancelled",
+          "vt_challenge_expired",
+          "vt_challenge_completed"
         ],
         "title": "NotificationType",
         "type": "string"
@@ -59435,6 +59470,165 @@
           }
         },
         "summary": "Camp Unenroll",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/challenges/send": {
+      "post": {
+        "operationId": "send_challenge_challenges_send_post",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_send_challenge_challenges_send_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Send Challenge",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/challenges/{challenge_id}/accept": {
+      "post": {
+        "operationId": "accept_challenge_challenges__challenge_id__accept_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "challenge_id",
+            "required": true,
+            "schema": {
+              "title": "Challenge Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Accept Challenge",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/challenges/{challenge_id}/cancel": {
+      "post": {
+        "operationId": "cancel_challenge_challenges__challenge_id__cancel_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "challenge_id",
+            "required": true,
+            "schema": {
+              "title": "Challenge Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Cancel Challenge",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/challenges/{challenge_id}/decline": {
+      "post": {
+        "operationId": "decline_challenge_challenges__challenge_id__decline_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "challenge_id",
+            "required": true,
+            "schema": {
+              "title": "Challenge Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Decline Challenge",
         "tags": [
           "web"
         ]

--- a/tests/unit/api/web_routes/test_vt_challenges.py
+++ b/tests/unit/api/web_routes/test_vt_challenges.py
@@ -1,0 +1,434 @@
+"""Unit tests for PR-C1 — VirtualTrainingChallenge lifecycle.
+
+CH-01  VirtualTrainingChallenge has expected columns
+CH-02  ChallengeStatus has all 6 expected values
+CH-03  CheckConstraint 'ck_challenge_no_self' in __table_args__
+CH-04  CHALLENGE_COMPATIBLE_GAMES contains expected game codes
+CH-05  make_expires_at returns created_at + 7 days
+CH-06  get_active_challenge returns challenge for PENDING (both FK directions)
+CH-07  POST /challenges/send — self-challenge → error=self_challenge
+CH-08  POST /challenges/send — target not found → error=user_not_found
+CH-09  POST /challenges/send — not friends → error=not_friends
+CH-10  POST /challenges/send — game not found → error=game_not_found
+CH-11  POST /challenges/send — incompatible game → error=game_not_compatible
+CH-12  POST /challenges/send — duplicate active challenge → error=challenge_active
+CH-13  POST /challenges/send — success: PENDING row created + VT_CHALLENGE_RECEIVED notification
+CH-14  POST /challenges/{id}/accept — wrong challenged_id → error=not_found
+CH-15  POST /challenges/{id}/accept — expired → status=EXPIRED + error=challenge_expired
+CH-16  POST /challenges/{id}/accept — success: ACCEPTED + VT_CHALLENGE_ACCEPTED notification
+CH-17  POST /challenges/{id}/decline — wrong challenged_id → error=not_found
+CH-18  POST /challenges/{id}/decline — success: DECLINED + VT_CHALLENGE_DECLINED notification
+CH-19  POST /challenges/{id}/cancel — wrong challenger_id → error=not_found
+CH-20  POST /challenges/{id}/cancel — non-cancellable status → error=cannot_cancel
+CH-21  POST /challenges/{id}/cancel — success from PENDING: CANCELLED + VT_CHALLENGE_CANCELLED
+CH-22  POST /challenges/{id}/cancel — success from ACCEPTED: CANCELLED + VT_CHALLENGE_CANCELLED
+CH-23  _trim_message: strips whitespace, empty→None, truncates at 500 chars
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.responses import RedirectResponse
+from sqlalchemy import CheckConstraint
+
+from app.models.vt_challenge import (
+    CHALLENGE_COMPATIBLE_GAMES,
+    ChallengeStatus,
+    VirtualTrainingChallenge,
+    get_active_challenge,
+    make_expires_at,
+)
+from app.models.notification import NotificationType
+
+_BASE = "app.api.web_routes.vt_challenges"
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+def _user(uid=1, active=True):
+    u = MagicMock()
+    u.id = uid
+    u.email = f"user{uid}@lfa.com"
+    u.nickname = None
+    u.is_active = active
+    return u
+
+
+def _db():
+    return MagicMock()
+
+
+def _game(gid=1, code="memory_sequence"):
+    g = MagicMock()
+    g.id = gid
+    g.code = code
+    return g
+
+
+def _challenge(
+    cid=10,
+    challenger_id=1,
+    challenged_id=2,
+    game_id=1,
+    status=ChallengeStatus.PENDING,
+    expires_at=None,
+):
+    c = MagicMock(spec=VirtualTrainingChallenge)
+    c.id = cid
+    c.challenger_id = challenger_id
+    c.challenged_id = challenged_id
+    c.game_id = game_id
+    c.status = status
+    c.expires_at = expires_at or (datetime.now(timezone.utc) + timedelta(days=7))
+    return c
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ── Model & enum tests ────────────────────────────────────────────────────────
+
+class TestVTChallengeModel:
+
+    def test_ch01_model_columns_present(self):
+        cols = {c.key for c in VirtualTrainingChallenge.__table__.columns}
+        assert {
+            "id", "challenger_id", "challenged_id", "game_id", "status",
+            "message", "challenger_attempt_id", "challenged_attempt_id",
+            "winner_id", "is_draw", "completed_at", "expires_at",
+            "created_at", "updated_at",
+        }.issubset(cols)
+
+    def test_ch02_challenge_status_values(self):
+        values = {e.value for e in ChallengeStatus}
+        assert values == {"pending", "accepted", "declined", "expired", "cancelled", "completed"}
+
+    def test_ch03_check_constraint_no_self(self):
+        args = VirtualTrainingChallenge.__table_args__
+        names = {c.name for c in args if isinstance(c, CheckConstraint)}
+        assert "ck_challenge_no_self" in names
+
+    def test_ch04_compatible_games_allowlist(self):
+        assert "memory_sequence" in CHALLENGE_COMPATIBLE_GAMES
+        assert "target_tracking" in CHALLENGE_COMPATIBLE_GAMES
+        assert "color_reaction" not in CHALLENGE_COMPATIBLE_GAMES
+
+    def test_ch05_make_expires_at_seven_days(self):
+        now = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        result = make_expires_at(now)
+        assert result == now + timedelta(days=7)
+
+    def test_ch05b_make_expires_at_defaults_to_now(self):
+        before = datetime.now(timezone.utc)
+        result = make_expires_at()
+        after = datetime.now(timezone.utc)
+        assert before + timedelta(days=7) <= result <= after + timedelta(days=7)
+
+
+class TestGetActiveChallenge:
+
+    def _make_db(self, row):
+        db = _db()
+        db.query.return_value.filter.return_value.first.return_value = row
+        return db
+
+    def test_ch06_returns_pending_challenge(self):
+        row = _challenge(challenger_id=1, challenged_id=2, status=ChallengeStatus.PENDING)
+        db = self._make_db(row)
+        result = get_active_challenge(db, user_a_id=1, user_b_id=2, game_id=1)
+        assert result is row
+
+    def test_ch06b_returns_none_when_no_active(self):
+        db = self._make_db(None)
+        result = get_active_challenge(db, user_a_id=1, user_b_id=2, game_id=1)
+        assert result is None
+
+
+# ── Route: send_challenge ─────────────────────────────────────────────────────
+
+class TestSendChallenge:
+
+    def test_ch07_self_challenge_blocked(self):
+        from app.api.web_routes.vt_challenges import send_challenge
+        user = _user(uid=5)
+        result = _run(send_challenge(
+            challenged_user_id=5, game_id=1, message=None,
+            db=_db(), user=user,
+        ))
+        assert isinstance(result, RedirectResponse)
+        assert "error=self_challenge" in result.headers["location"]
+
+    def test_ch08_target_not_found(self):
+        from app.api.web_routes.vt_challenges import send_challenge
+        user = _user(uid=1)
+        db = _db()
+        db.query.return_value.filter.return_value.first.return_value = None
+        result = _run(send_challenge(
+            challenged_user_id=99, game_id=1, message=None,
+            db=db, user=user,
+        ))
+        assert isinstance(result, RedirectResponse)
+        assert "error=user_not_found" in result.headers["location"]
+
+    def test_ch09_not_friends(self):
+        from app.api.web_routes.vt_challenges import send_challenge
+        user = _user(uid=1)
+        target = _user(uid=2)
+        db = _db()
+        db.query.return_value.filter.return_value.first.return_value = target
+
+        with patch(f"{_BASE}.is_friends", return_value=False):
+            result = _run(send_challenge(
+                challenged_user_id=2, game_id=1, message=None,
+                db=db, user=user,
+            ))
+        assert "error=not_friends" in result.headers["location"]
+
+    def test_ch10_game_not_found(self):
+        from app.api.web_routes.vt_challenges import send_challenge
+        user = _user(uid=1)
+        target = _user(uid=2)
+        db = _db()
+
+        call_results = [target, None]
+        db.query.return_value.filter.return_value.first.side_effect = call_results
+
+        with patch(f"{_BASE}.is_friends", return_value=True):
+            result = _run(send_challenge(
+                challenged_user_id=2, game_id=99, message=None,
+                db=db, user=user,
+            ))
+        assert "error=game_not_found" in result.headers["location"]
+
+    def test_ch11_incompatible_game(self):
+        from app.api.web_routes.vt_challenges import send_challenge
+        user = _user(uid=1)
+        target = _user(uid=2)
+        game = _game(code="color_reaction")
+        db = _db()
+
+        call_results = [target, game]
+        db.query.return_value.filter.return_value.first.side_effect = call_results
+
+        with patch(f"{_BASE}.is_friends", return_value=True):
+            result = _run(send_challenge(
+                challenged_user_id=2, game_id=1, message=None,
+                db=db, user=user,
+            ))
+        assert "error=game_not_compatible" in result.headers["location"]
+
+    def test_ch12_duplicate_active_challenge(self):
+        from app.api.web_routes.vt_challenges import send_challenge
+        user = _user(uid=1)
+        target = _user(uid=2)
+        game = _game(code="memory_sequence")
+        existing = _challenge()
+        db = _db()
+
+        call_results = [target, game]
+        db.query.return_value.filter.return_value.first.side_effect = call_results
+
+        with patch(f"{_BASE}.is_friends", return_value=True), \
+             patch(f"{_BASE}.get_active_challenge", return_value=existing):
+            result = _run(send_challenge(
+                challenged_user_id=2, game_id=1, message=None,
+                db=db, user=user,
+            ))
+        assert "error=challenge_active" in result.headers["location"]
+
+    def test_ch13_success_creates_pending_and_notifies(self):
+        from app.api.web_routes.vt_challenges import send_challenge
+        user = _user(uid=1)
+        target = _user(uid=2)
+        game = _game(code="memory_sequence")
+        db = _db()
+
+        call_results = [target, game]
+        db.query.return_value.filter.return_value.first.side_effect = call_results
+
+        with patch(f"{_BASE}.is_friends", return_value=True), \
+             patch(f"{_BASE}.get_active_challenge", return_value=None), \
+             patch(f"{_BASE}.notification_service") as mock_svc:
+            result = _run(send_challenge(
+                challenged_user_id=2, game_id=1, message="Good luck",
+                db=db, user=user,
+            ))
+
+        assert isinstance(result, RedirectResponse)
+        assert "success=challenge_sent" in result.headers["location"]
+        db.add.assert_called_once()
+        db.commit.assert_called_once()
+        mock_svc.create_notification.assert_called_once()
+        kwargs = mock_svc.create_notification.call_args.kwargs
+        assert kwargs["user_id"] == 2
+        assert kwargs["notification_type"] == NotificationType.VT_CHALLENGE_RECEIVED
+
+
+# ── Route: accept_challenge ───────────────────────────────────────────────────
+
+class TestAcceptChallenge:
+
+    def test_ch14_wrong_challenged_id(self):
+        from app.api.web_routes.vt_challenges import accept_challenge
+        user = _user(uid=3)
+        row = _challenge(challenged_id=2)
+        db = _db()
+        db.query.return_value.filter.return_value.first.return_value = row
+        result = _run(accept_challenge(challenge_id=10, db=db, user=user))
+        assert "error=not_found" in result.headers["location"]
+
+    def test_ch15_expired_marks_expired_status(self):
+        from app.api.web_routes.vt_challenges import accept_challenge
+        user = _user(uid=2)
+        row = _challenge(
+            challenged_id=2,
+            status=ChallengeStatus.PENDING,
+            expires_at=datetime(2020, 1, 1, tzinfo=timezone.utc),
+        )
+        db = _db()
+        db.query.return_value.filter.return_value.first.return_value = row
+        result = _run(accept_challenge(challenge_id=10, db=db, user=user))
+        assert row.status == ChallengeStatus.EXPIRED
+        assert "error=challenge_expired" in result.headers["location"]
+        db.commit.assert_called_once()
+
+    def test_ch16_accept_success(self):
+        from app.api.web_routes.vt_challenges import accept_challenge
+        user = _user(uid=2)
+        row = _challenge(
+            challenger_id=1, challenged_id=2,
+            status=ChallengeStatus.PENDING,
+        )
+        db = _db()
+        db.query.return_value.filter.return_value.first.return_value = row
+
+        with patch(f"{_BASE}.notification_service") as mock_svc:
+            result = _run(accept_challenge(challenge_id=10, db=db, user=user))
+
+        assert row.status == ChallengeStatus.ACCEPTED
+        assert "success=challenge_accepted" in result.headers["location"]
+        db.commit.assert_called_once()
+        mock_svc.create_notification.assert_called_once()
+        kwargs = mock_svc.create_notification.call_args.kwargs
+        assert kwargs["user_id"] == 1  # sent to challenger
+        assert kwargs["notification_type"] == NotificationType.VT_CHALLENGE_ACCEPTED
+
+
+# ── Route: decline_challenge ──────────────────────────────────────────────────
+
+class TestDeclineChallenge:
+
+    def test_ch17_wrong_challenged_id(self):
+        from app.api.web_routes.vt_challenges import decline_challenge
+        user = _user(uid=3)
+        row = _challenge(challenged_id=2)
+        db = _db()
+        db.query.return_value.filter.return_value.first.return_value = row
+        result = _run(decline_challenge(challenge_id=10, db=db, user=user))
+        assert "error=not_found" in result.headers["location"]
+
+    def test_ch18_decline_success(self):
+        from app.api.web_routes.vt_challenges import decline_challenge
+        user = _user(uid=2)
+        row = _challenge(
+            challenger_id=1, challenged_id=2,
+            status=ChallengeStatus.PENDING,
+        )
+        db = _db()
+        db.query.return_value.filter.return_value.first.return_value = row
+
+        with patch(f"{_BASE}.notification_service") as mock_svc:
+            result = _run(decline_challenge(challenge_id=10, db=db, user=user))
+
+        assert row.status == ChallengeStatus.DECLINED
+        assert "success=challenge_declined" in result.headers["location"]
+        db.commit.assert_called_once()
+        mock_svc.create_notification.assert_called_once()
+        kwargs = mock_svc.create_notification.call_args.kwargs
+        assert kwargs["user_id"] == 1  # sent to challenger
+        assert kwargs["notification_type"] == NotificationType.VT_CHALLENGE_DECLINED
+
+
+# ── Route: cancel_challenge ───────────────────────────────────────────────────
+
+class TestCancelChallenge:
+
+    def test_ch19_wrong_challenger_id(self):
+        from app.api.web_routes.vt_challenges import cancel_challenge
+        user = _user(uid=3)
+        row = _challenge(challenger_id=1)
+        db = _db()
+        db.query.return_value.filter.return_value.first.return_value = row
+        result = _run(cancel_challenge(challenge_id=10, db=db, user=user))
+        assert "error=not_found" in result.headers["location"]
+
+    def test_ch20_non_cancellable_status(self):
+        from app.api.web_routes.vt_challenges import cancel_challenge
+        user = _user(uid=1)
+        row = _challenge(challenger_id=1, status=ChallengeStatus.COMPLETED)
+        db = _db()
+        db.query.return_value.filter.return_value.first.return_value = row
+        result = _run(cancel_challenge(challenge_id=10, db=db, user=user))
+        assert "error=cannot_cancel" in result.headers["location"]
+
+    def test_ch21_cancel_from_pending(self):
+        from app.api.web_routes.vt_challenges import cancel_challenge
+        user = _user(uid=1)
+        row = _challenge(
+            challenger_id=1, challenged_id=2,
+            status=ChallengeStatus.PENDING,
+        )
+        db = _db()
+        db.query.return_value.filter.return_value.first.return_value = row
+
+        with patch(f"{_BASE}.notification_service") as mock_svc:
+            result = _run(cancel_challenge(challenge_id=10, db=db, user=user))
+
+        assert row.status == ChallengeStatus.CANCELLED
+        assert "success=challenge_cancelled" in result.headers["location"]
+        db.commit.assert_called_once()
+        mock_svc.create_notification.assert_called_once()
+        kwargs = mock_svc.create_notification.call_args.kwargs
+        assert kwargs["user_id"] == 2  # sent to challenged
+        assert kwargs["notification_type"] == NotificationType.VT_CHALLENGE_CANCELLED
+
+    def test_ch22_cancel_from_accepted(self):
+        from app.api.web_routes.vt_challenges import cancel_challenge
+        user = _user(uid=1)
+        row = _challenge(
+            challenger_id=1, challenged_id=2,
+            status=ChallengeStatus.ACCEPTED,
+        )
+        db = _db()
+        db.query.return_value.filter.return_value.first.return_value = row
+
+        with patch(f"{_BASE}.notification_service") as mock_svc:
+            result = _run(cancel_challenge(challenge_id=10, db=db, user=user))
+
+        assert row.status == ChallengeStatus.CANCELLED
+        assert "success=challenge_cancelled" in result.headers["location"]
+
+
+# ── _trim_message ─────────────────────────────────────────────────────────────
+
+class TestTrimMessage:
+
+    def test_ch23_strips_whitespace(self):
+        from app.api.web_routes.vt_challenges import _trim_message
+        assert _trim_message("  hello  ") == "hello"
+
+    def test_ch23b_empty_returns_none(self):
+        from app.api.web_routes.vt_challenges import _trim_message
+        assert _trim_message("") is None
+        assert _trim_message("   ") is None
+        assert _trim_message(None) is None
+
+    def test_ch23c_truncates_at_500(self):
+        from app.api.web_routes.vt_challenges import _trim_message
+        long_msg = "x" * 600
+        result = _trim_message(long_msg)
+        assert result == "x" * 500


### PR DESCRIPTION
## Summary

- **`VirtualTrainingChallenge` model** (`app/models/vt_challenge.py`): `ChallengeStatus` enum (6 values: pending/accepted/declined/expired/cancelled/completed), `CHALLENGE_COMPATIBLE_GAMES` allowlist (`memory_sequence`, `target_tracking`), `make_expires_at()` (+7 days), `get_active_challenge()` bidirectional helper
- **Migration `2026_05_24_1000`**: idempotent `challengestatus` enum, `vt_challenges` table via raw SQL (avoids double `CREATE TYPE`), 4 indexes, extends `notificationtype` with 6 `VT_CHALLENGE_*` values
- **4 lifecycle routes** (`app/api/web_routes/vt_challenges.py`): `POST /challenges/send`, `/{id}/accept`, `/{id}/decline`, `/{id}/cancel`
- **Guards**: self-challenge, friendship (`is_friends`), game existence, compatible game, duplicate active challenge (bidirectional), expiry auto-mark on accept, wrong ownership
- **Notifications**: `VT_CHALLENGE_RECEIVED` on send, `ACCEPTED`/`DECLINED`/`CANCELLED` on each transition

## Out of scope (deferred)
VT submit hook, winner calculation, challenge result page, challenge inbox UI, hub challenge button, Color Reaction / GNG compatibility

## Test plan
- [ ] 27 CH-* unit tests — 27/27 PASS
- [ ] Full unit regression — 10393/10393 PASS (0 new failures)
- [ ] OpenAPI snapshot refreshed (791 routes, +4)
- [ ] Migration applied locally (`alembic upgrade head` — clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)