### PR TITLE
feat(challenges): P1 async completion deadline + forfeit logic

### DIFF
--- a/alembic/versions/2026_05_25_1200_vt_challenge_completion_deadline.py
+++ b/alembic/versions/2026_05_25_1200_vt_challenge_completion_deadline.py
@@ -1,0 +1,48 @@
+"""Add completion deadline and forfeit fields to vt_challenges.
+
+Revision ID: 2026_05_25_1200
+Revises:     2026_05_25_1100
+Create Date: 2026-05-25 12:00:00
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision    = "2026_05_25_1200"
+down_revision = "2026_05_25_1100"
+branch_labels = None
+depends_on    = None
+
+
+def upgrade() -> None:
+    op.add_column("vt_challenges",
+        sa.Column("accepted_at", sa.DateTime(timezone=True), nullable=True))
+    op.add_column("vt_challenges",
+        sa.Column("completion_window_seconds", sa.Integer(), nullable=True))
+    op.add_column("vt_challenges",
+        sa.Column("completion_deadline", sa.DateTime(timezone=True), nullable=True))
+    op.add_column("vt_challenges",
+        sa.Column("forfeit_user_id",
+                  sa.Integer(),
+                  sa.ForeignKey("users.id", ondelete="SET NULL"),
+                  nullable=True))
+    op.add_column("vt_challenges",
+        sa.Column("forfeit_reason", sa.String(30), nullable=True))
+    op.create_check_constraint(
+        "ck_vt_forfeit_reason_valid",
+        "vt_challenges",
+        "forfeit_reason IS NULL OR forfeit_reason IN ('deadline_expired', 'no_contest')",
+    )
+    op.create_index("ix_vt_challenges_forfeit_user_id",
+                    "vt_challenges", ["forfeit_user_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_vt_challenges_forfeit_user_id", table_name="vt_challenges")
+    op.drop_constraint("ck_vt_forfeit_reason_valid", "vt_challenges", type_="check")
+    op.drop_column("vt_challenges", "forfeit_reason")
+    op.drop_column("vt_challenges", "forfeit_user_id")
+    op.drop_column("vt_challenges", "completion_deadline")
+    op.drop_column("vt_challenges", "completion_window_seconds")
+    op.drop_column("vt_challenges", "accepted_at")

--- a/app/api/web_routes/virtual_training.py
+++ b/app/api/web_routes/virtual_training.py
@@ -15,6 +15,7 @@ from ...models.user import User
 from ...models.virtual_training import VirtualTrainingAttempt, VirtualTrainingGame
 from ...models.vt_challenge import ChallengeStatus, VirtualTrainingChallenge
 from ...services import notification_service
+from ...services.challenge_completion_service import apply_forfeit_if_deadline_passed
 from ...services.virtual_training_service import VirtualTrainingService
 from .helpers import require_student_onboarding
 from .student_features import _spec_ctx
@@ -113,6 +114,12 @@ def _validate_challenge_pre_submit(
             status_code=409,
         )
 
+    # Late submit guard: block if deadline passed and this side has no prior attempt
+    if challenge.completion_deadline is not None and challenge.completion_deadline <= now:
+        apply_forfeit_if_deadline_passed(db, challenge, now)
+        db.commit()
+        return None, JSONResponse({"error": "challenge_deadline_passed"}, status_code=410)
+
     return challenge, None
 
 
@@ -137,7 +144,7 @@ def _send_completion_notifications(
             title="VT Challenge Completed",
             message=_msg(uid),
             notification_type=NotificationType.VT_CHALLENGE_COMPLETED,
-            link="/friends",
+            link="/challenges",
         )
 
 

--- a/app/api/web_routes/vt_challenges.py
+++ b/app/api/web_routes/vt_challenges.py
@@ -40,12 +40,16 @@ from ...models.user import User
 from ...models.virtual_training import VirtualTrainingAttempt, VirtualTrainingGame
 from ...models.vt_challenge import (
     CHALLENGE_COMPATIBLE_GAMES,
+    DEFAULT_COMPLETION_WINDOW,
     ChallengeStatus,
     VirtualTrainingChallenge,
     get_active_challenge,
+    make_completion_deadline,
     make_expires_at,
+    validate_completion_window,
 )
 from ...services import notification_service
+from ...services.challenge_completion_service import sweep_accepted_deadlines
 from ...services.challenge_snapshot_service import (
     generate_snapshot,
     validate_challenge_mode,
@@ -105,6 +109,8 @@ def _build_inbox_row(
     if ch.status == ChallengeStatus.COMPLETED:
         if ch.is_draw:
             outcome = "draw"
+        elif ch.forfeit_user_id is not None:
+            outcome = "forfeit_win" if ch.winner_id == user_id else "forfeit_loss"
         elif ch.winner_id == user_id:
             outcome = "won"
         else:
@@ -122,23 +128,26 @@ def _build_inbox_row(
         outcome = ch.status.value
 
     return {
-        "id":            ch.id,
-        "status":        ch.status.value,
-        "is_challenger": is_challenger,
-        "opponent_name": (opponent.nickname or opponent.email) if opponent else "Unknown",
-        "game_name":     game.name if game else "—",
-        "game_code":     game_code,
-        "difficulty_level": ch.difficulty_level,
-        "message":       ch.message,
-        "expires_at":    ch.expires_at,
-        "created_at":    ch.created_at,
-        "completed_at":  ch.completed_at,
-        "outcome":       outcome,
-        "play_url":      play_url,
-        "my_score":      my_attempt.score_normalized  if my_attempt  else None,
-        "opp_score":     opp_attempt.score_normalized if opp_attempt else None,
-        "winner_id":     ch.winner_id,
-        "is_draw":       ch.is_draw,
+        "id":                    ch.id,
+        "status":                ch.status.value,
+        "is_challenger":         is_challenger,
+        "opponent_name":         (opponent.nickname or opponent.email) if opponent else "Unknown",
+        "game_name":             game.name if game else "—",
+        "game_code":             game_code,
+        "difficulty_level":      ch.difficulty_level,
+        "message":               ch.message,
+        "expires_at":            ch.expires_at,
+        "created_at":            ch.created_at,
+        "completed_at":          ch.completed_at,
+        "outcome":               outcome,
+        "play_url":              play_url,
+        "my_score":              my_attempt.score_normalized  if my_attempt  else None,
+        "opp_score":             opp_attempt.score_normalized if opp_attempt else None,
+        "winner_id":             ch.winner_id,
+        "is_draw":               ch.is_draw,
+        "completion_deadline":   ch.completion_deadline,
+        "forfeit_user_id":       ch.forfeit_user_id,
+        "forfeit_reason":        ch.forfeit_reason,
     }
 
 
@@ -171,6 +180,16 @@ async def challenge_inbox(
                      if c.status in (ChallengeStatus.PENDING, ChallengeStatus.ACCEPTED)]
     terminal_chs  = [c for c in all_challenges
                      if c.status not in (ChallengeStatus.PENDING, ChallengeStatus.ACCEPTED)]
+
+    # Lazy deadline sweep — apply forfeit/no_contest for overdue ACCEPTED challenges
+    if sweep_accepted_deadlines(db, active_chs):
+        db.commit()
+        # Re-partition after sweep: some active_chs may now be terminal
+        active_chs   = [c for c in active_chs
+                        if c.status in (ChallengeStatus.PENDING, ChallengeStatus.ACCEPTED)]
+        terminal_chs = [c for c in all_challenges
+                        if c.status not in (ChallengeStatus.PENDING, ChallengeStatus.ACCEPTED)]
+
     terminal_chs  = terminal_chs[:_COMPLETED_LIMIT]
 
     shown = active_chs + terminal_chs
@@ -292,11 +311,12 @@ async def challenge_send_form(
 
 @router.post("/challenges/send")
 async def send_challenge(
-    challenged_user_id: int           = Form(...),
-    game_id:            int           = Form(...),
-    message:            str | None    = Form(default=None),
-    difficulty_level:   str | None    = Form(default=None),
-    challenge_mode:     str | None    = Form(default=None),
+    challenged_user_id:        int        = Form(...),
+    game_id:                   int        = Form(...),
+    message:                   str | None = Form(default=None),
+    difficulty_level:          str | None = Form(default=None),
+    challenge_mode:            str | None = Form(default=None),
+    completion_window_seconds: int | None = Form(default=None),
     db: Session = Depends(get_db),
     user: User  = Depends(get_current_user_web),
 ):
@@ -354,6 +374,16 @@ async def send_challenge(
                 url="/challenges/send?error=invalid_challenge_mode", status_code=303
             )
 
+    # Completion window validation — default 86400 (24h); completion_deadline set on accept
+    resolved_window = DEFAULT_COMPLETION_WINDOW
+    if isinstance(completion_window_seconds, int):
+        try:
+            resolved_window = validate_completion_window(completion_window_seconds)
+        except ValueError:
+            return RedirectResponse(
+                url="/challenges/send?error=invalid_completion_window", status_code=303
+            )
+
     # Snapshot generation — must succeed or challenge is NOT created
     try:
         snapshot = generate_snapshot(
@@ -368,16 +398,17 @@ async def send_challenge(
 
     now = datetime.now(timezone.utc)
     challenge = VirtualTrainingChallenge(
-        challenger_id             = user.id,
-        challenged_id             = challenged_user_id,
-        game_id                   = game_id,
-        status                    = ChallengeStatus.PENDING,
-        message                   = _trim_message(message),
-        difficulty_level          = resolved_difficulty,
-        challenge_mode            = resolved_mode,
-        challenge_config_snapshot = snapshot,
-        expires_at                = make_expires_at(now),
-        created_at                = now,
+        challenger_id              = user.id,
+        challenged_id              = challenged_user_id,
+        game_id                    = game_id,
+        status                     = ChallengeStatus.PENDING,
+        message                    = _trim_message(message),
+        difficulty_level           = resolved_difficulty,
+        challenge_mode             = resolved_mode,
+        challenge_config_snapshot  = snapshot,
+        completion_window_seconds  = resolved_window,
+        expires_at                 = make_expires_at(now),
+        created_at                 = now,
     )
     db.add(challenge)
     db.flush()
@@ -420,8 +451,13 @@ async def accept_challenge(
         db.commit()
         return RedirectResponse(url="/challenges?error=challenge_expired", status_code=303)
 
-    challenge.status     = ChallengeStatus.ACCEPTED
-    challenge.updated_at = now
+    challenge.status      = ChallengeStatus.ACCEPTED
+    challenge.accepted_at = now
+    challenge.updated_at  = now
+    if challenge.completion_window_seconds is not None:
+        challenge.completion_deadline = make_completion_deadline(
+            now, challenge.completion_window_seconds
+        )
 
     notification_service.create_notification(
         db=db,

--- a/app/models/notification.py
+++ b/app/models/notification.py
@@ -38,6 +38,7 @@ class NotificationType(enum.Enum):
     VT_CHALLENGE_CANCELLED = "vt_challenge_cancelled"
     VT_CHALLENGE_EXPIRED   = "vt_challenge_expired"
     VT_CHALLENGE_COMPLETED = "vt_challenge_completed"
+    VT_CHALLENGE_FORFEITED = "vt_challenge_forfeited"
 
 
 class Notification(Base):

--- a/app/models/vt_challenge.py
+++ b/app/models/vt_challenge.py
@@ -9,9 +9,23 @@ Lifecycle (PR-C1):
 PR-C2 adds:
   ACCEPTED → COMPLETED  (both attempts submitted, winner_id / is_draw set)
 
+PR-P1 adds:
+  ACCEPTED → COMPLETED  (one side played before deadline, other did not → forfeit win)
+  ACCEPTED → EXPIRED    (neither played before deadline → no_contest)
+
 Expiry:
   expires_at = created_at + 7 days (set at creation).
   Accept guard checks expires_at <= now() → rejects with EXPIRED status.
+
+Completion deadline (PR-P1):
+  accepted_at set when challenged accepts.
+  completion_deadline = accepted_at + completion_window_seconds.
+  NULL completion_deadline (legacy challenges) → deadline logic skipped entirely.
+
+Forfeit (PR-P1):
+  forfeit_user_id = user who did not play in time.
+  forfeit_reason  = 'deadline_expired' | 'no_contest'.
+  Late submit (after deadline, no prior attempt on that side) is blocked.
 
 Game compatibility:
   Only games in CHALLENGE_COMPATIBLE_GAMES (by game.code) are allowed.
@@ -24,7 +38,7 @@ from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import (
     Boolean, CheckConstraint, Column, DateTime, Enum,
-    ForeignKey, Integer, String, Text, UniqueConstraint,
+    ForeignKey, Integer, String, Text,
 )
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Session, relationship
@@ -37,6 +51,16 @@ CHALLENGE_COMPATIBLE_GAMES: frozenset[str] = frozenset({
     "target_tracking",
 })
 
+# ── Completion window options (seconds) ───────────────────────────────────────
+VALID_COMPLETION_WINDOWS: frozenset[int] = frozenset({
+    1800,    # 30 minutes
+    3600,    # 1 hour
+    86400,   # 24 hours (default)
+    259200,  # 3 days
+    604800,  # 7 days
+})
+DEFAULT_COMPLETION_WINDOW: int = 86400
+
 
 # ── Enum ───────────────────────────────────────────────────────────────────────
 
@@ -46,7 +70,7 @@ class ChallengeStatus(enum.Enum):
     DECLINED  = "declined"
     EXPIRED   = "expired"
     CANCELLED = "cancelled"
-    COMPLETED = "completed"   # set by PR-C2 submit hook
+    COMPLETED = "completed"
 
 
 # ── Model ──────────────────────────────────────────────────────────────────────
@@ -61,6 +85,10 @@ class VirtualTrainingChallenge(Base):
         CheckConstraint(
             "challenge_mode IN ('async', 'live')",
             name="ck_vt_challenge_mode_valid",
+        ),
+        CheckConstraint(
+            "forfeit_reason IS NULL OR forfeit_reason IN ('deadline_expired', 'no_contest')",
+            name="ck_vt_forfeit_reason_valid",
         ),
     )
 
@@ -85,7 +113,7 @@ class VirtualTrainingChallenge(Base):
     challenged_attempt_id = Column(Integer,
                                    ForeignKey("virtual_training_attempts.id", ondelete="SET NULL"),
                                    nullable=True)
-    difficulty_level           = Column(String(20), nullable=True)   # TT only; NULL for MS
+    difficulty_level           = Column(String(20), nullable=True)
     challenge_mode             = Column(String(10), nullable=False, default="async",
                                         server_default="async")
     challenge_config_snapshot  = Column(JSONB, nullable=True)
@@ -98,10 +126,20 @@ class VirtualTrainingChallenge(Base):
                                    default=lambda: datetime.now(timezone.utc))
     updated_at            = Column(DateTime(timezone=True), nullable=True)
 
-    challenger = relationship("User", foreign_keys=[challenger_id])
-    challenged = relationship("User", foreign_keys=[challenged_id])
-    winner     = relationship("User", foreign_keys=[winner_id])
-    game       = relationship("VirtualTrainingGame")
+    # PR-P1 — completion deadline + forfeit
+    accepted_at                = Column(DateTime(timezone=True), nullable=True)
+    completion_window_seconds  = Column(Integer, nullable=True)
+    completion_deadline        = Column(DateTime(timezone=True), nullable=True)
+    forfeit_user_id            = Column(Integer,
+                                        ForeignKey("users.id", ondelete="SET NULL"),
+                                        nullable=True, index=True)
+    forfeit_reason             = Column(String(30), nullable=True)
+
+    challenger   = relationship("User", foreign_keys=[challenger_id])
+    challenged   = relationship("User", foreign_keys=[challenged_id])
+    winner       = relationship("User", foreign_keys=[winner_id])
+    game         = relationship("VirtualTrainingGame")
+    forfeit_user = relationship("User", foreign_keys=[forfeit_user_id])
 
 
 # ── Helpers ────────────────────────────────────────────────────────────────────
@@ -109,6 +147,19 @@ class VirtualTrainingChallenge(Base):
 def make_expires_at(created_at: datetime | None = None) -> datetime:
     base = created_at or datetime.now(timezone.utc)
     return base + timedelta(days=7)
+
+
+def validate_completion_window(seconds: int) -> int:
+    if seconds not in VALID_COMPLETION_WINDOWS:
+        raise ValueError(
+            f"Invalid completion_window_seconds {seconds!r}. "
+            f"Must be one of: {sorted(VALID_COMPLETION_WINDOWS)}"
+        )
+    return seconds
+
+
+def make_completion_deadline(accepted_at: datetime, window_seconds: int) -> datetime:
+    return accepted_at + timedelta(seconds=window_seconds)
 
 
 def get_active_challenge(

--- a/app/services/challenge_completion_service.py
+++ b/app/services/challenge_completion_service.py
@@ -1,0 +1,128 @@
+"""challenge_completion_service — PR-P1 async deadline + forfeit logic.
+
+Forfeit rules (applied only when completion_deadline is not NULL):
+  - Only attempts submitted BEFORE the deadline count toward forfeit determination.
+  - A late submit (no prior attempt on that side) is BLOCKED at the route layer
+    before this service is called.
+  - apply_forfeit_if_deadline_passed() is idempotent: safe to call multiple times.
+
+Outcome matrix:
+  challenger played + challenged did not → challenger wins, challenged forfeits
+  challenged played + challenger did not → challenged wins, challenger forfeits
+  neither played                         → EXPIRED, no_contest
+  both played (already COMPLETED)        → no-op (status not ACCEPTED)
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from ..models.notification import NotificationType
+from ..models.vt_challenge import ChallengeStatus, VirtualTrainingChallenge
+from . import notification_service
+
+
+def apply_forfeit_if_deadline_passed(
+    db: Session,
+    challenge: VirtualTrainingChallenge,
+    now: datetime,
+) -> bool:
+    """Apply forfeit if completion_deadline has passed. Returns True if state changed.
+
+    Only acts on ACCEPTED challenges with a non-NULL completion_deadline.
+    Does NOT flush or commit — caller is responsible.
+    """
+    if challenge.status != ChallengeStatus.ACCEPTED:
+        return False
+    if challenge.completion_deadline is None:
+        return False
+    if challenge.completion_deadline > now:
+        return False
+
+    has_cr = challenge.challenger_attempt_id is not None
+    has_cd = challenge.challenged_attempt_id is not None
+
+    if has_cr and not has_cd:
+        challenge.winner_id       = challenge.challenger_id
+        challenge.is_draw         = False
+        challenge.forfeit_user_id = challenge.challenged_id
+        challenge.forfeit_reason  = "deadline_expired"
+        challenge.status          = ChallengeStatus.COMPLETED
+        challenge.completed_at    = now
+        challenge.updated_at      = now
+        _send_forfeit_notifications(db, challenge)
+    elif has_cd and not has_cr:
+        challenge.winner_id       = challenge.challenged_id
+        challenge.is_draw         = False
+        challenge.forfeit_user_id = challenge.challenger_id
+        challenge.forfeit_reason  = "deadline_expired"
+        challenge.status          = ChallengeStatus.COMPLETED
+        challenge.completed_at    = now
+        challenge.updated_at      = now
+        _send_forfeit_notifications(db, challenge)
+    else:
+        # neither played (or already both — but COMPLETED check above guards that)
+        challenge.status         = ChallengeStatus.EXPIRED
+        challenge.forfeit_reason = "no_contest"
+        challenge.updated_at     = now
+        _send_no_contest_notifications(db, challenge)
+
+    return True
+
+
+def sweep_accepted_deadlines(
+    db: Session,
+    challenges: list[VirtualTrainingChallenge],
+) -> int:
+    """Lazy sweep: apply forfeit to all ACCEPTED challenges past their deadline.
+
+    Flushes to DB if any changes were made. Does NOT commit — caller commits.
+    Returns count of modified challenges.
+    """
+    now = datetime.now(timezone.utc)
+    count = 0
+    for ch in challenges:
+        if apply_forfeit_if_deadline_passed(db, ch, now):
+            count += 1
+    if count:
+        db.flush()
+    return count
+
+
+def _send_forfeit_notifications(
+    db: Session,
+    challenge: VirtualTrainingChallenge,
+) -> None:
+    winner_id   = challenge.winner_id
+    forfeit_uid = challenge.forfeit_user_id
+
+    def _msg(for_uid: int) -> str:
+        if for_uid == winner_id:
+            return "You won by forfeit — your opponent did not play in time."
+        return "You lost by forfeit — you did not play in time."
+
+    for uid in (challenge.challenger_id, challenge.challenged_id):
+        notification_service.create_notification(
+            db=db,
+            user_id=uid,
+            title="VT Challenge — Forfeit",
+            message=_msg(uid),
+            notification_type=NotificationType.VT_CHALLENGE_FORFEITED,
+            link="/challenges",
+        )
+
+
+def _send_no_contest_notifications(
+    db: Session,
+    challenge: VirtualTrainingChallenge,
+) -> None:
+    for uid in (challenge.challenger_id, challenge.challenged_id):
+        notification_service.create_notification(
+            db=db,
+            user_id=uid,
+            title="VT Challenge — No Contest",
+            message="The challenge expired — neither player completed it in time.",
+            notification_type=NotificationType.VT_CHALLENGE_FORFEITED,
+            link="/challenges",
+        )

