### PR TITLE
feat(vt): PR-C3 — Challenge UI: inbox, send form, game integration, result context

### DIFF
--- a/alembic/versions/2026_05_24_1100_vt_challenge_difficulty.py
+++ b/alembic/versions/2026_05_24_1100_vt_challenge_difficulty.py
@@ -1,0 +1,27 @@
+"""Add difficulty_level to vt_challenges
+
+Allows Target Tracking challenges to carry a required difficulty level.
+MS challenges leave this NULL.
+
+Revision ID: 2026_05_24_1100
+Revises:     2026_05_24_1000
+Create Date: 2026-05-24 11:00:00
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision      = "2026_05_24_1100"
+down_revision = "2026_05_24_1000"
+branch_labels = None
+depends_on    = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "vt_challenges",
+        sa.Column("difficulty_level", sa.String(20), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("vt_challenges", "difficulty_level")

--- a/app/api/web_routes/virtual_training.py
+++ b/app/api/web_routes/virtual_training.py
@@ -192,6 +192,78 @@ def _link_attempt_to_challenge(
     }
 
 
+# ── PR-C3 Challenge Result Context ────────────────────────────────────────────
+
+def _build_challenge_result_ctx(
+    db: Session,
+    challenge_id: int,
+    user_id: int,
+    attempt_id: int,
+) -> dict | None:
+    """Build challenge context block for result pages.
+
+    Returns None if the challenge_id is invalid, the user is not a participant,
+    or the given attempt_id doesn't belong to this user's challenge slot.
+    """
+    ch = db.query(VirtualTrainingChallenge).filter(
+        VirtualTrainingChallenge.id == challenge_id
+    ).first()
+    if ch is None:
+        return None
+    if user_id not in (ch.challenger_id, ch.challenged_id):
+        return None
+
+    is_challenger   = ch.challenger_id == user_id
+    my_attempt_id   = ch.challenger_attempt_id if is_challenger else ch.challenged_attempt_id
+    opp_attempt_id  = ch.challenged_attempt_id if is_challenger else ch.challenger_attempt_id
+
+    # Only bind the block if this attempt belongs to the user's challenge slot
+    if my_attempt_id != attempt_id:
+        return None
+
+    opponent_id = ch.challenged_id if is_challenger else ch.challenger_id
+    opponent = db.query(User).filter(User.id == opponent_id).first()
+    opponent_name = (opponent.nickname or opponent.email) if opponent else "Unknown"
+
+    ctx: dict = {
+        "challenge_id":    ch.id,
+        "status":          ch.status.value,
+        "is_challenger":   is_challenger,
+        "opponent_name":   opponent_name,
+        "difficulty_level": ch.difficulty_level,
+        "my_score":        None,
+        "opp_score":       None,
+        "outcome":         ch.status.value,
+    }
+
+    if ch.status == ChallengeStatus.COMPLETED:
+        # Load both attempt scores
+        my_a  = db.query(VirtualTrainingAttempt).filter(
+            VirtualTrainingAttempt.id == my_attempt_id
+        ).first() if my_attempt_id else None
+        opp_a = db.query(VirtualTrainingAttempt).filter(
+            VirtualTrainingAttempt.id == opp_attempt_id
+        ).first() if opp_attempt_id else None
+
+        ctx["my_score"]  = my_a.score_normalized  if my_a  else None
+        ctx["opp_score"] = opp_a.score_normalized if opp_a else None
+
+        if ch.is_draw:
+            ctx["outcome"] = "draw"
+        elif ch.winner_id == user_id:
+            ctx["outcome"] = "won"
+        else:
+            ctx["outcome"] = "lost"
+
+    elif ch.status == ChallengeStatus.ACCEPTED:
+        if opp_attempt_id is None:
+            ctx["outcome"] = "waiting_for_opponent"
+        else:
+            ctx["outcome"] = "waiting_for_resolution"
+
+    return ctx
+
+
 # ── Hub ───────────────────────────────────────────────────────────────────────
 
 @router.get("/virtual-training", response_class=HTMLResponse)
@@ -870,6 +942,7 @@ async def virtual_training_target_tracking_submit(
 async def virtual_training_target_tracking_result(
     attempt_id: int,
     request: Request,
+    challenge_id: int | None = None,
     db: Session = Depends(get_db),
     user: User = Depends(get_current_user_web),
 ):
@@ -953,6 +1026,10 @@ async def virtual_training_target_tracking_result(
     from ...models.user import UserRole
     is_admin = user.role == UserRole.ADMIN
 
+    challenge_ctx = None
+    if challenge_id is not None:
+        challenge_ctx = _build_challenge_result_ctx(db, challenge_id, user.id, attempt_id)
+
     return templates.TemplateResponse(
         "virtual_training_target_tracking_result.html",
         {
@@ -969,6 +1046,7 @@ async def virtual_training_target_tracking_result(
             "difficulty_level":      difficulty_level,
             "difficulty_multiplier": difficulty_multiplier,
             "flash_summary":         flash_summary,
+            "challenge_ctx":         challenge_ctx,
         },
     )
 
@@ -1171,6 +1249,7 @@ async def virtual_training_memory_sequence_submit(
 async def virtual_training_memory_sequence_result(
     attempt_id: int,
     request: Request,
+    challenge_id: int | None = None,
     db: Session = Depends(get_db),
     user: User = Depends(get_current_user_web),
 ):
@@ -1253,6 +1332,10 @@ async def virtual_training_memory_sequence_result(
     from ...models.user import UserRole
     is_admin = user.role == UserRole.ADMIN
 
+    challenge_ctx = None
+    if challenge_id is not None:
+        challenge_ctx = _build_challenge_result_ctx(db, challenge_id, user.id, attempt_id)
+
     return templates.TemplateResponse(
         "virtual_training_memory_sequence_result.html",
         {
@@ -1267,5 +1350,6 @@ async def virtual_training_memory_sequence_result(
             "per_round":    per_round,
             "best_sequence_length": best_sequence_length,
             "is_admin":     is_admin,
+            "challenge_ctx": challenge_ctx,
         },
     )

--- a/app/api/web_routes/vt_challenges.py
+++ b/app/api/web_routes/vt_challenges.py
@@ -1,11 +1,13 @@
 """
-VT Challenge web routes — async friend-vs-friend challenge lifecycle (PR-C1).
+VT Challenge web routes — async friend-vs-friend challenge lifecycle (PR-C1/C3).
 
 Routes:
-  POST /challenges/send               → send challenge to a friend
-  POST /challenges/{id}/accept        → accept incoming challenge (challenged only)
-  POST /challenges/{id}/decline       → decline incoming challenge (challenged only)
-  POST /challenges/{id}/cancel        → cancel pending/accepted challenge (challenger only)
+  GET  /challenges                 → challenge inbox (received/sent/active/completed)
+  GET  /challenges/send            → send form (friends + compatible games)
+  POST /challenges/send            → create challenge
+  POST /challenges/{id}/accept     → accept incoming challenge (challenged only)
+  POST /challenges/{id}/decline    → decline incoming challenge (challenged only)
+  POST /challenges/{id}/cancel     → cancel pending/accepted challenge (challenger only)
 
 Guards (send):
   - self-challenge blocked
@@ -14,35 +16,28 @@ Guards (send):
   - game must exist
   - game must be in CHALLENGE_COMPATIBLE_GAMES
   - no duplicate active challenge between the pair on the same game
-
-Guards (accept):
-  - challenge must exist, current user must be challenged_id
-  - challenge must not be expired (auto-marks EXPIRED if so)
-
-Guards (decline/cancel):
-  - challenge must exist, correct ownership
-  - cancel allowed only for PENDING or ACCEPTED status
+  - TT: difficulty_level must be valid; expert gated by expert_unlocked
 
 Notifications:
