### PR TITLE
feat(vt): Virtual Challenge Social Cards + Challenge Card manager

### DIFF
--- a/app/api/web_routes/my_cards.py
+++ b/app/api/web_routes/my_cards.py
@@ -84,7 +84,7 @@ async def my_cards_challenge_card(
     user: User   = Depends(get_current_user_web),
 ):
     """Challenge Card design manager — theme picker + format overview."""
-    draft  = CardDraftService.get_or_create_singleton_draft(db, user.id, "challenge_card")
+    draft  = CardDraftService.get_or_create_singleton(db, user.id, "challenge_card")
     themes = get_all_themes(db=db)
     return templates.TemplateResponse(
         "my_cards_challenge_card.html",

--- a/app/api/web_routes/my_cards.py
+++ b/app/api/web_routes/my_cards.py
@@ -4,10 +4,14 @@ from pathlib import Path
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
+from sqlalchemy.orm import Session
 
+from ...database import get_db
 from ...dependencies import get_current_user_web
 from ...models.user import User
+from ...services.card_draft_service import CardDraftService
 from ...services.card_system import card_registry
+from ...services.card_theme_service import get_all_themes
 
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
 templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
@@ -54,4 +58,41 @@ async def my_cards_welcome_card(
     return RedirectResponse(
         url="/profile/onboarding-card",
         status_code=303,
+    )
+
+
+_CHALLENGE_CARD_FORMATS = [
+    {
+        "id":       "challenge_post_16_9",
+        "label":    "Post (16:9)",
+        "dims":     "1280×720",
+        "platform": "Facebook / Instagram Post",
+    },
+    {
+        "id":       "challenge_story_9_16",
+        "label":    "Story (9:16)",
+        "dims":     "1080×1920",
+        "platform": "TikTok / Instagram Story",
+    },
+]
+
+
+@router.get("/my-cards/challenge-card", response_class=HTMLResponse)
+async def my_cards_challenge_card(
+    request: Request,
+    db: Session = Depends(get_db),
+    user: User   = Depends(get_current_user_web),
+):
+    """Challenge Card design manager — theme picker + format overview."""
+    draft  = CardDraftService.get_or_create_singleton_draft(db, user.id, "challenge_card")
+    themes = get_all_themes(db=db)
+    return templates.TemplateResponse(
+        "my_cards_challenge_card.html",
+        {
+            "request": request,
+            "user":    user,
+            "draft":   draft,
+            "themes":  themes,
+            "formats": _CHALLENGE_CARD_FORMATS,
+        },
     )

--- a/app/api/web_routes/vt_challenges.py
+++ b/app/api/web_routes/vt_challenges.py
@@ -26,11 +26,12 @@ Notifications:
 """
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
-from fastapi import APIRouter, Depends, Form, Request
-from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+from fastapi import APIRouter, Depends, Form, HTTPException, Query, Request
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
 from fastapi.templating import Jinja2Templates
 from sqlalchemy import or_
 from sqlalchemy.orm import Session
@@ -52,6 +53,7 @@ from ...models.vt_challenge import (
     make_expires_at,
     validate_completion_window,
 )
+from ...services import card_export_service as _export_svc
 from ...services import notification_service
 from ...services.challenge_completion_service import sweep_accepted_deadlines
 from ...services.live_lobby_service import (
@@ -652,6 +654,181 @@ async def challenge_detail(
             "is_forfeit":               is_forfeit,
             "is_no_contest":            is_no_contest,
             "outcome_reason":           outcome_reason,
+        },
+    )
+
+
+# ── Challenge Social Card routes ─────────────────────────────────────────────
+
+CHALLENGE_CARD_PLATFORMS = frozenset({"challenge_post_16_9", "challenge_story_9_16"})
+
+_TERMINAL_STATUSES = frozenset({
+    ChallengeStatus.COMPLETED, ChallengeStatus.EXPIRED,
+    ChallengeStatus.DECLINED,  ChallengeStatus.CANCELLED,
+})
+
+_CTA_LABELS = {
+    "score_win":                 "Play again",
+    "draw":                      "Play again",
+    "forfeit_post_start_timeout":"Play again",
+    "forfeit_deadline":          "Play again",
+    "forfeit_no_show":           "Play again",
+    "forfeit":                   "Play again",
+    "no_contest":                "Play again",
+    "waiting_for_acceptance":    "View challenge",
+    "waiting_for_opponent":      "View challenge",
+    "in_lobby":                  "Join lobby",
+    "expired":                   "Challenge me",
+    "declined":                  "Challenge me",
+    "cancelled":                 "Challenge me",
+}
+
+
+def _display_name(user: Any) -> str:
+    return user.nickname if (user and user.nickname) else (user.email if user else "Unknown")
+
+
+def _compute_card_cta(ch: VirtualTrainingChallenge, viewer: User) -> str:
+    outcome = _compute_outcome_reason(ch)
+    return _CTA_LABELS.get(outcome, "View challenge")
+
+
+def _build_challenge_card_context(
+    ch: VirtualTrainingChallenge,
+    viewer: User,
+    challenger_attempt: Any,
+    challenged_attempt: Any,
+) -> dict:
+    def _skill_scores_map(attempt: Any) -> dict[str, float]:
+        if attempt is None or not attempt.skill_deltas:
+            return {}
+        return {k: float(v) for k, v in attempt.skill_deltas.items()}
+
+    is_challenger = viewer.id == ch.challenger_id
+    my_attempt    = challenger_attempt if is_challenger else challenged_attempt
+    opp_attempt   = challenged_attempt if is_challenger else challenger_attempt
+
+    my_score  = float(my_attempt.score_normalized)  if my_attempt  else None
+    opp_score = float(opp_attempt.score_normalized) if opp_attempt else None
+
+    outcome_reason = _compute_outcome_reason(ch)
+
+    return {
+        "challenge_id":     ch.id,
+        "challenger_name":  _display_name(ch.challenger),
+        "challenged_name":  _display_name(ch.challenged),
+        "game_name":        ch.game.name if ch.game else "Unknown Game",
+        "challenge_mode":   ch.challenge_mode or "async",
+        "outcome_reason":   outcome_reason,
+        "challenger_score": float(challenger_attempt.score_normalized) if challenger_attempt else None,
+        "challenged_score": float(challenged_attempt.score_normalized) if challenged_attempt else None,
+        "winner_name":      _display_name(ch.winner) if ch.winner else None,
+        "is_draw":          bool(ch.is_draw),
+        "my_score":         my_score,
+        "opp_score":        opp_score,
+        "my_skill_scores":  _skill_scores_map(my_attempt),
+        "is_viewer_winner": ch.winner_id is not None and ch.winner_id == viewer.id,
+        "cta_label":        _compute_card_cta(ch, viewer),
+        "completed_at":     ch.completed_at if ch.status == ChallengeStatus.COMPLETED else None,
+    }
+
+
+@router.get("/challenges/{challenge_id}/card/preview", response_class=HTMLResponse)
+async def challenge_card_preview(
+    challenge_id: int,
+    request: Request,
+    platform: str = Query("challenge_post_16_9"),
+    db: Session = Depends(get_db),
+    user: User  = Depends(get_current_user_web),
+):
+    """Render a challenge social card as HTML (used as Playwright render target)."""
+    if platform not in CHALLENGE_CARD_PLATFORMS:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Unsupported platform: {platform!r}. Valid: {sorted(CHALLENGE_CARD_PLATFORMS)}",
+        )
+
+    ch = db.query(VirtualTrainingChallenge).filter(
+        VirtualTrainingChallenge.id == challenge_id
+    ).first()
+    if ch is None:
+        raise HTTPException(status_code=404, detail="Challenge not found")
+    if user.id not in (ch.challenger_id, ch.challenged_id):
+        raise HTTPException(status_code=403, detail="Participants only")
+
+    challenger_attempt = (
+        db.query(VirtualTrainingAttempt).filter(
+            VirtualTrainingAttempt.id == ch.challenger_attempt_id
+        ).first() if ch.challenger_attempt_id else None
+    )
+    challenged_attempt = (
+        db.query(VirtualTrainingAttempt).filter(
+            VirtualTrainingAttempt.id == ch.challenged_attempt_id
+        ).first() if ch.challenged_attempt_id else None
+    )
+
+    ctx = _build_challenge_card_context(ch, user, challenger_attempt, challenged_attempt)
+    template_name = (
+        "public/export/challenge/post_16_9.html"
+        if platform == "challenge_post_16_9"
+        else "public/export/challenge/story_9_16.html"
+    )
+    return templates.TemplateResponse(template_name, {"request": request, **ctx})
+
+
+@router.get("/challenges/{challenge_id}/card/export")
+async def challenge_card_export(
+    challenge_id: int,
+    request: Request,
+    platform: str = Query("challenge_post_16_9"),
+    db: Session   = Depends(get_db),
+    user: User    = Depends(get_current_user_web),
+):
+    """Export a challenge social card as PNG. Participants only. Rate-limited 5/60s."""
+    from app.config import settings  # noqa: PLC0415
+
+    if platform not in CHALLENGE_CARD_PLATFORMS:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Unsupported platform: {platform!r}. Valid: {sorted(CHALLENGE_CARD_PLATFORMS)}",
+        )
+
+    ch = db.query(VirtualTrainingChallenge).filter(
+        VirtualTrainingChallenge.id == challenge_id
+    ).first()
+    if ch is None:
+        raise HTTPException(status_code=404, detail="Challenge not found")
+    if user.id not in (ch.challenger_id, ch.challenged_id):
+        raise HTTPException(status_code=403, detail="Participants only")
+
+    client_ip = request.client.host if request.client else "unknown"
+    rate_key  = f"vt_card:{challenge_id}:{user.id}:{client_ip}"
+    if not _export_svc.check_export_rate_limit(rate_key):
+        raise HTTPException(
+            status_code=429,
+            detail="Export rate limit exceeded (5 per minute). Please wait before exporting again.",
+        )
+
+    render_url = (
+        f"http://127.0.0.1:{settings.APP_INTERNAL_PORT}"
+        f"/challenges/{challenge_id}/card/preview?platform={platform}&export=1"
+    )
+
+    try:
+        png_bytes = await asyncio.to_thread(
+            _export_svc._sync_take_screenshot, render_url, platform
+        )
+    except _export_svc.CardExportTimeoutError:
+        raise HTTPException(status_code=504, detail="Card render timed out")
+
+    filename = f"lfa_challenge_{challenge_id}_{platform}.png"
+    return Response(
+        content=png_bytes,
+        media_type="image/png",
+        headers={
+            "Content-Disposition": f'attachment; filename="{filename}"',
+            "Cache-Control":       "no-store",
+            "X-Export-Platform":   platform,
         },
     )
 

--- a/app/services/card_constants.py
+++ b/app/services/card_constants.py
@@ -29,31 +29,35 @@ from __future__ import annotations
 # to the card-wrap bounding rect — height is content-determined at render time,
 # so the export is never truncated regardless of what this constant says.
 CANVAS_SIZES: dict[str, tuple[int, int]] = {
-    "default":            ( 820,  800),   # native FIFA Classic; clip = card-wrap bbox (est. 2026-05-12)
-    "instagram_square":   (1080, 1080),
-    "instagram_portrait": (1080, 1350),
-    "instagram_story":    (1080, 1920),
-    "tiktok":             (1080, 1920),
-    "facebook_square":    (1080, 1080),
-    "facebook_landscape": (1200,  630),
-    "og":                 (1200,  630),
-    "banner_custom":      (1500,  500),
-    "facebook_post":      (1200,  630),
+    "default":               ( 820,  800),   # native FIFA Classic; clip = card-wrap bbox (est. 2026-05-12)
+    "instagram_square":      (1080, 1080),
+    "instagram_portrait":    (1080, 1350),
+    "instagram_story":       (1080, 1920),
+    "tiktok":                (1080, 1920),
+    "facebook_square":       (1080, 1080),
+    "facebook_landscape":    (1200,  630),
+    "og":                    (1200,  630),
+    "banner_custom":         (1500,  500),
+    "facebook_post":         (1200,  630),
+    "challenge_post_16_9":   (1280,  720),
+    "challenge_story_9_16":  (1080, 1920),
 }
 
 # ── Export template routing ───────────────────────────────────────────────────
 # Maps platform preset id → template bucket directory.
 # Template path resolved as: public/export/{bucket}/{card_variant_id}.html
 EXPORT_FORMAT_BUCKETS: dict[str, str] = {
-    "instagram_square":   "square",
-    "facebook_square":    "square",
-    "instagram_portrait": "portrait",
-    "instagram_story":    "story",
-    "tiktok":             "tiktok",
-    "facebook_landscape": "landscape",
-    "og":                 "og",
-    "banner_custom":      "banner",
-    "facebook_post":      "landscape",
+    "instagram_square":     "square",
+    "facebook_square":      "square",
+    "instagram_portrait":   "portrait",
+    "instagram_story":      "story",
+    "tiktok":               "tiktok",
+    "facebook_landscape":   "landscape",
+    "og":                   "og",
+    "banner_custom":        "banner",
+    "facebook_post":        "landscape",
+    "challenge_post_16_9":  "challenge",
+    "challenge_story_9_16": "challenge",
 }
 
 # ── Animated video export capability registry ─────────────────────────────────

--- a/app/services/card_system/_challenge_card.py
+++ b/app/services/card_system/_challenge_card.py
@@ -1,0 +1,46 @@
+"""Challenge Card v1 specification — content contract + CardTypeSpec."""
+from app.services.card_system._types import (
+    CardContentContract,
+    CardTypeSpec,
+    ContentField,
+    ContentFieldKind,
+)
+
+_R = ContentFieldKind.REQUIRED
+_O = ContentFieldKind.OPTIONAL
+_C = ContentFieldKind.COMPUTED
+
+CHALLENGE_CARD_CONTRACT = CardContentContract(
+    card_type_id="challenge_card",
+    version=1,
+    fields=(
+        ContentField("challenger_name",    _R, "str",        "Challenger display name"),
+        ContentField("challenged_name",    _R, "str",        "Challenged display name"),
+        ContentField("game_name",          _R, "str",        "Game display name"),
+        ContentField("challenge_mode",     _R, "str",        "'live' or 'async'"),
+        ContentField("outcome_reason",     _R, "str",        "Outcome category string"),
+        ContentField("challenger_score",   _O, "float|None", "Challenger score_normalized (0-100)"),
+        ContentField("challenged_score",   _O, "float|None", "Challenged score_normalized (0-100)"),
+        ContentField("winner_name",        _O, "str|None",   "Winner display name; None for draw/no-contest"),
+        ContentField("is_draw",            _O, "bool",       "True when challenge ended in draw"),
+        ContentField("my_score",           _C, "float|None", "Viewer's own score"),
+        ContentField("opp_score",          _C, "float|None", "Opponent's score from viewer perspective"),
+        ContentField("my_skill_scores",    _C, "dict",       "Viewer's skill deltas (empty if no attempt)"),
+        ContentField("is_viewer_winner",   _C, "bool",       "True when viewing user is the winner"),
+        ContentField("cta_label",          _C, "str",        "CTA button text"),
+        ContentField("challenge_id",       _C, "int",        "Challenge DB id for CTA link"),
+        ContentField("completed_at",       _O, "datetime|None", "Completion timestamp"),
+    ),
+)
+
+CHALLENGE_CARD_SPEC = CardTypeSpec(
+    card_type_id="challenge_card",
+    label="Challenge Card",
+    description="Virtual Challenge result card for social sharing (16:9 post + 9:16 story).",
+    content_contract=CHALLENGE_CARD_CONTRACT,
+    supported_variant_ids=("challenge",),
+    supported_platform_ids=("challenge_post_16_9", "challenge_story_9_16"),
+    theme_compatible=False,
+    has_published_state=False,
+    is_editable=False,
+)

--- a/app/services/card_system/_challenge_card.py
+++ b/app/services/card_system/_challenge_card.py
@@ -40,7 +40,7 @@ CHALLENGE_CARD_SPEC = CardTypeSpec(
     content_contract=CHALLENGE_CARD_CONTRACT,
     supported_variant_ids=("challenge",),
     supported_platform_ids=("challenge_post_16_9", "challenge_story_9_16"),
-    theme_compatible=False,
+    theme_compatible=True,
     has_published_state=False,
-    is_editable=False,
+    is_editable=True,
 )

--- a/app/services/card_system/registry.py
+++ b/app/services/card_system/registry.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from app.services.card_constants import ANIMATED_EXPORT_CAPABLE
+from app.services.card_system._challenge_card import CHALLENGE_CARD_SPEC
 from app.services.card_system._player_card import PLAYER_CARD_SPEC
 from app.services.card_system._skeletal_specs import (
     BADGE_CARD_SPEC,
@@ -29,6 +30,7 @@ _VARIANT_CAPABILITIES: dict[str, VariantCapabilitySpec] = {
 _ALL_SPECS: tuple[CardTypeSpec, ...] = (
     PLAYER_CARD_SPEC,
     WELCOME_CARD_SPEC,
+    CHALLENGE_CARD_SPEC,
     MATCH_CARD_SPEC,
     EVENT_CARD_SPEC,
     BIRTHDAY_CARD_SPEC,

--- a/app/templates/my_cards_challenge_card.html
+++ b/app/templates/my_cards_challenge_card.html
@@ -1,0 +1,230 @@
+{% extends "student_base.html" %}
+
+{% block title %}Challenge Card — LFA Education Center{% endblock %}
+{% block active_page %}lfa-player{% endblock %}
+
+{% block student_header %}
+{% set _page_icon = '⚡' %}
+{% set _page_name = 'Challenge Card' %}
+{% include "includes/spec_subpage_hdr.html" %}
+{% endblock %}
+
+{% block extra_styles %}
+<style>
+    .cc-manager {
+        max-width: 860px;
+        margin: 0 auto;
+        padding: 1.5rem 1rem 3rem;
+    }
+
+    /* ── Section header ── */
+    .cc-section-title {
+        font-size: 0.72rem;
+        font-weight: 700;
+        color: var(--app-text-muted);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        margin: 2rem 0 0.75rem;
+    }
+
+    /* ── Page header ── */
+    .cc-header {
+        margin-bottom: 1.5rem;
+    }
+    .cc-header h1 {
+        font-size: 1.6rem;
+        font-weight: 700;
+        color: var(--app-text);
+        margin: 0 0 0.4rem;
+    }
+    .cc-header p {
+        font-size: 0.9rem;
+        color: var(--app-text-muted);
+        margin: 0;
+        max-width: 560px;
+    }
+
+    /* ── Format cards ── */
+    .cc-formats {
+        display: flex;
+        gap: 1rem;
+        flex-wrap: wrap;
+        margin-bottom: 0.5rem;
+    }
+    .cc-format-card {
+        background: var(--app-surface-2, #1e2335);
+        border: 1px solid var(--app-border, #2a3050);
+        border-radius: 10px;
+        padding: 1.1rem 1.4rem;
+        min-width: 200px;
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+    }
+    .cc-format-label {
+        font-size: 1rem;
+        font-weight: 700;
+        color: var(--app-text);
+    }
+    .cc-format-dims {
+        font-size: 0.78rem;
+        font-weight: 600;
+        color: var(--app-text-muted);
+        font-family: monospace;
+    }
+    .cc-format-platform {
+        font-size: 0.75rem;
+        color: var(--app-text-muted);
+    }
+    .cc-format-icon {
+        font-size: 1.5rem;
+        margin-bottom: 0.3rem;
+    }
+
+    /* ── Theme grid ── */
+    .cc-theme-grid {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.6rem;
+        margin-bottom: 0.5rem;
+    }
+    .cc-theme-chip {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.4rem 0.9rem;
+        border-radius: 20px;
+        border: 1.5px solid var(--app-border, #2a3050);
+        background: var(--app-surface-2, #1e2335);
+        font-size: 0.8rem;
+        font-weight: 600;
+        color: var(--app-text-muted);
+        cursor: default;
+        transition: border-color 0.15s;
+    }
+    .cc-theme-chip.active {
+        border-color: var(--app-accent, #667eea);
+        color: var(--app-text);
+    }
+    .cc-theme-dot {
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+        flex-shrink: 0;
+    }
+    .cc-theme-note {
+        font-size: 0.74rem;
+        color: var(--app-text-muted);
+        margin-top: 0.3rem;
+    }
+
+    /* ── CTA block ── */
+    .cc-cta-block {
+        display: flex;
+        align-items: center;
+        gap: 1.2rem;
+        flex-wrap: wrap;
+        padding: 1.2rem 1.4rem;
+        background: var(--app-surface-2, #1e2335);
+        border: 1px solid var(--app-border, #2a3050);
+        border-radius: 10px;
+    }
+    .cc-cta-text {
+        flex: 1;
+        min-width: 200px;
+    }
+    .cc-cta-text strong {
+        display: block;
+        font-size: 0.95rem;
+        color: var(--app-text);
+        margin-bottom: 0.2rem;
+    }
+    .cc-cta-text span {
+        font-size: 0.8rem;
+        color: var(--app-text-muted);
+    }
+    .cc-btn-challenges {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        padding: 0.55rem 1.2rem;
+        background: var(--app-accent, #667eea);
+        color: #fff;
+        font-weight: 700;
+        font-size: 0.85rem;
+        border-radius: 7px;
+        text-decoration: none;
+        white-space: nowrap;
+    }
+    .cc-btn-challenges:hover {
+        opacity: 0.88;
+    }
+
+    /* ── Back link ── */
+    .cc-back {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.3rem;
+        font-size: 0.8rem;
+        color: var(--app-text-muted);
+        text-decoration: none;
+        margin-bottom: 1.2rem;
+    }
+    .cc-back:hover { color: var(--app-text); }
+</style>
+{% endblock %}
+
+{% block student_content %}
+<div class="cc-manager">
+
+    <a href="/my-cards" class="cc-back">← My Cards</a>
+
+    <div class="cc-header">
+        <h1>⚡ Challenge Card</h1>
+        <p>Challenge cards are generated from your Virtual Challenge results. Choose your design theme below — it will be applied when you export from a challenge detail page.</p>
+    </div>
+
+    {# ── Export Formats ── #}
+    <div class="cc-section-title">Export Formats</div>
+    <div class="cc-formats">
+        {% for fmt in formats %}
+        <div class="cc-format-card">
+            <div class="cc-format-icon">
+                {%- if fmt.id == "challenge_post_16_9" %}🖼️
+                {%- elif fmt.id == "challenge_story_9_16" %}📱
+                {%- else %}🃏
+                {%- endif %}
+            </div>
+            <div class="cc-format-label">{{ fmt.label }}</div>
+            <div class="cc-format-dims">{{ fmt.dims }}</div>
+            <div class="cc-format-platform">{{ fmt.platform }}</div>
+        </div>
+        {% endfor %}
+    </div>
+
+    {# ── Theme Picker (read-only preview — save coming in Phase 2) ── #}
+    <div class="cc-section-title">Design Theme</div>
+    <div class="cc-theme-grid">
+        {% for theme in themes %}
+        <div class="cc-theme-chip {% if theme.id == draft.draft_theme %}active{% endif %}">
+            <span class="cc-theme-dot" style="background:{{ theme.dot_color }};"></span>
+            {{ theme.label }}
+            {% if theme.is_premium %}<span style="font-size:0.65rem;color:var(--app-text-muted);">★</span>{% endif %}
+        </div>
+        {% endfor %}
+    </div>
+    <div class="cc-theme-note">Theme selection will be saved in a future update. Current active theme: <strong>{{ draft.draft_theme }}</strong>.</div>
+
+    {# ── CTA: Go to Challenges ── #}
+    <div class="cc-section-title">Generate a Card</div>
+    <div class="cc-cta-block">
+        <div class="cc-cta-text">
+            <strong>Export from a challenge detail page</strong>
+            <span>Open any Virtual Challenge, then use the Share Card buttons to download your card.</span>
+        </div>
+        <a href="/challenges" class="cc-btn-challenges">Open Challenges →</a>
+    </div>
+
+</div>
+{% endblock %}

--- a/app/templates/public/export/challenge/post_16_9.html
+++ b/app/templates/public/export/challenge/post_16_9.html
@@ -1,0 +1,254 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=1280">
+<title>LFA Challenge Card</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    width: 1280px;
+    height: 720px;
+    overflow: hidden;
+    background: #0a0e1a;
+    color: #fff;
+    font-family: 'Rajdhani', 'Barlow Condensed', sans-serif;
+  }
+  .card-wrap {
+    width: 1280px;
+    height: 720px;
+    display: flex;
+    flex-direction: column;
+    background: linear-gradient(135deg, #0a0e1a 0%, #141929 60%, #1a2340 100%);
+    position: relative;
+    overflow: hidden;
+  }
+  /* Accent stripe */
+  .card-wrap::before {
+    content: '';
+    position: absolute;
+    top: 0; left: 0; right: 0;
+    height: 4px;
+    background: linear-gradient(90deg, #f5c518 0%, #e8a000 100%);
+  }
+
+  /* ── Header ── */
+  .card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 28px 52px 18px;
+  }
+  .lfa-brand {
+    font-size: 1.1rem;
+    font-weight: 700;
+    letter-spacing: 0.18em;
+    color: #f5c518;
+    text-transform: uppercase;
+  }
+  .card-meta {
+    font-size: 0.78rem;
+    color: #7a8aaa;
+    text-align: right;
+  }
+
+  /* ── VS block ── */
+  .vs-block {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 48px;
+    padding: 12px 52px 10px;
+    flex: 1;
+  }
+  .player-block {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    min-width: 220px;
+  }
+  .player-name {
+    font-size: 2rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-align: center;
+    color: #e8eaf0;
+    text-transform: uppercase;
+    line-height: 1.1;
+  }
+  .player-score {
+    font-size: 3.4rem;
+    font-weight: 800;
+    color: #f5c518;
+    line-height: 1;
+  }
+  .player-score.no-score {
+    font-size: 1.6rem;
+    color: #4a5570;
+  }
+  .vs-divider {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+    min-width: 120px;
+  }
+  .vs-label {
+    font-size: 2.6rem;
+    font-weight: 800;
+    color: #3a4460;
+    letter-spacing: 0.06em;
+  }
+  .outcome-badge {
+    padding: 6px 18px;
+    border-radius: 4px;
+    font-size: 0.78rem;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    background: #1e2840;
+    color: #f5c518;
+    border: 1px solid #f5c518;
+    text-align: center;
+    max-width: 200px;
+  }
+  .outcome-badge.win   { background: #1a3a20; color: #4caf50; border-color: #4caf50; }
+  .outcome-badge.draw  { background: #1a2840; color: #90caf9; border-color: #90caf9; }
+  .outcome-badge.loss  { background: #3a1a1a; color: #ef5350; border-color: #ef5350; }
+  .winner-label {
+    font-size: 0.72rem;
+    font-weight: 700;
+    color: #4caf50;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+
+  /* ── Skill row ── */
+  .skill-section {
+    padding: 8px 52px 14px;
+    display: flex;
+    gap: 32px;
+    justify-content: center;
+  }
+  .skill-col {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    min-width: 220px;
+  }
+  .skill-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 0.72rem;
+    color: #7a8aaa;
+  }
+  .skill-name { text-transform: uppercase; letter-spacing: 0.06em; }
+  .skill-delta { font-weight: 700; }
+  .skill-delta.pos { color: #4caf50; }
+  .skill-delta.neg { color: #ef5350; }
+  .skill-empty { font-size: 0.68rem; color: #3a4460; }
+
+  /* ── Footer ── */
+  .card-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 52px 22px;
+    border-top: 1px solid #1e2840;
+  }
+  .game-info { font-size: 0.78rem; color: #7a8aaa; }
+  .cta-label {
+    font-size: 0.84rem;
+    font-weight: 700;
+    color: #f5c518;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+  .ts { font-size: 0.66rem; color: #3a4460; }
+</style>
+</head>
+<body>
+<div class="card-wrap">
+  <!-- Header -->
+  <div class="card-header">
+    <div class="lfa-brand">⚽ LFA · Virtual Challenge</div>
+    <div class="card-meta">
+      <div>{{ challenge_mode | upper }} MODE</div>
+    </div>
+  </div>
+
+  <!-- VS block -->
+  <div class="vs-block">
+    <div class="player-block">
+      <div class="player-name">{{ challenger_name }}</div>
+      {% if challenger_score is not none %}
+        <div class="player-score">{{ "%.1f"|format(challenger_score) }}</div>
+      {% else %}
+        <div class="player-score no-score">—</div>
+      {% endif %}
+      {% if winner_name == challenger_name %}
+        <div class="winner-label">✓ WINNER</div>
+      {% endif %}
+    </div>
+
+    <div class="vs-divider">
+      <div class="vs-label">VS</div>
+      {% if outcome_reason == "score_win" %}
+        <div class="outcome-badge win">SCORE WIN</div>
+      {% elif outcome_reason == "draw" %}
+        <div class="outcome-badge draw">DRAW</div>
+      {% elif outcome_reason in ("forfeit_post_start_timeout", "forfeit_deadline", "forfeit_no_show", "forfeit") %}
+        <div class="outcome-badge loss">FORFEIT</div>
+      {% elif outcome_reason == "no_contest" %}
+        <div class="outcome-badge">NO CONTEST</div>
+      {% elif outcome_reason == "waiting_for_acceptance" %}
+        <div class="outcome-badge">PENDING</div>
+      {% elif outcome_reason in ("waiting_for_opponent", "in_lobby") %}
+        <div class="outcome-badge">IN PROGRESS</div>
+      {% elif outcome_reason == "expired" %}
+        <div class="outcome-badge">EXPIRED</div>
+      {% else %}
+        <div class="outcome-badge">{{ outcome_reason | upper | replace("_", " ") }}</div>
+      {% endif %}
+    </div>
+
+    <div class="player-block">
+      <div class="player-name">{{ challenged_name }}</div>
+      {% if challenged_score is not none %}
+        <div class="player-score">{{ "%.1f"|format(challenged_score) }}</div>
+      {% else %}
+        <div class="player-score no-score">—</div>
+      {% endif %}
+      {% if winner_name == challenged_name %}
+        <div class="winner-label">✓ WINNER</div>
+      {% endif %}
+    </div>
+  </div>
+
+  <!-- Skill deltas -->
+  {% if my_skill_scores %}
+  <div class="skill-section">
+    <div class="skill-col">
+      {% for skill, delta in my_skill_scores.items() %}
+      <div class="skill-row">
+        <span class="skill-name">{{ skill | replace("_", " ") }}</span>
+        <span class="skill-delta {% if delta > 0 %}pos{% elif delta < 0 %}neg{% endif %}">
+          {% if delta > 0 %}+{% endif %}{{ "%.2f"|format(delta) }}
+        </span>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+  {% endif %}
+
+  <!-- Footer -->
+  <div class="card-footer">
+    <div class="game-info">{{ game_name }}{% if completed_at %} · {{ completed_at.strftime("%b %d, %Y") }}{% endif %}</div>
+    <div class="cta-label">{{ cta_label }} →</div>
+    <div class="ts">lfa.gg</div>
+  </div>
+</div>
+</body>
+</html>

--- a/app/templates/public/export/challenge/story_9_16.html
+++ b/app/templates/public/export/challenge/story_9_16.html
@@ -1,0 +1,257 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=1080">
+<title>LFA Challenge Card</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    width: 1080px;
+    height: 1920px;
+    overflow: hidden;
+    background: #0a0e1a;
+    color: #fff;
+    font-family: 'Rajdhani', 'Barlow Condensed', sans-serif;
+  }
+  .card-wrap {
+    width: 1080px;
+    height: 1920px;
+    display: flex;
+    flex-direction: column;
+    background: linear-gradient(180deg, #0a0e1a 0%, #141929 50%, #1a2340 100%);
+    position: relative;
+    overflow: hidden;
+  }
+  .card-wrap::before {
+    content: '';
+    position: absolute;
+    top: 0; left: 0; right: 0;
+    height: 6px;
+    background: linear-gradient(90deg, #f5c518 0%, #e8a000 100%);
+  }
+
+  /* ── Header ── */
+  .card-header {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 80px 60px 40px;
+    gap: 12px;
+  }
+  .lfa-brand {
+    font-size: 1.5rem;
+    font-weight: 700;
+    letter-spacing: 0.2em;
+    color: #f5c518;
+    text-transform: uppercase;
+  }
+  .mode-badge {
+    font-size: 0.9rem;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    color: #7a8aaa;
+    text-transform: uppercase;
+  }
+
+  /* ── VS section ── */
+  .vs-section {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 40px 60px;
+    gap: 32px;
+  }
+  .player-block {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 14px;
+    width: 100%;
+  }
+  .player-name {
+    font-size: 3rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: #e8eaf0;
+    text-align: center;
+    line-height: 1.1;
+  }
+  .player-score {
+    font-size: 5.5rem;
+    font-weight: 800;
+    color: #f5c518;
+    line-height: 1;
+  }
+  .player-score.no-score {
+    font-size: 3rem;
+    color: #4a5570;
+  }
+  .winner-label {
+    font-size: 1rem;
+    font-weight: 700;
+    color: #4caf50;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+  }
+  .vs-divider {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 14px;
+    padding: 16px 0;
+  }
+  .vs-label {
+    font-size: 3rem;
+    font-weight: 800;
+    color: #3a4460;
+    letter-spacing: 0.1em;
+  }
+  .outcome-badge {
+    padding: 10px 36px;
+    border-radius: 6px;
+    font-size: 1.1rem;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    background: #1e2840;
+    color: #f5c518;
+    border: 2px solid #f5c518;
+    text-align: center;
+  }
+  .outcome-badge.win  { background: #1a3a20; color: #4caf50; border-color: #4caf50; }
+  .outcome-badge.draw { background: #1a2840; color: #90caf9; border-color: #90caf9; }
+  .outcome-badge.loss { background: #3a1a1a; color: #ef5350; border-color: #ef5350; }
+
+  /* ── Skill section ── */
+  .skill-section {
+    flex: 1;
+    padding: 40px 80px;
+  }
+  .skill-section-title {
+    font-size: 0.9rem;
+    font-weight: 700;
+    color: #4a5570;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    margin-bottom: 24px;
+    text-align: center;
+  }
+  .skill-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 1rem;
+    color: #7a8aaa;
+    padding: 10px 0;
+    border-bottom: 1px solid #1e2840;
+  }
+  .skill-name { text-transform: uppercase; letter-spacing: 0.06em; }
+  .skill-delta { font-weight: 700; font-size: 1.1rem; }
+  .skill-delta.pos { color: #4caf50; }
+  .skill-delta.neg { color: #ef5350; }
+  .skill-empty { font-size: 0.9rem; color: #3a4460; text-align: center; padding: 20px 0; }
+
+  /* ── Footer ── */
+  .card-footer {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+    padding: 40px 60px 80px;
+    border-top: 1px solid #1e2840;
+  }
+  .game-info { font-size: 1rem; color: #7a8aaa; text-align: center; }
+  .cta-label {
+    font-size: 1.2rem;
+    font-weight: 700;
+    color: #f5c518;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+  }
+  .lfa-footer { font-size: 0.78rem; color: #3a4460; letter-spacing: 0.1em; }
+</style>
+</head>
+<body>
+<div class="card-wrap">
+  <!-- Header -->
+  <div class="card-header">
+    <div class="lfa-brand">⚽ LFA · Virtual Challenge</div>
+    <div class="mode-badge">{{ challenge_mode | upper }} MODE</div>
+  </div>
+
+  <!-- VS section -->
+  <div class="vs-section">
+    <div class="player-block">
+      <div class="player-name">{{ challenger_name }}</div>
+      {% if challenger_score is not none %}
+        <div class="player-score">{{ "%.1f"|format(challenger_score) }}</div>
+      {% else %}
+        <div class="player-score no-score">—</div>
+      {% endif %}
+      {% if winner_name == challenger_name %}
+        <div class="winner-label">✓ WINNER</div>
+      {% endif %}
+    </div>
+
+    <div class="vs-divider">
+      <div class="vs-label">VS</div>
+      {% if outcome_reason == "score_win" %}
+        <div class="outcome-badge win">SCORE WIN</div>
+      {% elif outcome_reason == "draw" %}
+        <div class="outcome-badge draw">DRAW</div>
+      {% elif outcome_reason in ("forfeit_post_start_timeout", "forfeit_deadline", "forfeit_no_show", "forfeit") %}
+        <div class="outcome-badge loss">FORFEIT</div>
+      {% elif outcome_reason == "no_contest" %}
+        <div class="outcome-badge">NO CONTEST</div>
+      {% elif outcome_reason == "waiting_for_acceptance" %}
+        <div class="outcome-badge">PENDING</div>
+      {% elif outcome_reason in ("waiting_for_opponent", "in_lobby") %}
+        <div class="outcome-badge">IN PROGRESS</div>
+      {% elif outcome_reason == "expired" %}
+        <div class="outcome-badge">EXPIRED</div>
+      {% else %}
+        <div class="outcome-badge">{{ outcome_reason | upper | replace("_", " ") }}</div>
+      {% endif %}
+    </div>
+
+    <div class="player-block">
+      <div class="player-name">{{ challenged_name }}</div>
+      {% if challenged_score is not none %}
+        <div class="player-score">{{ "%.1f"|format(challenged_score) }}</div>
+      {% else %}
+        <div class="player-score no-score">—</div>
+      {% endif %}
+      {% if winner_name == challenged_name %}
+        <div class="winner-label">✓ WINNER</div>
+      {% endif %}
+    </div>
+  </div>
+
+  <!-- Skill deltas -->
+  <div class="skill-section">
+    <div class="skill-section-title">Skill Impact</div>
+    {% if my_skill_scores %}
+      {% for skill, delta in my_skill_scores.items() %}
+      <div class="skill-row">
+        <span class="skill-name">{{ skill | replace("_", " ") }}</span>
+        <span class="skill-delta {% if delta > 0 %}pos{% elif delta < 0 %}neg{% endif %}">
+          {% if delta > 0 %}+{% endif %}{{ "%.2f"|format(delta) }}
+        </span>
+      </div>
+      {% endfor %}
+    {% else %}
+      <div class="skill-empty">No skill delta recorded</div>
+    {% endif %}
+  </div>
+
+  <!-- Footer -->
+  <div class="card-footer">
+    <div class="game-info">{{ game_name }}{% if completed_at %} · {{ completed_at.strftime("%b %d, %Y") }}{% endif %}</div>
+    <div class="cta-label">{{ cta_label }} →</div>
+    <div class="lfa-footer">lfa.gg</div>
+  </div>
+</div>
+</body>
+</html>

--- a/app/templates/vt_challenge_detail.html
+++ b/app/templates/vt_challenge_detail.html
@@ -450,6 +450,30 @@
 </div>
 {% endif %}
 
+{# ── Social card export — completed + active challenges only ── #}
+{% if challenge.status.value not in ('declined', 'cancelled', 'expired') %}
+<div class="vcd-card" style="margin-top:1.5rem;">
+    <div style="font-size:0.78rem;font-weight:700;color:var(--app-text-muted);
+                text-transform:uppercase;letter-spacing:0.04em;margin-bottom:0.8rem;">Share Card</div>
+    <div style="display:flex;gap:0.75rem;flex-wrap:wrap;">
+        <a href="/challenges/{{ challenge.id }}/card/export?platform=challenge_post_16_9"
+           style="display:inline-flex;align-items:center;gap:0.4rem;padding:0.45rem 1rem;
+                  background:var(--app-surface-2,#1e2335);border:1px solid var(--app-border,#2a3050);
+                  border-radius:6px;font-size:0.8rem;font-weight:600;color:var(--app-text-muted);
+                  text-decoration:none;" download>
+            ↓ Post (16:9)
+        </a>
+        <a href="/challenges/{{ challenge.id }}/card/export?platform=challenge_story_9_16"
+           style="display:inline-flex;align-items:center;gap:0.4rem;padding:0.45rem 1rem;
+                  background:var(--app-surface-2,#1e2335);border:1px solid var(--app-border,#2a3050);
+                  border-radius:6px;font-size:0.8rem;font-weight:600;color:var(--app-text-muted);
+                  text-decoration:none;" download>
+            ↓ Story (9:16)
+        </a>
+    </div>
+</div>
+{% endif %}
+
 {# ── Footer ── #}
 <div class="vcd-footer">
     <a href="/challenges">← Back to Challenges</a>

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -60045,6 +60045,110 @@
         ]
       }
     },
+    "/challenges/{challenge_id}/card/export": {
+      "get": {
+        "description": "Export a challenge social card as PNG. Participants only. Rate-limited 5/60s.",
+        "operationId": "challenge_card_export_challenges__challenge_id__card_export_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "challenge_id",
+            "required": true,
+            "schema": {
+              "title": "Challenge Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "platform",
+            "required": false,
+            "schema": {
+              "default": "challenge_post_16_9",
+              "title": "Platform",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Challenge Card Export",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/challenges/{challenge_id}/card/preview": {
+      "get": {
+        "description": "Render a challenge social card as HTML (used as Playwright render target).",
+        "operationId": "challenge_card_preview_challenges__challenge_id__card_preview_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "challenge_id",
+            "required": true,
+            "schema": {
+              "title": "Challenge Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "platform",
+            "required": false,
+            "schema": {
+              "default": "challenge_post_16_9",
+              "title": "Platform",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Challenge Card Preview",
+        "tags": [
+          "web"
+        ]
+      }
+    },
     "/challenges/{challenge_id}/decline": {
       "post": {
         "operationId": "decline_challenge_challenges__challenge_id__decline_post",

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -62609,6 +62609,29 @@
         ]
       }
     },
+    "/my-cards/challenge-card": {
+      "get": {
+        "description": "Challenge Card design manager \u2014 theme picker + format overview.",
+        "operationId": "my_cards_challenge_card_my_cards_challenge_card_get",
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "My Cards Challenge Card",
+        "tags": [
+          "web",
+          "my-cards"
+        ]
+      }
+    },
     "/my-cards/player-card": {
       "get": {
         "description": "Detail entry point for Player Card \u2014 redirects to the card editor.",

--- a/tests/unit/api/web_routes/test_my_cards_hub.py
+++ b/tests/unit/api/web_routes/test_my_cards_hub.py
@@ -208,7 +208,7 @@ class TestMyCardsHubTemplate:
 
 class TestRegistryIntegration:
     def test_mch15_hub_spec_list_comes_from_registry(self):
-        """MCH-15: card_specs in hub context equals registry.list_card_type_ids() (6 types)."""
+        """MCH-15: card_specs in hub context equals registry.list_card_type_ids() (7 types)."""
         with patch(f"{_BASE}.templates") as mock_tmpl:
             mock_tmpl.TemplateResponse.return_value = MagicMock()
             _run(my_cards_hub(_req(), user=_user()))
@@ -217,7 +217,7 @@ class TestRegistryIntegration:
         expected_ids = set(card_registry.list_card_type_ids())
         actual_ids   = {s.card_type_id for s in ctx["card_specs"]}
         assert actual_ids == expected_ids
-        assert len(ctx["card_specs"]) == 6
+        assert len(ctx["card_specs"]) == 7
 
 
 # ── MCH-16/17: Dashboard template navigation updated ──────────────────────────

--- a/tests/unit/api/web_routes/test_my_cards_hub.py
+++ b/tests/unit/api/web_routes/test_my_cards_hub.py
@@ -289,7 +289,7 @@ class TestMyChallengeCardRoute:
              patch(f"{_CC_BASE}.CardDraftService") as mock_ds, \
              patch(f"{_CC_BASE}.get_all_themes", return_value=themes_mock):
             mock_tmpl.TemplateResponse.side_effect = _capture
-            mock_ds.get_or_create_singleton_draft.return_value = draft_mock
+            mock_ds.get_or_create_singleton.return_value = draft_mock
             _run(my_cards_challenge_card(
                 request=MagicMock(),
                 db=db,

--- a/tests/unit/api/web_routes/test_my_cards_hub.py
+++ b/tests/unit/api/web_routes/test_my_cards_hub.py
@@ -235,3 +235,129 @@ class TestDashboardNavUpdated:
     def test_mch17_hero_edit_cta_href_is_my_cards_player_card(self, dashboard_src):
         """MCH-17: dashboard hero Edit CTA href updated to /my-cards/player-card."""
         assert 'href="/my-cards/player-card"' in dashboard_src
+
+
+# ── MCH-CH-01..09: Challenge Card manager route ───────────────────────────────
+
+import pathlib as _pathlib
+
+_CC_TEMPLATE_PATH = (
+    _pathlib.Path(__file__).resolve().parents[4]
+    / "app" / "templates" / "my_cards_challenge_card.html"
+)
+
+_CC_BASE = "app.api.web_routes.my_cards"
+
+
+def _db_mock():
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = None
+    db.add = MagicMock()
+    db.commit = MagicMock()
+    db.refresh = MagicMock()
+    return db
+
+
+def _theme(tid, label, dot="#667eea", is_premium=False):
+    t = MagicMock()
+    t.id         = tid
+    t.label      = label
+    t.dot_color  = dot
+    t.is_premium = is_premium
+    return t
+
+
+class TestMyChallengeCardRoute:
+
+    def _call(self, *, user=None, db=None):
+        from app.api.web_routes.my_cards import my_cards_challenge_card
+        user = user or _user()
+        db   = db   or _db_mock()
+
+        captured = {}
+
+        def _capture(tmpl, ctx, **kw):
+            captured["template"] = tmpl
+            captured["context"]  = ctx
+            return MagicMock(status_code=200)
+
+        draft_mock = MagicMock()
+        draft_mock.draft_theme = "default"
+        themes_mock = [_theme("default", "Slate"), _theme("midnight", "Midnight")]
+
+        with patch(f"{_CC_BASE}.templates") as mock_tmpl, \
+             patch(f"{_CC_BASE}.CardDraftService") as mock_ds, \
+             patch(f"{_CC_BASE}.get_all_themes", return_value=themes_mock):
+            mock_tmpl.TemplateResponse.side_effect = _capture
+            mock_ds.get_or_create_singleton_draft.return_value = draft_mock
+            _run(my_cards_challenge_card(
+                request=MagicMock(),
+                db=db,
+                user=user,
+            ))
+
+        return captured
+
+    def test_mch_ch01_returns_200(self):
+        """MCH-CH-01: GET /my-cards/challenge-card logged-in user → 200."""
+        cap = self._call()
+        assert cap.get("template") == "my_cards_challenge_card.html"
+
+    def test_mch_ch02_route_has_auth_dependency(self):
+        """MCH-CH-02: route signature requires authenticated user."""
+        import inspect
+        from app.api.web_routes.my_cards import my_cards_challenge_card
+        sig = inspect.signature(my_cards_challenge_card)
+        assert "user" in sig.parameters
+
+    def test_mch_ch03_hub_card_specs_contains_challenge_card(self):
+        """MCH-CH-03: /my-cards hub card_specs includes challenge_card."""
+        with patch(f"{_CC_BASE}.templates") as mock_tmpl:
+            mock_tmpl.TemplateResponse.return_value = MagicMock()
+            _run(my_cards_hub(_req(), user=_user()))
+        _, ctx = mock_tmpl.TemplateResponse.call_args.args
+        ids = [s.card_type_id for s in ctx["card_specs"]]
+        assert "challenge_card" in ids
+
+    def test_mch_ch04_hub_tile_link_is_challenge_card_url(self):
+        """MCH-CH-04: hub template builds /my-cards/challenge-card via card_type_id replace('_','-').
+
+        The link is generated dynamically: /my-cards/{{ spec.card_type_id | replace('_', '-') }}
+        so the literal string 'challenge_card' does not appear in the source.
+        Verify the generation pattern is present and challenge_card is in the registry.
+        """
+        hub_html = _CC_TEMPLATE_PATH.parent.joinpath("my_cards_hub.html").read_text()
+        # Template uses dynamic generation — verify the replace pattern is present
+        assert "replace('_', '-')" in hub_html or "replace(\"_\", \"-\")" in hub_html
+        # Registry contains challenge_card → link will be /my-cards/challenge-card
+        from app.services.card_system import card_registry
+        assert "challenge_card" in card_registry.list_card_type_ids()
+
+    def test_mch_ch05_template_contains_post_16_9(self):
+        """MCH-CH-05: template references challenge_post_16_9 format."""
+        html = _CC_TEMPLATE_PATH.read_text()
+        assert "challenge_post_16_9" in html
+
+    def test_mch_ch06_template_contains_story_9_16(self):
+        """MCH-CH-06: template references challenge_story_9_16 format."""
+        html = _CC_TEMPLATE_PATH.read_text()
+        assert "challenge_story_9_16" in html
+
+    def test_mch_ch07_template_contains_challenges_link(self):
+        """MCH-CH-07: template contains /challenges CTA link."""
+        html = _CC_TEMPLATE_PATH.read_text()
+        assert "/challenges" in html
+
+    def test_mch_ch08_spec_is_editable_and_theme_compatible(self):
+        """MCH-CH-08: CHALLENGE_CARD_SPEC.is_editable=True, theme_compatible=True."""
+        from app.services.card_system._challenge_card import CHALLENGE_CARD_SPEC
+        assert CHALLENGE_CARD_SPEC.is_editable is True
+        assert CHALLENGE_CARD_SPEC.theme_compatible is True
+        assert CHALLENGE_CARD_SPEC.has_published_state is False
+
+    def test_mch_ch09_context_contains_formats_with_both_ids(self):
+        """MCH-CH-09: route context formats list contains both platform IDs."""
+        cap = self._call()
+        fmt_ids = [f["id"] for f in cap["context"]["formats"]]
+        assert "challenge_post_16_9"  in fmt_ids
+        assert "challenge_story_9_16" in fmt_ids

--- a/tests/unit/api/web_routes/test_vt_social_cards.py
+++ b/tests/unit/api/web_routes/test_vt_social_cards.py
@@ -1,0 +1,389 @@
+"""
+SC-01  preview: participant → 200 HTML
+SC-02  preview: non-participant → 403
+SC-03  preview: invalid platform → 422
+SC-04  export: participant → PNG bytes (mock Playwright)
+SC-05  export: non-participant → 403
+SC-06  export: rate limit 6th request → 429
+SC-07  Content-Disposition contains challenge id + platform
+SC-08  context score_win → is_viewer_winner=True when winner_id==viewer.id
+SC-09  context forfeit loser → my_score=None
+SC-10  context skill deltas come from viewer's attempt
+SC-11  context draw → is_draw=True, winner_name=None
+SC-12  context pending → challenger_score=None, challenged_score=None
+SC-13  CTA completed + viewer won → "Play again"
+SC-14  post_16_9 template contains outcome_reason, my_score, opp_score
+SC-15  story_9_16 template contains outcome_reason, my_skill_scores
+SC-16  both templates contain LFA branding marker
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.responses import HTMLResponse, Response
+
+from app.models.vt_challenge import ChallengeStatus, VirtualTrainingChallenge
+from app.models.virtual_training import VirtualTrainingAttempt
+
+_BASE = "app.api.web_routes.vt_challenges"
+_POST_TEMPLATE   = os.path.abspath(os.path.join(
+    os.path.dirname(__file__),
+    "../../../../app/templates/public/export/challenge/post_16_9.html",
+))
+_STORY_TEMPLATE  = os.path.abspath(os.path.join(
+    os.path.dirname(__file__),
+    "../../../../app/templates/public/export/challenge/story_9_16.html",
+))
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _user(uid=1):
+    u = MagicMock()
+    u.id       = uid
+    u.email    = f"u{uid}@lfa.com"
+    u.nickname = None
+    return u
+
+
+def _game():
+    g = MagicMock()
+    g.id   = 7
+    g.code = "target_tracking"
+    g.name = "Target Tracking"
+    g.config = {}
+    return g
+
+
+def _challenge(
+    *,
+    cid=10,
+    status=ChallengeStatus.COMPLETED,
+    challenger_id=1,
+    challenged_id=2,
+    winner_id=None,
+    is_draw=False,
+    forfeit_user_id=None,
+    forfeit_reason=None,
+    challenger_attempt_id=None,
+    challenged_attempt_id=None,
+    challenge_mode="live",
+):
+    from datetime import datetime, timezone
+    ch = MagicMock(spec=VirtualTrainingChallenge)
+    ch.id                    = cid
+    ch.status                = status
+    ch.challenger_id         = challenger_id
+    ch.challenged_id         = challenged_id
+    ch.winner_id             = winner_id
+    ch.is_draw               = is_draw
+    ch.forfeit_user_id       = forfeit_user_id
+    ch.forfeit_reason        = forfeit_reason
+    ch.challenger_attempt_id = challenger_attempt_id
+    ch.challenged_attempt_id = challenged_attempt_id
+    ch.game_id               = 7
+    ch.difficulty_level      = "hard"
+    ch.message               = None
+    ch.challenge_mode        = challenge_mode
+    ch.completion_deadline   = None
+    ch.completed_at          = datetime.now(timezone.utc) if status == ChallengeStatus.COMPLETED else None
+    ch.created_at            = datetime.now(timezone.utc)
+    ch.challenger            = _user(uid=challenger_id)
+    ch.challenged            = _user(uid=challenged_id)
+    ch.winner                = _user(uid=winner_id) if winner_id else None
+    ch.forfeit_user          = _user(uid=forfeit_user_id) if forfeit_user_id else None
+    ch.game                  = _game()
+    return ch
+
+
+def _attempt(aid=100, score=75.0, skill_deltas=None):
+    a = MagicMock(spec=VirtualTrainingAttempt)
+    a.id               = aid
+    a.is_valid         = True
+    a.score_normalized = score
+    a.skill_deltas     = skill_deltas or {}
+    return a
+
+
+# ── Shared call helpers ────────────────────────────────────────────────────────
+
+def _call_preview(*, ch, user_id=1, platform="challenge_post_16_9",
+                  challenger_attempt=None, challenged_attempt=None):
+    from app.api.web_routes.vt_challenges import challenge_card_preview
+
+    user = _user(uid=user_id)
+    db   = MagicMock()
+    firsts = iter([ch, challenger_attempt, challenged_attempt])
+    db.query.return_value.filter.return_value.first.side_effect = lambda: next(firsts, None)
+
+    captured = {}
+
+    def _capture(tmpl, ctx, **kw):
+        captured["template"] = tmpl
+        captured["context"]  = ctx
+        return MagicMock(spec=HTMLResponse)
+
+    with patch(f"{_BASE}.require_student_onboarding", return_value=None), \
+         patch(f"{_BASE}.templates.TemplateResponse", side_effect=_capture):
+        try:
+            asyncio.run(challenge_card_preview(
+                challenge_id=ch.id,
+                request=MagicMock(),
+                platform=platform,
+                db=db,
+                user=user,
+            ))
+        except Exception as exc:
+            captured["exc"] = exc
+
+    return captured
+
+
+def _call_export(*, ch, user_id=1, platform="challenge_post_16_9",
+                 challenger_attempt=None, challenged_attempt=None,
+                 rate_ok=True, png_bytes=b"PNG"):
+    from app.api.web_routes.vt_challenges import challenge_card_export
+
+    user = _user(uid=user_id)
+    db   = MagicMock()
+    firsts = iter([ch, challenger_attempt, challenged_attempt])
+    db.query.return_value.filter.return_value.first.side_effect = lambda: next(firsts, None)
+
+    captured = {}
+
+    async def _mock_to_thread(fn, *args, **kw):
+        return png_bytes
+
+    with patch(f"{_BASE}.require_student_onboarding", return_value=None), \
+         patch(f"{_BASE}._export_svc.check_export_rate_limit", return_value=rate_ok), \
+         patch(f"{_BASE}.asyncio.to_thread", side_effect=_mock_to_thread), \
+         patch("app.config.settings") as mock_settings:
+        mock_settings.APP_INTERNAL_PORT = 8000
+        try:
+            result = asyncio.run(challenge_card_export(
+                challenge_id=ch.id,
+                request=MagicMock(),
+                platform=platform,
+                db=db,
+                user=user,
+            ))
+            captured["result"] = result
+        except Exception as exc:
+            captured["exc"] = exc
+
+    return captured
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# SC-01..03  preview route
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestChallengeCardPreview:
+
+    def test_sc01_participant_gets_200(self):
+        ch = _challenge(challenger_id=1, challenged_id=2)
+        cap = _call_preview(ch=ch, user_id=1)
+        assert "exc" not in cap, f"Unexpected exception: {cap.get('exc')}"
+        assert "template" in cap
+
+    def test_sc01_template_name_post_16_9(self):
+        ch = _challenge(challenger_id=1, challenged_id=2)
+        cap = _call_preview(ch=ch, user_id=1, platform="challenge_post_16_9")
+        assert cap["template"] == "public/export/challenge/post_16_9.html"
+
+    def test_sc01_template_name_story_9_16(self):
+        ch = _challenge(challenger_id=1, challenged_id=2)
+        cap = _call_preview(ch=ch, user_id=1, platform="challenge_story_9_16")
+        assert cap["template"] == "public/export/challenge/story_9_16.html"
+
+    def test_sc02_non_participant_raises_403(self):
+        ch = _challenge(challenger_id=1, challenged_id=2)
+        cap = _call_preview(ch=ch, user_id=99)
+        exc = cap.get("exc")
+        assert exc is not None
+        from fastapi import HTTPException
+        assert isinstance(exc, HTTPException)
+        assert exc.status_code == 403
+
+    def test_sc03_invalid_platform_raises_422(self):
+        ch = _challenge(challenger_id=1, challenged_id=2)
+        cap = _call_preview(ch=ch, user_id=1, platform="instagram_portrait")
+        exc = cap.get("exc")
+        assert exc is not None
+        from fastapi import HTTPException
+        assert isinstance(exc, HTTPException)
+        assert exc.status_code == 422
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# SC-04..07  export route
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestChallengeCardExport:
+
+    def test_sc04_participant_gets_png(self):
+        ch  = _challenge(challenger_id=1, challenged_id=2)
+        cap = _call_export(ch=ch, user_id=1, png_bytes=b"FAKEPNG")
+        assert "exc" not in cap, f"Unexpected exception: {cap.get('exc')}"
+        result = cap["result"]
+        assert isinstance(result, Response)
+        assert result.media_type == "image/png"
+        assert result.body == b"FAKEPNG"
+
+    def test_sc05_non_participant_raises_403(self):
+        ch  = _challenge(challenger_id=1, challenged_id=2)
+        cap = _call_export(ch=ch, user_id=99)
+        exc = cap.get("exc")
+        assert exc is not None
+        from fastapi import HTTPException
+        assert isinstance(exc, HTTPException)
+        assert exc.status_code == 403
+
+    def test_sc06_rate_limit_raises_429(self):
+        ch  = _challenge(challenger_id=1, challenged_id=2)
+        cap = _call_export(ch=ch, user_id=1, rate_ok=False)
+        exc = cap.get("exc")
+        assert exc is not None
+        from fastapi import HTTPException
+        assert isinstance(exc, HTTPException)
+        assert exc.status_code == 429
+
+    def test_sc07_content_disposition_contains_id_and_platform(self):
+        ch  = _challenge(cid=42, challenger_id=1, challenged_id=2)
+        cap = _call_export(ch=ch, user_id=1, platform="challenge_post_16_9", png_bytes=b"X")
+        result = cap["result"]
+        cd = result.headers.get("Content-Disposition", "")
+        assert "42" in cd
+        assert "challenge_post_16_9" in cd
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# SC-08..13  context builder
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestChallengeCardContext:
+
+    def _ctx(self, ch, challenger_attempt=None, challenged_attempt=None, viewer_id=1):
+        from app.api.web_routes.vt_challenges import _build_challenge_card_context
+        viewer = _user(uid=viewer_id)
+        return _build_challenge_card_context(ch, viewer, challenger_attempt, challenged_attempt)
+
+    def test_sc08_score_win_viewer_is_winner(self):
+        ch = _challenge(
+            challenger_id=1, challenged_id=2,
+            winner_id=1, status=ChallengeStatus.COMPLETED,
+        )
+        ctx = self._ctx(ch, viewer_id=1)
+        assert ctx["is_viewer_winner"] is True
+
+    def test_sc08_score_win_loser_not_winner(self):
+        ch = _challenge(
+            challenger_id=1, challenged_id=2,
+            winner_id=1, status=ChallengeStatus.COMPLETED,
+        )
+        ctx = self._ctx(ch, viewer_id=2)
+        assert ctx["is_viewer_winner"] is False
+
+    def test_sc09_forfeit_loser_my_score_none(self):
+        """Forfeit: challenged (uid=2) submitted nothing → my_score=None when viewer=2."""
+        ch_attempt = _attempt(aid=10, score=80.0)
+        ch = _challenge(
+            challenger_id=1, challenged_id=2,
+            challenger_attempt_id=10, challenged_attempt_id=None,
+            forfeit_user_id=2, winner_id=1,
+        )
+        ctx = self._ctx(ch, challenger_attempt=ch_attempt, challenged_attempt=None, viewer_id=2)
+        assert ctx["my_score"] is None
+
+    def test_sc10_skill_deltas_from_viewer_attempt(self):
+        """my_skill_scores = viewer's attempt.skill_deltas."""
+        deltas = {"reactions": 0.08, "decision_making": -0.03}
+        ch_attempt = _attempt(aid=20, score=70.0, skill_deltas=deltas)
+        ch = _challenge(challenger_id=1, challenged_id=2, challenger_attempt_id=20)
+        ctx = self._ctx(ch, challenger_attempt=ch_attempt, challenged_attempt=None, viewer_id=1)
+        assert ctx["my_skill_scores"].get("reactions") == pytest.approx(0.08)
+        assert ctx["my_skill_scores"].get("decision_making") == pytest.approx(-0.03)
+
+    def test_sc11_draw_context(self):
+        ch = _challenge(
+            challenger_id=1, challenged_id=2,
+            is_draw=True, winner_id=None,
+        )
+        ctx = self._ctx(ch, viewer_id=1)
+        assert ctx["is_draw"] is True
+        assert ctx["winner_name"] is None
+
+    def test_sc12_pending_scores_are_none(self):
+        ch = _challenge(
+            challenger_id=1, challenged_id=2,
+            status=ChallengeStatus.PENDING,
+            challenger_attempt_id=None,
+            challenged_attempt_id=None,
+        )
+        ctx = self._ctx(ch, viewer_id=1)
+        assert ctx["challenger_score"] is None
+        assert ctx["challenged_score"] is None
+
+    def test_sc13_cta_winner_play_again(self):
+        ch = _challenge(
+            challenger_id=1, challenged_id=2,
+            winner_id=1, status=ChallengeStatus.COMPLETED,
+        )
+        ctx = self._ctx(ch, viewer_id=1)
+        assert ctx["cta_label"] == "Play again"
+
+    def test_sc13_cta_pending_view_challenge(self):
+        ch = _challenge(
+            challenger_id=1, challenged_id=2,
+            status=ChallengeStatus.PENDING,
+        )
+        ctx = self._ctx(ch, viewer_id=1)
+        assert ctx["cta_label"] == "View challenge"
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# SC-14..16  template content
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestChallengeCardTemplates:
+
+    def _post(self):
+        with open(_POST_TEMPLATE, encoding="utf-8") as fh:
+            return fh.read()
+
+    def _story(self):
+        with open(_STORY_TEMPLATE, encoding="utf-8") as fh:
+            return fh.read()
+
+    def test_sc14_post_template_has_outcome_reason(self):
+        assert "outcome_reason" in self._post()
+
+    def test_sc14_post_template_has_challenger_score(self):
+        assert "challenger_score" in self._post()
+
+    def test_sc14_post_template_has_challenged_score(self):
+        assert "challenged_score" in self._post()
+
+    def test_sc15_story_template_has_outcome_reason(self):
+        assert "outcome_reason" in self._story()
+
+    def test_sc15_story_template_has_my_skill_scores(self):
+        assert "my_skill_scores" in self._story()
+
+    def test_sc15_story_skill_delta_no_delta_message(self):
+        assert "No skill delta recorded" in self._story()
+
+    def test_sc16_post_has_lfa_branding(self):
+        html = self._post()
+        assert "LFA" in html
+
+    def test_sc16_story_has_lfa_branding(self):
+        html = self._story()
+        assert "LFA" in html
+
+    def test_sc16_both_templates_are_standalone_html(self):
+        for html in (self._post(), self._story()):
+            assert "<!DOCTYPE html>" in html

--- a/tests/unit/services/test_card_constants.py
+++ b/tests/unit/services/test_card_constants.py
@@ -34,7 +34,7 @@ import app.services.card_export_service as _export_svc
 # ── CC-01 / CC-02: CANVAS_SIZES structure ────────────────────────────────────
 
 def test_cc01_canvas_sizes_has_9_platforms():
-    assert len(CANVAS_SIZES) == 10  # 9 social + "default" native FIFA Classic export
+    assert len(CANVAS_SIZES) == 12  # 9 social + "default" native FIFA Classic export + 2 challenge
 
 
 def test_cc02_canvas_sizes_values_are_int_tuples():
@@ -62,7 +62,7 @@ def test_cc03_export_format_buckets_keys_match_canvas_sizes():
 
 
 def test_cc04_export_format_buckets_value_set():
-    expected_buckets = {"square", "portrait", "story", "tiktok", "landscape", "og", "banner"}
+    expected_buckets = {"square", "portrait", "story", "tiktok", "landscape", "og", "banner", "challenge"}
     actual_buckets = set(EXPORT_FORMAT_BUCKETS.values())
     assert actual_buckets == expected_buckets, (
         f"Unexpected bucket values: {actual_buckets - expected_buckets}. "

--- a/tests/unit/services/test_card_system_specs.py
+++ b/tests/unit/services/test_card_system_specs.py
@@ -177,6 +177,7 @@ class TestListCardTypeIds:
         assert set(ids) == {
             "player_card",
             "welcome_card",
+            "challenge_card",
             "match_card",
             "event_card",
             "birthday_card",


### PR DESCRIPTION
## Summary

- **Virtual Challenge Social Cards** — PNG export for challenge results in two formats: 16:9 Post (1280×720, Facebook/Instagram) and 9:16 Story (1080×1920, TikTok/Instagram Story)
- **Challenge Card registry spec** — `CHALLENGE_CARD_SPEC` v1 added to `CardRegistry` (`is_editable=True`, `theme_compatible=True`); 2 new export platforms in `card_constants` (`challenge_post_16_9`, `challenge_story_9_16`)
- **Export endpoints** — `GET /challenges/{id}/card/preview` (HTML preview) and `GET /challenges/{id}/card/export` (PNG download) with rate-limiting (5 req/60 s per user/IP), participation guard, and viewer-relative context (my_score, opp_score, is_viewer_winner)
- **Challenge Card manager** — `GET /my-cards/challenge-card` route + `my_cards_challenge_card.html` template (format overview, read-only theme grid, CTA → /challenges); resolves 404 from hub tile
- **My Cards hub** — 7-spec registry (was 6); challenge_card tile now links to `/my-cards/challenge-card`
- **OpenAPI snapshot** — refreshed to 813 routes

## Changed files (Social Cards scope only — 3 commits)

| Area | File |
|---|---|
| Constants | `app/services/card_constants.py` |
| Card spec | `app/services/card_system/_challenge_card.py` (new) |
| Registry | `app/services/card_system/registry.py` |
| Routes | `app/api/web_routes/vt_challenges.py`, `app/api/web_routes/my_cards.py` |
| Templates | `app/templates/public/export/challenge/post_16_9.html` (new) |
| | `app/templates/public/export/challenge/story_9_16.html` (new) |
| | `app/templates/my_cards_challenge_card.html` (new) |
| | `app/templates/vt_challenge_detail.html` |
| Tests | `tests/unit/api/web_routes/test_vt_social_cards.py` (new, 26 SC-* tests) |
| | `tests/unit/api/web_routes/test_my_cards_hub.py` (+9 MCH-CH-* tests) |
| | `tests/unit/services/test_card_constants.py` |
| | `tests/unit/services/test_card_system_specs.py` |
| Snapshot | `tests/snapshots/openapi_snapshot.json` |

> **Note:** This PR also contains earlier commits on the branch (Live Lobby, geo P0, outcome_reason, TT fairness, accounting). Those are part of the same branch lineage and were passing CI before Social Cards work began.

## Explicitly out of scope

- Video export
- Automatic social publish / external API
- On-site/Hybrid challenge card formats
- Personal Best / Highlight DB comparison
- New design system or Player Card dimension changes
- WebSocket, GPS/location, reward/credit changes

## Test plan

- [ ] `tests/unit/api/web_routes/test_vt_social_cards.py` — 26 SC-* tests (preview route, export route, context builder, rate-limit, participation guard)
- [ ] `tests/unit/api/web_routes/test_my_cards_hub.py` — MCH-CH-01..09 (manager route, theme grid, format list, registry integration)
- [ ] `tests/unit/services/test_card_constants.py` — CC-01 (12 platforms), CC-04 (challenge bucket)
- [ ] `tests/unit/services/test_card_system_specs.py` — CS-31 (7-type registry list)
- [ ] Full unit regression: 11,140 PASS / 0 FAIL (verified locally)
- [ ] OpenAPI snapshot matches 813 routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)