### PR TITLE
feat(vt-challenge): Live Challenge Lobby + Outcome Communication

### DIFF
--- a/app/api/web_routes/vt_challenges.py
+++ b/app/api/web_routes/vt_challenges.py
@@ -524,6 +524,51 @@ async def accept_challenge(
         return RedirectResponse(url="/challenges?success=challenge_accepted", status_code=303)
 
 
+# ── Outcome reason helper (view-layer only, no DB column) ─────────────────────
+
+def _compute_outcome_reason(ch: VirtualTrainingChallenge) -> str:
+    """Derive a human-readable outcome category from existing DB fields.
+
+    Returns one of:
+      score_win | draw |
+      forfeit_post_start_timeout | forfeit_deadline | forfeit_no_show | forfeit |
+      no_contest | waiting_for_acceptance | waiting_for_opponent | in_lobby |
+      expired | declined | cancelled
+
+    No DB migration required — fully derived from status + winner_id +
+    forfeit_user_id + forfeit_reason.
+    """
+    s = ch.status
+
+    if s == ChallengeStatus.PENDING:
+        return "waiting_for_acceptance"
+    if s == ChallengeStatus.LIVE_LOBBY:
+        return "in_lobby"
+    if s in (ChallengeStatus.ACCEPTED, ChallengeStatus.LIVE_IN_PROGRESS):
+        return "waiting_for_opponent"
+    if s == ChallengeStatus.DECLINED:
+        return "declined"
+    if s == ChallengeStatus.CANCELLED:
+        return "cancelled"
+    if s == ChallengeStatus.EXPIRED:
+        return "no_contest" if ch.forfeit_reason == "no_contest" else "expired"
+
+    # COMPLETED
+    if ch.forfeit_user_id is not None:
+        if ch.winner_id is None:
+            return "no_contest"
+        _reason_map = {
+            "post_start_timeout": "forfeit_post_start_timeout",
+            "deadline_expired":   "forfeit_deadline",
+            "no_show":            "forfeit_no_show",
+        }
+        return _reason_map.get(ch.forfeit_reason or "", "forfeit")
+
+    if ch.is_draw:
+        return "draw"
+    return "score_win"
+
+
 # ── GET /challenges/{id} — Virtual Challenge detail ───────────────────────────
 
 @router.get("/challenges/{challenge_id}", response_class=HTMLResponse)
@@ -572,33 +617,19 @@ async def challenge_detail(
         ).first() if ch.challenged_attempt_id else None
     )
 
-    # Compute per-skill scores for each attempt (same pattern as individual result pages)
-    def _skill_scores(attempt: VirtualTrainingAttempt | None, game) -> dict:
-        if attempt is None or not attempt.skill_deltas or game is None:
+    # Return the stored skill_deltas directly — additive float values, not recomputed scores.
+    # VTSkillScorer.score_all() returns performance scores (0-1) which are semantically wrong
+    # for display as "Skill Impact"; the stored deltas (positive/negative) are the correct values.
+    def _skill_scores(attempt: VirtualTrainingAttempt | None, _game=None) -> dict[str, float]:
+        if attempt is None or not attempt.skill_deltas:
             return {}
-        try:
-            from ...services.virtual_training_metrics import VTSignalExtractor, VTSkillScorer
-            cfg          = game.config or {}
-            phase_config = cfg.get("phases", []) if isinstance(cfg, dict) else []
-            signals = VTSignalExtractor.extract(
-                {
-                    "stimuli_count":     attempt.stimuli_count,
-                    "correct_count":     attempt.correct_count,
-                    "wrong_click_count": attempt.wrong_click_count,
-                    "error_count":       attempt.error_count,
-                    "avg_reaction_ms":   attempt.avg_reaction_ms,
-                    "raw_metrics":       attempt.raw_metrics,
-                },
-                phase_config,
-            )
-            return VTSkillScorer.score_all(signals, game.skill_targets or {})
-        except Exception:
-            return {}
+        return {k: float(v) for k, v in attempt.skill_deltas.items()}
 
     game = ch.game  # ORM relationship
 
-    is_forfeit   = ch.forfeit_user_id is not None
+    is_forfeit    = ch.forfeit_user_id is not None
     is_no_contest = is_forfeit and ch.winner_id is None
+    outcome_reason = _compute_outcome_reason(ch)
 
     return templates.TemplateResponse(
         "vt_challenge_detail.html",
@@ -620,6 +651,7 @@ async def challenge_detail(
             "is_challenger":            user.id == ch.challenger_id,
             "is_forfeit":               is_forfeit,
             "is_no_contest":            is_no_contest,
+            "outcome_reason":           outcome_reason,
         },
     )
 

--- a/app/middleware/security.py
+++ b/app/middleware/security.py
@@ -264,7 +264,7 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
             "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; "
             "img-src 'self' data: https://i.ytimg.com https:; "
             "frame-src 'self' https://www.youtube-nocookie.com https://www.youtube.com; "
-            "connect-src 'self' http://localhost:8000 http://192.168.1.129:8000; "
+            "connect-src 'self' http://localhost:8000; "
             "font-src 'self'"
         )
     

--- a/app/services/skill_progression/_views.py
+++ b/app/services/skill_progression/_views.py
@@ -180,17 +180,30 @@ _TIMELINE_EPOCH = datetime(1900, 1, 1, tzinfo=timezone.utc)
 def _collect_vt_timeline_events(db: Session, user_id: int, skill_key: str) -> List[dict]:
     """Return pre-shaped raw timeline event dicts for valid VT attempts that affect skill_key.
 
-    Filtered at DB level: is_valid=True, xp_awarded>0.
+    Filtered at DB level:
+      - is_valid=True
+      - xp_awarded>0  OR  skill_deltas != '{}'  (non-empty)
+        The second branch catches Virtual Challenge attempts where the daily
+        cap was bypassed (xp_awarded=0) but skill_deltas were still computed
+        because is_challenge=True.  Solo attempts that hit the cap produce
+        skill_deltas='{}' and are correctly excluded by the second branch.
     Filtered at Python level: skill_key present in skill_deltas JSONB.
     """
+    from sqlalchemy import cast, or_
+    from sqlalchemy.dialects.postgresql import JSONB
     from app.models.virtual_training import VirtualTrainingAttempt