-  - send   → VT_CHALLENGE_RECEIVED  to challenged_id
-  - accept → VT_CHALLENGE_ACCEPTED  to challenger_id
-  - decline→ VT_CHALLENGE_DECLINED  to challenger_id
-  - cancel → VT_CHALLENGE_CANCELLED to challenged_id
+  All notification links point to /challenges.
 """
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from typing import Any
 
-from fastapi import APIRouter, Depends, Form
-from fastapi.responses import RedirectResponse
+from fastapi import APIRouter, Depends, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
 from ...database import get_db
 from ...dependencies import get_current_user_web
-from ...models.friendship import is_friends
+from ...models.friendship import Friendship, FriendshipStatus, is_friends
 from ...models.notification import NotificationType
 from ...models.user import User
-from ...models.virtual_training import VirtualTrainingGame
+from ...models.virtual_training import VirtualTrainingAttempt, VirtualTrainingGame
 from ...models.vt_challenge import (
     CHALLENGE_COMPATIBLE_GAMES,
     ChallengeStatus,
@@ -51,10 +46,16 @@ from ...models.vt_challenge import (
     make_expires_at,
 )
 from ...services import notification_service
+from ...services.virtual_training_service import VirtualTrainingService
+from .helpers import require_student_onboarding
+from .student_features import _spec_ctx
 
-router = APIRouter()
+router    = APIRouter()
+templates = Jinja2Templates(directory="app/templates")
 
-_MAX_MSG = 500
+_MAX_MSG         = 500
+_COMPLETED_LIMIT = 20
+_VALID_DIFFICULTIES = {"easy", "medium", "hard", "expert"}
 
 
 def _trim_message(raw: str | None) -> str | None:
@@ -64,55 +65,287 @@ def _trim_message(raw: str | None) -> str | None:
     return trimmed or None
 
 
-# ── Send ───────────────────────────────────────────────────────────────────────
+
+# ── Helpers for inbox ──────────────────────────────────────────────────────────
+
+def _build_inbox_row(
+    ch: VirtualTrainingChallenge,
+    user_id: int,
+    attempts_map: dict[int, "VirtualTrainingAttempt"],
+    users_map: dict[int, User],
+    games_map: dict[int, VirtualTrainingGame],
+) -> dict[str, Any]:
+    is_challenger = ch.challenger_id == user_id
+    opponent_id   = ch.challenged_id if is_challenger else ch.challenger_id
+    opponent      = users_map.get(opponent_id)
+    game          = games_map.get(ch.game_id)
+
+    my_attempt_id  = ch.challenger_attempt_id if is_challenger else ch.challenged_attempt_id
+    opp_attempt_id = ch.challenged_attempt_id if is_challenger else ch.challenger_attempt_id
+
+    my_attempt  = attempts_map.get(my_attempt_id)  if my_attempt_id  else None
+    opp_attempt = attempts_map.get(opp_attempt_id) if opp_attempt_id else None
+
+    game_code = game.code if game else ""
+    diff      = ch.difficulty_level or "easy"
+
+    if game_code == "memory_sequence":
+        play_url = f"/virtual-training/memory-sequence?challenge_id={ch.id}"
+    elif game_code == "target_tracking":
+        play_url = f"/virtual-training/target-tracking?challenge_id={ch.id}&difficulty={diff}"
+    else:
+        play_url = "/virtual-training"
+
+    # outcome
+    outcome: str
+    if ch.status == ChallengeStatus.COMPLETED:
+        if ch.is_draw:
+            outcome = "draw"
+        elif ch.winner_id == user_id:
+            outcome = "won"
+        else:
+            outcome = "lost"
+    elif ch.status == ChallengeStatus.ACCEPTED:
+        if my_attempt_id is None:
+            outcome = "play_now"
+        elif opp_attempt_id is None:
+            outcome = "waiting_for_opponent"
+        else:
+            outcome = "accepted"   # both submitted, awaiting completion write
+    elif ch.status == ChallengeStatus.PENDING:
+        outcome = "received" if not is_challenger else "sent"
+    else:
+        outcome = ch.status.value
+
+    return {
+        "id":            ch.id,
+        "status":        ch.status.value,
+        "is_challenger": is_challenger,
+        "opponent_name": (opponent.nickname or opponent.email) if opponent else "Unknown",
+        "game_name":     game.name if game else "—",
+        "game_code":     game_code,
+        "difficulty_level": ch.difficulty_level,
+        "message":       ch.message,
+        "expires_at":    ch.expires_at,
+        "created_at":    ch.created_at,
+        "completed_at":  ch.completed_at,
+        "outcome":       outcome,
+        "play_url":      play_url,
+        "my_score":      my_attempt.score_normalized  if my_attempt  else None,
+        "opp_score":     opp_attempt.score_normalized if opp_attempt else None,
+        "winner_id":     ch.winner_id,
+        "is_draw":       ch.is_draw,
+    }
+
+
+# ── GET /challenges ────────────────────────────────────────────────────────────
+
+@router.get("/challenges", response_class=HTMLResponse)
+async def challenge_inbox(
+    request: Request,
+    db: Session  = Depends(get_db),
+    user: User   = Depends(get_current_user_web),
+):
+    guard = require_student_onboarding(user)
+    if guard:
+        return guard
+
+    all_challenges = (
+        db.query(VirtualTrainingChallenge)
+        .filter(
+            or_(
+                VirtualTrainingChallenge.challenger_id == user.id,
+                VirtualTrainingChallenge.challenged_id == user.id,
+            )
+        )
+        .order_by(VirtualTrainingChallenge.created_at.desc())
+        .all()
+    )
+
+    # Separate active vs completed/terminal
+    active_chs    = [c for c in all_challenges
+                     if c.status in (ChallengeStatus.PENDING, ChallengeStatus.ACCEPTED)]
+    terminal_chs  = [c for c in all_challenges
+                     if c.status not in (ChallengeStatus.PENDING, ChallengeStatus.ACCEPTED)]
+    terminal_chs  = terminal_chs[:_COMPLETED_LIMIT]
+
+    shown = active_chs + terminal_chs
+
+    # Batch-load opponents, games, attempts
+    user_ids = set()
+    game_ids = set()
+    attempt_ids = set()
+    for c in shown:
+        user_ids.add(c.challenger_id)
+        user_ids.add(c.challenged_id)
+        if c.winner_id:
+            user_ids.add(c.winner_id)
+        game_ids.add(c.game_id)
+        if c.challenger_attempt_id:
+            attempt_ids.add(c.challenger_attempt_id)
+        if c.challenged_attempt_id:
+            attempt_ids.add(c.challenged_attempt_id)
+
+    users_map: dict[int, User] = {}
+    if user_ids:
+        for u in db.query(User).filter(User.id.in_(user_ids)).all():
+            users_map[u.id] = u
+
+    games_map: dict[int, VirtualTrainingGame] = {}
+    if game_ids:
+        for g in db.query(VirtualTrainingGame).filter(VirtualTrainingGame.id.in_(game_ids)).all():
+            games_map[g.id] = g
+
+    attempts_map: dict[int, VirtualTrainingAttempt] = {}
+    if attempt_ids:
+        for a in db.query(VirtualTrainingAttempt).filter(
+            VirtualTrainingAttempt.id.in_(attempt_ids)
+        ).all():
+            attempts_map[a.id] = a
+
+    active_rows   = [_build_inbox_row(c, user.id, attempts_map, users_map, games_map)
+                     for c in active_chs]
+    terminal_rows = [_build_inbox_row(c, user.id, attempts_map, users_map, games_map)
+                     for c in terminal_chs]
+
+    return templates.TemplateResponse("vt_challenges.html", {
+        "request":       request,
+        "user":          user,
+        **_spec_ctx(user, db),
+        "active_rows":   active_rows,
+        "terminal_rows": terminal_rows,
+        "success":       request.query_params.get("success"),
+        "error":         request.query_params.get("error"),
+    })
+
+
+# ── GET /challenges/send ───────────────────────────────────────────────────────
+
+def _accepted_friends(db: Session, user_id: int) -> list[User]:
+    rows = (
+        db.query(Friendship)
+        .filter(
+            Friendship.status == FriendshipStatus.ACCEPTED,
+            (Friendship.requester_id == user_id) | (Friendship.addressee_id == user_id),
+        )
+        .all()
+    )
+    friends = []
+    for row in rows:
+        other_id = row.addressee_id if row.requester_id == user_id else row.requester_id
+        u = db.query(User).filter(User.id == other_id).first()
+        if u:
+            friends.append(u)
+    return friends
+
+
+@router.get("/challenges/send", response_class=HTMLResponse)
+async def challenge_send_form(
+    request: Request,
+    friend_id: int  | None = None,
+    game_code:  str | None = None,
+    db: Session  = Depends(get_db),
+    user: User   = Depends(get_current_user_web),
+):
+    guard = require_student_onboarding(user)
+    if guard:
+        return guard
+
+    friends_rows = _accepted_friends(db, user.id)
+    compatible_games = (
+        db.query(VirtualTrainingGame)
+        .filter(
+            VirtualTrainingGame.code.in_(CHALLENGE_COMPATIBLE_GAMES),
+            VirtualTrainingGame.is_active.is_(True),
+        )
+        .all()
+    )
+
+    # expert_unlocked — check for TT game if present
+    expert_unlocked = False
+    tt_game = next((g for g in compatible_games if g.code == "target_tracking"), None)
+    if tt_game:
+        expert_unlocked = VirtualTrainingService.is_expert_unlocked(db, user.id, tt_game.id)
+
+    # Preselect friend/game from query params
+    preselected_friend_id = friend_id
+    preselected_game_code = game_code
+
+    return templates.TemplateResponse("vt_challenge_send.html", {
+        "request":               request,
+        "user":                  user,
+        **_spec_ctx(user, db),
+        "friends_rows":          friends_rows,
+        "compatible_games":      compatible_games,
+        "expert_unlocked":       expert_unlocked,
+        "preselected_friend_id": preselected_friend_id,
+        "preselected_game_code": preselected_game_code,
+        "error":                 request.query_params.get("error"),
+    })
+
+
+# ── POST /challenges/send ──────────────────────────────────────────────────────
 
 @router.post("/challenges/send")
 async def send_challenge(
-    challenged_user_id: int = Form(...),
-    game_id: int = Form(...),
-    message: str | None = Form(default=None),
+    challenged_user_id: int           = Form(...),
+    game_id:            int           = Form(...),
+    message:            str | None    = Form(default=None),
+    difficulty_level:   str | None    = Form(default=None),
     db: Session = Depends(get_db),
-    user: User = Depends(get_current_user_web),
+    user: User  = Depends(get_current_user_web),
 ):
     # Self-challenge guard
     if challenged_user_id == user.id:
-        return RedirectResponse(url="/friends?error=self_challenge", status_code=303)
+        return RedirectResponse(url="/challenges/send?error=self_challenge", status_code=303)
 
     # Target must be active
     target = db.query(User).filter(
-        User.id == challenged_user_id, User.is_active == True
+        User.id == challenged_user_id, User.is_active.is_(True)
     ).first()
     if not target:
-        return RedirectResponse(url="/friends?error=user_not_found", status_code=303)
+        return RedirectResponse(url="/challenges/send?error=user_not_found", status_code=303)
 
     # Friendship guard
     if not is_friends(db, user.id, challenged_user_id):
-        return RedirectResponse(url="/friends?error=not_friends", status_code=303)
+        return RedirectResponse(url="/challenges/send?error=not_friends", status_code=303)
 
     # Game existence guard
     game = db.query(VirtualTrainingGame).filter(
         VirtualTrainingGame.id == game_id
     ).first()
     if not game:
-        return RedirectResponse(url="/friends?error=game_not_found", status_code=303)
+        return RedirectResponse(url="/challenges/send?error=game_not_found", status_code=303)
 
     # Compatible game guard
     if game.code not in CHALLENGE_COMPATIBLE_GAMES:
-        return RedirectResponse(url="/friends?error=game_not_compatible", status_code=303)
+        return RedirectResponse(url="/challenges/send?error=game_not_compatible", status_code=303)
 
     # Duplicate active challenge guard (bidirectional)
     if get_active_challenge(db, user.id, challenged_user_id, game_id):
-        return RedirectResponse(url="/friends?error=challenge_active", status_code=303)
+        return RedirectResponse(url="/challenges/send?error=challenge_active", status_code=303)
+
+    # Difficulty validation (TT only)
+    resolved_difficulty: str | None = None
+    if game.code == "target_tracking":
+        lvl = (difficulty_level or "easy").strip().lower()
+        if lvl not in _VALID_DIFFICULTIES:
+            return RedirectResponse(url="/challenges/send?error=invalid_difficulty", status_code=303)
+        if lvl == "expert":
+            if not VirtualTrainingService.is_expert_unlocked(db, user.id, game.id):
+                return RedirectResponse(url="/challenges/send?error=expert_locked", status_code=303)
+        resolved_difficulty = lvl
 
     now = datetime.now(timezone.utc)
     challenge = VirtualTrainingChallenge(
-        challenger_id=user.id,
-        challenged_id=challenged_user_id,
-        game_id=game_id,
-        status=ChallengeStatus.PENDING,
-        message=_trim_message(message),
-        expires_at=make_expires_at(now),
-        created_at=now,
+        challenger_id    = user.id,
+        challenged_id    = challenged_user_id,
+        game_id          = game_id,
+        status           = ChallengeStatus.PENDING,
+        message          = _trim_message(message),
+        difficulty_level = resolved_difficulty,
+        expires_at       = make_expires_at(now),
+        created_at       = now,
     )
     db.add(challenge)
     db.flush()
@@ -123,38 +356,37 @@ async def send_challenge(
         title="Challenge Received",
         message=f"{user.nickname or user.email} challenged you to a VT game.",
         notification_type=NotificationType.VT_CHALLENGE_RECEIVED,
-        link="/friends",
+        link="/challenges",
     )
 
     db.commit()
-    return RedirectResponse(url="/friends?success=challenge_sent", status_code=303)
+    return RedirectResponse(url="/challenges?success=challenge_sent", status_code=303)
 
 
-# ── Accept ─────────────────────────────────────────────────────────────────────
+# ── POST /challenges/{id}/accept ──────────────────────────────────────────────
 
 @router.post("/challenges/{challenge_id}/accept")
 async def accept_challenge(
     challenge_id: int,
     db: Session = Depends(get_db),
-    user: User = Depends(get_current_user_web),
+    user: User  = Depends(get_current_user_web),
 ):
     challenge = db.query(VirtualTrainingChallenge).filter(
         VirtualTrainingChallenge.id == challenge_id
     ).first()
 
     if not challenge or challenge.challenged_id != user.id:
-        return RedirectResponse(url="/friends?error=not_found", status_code=303)
+        return RedirectResponse(url="/challenges?error=not_found", status_code=303)
 
     if challenge.status != ChallengeStatus.PENDING:
-        return RedirectResponse(url="/friends?error=not_pending", status_code=303)
+        return RedirectResponse(url="/challenges?error=not_pending", status_code=303)
 
-    # Expiry guard — auto-mark expired
     now = datetime.now(timezone.utc)
     if challenge.expires_at <= now:
         challenge.status     = ChallengeStatus.EXPIRED
         challenge.updated_at = now
         db.commit()
-        return RedirectResponse(url="/friends?error=challenge_expired", status_code=303)
+        return RedirectResponse(url="/challenges?error=challenge_expired", status_code=303)
 
     challenge.status     = ChallengeStatus.ACCEPTED
     challenge.updated_at = now
@@ -165,30 +397,30 @@ async def accept_challenge(
         title="Challenge Accepted",
         message=f"{user.nickname or user.email} accepted your VT challenge.",
         notification_type=NotificationType.VT_CHALLENGE_ACCEPTED,
-        link="/friends",
+        link="/challenges",
     )
 
     db.commit()
-    return RedirectResponse(url="/friends?success=challenge_accepted", status_code=303)
+    return RedirectResponse(url="/challenges?success=challenge_accepted", status_code=303)
 
 
-# ── Decline ────────────────────────────────────────────────────────────────────
+# ── POST /challenges/{id}/decline ─────────────────────────────────────────────
 
 @router.post("/challenges/{challenge_id}/decline")
 async def decline_challenge(
     challenge_id: int,
     db: Session = Depends(get_db),
-    user: User = Depends(get_current_user_web),
+    user: User  = Depends(get_current_user_web),
 ):
     challenge = db.query(VirtualTrainingChallenge).filter(
         VirtualTrainingChallenge.id == challenge_id
     ).first()
 
     if not challenge or challenge.challenged_id != user.id:
-        return RedirectResponse(url="/friends?error=not_found", status_code=303)
+        return RedirectResponse(url="/challenges?error=not_found", status_code=303)
 
     if challenge.status != ChallengeStatus.PENDING:
-        return RedirectResponse(url="/friends?error=not_pending", status_code=303)
+        return RedirectResponse(url="/challenges?error=not_pending", status_code=303)
 
     now = datetime.now(timezone.utc)
     challenge.status     = ChallengeStatus.DECLINED
@@ -200,30 +432,30 @@ async def decline_challenge(
         title="Challenge Declined",
         message=f"{user.nickname or user.email} declined your VT challenge.",
         notification_type=NotificationType.VT_CHALLENGE_DECLINED,
-        link="/friends",
+        link="/challenges",
     )
 
     db.commit()
-    return RedirectResponse(url="/friends?success=challenge_declined", status_code=303)
+    return RedirectResponse(url="/challenges?success=challenge_declined", status_code=303)
 
 
-# ── Cancel ─────────────────────────────────────────────────────────────────────
+# ── POST /challenges/{id}/cancel ──────────────────────────────────────────────
 
 @router.post("/challenges/{challenge_id}/cancel")
 async def cancel_challenge(
     challenge_id: int,
     db: Session = Depends(get_db),
-    user: User = Depends(get_current_user_web),
+    user: User  = Depends(get_current_user_web),
 ):
     challenge = db.query(VirtualTrainingChallenge).filter(
         VirtualTrainingChallenge.id == challenge_id
     ).first()
 
     if not challenge or challenge.challenger_id != user.id:
-        return RedirectResponse(url="/friends?error=not_found", status_code=303)
+        return RedirectResponse(url="/challenges?error=not_found", status_code=303)
 
     if challenge.status not in (ChallengeStatus.PENDING, ChallengeStatus.ACCEPTED):
-        return RedirectResponse(url="/friends?error=cannot_cancel", status_code=303)
+        return RedirectResponse(url="/challenges?error=cannot_cancel", status_code=303)
 
     now = datetime.now(timezone.utc)
     challenge.status     = ChallengeStatus.CANCELLED
@@ -235,8 +467,8 @@ async def cancel_challenge(
         title="Challenge Cancelled",
         message=f"{user.nickname or user.email} cancelled their VT challenge.",
         notification_type=NotificationType.VT_CHALLENGE_CANCELLED,
-        link="/friends",
+        link="/challenges",
     )
 
     db.commit()
-    return RedirectResponse(url="/friends?success=challenge_cancelled", status_code=303)
+    return RedirectResponse(url="/challenges?success=challenge_cancelled", status_code=303)

--- a/app/models/vt_challenge.py
+++ b/app/models/vt_challenge.py
@@ -24,7 +24,7 @@ from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import (
     Boolean, CheckConstraint, Column, DateTime, Enum,
-    ForeignKey, Integer, Text, UniqueConstraint,
+    ForeignKey, Integer, String, Text, UniqueConstraint,
 )
 from sqlalchemy.orm import Session, relationship
 
@@ -80,6 +80,7 @@ class VirtualTrainingChallenge(Base):
     challenged_attempt_id = Column(Integer,
                                    ForeignKey("virtual_training_attempts.id", ondelete="SET NULL"),
                                    nullable=True)
+    difficulty_level      = Column(String(20), nullable=True)   # TT only; NULL for MS
     winner_id             = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"),
                                    nullable=True)
     is_draw               = Column(Boolean, nullable=False, default=False)

--- a/app/templates/friends.html
+++ b/app/templates/friends.html
@@ -182,6 +182,8 @@
                 <div class="fr-card-name">{{ f.nickname or f.email }}</div>
                 <div class="fr-card-meta">{{ f.email }}</div>
                 <div class="fr-card-actions">
+                    <a href="/challenges/send?friend_id={{ f.id }}"
+                       class="fr-btn fr-btn-muted" style="text-decoration:none;">⚔ Challenge</a>
                     <form method="post" action="/friends/remove/{{ f.id }}">
                         <input type="hidden" name="csrf_token" value="{{ request.cookies.get('csrf_token', '') }}">
                         <button type="submit" class="fr-btn fr-btn-danger"

--- a/app/templates/notifications.html
+++ b/app/templates/notifications.html
@@ -141,6 +141,15 @@
             'tournament_direct_invitation':    '📩',
             'tournament_instructor_accepted':  '🤝',
             'tournament_instructor_declined':  '❌',
+            'skill_tier_reached':              '⭐',
+            'friend_request_received':         '👥',
+            'friend_request_accepted':         '🤝',
+            'vt_challenge_received':           '⚔️',
+            'vt_challenge_accepted':           '✅',
+            'vt_challenge_declined':           '✗',
+            'vt_challenge_cancelled':          '✕',
+            'vt_challenge_expired':            '⌛',
+            'vt_challenge_completed':          '🏆',
         }.get(n.type.value, '📢') %}
         <div class="notif-card {% if not n.is_read %}unread{% endif %}" id="notif-{{ n.id }}">
             <div class="notif-icon">{{ icon }}</div>

--- a/app/templates/virtual_training_hub.html
+++ b/app/templates/virtual_training_hub.html
@@ -314,6 +314,14 @@
                    class="vg-btn-play {% if _used >= _max %}vg-btn-capped{% endif %}">
                     {% if _used >= _max %}✓ Done today{% else %}▶ Play{% endif %}
                 </a>
+                {% if game.code in ['memory_sequence', 'target_tracking'] %}
+                <a href="/challenges/send?game_code={{ game.code }}"
+                   style="display:inline-block;margin-left:0.5rem;font-size:0.8rem;font-weight:700;
+                          color:#4f46e5;text-decoration:none;padding:0.3rem 0.7rem;
+                          border:1.5px solid #4f46e5;border-radius:7px;">
+                    ⚔ Challenge
+                </a>
+                {% endif %}
                 {% else %}
                 <button class="vg-btn-coming-soon" disabled>Coming soon</button>
                 {% endif %}

--- a/app/templates/virtual_training_memory_sequence.html
+++ b/app/templates/virtual_training_memory_sequence.html
@@ -217,8 +217,10 @@
 (function () {
     var PHASES      = {{ game.config.phases | tojson }};
     var TILE_COLORS = {{ game.config.tile_colors | tojson }};
-    var CSRF_TOKEN  = "{{ request.cookies.get('csrf_token', '') }}";
-    var SUBMIT_URL  = "/virtual-training/memory-sequence/submit";
+    var CSRF_TOKEN   = "{{ request.cookies.get('csrf_token', '') }}";
+    var SUBMIT_URL   = "/virtual-training/memory-sequence/submit";
+    var _urlParams   = new URLSearchParams(window.location.search);
+    var CHALLENGE_ID = _urlParams.get('challenge_id') || null;
 
     // Build flat round list (9 rounds: 3 phases × 3 rounds each)
     var ROUNDS = [];
@@ -516,6 +518,7 @@
             score_normalized:  scoreNorm,
             raw_metrics:       rawMetrics
         };
+        if (CHALLENGE_ID) { payload.challenge_id = parseInt(CHALLENGE_ID, 10); }
 
         fetch(SUBMIT_URL, {
             method:  "POST",
@@ -525,7 +528,9 @@
         .then(function (r) { return r.json(); })
         .then(function (data) {
             if (data.attempt_id) {
-                window.location.href = "/virtual-training/memory-sequence/result/" + data.attempt_id;
+                var dest = "/virtual-training/memory-sequence/result/" + data.attempt_id;
+                if (CHALLENGE_ID) { dest += "?challenge_id=" + CHALLENGE_ID; }
+                window.location.href = dest;
             } else {
                 elSubmitting.innerHTML = "<p>⚠️ Could not save attempt. <a href='/virtual-training'>Back to hub</a></p>";
             }

--- a/app/templates/virtual_training_memory_sequence_result.html
+++ b/app/templates/virtual_training_memory_sequence_result.html
@@ -307,11 +307,58 @@
     </div>
     {% endif %}
 
+    {# ── Challenge context block ─────────────────────────────────────────────── #}
+    {% if challenge_ctx %}
+    <div style="background:var(--app-card);border-radius:14px;padding:1.1rem 1.25rem;
+                box-shadow:0 2px 8px rgba(0,0,0,0.06);margin-bottom:1.25rem;
+                border-left:4px solid
+                {% if challenge_ctx.outcome == 'won' %}#16a34a
+                {% elif challenge_ctx.outcome == 'lost' %}#dc2626
+                {% elif challenge_ctx.outcome == 'draw' %}#6b7280
+                {% else %}#4f46e5{% endif %};">
+        <div style="font-size:0.78rem;font-weight:700;color:var(--app-text-muted);
+                    text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.5rem;">
+            Challenge vs {{ challenge_ctx.opponent_name }}
+        </div>
+        {% if challenge_ctx.outcome == 'won' %}
+        <div style="font-size:1.05rem;font-weight:800;color:#16a34a;margin-bottom:0.4rem;">🏆 You won!</div>
+        {% elif challenge_ctx.outcome == 'lost' %}
+        <div style="font-size:1.05rem;font-weight:800;color:#dc2626;margin-bottom:0.4rem;">✗ You lost</div>
+        {% elif challenge_ctx.outcome == 'draw' %}
+        <div style="font-size:1.05rem;font-weight:800;color:#6b7280;margin-bottom:0.4rem;">= Draw</div>
+        {% elif challenge_ctx.outcome == 'waiting_for_opponent' %}
+        <div style="font-size:0.95rem;color:#4f46e5;margin-bottom:0.4rem;">
+            ⏳ Waiting for {{ challenge_ctx.opponent_name }} to play…
+        </div>
+        {% elif challenge_ctx.outcome == 'waiting_for_resolution' %}
+        <div style="font-size:0.95rem;color:#4f46e5;margin-bottom:0.4rem;">
+            ⏳ Both attempts submitted — result pending…
+        </div>
+        {% endif %}
+        {% if challenge_ctx.outcome in ['won', 'lost', 'draw'] and (challenge_ctx.my_score is not none or challenge_ctx.opp_score is not none) %}
+        <div style="display:flex;gap:1.5rem;font-size:0.85rem;flex-wrap:wrap;margin-bottom:0.4rem;">
+            <div>
+                <span style="font-size:0.7rem;color:var(--app-text-muted);text-transform:uppercase;display:block;">You</span>
+                <strong>{% if challenge_ctx.my_score is not none %}{{ challenge_ctx.my_score | round(0) | int }}%{% else %}—{% endif %}</strong>
+            </div>
+            <div style="align-self:center;color:var(--app-text-muted);">vs</div>
+            <div>
+                <span style="font-size:0.7rem;color:var(--app-text-muted);text-transform:uppercase;display:block;">{{ challenge_ctx.opponent_name }}</span>
+                <strong>{% if challenge_ctx.opp_score is not none %}{{ challenge_ctx.opp_score | round(0) | int }}%{% else %}—{% endif %}</strong>
+            </div>
+        </div>
+        {% endif %}
+        <a href="/challenges" style="font-size:0.82rem;color:#4f46e5;font-weight:700;text-decoration:none;">
+            → View all challenges
+        </a>
+    </div>
+    {% endif %}
+
     <div class="msr-footer">
         <a href="/virtual-training">💻 All Games</a>
         <a href="/virtual-training/history">📋 History</a>
+        <a href="/challenges">⚔ Challenges</a>
         <a href="/training">🎓 Training</a>
-        <a href="/dashboard/lfa-football-player">⚽ Dashboard</a>
     </div>
 
 </div>

--- a/app/templates/virtual_training_target_tracking.html
+++ b/app/templates/virtual_training_target_tracking.html
@@ -489,7 +489,10 @@ function getRadius() {
     return Math.max(24, Math.round(40 * scale));
 }
 
-const SUBMIT_URL = '/virtual-training/target-tracking/submit';
+const SUBMIT_URL   = '/virtual-training/target-tracking/submit';
+const _ttUrlParams = new URLSearchParams(window.location.search);
+const CHALLENGE_ID = _ttUrlParams.get('challenge_id') || null;
+const LOCKED_DIFF  = _ttUrlParams.get('difficulty')   || null;
 
 /* Flash mechanic constants */
 const FLASH_DURATION_MS  = 400;
@@ -517,6 +520,18 @@ function selectDifficulty(level) {
 
 /* Expose for onclick in markup */
 window.selectDifficulty = selectDifficulty;
+
+/* If challenge locks difficulty: preselect and disable all other cards */
+if (LOCKED_DIFF && ['easy', 'medium', 'hard', 'expert'].includes(LOCKED_DIFF)) {
+    selectDifficulty(LOCKED_DIFF);
+    ['easy', 'medium', 'hard', 'expert'].forEach(function (l) {
+        var card = document.getElementById('tt-diff-' + l);
+        if (card && l !== LOCKED_DIFF) {
+            card.classList.add('tt-diff-disabled');
+            card.onclick = null;
+        }
+    });
+}
 
 /* ── Game state ───────────────────────────────────────────────────────────── */
 let PHASES       = [];
@@ -1013,6 +1028,7 @@ function finishGame() {
             },
         },
     };
+    if (CHALLENGE_ID) { payload.challenge_id = parseInt(CHALLENGE_ID, 10); }
 
     fetch(SUBMIT_URL, {
         method:  'POST',
@@ -1022,7 +1038,9 @@ function finishGame() {
     .then(function (r) { return r.json(); })
     .then(function (data) {
         if (data.attempt_id) {
-            window.location.href = '/virtual-training/target-tracking/result/' + data.attempt_id;
+            var dest = '/virtual-training/target-tracking/result/' + data.attempt_id;
+            if (CHALLENGE_ID) { dest += '?challenge_id=' + CHALLENGE_ID; }
+            window.location.href = dest;
         } else {
             document.getElementById('tt-submitting').innerHTML =
                 '<p style="color:#ef4444">⚠ Could not save result. <a href="/virtual-training">Back to hub</a></p>';

--- a/app/templates/virtual_training_target_tracking_result.html
+++ b/app/templates/virtual_training_target_tracking_result.html
@@ -505,11 +505,60 @@
     </details>
     {% endif %}
 
+    {# ── Challenge context block ─────────────────────────────────────────────── #}
+    {% if challenge_ctx %}
+    <div style="background:var(--app-card);border-radius:14px;padding:1.1rem 1.25rem;
+                box-shadow:0 2px 8px rgba(0,0,0,0.06);margin-bottom:1.25rem;
+                border-left:4px solid
+                {% if challenge_ctx.outcome == 'won' %}#16a34a
+                {% elif challenge_ctx.outcome == 'lost' %}#dc2626
+                {% elif challenge_ctx.outcome == 'draw' %}#6b7280
+                {% else %}#4f46e5{% endif %};">
+        <div style="font-size:0.78rem;font-weight:700;color:var(--app-text-muted);
+                    text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.5rem;">
+            Challenge vs {{ challenge_ctx.opponent_name }}
+            {% if challenge_ctx.difficulty_level %} · {{ challenge_ctx.difficulty_level | title }}{% endif %}
+        </div>
+        {% if challenge_ctx.outcome == 'won' %}
+        <div style="font-size:1.05rem;font-weight:800;color:#16a34a;margin-bottom:0.4rem;">🏆 You won!</div>
+        {% elif challenge_ctx.outcome == 'lost' %}
+        <div style="font-size:1.05rem;font-weight:800;color:#dc2626;margin-bottom:0.4rem;">✗ You lost</div>
+        {% elif challenge_ctx.outcome == 'draw' %}
+        <div style="font-size:1.05rem;font-weight:800;color:#6b7280;margin-bottom:0.4rem;">= Draw</div>
+        {% elif challenge_ctx.outcome == 'waiting_for_opponent' %}
+        <div style="font-size:0.95rem;color:#4f46e5;margin-bottom:0.4rem;">
+            ⏳ Waiting for {{ challenge_ctx.opponent_name }} to play…
+        </div>
+        {% elif challenge_ctx.outcome == 'waiting_for_resolution' %}
+        <div style="font-size:0.95rem;color:#4f46e5;margin-bottom:0.4rem;">
+            ⏳ Both attempts submitted — result pending…
+        </div>
+        {% endif %}
+        {% if challenge_ctx.outcome in ['won', 'lost', 'draw'] and (challenge_ctx.my_score is not none or challenge_ctx.opp_score is not none) %}
+        <div style="display:flex;gap:1.5rem;font-size:0.85rem;flex-wrap:wrap;margin-bottom:0.4rem;">
+            <div>
+                <span style="font-size:0.7rem;color:var(--app-text-muted);text-transform:uppercase;display:block;">You</span>
+                <strong>{% if challenge_ctx.my_score is not none %}{{ challenge_ctx.my_score | round(0) | int }}%{% else %}—{% endif %}</strong>
+            </div>
+            <div style="align-self:center;color:var(--app-text-muted);">vs</div>
+            <div>
+                <span style="font-size:0.7rem;color:var(--app-text-muted);text-transform:uppercase;display:block;">{{ challenge_ctx.opponent_name }}</span>
+                <strong>{% if challenge_ctx.opp_score is not none %}{{ challenge_ctx.opp_score | round(0) | int }}%{% else %}—{% endif %}</strong>
+            </div>
+        </div>
+        {% endif %}
+        <a href="/challenges" style="font-size:0.82rem;color:#4f46e5;font-weight:700;text-decoration:none;">
+            → View all challenges
+        </a>
+    </div>
+    {% endif %}
+
     <!-- ── Navigation ───────────────────────────────────────────────────────── -->
     <div class="ttr-actions">
         <a href="/virtual-training/target-tracking" class="ttr-btn ttr-btn-primary">▶ Play again</a>
         <a href="/virtual-training" class="ttr-btn ttr-btn-secondary">← All games</a>
         <a href="/virtual-training/history" class="ttr-btn ttr-btn-secondary">📋 History</a>
+        <a href="/challenges" class="ttr-btn ttr-btn-secondary">⚔ Challenges</a>
     </div>
     {% set _diff = difficulty_level | default('easy') %}
     {% if _diff == 'easy' %}

--- a/app/templates/vt_challenge_send.html
+++ b/app/templates/vt_challenge_send.html
@@ -1,0 +1,254 @@
+{% extends "student_base.html" %}
+
+{% block title %}Send Challenge — Virtual Training{% endblock %}
+{% block active_page %}lfa-player{% endblock %}
+
+{% block student_header %}
+{% set _page_icon = '⚔️' %}
+{% set _page_name = 'Send Challenge' %}
+{% include "includes/spec_subpage_hdr.html" %}
+{% endblock %}
+
+{% block extra_styles %}
+<style>
+.cs-container { max-width: 520px; margin: 0 auto; padding: 1.5rem 1rem 3rem; }
+
+.cs-card {
+    background: var(--app-card); border-radius: 16px;
+    padding: 1.75rem 1.5rem; box-shadow: 0 2px 10px rgba(0,0,0,0.07);
+    margin-bottom: 1rem;
+}
+.cs-card h2 { font-size: 1.15rem; font-weight: 800; color: var(--app-text);
+              margin: 0 0 1.25rem; }
+
+.cs-field { margin-bottom: 1.1rem; }
+.cs-label { display: block; font-size: 0.82rem; font-weight: 700;
+            color: var(--app-text-muted); text-transform: uppercase;
+            letter-spacing: 0.04em; margin-bottom: 0.4rem; }
+.cs-select, .cs-textarea {
+    width: 100%; font-size: 0.92rem; padding: 0.55rem 0.75rem;
+    border: 1px solid #d1d5db; border-radius: 8px;
+    background: #fafafa; color: var(--app-text); box-sizing: border-box;
+}
+.cs-select:focus, .cs-textarea:focus {
+    outline: none; border-color: #4f46e5;
+    box-shadow: 0 0 0 3px rgba(79,70,229,0.12);
+}
+.cs-textarea { min-height: 80px; resize: vertical; }
+
+/* Difficulty grid */
+.cs-diff-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 0.6rem; }
+.cs-diff-card {
+    border: 2px solid #e5e7eb; border-radius: 10px; padding: 0.65rem 0.75rem;
+    cursor: pointer; transition: border-color 0.15s, background 0.15s;
+    background: #fff;
+}
+.cs-diff-card:hover { border-color: #4f46e5; }
+.cs-diff-card.selected { border-color: #4f46e5; background: #eef2ff; }
+.cs-diff-card.disabled { opacity: 0.45; cursor: not-allowed; }
+.cs-diff-name  { font-size: 0.88rem; font-weight: 700; color: var(--app-text); }
+.cs-diff-mult  { font-size: 0.75rem; color: #4f46e5; font-weight: 700; }
+.cs-diff-meta  { font-size: 0.72rem; color: var(--app-text-muted); margin-top: 0.15rem; }
+.cs-diff-locked { font-size: 0.7rem; color: #d97706; margin-top: 0.2rem; }
+
+#cs-diff-section { display: none; }
+
+.cs-flash-err {
+    background: #fef2f2; color: #b91c1c; border: 1px solid #fca5a5;
+    border-radius: 8px; padding: 0.7rem 1rem; font-size: 0.88rem;
+    font-weight: 600; margin-bottom: 1rem;
+}
+
+.cs-btn-submit {
+    width: 100%; background: #4f46e5; color: #fff; font-size: 1rem;
+    font-weight: 700; padding: 0.7rem 1rem; border: none;
+    border-radius: 10px; cursor: pointer; transition: background 0.15s;
+}
+.cs-btn-submit:hover { background: #4338ca; }
+.cs-btn-submit:disabled { background: #a5b4fc; cursor: not-allowed; }
+
+.cs-no-friends { text-align: center; padding: 2rem 1rem; color: var(--app-text-muted); }
+.cs-no-games   { text-align: center; padding: 1rem; color: var(--app-text-muted); font-size: 0.9rem; }
+
+.cs-footer { margin-top: 1rem; text-align: center; }
+.cs-footer a { color: #667eea; font-size: 0.88rem; font-weight: 600; text-decoration: none; }
+</style>
+{% endblock %}
+
+{% block student_content %}
+<div class="cs-container">
+
+{% if error %}
+<div class="cs-flash-err">
+    {% if error == "self_challenge"      %}You cannot challenge yourself.
+    {% elif error == "not_friends"       %}You can only challenge accepted friends.
+    {% elif error == "challenge_active"  %}There is already an active challenge between you and this player on that game.
+    {% elif error == "game_not_found"    %}Game not found.
+    {% elif error == "game_not_compatible" %}This game does not support challenges.
+    {% elif error == "invalid_difficulty" %}Invalid difficulty selected.
+    {% elif error == "expert_locked"     %}Expert difficulty is not unlocked yet (need 70%+ on 3 Hard attempts).
+    {% elif error == "user_not_found"    %}Player not found.
+    {% else %}{{ error }}
+    {% endif %}
+</div>
+{% endif %}
+
+{% if not friends_rows %}
+<div class="cs-card">
+    <div class="cs-no-friends">
+        <p style="font-size:1.5rem;margin-bottom:0.5rem;">👥</p>
+        <p>You have no accepted friends yet.</p>
+        <p style="margin-top:0.5rem;">
+            <a href="/friends" style="color:#4f46e5;font-weight:700;">Add friends →</a>
+        </p>
+    </div>
+</div>
+{% elif not compatible_games %}
+<div class="cs-card">
+    <div class="cs-no-games">No challenge-compatible games are available right now.</div>
+</div>
+{% else %}
+
+<div class="cs-card">
+    <h2>⚔ New Challenge</h2>
+    <form method="post" action="/challenges/send" id="cs-form">
+        <input type="hidden" name="csrf_token" value="{{ request.cookies.get('csrf_token', '') }}">
+        <input type="hidden" name="difficulty_level" id="cs-diff-input" value="easy">
+
+        {# ── Friend selector ── #}
+        <div class="cs-field">
+            <label class="cs-label" for="cs-friend">Opponent</label>
+            <select name="challenged_user_id" id="cs-friend" class="cs-select" required>
+                <option value="">— select a friend —</option>
+                {% for f in friends_rows %}
+                <option value="{{ f.id }}"
+                    {% if preselected_friend_id and f.id == preselected_friend_id %}selected{% endif %}>
+                    {{ f.nickname or f.email }}
+                </option>
+                {% endfor %}
+            </select>
+        </div>
+
+        {# ── Game selector ── #}
+        <div class="cs-field">
+            <label class="cs-label" for="cs-game">Game</label>
+            <select name="game_id" id="cs-game" class="cs-select" required>
+                <option value="">— select a game —</option>
+                {% for g in compatible_games %}
+                <option value="{{ g.id }}" data-code="{{ g.code }}"
+                    {% if preselected_game_code and g.code == preselected_game_code %}selected{% endif %}>
+                    {{ g.name }}
+                </option>
+                {% endfor %}
+            </select>
+        </div>
+
+        {# ── Difficulty (shown only for Target Tracking) ── #}
+        <div class="cs-field" id="cs-diff-section">
+            <label class="cs-label">Difficulty</label>
+            <div class="cs-diff-grid">
+                <div class="cs-diff-card selected" id="cs-diff-easy" onclick="selectDiff('easy')">
+                    <div class="cs-diff-name">Easy</div>
+                    <div class="cs-diff-mult">1.00×</div>
+                    <div class="cs-diff-meta">3–5 objects · 9 rounds</div>
+                </div>
+                <div class="cs-diff-card" id="cs-diff-medium" onclick="selectDiff('medium')">
+                    <div class="cs-diff-name">Medium</div>
+                    <div class="cs-diff-mult">1.30×</div>
+                    <div class="cs-diff-meta">5–7 objects · 9 rounds</div>
+                </div>
+                <div class="cs-diff-card" id="cs-diff-hard" onclick="selectDiff('hard')">
+                    <div class="cs-diff-name">Hard</div>
+                    <div class="cs-diff-mult">1.70×</div>
+                    <div class="cs-diff-meta">6–8 objects · 12 rounds</div>
+                </div>
+                {% if expert_unlocked %}
+                <div class="cs-diff-card" id="cs-diff-expert" onclick="selectDiff('expert')">
+                    <div class="cs-diff-name">Expert</div>
+                    <div class="cs-diff-mult">2.20×</div>
+                    <div class="cs-diff-meta">7–9 objects · 12 rounds</div>
+                </div>
+                {% else %}
+                <div class="cs-diff-card disabled" id="cs-diff-expert">
+                    <div class="cs-diff-name">Expert 🔒</div>
+                    <div class="cs-diff-mult">2.20×</div>
+                    <div class="cs-diff-meta">7–9 objects · 12 rounds</div>
+                    <div class="cs-diff-locked">Unlock: 70%+ on 3 Hard attempts</div>
+                </div>
+                {% endif %}
+            </div>
+        </div>
+
+        {# ── Optional message ── #}
+        <div class="cs-field">
+            <label class="cs-label" for="cs-msg">Message (optional)</label>
+            <textarea name="message" id="cs-msg" class="cs-textarea"
+                      maxlength="500" placeholder="Trash-talk or encouragement…"></textarea>
+        </div>
+
+        <button type="submit" class="cs-btn-submit" id="cs-submit">⚔ Send Challenge</button>
+    </form>
+</div>
+{% endif %}
+
+<div class="cs-footer">
+    <a href="/challenges">← Back to Challenges</a>
+</div>
+
+</div>
+{% endblock %}
+
+{% block extra_scripts %}
+<script>
+(function () {
+'use strict';
+
+var EXPERT_UNLOCKED = {{ 'true' if expert_unlocked else 'false' }};
+var selectedDiff    = 'easy';
+
+function selectDiff(level) {
+    if (level === 'expert' && !EXPERT_UNLOCKED) return;
+    selectedDiff = level;
+    ['easy', 'medium', 'hard', 'expert'].forEach(function (l) {
+        var card = document.getElementById('cs-diff-' + l);
+        if (!card) return;
+        if (card.classList.contains('disabled')) return;
+        card.classList.toggle('selected', l === level);
+    });
+    document.getElementById('cs-diff-input').value = level;
+}
+window.selectDiff = selectDiff;
+
+// Show/hide difficulty section based on game selection
+var gameSelect = document.getElementById('cs-game');
+var diffSection = document.getElementById('cs-diff-section');
+
+function updateDiffVisibility() {
+    var opt = gameSelect.options[gameSelect.selectedIndex];
+    var code = opt ? opt.getAttribute('data-code') : '';
+    if (diffSection) {
+        diffSection.style.display = (code === 'target_tracking') ? 'block' : 'none';
+    }
+}
+
+if (gameSelect) {
+    gameSelect.addEventListener('change', updateDiffVisibility);
+    updateDiffVisibility(); // init
+}
+
+// Preselect game from URL ?game_code= param if present
+var urlParams = new URLSearchParams(window.location.search);
+var preCode   = urlParams.get('game_code');
+if (preCode && gameSelect) {
+    for (var i = 0; i < gameSelect.options.length; i++) {
+        if (gameSelect.options[i].getAttribute('data-code') === preCode) {
+            gameSelect.selectedIndex = i;
+            updateDiffVisibility();
+            break;
+        }
+    }
+}
+
+})();
+</script>
+{% endblock %}

--- a/app/templates/vt_challenges.html
+++ b/app/templates/vt_challenges.html
@@ -1,0 +1,269 @@
+{% extends "student_base.html" %}
+
+{% block title %}Challenges — Virtual Training{% endblock %}
+{% block active_page %}lfa-player{% endblock %}
+
+{% block student_header %}
+{% set _page_icon = '⚔️' %}
+{% set _page_name = 'Challenges' %}
+{% include "includes/spec_subpage_hdr.html" %}
+{% endblock %}
+
+{% block extra_styles %}
+<style>
+.ch-container { max-width: 620px; margin: 0 auto; padding: 1.5rem 1rem 3rem; }
+
+.ch-flash { padding: 0.75rem 1rem; border-radius: 8px; margin-bottom: 1rem;
+            font-size: 0.9rem; font-weight: 600; }
+.ch-flash-ok  { background: #f0fdf4; color: #166534; border: 1px solid #86efac; }
+.ch-flash-err { background: #fef2f2; color: #b91c1c; border: 1px solid #fca5a5; }
+
+.ch-actions-top {
+    display: flex; justify-content: flex-end; margin-bottom: 1.25rem;
+}
+.ch-btn-send {
+    display: inline-block; background: #4f46e5; color: #fff;
+    font-size: 0.9rem; font-weight: 700; padding: 0.55rem 1.25rem;
+    border-radius: 8px; text-decoration: none; transition: background 0.15s;
+}
+.ch-btn-send:hover { background: #4338ca; }
+
+.ch-section-title {
+    font-size: 0.8rem; font-weight: 700; color: var(--app-text-muted);
+    text-transform: uppercase; letter-spacing: 0.05em;
+    margin: 1.5rem 0 0.75rem;
+}
+.ch-section-title:first-of-type { margin-top: 0; }
+
+.ch-card {
+    background: var(--app-card); border-radius: 14px;
+    padding: 1rem 1.1rem; box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+    margin-bottom: 0.75rem;
+}
+
+.ch-card-top {
+    display: flex; justify-content: space-between; align-items: flex-start;
+    gap: 0.5rem; margin-bottom: 0.5rem;
+}
+.ch-opponent { font-size: 0.95rem; font-weight: 700; color: var(--app-text); }
+.ch-game     { font-size: 0.82rem; color: var(--app-text-muted); margin-top: 0.15rem; }
+
+.ch-badge {
+    display: inline-block; font-size: 0.75rem; font-weight: 700;
+    padding: 0.2rem 0.65rem; border-radius: 20px; white-space: nowrap;
+}
+.ch-badge-pending   { background: #fef9c3; color: #854d0e; }
+.ch-badge-accepted  { background: #dbeafe; color: #1e40af; }
+.ch-badge-won       { background: #dcfce7; color: #166534; }
+.ch-badge-lost      { background: #fee2e2; color: #991b1b; }
+.ch-badge-draw      { background: #f3f4f6; color: #374151; }
+.ch-badge-declined  { background: #f3f4f6; color: #6b7280; }
+.ch-badge-cancelled { background: #f3f4f6; color: #6b7280; }
+.ch-badge-expired   { background: #fef3c7; color: #92400e; }
+
+.ch-meta { font-size: 0.78rem; color: var(--app-text-muted); margin-bottom: 0.6rem; }
+.ch-message {
+    font-size: 0.85rem; color: var(--app-text); font-style: italic;
+    background: #f9fafb; border-radius: 6px; padding: 0.45rem 0.6rem;
+    margin-bottom: 0.6rem;
+}
+.ch-scores {
+    display: flex; gap: 1.5rem; font-size: 0.85rem;
+    margin-bottom: 0.6rem; flex-wrap: wrap;
+}
+.ch-score-item { display: flex; flex-direction: column; align-items: center; }
+.ch-score-lbl  { font-size: 0.7rem; color: var(--app-text-muted); text-transform: uppercase; letter-spacing: 0.04em; margin-bottom: 0.1rem; }
+.ch-score-val  { font-size: 1.1rem; font-weight: 800; color: var(--app-text); }
+.ch-score-val.win  { color: #16a34a; }
+.ch-score-val.lose { color: #dc2626; }
+
+.ch-btns { display: flex; gap: 0.5rem; flex-wrap: wrap; margin-top: 0.5rem; }
+.ch-btn {
+    display: inline-block; font-size: 0.82rem; font-weight: 700;
+    padding: 0.35rem 0.85rem; border-radius: 7px; text-decoration: none;
+    cursor: pointer; border: none; transition: opacity 0.15s;
+}
+.ch-btn:hover { opacity: 0.85; }
+.ch-btn-play     { background: #4f46e5; color: #fff; }
+.ch-btn-accept   { background: #16a34a; color: #fff; }
+.ch-btn-decline  { background: #f3f4f6; color: #374151; }
+.ch-btn-cancel   { background: #fef2f2; color: #b91c1c; }
+
+.ch-waiting { font-size: 0.85rem; color: var(--app-text-muted); font-style: italic; padding: 0.3rem 0; }
+
+.ch-empty { text-align: center; padding: 2.5rem 1rem; color: var(--app-text-muted); }
+.ch-empty p { font-size: 0.95rem; }
+
+.ch-footer { margin-top: 2rem; padding-top: 1rem; border-top: 1px solid #e5e7eb;
+             text-align: center; }
+.ch-footer a { color: #667eea; text-decoration: none; margin: 0 0.6rem;
+               font-size: 0.88rem; font-weight: 600; }
+.ch-footer a:hover { text-decoration: underline; }
+</style>
+{% endblock %}
+
+{% block student_content %}
+<div class="ch-container">
+
+{% if success %}
+<div class="ch-flash ch-flash-ok">
+    {% if success == "challenge_sent"      %}✓ Challenge sent!
+    {% elif success == "challenge_accepted" %}✓ Challenge accepted — go play!
+    {% elif success == "challenge_declined" %}✓ Challenge declined.
+    {% elif success == "challenge_cancelled" %}✓ Challenge cancelled.
+    {% else %}✓ Done.
+    {% endif %}
+</div>
+{% endif %}
+
+{% if error %}
+<div class="ch-flash ch-flash-err">
+    {% if error == "not_found"          %}Challenge not found.
+    {% elif error == "not_pending"      %}That challenge is no longer pending.
+    {% elif error == "cannot_cancel"    %}This challenge can no longer be cancelled.
+    {% elif error == "challenge_expired" %}Challenge expired — it has been marked as expired.
+    {% else %}{{ error }}
+    {% endif %}
+</div>
+{% endif %}
+
+<div class="ch-actions-top">
+    <a href="/challenges/send" class="ch-btn-send">⚔ New challenge</a>
+</div>
+
+{# ── Active challenges ── #}
+<div class="ch-section-title">Active ({{ active_rows | length }})</div>
+
+{% if active_rows %}
+{% for row in active_rows %}
+<div class="ch-card">
+    <div class="ch-card-top">
+        <div>
+            <div class="ch-opponent">
+                {% if row.is_challenger %}You → {{ row.opponent_name }}
+                {% else %}{{ row.opponent_name }} → You{% endif %}
+            </div>
+            <div class="ch-game">
+                {{ row.game_name }}
+                {% if row.difficulty_level %} · {{ row.difficulty_level | title }}{% endif %}
+            </div>
+        </div>
+        <span class="ch-badge ch-badge-{{ row.status }}">
+            {% if row.status == "pending" %}Pending
+            {% elif row.status == "accepted" %}Accepted
+            {% else %}{{ row.status | title }}
+            {% endif %}
+        </span>
+    </div>
+
+    <div class="ch-meta">
+        Sent {{ row.created_at.strftime('%Y-%m-%d') }} ·
+        Expires {{ row.expires_at.strftime('%Y-%m-%d') }}
+    </div>
+
+    {% if row.message %}
+    <div class="ch-message">"{{ row.message }}"</div>
+    {% endif %}
+
+    <div class="ch-btns">
+        {% if row.outcome == "play_now" %}
+        <a href="{{ row.play_url }}" class="ch-btn ch-btn-play">▶ Play now</a>
+
+        {% elif row.outcome == "waiting_for_opponent" %}
+        <span class="ch-waiting">⏳ Waiting for {{ row.opponent_name }} to play…</span>
+
+        {% elif row.outcome == "received" %}
+        <form method="post" action="/challenges/{{ row.id }}/accept" style="margin:0;">
+            <input type="hidden" name="csrf_token" value="{{ request.cookies.get('csrf_token', '') }}">
+            <button type="submit" class="ch-btn ch-btn-accept">✓ Accept</button>
+        </form>
+        <form method="post" action="/challenges/{{ row.id }}/decline" style="margin:0;">
+            <input type="hidden" name="csrf_token" value="{{ request.cookies.get('csrf_token', '') }}">
+            <button type="submit" class="ch-btn ch-btn-decline">✗ Decline</button>
+        </form>
+
+        {% elif row.outcome == "sent" %}
+        <form method="post" action="/challenges/{{ row.id }}/cancel" style="margin:0;">
+            <input type="hidden" name="csrf_token" value="{{ request.cookies.get('csrf_token', '') }}">
+            <button type="submit" class="ch-btn ch-btn-cancel">✕ Cancel</button>
+        </form>
+        <span class="ch-waiting">Awaiting {{ row.opponent_name }}'s response…</span>
+        {% endif %}
+    </div>
+</div>
+{% endfor %}
+{% else %}
+<div class="ch-empty"><p>No active challenges.</p></div>
+{% endif %}
+
+{# ── Terminal challenges ── #}
+{% if terminal_rows %}
+<div class="ch-section-title">Recent (last {{ terminal_rows | length }})</div>
+{% for row in terminal_rows %}
+<div class="ch-card">
+    <div class="ch-card-top">
+        <div>
+            <div class="ch-opponent">
+                {% if row.is_challenger %}You vs {{ row.opponent_name }}
+                {% else %}{{ row.opponent_name }} vs You{% endif %}
+            </div>
+            <div class="ch-game">
+                {{ row.game_name }}
+                {% if row.difficulty_level %} · {{ row.difficulty_level | title }}{% endif %}
+            </div>
+        </div>
+        {% if row.outcome == "won" %}
+        <span class="ch-badge ch-badge-won">🏆 Won</span>
+        {% elif row.outcome == "lost" %}
+        <span class="ch-badge ch-badge-lost">✗ Lost</span>
+        {% elif row.outcome == "draw" %}
+        <span class="ch-badge ch-badge-draw">= Draw</span>
+        {% elif row.status == "declined" %}
+        <span class="ch-badge ch-badge-declined">Declined</span>
+        {% elif row.status == "cancelled" %}
+        <span class="ch-badge ch-badge-cancelled">Cancelled</span>
+        {% elif row.status == "expired" %}
+        <span class="ch-badge ch-badge-expired">Expired</span>
+        {% else %}
+        <span class="ch-badge ch-badge-declined">{{ row.status | title }}</span>
+        {% endif %}
+    </div>
+
+    <div class="ch-meta">
+        {{ row.created_at.strftime('%Y-%m-%d') }}
+        {% if row.completed_at %} · Completed {{ row.completed_at.strftime('%Y-%m-%d') }}{% endif %}
+    </div>
+
+    {% if row.message %}
+    <div class="ch-message">"{{ row.message }}"</div>
+    {% endif %}
+
+    {% if row.outcome in ["won", "lost", "draw"] and (row.my_score is not none or row.opp_score is not none) %}
+    <div class="ch-scores">
+        <div class="ch-score-item">
+            <span class="ch-score-lbl">You</span>
+            <span class="ch-score-val {% if row.outcome == 'won' %}win{% elif row.outcome == 'lost' %}lose{% endif %}">
+                {% if row.my_score is not none %}{{ row.my_score | round(0) | int }}%{% else %}—{% endif %}
+            </span>
+        </div>
+        <div class="ch-score-item" style="color:var(--app-text-muted);align-self:center;font-size:1.2rem;">vs</div>
+        <div class="ch-score-item">
+            <span class="ch-score-lbl">{{ row.opponent_name }}</span>
+            <span class="ch-score-val {% if row.outcome == 'lost' %}win{% elif row.outcome == 'won' %}lose{% endif %}">
+                {% if row.opp_score is not none %}{{ row.opp_score | round(0) | int }}%{% else %}—{% endif %}
+            </span>
+        </div>
+    </div>
+    {% endif %}
+</div>
+{% endfor %}
+{% endif %}
+
+<div class="ch-footer">
+    <a href="/virtual-training">💻 All Games</a>
+    <a href="/friends">👥 Friends</a>
+    <a href="/training">🎓 Training</a>
+</div>
+
+</div>
+{% endblock %}

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -4155,6 +4155,17 @@
             "title": "Challenged User Id",
             "type": "integer"
           },
+          "difficulty_level": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Difficulty Level"
+          },
           "game_id": {
             "title": "Game Id",
             "type": "integer"
@@ -59475,7 +59486,91 @@
         ]
       }
     },
+    "/challenges": {
+      "get": {
+        "operationId": "challenge_inbox_challenges_get",
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Challenge Inbox",
+        "tags": [
+          "web"
+        ]
+      }
+    },
     "/challenges/send": {
+      "get": {
+        "operationId": "challenge_send_form_challenges_send_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "friend_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Friend Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "game_code",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Game Code"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Challenge Send Form",
+        "tags": [
+          "web"
+        ]
+      },
       "post": {
         "operationId": "send_challenge_challenges_send_post",
         "requestBody": {
@@ -64623,6 +64718,22 @@
               "title": "Attempt Id",
               "type": "integer"
             }
+          },
+          {
+            "in": "query",
+            "name": "challenge_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Challenge Id"
+            }
           }
         ],
         "responses": {
@@ -64710,6 +64821,22 @@
             "schema": {
               "title": "Attempt Id",
               "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "challenge_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Challenge Id"
             }
           }
         ],

--- a/tests/unit/api/web_routes/test_vt_challenges_ui.py
+++ b/tests/unit/api/web_routes/test_vt_challenges_ui.py
@@ -1,0 +1,703 @@
+"""Unit tests for PR-C3 — VT Challenge UI + inbox + end-to-end flow.
+
+UI-01  VirtualTrainingChallenge model has difficulty_level column
+UI-02  _build_inbox_row: pending received → outcome=received, play_url correct (MS)
+UI-03  _build_inbox_row: pending sent → outcome=sent
+UI-04  _build_inbox_row: accepted + no my attempt → outcome=play_now, MS play_url
+UI-05  _build_inbox_row: accepted + my attempt + no opp attempt → outcome=waiting_for_opponent
+UI-06  _build_inbox_row: completed won → outcome=won, scores populated
+UI-07  _build_inbox_row: completed lost → outcome=lost
+UI-08  _build_inbox_row: completed draw → outcome=draw, is_draw=True
+UI-09  _build_inbox_row: TT challenge → play_url includes difficulty
+UI-10  _build_inbox_row: unknown game code → play_url=/virtual-training
+UI-11  _build_challenge_result_ctx: challenge not found → None
+UI-12  _build_challenge_result_ctx: user not participant → None
+UI-13  _build_challenge_result_ctx: attempt_id mismatch → None
+UI-14  _build_challenge_result_ctx: accepted + no opp attempt → waiting_for_opponent
+UI-15  _build_challenge_result_ctx: accepted + opp attempt set → waiting_for_resolution
+UI-16  _build_challenge_result_ctx: completed won (challenger side)
+UI-17  _build_challenge_result_ctx: completed lost (challenged side)
+UI-18  _build_challenge_result_ctx: completed draw
+UI-19  POST /challenges/send: TT + valid difficulty → difficulty_level stored
+UI-20  POST /challenges/send: TT + invalid difficulty → error=invalid_difficulty
+UI-21  POST /challenges/send: TT + expert + not unlocked → error=expert_locked
+UI-22  POST /challenges/send: MS game → difficulty_level=NULL stored
+UI-23  GET /challenges: renders inbox template (200)
+UI-24  GET /challenges/send: renders send form (200, friends + games in context)
+UI-25  Notification links: all POST actions redirect to /challenges
+UI-26  _accepted_friends: returns User objects for both FK directions
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from app.models.vt_challenge import (
+    CHALLENGE_COMPATIBLE_GAMES,
+    ChallengeStatus,
+    VirtualTrainingChallenge,
+)
+
+_BASE  = "app.api.web_routes.vt_challenges"
+_VT    = "app.api.web_routes.virtual_training"
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+def _user(uid=1, email=None, nick=None, active=True):
+    u = MagicMock()
+    u.id       = uid
+    u.email    = email or f"user{uid}@lfa.com"
+    u.nickname = nick
+    u.is_active = active
+    return u
+
+
+def _game(gid=1, code="memory_sequence", name="Memory Sequence"):
+    g = MagicMock()
+    g.id   = gid
+    g.code = code
+    g.name = name
+    return g
+
+
+def _attempt(aid=100, score=75.0):
+    a = MagicMock()
+    a.id               = aid
+    a.score_normalized = score
+    return a
+
+
+def _challenge(
+    cid=10,
+    challenger_id=1,
+    challenged_id=2,
+    game_id=1,
+    status=ChallengeStatus.PENDING,
+    expires_at=None,
+    challenger_attempt_id=None,
+    challenged_attempt_id=None,
+    winner_id=None,
+    is_draw=False,
+    difficulty_level=None,
+    completed_at=None,
+    message=None,
+    created_at=None,
+):
+    c = MagicMock(spec=VirtualTrainingChallenge)
+    c.id                    = cid
+    c.challenger_id         = challenger_id
+    c.challenged_id         = challenged_id
+    c.game_id               = game_id
+    c.status                = status
+    c.expires_at            = expires_at or (datetime.now(timezone.utc) + timedelta(days=7))
+    c.challenger_attempt_id = challenger_attempt_id
+    c.challenged_attempt_id = challenged_attempt_id
+    c.winner_id             = winner_id
+    c.is_draw               = is_draw
+    c.difficulty_level      = difficulty_level
+    c.completed_at          = completed_at
+    c.message               = message
+    c.created_at            = created_at or datetime.now(timezone.utc)
+    return c
+
+
+def _db():
+    return MagicMock()
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ── UI-01: Model column ────────────────────────────────────────────────────────
+
+class TestModelColumn:
+
+    def test_ui01_difficulty_level_column_exists(self):
+        cols = {c.key for c in VirtualTrainingChallenge.__table__.columns}
+        assert "difficulty_level" in cols
+
+
+# ── UI-02..UI-10: _build_inbox_row ────────────────────────────────────────────
+
+class TestBuildInboxRow:
+
+    def _row(self, ch, user_id, my_score=None, opp_score=None, game=None, opp=None):
+        from app.api.web_routes.vt_challenges import _build_inbox_row
+
+        my_a  = _attempt(score=my_score)  if my_score  is not None else None
+        opp_a = _attempt(score=opp_score) if opp_score is not None else None
+
+        a_map = {}
+        if ch.challenger_attempt_id and my_score is not None:
+            a_map[ch.challenger_attempt_id] = my_a
+        if ch.challenged_attempt_id and opp_score is not None:
+            a_map[ch.challenged_attempt_id] = opp_a
+
+        g = game or _game(gid=ch.game_id)
+        opp_user = opp or _user(uid=2)
+
+        u_map = {user_id: _user(uid=user_id), opp_user.id: opp_user}
+        g_map = {g.id: g}
+
+        return _build_inbox_row(ch, user_id, a_map, u_map, g_map)
+
+    def test_ui02_pending_received_ms(self):
+        ch = _challenge(challenger_id=2, challenged_id=1, status=ChallengeStatus.PENDING)
+        row = self._row(ch, user_id=1)
+        assert row["outcome"]       == "received"
+        assert row["is_challenger"] is False
+        # play_url pre-computed (used after accepting, not shown for pending)
+        assert "memory-sequence" in row["play_url"]
+        assert "challenge_id=10"  in row["play_url"]
+
+    def test_ui03_pending_sent(self):
+        ch = _challenge(challenger_id=1, challenged_id=2, status=ChallengeStatus.PENDING)
+        row = self._row(ch, user_id=1)
+        assert row["outcome"] == "sent"
+        assert row["is_challenger"] is True
+
+    def test_ui04_accepted_no_my_attempt_ms(self):
+        ch = _challenge(
+            challenger_id=1, challenged_id=2,
+            status=ChallengeStatus.ACCEPTED,
+            challenger_attempt_id=None,
+            challenged_attempt_id=None,
+        )
+        row = self._row(ch, user_id=1)
+        assert row["outcome"] == "play_now"
+        assert "memory-sequence" in row["play_url"]
+        assert "challenge_id=10" in row["play_url"]
+
+    def test_ui05_accepted_my_attempt_no_opp(self):
+        ch = _challenge(
+            challenger_id=1, challenged_id=2,
+            status=ChallengeStatus.ACCEPTED,
+            challenger_attempt_id=100,
+            challenged_attempt_id=None,
+        )
+        row = self._row(ch, user_id=1, my_score=80.0)
+        assert row["outcome"] == "waiting_for_opponent"
+
+    def test_ui06_completed_won(self):
+        ch = _challenge(
+            challenger_id=1, challenged_id=2,
+            status=ChallengeStatus.COMPLETED,
+            challenger_attempt_id=100,
+            challenged_attempt_id=200,
+            winner_id=1,
+            is_draw=False,
+        )
+        from app.api.web_routes.vt_challenges import _build_inbox_row
+
+        my_a  = _attempt(aid=100, score=90.0)
+        opp_a = _attempt(aid=200, score=70.0)
+        a_map = {100: my_a, 200: opp_a}
+        u_map = {1: _user(uid=1), 2: _user(uid=2)}
+        g_map = {1: _game()}
+        row = _build_inbox_row(ch, 1, a_map, u_map, g_map)
+        assert row["outcome"]  == "won"
+        assert row["my_score"] == 90.0
+        assert row["opp_score"] == 70.0
+
+    def test_ui07_completed_lost(self):
+        ch = _challenge(
+            challenger_id=1, challenged_id=2,
+            status=ChallengeStatus.COMPLETED,
+            challenger_attempt_id=100,
+            challenged_attempt_id=200,
+            winner_id=2,
+            is_draw=False,
+        )
+        from app.api.web_routes.vt_challenges import _build_inbox_row
+        my_a  = _attempt(aid=100, score=60.0)
+        opp_a = _attempt(aid=200, score=85.0)
+        a_map = {100: my_a, 200: opp_a}
+        u_map = {1: _user(uid=1), 2: _user(uid=2)}
+        g_map = {1: _game()}
+        row = _build_inbox_row(ch, 1, a_map, u_map, g_map)
+        assert row["outcome"] == "lost"
+
+    def test_ui08_completed_draw(self):
+        ch = _challenge(
+            challenger_id=1, challenged_id=2,
+            status=ChallengeStatus.COMPLETED,
+            challenger_attempt_id=100,
+            challenged_attempt_id=200,
+            winner_id=None,
+            is_draw=True,
+        )
+        from app.api.web_routes.vt_challenges import _build_inbox_row
+        a_map = {100: _attempt(aid=100, score=75.0), 200: _attempt(aid=200, score=75.0)}
+        u_map = {1: _user(uid=1), 2: _user(uid=2)}
+        g_map = {1: _game()}
+        row = _build_inbox_row(ch, 1, a_map, u_map, g_map)
+        assert row["outcome"] == "draw"
+
+    def test_ui09_tt_play_url_includes_difficulty(self):
+        ch = _challenge(
+            game_id=2,
+            status=ChallengeStatus.ACCEPTED,
+            challenger_attempt_id=None,
+            difficulty_level="hard",
+        )
+        tt_game = _game(gid=2, code="target_tracking", name="Target Tracking")
+        row = self._row(ch, user_id=1, game=tt_game)
+        assert row["outcome"] == "play_now"
+        assert "target-tracking" in row["play_url"]
+        assert "challenge_id=10" in row["play_url"]
+        assert "difficulty=hard"  in row["play_url"]
+
+    def test_ui10_unknown_game_code_fallback_url(self):
+        ch = _challenge(game_id=9, status=ChallengeStatus.ACCEPTED)
+        unknown_game = _game(gid=9, code="unknown_game", name="Unknown")
+        row = self._row(ch, user_id=1, game=unknown_game)
+        assert row["play_url"] == "/virtual-training"
+
+
+# ── UI-11..UI-18: _build_challenge_result_ctx ─────────────────────────────────
+
+class TestBuildChallengeResultCtx:
+
+    def _ctx(self, ch, user_id, attempt_id, opp_user=None, my_attempt=None, opp_attempt=None):
+        from app.api.web_routes.virtual_training import _build_challenge_result_ctx
+
+        db = _db()
+
+        def _query_side_effect(model):
+            q = MagicMock()
+            store = {"ch": ch, "opp": opp_user, "my_a": my_attempt, "opp_a": opp_attempt}
+
+            def _filter(*_a, **_kw):
+                inner = MagicMock()
+                # Determine which entity by inspecting call order — use a queue
+                if not hasattr(_filter, "_calls"):
+                    _filter._calls = []
+                return inner
+
+            q.filter.return_value.first.side_effect = [
+                opp_user,
+                my_attempt,
+                opp_attempt,
+            ]
+            return q
+
+        # Patch internal db queries via a single mock chain
+        db.query.return_value.filter.return_value.first.side_effect = [
+            ch,            # VirtualTrainingChallenge lookup
+            opp_user,      # opponent User lookup
+            my_attempt,    # my attempt lookup (only when COMPLETED)
+            opp_attempt,   # opp attempt lookup (only when COMPLETED)
+        ]
+
+        return _build_challenge_result_ctx(db, ch.id if ch else 99, user_id, attempt_id)
+
+    def test_ui11_challenge_not_found_returns_none(self):
+        from app.api.web_routes.virtual_training import _build_challenge_result_ctx
+        db = _db()
+        db.query.return_value.filter.return_value.first.return_value = None
+        result = _build_challenge_result_ctx(db, challenge_id=99, user_id=1, attempt_id=100)
+        assert result is None
+
+    def test_ui12_user_not_participant_returns_none(self):
+        from app.api.web_routes.virtual_training import _build_challenge_result_ctx
+        ch = _challenge(challenger_id=3, challenged_id=4)
+        db = _db()
+        db.query.return_value.filter.return_value.first.return_value = ch
+        result = _build_challenge_result_ctx(db, challenge_id=10, user_id=1, attempt_id=100)
+        assert result is None
+
+    def test_ui13_attempt_id_mismatch_returns_none(self):
+        from app.api.web_routes.virtual_training import _build_challenge_result_ctx
+        ch = _challenge(
+            challenger_id=1, challenged_id=2,
+            status=ChallengeStatus.ACCEPTED,
+            challenger_attempt_id=999,   # different from attempt_id
+        )
+        db = _db()
+        db.query.return_value.filter.return_value.first.return_value = ch
+        result = _build_challenge_result_ctx(db, challenge_id=10, user_id=1, attempt_id=100)
+        assert result is None
+
+    def test_ui14_accepted_no_opp_attempt_waiting(self):
+        from app.api.web_routes.virtual_training import _build_challenge_result_ctx
+        ch = _challenge(
+            challenger_id=1, challenged_id=2,
+            status=ChallengeStatus.ACCEPTED,
+            challenger_attempt_id=100,
+            challenged_attempt_id=None,
+        )
+        opp = _user(uid=2, nick="Bob")
+        db = _db()
+        db.query.return_value.filter.return_value.first.side_effect = [ch, opp]
+        result = _build_challenge_result_ctx(db, challenge_id=10, user_id=1, attempt_id=100)
+        assert result is not None
+        assert result["outcome"] == "waiting_for_opponent"
+        assert result["opponent_name"] == "Bob"
+
+    def test_ui15_accepted_both_attempts_waiting_resolution(self):
+        from app.api.web_routes.virtual_training import _build_challenge_result_ctx
+        ch = _challenge(
+            challenger_id=1, challenged_id=2,
+            status=ChallengeStatus.ACCEPTED,
+            challenger_attempt_id=100,
+            challenged_attempt_id=200,
+        )
+        opp = _user(uid=2)
+        db = _db()
+        db.query.return_value.filter.return_value.first.side_effect = [ch, opp]
+        result = _build_challenge_result_ctx(db, challenge_id=10, user_id=1, attempt_id=100)
+        assert result is not None
+        assert result["outcome"] == "waiting_for_resolution"
+
+    def test_ui16_completed_won_challenger_side(self):
+        from app.api.web_routes.virtual_training import _build_challenge_result_ctx
+        ch = _challenge(
+            challenger_id=1, challenged_id=2,
+            status=ChallengeStatus.COMPLETED,
+            challenger_attempt_id=100,
+            challenged_attempt_id=200,
+            winner_id=1,
+            is_draw=False,
+        )
+        opp      = _user(uid=2, nick="Opp")
+        my_att   = _attempt(aid=100, score=90.0)
+        opp_att  = _attempt(aid=200, score=60.0)
+        db = _db()
+        db.query.return_value.filter.return_value.first.side_effect = [
+            ch, opp, my_att, opp_att
+        ]
+        result = _build_challenge_result_ctx(db, challenge_id=10, user_id=1, attempt_id=100)
+        assert result["outcome"]    == "won"
+        assert result["my_score"]   == 90.0
+        assert result["opp_score"]  == 60.0
+
+    def test_ui17_completed_lost_challenged_side(self):
+        from app.api.web_routes.virtual_training import _build_challenge_result_ctx
+        ch = _challenge(
+            challenger_id=1, challenged_id=2,
+            status=ChallengeStatus.COMPLETED,
+            challenger_attempt_id=100,
+            challenged_attempt_id=200,
+            winner_id=1,
+            is_draw=False,
+        )
+        opp     = _user(uid=1)
+        my_att  = _attempt(aid=200, score=60.0)
+        opp_att = _attempt(aid=100, score=90.0)
+        db = _db()
+        db.query.return_value.filter.return_value.first.side_effect = [
+            ch, opp, my_att, opp_att
+        ]
+        result = _build_challenge_result_ctx(db, challenge_id=10, user_id=2, attempt_id=200)
+        assert result["outcome"] == "lost"
+
+    def test_ui18_completed_draw(self):
+        from app.api.web_routes.virtual_training import _build_challenge_result_ctx
+        ch = _challenge(
+            challenger_id=1, challenged_id=2,
+            status=ChallengeStatus.COMPLETED,
+            challenger_attempt_id=100,
+            challenged_attempt_id=200,
+            winner_id=None,
+            is_draw=True,
+        )
+        opp     = _user(uid=2)
+        my_att  = _attempt(aid=100, score=75.0)
+        opp_att = _attempt(aid=200, score=75.0)
+        db = _db()
+        db.query.return_value.filter.return_value.first.side_effect = [
+            ch, opp, my_att, opp_att
+        ]
+        result = _build_challenge_result_ctx(db, challenge_id=10, user_id=1, attempt_id=100)
+        assert result["outcome"] == "draw"
+
+
+# ── UI-19..UI-22: POST /challenges/send difficulty guards ─────────────────────
+
+class TestSendChallengeDifficulty:
+
+    def _target_and_game(self, db, target_uid=2, game_code="target_tracking"):
+        target = _user(uid=target_uid)
+        game   = _game(gid=2, code=game_code)
+        db.query.return_value.filter.return_value.first.side_effect = [target, game, None]
+        return target, game
+
+    def test_ui19_tt_valid_difficulty_stored(self):
+        from app.api.web_routes.vt_challenges import send_challenge
+        user = _user(uid=1)
+        db   = _db()
+        target = _user(uid=2)
+        game   = _game(gid=2, code="target_tracking")
+        db.query.return_value.filter.return_value.first.side_effect = [target, game, None]
+
+        created_challenge = None
+
+        def _capture_add(obj):
+            nonlocal created_challenge
+            created_challenge = obj
+        db.add.side_effect = _capture_add
+
+        with patch(f"{_BASE}.is_friends",        return_value=True), \
+             patch(f"{_BASE}.get_active_challenge", return_value=None), \
+             patch(f"{_BASE}.VirtualTrainingService.is_expert_unlocked", return_value=False), \
+             patch(f"{_BASE}.notification_service.create_notification"), \
+             patch(f"{_BASE}.VirtualTrainingChallenge") as MockCh:
+            MockCh.return_value = MagicMock()
+            result = _run(send_challenge(
+                challenged_user_id=2, game_id=2, message=None,
+                difficulty_level="hard",
+                db=db, user=user,
+            ))
+
+        assert "error" not in result.headers["location"]
+        # Verify VirtualTrainingChallenge was called with difficulty_level="hard"
+        call_kwargs = MockCh.call_args[1] if MockCh.call_args else {}
+        assert call_kwargs.get("difficulty_level") == "hard"
+
+    def test_ui20_tt_invalid_difficulty_rejected(self):
+        from app.api.web_routes.vt_challenges import send_challenge
+        user = _user(uid=1)
+        db   = _db()
+        target = _user(uid=2)
+        game   = _game(gid=2, code="target_tracking")
+        db.query.return_value.filter.return_value.first.side_effect = [target, game, None]
+
+        with patch(f"{_BASE}.is_friends",        return_value=True), \
+             patch(f"{_BASE}.get_active_challenge", return_value=None):
+            result = _run(send_challenge(
+                challenged_user_id=2, game_id=2, message=None,
+                difficulty_level="legendary",
+                db=db, user=user,
+            ))
+        assert "error=invalid_difficulty" in result.headers["location"]
+
+    def test_ui21_tt_expert_not_unlocked_rejected(self):
+        from app.api.web_routes.vt_challenges import send_challenge
+        user = _user(uid=1)
+        db   = _db()
+        target = _user(uid=2)
+        game   = _game(gid=2, code="target_tracking")
+        db.query.return_value.filter.return_value.first.side_effect = [target, game, None]
+
+        with patch(f"{_BASE}.is_friends",                return_value=True), \
+             patch(f"{_BASE}.get_active_challenge",        return_value=None), \
+             patch(f"{_BASE}.VirtualTrainingService.is_expert_unlocked", return_value=False):
+            result = _run(send_challenge(
+                challenged_user_id=2, game_id=2, message=None,
+                difficulty_level="expert",
+                db=db, user=user,
+            ))
+        assert "error=expert_locked" in result.headers["location"]
+
+    def test_ui22_ms_game_no_difficulty_stored(self):
+        from app.api.web_routes.vt_challenges import send_challenge
+        user = _user(uid=1)
+        db   = _db()
+        target = _user(uid=2)
+        game   = _game(gid=1, code="memory_sequence")
+        db.query.return_value.filter.return_value.first.side_effect = [target, game, None]
+
+        with patch(f"{_BASE}.is_friends",          return_value=True), \
+             patch(f"{_BASE}.get_active_challenge",  return_value=None), \
+             patch(f"{_BASE}.notification_service.create_notification"), \
+             patch(f"{_BASE}.VirtualTrainingChallenge") as MockCh:
+            MockCh.return_value = MagicMock()
+            result = _run(send_challenge(
+                challenged_user_id=2, game_id=1, message=None,
+                difficulty_level=None,
+                db=db, user=user,
+            ))
+
+        call_kwargs = MockCh.call_args[1] if MockCh.call_args else {}
+        assert call_kwargs.get("difficulty_level") is None
+
+
+# ── UI-23: GET /challenges inbox ──────────────────────────────────────────────
+
+class TestChallengeInbox:
+
+    def test_ui23_inbox_renders_200(self):
+        from app.api.web_routes.vt_challenges import challenge_inbox
+        user = _user(uid=1)
+        db   = _db()
+        db.query.return_value.filter.return_value.order_by.return_value.all.return_value = []
+
+        request = MagicMock()
+        request.query_params.get.return_value = None
+
+        with patch(f"{_BASE}.require_student_onboarding", return_value=None), \
+             patch(f"{_BASE}._spec_ctx",                  return_value={}), \
+             patch(f"{_BASE}.templates.TemplateResponse") as mock_tmpl:
+            mock_tmpl.return_value = MagicMock()
+            result = _run(challenge_inbox(request=request, db=db, user=user))
+
+        mock_tmpl.assert_called_once()
+        args = mock_tmpl.call_args
+        assert args[0][0] == "vt_challenges.html"
+        ctx = args[0][1]
+        assert "active_rows"   in ctx
+        assert "terminal_rows" in ctx
+
+
+# ── UI-24: GET /challenges/send form ─────────────────────────────────────────
+
+class TestSendForm:
+
+    def test_ui24_send_form_renders_200(self):
+        from app.api.web_routes.vt_challenges import challenge_send_form
+        user = _user(uid=1)
+        db   = _db()
+        ms_game = _game(gid=1, code="memory_sequence", name="Memory Sequence")
+        tt_game = _game(gid=2, code="target_tracking", name="Target Tracking")
+        tt_game.is_active = True
+        ms_game.is_active = True
+
+        # _accepted_friends returns empty list; compatible_games returns 2 games
+        db.query.return_value.filter.return_value.all.side_effect = [
+            [],            # Friendship rows
+            [ms_game, tt_game],  # compatible games
+        ]
+
+        request = MagicMock()
+        request.query_params.get.return_value = None
+
+        with patch(f"{_BASE}.require_student_onboarding",               return_value=None), \
+             patch(f"{_BASE}._spec_ctx",                                 return_value={}), \
+             patch(f"{_BASE}.VirtualTrainingService.is_expert_unlocked", return_value=False), \
+             patch(f"{_BASE}.templates.TemplateResponse") as mock_tmpl:
+            mock_tmpl.return_value = MagicMock()
+            result = _run(challenge_send_form(
+                request=request, friend_id=None, game_code=None,
+                db=db, user=user,
+            ))
+
+        mock_tmpl.assert_called_once()
+        assert mock_tmpl.call_args[0][0] == "vt_challenge_send.html"
+
+
+# ── UI-25: Notification links → /challenges ───────────────────────────────────
+
+class TestNotificationLinks:
+
+    def _mock_db_for_challenge(self, ch):
+        db = _db()
+        db.query.return_value.filter.return_value.first.return_value = ch
+        return db
+
+    def test_ui25a_accept_notif_link(self):
+        from app.api.web_routes.vt_challenges import accept_challenge
+        ch = MagicMock()
+        ch.id             = 10
+        ch.challenged_id  = 2
+        ch.challenger_id  = 1
+        ch.status         = ChallengeStatus.PENDING
+        ch.expires_at     = datetime.now(timezone.utc) + timedelta(days=7)
+        db = self._mock_db_for_challenge(ch)
+        user = _user(uid=2)
+
+        captured_link = {}
+
+        def _capture(**kwargs):
+            captured_link["link"] = kwargs.get("link")
+        with patch(f"{_BASE}.notification_service.create_notification", side_effect=_capture):
+            _run(accept_challenge(challenge_id=10, db=db, user=user))
+
+        assert captured_link.get("link") == "/challenges"
+
+    def test_ui25b_decline_notif_link(self):
+        from app.api.web_routes.vt_challenges import decline_challenge
+        ch = MagicMock()
+        ch.id             = 10
+        ch.challenged_id  = 2
+        ch.challenger_id  = 1
+        ch.status         = ChallengeStatus.PENDING
+        db = self._mock_db_for_challenge(ch)
+        user = _user(uid=2)
+
+        captured_link = {}
+
+        def _capture(**kwargs):
+            captured_link["link"] = kwargs.get("link")
+        with patch(f"{_BASE}.notification_service.create_notification", side_effect=_capture):
+            _run(decline_challenge(challenge_id=10, db=db, user=user))
+
+        assert captured_link.get("link") == "/challenges"
+
+    def test_ui25c_cancel_notif_link(self):
+        from app.api.web_routes.vt_challenges import cancel_challenge
+        ch = MagicMock()
+        ch.id             = 10
+        ch.challenger_id  = 1
+        ch.challenged_id  = 2
+        ch.status         = ChallengeStatus.PENDING
+        db = self._mock_db_for_challenge(ch)
+        user = _user(uid=1)
+
+        captured_link = {}
+
+        def _capture(**kwargs):
+            captured_link["link"] = kwargs.get("link")
+        with patch(f"{_BASE}.notification_service.create_notification", side_effect=_capture):
+            _run(cancel_challenge(challenge_id=10, db=db, user=user))
+
+        assert captured_link.get("link") == "/challenges"
+
+    def test_ui25d_send_notif_link(self):
+        from app.api.web_routes.vt_challenges import send_challenge
+        user   = _user(uid=1)
+        target = _user(uid=2)
+        game   = _game(code="memory_sequence")
+        db     = _db()
+        db.query.return_value.filter.return_value.first.side_effect = [target, game, None]
+
+        captured_link = {}
+
+        def _capture(**kwargs):
+            captured_link["link"] = kwargs.get("link")
+
+        with patch(f"{_BASE}.is_friends",           return_value=True), \
+             patch(f"{_BASE}.get_active_challenge",   return_value=None), \
+             patch(f"{_BASE}.VirtualTrainingChallenge", MagicMock), \
+             patch(f"{_BASE}.notification_service.create_notification", side_effect=_capture):
+            _run(send_challenge(
+                challenged_user_id=2, game_id=1, message=None,
+                difficulty_level=None, db=db, user=user,
+            ))
+
+        assert captured_link.get("link") == "/challenges"
+
+
+# ── UI-26: _accepted_friends ──────────────────────────────────────────────────
+
+class TestAcceptedFriends:
+
+    def test_ui26_returns_friends_both_directions(self):
+        from app.api.web_routes.vt_challenges import _accepted_friends
+        from app.models.friendship import Friendship, FriendshipStatus
+
+        row1 = MagicMock(spec=Friendship)
+        row1.requester_id = 1
+        row1.addressee_id = 2
+        row1.status       = FriendshipStatus.ACCEPTED
+
+        row2 = MagicMock(spec=Friendship)
+        row2.requester_id = 3
+        row2.addressee_id = 1
+        row2.status       = FriendshipStatus.ACCEPTED
+
+        friend_a = _user(uid=2)
+        friend_b = _user(uid=3)
+
+        db = _db()
+        db.query.return_value.filter.return_value.all.return_value = [row1, row2]
+        db.query.return_value.filter.return_value.first.side_effect = [friend_a, friend_b]
+
+        result = _accepted_friends(db, user_id=1)
+        assert len(result) == 2
+        ids = {u.id for u in result}
+        assert ids == {2, 3}