--- a/app/templates/vt_challenge_send.html
+++ b/app/templates/vt_challenge_send.html
@@ -86,8 +86,9 @@
     {% elif error == "game_not_found"    %}Game not found.
     {% elif error == "game_not_compatible" %}This game does not support challenges.
     {% elif error == "invalid_difficulty" %}Invalid difficulty selected.
-    {% elif error == "expert_locked"     %}Expert difficulty is not unlocked yet (need 70%+ on 3 Hard attempts).
-    {% elif error == "user_not_found"    %}Player not found.
+    {% elif error == "expert_locked"             %}Expert difficulty is not unlocked yet (need 70%+ on 3 Hard attempts).
+    {% elif error == "user_not_found"            %}Player not found.
+    {% elif error == "invalid_completion_window" %}Invalid completion window selected.
     {% else %}{{ error }}
     {% endif %}
 </div>
@@ -176,6 +177,21 @@
                     <div class="cs-diff-locked">Unlock: 70%+ on 3 Hard attempts</div>
                 </div>
                 {% endif %}
+            </div>
+        </div>
+
+        {# ── Completion window ── #}
+        <div class="cs-field">
+            <label class="cs-label" for="cs-window">Completion Window</label>
+            <select name="completion_window_seconds" id="cs-window" class="cs-select">
+                <option value="1800">30 minutes</option>
+                <option value="3600">1 hour</option>
+                <option value="86400" selected>24 hours (default)</option>
+                <option value="259200">3 days</option>
+                <option value="604800">7 days</option>
+            </select>
+            <div style="font-size:0.75rem;color:var(--app-text-muted);margin-top:0.3rem;">
+                Timer starts after opponent accepts.
             </div>
         </div>
 

--- a/app/templates/vt_challenges.html
+++ b/app/templates/vt_challenges.html
@@ -52,14 +52,26 @@
     display: inline-block; font-size: 0.75rem; font-weight: 700;
     padding: 0.2rem 0.65rem; border-radius: 20px; white-space: nowrap;
 }