+
+    _empty_jsonb = cast("{}", JSONB)
 
     attempts = (
         db.query(VirtualTrainingAttempt)
         .filter(
             VirtualTrainingAttempt.user_id == user_id,
             VirtualTrainingAttempt.is_valid == True,
-            VirtualTrainingAttempt.xp_awarded > 0,
+            or_(
+                VirtualTrainingAttempt.xp_awarded > 0,
+                VirtualTrainingAttempt.skill_deltas != _empty_jsonb,
+            ),
         )
         .order_by(VirtualTrainingAttempt.started_at.asc())
         .all()

--- a/app/templates/dashboard/lfa_public_profile_editor.html
+++ b/app/templates/dashboard/lfa_public_profile_editor.html
@@ -1084,42 +1084,115 @@
 
     // ── Geolocation flow ───────────────────────────────────────────────────────
     window.wpRequestGeolocation = function () {
+        // P0: Secure context guard — HTTP over WiFi IP returns code=1 immediately on iOS
+        if (!window.isSecureContext) {
+            console.warn("[geo] insecure context", {
+                protocol: location.protocol,
+                host:     location.host,
+                secure:   window.isSecureContext
+            });
+            document.getElementById("wp-geo-error-msg").textContent =
+                "Location requires HTTPS on mobile. Use https://… or localhost.";
+            wpGeoSetState("error");
+            return;
+        }
         if (!navigator.geolocation) {
             document.getElementById("wp-geo-error-msg").textContent =
                 "Geolocation is not supported by your browser.";
             wpGeoSetState("error");
             return;
         }
+
         wpGeoSetState("loading");
-        navigator.geolocation.getCurrentPosition(
-            function (pos) {
-                var acc = pos.coords.accuracy;
-                if (acc > 200) {
+
+        var _permState = "unknown";
+
+        function onSuccess(pos) {
+            var acc = pos.coords.accuracy;
+            if (acc > 200) {
+                document.getElementById("wp-geo-error-msg").textContent =
+                    "Location accuracy too low (" + Math.round(acc) + " m). " +
+                    "Please try again or move to an open area.";
+                wpGeoSetState("error");
+                return;
+            }
+            _wpGeoCoords = {
+                lat:        pos.coords.latitude,
+                lon:        pos.coords.longitude,
+                accuracy_m: acc,
+            };
+            document.getElementById("wp-geo-ready-msg").textContent =
+                "Location captured (±" + Math.round(acc) + " m). Ready to save.";
+            wpGeoSetState("ready");
+        }
+
+        function onError(err) {
+            console.error("[geo] error", {
+                code:    err.code,
+                message: err.message,
+                secure:  window.isSecureContext,
+                perm:    _permState,
+                ua:      navigator.userAgent.slice(0, 80)
+            });
+            var msg = "Location unavailable.";
+            if (err.code === 1) {
+                msg = "Location permission denied. Please allow location access in your browser settings.";
+            } else if (err.code === 3) {
+                msg = "Location request timed out. Please try again or move to an open area.";
+            } else if (err.code === 2) {
+                msg = "Location unavailable. Please check your GPS or network connection.";
+            }
+            document.getElementById("wp-geo-error-msg").textContent = msg;
+            wpGeoSetState("error");
+        }
+
+        function doRequest() {
+            // Attempt 1: high accuracy (GPS), 15 s — allows iOS time to get GPS lock
+            navigator.geolocation.getCurrentPosition(
+                onSuccess,
+                function (err) {
+                    // iOS can return code=1 on GPS timeout with enableHighAccuracy=true;
+                    // retry once with low accuracy before treating as real permission denial
+                    if (err.code === 1 || err.code === 3) {
+                        console.warn("[geo] attempt-1 failed (code " + err.code + "), retrying low-accuracy", {
+                            message: err.message,
+                            secure:  window.isSecureContext,
+                            perm:    _permState,
+                            ua:      navigator.userAgent.slice(0, 80)
+                        });
+                        navigator.geolocation.getCurrentPosition(
+                            onSuccess,
+                            onError,
+                            { enableHighAccuracy: false, timeout: 10000, maximumAge: 120000 }
+                        );
+                    } else {
+                        onError(err);
+                    }
+                },
+                { enableHighAccuracy: true, timeout: 15000, maximumAge: 60000 }
+            );
+        }
+
+        // P1: Permission diagnostics — navigator.permissions not available in all Safari versions
+        try {
+            navigator.permissions.query({ name: "geolocation" }).then(function (result) {
+                _permState = result.state;
+                console.info("[geo] permission:", result.state);
+                if (result.state === "denied") {
                     document.getElementById("wp-geo-error-msg").textContent =
-                        "Location accuracy too low (" + Math.round(acc) + " m). " +
-                        "Please try again or move to an open area.";
+                        "Location access is blocked in your browser settings. " +
+                        "Please allow it for this site and try again.";
                     wpGeoSetState("error");
                     return;
                 }
-                _wpGeoCoords = {
-                    lat:        pos.coords.latitude,
-                    lon:        pos.coords.longitude,
-                    accuracy_m: acc,
-                };
-                document.getElementById("wp-geo-ready-msg").textContent =
-                    "Location captured (±" + Math.round(acc) + " m). Ready to save.";
-                wpGeoSetState("ready");
-            },
-            function (err) {
-                var msg = "Location unavailable.";
-                if      (err.code === 1) msg = "Location permission denied. Please allow location access in your browser settings.";
-                else if (err.code === 3) msg = "Location request timed out. Please try again.";
-                else if (err.code === 2) msg = "Location unavailable. Please check your GPS or network connection.";
-                document.getElementById("wp-geo-error-msg").textContent = msg;
-                wpGeoSetState("error");
-            },
-            { enableHighAccuracy: true, timeout: 10000, maximumAge: 60000 }
-        );
+                doRequest();
+            }).catch(function () {
+                doRequest();
+            });
+        } catch (e) {
+            // Safari < 16 throws synchronously on navigator.permissions.query
+            doRequest();
+        }
     };
     // Expose wpGeoReset for inline onclick handlers
     window.wpGeoReset = wpGeoReset;

--- a/app/templates/vt_challenge_detail.html
+++ b/app/templates/vt_challenge_detail.html
@@ -55,22 +55,39 @@
     font-size: 2rem; font-weight: 800; color: var(--app-text);
     margin: 0.25rem 0 0.1rem;
 }
-.vcd-player-score.won  { color: #16a34a; }
-.vcd-player-score.lost { color: #dc2626; }
+.vcd-player-score.won       { color: #16a34a; }
+.vcd-player-score.lost      { color: #dc2626; }
+.vcd-player-score.not-used  { color: var(--app-text-muted); opacity: 0.6; font-size: 1.6rem; }
+.vcd-no-attempt {
+    font-size: 0.78rem; color: var(--app-text-muted);
+    margin: 0.3rem 0 0; font-style: italic;
+}
 .vcd-vs-sep { font-size: 1.1rem; font-weight: 700; color: var(--app-text-muted); text-align: center; }
+
+/* ── Score disclaimer ── */
+.vcd-score-disclaimer {
+    font-size: 0.78rem; color: #92400e;
+    background: #fef3c7; border-radius: 8px;
+    padding: 0.45rem 0.75rem; margin-top: 0.5rem;
+    text-align: center;
+}
 
 /* ── Outcome banner ── */
 .vcd-outcome-banner {
     text-align: center; padding: 0.75rem 1rem;
-    border-radius: 10px; margin: 0.5rem 0 1rem; font-weight: 700;
+    border-radius: 10px; margin: 0.5rem 0 0.75rem; font-weight: 700;
 }
-.vcd-outcome-banner.won  { background: #dcfce7; color: #166534; }
-.vcd-outcome-banner.lost { background: #fee2e2; color: #991b1b; }
-.vcd-outcome-banner.draw { background: #f3f4f6; color: #374151; }
-.vcd-outcome-banner.pending { background: #eff6ff; color: #1e40af; }
+.vcd-outcome-banner.won       { background: #dcfce7; color: #166534; }
+.vcd-outcome-banner.lost      { background: #fee2e2; color: #991b1b; }
+.vcd-outcome-banner.draw      { background: #f3f4f6; color: #374151; }
+.vcd-outcome-banner.pending   { background: #eff6ff; color: #1e40af; }
 .vcd-outcome-banner.forfeit-win  { background: #dcfce7; color: #166534; }
 .vcd-outcome-banner.no-contest   { background: #fef3c7; color: #92400e; }
-.vcd-outcome-banner.info { background: #f0f9ff; color: #0c4a6e; }
+.vcd-outcome-banner.info      { background: #f0f9ff; color: #0c4a6e; }
+.vcd-outcome-sub {
+    font-size: 0.82rem; font-weight: 400; color: var(--app-text-muted);
+    text-align: center; margin: 0 0 0.25rem;
+}
 
 /* ── Skill deltas ── */
 .vcd-deltas-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-top: 0.5rem; }
@@ -103,7 +120,7 @@
 {% block student_content %}
 <div class="vcd-container">
 
-{# ── Header card ── #}
+{# ── [A] HEADER CARD ── #}
 <div class="vcd-card">
     <div class="vcd-header-row">
         <div>
@@ -122,38 +139,36 @@
                 {% endif %}
             </p>
         </div>
-        {# Status badge #}
-        {% if challenge.status.value == "completed" and not is_forfeit %}
-            {% if is_challenger %}
-                {% set _my_score = challenger_attempt.score_normalized if challenger_attempt else None %}
-                {% set _op_score = challenged_attempt.score_normalized if challenged_attempt else None %}
-            {% else %}
-                {% set _my_score = challenged_attempt.score_normalized if challenged_attempt else None %}
-                {% set _op_score = challenger_attempt.score_normalized if challenger_attempt else None %}
-            {% endif %}
-            {% if challenge.is_draw %}
-                <span class="vcd-badge vcd-badge-draw">= Draw</span>
-            {% elif challenge.winner_id == user.id %}
+
+        {# Status badge — derived from outcome_reason #}
+        {% if outcome_reason == "score_win" %}
+            {% if challenge.winner_id == user.id %}
                 <span class="vcd-badge vcd-badge-won">🏆 Won</span>
             {% else %}
                 <span class="vcd-badge vcd-badge-lost">✗ Lost</span>
             {% endif %}
-        {% elif is_no_contest %}
-            <span class="vcd-badge vcd-badge-expired">No Contest</span>
-        {% elif is_forfeit %}
+        {% elif outcome_reason == "draw" %}
+            <span class="vcd-badge vcd-badge-draw">= Draw</span>
+        {% elif outcome_reason in ["forfeit_post_start_timeout", "forfeit_deadline", "forfeit_no_show", "forfeit"] %}
             {% if challenge.winner_id == user.id %}
-            <span class="vcd-badge vcd-badge-won">🏆 Won (Forfeit)</span>
+                <span class="vcd-badge vcd-badge-won">🏆 Won (Forfeit)</span>
             {% else %}
-            <span class="vcd-badge vcd-badge-lost">✗ Lost (Forfeit)</span>
+                <span class="vcd-badge vcd-badge-lost">✗ Lost (Forfeit)</span>
             {% endif %}
-        {% elif challenge.status.value in ["accepted", "live_in_progress"] %}
+        {% elif outcome_reason == "no_contest" %}
+            <span class="vcd-badge vcd-badge-expired">No Contest</span>
+        {% elif outcome_reason == "waiting_for_opponent" %}
             <span class="vcd-badge vcd-badge-accepted">In Progress</span>
-        {% elif challenge.status.value == "pending" %}
+        {% elif outcome_reason == "waiting_for_acceptance" %}
             <span class="vcd-badge vcd-badge-pending">Pending</span>
-        {% elif challenge.status.value == "live_lobby" %}
+        {% elif outcome_reason == "in_lobby" %}
             <span class="vcd-badge vcd-badge-live">⚡ Live Lobby</span>
-        {% elif challenge.status.value == "expired" %}
+        {% elif outcome_reason == "expired" %}
             <span class="vcd-badge vcd-badge-expired">Expired</span>
+        {% elif outcome_reason == "declined" %}
+            <span class="vcd-badge vcd-badge-other">Declined</span>
+        {% elif outcome_reason == "cancelled" %}
+            <span class="vcd-badge vcd-badge-other">Cancelled</span>
         {% else %}
             <span class="vcd-badge vcd-badge-other">{{ challenge.status.value | title }}</span>
         {% endif %}
@@ -200,163 +215,229 @@
     </div>
 </div>
 
-{# ── Live lobby redirect notice ── #}
-{% if challenge.status.value == "live_lobby" %}
+{# ── [B] OUTCOME BLOCK — always shown, outcome_reason-driven ── #}
 <div class="vcd-card">
-    <div class="vcd-outcome-banner info">
-        ⚡ This challenge is in the live lobby.
-    </div>
-    <div style="text-align:center;">
+
+    {# ── outcome_reason = waiting_for_acceptance (PENDING) ── #}
+    {% if outcome_reason == "waiting_for_acceptance" %}
+    <div class="vcd-outcome-banner pending">⏳ Waiting for opponent to accept.</div>
+
+    {# ── outcome_reason = in_lobby (LIVE_LOBBY) ── #}
+    {% elif outcome_reason == "in_lobby" %}
+    <div class="vcd-outcome-banner info">⚡ This challenge is in the live lobby.</div>
+    <div style="text-align:center;margin-top:0.75rem;">
         <a href="/challenges/{{ challenge.id }}/lobby"
            style="display:inline-block;background:#f59e0b;color:#fff;font-weight:700;
                   padding:0.6rem 1.5rem;border-radius:8px;text-decoration:none;">
             Enter Lobby →
         </a>
     </div>
-</div>
 
-{# ── In-progress notice ── #}
-{% elif challenge.status.value == "live_in_progress" %}
-<div class="vcd-card">
+    {# ── outcome_reason = waiting_for_opponent (ACCEPTED / LIVE_IN_PROGRESS) ── #}
+    {% elif outcome_reason == "waiting_for_opponent" %}
+    {% if challenge.status.value == "live_in_progress" %}
     <div class="vcd-outcome-banner info">▶ Live challenge in progress.</div>
-    <div style="text-align:center;">
+    <div style="text-align:center;margin-top:0.75rem;">
         <a href="/challenges/{{ challenge.id }}/lobby"
            style="display:inline-block;background:#4f46e5;color:#fff;font-weight:700;
                   padding:0.6rem 1.5rem;border-radius:8px;text-decoration:none;">
             Rejoin Lobby →
         </a>
     </div>
-</div>
+    {% else %}
+    <div class="vcd-outcome-banner pending">⏳ Challenge accepted — waiting for both players to submit.</div>
+    {% endif %}
 
-{# ── Pending / accepted ── #}
-{% elif challenge.status.value in ["pending", "accepted"] %}
-<div class="vcd-card">
-    <div class="vcd-outcome-banner pending">
-        {% if challenge.status.value == "pending" %}⏳ Waiting for opponent to accept.
-        {% else %}⏳ Challenge accepted — waiting for both players to submit.{% endif %}
-    </div>
-</div>
+    {# ── outcome_reason = declined ── #}
+    {% elif outcome_reason == "declined" %}
+    <div class="vcd-outcome-banner no-contest">✗ Challenge was declined.</div>
 
-{# ── Expired / declined / cancelled ── #}
-{% elif challenge.status.value in ["expired", "declined", "cancelled"] and not is_forfeit %}
-<div class="vcd-card">
-    <div class="vcd-outcome-banner no-contest">
-        {% if challenge.status.value == "expired" %}⏰ Challenge expired — no one played in time.
-        {% elif challenge.status.value == "declined" %}✗ Challenge was declined.
-        {% else %}✕ Challenge was cancelled.{% endif %}
-    </div>
-</div>
+    {# ── outcome_reason = cancelled ── #}
+    {% elif outcome_reason == "cancelled" %}
+    <div class="vcd-outcome-banner no-contest">✕ Challenge was cancelled.</div>
 
-{# ── Forfeit / no-contest ── #}
-{% elif is_forfeit %}
-<div class="vcd-card">
-    {% if is_no_contest %}
+    {# ── outcome_reason = expired (no forfeit / no_contest) ── #}
+    {% elif outcome_reason == "expired" %}
+    <div class="vcd-outcome-banner no-contest">⏰ Challenge expired — no one played in time.</div>
+
+    {# ── outcome_reason = no_contest ── #}
+    {% elif outcome_reason == "no_contest" %}
     <div class="vcd-outcome-banner no-contest">No Contest — neither player submitted in time.</div>
-    {% elif challenge.winner_id == user.id %}
+    <p class="vcd-outcome-sub">Score comparison was not used.</p>
+
+    {# ── outcome_reason = forfeit_* ── #}
+    {% elif outcome_reason in ["forfeit_post_start_timeout", "forfeit_deadline", "forfeit_no_show", "forfeit"] %}
+    {% if challenge.winner_id == user.id %}
     <div class="vcd-outcome-banner forfeit-win">🏆 You won by forfeit.</div>
     {% else %}
     <div class="vcd-outcome-banner lost">✗ You lost by forfeit.</div>
     {% endif %}
     {% if forfeit_user %}
-    <p style="font-size:0.85rem;color:var(--app-text-muted);margin:0.5rem 0 0;text-align:center;">
+    <p class="vcd-outcome-sub">
         {{ forfeit_user.nickname or forfeit_user.email }}
-        {% if challenge.forfeit_reason == "deadline_expired" %} did not play before the deadline.
-        {% elif challenge.forfeit_reason == "no_show" %} did not ready up in the lobby.
-        {% elif challenge.forfeit_reason == "post_start_timeout" %} did not submit within the live window.
-        {% elif challenge.forfeit_reason == "no_contest" %} — no contest.
+        {% if outcome_reason == "forfeit_deadline" %} did not play before the deadline.
+        {% elif outcome_reason == "forfeit_no_show" %} did not ready up in the lobby.
+        {% elif outcome_reason == "forfeit_post_start_timeout" %} did not submit within the live challenge time window.
+        {% else %} forfeited.
         {% endif %}
     </p>
     {% endif %}
-</div>
 
-{# ── Completed (normal) ── #}
-{% elif challenge.status.value == "completed" %}
-<div class="vcd-card">
-    {# Outcome banner #}
-    {% if challenge.is_draw %}
+    {# ── outcome_reason = draw ── #}
+    {% elif outcome_reason == "draw" %}
     <div class="vcd-outcome-banner draw">= It's a draw!</div>
-    {% elif challenge.winner_id == user.id %}
+    <p class="vcd-outcome-sub">Winner decided by score — both players had equal results.</p>
+
+    {# ── outcome_reason = score_win ── #}
+    {% elif outcome_reason == "score_win" %}
+    {% if challenge.winner_id == user.id %}
     <div class="vcd-outcome-banner won">🏆 You won!</div>
+    <p class="vcd-outcome-sub">Winner decided by higher score.</p>
     {% else %}
-    <div class="vcd-outcome-banner lost">✗ You lost</div>
+    <div class="vcd-outcome-banner lost">✗ You lost.</div>
+    <p class="vcd-outcome-sub">Winner decided by higher score.</p>
     {% endif %}
 
-    {# VS score layout #}
+    {% endif %}
+</div>
+
+{# ── [C] SCORE BLOCK — shown whenever the challenge is completed or has attempts ── #}
+{# Also shown during waiting_for_opponent if the viewing user already submitted. #}
+{% set _show_score_block = (
+    outcome_reason in ["score_win", "draw",
+                       "forfeit_post_start_timeout", "forfeit_deadline",
+                       "forfeit_no_show", "forfeit", "no_contest"]
+    or (outcome_reason == "waiting_for_opponent"
+        and (challenger_attempt is not none or challenged_attempt is not none))
+) %}
+{% if _show_score_block %}
+<div class="vcd-card">
+    <div style="font-size:0.78rem;font-weight:700;color:var(--app-text-muted);
+                text-transform:uppercase;letter-spacing:0.04em;margin-bottom:0.75rem;">
+        Score
+    </div>
+
+    {# Determine score CSS classes for each side #}
+    {% set _cr_won = (challenge.winner_id == challenge.challenger_id and not challenge.is_draw) %}
+    {% set _cd_won = (challenge.winner_id == challenge.challenged_id and not challenge.is_draw) %}
+    {% set _is_forfeit_outcome = outcome_reason in ["forfeit_post_start_timeout","forfeit_deadline","forfeit_no_show","forfeit"] %}
+
     <div class="vcd-vs-grid">
+        {# ── Challenger side ── #}
         <div class="vcd-player">
             <div class="vcd-player-label">{% if is_challenger %}You{% else %}{{ challenger.nickname or challenger.email }}{% endif %}</div>
             <div class="vcd-player-name">{{ challenger.nickname or challenger.email }}</div>
             {% if challenger_attempt %}
-            <div class="vcd-player-score {% if challenge.winner_id == challenge.challenger_id and not challenge.is_draw %}won{% elif challenge.winner_id and challenge.winner_id != challenge.challenger_id %}lost{% endif %}">
-                {% if challenger_attempt.score_normalized is not none %}{{ challenger_attempt.score_normalized | round(0) | int }}%{% else %}—{% endif %}
-            </div>
-            <a href="/virtual-training/{{ game.code | replace('_', '-') }}/result/{{ challenger_attempt.id }}?challenge_id={{ challenge.id }}"
-               class="vcd-attempt-link">View attempt →</a>
+                <div class="vcd-player-score
+                    {%- if _is_forfeit_outcome %} not-used
+                    {%- elif _cr_won %} won
+                    {%- elif challenge.winner_id and not _cr_won %} lost
+                    {%- endif %}">
+                    {% if challenger_attempt.score_normalized is not none %}{{ challenger_attempt.score_normalized | round(0) | int }}%{% else %}—{% endif %}
+                </div>
+                {% if not _is_forfeit_outcome %}
+                <a href="/virtual-training/{{ game.code | replace('_', '-') }}/result/{{ challenger_attempt.id }}?challenge_id={{ challenge.id }}"
+                   class="vcd-attempt-link">View attempt →</a>
+                {% else %}
+                <p style="font-size:0.72rem;color:var(--app-text-muted);margin:0.2rem 0 0;">
+                    Your performance (not used for result)
+                </p>
+                <a href="/virtual-training/{{ game.code | replace('_', '-') }}/result/{{ challenger_attempt.id }}?challenge_id={{ challenge.id }}"
+                   class="vcd-attempt-link">View attempt →</a>
+                {% endif %}
             {% else %}
-            <div class="vcd-player-score">—</div>
+                <div class="vcd-player-score">—</div>
+                <p class="vcd-no-attempt">No attempt submitted</p>
             {% endif %}
         </div>
+
         <div class="vcd-vs-sep">vs</div>
+
+        {# ── Challenged side ── #}
         <div class="vcd-player">
             <div class="vcd-player-label">{% if not is_challenger %}You{% else %}{{ challenged.nickname or challenged.email }}{% endif %}</div>
             <div class="vcd-player-name">{{ challenged.nickname or challenged.email }}</div>
             {% if challenged_attempt %}
-            <div class="vcd-player-score {% if challenge.winner_id == challenge.challenged_id and not challenge.is_draw %}won{% elif challenge.winner_id and challenge.winner_id != challenge.challenged_id %}lost{% endif %}">
-                {% if challenged_attempt.score_normalized is not none %}{{ challenged_attempt.score_normalized | round(0) | int }}%{% else %}—{% endif %}
-            </div>
-            <a href="/virtual-training/{{ game.code | replace('_', '-') }}/result/{{ challenged_attempt.id }}?challenge_id={{ challenge.id }}"
-               class="vcd-attempt-link">View attempt →</a>
+                <div class="vcd-player-score
+                    {%- if _is_forfeit_outcome %} not-used
+                    {%- elif _cd_won %} won
+                    {%- elif challenge.winner_id and not _cd_won %} lost
+                    {%- endif %}">
+                    {% if challenged_attempt.score_normalized is not none %}{{ challenged_attempt.score_normalized | round(0) | int }}%{% else %}—{% endif %}
+                </div>
+                {% if not _is_forfeit_outcome %}
+                <a href="/virtual-training/{{ game.code | replace('_', '-') }}/result/{{ challenged_attempt.id }}?challenge_id={{ challenge.id }}"
+                   class="vcd-attempt-link">View attempt →</a>
+                {% else %}
+                <p style="font-size:0.72rem;color:var(--app-text-muted);margin:0.2rem 0 0;">
+                    Your performance (not used for result)
+                </p>
+                <a href="/virtual-training/{{ game.code | replace('_', '-') }}/result/{{ challenged_attempt.id }}?challenge_id={{ challenge.id }}"
+                   class="vcd-attempt-link">View attempt →</a>
+                {% endif %}
             {% else %}
-            <div class="vcd-player-score">—</div>
+                <div class="vcd-player-score">—</div>
+                <p class="vcd-no-attempt">No attempt submitted</p>
             {% endif %}
         </div>
     </div>
 
-    {# Skill deltas — both players #}
-    {% if challenger_skill_scores or challenged_skill_scores %}
-    <div style="margin-top:0.75rem;">
-        <div style="font-size:0.78rem;font-weight:700;color:var(--app-text-muted);
-                    text-transform:uppercase;letter-spacing:0.04em;margin-bottom:0.5rem;">
-            Skill Impact
-        </div>
-        <div class="vcd-deltas-grid">
+    {# Forfeit score disclaimer #}
+    {% if _is_forfeit_outcome %}
+    <p class="vcd-score-disclaimer">
+        ⚠ Score comparison was not used — only one player submitted.
+    </p>
+    {% endif %}
+</div>
+{% endif %}
+
+{# ── [D] SKILL DELTA BLOCK — shown for completed challenges (all outcomes) ── #}
+{% set _show_delta_block = (
+    outcome_reason in ["score_win", "draw",
+                       "forfeit_post_start_timeout", "forfeit_deadline",
+                       "forfeit_no_show", "forfeit", "no_contest"]
+    or (challenger_skill_scores or challenged_skill_scores)
+) %}
+{% if _show_delta_block %}
+<div class="vcd-card">
+    <div style="font-size:0.78rem;font-weight:700;color:var(--app-text-muted);
+                text-transform:uppercase;letter-spacing:0.04em;margin-bottom:0.5rem;">
+        Skill Impact
+    </div>
+    <div class="vcd-deltas-grid">
+        {# ── Challenger side ── #}
+        <div class="vcd-deltas-block">
+            <h4>{{ challenger.nickname or challenger.email }}</h4>
             {% if challenger_skill_scores %}
-            <div class="vcd-deltas-block">
-                <h4>{{ challenger.nickname or challenger.email }}</h4>
-                {% for skill, info in challenger_skill_scores.items() %}
-                {% set delta = info.delta if info is mapping else 0 %}
+                {% for skill, delta in challenger_skill_scores.items() %}
                 <div class="vcd-delta-row {% if delta < 0 %}neg{% endif %}">
                     <span>{{ skill | replace('_', ' ') | title }}</span>
                     <span>{% if delta > 0 %}+{% endif %}{{ delta | round(3) }}</span>
                 </div>
                 {% endfor %}
-            </div>
+            {% elif challenger_attempt %}
+                <p style="font-size:0.8rem;color:var(--app-text-muted);margin:0;">No skill delta recorded</p>
             {% else %}
-            <div class="vcd-deltas-block">
-                <h4>{{ challenger.nickname or challenger.email }}</h4>
-                <p style="font-size:0.8rem;color:var(--app-text-muted);margin:0;">No data</p>
-            </div>
+                <p style="font-size:0.8rem;color:var(--app-text-muted);margin:0;">No attempt submitted</p>
             {% endif %}
+        </div>
+        {# ── Challenged side ── #}
+        <div class="vcd-deltas-block">
+            <h4>{{ challenged.nickname or challenged.email }}</h4>
             {% if challenged_skill_scores %}
-            <div class="vcd-deltas-block">
-                <h4>{{ challenged.nickname or challenged.email }}</h4>
-                {% for skill, info in challenged_skill_scores.items() %}
-                {% set delta = info.delta if info is mapping else 0 %}
+                {% for skill, delta in challenged_skill_scores.items() %}
                 <div class="vcd-delta-row {% if delta < 0 %}neg{% endif %}">
                     <span>{{ skill | replace('_', ' ') | title }}</span>
                     <span>{% if delta > 0 %}+{% endif %}{{ delta | round(3) }}</span>
                 </div>
                 {% endfor %}
-            </div>
+            {% elif challenged_attempt %}
+                <p style="font-size:0.8rem;color:var(--app-text-muted);margin:0;">No skill delta recorded</p>
             {% else %}
-            <div class="vcd-deltas-block">
-                <h4>{{ challenged.nickname or challenged.email }}</h4>
-                <p style="font-size:0.8rem;color:var(--app-text-muted);margin:0;">No data</p>
-            </div>
+                <p style="font-size:0.8rem;color:var(--app-text-muted);margin:0;">No attempt submitted</p>
             {% endif %}
         </div>
     </div>
-    {% endif %}
 </div>
 {% endif %}
 
@@ -376,4 +457,8 @@
 </div>
 
 </div>
+
+{# P1 TODO: game.config["live_submit_window_seconds"] per-game override for POST_START_SUBMIT_WINDOW_SECONDS #}
+{# P2 TECH DEBT (TRUST-VT-SCORE-01): score_normalized is client-submitted; server-side
+   recomputation from raw_metrics.per_round needed to prevent score manipulation in score_win cases. #}
 {% endblock %}

--- a/scripts/dev_cleanup_stuck_challenges.py
+++ b/scripts/dev_cleanup_stuck_challenges.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""
+Dev-only: Clean up stuck / broken VT challenge records.
+
+A challenge is "stuck" when it is in PENDING or ACCEPTED status but has
+challenge_config_snapshot=NULL and no linked attempts, making it both
+unplayable (snapshot guard in submit route) and permanently blocking new
+challenges between the same pair on the same game.
+
+Usage:
+    python scripts/dev_cleanup_stuck_challenges.py          # dry-run (default)
+    python scripts/dev_cleanup_stuck_challenges.py --apply  # execute deletes
+
+Safety:
+    - Refuses to run outside ENVIRONMENT=development / dev.
+    - Every deletion is gated by explicit assertions; aborts on any failure.
+    - Never touches users, friendships, licenses, skill profiles,
+      virtual_training_attempts, completed challenges, or notifications.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+# ── Safety: dev-only ──────────────────────────────────────────────────────────
+_ENV = os.getenv("ENVIRONMENT", "development").lower()
+if _ENV not in ("development", "dev"):
+    print(f"[ABORT] Refusing to run in ENVIRONMENT={_ENV!r}. Dev-only script.")
+    sys.exit(1)
+
+DRY_RUN: bool = "--apply" not in sys.argv
+
+# ── Stuck challenge specification ─────────────────────────────────────────────
+# Each entry is a dict of expected field values.  ALL must match before delete.
+_STUCK_CHALLENGES: list[dict] = [
+    {
+        "id":                    1,
+        "status":                "accepted",
+        "snapshot_must_be_null": True,
+        "challenger_attempt_id": None,
+        "challenged_attempt_id": None,
+        "challenger_id":         3,
+        "challenged_id":         3617,
+        "game_id":               6,
+        "description":           "Async MS challenge accepted pre-snapshot, never played",
+    },
+]
+
+
+def _assert(cond: bool, msg: str) -> None:
+    if not cond:
+        print(f"[ABORT] Assertion failed: {msg}")
+        sys.exit(2)
+
+
+def run() -> None:
+    # Import app DB *after* env guard so tests can mock without a real DB
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    from app.database import SessionLocal
+    from app.models.vt_challenge import VirtualTrainingChallenge, ChallengeStatus
+
+    db = SessionLocal()
+    try:
+        deleted = 0
+        skipped = 0
+
+        for spec in _STUCK_CHALLENGES:
+            cid  = spec["id"]
+            desc = spec["description"]
+
+            ch = (
+                db.query(VirtualTrainingChallenge)
+                .filter(VirtualTrainingChallenge.id == cid)
+                .first()
+            )
+
+            if ch is None:
+                print(f"[SKIP] Challenge {cid} not found — already deleted or never existed.")
+                skipped += 1
+                continue
+
+            print(f"\n[FOUND] Challenge id={cid}: {desc}")
+            print(f"        status={ch.status.value}  game_id={ch.game_id}")
+            print(f"        challenger={ch.challenger_id}  challenged={ch.challenged_id}")
+            print(f"        snapshot={'PRESENT' if ch.challenge_config_snapshot is not None else 'NULL'}")
+            print(f"        challenger_attempt_id={ch.challenger_attempt_id}")
+            print(f"        challenged_attempt_id={ch.challenged_attempt_id}")
+
+            # ── Safety assertions ─────────────────────────────────────────────
+            _assert(
+                ch.challenger_attempt_id is None,
+                f"Challenge {cid} has challenger_attempt_id={ch.challenger_attempt_id} — NOT safe to delete",
+            )
+            _assert(
+                ch.challenged_attempt_id is None,
+                f"Challenge {cid} has challenged_attempt_id={ch.challenged_attempt_id} — NOT safe to delete",
+            )
+            _assert(
+                ch.challenge_config_snapshot is None,
+                f"Challenge {cid} has a snapshot — this is not a broken record, aborting",
+            )
+            _assert(
+                ch.status in (ChallengeStatus.PENDING, ChallengeStatus.ACCEPTED),
+                f"Challenge {cid} status={ch.status.value} is not PENDING/ACCEPTED — aborting",
+            )
+            _assert(
+                ch.challenger_id == spec["challenger_id"],
+                f"Challenge {cid} challenger_id={ch.challenger_id} != expected {spec['challenger_id']}",
+            )
+            _assert(
+                ch.challenged_id == spec["challenged_id"],
+                f"Challenge {cid} challenged_id={ch.challenged_id} != expected {spec['challenged_id']}",
+            )
+            _assert(
+                ch.game_id == spec["game_id"],
+                f"Challenge {cid} game_id={ch.game_id} != expected {spec['game_id']}",
+            )
+
+            if DRY_RUN:
+                print(f"  [DRY-RUN] Would DELETE challenge {cid}. Run with --apply to execute.")
+                skipped += 1
+            else:
+                db.delete(ch)
+                db.commit()
+                print(f"  [DELETED] Challenge {cid} removed from vt_challenges.")
+                deleted += 1
+
+        print(f"\n{'[DRY-RUN] ' if DRY_RUN else ''}Summary: {deleted} deleted, {skipped} skipped.")
+        if DRY_RUN and skipped:
+            print("  Run with --apply to execute deletes.")
+
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/unit/api/web_routes/test_outcome_reason.py
+++ b/tests/unit/api/web_routes/test_outcome_reason.py
@@ -1,0 +1,317 @@
+"""
+OUTCOME-01  post_start_timeout forfeit → outcome_reason = forfeit_post_start_timeout
+OUTCOME-02  completed normal winner   → outcome_reason = score_win
+OUTCOME-03  completed draw            → outcome_reason = draw
+OUTCOME-04  deadline_expired forfeit  → outcome_reason = forfeit_deadline
+OUTCOME-05  expired + no_contest      → outcome_reason = no_contest
+OUTCOME-06  live_in_progress (one attempt) → outcome_reason = waiting_for_opponent
+OUTCOME-07  forfeit detail HTML contains "Score comparison was not used"
+OUTCOME-08  forfeit detail HTML contains "No attempt submitted"
+OUTCOME-09  forfeit detail HTML shows submitted player score
+OUTCOME-10  score_win detail HTML has no forfeit disclaimer
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.responses import HTMLResponse
+
+from app.models.vt_challenge import ChallengeStatus, VirtualTrainingChallenge
+from app.models.virtual_training import VirtualTrainingAttempt
+
+_BASE = "app.api.web_routes.vt_challenges"
+_TEMPLATE_PATH = os.path.abspath(
+    os.path.join(
+        os.path.dirname(__file__),
+        "../../../../app/templates/vt_challenge_detail.html",
+    )
+)
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _user(uid=1):
+    u = MagicMock()
+    u.id       = uid
+    u.email    = f"u{uid}@lfa.com"
+    u.nickname = None
+    return u
+
+
+def _game():
+    g = MagicMock()
+    g.id = 7; g.code = "target_tracking"; g.name = "Target Tracking"
+    g.config = {}; g.skill_targets = {}
+    return g
+
+
+def _challenge(
+    *,
+    cid=10,
+    status=ChallengeStatus.COMPLETED,
+    challenger_id=1,
+    challenged_id=2,
+    winner_id=None,
+    is_draw=False,
+    forfeit_user_id=None,
+    forfeit_reason=None,
+    challenger_attempt_id=None,
+    challenged_attempt_id=None,
+):
+    ch = MagicMock(spec=VirtualTrainingChallenge)
+    ch.id                    = cid
+    ch.status                = status
+    ch.challenger_id         = challenger_id
+    ch.challenged_id         = challenged_id
+    ch.winner_id             = winner_id
+    ch.is_draw               = is_draw
+    ch.forfeit_user_id       = forfeit_user_id
+    ch.forfeit_reason        = forfeit_reason
+    ch.challenger_attempt_id = challenger_attempt_id
+    ch.challenged_attempt_id = challenged_attempt_id
+    ch.game_id               = 7
+    ch.difficulty_level      = "hard"
+    ch.message               = None
+    ch.challenge_mode        = "live"
+    ch.completion_deadline   = None
+    ch.completed_at          = datetime.now(timezone.utc)
+    ch.created_at            = datetime.now(timezone.utc)
+    ch.challenger            = _user(uid=challenger_id)
+    ch.challenged            = _user(uid=challenged_id)
+    ch.winner                = _user(uid=winner_id) if winner_id else None
+    ch.forfeit_user          = _user(uid=forfeit_user_id) if forfeit_user_id else None
+    ch.game                  = _game()
+    return ch
+
+
+def _attempt(aid=100, score=75.0, skill_deltas=None):
+    a = MagicMock(spec=VirtualTrainingAttempt)
+    a.id               = aid
+    a.is_valid         = True
+    a.score_normalized = score
+    a.skill_deltas     = skill_deltas if skill_deltas is not None else {}
+    a.stimuli_count    = 12
+    a.correct_count    = 2
+    a.wrong_click_count = 5
+    a.error_count      = 5
+    a.avg_reaction_ms  = 1134.0
+    a.raw_metrics      = {}
+    return a
+
+
+# ── outcome_reason unit tests ─────────────────────────────────────────────────
+
+class TestComputeOutcomeReason:
+
+    def _reason(self, ch):
+        from app.api.web_routes.vt_challenges import _compute_outcome_reason
+        return _compute_outcome_reason(ch)
+
+    def test_outcome01_post_start_timeout_forfeit(self):
+        ch = _challenge(
+            status=ChallengeStatus.COMPLETED,
+            winner_id=1, forfeit_user_id=2,
+            forfeit_reason="post_start_timeout",
+        )
+        assert self._reason(ch) == "forfeit_post_start_timeout"
+
+    def test_outcome02_completed_normal_winner(self):
+        ch = _challenge(
+            status=ChallengeStatus.COMPLETED,
+            winner_id=1, forfeit_user_id=None,
+        )
+        assert self._reason(ch) == "score_win"
+
+    def test_outcome03_completed_draw(self):
+        ch = _challenge(
+            status=ChallengeStatus.COMPLETED,
+            winner_id=None, is_draw=True, forfeit_user_id=None,
+        )
+        assert self._reason(ch) == "draw"
+
+    def test_outcome04_deadline_expired_forfeit(self):
+        ch = _challenge(
+            status=ChallengeStatus.COMPLETED,
+            winner_id=1, forfeit_user_id=2,
+            forfeit_reason="deadline_expired",
+        )
+        assert self._reason(ch) == "forfeit_deadline"
+
+    def test_outcome05_expired_no_contest(self):
+        ch = _challenge(
+            status=ChallengeStatus.EXPIRED,
+            winner_id=None, forfeit_user_id=None,
+            forfeit_reason="no_contest",
+        )
+        assert self._reason(ch) == "no_contest"
+
+    def test_outcome06_live_in_progress(self):
+        ch = _challenge(status=ChallengeStatus.LIVE_IN_PROGRESS)
+        assert self._reason(ch) == "waiting_for_opponent"
+
+    def test_pending_maps_to_waiting_for_acceptance(self):
+        ch = _challenge(status=ChallengeStatus.PENDING)
+        assert self._reason(ch) == "waiting_for_acceptance"
+
+    def test_accepted_maps_to_waiting_for_opponent(self):
+        ch = _challenge(status=ChallengeStatus.ACCEPTED)
+        assert self._reason(ch) == "waiting_for_opponent"
+
+    def test_live_lobby_maps_to_in_lobby(self):
+        ch = _challenge(status=ChallengeStatus.LIVE_LOBBY)
+        assert self._reason(ch) == "in_lobby"
+
+    def test_declined_maps_to_declined(self):
+        ch = _challenge(status=ChallengeStatus.DECLINED)
+        assert self._reason(ch) == "declined"
+
+    def test_cancelled_maps_to_cancelled(self):
+        ch = _challenge(status=ChallengeStatus.CANCELLED)
+        assert self._reason(ch) == "cancelled"
+
+    def test_expired_no_forfeit_maps_to_expired(self):
+        ch = _challenge(
+            status=ChallengeStatus.EXPIRED,
+            forfeit_reason=None,
+        )
+        assert self._reason(ch) == "expired"
+
+    def test_forfeit_no_show(self):
+        ch = _challenge(
+            status=ChallengeStatus.COMPLETED,
+            winner_id=1, forfeit_user_id=2,
+            forfeit_reason="no_show",
+        )
+        assert self._reason(ch) == "forfeit_no_show"
+
+    def test_completed_forfeit_no_winner_is_no_contest(self):
+        ch = _challenge(
+            status=ChallengeStatus.COMPLETED,
+            winner_id=None, forfeit_user_id=2,
+            forfeit_reason="no_contest",
+        )
+        assert self._reason(ch) == "no_contest"
+
+
+# ── outcome_reason injected into route context ────────────────────────────────
+
+def _call_detail(*, ch, user_id=1, challenger_attempt=None, challenged_attempt=None):
+    from app.api.web_routes.vt_challenges import challenge_detail
+
+    user = _user(uid=user_id)
+    db   = MagicMock()
+
+    firsts = iter([ch, challenger_attempt, challenged_attempt])
+    db.query.return_value.filter.return_value.first.side_effect = lambda: next(firsts, None)
+
+    ctx = {}
+
+    def _capture(tmpl, context, **kw):
+        ctx["template"] = tmpl
+        ctx["context"]  = context
+        return MagicMock(spec=HTMLResponse)
+
+    with patch(f"{_BASE}.require_student_onboarding", return_value=None), \
+         patch(f"{_BASE}._spec_ctx", return_value={}), \
+         patch(f"{_BASE}.templates.TemplateResponse", side_effect=_capture):
+        asyncio.run(challenge_detail(
+            challenge_id=ch.id,
+            request=MagicMock(),
+            db=db,
+            user=user,
+        ))
+
+    return ctx.get("context", {})
+
+
+class TestOutcomeReasonInContext:
+
+    def test_outcome_reason_present_in_context(self):
+        ch = _challenge(
+            status=ChallengeStatus.COMPLETED,
+            winner_id=1, forfeit_user_id=2,
+            forfeit_reason="post_start_timeout",
+        )
+        ctx = _call_detail(ch=ch, user_id=1)
+        assert "outcome_reason" in ctx
+        assert ctx["outcome_reason"] == "forfeit_post_start_timeout"
+
+    def test_score_win_context(self):
+        ch = _challenge(
+            status=ChallengeStatus.COMPLETED,
+            winner_id=1, forfeit_user_id=None,
+        )
+        ctx = _call_detail(ch=ch, user_id=1)
+        assert ctx["outcome_reason"] == "score_win"
+
+    def test_draw_context(self):
+        ch = _challenge(
+            status=ChallengeStatus.COMPLETED,
+            winner_id=None, is_draw=True, forfeit_user_id=None,
+        )
+        ctx = _call_detail(ch=ch, user_id=1)
+        assert ctx["outcome_reason"] == "draw"
+
+
+# ── Template content tests ────────────────────────────────────────────────────
+
+class TestOutcomeTemplateContent:
+
+    def _html(self):
+        with open(_TEMPLATE_PATH, encoding="utf-8") as fh:
+            return fh.read()
+
+    # The forfeit score-block disclaimer uses the more specific "— only one player submitted." suffix
+    # to distinguish it from the shorter "Score comparison was not used." in the no_contest branch.
+    _FORFEIT_DISCLAIMER = "Score comparison was not used — only one player submitted."
+
+    def test_outcome07_forfeit_disclaimer_present(self):
+        """OUTCOME-07: template contains the forfeit score-block disclaimer."""
+        html = self._html()
+        assert self._FORFEIT_DISCLAIMER in html
+
+    def test_outcome08_no_attempt_submitted_text_present(self):
+        """OUTCOME-08: template contains 'No attempt submitted' for forfeit side."""
+        html = self._html()
+        assert "No attempt submitted" in html
+
+    def test_outcome09_forfeit_submitted_player_score_rendered(self):
+        """OUTCOME-09: forfeit block renders the submitted player's score_normalized."""
+        html = self._html()
+        # Score block is shown for all forfeit outcomes — verify score render path exists
+        assert "score_normalized" in html or "challenger_attempt.score_normalized" in html
+
+    def test_outcome10_no_forfeit_disclaimer_in_score_win_branch(self):
+        """OUTCOME-10: forfeit disclaimer is gated by _is_forfeit_outcome flag."""
+        html = self._html()
+        # Both the flag and the full-length disclaimer must be present
+        assert "_is_forfeit_outcome" in html
+        assert self._FORFEIT_DISCLAIMER in html
+        # The set-variable declaration must appear before the disclaimer is used
+        set_pos        = html.find("{% set _is_forfeit_outcome")
+        disclaimer_pos = html.find(self._FORFEIT_DISCLAIMER)
+        assert set_pos != -1, "{% set _is_forfeit_outcome %} not found in template"
+        assert set_pos < disclaimer_pos, (
+            "_is_forfeit_outcome must be set before the score disclaimer renders"
+        )
+
+    def test_template_uses_outcome_reason_variable(self):
+        """Template must reference outcome_reason for branching."""
+        html = self._html()
+        assert "outcome_reason" in html
+
+    def test_template_has_not_used_score_class(self):
+        """Forfeit scores must use .not-used CSS class."""
+        html = self._html()
+        assert "not-used" in html
+
+    def test_template_skill_delta_block_no_attempt_submitted(self):
+        """Skill delta block shows 'No attempt submitted' when no attempt linked."""
+        html = self._html()
+        # Both "No attempt submitted" and "No skill delta recorded" must be present
+        assert "No attempt submitted" in html
+        assert "No skill delta recorded" in html

--- a/tests/unit/api/web_routes/test_skill_display.py
+++ b/tests/unit/api/web_routes/test_skill_display.py
@@ -1,0 +1,281 @@
+"""
+SKILL-DISPLAY-01  _skill_scores() passes attempt.skill_deltas values into context
+SKILL-DISPLAY-02  challenge detail template shows +/- delta with correct CSS class
+SKILL-DISPLAY-03  forfeit / no-attempt side shows "No skill delta recorded"
+SKILL-DISPLAY-04  VTSkillScorer.score_all() is NOT called — performance scores
+                  are not mixed in for the Skill Impact section
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.responses import HTMLResponse
+
+from app.models.vt_challenge import ChallengeStatus, VirtualTrainingChallenge
+from app.models.virtual_training import VirtualTrainingAttempt
+
+_BASE = "app.api.web_routes.vt_challenges"
+_TEMPLATE_PATH = os.path.abspath(
+    os.path.join(
+        os.path.dirname(__file__),
+        "../../../../app/templates/vt_challenge_detail.html",
+    )
+)
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _user(uid=1):
+    u = MagicMock()
+    u.id       = uid
+    u.email    = f"u{uid}@lfa.com"
+    u.nickname = None
+    return u
+
+
+def _challenge(cid=10, challenger_id=1, challenged_id=2,
+               challenger_attempt_id=None, challenged_attempt_id=None):
+    ch = MagicMock(spec=VirtualTrainingChallenge)
+    ch.id                     = cid
+    ch.challenger_id          = challenger_id
+    ch.challenged_id          = challenged_id
+    ch.game_id                = 1
+    ch.status                 = ChallengeStatus.COMPLETED
+    ch.winner_id              = None
+    ch.is_draw                = False
+    ch.challenger_attempt_id  = challenger_attempt_id
+    ch.challenged_attempt_id  = challenged_attempt_id
+    ch.forfeit_user_id        = None
+    ch.difficulty_level       = None
+    ch.message                = None
+    ch.challenger             = _user(uid=challenger_id)
+    ch.challenged             = _user(uid=challenged_id)
+    ch.winner                 = None
+    ch.forfeit_user           = None
+    game = MagicMock()
+    game.id = 1; game.code = "memory_sequence"; game.name = "Memory Sequence"
+    game.config = {}; game.skill_targets = {}
+    ch.game = game
+    return ch
+
+
+def _attempt(aid=100, skill_deltas=None):
+    a = MagicMock(spec=VirtualTrainingAttempt)
+    a.id               = aid
+    a.is_valid         = True
+    a.score_normalized = 75.0
+    a.skill_deltas     = skill_deltas if skill_deltas is not None else {}
+    a.stimuli_count    = 36
+    a.correct_count    = 34
+    a.wrong_click_count = 2
+    a.error_count      = 2
+    a.avg_reaction_ms  = 300.0
+    a.raw_metrics      = {}
+    return a
+
+
+def _call_detail(*, user_id=1, ch, db_attempts=None):
+    """Run challenge_detail and return captured template context."""
+    from app.api.web_routes.vt_challenges import challenge_detail
+
+    user = _user(uid=user_id)
+    db   = MagicMock()
+    db.query.return_value.filter.return_value.first.side_effect = (
+        _db_side_effect(ch, db_attempts or {})
+    )
+
+    ctx = {}
+
+    def _capture(tmpl_name, context, **kw):
+        ctx["template"] = tmpl_name
+        ctx["context"]  = context
+        r = MagicMock(spec=HTMLResponse)
+        r.status_code = kw.get("status_code", 200)
+        return r
+
+    with patch(f"{_BASE}.require_student_onboarding", return_value=None), \
+         patch(f"{_BASE}._spec_ctx", return_value={}), \
+         patch(f"{_BASE}.templates.TemplateResponse", side_effect=_capture):
+        asyncio.run(challenge_detail(
+            challenge_id=ch.id,
+            request=MagicMock(),
+            db=db,
+            user=user,
+        ))
+
+    return ctx.get("context", {})
+
+
+def _db_side_effect(ch, attempt_map: dict):
+    """Return a side_effect callable that maps attempt id → attempt object."""
+    call_count = [0]
+
+    def _first():
+        call_count[0] += 1
+        if call_count[0] == 1:
+            return ch
+        # Subsequent calls return attempt by id from attempt_map
+        return None
+
+    # We need a richer mock for the chained calls.
+    # Simpler: just return the challenge, and patch attempt fetching separately.
+    return _first
+
+
+# ── Better call helper that patches attempt lookups ───────────────────────────
+
+def _call_detail_full(*, ch, challenger_attempt=None, challenged_attempt=None):
+    from app.api.web_routes.vt_challenges import challenge_detail
+
+    user = _user(uid=ch.challenger_id)
+    db   = MagicMock()
+
+    # First .first() → challenge; subsequent → attempts by position
+    firsts = iter([ch, challenger_attempt, challenged_attempt])
+    db.query.return_value.filter.return_value.first.side_effect = lambda: next(firsts, None)
+
+    ctx = {}
+
+    def _capture(tmpl_name, context, **kw):
+        ctx["template"] = tmpl_name
+        ctx["context"]  = context
+        return MagicMock(spec=HTMLResponse)
+
+    with patch(f"{_BASE}.require_student_onboarding", return_value=None), \
+         patch(f"{_BASE}._spec_ctx", return_value={}), \
+         patch(f"{_BASE}.templates.TemplateResponse", side_effect=_capture):
+        asyncio.run(challenge_detail(
+            challenge_id=ch.id,
+            request=MagicMock(),
+            db=db,
+            user=user,
+        ))
+
+    return ctx.get("context", {})
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# SKILL-DISPLAY-01  skill_deltas values are passed into context unchanged
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestSkillDisplayDeltas:
+
+    def test_sd01_skill_deltas_passed_as_context(self):
+        """challenger_skill_scores in context equals attempt.skill_deltas (float cast)."""
+        deltas = {"reactions": 0.09, "anticipation": -0.14, "decision_making": 0.03}
+        ch_attempt = _attempt(aid=10, skill_deltas=deltas)
+
+        ch = _challenge(challenger_attempt_id=10, challenged_attempt_id=None)
+        ctx = _call_detail_full(
+            ch=ch,
+            challenger_attempt=ch_attempt,
+            challenged_attempt=None,
+        )
+
+        scores = ctx.get("challenger_skill_scores", {})
+        assert scores.get("reactions") == pytest.approx(0.09)
+        assert scores.get("anticipation") == pytest.approx(-0.14)
+        assert scores.get("decision_making") == pytest.approx(0.03)
+
+    def test_sd01_no_attempt_returns_empty_dict(self):
+        ch = _challenge(challenger_attempt_id=None, challenged_attempt_id=None)
+        ctx = _call_detail_full(ch=ch)
+
+        assert ctx.get("challenger_skill_scores") == {}
+        assert ctx.get("challenged_skill_scores") == {}
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# SKILL-DISPLAY-02  template marks positive/negative delta correctly
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestSkillDisplayTemplate:
+
+    def _read_template(self):
+        with open(_TEMPLATE_PATH, encoding="utf-8") as fh:
+            return fh.read()
+
+    def test_sd02_negative_delta_uses_neg_class(self):
+        html = self._read_template()
+        # Template must apply 'neg' CSS class when delta < 0
+        assert "{% if delta < 0 %}neg{% endif %}" in html
+
+    def test_sd02_positive_delta_shows_plus_sign(self):
+        html = self._read_template()
+        # Template must prefix '+' when delta > 0
+        assert "{% if delta > 0 %}+{% endif %}" in html
+
+    def test_sd02_iterates_skill_delta_directly(self):
+        html = self._read_template()
+        # Must unpack (skill, delta) — NOT (skill, info)
+        assert "{% for skill, delta in challenger_skill_scores.items() %}" in html
+        assert "{% for skill, delta in challenged_skill_scores.items() %}" in html
+
+    def test_sd03_empty_side_shows_no_delta_message(self):
+        html = self._read_template()
+        assert "No skill delta recorded" in html
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# SKILL-DISPLAY-03  forfeit side (no attempt) shows fallback message via route
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestSkillDisplayForfeit:
+
+    def test_sd03_forfeit_challenged_has_empty_scores(self):
+        """Forfeit user has no attempt → challenged_skill_scores == {}."""
+        ch_attempt = _attempt(aid=20, skill_deltas={"reactions": 0.05})
+        ch = _challenge(
+            challenger_id=1, challenged_id=2,
+            challenger_attempt_id=20, challenged_attempt_id=None,
+        )
+        ch.forfeit_user_id = 2  # challenged forfeited
+
+        ctx = _call_detail_full(
+            ch=ch,
+            challenger_attempt=ch_attempt,
+            challenged_attempt=None,
+        )
+
+        assert ctx.get("challenged_skill_scores") == {}
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# SKILL-DISPLAY-04  VTSkillScorer.score_all() is NOT called
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestSkillDisplayNoScorer:
+
+    def test_sd04_vt_skill_scorer_not_imported_in_module(self):
+        """VTSkillScorer must not be in vt_challenges module namespace.
+
+        The old broken _skill_scores() imported and called VTSkillScorer.score_all()
+        which returns 0-1 performance floats instead of stored skill deltas. Verify
+        the module no longer imports the scorer so the regression cannot be reintroduced
+        without this test failing.
+        """
+        import app.api.web_routes.vt_challenges as mod
+        assert not hasattr(mod, "VTSkillScorer"), (
+            "VTSkillScorer found in vt_challenges — risk of performance score being "
+            "mixed in for Skill Impact display. Remove import or revert _skill_scores()."
+        )
+
+    def test_sd04_negative_delta_preserved_in_context(self):
+        """Negative deltas (impossible for 0-1 scorer) must survive into context unchanged."""
+        deltas = {"reactions": -0.14}
+        ch_attempt = _attempt(aid=31, skill_deltas=deltas)
+        ch = _challenge(challenger_attempt_id=31, challenged_attempt_id=None)
+
+        ctx = _call_detail_full(
+            ch=ch,
+            challenger_attempt=ch_attempt,
+            challenged_attempt=None,
+        )
+
+        scores = ctx.get("challenger_skill_scores", {})
+        assert scores.get("reactions") == pytest.approx(-0.14), (
+            "Negative delta was lost — VTSkillScorer (which clamps to 0-1) may be in use"
+        )

--- a/tests/unit/middleware/test_security_middleware.py
+++ b/tests/unit/middleware/test_security_middleware.py
@@ -586,6 +586,35 @@ class TestSecurityHeadersMiddleware:
         csp = response.headers["Content-Security-Policy"]
         assert "default-src" in csp
 
+    # GEO-SEC-01
+    def test_geo_sec_01_connect_src_no_hardcoded_lan_ip(self):
+        """GEO-SEC-01: Default CSP connect-src must not contain hardcoded LAN IP."""
+        response = self._dispatch()
+        csp = response.headers["Content-Security-Policy"]
+        assert "192.168." not in csp, (
+            "CSP connect-src must not contain hardcoded LAN IP (192.168.x.x)"
+        )
+
+    # GEO-SEC-02
+    def test_geo_sec_02_connect_src_contains_self(self):
+        """GEO-SEC-02: Default CSP connect-src must include 'self'."""
+        response = self._dispatch()
+        csp = response.headers["Content-Security-Policy"]
+        assert "connect-src" in csp
+        connect_src_part = [p for p in csp.split(";") if "connect-src" in p][0]
+        assert "'self'" in connect_src_part, (
+            "CSP connect-src must include 'self'"
+        )
+
+    # GEO-SEC-03
+    def test_geo_sec_03_permissions_policy_geolocation_self(self):
+        """GEO-SEC-03: Permissions-Policy must allow geolocation for same origin."""
+        response = self._dispatch()
+        pp = response.headers.get("Permissions-Policy", "")
+        assert "geolocation=(self)" in pp, (
+            "Permissions-Policy must include geolocation=(self)"
+        )
+
 
 # ──────────────────────────────────────────────────────────────────────────────
 # RequestSizeLimitMiddleware

--- a/tests/unit/skill/test_vt_timeline_filter.py
+++ b/tests/unit/skill/test_vt_timeline_filter.py
@@ -1,0 +1,158 @@
+"""
+SKILL-TL-01  xp_awarded=0 + non-empty skill_deltas → appears in timeline
+SKILL-TL-02  xp_awarded=0 + empty skill_deltas → NOT in timeline
+SKILL-TL-03  xp_awarded>0 + non-empty skill_deltas → appears (existing behaviour)
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+_VIEWS = "app.services.skill_progression._views"
+_NOW = datetime(2026, 5, 26, 10, 0, 0, tzinfo=timezone.utc)
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _mock_attempt(
+    *,
+    aid: int = 1,
+    user_id: int = 42,
+    xp_awarded: int = 0,
+    skill_deltas: dict | None = None,
+    started_at: datetime | None = None,
+) -> MagicMock:
+    a = MagicMock()
+    a.id               = aid
+    a.user_id          = user_id
+    a.is_valid         = True
+    a.xp_awarded       = xp_awarded
+    a.skill_deltas     = skill_deltas if skill_deltas is not None else {}
+    a.started_at       = started_at or _NOW
+    a.score_normalized = 55.0
+    a.attempt_index_today = 1
+    a.stimuli_count    = 36
+    a.correct_count    = 30
+    a.wrong_click_count = 6
+    a.error_count      = 6
+    a.avg_reaction_ms  = 400.0
+    a.min_reaction_ms  = 220.0
+    a.duration_seconds = 90
+
+    game = MagicMock()
+    game.code = "memory_sequence"
+    game.name = "Memory Sequence"
+    a.game = game
+
+    return a
+
+
+def _make_db(attempts: list) -> MagicMock:
+    db = MagicMock()
+    db.query.return_value.filter.return_value.order_by.return_value.all.return_value = attempts
+    return db
+
+
+def _call(db, user_id=42, skill_key="reactions"):
+    from app.services.skill_progression._views import _collect_vt_timeline_events
+    return _collect_vt_timeline_events(db, user_id, skill_key)
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# SKILL-TL-01  challenge cap-bypass attempt (xp=0, skill_deltas non-empty)
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestVtTimelineFilter:
+
+    def test_tl01_zero_xp_nonempty_deltas_included(self):
+        """Virtual Challenge attempt with xp_awarded=0 but skill_deltas must appear."""
+        attempt = _mock_attempt(
+            xp_awarded=0,
+            skill_deltas={"reactions": 0.09, "anticipation": -0.14},
+        )
+        db = _make_db([attempt])
+
+        events = _call(db)
+
+        assert len(events) == 1
+        assert events[0]["_vt_delta"] == pytest.approx(0.09)
+        assert events[0]["event_type"] == "virtual_training"
+        assert events[0]["xp_awarded"] == 0
+
+    # ── SKILL-TL-02 ──────────────────────────────────────────────────────────
+
+    def test_tl02_zero_xp_empty_deltas_excluded(self):
+        """Solo attempt hitting daily cap: xp_awarded=0, skill_deltas={} → not shown."""
+        attempt = _mock_attempt(
+            xp_awarded=0,
+            skill_deltas={},
+        )
+        db = _make_db([attempt])
+
+        events = _call(db)
+
+        # The Python-level filter skips because skill_key not in {}
+        assert events == []
+
+    def test_tl02_zero_xp_delta_for_different_skill_excluded(self):
+        """Cap-bypass with deltas for a different skill → not in this skill's timeline."""
+        attempt = _mock_attempt(
+            xp_awarded=0,
+            skill_deltas={"decision_making": 0.05},  # not "reactions"
+        )
+        db = _make_db([attempt])
+
+        events = _call(db, skill_key="reactions")
+
+        assert events == []
+
+    # ── SKILL-TL-03 ──────────────────────────────────────────────────────────
+
+    def test_tl03_positive_xp_nonempty_deltas_included(self):
+        """Standard attempt (xp_awarded>0) still appears — existing behaviour unchanged."""
+        attempt = _mock_attempt(
+            xp_awarded=12,
+            skill_deltas={"reactions": 0.05},
+        )
+        db = _make_db([attempt])
+
+        events = _call(db)
+
+        assert len(events) == 1
+        assert events[0]["_vt_delta"] == pytest.approx(0.05)
+        assert events[0]["xp_awarded"] == 12
+
+    def test_tl03_delta_value_stored_as_float(self):
+        """_vt_delta is cast to float regardless of stored type."""
+        attempt = _mock_attempt(
+            xp_awarded=8,
+            skill_deltas={"reactions": "0.07"},  # string in JSONB
+        )
+        db = _make_db([attempt])
+
+        events = _call(db)
+
+        assert len(events) == 1
+        assert isinstance(events[0]["_vt_delta"], float)
+        assert events[0]["_vt_delta"] == pytest.approx(0.07)
+
+    def test_tl01_event_fields_populated(self):
+        """Timeline event dict has all required fields for skill_history.html."""
+        attempt = _mock_attempt(
+            xp_awarded=0,
+            skill_deltas={"reactions": 0.09},
+        )
+        db = _make_db([attempt])
+
+        events = _call(db)
+        ev = events[0]
+
+        assert ev["event_type"]      == "virtual_training"
+        assert ev["game_code"]       == "memory_sequence"
+        assert ev["attempt_id"]      == attempt.id
+        assert ev["score_normalized"] == attempt.score_normalized
+        assert ev["xp_awarded"]      == 0
+        assert "event_name" in ev
+        assert "achieved_at" in ev

--- a/tests/unit/test_cleanup_stuck_challenges.py
+++ b/tests/unit/test_cleanup_stuck_challenges.py
@@ -1,0 +1,174 @@
+"""
+CLEAN-01  dry-run (default) — does NOT call db.delete()
+CLEAN-02  --apply flag — deletes challenge id=1 when all safety assertions pass
+CLEAN-03  --apply aborts (SystemExit 2) if challenger_attempt_id is set
+CLEAN-04  --apply aborts (SystemExit 2) if challenge_config_snapshot is not NULL
+CLEAN-05  script refuses to run (SystemExit 1) outside development/dev environment
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_SCRIPT_PATH = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "../../scripts/dev_cleanup_stuck_challenges.py")
+)
+_APP_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
+
+
+def _load_script(argv=None):
+    """Load the cleanup script as a module with optional sys.argv override."""
+    original_argv = sys.argv[:]
+    if argv is not None:
+        sys.argv = argv
+    try:
+        spec = importlib.util.spec_from_file_location("_cleanup_mod", _SCRIPT_PATH)
+        mod = importlib.util.module_from_spec(spec)
+        # Ensure app is importable from run()
+        if _APP_ROOT not in sys.path:
+            sys.path.insert(0, _APP_ROOT)
+        spec.loader.exec_module(mod)
+        return mod
+    finally:
+        sys.argv = original_argv
+
+
+def _mock_challenge(
+    challenger_attempt_id=None,
+    challenged_attempt_id=None,
+    challenge_config_snapshot=None,
+    challenger_id=3,
+    challenged_id=3617,
+    game_id=6,
+):
+    from app.models.vt_challenge import ChallengeStatus
+
+    ch = MagicMock()
+    ch.status = ChallengeStatus.ACCEPTED
+    ch.challenger_attempt_id = challenger_attempt_id
+    ch.challenged_attempt_id = challenged_attempt_id
+    ch.challenge_config_snapshot = challenge_config_snapshot
+    ch.challenger_id = challenger_id
+    ch.challenged_id = challenged_id
+    ch.game_id = game_id
+    return ch
+
+
+def _make_mock_db(challenge_obj):
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = challenge_obj
+    return db
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# CLEAN-01  dry-run does not delete
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestClean01DryRunNoDelete:
+
+    def test_clean01_dryrun_does_not_call_delete(self):
+        mod = _load_script(argv=["script.py"])  # no --apply → DRY_RUN=True
+        assert mod.DRY_RUN is True
+
+        ch = _mock_challenge()
+        mock_db = _make_mock_db(ch)
+
+        with patch("app.database.SessionLocal", return_value=mock_db):
+            mod.run()
+
+        mock_db.delete.assert_not_called()
+        mock_db.commit.assert_not_called()
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# CLEAN-02  --apply deletes the stuck challenge
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestClean02ApplyDeletes:
+
+    def test_clean02_apply_deletes_challenge(self):
+        mod = _load_script(argv=["script.py", "--apply"])
+        assert mod.DRY_RUN is False
+
+        ch = _mock_challenge()
+        mock_db = _make_mock_db(ch)
+
+        with patch("app.database.SessionLocal", return_value=mock_db):
+            mod.run()
+
+        mock_db.delete.assert_called_once_with(ch)
+        mock_db.commit.assert_called_once()
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# CLEAN-03  aborts if challenger_attempt_id is set
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestClean03LinkedAttemptAbort:
+
+    def test_clean03_abort_if_challenger_attempt_linked(self):
+        mod = _load_script(argv=["script.py", "--apply"])
+
+        ch = _mock_challenge(challenger_attempt_id=99)
+        mock_db = _make_mock_db(ch)
+
+        with patch("app.database.SessionLocal", return_value=mock_db):
+            with pytest.raises(SystemExit) as exc:
+                mod.run()
+
+        assert exc.value.code == 2
+        mock_db.delete.assert_not_called()
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# CLEAN-04  aborts if snapshot is not NULL
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestClean04SnapshotNotNullAbort:
+
+    def test_clean04_abort_if_snapshot_present(self):
+        mod = _load_script(argv=["script.py", "--apply"])
+
+        ch = _mock_challenge(challenge_config_snapshot={"game": "memory_sequence"})
+        mock_db = _make_mock_db(ch)
+
+        with patch("app.database.SessionLocal", return_value=mock_db):
+            with pytest.raises(SystemExit) as exc:
+                mod.run()
+
+        assert exc.value.code == 2
+        mock_db.delete.assert_not_called()
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# CLEAN-05  refuses to run outside development env
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestClean05NonDevRefused:
+
+    def test_clean05_refuses_in_production(self):
+        env = {**os.environ, "ENVIRONMENT": "production"}
+        result = subprocess.run(
+            [sys.executable, _SCRIPT_PATH],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 1
+        assert "ABORT" in result.stdout
+
+    def test_clean05_refuses_in_staging(self):
+        env = {**os.environ, "ENVIRONMENT": "staging"}
+        result = subprocess.run(
+            [sys.executable, _SCRIPT_PATH],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 1
+        assert "ABORT" in result.stdout

--- a/tests/unit/test_geolocation_template.py
+++ b/tests/unit/test_geolocation_template.py
@@ -1,0 +1,67 @@
+"""Static template tests for geolocation P0+P1 mobile fix.
+
+Tests parse the raw HTML template — no running server required.
+
+GEO-01  isSecureContext guard present before geolocation call
+GEO-02  Insecure context error message present
+GEO-03  navigator.permissions.query call present
+GEO-04  Safari try/catch fallback wraps permissions.query
+GEO-05  High accuracy (enableHighAccuracy:true, timeout:15000) used for first attempt
+GEO-06  Low accuracy fallback (enableHighAccuracy:false, timeout:10000) used for retry
+GEO-07  Error handler logs err.code, err.message, isSecureContext, perm, ua
+"""
+import pathlib
+
+_TEMPLATE = (
+    pathlib.Path(__file__).parents[2]
+    / "app" / "templates" / "dashboard" / "lfa_public_profile_editor.html"
+).read_text(encoding="utf-8")
+
+
+def test_geo_01_secure_context_guard():
+    assert "window.isSecureContext" in _TEMPLATE, (
+        "lfa_public_profile_editor.html is missing window.isSecureContext guard"
+    )
+
+
+def test_geo_02_insecure_context_error_message():
+    assert "Location requires HTTPS on mobile" in _TEMPLATE, (
+        "lfa_public_profile_editor.html is missing insecure context error message"
+    )
+
+
+def test_geo_03_permissions_query_call():
+    assert 'navigator.permissions.query' in _TEMPLATE, (
+        "lfa_public_profile_editor.html is missing navigator.permissions.query call"
+    )
+
+
+def test_geo_04_safari_try_catch_fallback():
+    # The permissions.query call must be wrapped in a try/catch block
+    assert "} catch (e) {" in _TEMPLATE, (
+        "lfa_public_profile_editor.html is missing try/catch fallback for Safari"
+    )
+    # Verify the catch includes a comment about Safari
+    assert "Safari" in _TEMPLATE, (
+        "lfa_public_profile_editor.html is missing Safari compatibility comment"
+    )
+
+
+def test_geo_05_high_accuracy_first_attempt():
+    assert "enableHighAccuracy: true, timeout: 15000" in _TEMPLATE, (
+        "lfa_public_profile_editor.html must use enableHighAccuracy:true, timeout:15000 for first attempt"
+    )
+
+
+def test_geo_06_low_accuracy_fallback():
+    assert "enableHighAccuracy: false, timeout: 10000" in _TEMPLATE, (
+        "lfa_public_profile_editor.html must use enableHighAccuracy:false, timeout:10000 for retry"
+    )
+
+
+def test_geo_07_error_handler_logs_diagnostics():
+    # All four diagnostic fields must appear in the error logging block
+    for field in ("err.code", "err.message", "window.isSecureContext", "navigator.userAgent"):
+        assert field in _TEMPLATE, (
+            f"lfa_public_profile_editor.html error handler is missing diagnostic field: {field}"
+        )


### PR DESCRIPTION
## Summary

- **outcome_reason display** — `_compute_outcome_reason()` pure helper maps 13 challenge states to named outcome categories; injected into `challenge_detail` route context
- **forfeit result communication** — `vt_challenge_detail.html` refactored into four independent blocks (header, outcome banner, score block, skill delta block); every `outcome_reason` has a dedicated banner + sub-text
- **score "not used for result" disclaimer** — forfeit-winner score rendered with `.not-used` CSS (opacity 0.6) + "Your performance (not used for result)" label; "⚠ Score comparison was not used — only one player submitted." disclaimer gated by `_is_forfeit_outcome` flag
- **skill delta display fix** — `_skill_scores()` reads `attempt.skill_deltas` directly; `VTSkillScorer` not imported (regression guard SKILL-DISPLAY-04); negative deltas preserved
- **timeline filter fix** — `_collect_vt_timeline_events()` includes `xp_awarded=0` attempts when `skill_deltas` is non-empty (challenge cap-bypass attempts)
- **dev cleanup script** — `scripts/dev_cleanup_stuck_challenges.py` with dry-run / `--apply` safety guard; aborts if attempt linked or snapshot present; refuses in production/staging

## Test results

- **11 103 unit tests PASS**, 0 failures, 0 errors
- **OUTCOME-01..10**: 24/24 PASS (direct helper + route context + template static assertions)
- **SKILL-DISPLAY-01..04**: 9/9 PASS
- **SKILL-TL-01..03**: 6/6 PASS
- **CLEAN-01..06**: 6/6 PASS
- **OpenAPI snapshot**: unchanged (no new routes)
- **Challenge detail + live-lobby regression**: 239/239 PASS

## Manual validation — /challenges/2 (16/16 PASS)

**rdias POV (winner by forfeit):**
- ✅ `🏆 You won by forfeit.`
- ✅ `T1B1K3 did not submit within the live challenge time window.`
- ✅ Score cell renders with `.not-used` class (34%, faded)
- ✅ `Your performance (not used for result)` label visible
- ✅ `⚠ Score comparison was not used — only one player submitted.`
- ✅ johny7/T1B1K3 side: `No attempt submitted`
- ✅ rdias skill deltas visible: `Reactions +0.094`, `Anticipation -0.141`
- ✅ johny7 skill delta block: `No attempt submitted`

**johny7 POV (forfeit loser):**
- ✅ `✗ You lost by forfeit.`
- ✅ `T1B1K3 did not submit within the live challenge time window.`
- ✅ Own side: `No attempt submitted`
- ✅ Own score cell: `.not-used`
- ✅ rdias score (34%) visible
- ✅ Disclaimer present

## Scope exclusions

No DB migration, no timeout modification, no server-side score recomputation, no WebSocket, no new route, no reward/credit change.

## Tech debt notes (in template comments)

- P1: `game.config["live_submit_window_seconds"]` per-game override for `POST_START_SUBMIT_WINDOW_SECONDS`
- P2 (TRUST-VT-SCORE-01): `score_normalized` is client-submitted; server-side recomputation from `raw_metrics` deferred

🤖 Generated with [Claude Code](https://claude.com/claude-code)