### PR DESCRIPTION
## Summary

- **GET /challenges** — challenge inbox (active split from terminal/completed, 20 limit)
- **GET /challenges/send** — send form: friend selector, game selector (MS+TT only), TT difficulty selector (easy/medium/hard/expert with expert_unlocked guard), optional message
- **POST /challenges/send** — stores `difficulty_level` for TT; NULL for MS; invalid difficulty / expert_locked guard
- **Migration 2026_05_24_1100** — `difficulty_level VARCHAR(20)` column on `vt_challenges`
- **VT Hub** — ⚔ Challenge button on Memory Sequence and Target Tracking cards only
- **Friends page** — ⚔ Challenge button per accepted friend card
- **MS game template** — reads `?challenge_id` from URL → injects into fetch payload → appends `?challenge_id=X` to result redirect
- **TT game template** — reads `?challenge_id` + `?difficulty` from URL → preselects and locks difficulty selector → injects into fetch payload → appends `?challenge_id=X` to result redirect
- **MS/TT result pages** — challenge context block: won/lost/draw/waiting for opponent/both scores; link to /challenges
- **Notifications** — VT_CHALLENGE_* icons (⚔️ received, ✅ accepted, etc.); all notification links updated from /friends → /challenges
- **`_build_challenge_result_ctx`** — helper in virtual_training.py: validates participation + attempt ownership, builds context dict for result templates
- **`_build_inbox_row`** — helper in vt_challenges.py: builds inbox row including play_url (MS: `?challenge_id=X`; TT: `?challenge_id=X&difficulty=hard`)

## Test plan

- [x] 29 UI-01..UI-29 tests in `test_vt_challenges_ui.py` (all pass)
- [x] Existing 27 CH-* tests in `test_vt_challenges.py` (all pass)
- [x] Existing 31 S-* tests in `test_vt_submit_hook.py` (all pass)
- [x] Full unit suite: **10453 passed, 0 failed**
- [x] OpenAPI snapshot updated (792 routes)

## Forbidden scope (not in this PR)

Live challenge, WebSocket, challenge_seed, leaderboard, reward/XP bonus, CR/GNG challenge support, new scoring logic, pagination, real-time state sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)