-.ch-badge-pending   { background: #fef9c3; color: #854d0e; }
-.ch-badge-accepted  { background: #dbeafe; color: #1e40af; }
-.ch-badge-won       { background: #dcfce7; color: #166534; }
-.ch-badge-lost      { background: #fee2e2; color: #991b1b; }
-.ch-badge-draw      { background: #f3f4f6; color: #374151; }
-.ch-badge-declined  { background: #f3f4f6; color: #6b7280; }
-.ch-badge-cancelled { background: #f3f4f6; color: #6b7280; }
-.ch-badge-expired   { background: #fef3c7; color: #92400e; }
+.ch-badge-pending      { background: #fef9c3; color: #854d0e; }
+.ch-badge-accepted     { background: #dbeafe; color: #1e40af; }
+.ch-badge-won          { background: #dcfce7; color: #166534; }
+.ch-badge-lost         { background: #fee2e2; color: #991b1b; }
+.ch-badge-draw         { background: #f3f4f6; color: #374151; }
+.ch-badge-declined     { background: #f3f4f6; color: #6b7280; }
+.ch-badge-cancelled    { background: #f3f4f6; color: #6b7280; }
+.ch-badge-expired      { background: #fef3c7; color: #92400e; }
+.ch-badge-forfeit-win  { background: #dcfce7; color: #166534; }
+.ch-badge-forfeit-loss { background: #fee2e2; color: #991b1b; }
+.ch-badge-no-contest   { background: #fef3c7; color: #92400e; }
+
+.ch-deadline {
+    font-size: 0.78rem; color: #6b7280; margin-bottom: 0.5rem;
+}
+.ch-deadline.urgent { color: #b45309; font-weight: 600; }
+.ch-outcome-note {
+    font-size: 0.8rem; color: var(--app-text-muted); font-style: italic;
+    margin-top: 0.35rem;
+}
 
 .ch-meta { font-size: 0.78rem; color: var(--app-text-muted); margin-bottom: 0.6rem; }
 .ch-message {
@@ -161,6 +173,12 @@
         Expires {{ row.expires_at.strftime('%Y-%m-%d') }}
     </div>
 
+    {% if row.status == "accepted" and row.completion_deadline %}
+    <div class="ch-deadline">
+        ⏱ Deadline: {{ row.completion_deadline.strftime('%Y-%m-%d %H:%M') }} UTC
+    </div>
+    {% endif %}
+
     {% if row.message %}
     <div class="ch-message">"{{ row.message }}"</div>
     {% endif %}
@@ -218,10 +236,16 @@
         <span class="ch-badge ch-badge-lost">✗ Lost</span>
         {% elif row.outcome == "draw" %}
         <span class="ch-badge ch-badge-draw">= Draw</span>
+        {% elif row.outcome == "forfeit_win" %}
+        <span class="ch-badge ch-badge-forfeit-win">🏆 Won (Forfeit)</span>
+        {% elif row.outcome == "forfeit_loss" %}
+        <span class="ch-badge ch-badge-forfeit-loss">✗ Lost (Forfeit)</span>
         {% elif row.status == "declined" %}
         <span class="ch-badge ch-badge-declined">Declined</span>
         {% elif row.status == "cancelled" %}
         <span class="ch-badge ch-badge-cancelled">Cancelled</span>
+        {% elif row.status == "expired" and row.forfeit_reason == "no_contest" %}
+        <span class="ch-badge ch-badge-no-contest">No Contest</span>
         {% elif row.status == "expired" %}
         <span class="ch-badge ch-badge-expired">Expired</span>
         {% else %}
@@ -254,6 +278,14 @@
             </span>
         </div>
     </div>
+    {% endif %}
+
+    {% if row.outcome == "forfeit_win" %}
+    <div class="ch-outcome-note">Won by forfeit — opponent did not play in time.</div>
+    {% elif row.outcome == "forfeit_loss" %}
+    <div class="ch-outcome-note">Lost by forfeit — you did not play in time.</div>
+    {% elif row.status == "expired" and row.forfeit_reason == "no_contest" %}
+    <div class="ch-outcome-note">No contest — deadline passed and nobody played.</div>
     {% endif %}
 </div>
 {% endfor %}

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -4234,6 +4234,17 @@
             "title": "Challenged User Id",
             "type": "integer"
           },
+          "completion_window_seconds": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Completion Window Seconds"
+          },
           "difficulty_level": {
             "anyOf": [
               {
@@ -11455,7 +11466,8 @@
           "vt_challenge_declined",
           "vt_challenge_cancelled",
           "vt_challenge_expired",
-          "vt_challenge_completed"
+          "vt_challenge_completed",
+          "vt_challenge_forfeited"
         ],
         "title": "NotificationType",
         "type": "string"

--- a/tests/unit/api/web_routes/test_virtual_training.py
+++ b/tests/unit/api/web_routes/test_virtual_training.py
@@ -1207,3 +1207,91 @@ class TestSnapshotGetRoutes:
         assert "_snapSeq(" in content
         # The sampleIndices function is still defined (used for normal mode in else branch)
         assert "sampleIndices" in content
+
+
+# ── PR-P1: Late submit guard + notification link ──────────────────────────────
+
+class TestLateSubmitGuard:
+    """ASYNC-06, ASYNC-13: _validate_challenge_pre_submit blocks past-deadline submits."""
+
+    _BASE_VT = "app.api.web_routes.virtual_training"
+
+    def _ch_mock(self, challenger_attempt_id=None, challenged_attempt_id=None):
+        from app.models.vt_challenge import ChallengeStatus, VirtualTrainingChallenge
+        from datetime import datetime, timezone
+        c = MagicMock(spec=VirtualTrainingChallenge)
+        c.id = 10
+        c.challenger_id = 1
+        c.challenged_id = 2
+        c.game_id = 5
+        c.status = ChallengeStatus.ACCEPTED
+        c.expires_at = datetime(2099, 1, 1, tzinfo=timezone.utc)
+        c.completion_deadline = datetime(2020, 1, 1, tzinfo=timezone.utc)  # past
+        c.challenger_attempt_id = challenger_attempt_id
+        c.challenged_attempt_id = challenged_attempt_id
+        return c
+
+    def test_async06_deadline_passed_opponent_played_returns_410(self):
+        """Late submit blocked: deadline past, opponent already has an attempt."""
+        from app.api.web_routes.virtual_training import _validate_challenge_pre_submit
+        ch = self._ch_mock(challenger_attempt_id=None, challenged_attempt_id=88)
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = ch
+
+        with patch(f"{self._BASE_VT}.apply_forfeit_if_deadline_passed") as mock_forfeit:
+            challenge_result, err = _validate_challenge_pre_submit(db, 10, user_id=1, game_id=5)
+
+        assert challenge_result is None
+        assert err is not None
+        assert err.status_code == 410
+        mock_forfeit.assert_called_once()
+        db.commit.assert_called_once()
+
+    def test_async13_deadline_passed_neither_played_returns_410(self):
+        """Late submit blocked: deadline past, neither player has attempted yet."""
+        from app.api.web_routes.virtual_training import _validate_challenge_pre_submit
+        ch = self._ch_mock(challenger_attempt_id=None, challenged_attempt_id=None)
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = ch
+
+        with patch(f"{self._BASE_VT}.apply_forfeit_if_deadline_passed") as mock_forfeit:
+            challenge_result, err = _validate_challenge_pre_submit(db, 10, user_id=1, game_id=5)
+
+        assert challenge_result is None
+        assert err is not None
+        assert err.status_code == 410
+        mock_forfeit.assert_called_once()
+        db.commit.assert_called_once()
+
+
+class TestCompletionNotificationLink:
+    """ASYNC-11: _send_completion_notifications uses /challenges not /friends."""
+
+    def test_async11_winner_notification_links_to_challenges(self):
+        from app.api.web_routes.virtual_training import _send_completion_notifications
+        from app.models.notification import NotificationType
+        ch = MagicMock()
+        ch.challenger_id = 1
+        ch.challenged_id = 2
+        db = MagicMock()
+
+        with patch("app.api.web_routes.virtual_training.notification_service") as mock_svc:
+            _send_completion_notifications(db, ch, winner_id=1, is_draw=False)
+
+        assert mock_svc.create_notification.call_count == 2
+        for call in mock_svc.create_notification.call_args_list:
+            assert call.kwargs["link"] == "/challenges"
+            assert call.kwargs["notification_type"] == NotificationType.VT_CHALLENGE_COMPLETED
+
+    def test_async11b_draw_notification_links_to_challenges(self):
+        from app.api.web_routes.virtual_training import _send_completion_notifications
+        ch = MagicMock()
+        ch.challenger_id = 1
+        ch.challenged_id = 2
+        db = MagicMock()
+
+        with patch("app.api.web_routes.virtual_training.notification_service") as mock_svc:
+            _send_completion_notifications(db, ch, winner_id=None, is_draw=True)
+
+        for call in mock_svc.create_notification.call_args_list:
+            assert call.kwargs["link"] == "/challenges"

--- a/tests/unit/api/web_routes/test_vt_challenges.py
+++ b/tests/unit/api/web_routes/test_vt_challenges.py
@@ -75,6 +75,11 @@ def _challenge(
     game_id=1,
     status=ChallengeStatus.PENDING,
     expires_at=None,
+    completion_window_seconds=None,
+    completion_deadline=None,
+    accepted_at=None,
+    challenger_attempt_id=None,
+    challenged_attempt_id=None,
 ):
     c = MagicMock(spec=VirtualTrainingChallenge)
     c.id = cid
@@ -83,6 +88,11 @@ def _challenge(
     c.game_id = game_id
     c.status = status
     c.expires_at = expires_at or (datetime.now(timezone.utc) + timedelta(days=7))
+    c.completion_window_seconds = completion_window_seconds
+    c.completion_deadline = completion_deadline
+    c.accepted_at = accepted_at
+    c.challenger_attempt_id = challenger_attempt_id
+    c.challenged_attempt_id = challenged_attempt_id
     return c
 
 
@@ -650,3 +660,127 @@ class TestModelSnapshotColumns:
         args = VirtualTrainingChallenge.__table_args__
         names = {c.name for c in args if isinstance(c, CheckConstraint)}
         assert "ck_vt_challenge_mode_valid" in names
+
+
+# ── PR-P1: Completion window / deadline / forfeit ─────────────────────────────
+
+class TestCompletionWindowModel:
+    """ASYNC-01..03: model helpers."""
+
+    def test_async01_new_columns_present(self):
+        cols = {c.key for c in VirtualTrainingChallenge.__table__.columns}
+        assert {"accepted_at", "completion_window_seconds",
+                "completion_deadline", "forfeit_user_id",
+                "forfeit_reason"}.issubset(cols)
+
+    def test_async01b_forfeit_reason_check_constraint_present(self):
+        args = VirtualTrainingChallenge.__table_args__
+        names = {c.name for c in args if isinstance(c, CheckConstraint)}
+        assert "ck_vt_forfeit_reason_valid" in names
+
+    def test_async02_valid_completion_windows_has_five_values(self):
+        from app.models.vt_challenge import VALID_COMPLETION_WINDOWS
+        assert len(VALID_COMPLETION_WINDOWS) == 5
+        assert {1800, 3600, 86400, 259200, 604800} == VALID_COMPLETION_WINDOWS
+
+    def test_async03a_validate_completion_window_accepts_all_valid(self):
+        from app.models.vt_challenge import validate_completion_window, VALID_COMPLETION_WINDOWS
+        for v in VALID_COMPLETION_WINDOWS:
+            assert validate_completion_window(v) == v
+
+    def test_async03b_validate_completion_window_rejects_invalid(self):
+        from app.models.vt_challenge import validate_completion_window
+        import pytest
+        with pytest.raises(ValueError):
+            validate_completion_window(9999)
+
+    def test_async03c_make_completion_deadline_correct(self):
+        from app.models.vt_challenge import make_completion_deadline
+        t0 = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        result = make_completion_deadline(t0, 86400)
+        assert result == t0 + timedelta(seconds=86400)
+
+
+class TestSendChallengeCompletionWindow:
+    """ASYNC-04, ASYNC-05, ASYNC-15: send_challenge completion window handling."""
+
+    def _send(self, completion_window_seconds=None):
+        from app.api.web_routes.vt_challenges import send_challenge
+        user   = _user(uid=1)
+        target = _user(uid=2)
+        game   = _game(code="memory_sequence")
+        db     = _db()
+        db.query.return_value.filter.return_value.first.side_effect = [target, game]
+
+        _snap = {"game_code": "memory_sequence", "grid_tiles": 12, "phases": []}
+        with patch(f"{_BASE}.is_friends", return_value=True), \
+             patch(f"{_BASE}.get_active_challenge", return_value=None), \
+             patch(f"{_BASE}.generate_snapshot", return_value=_snap), \
+             patch(f"{_BASE}.notification_service"):
+            result = _run(send_challenge(
+                challenged_user_id=2,
+                game_id=1,
+                message=None,
+                completion_window_seconds=completion_window_seconds,
+                db=db,
+                user=user,
+            ))
+        return result, db
+
+    def test_async04_default_window_stored_when_none(self):
+        result, db = self._send(completion_window_seconds=None)
+        assert "success=challenge_sent" in result.headers["location"]
+        added = db.add.call_args[0][0]
+        assert added.completion_window_seconds == 86400
+
+    def test_async05_explicit_valid_window_stored(self):
+        result, db = self._send(completion_window_seconds=3600)
+        assert "success=challenge_sent" in result.headers["location"]
+        added = db.add.call_args[0][0]
+        assert added.completion_window_seconds == 3600
+
+    def test_async15_invalid_window_redirects_with_error(self):
+        result, db = self._send(completion_window_seconds=9999)
+        assert isinstance(result, RedirectResponse)
+        assert "error=invalid_completion_window" in result.headers["location"]
+        db.add.assert_not_called()
+
+
+class TestAcceptChallengeDeadline:
+    """ASYNC-10: accept_challenge sets accepted_at + completion_deadline."""
+
+    def test_async10_accept_sets_accepted_at_and_deadline(self):
+        from app.api.web_routes.vt_challenges import accept_challenge
+        user = _user(uid=2)
+        row = _challenge(
+            challenger_id=1, challenged_id=2,
+            status=ChallengeStatus.PENDING,
+            completion_window_seconds=86400,
+        )
+        db = _db()
+        db.query.return_value.filter.return_value.first.return_value = row
+
+        with patch(f"{_BASE}.notification_service"):
+            _run(accept_challenge(challenge_id=10, db=db, user=user))
+
+        assert row.accepted_at is not None
+        assert row.completion_deadline is not None
+        delta = row.completion_deadline - row.accepted_at
+        assert abs(delta.total_seconds() - 86400) < 2
+
+    def test_async10b_null_window_no_deadline_set(self):
+        from app.api.web_routes.vt_challenges import accept_challenge
+        user = _user(uid=2)
+        row = _challenge(
+            challenger_id=1, challenged_id=2,
+            status=ChallengeStatus.PENDING,
+            completion_window_seconds=None,
+        )
+        db = _db()
+        db.query.return_value.filter.return_value.first.return_value = row
+
+        with patch(f"{_BASE}.notification_service"):
+            _run(accept_challenge(challenge_id=10, db=db, user=user))
+
+        # completion_deadline should remain None since window is None
+        assert row.completion_deadline is None

--- a/tests/unit/api/web_routes/test_vt_challenges_ui.py
+++ b/tests/unit/api/web_routes/test_vt_challenges_ui.py
@@ -86,6 +86,9 @@ def _challenge(
     completed_at=None,
     message=None,
     created_at=None,
+    forfeit_user_id=None,
+    forfeit_reason=None,
+    completion_deadline=None,
 ):
     c = MagicMock(spec=VirtualTrainingChallenge)
     c.id                    = cid
@@ -102,6 +105,9 @@ def _challenge(
     c.completed_at          = completed_at
     c.message               = message
     c.created_at            = created_at or datetime.now(timezone.utc)
+    c.forfeit_user_id       = forfeit_user_id
+    c.forfeit_reason        = forfeit_reason
+    c.completion_deadline   = completion_deadline
     return c
 
 
@@ -597,11 +603,12 @@ class TestNotificationLinks:
     def test_ui25a_accept_notif_link(self):
         from app.api.web_routes.vt_challenges import accept_challenge
         ch = MagicMock()
-        ch.id             = 10
-        ch.challenged_id  = 2
-        ch.challenger_id  = 1
-        ch.status         = ChallengeStatus.PENDING
-        ch.expires_at     = datetime.now(timezone.utc) + timedelta(days=7)
+        ch.id                       = 10
+        ch.challenged_id            = 2
+        ch.challenger_id            = 1
+        ch.status                   = ChallengeStatus.PENDING
+        ch.expires_at               = datetime.now(timezone.utc) + timedelta(days=7)
+        ch.completion_window_seconds = None
         db = self._mock_db_for_challenge(ch)
         user = _user(uid=2)
 

--- a/tests/unit/api/web_routes/test_vt_submit_hook.py
+++ b/tests/unit/api/web_routes/test_vt_submit_hook.py
@@ -107,6 +107,7 @@ def _challenge(
     expires_at=None,
     challenger_attempt_id=None,
     challenged_attempt_id=None,
+    completion_deadline=None,
 ):
     c = MagicMock(spec=VirtualTrainingChallenge)
     c.id = cid
@@ -117,6 +118,7 @@ def _challenge(
     c.expires_at = expires_at or (datetime.now(timezone.utc) + timedelta(days=5))
     c.challenger_attempt_id = challenger_attempt_id
     c.challenged_attempt_id = challenged_attempt_id
+    c.completion_deadline = completion_deadline
     c.winner_id = None
     c.is_draw = False
     c.completed_at = None

--- a/tests/unit/services/test_challenge_completion_service.py
+++ b/tests/unit/services/test_challenge_completion_service.py
@@ -1,0 +1,181 @@
+"""Unit tests for challenge_completion_service — PR-P1 async deadline + forfeit logic.
+
+ASYNC-07  apply_forfeit_if_deadline_passed — non-ACCEPTED status → no-op, returns False
+ASYNC-08  apply_forfeit_if_deadline_passed — deadline in future → no-op, returns False
+ASYNC-09  apply_forfeit_if_deadline_passed — challenger played, challenged didn't → forfeit win (challenger)
+ASYNC-12  apply_forfeit_if_deadline_passed — challenged played, challenger didn't → forfeit win (challenged)
+ASYNC-14  sweep_accepted_deadlines — applies to past-deadline challenges, returns count, flushes once
+ASYNC-16  apply_forfeit_if_deadline_passed — NULL completion_deadline → no-op, returns False
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+from app.models.vt_challenge import ChallengeStatus, VirtualTrainingChallenge
+
+_BASE_SVC = "app.services.challenge_completion_service"
+
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+
+def _ch(
+    status=ChallengeStatus.ACCEPTED,
+    completion_deadline=None,
+    challenger_attempt_id=None,
+    challenged_attempt_id=None,
+    challenger_id=1,
+    challenged_id=2,
+):
+    c = MagicMock(spec=VirtualTrainingChallenge)
+    c.status = status
+    c.completion_deadline = completion_deadline
+    c.challenger_attempt_id = challenger_attempt_id
+    c.challenged_attempt_id = challenged_attempt_id
+    c.challenger_id = challenger_id
+    c.challenged_id = challenged_id
+    c.winner_id = None
+    c.is_draw = False
+    c.forfeit_user_id = None
+    c.forfeit_reason = None
+    return c
+
+
+def _db():
+    return MagicMock()
+
+
+_PAST = datetime(2020, 1, 1, tzinfo=timezone.utc)
+_NOW  = datetime(2026, 5, 25, 12, 0, 0, tzinfo=timezone.utc)
+_FUTURE = datetime(2099, 1, 1, tzinfo=timezone.utc)
+
+
+# ── ASYNC-07 ───────────────────────────────────────────────────────────────────
+
+class TestApplyForfeitNoOps:
+
+    def test_async07_non_accepted_status_returns_false(self):
+        from app.services.challenge_completion_service import apply_forfeit_if_deadline_passed
+        for st in (ChallengeStatus.PENDING, ChallengeStatus.COMPLETED,
+                   ChallengeStatus.EXPIRED, ChallengeStatus.DECLINED,
+                   ChallengeStatus.CANCELLED):
+            c = _ch(status=st, completion_deadline=_PAST)
+            result = apply_forfeit_if_deadline_passed(_db(), c, _NOW)
+            assert result is False, f"Expected False for status={st}"
+            assert c.status == st  # unchanged
+
+    # ASYNC-08
+    def test_async08_deadline_in_future_returns_false(self):
+        from app.services.challenge_completion_service import apply_forfeit_if_deadline_passed
+        c = _ch(completion_deadline=_FUTURE)
+        result = apply_forfeit_if_deadline_passed(_db(), c, _NOW)
+        assert result is False
+        assert c.status == ChallengeStatus.ACCEPTED
+
+    # ASYNC-16
+    def test_async16_null_deadline_returns_false(self):
+        from app.services.challenge_completion_service import apply_forfeit_if_deadline_passed
+        c = _ch(completion_deadline=None)
+        result = apply_forfeit_if_deadline_passed(_db(), c, _NOW)
+        assert result is False
+        assert c.status == ChallengeStatus.ACCEPTED
+
+
+# ── ASYNC-09 ───────────────────────────────────────────────────────────────────
+
+class TestApplyForfeitChallenger:
+
+    def test_async09_challenger_played_challenged_forfeits(self):
+        from app.services.challenge_completion_service import apply_forfeit_if_deadline_passed
+        c = _ch(
+            completion_deadline=_PAST,
+            challenger_attempt_id=99,   # challenger played
+            challenged_attempt_id=None, # challenged did not
+        )
+        db = _db()
+        with patch(f"{_BASE_SVC}.notification_service"):
+            result = apply_forfeit_if_deadline_passed(db, c, _NOW)
+
+        assert result is True
+        assert c.status == ChallengeStatus.COMPLETED
+        assert c.winner_id == 1          # challenger_id
+        assert c.forfeit_user_id == 2    # challenged_id
+        assert c.forfeit_reason == "deadline_expired"
+        assert c.is_draw is False
+        assert c.completed_at == _NOW
+        assert c.updated_at == _NOW
+
+
+# ── ASYNC-12 ───────────────────────────────────────────────────────────────────
+
+class TestApplyForfeitChallenged:
+
+    def test_async12_challenged_played_challenger_forfeits(self):
+        from app.services.challenge_completion_service import apply_forfeit_if_deadline_passed
+        c = _ch(
+            completion_deadline=_PAST,
+            challenger_attempt_id=None, # challenger did not play
+            challenged_attempt_id=88,   # challenged played
+        )
+        db = _db()
+        with patch(f"{_BASE_SVC}.notification_service"):
+            result = apply_forfeit_if_deadline_passed(db, c, _NOW)
+
+        assert result is True
+        assert c.status == ChallengeStatus.COMPLETED
+        assert c.winner_id == 2          # challenged_id
+        assert c.forfeit_user_id == 1    # challenger_id
+        assert c.forfeit_reason == "deadline_expired"
+        assert c.is_draw is False
+
+    def test_async12b_neither_played_no_contest(self):
+        from app.services.challenge_completion_service import apply_forfeit_if_deadline_passed
+        c = _ch(
+            completion_deadline=_PAST,
+            challenger_attempt_id=None,
+            challenged_attempt_id=None,
+        )
+        db = _db()
+        with patch(f"{_BASE_SVC}.notification_service"):
+            result = apply_forfeit_if_deadline_passed(db, c, _NOW)
+
+        assert result is True
+        assert c.status == ChallengeStatus.EXPIRED
+        assert c.forfeit_reason == "no_contest"
+        assert c.updated_at == _NOW
+
+
+# ── ASYNC-14 ───────────────────────────────────────────────────────────────────
+
+class TestSweepAcceptedDeadlines:
+
+    def test_async14_sweep_returns_count_and_flushes_once(self):
+        from app.services.challenge_completion_service import sweep_accepted_deadlines
+        db = _db()
+
+        # 2 applied + 1 no-op
+        with patch(f"{_BASE_SVC}.apply_forfeit_if_deadline_passed",
+                   side_effect=[True, True, False]) as mock_apply:
+            count = sweep_accepted_deadlines(db, ["ch1", "ch2", "ch3"])
+
+        assert count == 2
+        assert mock_apply.call_count == 3
+        db.flush.assert_called_once()
+
+    def test_async14b_sweep_no_changes_does_not_flush(self):
+        from app.services.challenge_completion_service import sweep_accepted_deadlines
+        db = _db()
+
+        with patch(f"{_BASE_SVC}.apply_forfeit_if_deadline_passed",
+                   return_value=False):
+            count = sweep_accepted_deadlines(db, ["ch1", "ch2"])
+
+        assert count == 0
+        db.flush.assert_not_called()
+
+    def test_async14c_empty_list_returns_zero(self):
+        from app.services.challenge_completion_service import sweep_accepted_deadlines
+        db = _db()
+        count = sweep_accepted_deadlines(db, [])
+        assert count == 0
+        db.flush.assert_not_called()


### PR DESCRIPTION
## Summary

- New migration `2026_05_25_1200`: 5 columns on `vt_challenges` — `accepted_at`, `completion_window_seconds`, `completion_deadline`, `forfeit_user_id`, `forfeit_reason` + `ck_vt_forfeit_reason_valid` CHECK + index
- New `challenge_completion_service` with idempotent `apply_forfeit_if_deadline_passed()` and `sweep_accepted_deadlines()`
- `accept_challenge()` sets `accepted_at` + computes `completion_deadline`
- `_validate_challenge_pre_submit()` blocks late submits (HTTP 410) before writing any attempt
- Inbox lazy sweep: deadline-passed challenges resolved on GET `/challenges`
- Send form: completion window selector (30 min / 1 h / 24 h / 3 days / 7 days)
- Inbox: deadline countdown display + forfeit/no-contest badges + outcome text
- Completion notification link fixed: `/friends` → `/challenges`

## Test plan

- [x] 24 new ASYNC-* unit tests (ASYNC-01..16 + variants) — all PASS
- [x] Full unit regression: 10965 passed, 0 failed
- [x] FAIR snapshot regression: PASS
- [x] Migration chain: `2026_05_25_1100` → `2026_05_25_1200` → head
- [x] OpenAPI snapshot updated (806 routes)
- [x] 3 existing fixture patches in `test_vt_challenges_ui.py` + `test_vt_submit_hook.py` (MagicMock `completion_deadline=None` guard)

## Out of scope (not included)

- Live lobby / ready state / `live_start_at`
- WebSocket
- GPS / location challenge
- Reward / credit modification
- New game type

🤖 Generated with [Claude Code](https://claude.com/claude-code)