### PR TITLE
feat(mood-photos): Hangulatkép MVP + 6 slot (Angry + Surprised)

### DIFF
--- a/alembic/versions/2026_05_26_1100_user_mood_photos.py
+++ b/alembic/versions/2026_05_26_1100_user_mood_photos.py
@@ -1,0 +1,76 @@
+"""Add user_mood_photos table (hangulatkép feature).
+
+Revision ID: 2026_05_26_1100
+Revises:     2026_05_25_1400
+Create Date: 2026-05-26 11:00:00
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision    = "2026_05_26_1100"
+down_revision = "2026_05_25_1400"
+branch_labels = None
+depends_on    = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_mood_photos",
+        sa.Column("id",      sa.Integer, primary_key=True),
+        sa.Column(
+            "user_id",
+            sa.Integer,
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "license_id",
+            sa.Integer,
+            sa.ForeignKey("user_licenses.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("slot",              sa.String(30),  nullable=False),
+        sa.Column("original_url",      sa.String(512), nullable=False),
+        sa.Column("processed_png_url", sa.String(512), nullable=True),
+        sa.Column(
+            "status",
+            sa.String(20),
+            nullable=False,
+            server_default="uploaded",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("processed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.UniqueConstraint("user_id", "slot", name="uq_mood_photo_user_slot"),
+        sa.CheckConstraint(
+            "slot IN ('mood_intro_neutral','mood_happy_smile',"
+            "'mood_celebration','mood_sad_disappointed')",
+            name="ck_mood_photo_slot_valid",
+        ),
+    )
+    op.create_index(
+        "ix_user_mood_photos_user_id",
+        "user_mood_photos",
+        ["user_id"],
+    )
+    op.create_index(
+        "ix_user_mood_photos_license_id",
+        "user_mood_photos",
+        ["license_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_user_mood_photos_license_id", table_name="user_mood_photos")
+    op.drop_index("ix_user_mood_photos_user_id",    table_name="user_mood_photos")
+    op.drop_table("user_mood_photos")

--- a/alembic/versions/2026_05_26_1200_mood_photos_6slots.py
+++ b/alembic/versions/2026_05_26_1200_mood_photos_6slots.py
@@ -1,0 +1,60 @@
+"""Expand mood photo slots from 4 to 6.
+
+Adds mood_angry_competitive and mood_surprised_shocked to the
+ck_mood_photo_slot_valid CHECK constraint on user_mood_photos.
+
+PostgreSQL does not support ALTER CHECK in-place; the constraint must be
+dropped and recreated.  The table data is not touched — existing rows
+(4 old slots) satisfy the wider constraint.
+
+Revision ID: 2026_05_26_1200
+Revises:     2026_05_26_1100
+Create Date: 2026-05-26 12:00:00
+"""
+from alembic import op
+
+revision      = "2026_05_26_1200"
+down_revision = "2026_05_26_1100"
+branch_labels = None
+depends_on    = None
+
+_TABLE      = "user_mood_photos"
+_CONSTRAINT = "ck_mood_photo_slot_valid"
+
+_SLOTS_V2 = (
+    "mood_intro_neutral",
+    "mood_happy_smile",
+    "mood_celebration",
+    "mood_sad_disappointed",
+    "mood_angry_competitive",
+    "mood_surprised_shocked",
+)
+
+_SLOTS_V1 = (
+    "mood_intro_neutral",
+    "mood_happy_smile",
+    "mood_celebration",
+    "mood_sad_disappointed",
+)
+
+
+def _slots_sql(slots: tuple[str, ...]) -> str:
+    return ", ".join(f"'{s}'" for s in slots)
+
+
+def upgrade() -> None:
+    op.drop_constraint(_CONSTRAINT, _TABLE, type_="check")
+    op.create_check_constraint(
+        _CONSTRAINT,
+        _TABLE,
+        f"slot IN ({_slots_sql(_SLOTS_V2)})",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(_CONSTRAINT, _TABLE, type_="check")
+    op.create_check_constraint(
+        _CONSTRAINT,
+        _TABLE,
+        f"slot IN ({_slots_sql(_SLOTS_V1)})",
+    )

--- a/app/api/web_routes/__init__.py
+++ b/app/api/web_routes/__init__.py
@@ -31,6 +31,7 @@ from . import (
     friends,
     vt_challenges,
     ws_events,
+    mood_photos,
 )
 from .admin import router as admin_router
 from .tournaments import router as tournaments_router
@@ -67,3 +68,4 @@ router.include_router(my_cards.router)           # 🃏 My Cards hub (/my-cards)
 router.include_router(friends.router)            # 👥 Friendship system (/friends)
 router.include_router(vt_challenges.router)      # 🎮 VT Challenges (/challenges)
 router.include_router(ws_events.router)           # 🔌 Per-user WS event stream (/ws/events)
+router.include_router(mood_photos.router)         # 📸 Hangulatképek (/profile/my-mood-photos)

--- a/app/api/web_routes/mood_photos.py
+++ b/app/api/web_routes/mood_photos.py
@@ -1,0 +1,148 @@
+"""
+mood_photos — web routes for the hangulatkép (mood photo) feature.
+
+Routes
+------
+GET  /profile/my-mood-photos            — management page
+POST /profile/my-mood-photos/{slot}/upload  — upload / replace a slot
+POST /profile/my-mood-photos/{slot}/delete  — HTML-form delete fallback
+DELETE /profile/my-mood-photos/{slot}       — JS-fetch delete endpoint
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+from sqlalchemy.orm import Session
+
+from ...database import get_db
+from ...dependencies import get_current_user_web
+from ...models.user import User
+from ...models.license import UserLicense
+from ...models.user_mood_photos import MOOD_PHOTO_SLOTS
+from ...services.mood_photo_service import (
+    delete_mood_photo,
+    get_mood_photos_for_user,
+    save_mood_photo,
+)
+
+logger = logging.getLogger(__name__)
+
+BASE_DIR  = Path(__file__).resolve().parent.parent.parent
+templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
+
+router = APIRouter()
+
+# Ordered for consistent display in the template
+_SLOT_META: list[dict] = [
+    {"slot": "mood_intro_neutral",    "label": "Semleges",  "emoji": "😐"},
+    {"slot": "mood_happy_smile",      "label": "Boldog",    "emoji": "😊"},
+    {"slot": "mood_celebration",      "label": "Ünneplés",  "emoji": "🎉"},
+    {"slot": "mood_sad_disappointed", "label": "Szomorú",   "emoji": "😔"},
+]
+
+
+# ── GET /profile/my-mood-photos ───────────────────────────────────────────────
+
+@router.get("/profile/my-mood-photos", response_class=HTMLResponse)
+async def mood_photos_page(
+    request: Request,
+    user:    User    = Depends(get_current_user_web),
+    db:      Session = Depends(get_db),
+) -> HTMLResponse:
+    mood_photos = get_mood_photos_for_user(user.id, db)
+    return templates.TemplateResponse(
+        "lfa_player_mood_photos.html",
+        {
+            "request":     request,
+            "user":        user,
+            "mood_photos": mood_photos,
+            "slots_meta":  _SLOT_META,
+        },
+    )
+
+
+# ── POST /profile/my-mood-photos/{slot}/upload ────────────────────────────────
+
+@router.post("/profile/my-mood-photos/{slot}/upload")
+async def mood_photo_upload(
+    slot:    str,
+    request: Request,
+    photo:   UploadFile = File(...),
+    user:    User       = Depends(get_current_user_web),
+    db:      Session    = Depends(get_db),
+):
+    if slot not in MOOD_PHOTO_SLOTS:
+        raise HTTPException(status_code=422, detail=f"Invalid slot: {slot!r}")
+
+    file_bytes   = await photo.read()
+    content_type = photo.content_type or ""
+
+    license_id: int | None = None
+    lic = db.query(UserLicense).filter_by(user_id=user.id).first()
+    if lic:
+        license_id = lic.id
+
+    try:
+        save_mood_photo(
+            file_bytes   = file_bytes,
+            content_type = content_type,
+            user_id      = user.id,
+            slot         = slot,
+            db           = db,
+            license_id   = license_id,
+        )
+        db.commit()
+        logger.info(
+            "mood_photo_uploaded",
+            extra={"user": user.email, "slot": slot},
+        )
+    except ValueError as exc:
+        db.rollback()
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    accepts_json = "application/json" in (request.headers.get("accept", ""))
+    if accepts_json:
+        row = get_mood_photos_for_user(user.id, db).get(slot)
+        return JSONResponse(
+            {
+                "slot":         slot,
+                "original_url": row.original_url if row else None,
+                "status":       row.status if row else "uploaded",
+            }
+        )
+    return RedirectResponse(url="/profile/my-mood-photos", status_code=303)
+
+
+# ── POST /profile/my-mood-photos/{slot}/delete  (HTML-form fallback) ─────────
+
+@router.post("/profile/my-mood-photos/{slot}/delete")
+async def mood_photo_delete_form(
+    slot: str,
+    user: User    = Depends(get_current_user_web),
+    db:   Session = Depends(get_db),
+):
+    if slot not in MOOD_PHOTO_SLOTS:
+        raise HTTPException(status_code=422, detail=f"Invalid slot: {slot!r}")
+    delete_mood_photo(user.id, slot, db)
+    db.commit()
+    logger.info("mood_photo_deleted", extra={"user": user.email, "slot": slot})
+    return RedirectResponse(url="/profile/my-mood-photos", status_code=303)
+
+
+# ── DELETE /profile/my-mood-photos/{slot}  (JS fetch endpoint) ───────────────
+
+@router.delete("/profile/my-mood-photos/{slot}", status_code=204)
+async def mood_photo_delete_api(
+    slot: str,
+    user: User    = Depends(get_current_user_web),
+    db:   Session = Depends(get_db),
+):
+    if slot not in MOOD_PHOTO_SLOTS:
+        raise HTTPException(status_code=422, detail=f"Invalid slot: {slot!r}")
+    delete_mood_photo(user.id, slot, db)
+    db.commit()
+    logger.info("mood_photo_deleted_api", extra={"user": user.email, "slot": slot})

--- a/app/api/web_routes/mood_photos.py
+++ b/app/api/web_routes/mood_photos.py
@@ -36,12 +36,45 @@ templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
 
 router = APIRouter()
 
-# Ordered for consistent display in the template
+# Ordered for consistent display in the template.
+# description is rendered verbatim in the card; keep it to one short sentence.
 _SLOT_META: list[dict] = [
-    {"slot": "mood_intro_neutral",    "label": "Neutral",      "emoji": "😐"},
-    {"slot": "mood_happy_smile",      "label": "Happy",        "emoji": "😊"},
-    {"slot": "mood_celebration",      "label": "Celebration",  "emoji": "🎉"},
-    {"slot": "mood_sad_disappointed", "label": "Sad",          "emoji": "😔"},
+    {
+        "slot":        "mood_intro_neutral",
+        "label":       "Neutral",
+        "emoji":       "😐",
+        "description": "Your default neutral expression — shown when no other mood applies.",
+    },
+    {
+        "slot":        "mood_happy_smile",
+        "label":       "Happy",
+        "emoji":       "😊",
+        "description": "A happy or smiling photo — after a good training session.",
+    },
+    {
+        "slot":        "mood_celebration",
+        "label":       "Celebration",
+        "emoji":       "🎉",
+        "description": "A celebration shot — winning a match or achieving a goal.",
+    },
+    {
+        "slot":        "mood_sad_disappointed",
+        "label":       "Sad",
+        "emoji":       "😔",
+        "description": "A disappointed expression — after a tough defeat.",
+    },
+    {
+        "slot":        "mood_angry_competitive",
+        "label":       "Angry",
+        "emoji":       "😤",
+        "description": "A fired-up, competitive look — before a big match.",
+    },
+    {
+        "slot":        "mood_surprised_shocked",
+        "label":       "Surprised",
+        "emoji":       "😲",
+        "description": "A shocked or surprised reaction — an unexpected result.",
+    },
 ]
 
 

--- a/app/api/web_routes/mood_photos.py
+++ b/app/api/web_routes/mood_photos.py
@@ -1,5 +1,5 @@
 """
-mood_photos — web routes for the hangulatkép (mood photo) feature.
+mood_photos — web routes for the mood photo feature.
 
 Routes
 ------
@@ -38,10 +38,10 @@ router = APIRouter()
 
 # Ordered for consistent display in the template
 _SLOT_META: list[dict] = [
-    {"slot": "mood_intro_neutral",    "label": "Semleges",  "emoji": "😐"},
-    {"slot": "mood_happy_smile",      "label": "Boldog",    "emoji": "😊"},
-    {"slot": "mood_celebration",      "label": "Ünneplés",  "emoji": "🎉"},
-    {"slot": "mood_sad_disappointed", "label": "Szomorú",   "emoji": "😔"},
+    {"slot": "mood_intro_neutral",    "label": "Neutral",      "emoji": "😐"},
+    {"slot": "mood_happy_smile",      "label": "Happy",        "emoji": "😊"},
+    {"slot": "mood_celebration",      "label": "Celebration",  "emoji": "🎉"},
+    {"slot": "mood_sad_disappointed", "label": "Sad",          "emoji": "😔"},
 ]
 
 

--- a/app/api/web_routes/mood_photos.py
+++ b/app/api/web_routes/mood_photos.py
@@ -61,6 +61,13 @@ async def mood_photos_page(
             "user":        user,
             "mood_photos": mood_photos,
             "slots_meta":  _SLOT_META,
+            # Explicit LFA spec context — mood photos is an LFA Football Player
+            # feature; do not rely on user.specialization which can be any active
+            # spec (e.g. GANCUJU_PLAYER) on multi-spec accounts.
+            "spec_dashboard_url":  "/dashboard/lfa-football-player",
+            "spec_dashboard_icon": "⚽",
+            "spec_profile_url":    "/profile/lfa-football-player",
+            "spec_profile_icon":   "🪪",
         },
     )
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -64,6 +64,7 @@ from .vt_challenge import (
     VirtualTrainingChallenge, ChallengeStatus,
     CHALLENGE_COMPATIBLE_GAMES, make_expires_at, get_active_challenge,
 )
+from .user_mood_photos import UserMoodPhoto, MOOD_PHOTO_SLOTS, MoodPhotoStatus
 
 # 🎓 New Track-Based Modular Education System
 from .track import Track, Module, ModuleComponent
@@ -235,4 +236,8 @@ __all__ = [
     # Virtual Training
     "VirtualTrainingGame",
     "VirtualTrainingAttempt",
+    # Mood Photos (hangulatkép)
+    "UserMoodPhoto",
+    "MOOD_PHOTO_SLOTS",
+    "MoodPhotoStatus",
 ]

--- a/app/models/user_mood_photos.py
+++ b/app/models/user_mood_photos.py
@@ -1,0 +1,92 @@
+"""
+user_mood_photos — per-user optional "hangulatkép" slots.
+
+Completely independent from player_card_photo_url, wc_photo_url,
+and every other photo column on UserLicense.  No fallback in either
+direction.
+"""
+from __future__ import annotations
+
+import enum
+from datetime import datetime, timezone
+
+from sqlalchemy import (
+    CheckConstraint,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    UniqueConstraint,
+)
+
+from app.database import Base
+
+MOOD_PHOTO_SLOTS: frozenset[str] = frozenset(
+    {
+        "mood_intro_neutral",
+        "mood_happy_smile",
+        "mood_celebration",
+        "mood_sad_disappointed",
+    }
+)
+
+
+class MoodPhotoStatus(str, enum.Enum):
+    uploaded   = "uploaded"    # raw upload done; bg removal not yet run
+    processing = "processing"  # bg removal in progress (future phase)
+    ready      = "ready"       # processed_png_url populated (future phase)
+    failed     = "failed"      # bg removal failed; original_url still usable
+
+
+class UserMoodPhoto(Base):
+    __tablename__ = "user_mood_photos"
+
+    id    = Column(Integer, primary_key=True)
+    user_id = Column(
+        Integer,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    # nullable: allows mood photos to exist before a license is assigned,
+    # and survives license row deletion without orphaning the photo record.
+    license_id = Column(
+        Integer,
+        ForeignKey("user_licenses.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    slot              = Column(String(30), nullable=False)
+    original_url      = Column(String(512), nullable=False)
+    processed_png_url = Column(String(512), nullable=True)  # NULL throughout MVP
+    status            = Column(
+        String(20), nullable=False, default=MoodPhotoStatus.uploaded.value
+    )
+    created_at  = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+    updated_at  = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+    processed_at = Column(DateTime(timezone=True), nullable=True)  # NULL in MVP
+
+    __table_args__ = (
+        UniqueConstraint("user_id", "slot", name="uq_mood_photo_user_slot"),
+        CheckConstraint(
+            "slot IN ('mood_intro_neutral','mood_happy_smile',"
+            "'mood_celebration','mood_sad_disappointed')",
+            name="ck_mood_photo_slot_valid",
+        ),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<UserMoodPhoto user_id={self.user_id} slot={self.slot!r}"
+            f" status={self.status!r}>"
+        )

--- a/app/models/user_mood_photos.py
+++ b/app/models/user_mood_photos.py
@@ -28,6 +28,8 @@ MOOD_PHOTO_SLOTS: frozenset[str] = frozenset(
         "mood_happy_smile",
         "mood_celebration",
         "mood_sad_disappointed",
+        "mood_angry_competitive",
+        "mood_surprised_shocked",
     }
 )
 
@@ -80,7 +82,8 @@ class UserMoodPhoto(Base):
         UniqueConstraint("user_id", "slot", name="uq_mood_photo_user_slot"),
         CheckConstraint(
             "slot IN ('mood_intro_neutral','mood_happy_smile',"
-            "'mood_celebration','mood_sad_disappointed')",
+            "'mood_celebration','mood_sad_disappointed',"
+            "'mood_angry_competitive','mood_surprised_shocked')",
             name="ck_mood_photo_slot_valid",
         ),
     )

--- a/app/services/mood_photo_service.py
+++ b/app/services/mood_photo_service.py
@@ -1,0 +1,169 @@
+"""
+mood_photo_service — save / replace / delete / list hangulatkép slots.
+
+Completely independent from player_photo_service.  Never reads or writes
+player_card_photo_url, wc_photo_url, or any other UserLicense photo field.
+No fallback in either direction.
+
+Background removal (processed_png_url) is NOT implemented in this module —
+that is a future phase requiring separate approval.
+"""
+from __future__ import annotations
+
+import io
+import time
+from pathlib import Path
+
+from PIL import Image
+from sqlalchemy.orm import Session
+
+from app.models.user_mood_photos import MOOD_PHOTO_SLOTS, MoodPhotoStatus, UserMoodPhoto
+
+MOOD_PHOTO_DIR: Path = Path("app/static/uploads/mood_photos")
+MAX_BYTES: int       = 5 * 1024 * 1024   # 5 MB
+_ALLOWED_MIME: frozenset[str] = frozenset(
+    {"image/jpeg", "image/png", "image/webp"}
+)
+_MAX_DIMENSION: int = 2048   # pixels; larger images are resized down
+
+
+# ── Public API ────────────────────────────────────────────────────────────────
+
+def save_mood_photo(
+    file_bytes:  bytes,
+    content_type: str,
+    user_id:     int,
+    slot:        str,
+    db:          Session,
+    license_id:  int | None = None,
+) -> UserMoodPhoto:
+    """
+    Validate, save, and upsert one hangulatkép slot.
+
+    - Deletes the previous file for this (user_id, slot) pair before saving.
+    - Sets status='uploaded', processed_png_url=NULL, processed_at=NULL.
+    - Returns the upserted UserMoodPhoto row (already committed).
+    """
+    _validate_slot(slot)
+    _validate_upload(file_bytes, content_type)
+
+    url = _write_file(file_bytes, content_type, user_id, slot)
+
+    existing = (
+        db.query(UserMoodPhoto)
+        .filter_by(user_id=user_id, slot=slot)
+        .first()
+    )
+    if existing:
+        existing.original_url      = url
+        existing.processed_png_url = None
+        existing.status            = MoodPhotoStatus.uploaded.value
+        existing.processed_at      = None
+        if license_id is not None:
+            existing.license_id = license_id
+        db.flush()
+        db.refresh(existing)
+        return existing
+
+    record = UserMoodPhoto(
+        user_id           = user_id,
+        license_id        = license_id,
+        slot              = slot,
+        original_url      = url,
+        processed_png_url = None,
+        status            = MoodPhotoStatus.uploaded.value,
+        processed_at      = None,
+    )
+    db.add(record)
+    db.flush()
+    db.refresh(record)
+    return record
+
+
+def delete_mood_photo(user_id: int, slot: str, db: Session) -> None:
+    """
+    Delete the DB row and disk files for (user_id, slot).  Idempotent — no-op
+    if the slot has no record.  Does NOT touch any other photo fields.
+    """
+    _validate_slot(slot)
+    record = (
+        db.query(UserMoodPhoto)
+        .filter_by(user_id=user_id, slot=slot)
+        .first()
+    )
+    if record is None:
+        return
+    _delete_files_for_slot(user_id, slot)
+    db.delete(record)
+    db.flush()
+
+
+def get_mood_photos_for_user(
+    user_id: int, db: Session
+) -> dict[str, UserMoodPhoto | None]:
+    """
+    Return {slot: record_or_None} for all 4 MOOD_PHOTO_SLOTS.
+
+    Always returns all 4 keys so callers can iterate predictably.
+    """
+    rows = (
+        db.query(UserMoodPhoto)
+        .filter_by(user_id=user_id)
+        .all()
+    )
+    by_slot: dict[str, UserMoodPhoto | None] = {s: None for s in MOOD_PHOTO_SLOTS}
+    for row in rows:
+        if row.slot in by_slot:
+            by_slot[row.slot] = row
+    return by_slot
+
+
+# ── Internal helpers ──────────────────────────────────────────────────────────
+
+def _validate_slot(slot: str) -> None:
+    if slot not in MOOD_PHOTO_SLOTS:
+        raise ValueError(
+            f"Invalid mood photo slot: {slot!r}. "
+            f"Allowed: {sorted(MOOD_PHOTO_SLOTS)}"
+        )
+
+
+def _validate_upload(file_bytes: bytes, content_type: str) -> None:
+    if content_type not in _ALLOWED_MIME:
+        raise ValueError(
+            f"Unsupported content type: {content_type!r}. "
+            f"Allowed: {sorted(_ALLOWED_MIME)}"
+        )
+    if len(file_bytes) > MAX_BYTES:
+        raise ValueError(
+            f"File too large: {len(file_bytes)} bytes (max {MAX_BYTES})."
+        )
+
+
+def _write_file(
+    file_bytes: bytes, content_type: str, user_id: int, slot: str
+) -> str:
+    """Resize if needed, save as PNG, delete previous slot files. Returns URL."""
+    _delete_files_for_slot(user_id, slot)
+    MOOD_PHOTO_DIR.mkdir(parents=True, exist_ok=True)
+
+    img = Image.open(io.BytesIO(file_bytes)).convert("RGBA")
+    if max(img.size) > _MAX_DIMENSION:
+        img.thumbnail((_MAX_DIMENSION, _MAX_DIMENSION), Image.LANCZOS)
+
+    ts       = int(time.time())
+    filename = f"{user_id}_mood_{slot}_orig_{ts}.png"
+    out_path = MOOD_PHOTO_DIR / filename
+    img.save(out_path, "PNG", optimize=True)
+
+    return f"/static/uploads/mood_photos/{filename}"
+
+
+def _delete_files_for_slot(user_id: int, slot: str) -> None:
+    if not MOOD_PHOTO_DIR.exists():
+        return
+    for f in MOOD_PHOTO_DIR.glob(f"{user_id}_mood_{slot}_*.png"):
+        try:
+            f.unlink(missing_ok=True)
+        except OSError:
+            pass

--- a/app/templates/dashboard_card_editor.html
+++ b/app/templates/dashboard_card_editor.html
@@ -1150,6 +1150,12 @@ function switchTab(tabId) {
     if (panelEl) { panelEl.classList.add('active'); }
 }
 
+// Deep-link support: /card-editor#media activates the Media tab on load
+(function () {
+    var h = window.location.hash.slice(1);
+    if (h && document.getElementById('tab-' + h)) { switchTab(h); }
+}());
+
 function _csrf() {
     return (document.cookie.split('; ').find(r => r.startsWith('csrf_token=')) || '').split('=')[1];
 }

--- a/app/templates/dashboard_student_new.html
+++ b/app/templates/dashboard_student_new.html
@@ -157,6 +157,7 @@
     .s-pp-btn:hover { opacity: 0.82; }
     .s-pp-btn-view { background: #e8f0fe; color: #1a56db; }
     .s-pp-btn-edit { background: #0B0B0B; color: #FFD200; }
+    .s-pp-btn-mood { background: #1e293b; color: #94a3b8; border: 1px solid #334155; }
 
     /* ── Social section ──────────────────────────────────────────────────────── */
     .mod-social-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1rem; }
@@ -306,6 +307,7 @@
             <div class="s-pp-actions">
                 <a href="{{ public_profile_url }}" target="_blank" class="s-pp-btn s-pp-btn-view">View Profile ↗</a>
                 <a href="{{ grid_editor_url }}" class="s-pp-btn s-pp-btn-edit">Edit Grid</a>
+                <a href="/profile/my-mood-photos" class="s-pp-btn s-pp-btn-mood">📸 Hangulatképek</a>
             </div>
         </div>
     </section>

--- a/app/templates/dashboard_student_new.html
+++ b/app/templates/dashboard_student_new.html
@@ -157,7 +157,21 @@
     .s-pp-btn:hover { opacity: 0.82; }
     .s-pp-btn-view { background: #e8f0fe; color: #1a56db; }
     .s-pp-btn-edit { background: #0B0B0B; color: #FFD200; }
-    .s-pp-btn-mood { background: #1e293b; color: #94a3b8; border: 1px solid #334155; }
+
+    /* ── My Card Media section ───────────────────────────────────────────────── */
+    .s-cm-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1rem; }
+    @media (max-width: 520px) { .s-cm-grid { grid-template-columns: 1fr; } }
+    .s-cm-tile {
+        display: flex; flex-direction: column; align-items: flex-start; gap: 0.3rem;
+        background: var(--app-card-alt); border: 1px solid var(--app-border);
+        border-radius: 12px; padding: 1rem 1.1rem;
+        text-decoration: none; color: var(--app-text);
+        transition: box-shadow 0.18s, transform 0.18s;
+    }
+    .s-cm-tile:hover { box-shadow: 0 4px 16px rgba(0,0,0,0.18); transform: translateY(-2px); }
+    .s-cm-icon  { font-size: 1.5rem; }
+    .s-cm-title { font-size: 0.88rem; font-weight: 700; }
+    .s-cm-sub   { font-size: 0.75rem; color: var(--app-text-muted, #94a3b8); }
 
     /* ── Social section ──────────────────────────────────────────────────────── */
     .mod-social-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1rem; }
@@ -307,8 +321,34 @@
             <div class="s-pp-actions">
                 <a href="{{ public_profile_url }}" target="_blank" class="s-pp-btn s-pp-btn-view">View Profile ↗</a>
                 <a href="{{ grid_editor_url }}" class="s-pp-btn s-pp-btn-edit">Edit Grid</a>
-                <a href="/profile/my-mood-photos" class="s-pp-btn s-pp-btn-mood">📸 Mood Photos</a>
             </div>
+        </div>
+    </section>
+
+    {# ── My Card Media (LFA_FOOTBALL_PLAYER only) ─────────────────────────────── #}
+    <section class="section-block">
+        <div class="section-header">
+            <span class="section-title" style="font-weight:800;font-size:1rem;">My Card Media</span>
+        </div>
+        <p style="font-size:0.82rem;color:var(--app-text-muted,#94a3b8);margin-bottom:1rem;">
+            Photos used in your Player Cards, Welcome Cards, and Challenge Cards.
+        </p>
+        <div class="s-cm-grid">
+            <a href="/dashboard/lfa-football-player/card-editor#media" class="s-cm-tile">
+                <span class="s-cm-icon">📷</span>
+                <span class="s-cm-title">Card Photos</span>
+                <span class="s-cm-sub">Player &amp; Welcome Card photos (Media tab)</span>
+            </a>
+            <a href="/profile/my-mood-photos" class="s-cm-tile">
+                <span class="s-cm-icon">📸</span>
+                <span class="s-cm-title">Mood Photos</span>
+                <span class="s-cm-sub">4 expression slots for future card use</span>
+            </a>
+            <a href="/dashboard/lfa-football-player/card-editor" class="s-cm-tile">
+                <span class="s-cm-icon">🎴</span>
+                <span class="s-cm-title">Card Editor</span>
+                <span class="s-cm-sub">Full card design &amp; export tools</span>
+            </a>
         </div>
     </section>
     {% endif %}

--- a/app/templates/dashboard_student_new.html
+++ b/app/templates/dashboard_student_new.html
@@ -307,7 +307,7 @@
             <div class="s-pp-actions">
                 <a href="{{ public_profile_url }}" target="_blank" class="s-pp-btn s-pp-btn-view">View Profile ↗</a>
                 <a href="{{ grid_editor_url }}" class="s-pp-btn s-pp-btn-edit">Edit Grid</a>
-                <a href="/profile/my-mood-photos" class="s-pp-btn s-pp-btn-mood">📸 Hangulatképek</a>
+                <a href="/profile/my-mood-photos" class="s-pp-btn s-pp-btn-mood">📸 Mood Photos</a>
             </div>
         </div>
     </section>

--- a/app/templates/dashboard_student_new.html
+++ b/app/templates/dashboard_student_new.html
@@ -294,6 +294,19 @@
                 <span class="mod-nav-icon">🏅</span>
                 <span class="mod-nav-title">Achievements</span>
             </a>
+            {# Row 3 — profile + card tools #}
+            <a href="/profile/lfa-football-player" class="mod-nav-card">
+                <span class="mod-nav-icon">🪪</span>
+                <span class="mod-nav-title">Profile</span>
+            </a>
+            <a href="/dashboard/lfa-football-player/card-editor" class="mod-nav-card">
+                <span class="mod-nav-icon">🎴</span>
+                <span class="mod-nav-title">Card Editor</span>
+            </a>
+            <a href="/profile/my-mood-photos" class="mod-nav-card">
+                <span class="mod-nav-icon">📸</span>
+                <span class="mod-nav-title">Mood Photos</span>
+            </a>
         </div>
     </section>
 

--- a/app/templates/includes/spec_subpage_hdr.html
+++ b/app/templates/includes/spec_subpage_hdr.html
@@ -54,7 +54,10 @@
 {# ── LFA Football Player quicknav strip ─────────────────────────────────────
    Shown on all LFA sub-pages. Horizontal scroll on mobile (no wrapping).
    Active item highlighted by matching request path. #}
-{% set _lfa_qn = ((user.specialization.value if user.specialization else '') if user else '') == 'LFA_FOOTBALL_PLAYER' %}
+{% set _lfa_qn = (
+    ((user.specialization.value if user.specialization else '') if user else '') == 'LFA_FOOTBALL_PLAYER'
+    or (spec_dashboard_url | default('')) == '/dashboard/lfa-football-player'
+) %}
 
 <style>
 .spec-quicknav {

--- a/app/templates/includes/spec_subpage_hdr.html
+++ b/app/templates/includes/spec_subpage_hdr.html
@@ -51,6 +51,44 @@
   {% endif %}
 {% endif %}
 
+{# ── LFA Football Player quicknav strip ─────────────────────────────────────
+   Shown on all LFA sub-pages. Horizontal scroll on mobile (no wrapping).
+   Active item highlighted by matching request path. #}
+{% set _lfa_qn = ((user.specialization.value if user.specialization else '') if user else '') == 'LFA_FOOTBALL_PLAYER' %}
+
+<style>
+.spec-quicknav {
+    display: flex;
+    gap: 0.2rem;
+    padding: 0 1rem 0.5rem;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+}
+.spec-quicknav::-webkit-scrollbar { display: none; }
+.spec-qn-item {
+    flex-shrink: 0;
+    padding: 0.28rem 0.7rem;
+    border-radius: 6px;
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: rgba(255,255,255,0.55);
+    text-decoration: none;
+    white-space: nowrap;
+    transition: background 0.15s, color 0.15s;
+    border: 1px solid transparent;
+}
+.spec-qn-item:hover {
+    background: rgba(255,255,255,0.1);
+    color: rgba(255,255,255,0.9);
+}
+.spec-qn-item.sqn-active {
+    background: rgba(255,255,255,0.13);
+    color: #fff;
+    border-color: rgba(255,255,255,0.12);
+}
+</style>
+
 <div class="student-header spec-pg-hdr">
     <div class="student-header-inner">
         <a href="/dashboard" class="s-hdr-btn" title="Hub">🏠</a>
@@ -63,4 +101,21 @@
             <a href="/logout"  class="s-hdr-btn" title="Logout">🚪</a>
         </div>
     </div>
+    {% if _lfa_qn %}
+    {% set _rp = request.url.path %}
+    <nav class="spec-quicknav" aria-label="LFA Player quick navigation">
+        <a href="/profile/lfa-football-player"
+           class="spec-qn-item{% if _rp == '/profile/lfa-football-player' %} sqn-active{% endif %}">🪪 Profile</a>
+        <a href="/my-cards"
+           class="spec-qn-item{% if _rp.startswith('/my-cards') %} sqn-active{% endif %}">🃏 My Cards</a>
+        <a href="/dashboard/lfa-football-player/card-editor"
+           class="spec-qn-item{% if 'card-editor' in _rp %} sqn-active{% endif %}">🎴 Card Editor</a>
+        <a href="/profile/my-mood-photos"
+           class="spec-qn-item{% if _rp == '/profile/my-mood-photos' %} sqn-active{% endif %}">📸 Mood Photos</a>
+        <a href="/events"
+           class="spec-qn-item{% if _rp.startswith('/events') %} sqn-active{% endif %}">📅 Events</a>
+        <a href="/training"
+           class="spec-qn-item{% if _rp.startswith('/training') %} sqn-active{% endif %}">🎓 Training</a>
+    </nav>
+    {% endif %}
 </div>

--- a/app/templates/lfa_player_mood_photos.html
+++ b/app/templates/lfa_player_mood_photos.html
@@ -175,6 +175,32 @@
 </style>
 {% endblock %}
 
+{% block extra_scripts %}
+<script>
+/* Mood photo upload: must use fetch() + X-CSRF-Token header.
+   form.submit() skips the submit event so base.html CSRF interceptor never fires.
+   Using FormData (not URLSearchParams) preserves the file as multipart/form-data. */
+function _mpUpload(input) {
+    var form = input.closest('form');
+    var m    = document.cookie.match(/(?:^|;\s*)csrf_token=([^;]+)/);
+    var tok  = m ? decodeURIComponent(m[1]) : null;
+    if (!tok || !input.files || !input.files[0]) return;
+
+    fetch(form.action, {
+        method:      'POST',
+        headers:     { 'X-CSRF-Token': tok },
+        body:        new FormData(form),   // multipart/form-data + boundary set by browser
+        credentials: 'include',
+        redirect:    'follow',
+    }).then(function (r) {
+        window.location.href = r.redirected ? r.url : '/profile/my-mood-photos';
+    }).catch(function () {
+        window.location.reload();
+    });
+}
+</script>
+{% endblock %}
+
 {% block student_content %}
 <div class="mp-container">
 
@@ -245,7 +271,7 @@
                            name="photo"
                            accept="image/jpeg,image/png,image/webp"
                            style="display:none;"
-                           onchange="this.form.submit()">
+                           onchange="_mpUpload(this)">
                 </form>
 
                 {% if record %}

--- a/app/templates/lfa_player_mood_photos.html
+++ b/app/templates/lfa_player_mood_photos.html
@@ -1,0 +1,219 @@
+{% extends "student_base.html" %}
+
+{% block title %}Hangulatképek — LFA Football Player{% endblock %}
+
+{% block head_extra %}
+<style>
+    .mood-page-wrap {
+        max-width: 860px;
+        margin: 2rem auto;
+        padding: 0 1rem 4rem;
+    }
+    .mood-back-link {
+        display: inline-block;
+        margin-bottom: 1.2rem;
+        font-size: 0.9rem;
+        color: var(--link-color, #60a5fa);
+        text-decoration: none;
+    }
+    .mood-back-link:hover { text-decoration: underline; }
+
+    .mood-page-title {
+        font-size: 1.6rem;
+        font-weight: 800;
+        color: var(--text-primary, #f1f5f9);
+        margin-bottom: 0.3rem;
+    }
+    .mood-page-sub {
+        font-size: 0.9rem;
+        color: var(--text-muted, #94a3b8);
+        margin-bottom: 2rem;
+    }
+
+    /* 2-column grid on wider screens, 1 column on narrow */
+    .mood-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+        gap: 1.25rem;
+    }
+
+    .mood-card {
+        background: var(--card-bg, #1e293b);
+        border: 1px solid var(--card-border, #334155);
+        border-radius: 12px;
+        padding: 1.25rem 1.5rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.8rem;
+    }
+    .mood-card-header {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        font-size: 1.05rem;
+        font-weight: 700;
+        color: var(--text-primary, #f1f5f9);
+    }
+    .mood-card-emoji { font-size: 1.4rem; }
+
+    .mood-thumb-wrap {
+        width: 100%;
+        height: 140px;
+        border-radius: 8px;
+        background: var(--input-bg, #0f172a);
+        border: 1px dashed var(--card-border, #334155);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        overflow: hidden;
+    }
+    .mood-thumb {
+        max-width: 100%;
+        max-height: 140px;
+        object-fit: contain;
+        border-radius: 6px;
+    }
+    .mood-thumb-placeholder {
+        color: var(--text-muted, #94a3b8);
+        font-size: 0.85rem;
+        text-align: center;
+        padding: 0.5rem;
+    }
+
+    .mood-status-badge {
+        display: inline-block;
+        font-size: 0.75rem;
+        font-weight: 600;
+        padding: 0.2rem 0.6rem;
+        border-radius: 20px;
+        background: var(--badge-bg, #334155);
+        color: var(--text-muted, #94a3b8);
+    }
+    .mood-status-badge.uploaded {
+        background: #14532d;
+        color: #86efac;
+    }
+
+    .mood-actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        align-items: center;
+    }
+    .mood-btn-upload {
+        background: var(--btn-primary-bg, #2563eb);
+        color: #fff;
+        border: none;
+        border-radius: 8px;
+        padding: 0.45rem 1rem;
+        font-size: 0.85rem;
+        font-weight: 600;
+        cursor: pointer;
+        text-decoration: none;
+        display: inline-block;
+    }
+    .mood-btn-upload:hover { background: var(--btn-primary-hover, #1d4ed8); }
+
+    .mood-btn-delete {
+        background: transparent;
+        color: #f87171;
+        border: 1px solid #f87171;
+        border-radius: 8px;
+        padding: 0.4rem 0.9rem;
+        font-size: 0.85rem;
+        font-weight: 600;
+        cursor: pointer;
+    }
+    .mood-btn-delete:hover { background: rgba(248,113,113,0.1); }
+
+    .mood-hint {
+        font-size: 0.78rem;
+        color: var(--text-muted, #94a3b8);
+        margin-top: 0.2rem;
+    }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="mood-page-wrap">
+
+    <a class="mood-back-link" href="/profile/lfa-football-player">← Vissza a profilra</a>
+
+    <h1 class="mood-page-title">📸 Hangulatképek</h1>
+    <p class="mood-page-sub">
+        Töltsd fel a saját hangulatképeidet a profilodhoz. Minden szlot
+        önállóan feltölthető, cserélhető és törölhető. Nem kötelező —
+        a profilképet és a kártyaképeket nem befolyásolja.
+    </p>
+
+    <div class="mood-grid">
+        {% for meta in slots_meta %}
+        {% set record = mood_photos[meta.slot] %}
+        <div class="mood-card">
+
+            <div class="mood-card-header">
+                <span class="mood-card-emoji">{{ meta.emoji }}</span>
+                <span>{{ meta.label }}</span>
+                {% if record %}
+                <span class="mood-status-badge uploaded">✓ Feltöltve</span>
+                {% else %}
+                <span class="mood-status-badge">— Nincs feltöltve</span>
+                {% endif %}
+            </div>
+
+            <!-- Thumbnail preview -->
+            <div class="mood-thumb-wrap">
+                {% if record %}
+                <img class="mood-thumb"
+                     src="{{ record.original_url }}"
+                     alt="Hangulatkép — {{ meta.label }}">
+                {% else %}
+                <div class="mood-thumb-placeholder">
+                    Még nincs hangulatkép feltöltve<br>
+                    <small>JPEG · PNG · WebP · max 5 MB</small>
+                </div>
+                {% endif %}
+            </div>
+
+            <!-- Upload form -->
+            <div class="mood-actions">
+                <form method="post"
+                      action="/profile/my-mood-photos/{{ meta.slot }}/upload"
+                      enctype="multipart/form-data"
+                      style="display:inline-flex; align-items:center; gap:0.5rem; flex-wrap:wrap;">
+                    <label class="mood-btn-upload" for="file-{{ meta.slot }}">
+                        {% if record %}🔄 Csere{% else %}📷 Feltöltés{% endif %}
+                    </label>
+                    <input id="file-{{ meta.slot }}"
+                           type="file"
+                           name="photo"
+                           accept="image/jpeg,image/png,image/webp"
+                           style="display:none;"
+                           onchange="this.form.submit()">
+                </form>
+
+                <!-- Delete form (HTML fallback — browser can't send DELETE) -->
+                {% if record %}
+                <form method="post"
+                      action="/profile/my-mood-photos/{{ meta.slot }}/delete"
+                      onsubmit="return confirm('Biztosan törlöd ezt a hangulatképet?');">
+                    <button type="submit" class="mood-btn-delete">🗑 Törlés</button>
+                </form>
+                {% endif %}
+            </div>
+
+            {% if record %}
+            <div class="mood-hint">
+                Feltöltve: {{ record.created_at.strftime('%Y-%m-%d %H:%M') if record.created_at else '—' }}
+                {% if record.updated_at and record.updated_at != record.created_at %}
+                · Frissítve: {{ record.updated_at.strftime('%Y-%m-%d %H:%M') }}
+                {% endif %}
+            </div>
+            {% endif %}
+
+        </div>
+        {% endfor %}
+    </div>
+
+</div>
+{% endblock %}

--- a/app/templates/lfa_player_mood_photos.html
+++ b/app/templates/lfa_player_mood_photos.html
@@ -2,186 +2,242 @@
 
 {% block title %}Mood Photos — LFA Football Player{% endblock %}
 
-{% block head_extra %}
-<style>
-    .mood-page-wrap {
-        max-width: 860px;
-        margin: 2rem auto;
-        padding: 0 1rem 4rem;
-    }
-    .mood-back-link {
-        display: inline-block;
-        margin-bottom: 1.2rem;
-        font-size: 0.9rem;
-        color: var(--link-color, #60a5fa);
-        text-decoration: none;
-    }
-    .mood-back-link:hover { text-decoration: underline; }
+{% block active_page %}lfa-player{% endblock %}
 
-    .mood-page-title {
-        font-size: 1.6rem;
-        font-weight: 800;
-        color: var(--text-primary, #f1f5f9);
-        margin-bottom: 0.3rem;
+{% block student_header %}
+{% set _page_icon = '📸' %}
+{% set _page_name = 'Mood Photos' %}
+{% include "includes/spec_subpage_hdr.html" %}
+{% endblock %}
+
+{% block extra_styles %}
+<style>
+    .mp-container {
+        max-width: 900px;
+        margin: 0 auto;
+        padding: 2rem;
     }
-    .mood-page-sub {
-        font-size: 0.9rem;
-        color: var(--text-muted, #94a3b8);
+
+    /* ── Page header ── */
+    .mp-page-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-start;
+        flex-wrap: wrap;
+        gap: 1rem;
         margin-bottom: 2rem;
     }
-
-    /* 2-column grid on wider screens, 1 column on narrow */
-    .mood-grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
-        gap: 1.25rem;
+    .mp-page-title {
+        font-size: 1.8rem;
+        font-weight: 800;
+        color: var(--hub-text-primary);
+        margin: 0 0 0.3rem;
+    }
+    .mp-page-sub {
+        font-size: 0.9rem;
+        color: var(--hub-text-muted);
+        margin: 0;
     }
 
-    .mood-card {
-        background: var(--card-bg, #1e293b);
-        border: 1px solid var(--card-border, #334155);
-        border-radius: 12px;
-        padding: 1.25rem 1.5rem;
+    /* ── Back link as secondary button ── */
+    .btn {
+        padding: 0.75rem 1.4rem;
+        border: none;
+        border-radius: 8px;
+        font-size: 0.95rem;
+        font-weight: 600;
+        cursor: pointer;
+        text-decoration: none;
+        display: inline-block;
+        transition: transform 0.15s, box-shadow 0.15s;
+    }
+    .btn:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 3px 10px rgba(0,0,0,0.15);
+    }
+    .btn-secondary {
+        background: var(--hub-card-bg, #1e293b);
+        color: var(--hub-text-secondary, #94a3b8);
+        border: 1px solid var(--hub-divider, #334155);
+    }
+    .btn-primary {
+        background: var(--hub-btn-bg, #2563eb);
+        color: var(--hub-btn-text, #fff);
+        border: none;
+    }
+    .btn-danger {
+        background: transparent;
+        color: #f87171;
+        border: 1px solid #f87171;
+    }
+    .btn-danger:hover { background: rgba(248,113,113,0.1); }
+    .btn-sm { padding: 0.45rem 0.9rem; font-size: 0.85rem; }
+
+    /* ── 2×2 mood grid ── */
+    .mp-grid {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        gap: 1.5rem;
+    }
+    @media (max-width: 600px) {
+        .mp-grid { grid-template-columns: 1fr; }
+        .mp-container { padding: 1rem; }
+    }
+
+    /* ── Individual slot card ── */
+    .mp-card {
+        background: var(--hub-card-bg, #1e293b);
+        border-radius: 14px;
+        padding: 1.5rem;
+        box-shadow: var(--hub-card-shadow, 0 2px 8px rgba(0,0,0,0.25));
         display: flex;
         flex-direction: column;
-        gap: 0.8rem;
+        gap: 0.9rem;
     }
-    .mood-card-header {
+
+    .mp-card-header {
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        font-size: 1.05rem;
-        font-weight: 700;
-        color: var(--text-primary, #f1f5f9);
     }
-    .mood-card-emoji { font-size: 1.4rem; }
+    .mp-card-emoji { font-size: 1.5rem; }
+    .mp-card-title {
+        font-size: 1.1rem;
+        font-weight: 700;
+        color: var(--hub-text-primary, #f1f5f9);
+        flex: 1;
+    }
 
-    .mood-thumb-wrap {
+    /* ── Status badge ── */
+    .mp-badge {
+        display: inline-block;
+        font-size: 0.72rem;
+        font-weight: 700;
+        padding: 0.2rem 0.55rem;
+        border-radius: 20px;
+        text-transform: uppercase;
+        letter-spacing: 0.03em;
+        background: rgba(148,163,184,0.12);
+        color: var(--hub-text-muted, #94a3b8);
+    }
+    .mp-badge-uploaded {
+        background: rgba(134,239,172,0.15);
+        color: #86efac;
+    }
+
+    /* ── Instruction text ── */
+    .mp-instruction {
+        font-size: 0.82rem;
+        color: var(--hub-text-muted, #94a3b8);
+        margin: 0;
+        line-height: 1.5;
+    }
+
+    /* ── Photo preview area ── */
+    .mp-preview {
         width: 100%;
-        height: 140px;
-        border-radius: 8px;
-        background: var(--input-bg, #0f172a);
-        border: 1px dashed var(--card-border, #334155);
+        height: 150px;
+        border-radius: 10px;
+        background: rgba(15,23,42,0.6);
+        border: 1px dashed var(--hub-divider, #334155);
         display: flex;
         align-items: center;
         justify-content: center;
         overflow: hidden;
     }
-    .mood-thumb {
+    .mp-preview img {
         max-width: 100%;
-        max-height: 140px;
+        max-height: 150px;
         object-fit: contain;
-        border-radius: 6px;
+        border-radius: 8px;
     }
-    .mood-thumb-placeholder {
-        color: var(--text-muted, #94a3b8);
-        font-size: 0.85rem;
+    .mp-preview-placeholder {
         text-align: center;
-        padding: 0.5rem;
+        color: var(--hub-text-muted, #94a3b8);
+        font-size: 0.82rem;
+        line-height: 1.6;
     }
 
-    .mood-status-badge {
-        display: inline-block;
-        font-size: 0.75rem;
-        font-weight: 600;
-        padding: 0.2rem 0.6rem;
-        border-radius: 20px;
-        background: var(--badge-bg, #334155);
-        color: var(--text-muted, #94a3b8);
-    }
-    .mood-status-badge.uploaded {
-        background: #14532d;
-        color: #86efac;
-    }
-
-    .mood-actions {
+    /* ── Action row ── */
+    .mp-actions {
         display: flex;
         flex-wrap: wrap;
         gap: 0.5rem;
         align-items: center;
     }
-    .mood-btn-upload {
-        background: var(--btn-primary-bg, #2563eb);
-        color: #fff;
-        border: none;
-        border-radius: 8px;
-        padding: 0.45rem 1rem;
-        font-size: 0.85rem;
-        font-weight: 600;
-        cursor: pointer;
-        text-decoration: none;
-        display: inline-block;
-    }
-    .mood-btn-upload:hover { background: var(--btn-primary-hover, #1d4ed8); }
 
-    .mood-btn-delete {
-        background: transparent;
-        color: #f87171;
-        border: 1px solid #f87171;
-        border-radius: 8px;
-        padding: 0.4rem 0.9rem;
-        font-size: 0.85rem;
-        font-weight: 600;
-        cursor: pointer;
-    }
-    .mood-btn-delete:hover { background: rgba(248,113,113,0.1); }
-
-    .mood-hint {
-        font-size: 0.78rem;
-        color: var(--text-muted, #94a3b8);
-        margin-top: 0.2rem;
+    /* ── Timestamp hint ── */
+    .mp-hint {
+        font-size: 0.75rem;
+        color: var(--hub-text-muted, #94a3b8);
+        margin: 0;
     }
 </style>
 {% endblock %}
 
-{% block content %}
-<div class="mood-page-wrap">
+{% block student_content %}
+<div class="mp-container">
 
-    <a class="mood-back-link" href="/profile/lfa-football-player">← Back to profile</a>
+    <div class="mp-page-header">
+        <div>
+            <h1 class="mp-page-title">Mood Photos</h1>
+            <p class="mp-page-sub">
+                Upload a photo for each mood state. Each slot is independent —
+                uploading or deleting one does not affect the others or your
+                Player Card photos.
+            </p>
+        </div>
+        <a class="btn btn-secondary btn-sm" href="/profile/lfa-football-player">← Back to profile</a>
+    </div>
 
-    <h1 class="mood-page-title">📸 Mood Photos</h1>
-    <p class="mood-page-sub">
-        Upload your mood photos to your profile. Each slot can be uploaded,
-        replaced, or deleted independently. Optional — does not affect your
-        profile photo or card photos.
-    </p>
-
-    <div class="mood-grid">
+    <div class="mp-grid">
         {% for meta in slots_meta %}
         {% set record = mood_photos[meta.slot] %}
-        <div class="mood-card">
+        <div class="mp-card">
 
-            <div class="mood-card-header">
-                <span class="mood-card-emoji">{{ meta.emoji }}</span>
-                <span>{{ meta.label }}</span>
+            <!-- Card header: emoji + title + status badge -->
+            <div class="mp-card-header">
+                <span class="mp-card-emoji">{{ meta.emoji }}</span>
+                <span class="mp-card-title">{{ meta.label }}</span>
                 {% if record %}
-                <span class="mood-status-badge uploaded">✓ Uploaded</span>
+                <span class="mp-badge mp-badge-uploaded">✓ Uploaded</span>
                 {% else %}
-                <span class="mood-status-badge">— Not uploaded</span>
+                <span class="mp-badge">Not uploaded</span>
                 {% endif %}
             </div>
 
-            <!-- Thumbnail preview -->
-            <div class="mood-thumb-wrap">
-                {% if record %}
-                <img class="mood-thumb"
-                     src="{{ record.original_url }}"
-                     alt="Mood photo — {{ meta.label }}">
+            <!-- Short instruction -->
+            <p class="mp-instruction">
+                {% if meta.slot == 'mood_intro_neutral' %}
+                    Your default neutral expression — shown when no other mood applies.
+                {% elif meta.slot == 'mood_happy_smile' %}
+                    A happy or smiling photo — after a good training session.
+                {% elif meta.slot == 'mood_celebration' %}
+                    A celebration shot — winning a match or achieving a goal.
                 {% else %}
-                <div class="mood-thumb-placeholder">
-                    No mood photo uploaded yet<br>
+                    A disappointed or sad expression — after a tough defeat.
+                {% endif %}
+            </p>
+
+            <!-- Photo preview -->
+            <div class="mp-preview">
+                {% if record %}
+                <img src="{{ record.original_url }}" alt="Mood photo — {{ meta.label }}">
+                {% else %}
+                <div class="mp-preview-placeholder">
+                    No photo uploaded yet<br>
                     <small>JPEG · PNG · WebP · max 5 MB</small>
                 </div>
                 {% endif %}
             </div>
 
-            <!-- Upload form -->
-            <div class="mood-actions">
+            <!-- Actions: Upload/Replace + Delete -->
+            <div class="mp-actions">
                 <form method="post"
                       action="/profile/my-mood-photos/{{ meta.slot }}/upload"
                       enctype="multipart/form-data"
-                      style="display:inline-flex; align-items:center; gap:0.5rem; flex-wrap:wrap;">
-                    <label class="mood-btn-upload" for="file-{{ meta.slot }}">
+                      style="display:contents;">
+                    <label class="btn btn-primary btn-sm" for="file-{{ meta.slot }}" style="cursor:pointer;">
                         {% if record %}🔄 Replace{% else %}📷 Upload{% endif %}
                     </label>
                     <input id="file-{{ meta.slot }}"
@@ -192,23 +248,24 @@
                            onchange="this.form.submit()">
                 </form>
 
-                <!-- Delete form (HTML fallback — browser can't send DELETE) -->
                 {% if record %}
                 <form method="post"
                       action="/profile/my-mood-photos/{{ meta.slot }}/delete"
-                      onsubmit="return confirm('Delete this mood photo?');">
-                    <button type="submit" class="mood-btn-delete">🗑 Delete</button>
+                      onsubmit="return confirm('Delete this mood photo?');"
+                      style="display:contents;">
+                    <button type="submit" class="btn btn-danger btn-sm">🗑 Delete</button>
                 </form>
                 {% endif %}
             </div>
 
+            <!-- Timestamp hint if photo exists -->
             {% if record %}
-            <div class="mood-hint">
-                Uploaded: {{ record.created_at.strftime('%Y-%m-%d %H:%M') if record.created_at else '—' }}
+            <p class="mp-hint">
+                Uploaded {{ record.created_at.strftime('%Y-%m-%d %H:%M') if record.created_at else '—' }}
                 {% if record.updated_at and record.updated_at != record.created_at %}
-                · Updated: {{ record.updated_at.strftime('%Y-%m-%d %H:%M') }}
+                · Updated {{ record.updated_at.strftime('%Y-%m-%d %H:%M') }}
                 {% endif %}
-            </div>
+            </p>
             {% endif %}
 
         </div>

--- a/app/templates/lfa_player_mood_photos.html
+++ b/app/templates/lfa_player_mood_photos.html
@@ -180,16 +180,41 @@
 /* Mood photo upload: must use fetch() + X-CSRF-Token header.
    form.submit() skips the submit event so base.html CSRF interceptor never fires.
    Using FormData (not URLSearchParams) preserves the file as multipart/form-data. */
+function _mpCsrfToken() {
+    var m = document.cookie.match(/(?:^|;\s*)csrf_token=([^;]+)/);
+    return m ? decodeURIComponent(m[1]) : null;
+}
+
+/* Upload: form.submit() bypasses submit event so base.html CSRF interceptor
+   never fires. Sending FormData directly preserves the file as multipart. */
 function _mpUpload(input) {
     var form = input.closest('form');
-    var m    = document.cookie.match(/(?:^|;\s*)csrf_token=([^;]+)/);
-    var tok  = m ? decodeURIComponent(m[1]) : null;
+    var tok  = _mpCsrfToken();
     if (!tok || !input.files || !input.files[0]) return;
 
     fetch(form.action, {
         method:      'POST',
         headers:     { 'X-CSRF-Token': tok },
-        body:        new FormData(form),   // multipart/form-data + boundary set by browser
+        body:        new FormData(form),
+        credentials: 'include',
+        redirect:    'follow',
+    }).then(function (r) {
+        window.location.href = r.redirected ? r.url : '/profile/my-mood-photos';
+    }).catch(function () {
+        window.location.reload();
+    });
+}
+
+/* Delete: type="button" avoids submit event entirely; confirm() runs first so
+   the user can cancel before the request is sent. */
+function _mpDelete(url) {
+    if (!confirm('Delete this mood photo?')) return;
+    var tok = _mpCsrfToken();
+    if (!tok) { window.location.reload(); return; }
+
+    fetch(url, {
+        method:      'POST',
+        headers:     { 'X-CSRF-Token': tok, 'Content-Type': 'application/x-www-form-urlencoded' },
         credentials: 'include',
         redirect:    'follow',
     }).then(function (r) {
@@ -275,12 +300,11 @@ function _mpUpload(input) {
                 </form>
 
                 {% if record %}
-                <form method="post"
-                      action="/profile/my-mood-photos/{{ meta.slot }}/delete"
-                      onsubmit="return confirm('Delete this mood photo?');"
-                      style="display:contents;">
-                    <button type="submit" class="btn btn-danger btn-sm">🗑 Delete</button>
-                </form>
+                <button type="button"
+                        class="btn btn-danger btn-sm"
+                        onclick="_mpDelete('/profile/my-mood-photos/{{ meta.slot }}/delete')">
+                    🗑 Delete
+                </button>
                 {% endif %}
             </div>
 

--- a/app/templates/lfa_player_mood_photos.html
+++ b/app/templates/lfa_player_mood_photos.html
@@ -1,6 +1,6 @@
 {% extends "student_base.html" %}
 
-{% block title %}Hangulatképek — LFA Football Player{% endblock %}
+{% block title %}Mood Photos — LFA Football Player{% endblock %}
 
 {% block head_extra %}
 <style>
@@ -137,13 +137,13 @@
 {% block content %}
 <div class="mood-page-wrap">
 
-    <a class="mood-back-link" href="/profile/lfa-football-player">← Vissza a profilra</a>
+    <a class="mood-back-link" href="/profile/lfa-football-player">← Back to profile</a>
 
-    <h1 class="mood-page-title">📸 Hangulatképek</h1>
+    <h1 class="mood-page-title">📸 Mood Photos</h1>
     <p class="mood-page-sub">
-        Töltsd fel a saját hangulatképeidet a profilodhoz. Minden szlot
-        önállóan feltölthető, cserélhető és törölhető. Nem kötelező —
-        a profilképet és a kártyaképeket nem befolyásolja.
+        Upload your mood photos to your profile. Each slot can be uploaded,
+        replaced, or deleted independently. Optional — does not affect your
+        profile photo or card photos.
     </p>
 
     <div class="mood-grid">
@@ -155,9 +155,9 @@
                 <span class="mood-card-emoji">{{ meta.emoji }}</span>
                 <span>{{ meta.label }}</span>
                 {% if record %}
-                <span class="mood-status-badge uploaded">✓ Feltöltve</span>
+                <span class="mood-status-badge uploaded">✓ Uploaded</span>
                 {% else %}
-                <span class="mood-status-badge">— Nincs feltöltve</span>
+                <span class="mood-status-badge">— Not uploaded</span>
                 {% endif %}
             </div>
 
@@ -166,10 +166,10 @@
                 {% if record %}
                 <img class="mood-thumb"
                      src="{{ record.original_url }}"
-                     alt="Hangulatkép — {{ meta.label }}">
+                     alt="Mood photo — {{ meta.label }}">
                 {% else %}
                 <div class="mood-thumb-placeholder">
-                    Még nincs hangulatkép feltöltve<br>
+                    No mood photo uploaded yet<br>
                     <small>JPEG · PNG · WebP · max 5 MB</small>
                 </div>
                 {% endif %}
@@ -182,7 +182,7 @@
                       enctype="multipart/form-data"
                       style="display:inline-flex; align-items:center; gap:0.5rem; flex-wrap:wrap;">
                     <label class="mood-btn-upload" for="file-{{ meta.slot }}">
-                        {% if record %}🔄 Csere{% else %}📷 Feltöltés{% endif %}
+                        {% if record %}🔄 Replace{% else %}📷 Upload{% endif %}
                     </label>
                     <input id="file-{{ meta.slot }}"
                            type="file"
@@ -196,17 +196,17 @@
                 {% if record %}
                 <form method="post"
                       action="/profile/my-mood-photos/{{ meta.slot }}/delete"
-                      onsubmit="return confirm('Biztosan törlöd ezt a hangulatképet?');">
-                    <button type="submit" class="mood-btn-delete">🗑 Törlés</button>
+                      onsubmit="return confirm('Delete this mood photo?');">
+                    <button type="submit" class="mood-btn-delete">🗑 Delete</button>
                 </form>
                 {% endif %}
             </div>
 
             {% if record %}
             <div class="mood-hint">
-                Feltöltve: {{ record.created_at.strftime('%Y-%m-%d %H:%M') if record.created_at else '—' }}
+                Uploaded: {{ record.created_at.strftime('%Y-%m-%d %H:%M') if record.created_at else '—' }}
                 {% if record.updated_at and record.updated_at != record.created_at %}
-                · Frissítve: {{ record.updated_at.strftime('%Y-%m-%d %H:%M') }}
+                · Updated: {{ record.updated_at.strftime('%Y-%m-%d %H:%M') }}
                 {% endif %}
             </div>
             {% endif %}

--- a/app/templates/lfa_player_mood_photos.html
+++ b/app/templates/lfa_player_mood_photos.html
@@ -257,18 +257,8 @@ function _mpDelete(url) {
                 {% endif %}
             </div>
 
-            <!-- Short instruction -->
-            <p class="mp-instruction">
-                {% if meta.slot == 'mood_intro_neutral' %}
-                    Your default neutral expression — shown when no other mood applies.
-                {% elif meta.slot == 'mood_happy_smile' %}
-                    A happy or smiling photo — after a good training session.
-                {% elif meta.slot == 'mood_celebration' %}
-                    A celebration shot — winning a match or achieving a goal.
-                {% else %}
-                    A disappointed or sad expression — after a tough defeat.
-                {% endif %}
-            </p>
+            <!-- Short instruction (driven by _SLOT_META description) -->
+            <p class="mp-instruction">{{ meta.description }}</p>
 
             <!-- Photo preview -->
             <div class="mp-preview">

--- a/app/templates/lfa_player_onboarding.html
+++ b/app/templates/lfa_player_onboarding.html
@@ -433,6 +433,22 @@
                 <div id="step7-photo-status" style="font-size:0.8rem; margin-top:6px; color:#94a3b8;"></div>
             </div>
 
+            <!-- ── Hangulatképek — opcionális ajánló blokk (nem kötelező) ── -->
+            <div class="step7-mood-offer" style="margin:1.2rem 0; padding:1rem 1.2rem; background:rgba(255,255,255,0.04); border:1px solid rgba(255,255,255,0.08); border-radius:10px; text-align:center;">
+                <p style="font-weight:700; font-size:0.95rem; margin-bottom:0.3rem; color:var(--onboarding-accent,#f5c518);">📸 Hangulatképek (opcionális)</p>
+                <p style="font-size:0.82rem; color:#94a3b8; margin-bottom:0.8rem;">
+                    Töltsd fel a saját hangulatképeidet a profilodhoz.<br>
+                    Nem kötelező — bármikor pótolhatod később is.
+                </p>
+                <a href="/profile/my-mood-photos"
+                   class="btn btn-secondary"
+                   target="_blank"
+                   style="font-size:0.85rem;">
+                    📷 Hangulatképek feltöltése
+                </a>
+                <div style="margin-top:0.5rem; font-size:0.78rem; color:#64748b;">vagy folytasd az alábbi gombokkal</div>
+            </div>
+
             <div class="welcome-cta-row">
                 <a id="btn-go-profile"        href="/profile/lfa-football-player"   class="btn btn-secondary">🪪 Go to Profile</a>
                 <a id="btn-go-dashboard"      href="/dashboard/lfa-football-player" class="btn btn-primary">⚽ Continue to Dashboard</a>

--- a/app/templates/lfa_player_onboarding.html
+++ b/app/templates/lfa_player_onboarding.html
@@ -433,20 +433,20 @@
                 <div id="step7-photo-status" style="font-size:0.8rem; margin-top:6px; color:#94a3b8;"></div>
             </div>
 
-            <!-- ── Hangulatképek — opcionális ajánló blokk (nem kötelező) ── -->
+            <!-- ── Mood Photos — optional offer block (not required) ── -->
             <div class="step7-mood-offer" style="margin:1.2rem 0; padding:1rem 1.2rem; background:rgba(255,255,255,0.04); border:1px solid rgba(255,255,255,0.08); border-radius:10px; text-align:center;">
-                <p style="font-weight:700; font-size:0.95rem; margin-bottom:0.3rem; color:var(--onboarding-accent,#f5c518);">📸 Hangulatképek (opcionális)</p>
+                <p style="font-weight:700; font-size:0.95rem; margin-bottom:0.3rem; color:var(--onboarding-accent,#f5c518);">📸 Mood Photos (optional)</p>
                 <p style="font-size:0.82rem; color:#94a3b8; margin-bottom:0.8rem;">
-                    Töltsd fel a saját hangulatképeidet a profilodhoz.<br>
-                    Nem kötelező — bármikor pótolhatod később is.
+                    Upload your mood photos to your profile.<br>
+                    Optional — you can add these any time later.
                 </p>
                 <a href="/profile/my-mood-photos"
                    class="btn btn-secondary"
                    target="_blank"
                    style="font-size:0.85rem;">
-                    📷 Hangulatképek feltöltése
+                    📷 Manage Mood Photos
                 </a>
-                <div style="margin-top:0.5rem; font-size:0.78rem; color:#64748b;">vagy folytasd az alábbi gombokkal</div>
+                <div style="margin-top:0.5rem; font-size:0.78rem; color:#64748b;">or continue with the buttons below</div>
             </div>
 
             <div class="welcome-cta-row">

--- a/app/templates/lfa_player_profile.html
+++ b/app/templates/lfa_player_profile.html
@@ -307,6 +307,7 @@
         <div class="page-header-actions">
             <a href="/profile/lfa-football-player/edit" class="btn btn-primary">✏️ Edit Profile</a>
             <a href="/dashboard/lfa-football-player" class="btn btn-secondary">⚽ Dashboard</a>
+            <a href="/profile/my-mood-photos" class="btn btn-secondary">📸 Hangulatképek</a>
         </div>
     </div>
 

--- a/app/templates/lfa_player_profile.html
+++ b/app/templates/lfa_player_profile.html
@@ -307,7 +307,6 @@
         <div class="page-header-actions">
             <a href="/profile/lfa-football-player/edit" class="btn btn-primary">✏️ Edit Profile</a>
             <a href="/dashboard/lfa-football-player" class="btn btn-secondary">⚽ Dashboard</a>
-            <a href="/profile/my-mood-photos" class="btn btn-secondary">📸 Mood Photos</a>
         </div>
     </div>
 
@@ -484,6 +483,32 @@
             {% else %}
             <p style="color: var(--hub-text-muted); font-size:0.9rem;">No foot assessment data recorded during onboarding.</p>
             {% endif %}
+        </div>
+
+        <!-- My Card Media -->
+        <div class="card">
+            <h2>🖼 My Card Media</h2>
+            <p style="font-size:0.82rem;color:var(--hub-text-muted);margin-bottom:1rem;">
+                Photos used in your Player Cards, Welcome Cards, and Challenge Cards.
+            </p>
+            <div style="display:flex;flex-direction:column;gap:0.6rem;">
+                <a href="/dashboard/lfa-football-player/card-editor#media"
+                   style="display:flex;align-items:center;gap:0.6rem;padding:0.55rem 0.8rem;border-radius:8px;background:var(--hub-section-bg,#f8fafc);border:1px solid var(--hub-divider);text-decoration:none;color:var(--hub-text-primary);">
+                    <span style="font-size:1.1rem;">📷</span>
+                    <span>
+                        <strong style="font-size:0.88rem;">Card Photos</strong><br>
+                        <span style="font-size:0.76rem;color:var(--hub-text-muted);">Player &amp; Welcome Card photos (Media tab)</span>
+                    </span>
+                </a>
+                <a href="/profile/my-mood-photos"
+                   style="display:flex;align-items:center;gap:0.6rem;padding:0.55rem 0.8rem;border-radius:8px;background:var(--hub-section-bg,#f8fafc);border:1px solid var(--hub-divider);text-decoration:none;color:var(--hub-text-primary);">
+                    <span style="font-size:1.1rem;">📸</span>
+                    <span>
+                        <strong style="font-size:0.88rem;">Mood Photos</strong><br>
+                        <span style="font-size:0.76rem;color:var(--hub-text-muted);">4 expression slots for future card use</span>
+                    </span>
+                </a>
+            </div>
         </div>
 
     </div>

--- a/app/templates/lfa_player_profile.html
+++ b/app/templates/lfa_player_profile.html
@@ -307,7 +307,7 @@
         <div class="page-header-actions">
             <a href="/profile/lfa-football-player/edit" class="btn btn-primary">✏️ Edit Profile</a>
             <a href="/dashboard/lfa-football-player" class="btn btn-secondary">⚽ Dashboard</a>
-            <a href="/profile/my-mood-photos" class="btn btn-secondary">📸 Hangulatképek</a>
+            <a href="/profile/my-mood-photos" class="btn btn-secondary">📸 Mood Photos</a>
         </div>
     </div>
 

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -4009,6 +4009,20 @@
         "title": "Body_message_send_messages_send_post",
         "type": "object"
       },
+      "Body_mood_photo_upload_profile_my_mood_photos__slot__upload_post": {
+        "properties": {
+          "photo": {
+            "format": "binary",
+            "title": "Photo",
+            "type": "string"
+          }
+        },
+        "required": [
+          "photo"
+        ],
+        "title": "Body_mood_photo_upload_profile_my_mood_photos__slot__upload_post",
+        "type": "object"
+      },
       "Body_motivation_assessment_submit_admin_students__student_id__motivation__specialization__post": {
         "properties": {
           "commitment_level": {
@@ -63442,6 +63456,152 @@
           }
         },
         "summary": "Lfa Player Profile Positions Submit",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/profile/my-mood-photos": {
+      "get": {
+        "operationId": "mood_photos_page_profile_my_mood_photos_get",
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Mood Photos Page",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/profile/my-mood-photos/{slot}": {
+      "delete": {
+        "operationId": "mood_photo_delete_api_profile_my_mood_photos__slot__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slot",
+            "required": true,
+            "schema": {
+              "title": "Slot",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Mood Photo Delete Api",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/profile/my-mood-photos/{slot}/delete": {
+      "post": {
+        "operationId": "mood_photo_delete_form_profile_my_mood_photos__slot__delete_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slot",
+            "required": true,
+            "schema": {
+              "title": "Slot",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Mood Photo Delete Form",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/profile/my-mood-photos/{slot}/upload": {
+      "post": {
+        "operationId": "mood_photo_upload_profile_my_mood_photos__slot__upload_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slot",
+            "required": true,
+            "schema": {
+              "title": "Slot",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_mood_photo_upload_profile_my_mood_photos__slot__upload_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Mood Photo Upload",
         "tags": [
           "web"
         ]

--- a/tests/unit/api/web_routes/test_mood_photos.py
+++ b/tests/unit/api/web_routes/test_mood_photos.py
@@ -414,6 +414,17 @@ def test_mp_r16_template_uses_correct_blocks():
     assert "spec_subpage_hdr.html" in content, (
         "template must include spec_subpage_hdr.html for platform header"
     )
+    assert "_mpUpload(this)" in content, (
+        "file input must use _mpUpload(this) — form.submit() skips submit event "
+        "so the base.html CSRF interceptor never fires, causing 403"
+    )
+    assert "this.form.submit()" not in content, (
+        "file input must NOT use form.submit() — it bypasses the submit event "
+        "and the CSRF interceptor, causing 403 CSRF_VALIDATION_FAILED"
+    )
+    assert "X-CSRF-Token" in content, (
+        "template must include X-CSRF-Token fetch header for CSRF validation"
+    )
 
 
 # ── MP-R17 ── spec_subpage_hdr has LFA quicknav strip with all key links ─────

--- a/tests/unit/api/web_routes/test_mood_photos.py
+++ b/tests/unit/api/web_routes/test_mood_photos.py
@@ -291,3 +291,85 @@ def test_mp_r11_management_template_is_english():
     assert "Upload" in content
     assert "Delete" in content
     assert "Not uploaded" in content
+
+
+# ── MP-R12 ── dashboard has My Card Media section + correct links ─────────────
+
+def test_mp_r12_dashboard_has_card_media_section():
+    from pathlib import Path
+
+    content = (
+        Path(__file__).resolve()
+        .parent.parent.parent.parent.parent
+        / "app" / "templates" / "dashboard_student_new.html"
+    ).read_text(encoding="utf-8")
+
+    assert "My Card Media" in content, "dashboard missing 'My Card Media' section title"
+    assert "/profile/my-mood-photos" in content, "dashboard missing /profile/my-mood-photos link"
+    assert "/dashboard/lfa-football-player/card-editor#media" in content, (
+        "dashboard missing card editor #media deep link"
+    )
+    assert "/dashboard/lfa-football-player/card-editor" in content, (
+        "dashboard missing card editor link"
+    )
+
+
+# ── MP-R13 ── Public Profile action row no longer contains Mood Photos ────────
+
+def test_mp_r13_public_profile_section_has_no_mood_photos_button():
+    from pathlib import Path
+
+    content = (
+        Path(__file__).resolve()
+        .parent.parent.parent.parent.parent
+        / "app" / "templates" / "dashboard_student_new.html"
+    ).read_text(encoding="utf-8")
+
+    # Extract only the Public Profile section (between its section tags)
+    pp_start = content.find("Public Profile entry point")
+    pp_end   = content.find("My Card Media", pp_start)
+    pp_block = content[pp_start:pp_end] if pp_start != -1 and pp_end != -1 else ""
+
+    assert "my-mood-photos" not in pp_block, (
+        "Mood Photos link must not appear inside the Public Profile section — "
+        "it must only be in the My Card Media section"
+    )
+
+
+# ── MP-R14 ── profile page cards-grid contains Card Media card ───────────────
+
+def test_mp_r14_profile_page_has_card_media_card():
+    from pathlib import Path
+
+    content = (
+        Path(__file__).resolve()
+        .parent.parent.parent.parent.parent
+        / "app" / "templates" / "lfa_player_profile.html"
+    ).read_text(encoding="utf-8")
+
+    assert "My Card Media" in content, "profile page missing 'My Card Media' card"
+    assert "/profile/my-mood-photos" in content, "profile page missing /profile/my-mood-photos link"
+    assert "/dashboard/lfa-football-player/card-editor#media" in content, (
+        "profile page missing card editor #media deep link"
+    )
+
+
+# ── MP-R15 ── profile page header no longer contains Mood Photos button ───────
+
+def test_mp_r15_profile_header_has_no_mood_photos_button():
+    from pathlib import Path
+
+    content = (
+        Path(__file__).resolve()
+        .parent.parent.parent.parent.parent
+        / "app" / "templates" / "lfa_player_profile.html"
+    ).read_text(encoding="utf-8")
+
+    # The header block ends before cards-grid
+    header_end = content.find('class="cards-grid"')
+    header_block = content[:header_end] if header_end != -1 else content[:500]
+
+    assert "my-mood-photos" not in header_block, (
+        "Mood Photos link must not appear in the profile page header — "
+        "it must only be in the My Card Media card inside cards-grid"
+    )

--- a/tests/unit/api/web_routes/test_mood_photos.py
+++ b/tests/unit/api/web_routes/test_mood_photos.py
@@ -1,0 +1,238 @@
+"""
+MP-R01..MP-R09 — unit tests for mood_photos web routes.
+
+Tests call route functions directly (asyncio.run) with patched
+dependencies — no TestClient, no real DB, no disk I/O.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+from fastapi.responses import RedirectResponse
+
+_BASE = "app.api.web_routes.mood_photos"
+_SVC  = "app.services.mood_photo_service"
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+def _user(uid: int = 1):
+    u = MagicMock()
+    u.id    = uid
+    u.email = f"user{uid}@lfa.com"
+    return u
+
+
+def _db():
+    db = MagicMock()
+    db.query.return_value.filter_by.return_value.first.return_value = None
+    return db
+
+
+def _request(accept: str = "text/html"):
+    req = MagicMock()
+    req.headers = {"accept": accept}
+    return req
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _mock_photo(content: bytes = b"\xff\xd8\xff", content_type: str = "image/jpeg"):
+    f = AsyncMock()
+    f.read = AsyncMock(return_value=content)
+    f.content_type = content_type
+    return f
+
+
+# ── MP-R01 ── authenticated upload → 303 redirect ────────────────────────────
+
+def test_mp_r01_authenticated_upload_redirects():
+    from app.api.web_routes.mood_photos import mood_photo_upload
+
+    with patch(f"{_BASE}.save_mood_photo") as mock_save, \
+         patch(f"{_BASE}.get_mood_photos_for_user", return_value={}):
+        mock_save.return_value = MagicMock()
+
+        resp = _run(
+            mood_photo_upload(
+                slot    = "mood_happy_smile",
+                request = _request(),
+                photo   = _mock_photo(),
+                user    = _user(),
+                db      = _db(),
+            )
+        )
+
+    assert isinstance(resp, RedirectResponse)
+    assert resp.status_code == 303
+    assert "/profile/my-mood-photos" in str(resp.headers.get("location", ""))
+
+
+# ── MP-R02 ── unauthenticated → dependency raises (simulated 401) ─────────────
+
+def test_mp_r02_unauthenticated_raises():
+    from app.api.web_routes.mood_photos import mood_photo_upload
+
+    async def _raise():
+        raise HTTPException(status_code=401, detail="Not authenticated")
+
+    with pytest.raises(HTTPException) as exc_info:
+        _run(
+            mood_photo_upload(
+                slot    = "mood_happy_smile",
+                request = _request(),
+                photo   = _mock_photo(),
+                user    = await_raises(401),
+                db      = _db(),
+            )
+        )
+
+
+def await_raises(status: int):
+    raise HTTPException(status_code=status)
+
+
+# ── MP-R03 ── invalid slot → HTTPException 422 ───────────────────────────────
+
+def test_mp_r03_invalid_slot_raises_422():
+    from app.api.web_routes.mood_photos import mood_photo_upload
+
+    with pytest.raises(HTTPException) as exc_info:
+        _run(
+            mood_photo_upload(
+                slot    = "angry_rage",
+                request = _request(),
+                photo   = _mock_photo(),
+                user    = _user(),
+                db      = _db(),
+            )
+        )
+    assert exc_info.value.status_code == 422
+
+
+# ── MP-R04 ── GET page returns 4-slot context ─────────────────────────────────
+
+def test_mp_r04_get_page_returns_all_slots():
+    from app.api.web_routes.mood_photos import mood_photos_page
+
+    four_slots = {
+        "mood_intro_neutral":    None,
+        "mood_happy_smile":      None,
+        "mood_celebration":      None,
+        "mood_sad_disappointed": None,
+    }
+
+    with patch(f"{_BASE}.get_mood_photos_for_user", return_value=four_slots), \
+         patch(f"{_BASE}.templates") as mock_tpl:
+        mock_tpl.TemplateResponse.return_value = MagicMock()
+
+        _run(mood_photos_page(request=_request(), user=_user(), db=_db()))
+
+        call_kwargs = mock_tpl.TemplateResponse.call_args
+        ctx = call_kwargs[0][1]
+        assert "mood_photos" in ctx
+        assert set(ctx["mood_photos"].keys()) == set(four_slots.keys())
+        assert "slots_meta" in ctx
+        assert len(ctx["slots_meta"]) == 4
+
+
+# ── MP-R05 ── GET only queries own user_id ───────────────────────────────────
+
+def test_mp_r05_get_queries_correct_user_id():
+    from app.api.web_routes.mood_photos import mood_photos_page
+
+    with patch(f"{_BASE}.get_mood_photos_for_user") as mock_get, \
+         patch(f"{_BASE}.templates") as mock_tpl:
+        mock_get.return_value = {s: None for s in [
+            "mood_intro_neutral", "mood_happy_smile",
+            "mood_celebration",   "mood_sad_disappointed",
+        ]}
+        mock_tpl.TemplateResponse.return_value = MagicMock()
+
+        db = _db()
+        _run(mood_photos_page(request=_request(), user=_user(uid=42), db=db))
+
+        called_uid = mock_get.call_args[0][0]
+        assert called_uid == 42
+
+
+# ── MP-R06 ── POST /delete form fallback → 303 ───────────────────────────────
+
+def test_mp_r06_form_delete_redirects():
+    from app.api.web_routes.mood_photos import mood_photo_delete_form
+
+    with patch(f"{_BASE}.delete_mood_photo") as mock_del:
+        resp = _run(
+            mood_photo_delete_form(
+                slot = "mood_intro_neutral",
+                user = _user(),
+                db   = _db(),
+            )
+        )
+
+    mock_del.assert_called_once()
+    assert isinstance(resp, RedirectResponse)
+    assert resp.status_code == 303
+
+
+# ── MP-R07 ── DELETE endpoint → 204 (None return) ────────────────────────────
+
+def test_mp_r07_delete_api_returns_none():
+    from app.api.web_routes.mood_photos import mood_photo_delete_api
+
+    with patch(f"{_BASE}.delete_mood_photo"):
+        result = _run(
+            mood_photo_delete_api(
+                slot = "mood_celebration",
+                user = _user(),
+                db   = _db(),
+            )
+        )
+    assert result is None  # 204 = no body
+
+
+# ── MP-R08 ── delete invalid slot → 422 ──────────────────────────────────────
+
+def test_mp_r08_delete_invalid_slot_raises_422():
+    from app.api.web_routes.mood_photos import mood_photo_delete_form
+
+    with pytest.raises(HTTPException) as exc_info:
+        _run(
+            mood_photo_delete_form(
+                slot = "unknown_slot_xyz",
+                user = _user(),
+                db   = _db(),
+            )
+        )
+    assert exc_info.value.status_code == 422
+
+
+# ── MP-R09 ── onboarding Step 7 contains hangulatkep offer block ──────────────
+
+def test_mp_r09_onboarding_template_contains_mood_offer():
+    from pathlib import Path
+
+    template_path = (
+        Path(__file__).resolve()
+        .parent.parent.parent.parent.parent
+        / "app" / "templates" / "lfa_player_onboarding.html"
+    )
+    content = template_path.read_text(encoding="utf-8")
+    assert "step7-mood-offer" in content, (
+        "lfa_player_onboarding.html missing step7-mood-offer block"
+    )
+    assert "/profile/my-mood-photos" in content, (
+        "lfa_player_onboarding.html missing link to /profile/my-mood-photos"
+    )
+    assert "Hangulatk" in content, (
+        "lfa_player_onboarding.html missing 'Hangulatkép' text"
+    )
+    # Onboarding completion gate must NOT mention mood in submit handler
+    assert "mood" not in content.split("lfa_player_onboarding_web_submit")[0].lower() \
+        or "onboarding_completed" not in content.split("step7-mood-offer")[0], \
+        "onboarding_completed must not be gated on mood upload"

--- a/tests/unit/api/web_routes/test_mood_photos.py
+++ b/tests/unit/api/web_routes/test_mood_photos.py
@@ -373,3 +373,44 @@ def test_mp_r15_profile_header_has_no_mood_photos_button():
         "Mood Photos link must not appear in the profile page header — "
         "it must only be in the My Card Media card inside cards-grid"
     )
+
+
+# ── MP-R16 ── mood photos template uses correct block names (layout gate) ────
+
+def test_mp_r16_template_uses_correct_blocks():
+    from pathlib import Path
+
+    content = (
+        Path(__file__).resolve()
+        .parent.parent.parent.parent.parent
+        / "app" / "templates" / "lfa_player_mood_photos.html"
+    ).read_text(encoding="utf-8")
+
+    assert "{% block student_content %}" in content, (
+        "lfa_player_mood_photos.html must use student_content block "
+        "(not 'content') — otherwise the student nav/header is stripped"
+    )
+    assert "{% block extra_styles %}" in content, (
+        "lfa_player_mood_photos.html must use extra_styles block "
+        "(not 'head_extra') — otherwise CSS is dropped"
+    )
+    assert "{% block active_page %}lfa-player{% endblock %}" in content, (
+        "lfa_player_mood_photos.html must set active_page=lfa-player "
+        "to highlight the correct nav item"
+    )
+    assert "{% block content %}" not in content, (
+        "lfa_player_mood_photos.html must NOT use 'content' block — "
+        "it replaces the entire student layout"
+    )
+    assert "{% block head_extra %}" not in content, (
+        "lfa_player_mood_photos.html must NOT use 'head_extra' block — "
+        "use 'extra_styles' instead"
+    )
+    assert "mp-grid" in content, "template must contain mp-grid class for 2×2 slot layout"
+    assert "mp-card" in content, "template must contain mp-card class for slot cards"
+    assert "btn btn-primary" in content, "template must use btn btn-primary for upload button"
+    assert "btn btn-secondary" in content, "template must use btn btn-secondary for back link"
+    assert "btn btn-danger" in content, "template must use btn btn-danger for delete button"
+    assert "spec_subpage_hdr.html" in content, (
+        "template must include spec_subpage_hdr.html for platform header"
+    )

--- a/tests/unit/api/web_routes/test_mood_photos.py
+++ b/tests/unit/api/web_routes/test_mood_photos.py
@@ -414,3 +414,65 @@ def test_mp_r16_template_uses_correct_blocks():
     assert "spec_subpage_hdr.html" in content, (
         "template must include spec_subpage_hdr.html for platform header"
     )
+
+
+# ── MP-R17 ── spec_subpage_hdr has LFA quicknav strip with all key links ─────
+
+def test_mp_r17_spec_subpage_hdr_has_lfa_quicknav():
+    from pathlib import Path
+
+    content = (
+        Path(__file__).resolve()
+        .parent.parent.parent.parent.parent
+        / "app" / "templates" / "includes" / "spec_subpage_hdr.html"
+    ).read_text(encoding="utf-8")
+
+    assert "spec-quicknav" in content, "spec_subpage_hdr must contain .spec-quicknav nav strip"
+    assert "LFA_FOOTBALL_PLAYER" in content, "quicknav must be gated on LFA_FOOTBALL_PLAYER"
+
+    required_links = {
+        "/profile/lfa-football-player": "Profile",
+        "/my-cards":                    "My Cards",
+        "/dashboard/lfa-football-player/card-editor": "Card Editor",
+        "/profile/my-mood-photos":      "Mood Photos",
+        "/events":                      "Events",
+        "/training":                    "Training",
+    }
+    for url, label in required_links.items():
+        assert url in content, f"spec quicknav missing link: {url!r} ({label})"
+        assert label in content, f"spec quicknav missing label: {label!r}"
+
+    assert "sqn-active" in content, "quicknav must highlight active item (sqn-active class)"
+    assert "spec-qn-item" in content, "quicknav items must use spec-qn-item class"
+
+
+# ── MP-R18 ── dashboard mod-nav has 9 items including Profile/Editor/Mood ────
+
+def test_mp_r18_dashboard_modnav_has_profile_editor_moodphotos():
+    from pathlib import Path
+
+    content = (
+        Path(__file__).resolve()
+        .parent.parent.parent.parent.parent
+        / "app" / "templates" / "dashboard_student_new.html"
+    ).read_text(encoding="utf-8")
+
+    # All 9 mod-nav destinations must be present
+    required = [
+        ("/events",                                    "Events"),
+        ("/my-cards",                                  "My Cards"),
+        ("/training",                                  "Training"),
+        ("/skills/history",                            "Skill History"),
+        ("/calendar",                                  "Calendar"),
+        ("/achievements",                              "Achievements"),
+        ("/profile/lfa-football-player",               "Profile"),
+        ("/dashboard/lfa-football-player/card-editor", "Card Editor"),
+        ("/profile/my-mood-photos",                    "Mood Photos"),
+    ]
+    modnav_start = content.find('<section class="mod-nav-section">')
+    modnav_end   = content.find("</section>", modnav_start)
+    modnav_block = content[modnav_start:modnav_end] if modnav_start != -1 else content
+
+    for url, label in required:
+        assert url in modnav_block, f"dashboard mod-nav missing: {url!r} ({label})"
+        assert label in modnav_block, f"dashboard mod-nav missing label: {label!r}"

--- a/tests/unit/api/web_routes/test_mood_photos.py
+++ b/tests/unit/api/web_routes/test_mood_photos.py
@@ -115,19 +115,24 @@ def test_mp_r03_invalid_slot_raises_422():
     assert exc_info.value.status_code == 422
 
 
-# ── MP-R04 ── GET page returns 4-slot context ─────────────────────────────────
+# ── MP-R04 ── GET page returns 6-slot context ─────────────────────────────────
+
+_ALL_SLOTS = [
+    "mood_intro_neutral",
+    "mood_happy_smile",
+    "mood_celebration",
+    "mood_sad_disappointed",
+    "mood_angry_competitive",
+    "mood_surprised_shocked",
+]
+
 
 def test_mp_r04_get_page_returns_all_slots():
     from app.api.web_routes.mood_photos import mood_photos_page
 
-    four_slots = {
-        "mood_intro_neutral":    None,
-        "mood_happy_smile":      None,
-        "mood_celebration":      None,
-        "mood_sad_disappointed": None,
-    }
+    six_slots = {s: None for s in _ALL_SLOTS}
 
-    with patch(f"{_BASE}.get_mood_photos_for_user", return_value=four_slots), \
+    with patch(f"{_BASE}.get_mood_photos_for_user", return_value=six_slots), \
          patch(f"{_BASE}.templates") as mock_tpl:
         mock_tpl.TemplateResponse.return_value = MagicMock()
 
@@ -136,9 +141,9 @@ def test_mp_r04_get_page_returns_all_slots():
         call_kwargs = mock_tpl.TemplateResponse.call_args
         ctx = call_kwargs[0][1]
         assert "mood_photos" in ctx
-        assert set(ctx["mood_photos"].keys()) == set(four_slots.keys())
+        assert set(ctx["mood_photos"].keys()) == set(six_slots.keys())
         assert "slots_meta" in ctx
-        assert len(ctx["slots_meta"]) == 4
+        assert len(ctx["slots_meta"]) == 6
 
 
 # ── MP-R05 ── GET only queries own user_id ───────────────────────────────────
@@ -148,10 +153,7 @@ def test_mp_r05_get_queries_correct_user_id():
 
     with patch(f"{_BASE}.get_mood_photos_for_user") as mock_get, \
          patch(f"{_BASE}.templates") as mock_tpl:
-        mock_get.return_value = {s: None for s in [
-            "mood_intro_neutral", "mood_happy_smile",
-            "mood_celebration",   "mood_sad_disappointed",
-        ]}
+        mock_get.return_value = {s: None for s in _ALL_SLOTS}
         mock_tpl.TemplateResponse.return_value = MagicMock()
 
         db = _db()
@@ -242,12 +244,7 @@ def test_mp_r09_onboarding_template_contains_mood_offer():
 def test_mp_r10_management_page_zero_state_renders():
     from app.api.web_routes.mood_photos import mood_photos_page
 
-    empty_slots = {
-        "mood_intro_neutral":    None,
-        "mood_happy_smile":      None,
-        "mood_celebration":      None,
-        "mood_sad_disappointed": None,
-    }
+    empty_slots = {s: None for s in _ALL_SLOTS}
 
     with patch(f"{_BASE}.get_mood_photos_for_user", return_value=empty_slots), \
          patch(f"{_BASE}.templates") as mock_tpl:
@@ -263,7 +260,7 @@ def test_mp_r10_management_page_zero_state_renders():
         assert all(v is None for v in ctx["mood_photos"].values()), (
             "zero-state: all slots must be None when nothing uploaded"
         )
-        assert len(ctx["slots_meta"]) == 4
+        assert len(ctx["slots_meta"]) == 6
 
 
 # ── MP-R11 ── mood photo template uses English labels only ───────────────────
@@ -506,12 +503,7 @@ def test_mp_r19_route_passes_lfa_spec_context():
     """
     from app.api.web_routes.mood_photos import mood_photos_page
 
-    four_slots = {s: None for s in [
-        "mood_intro_neutral", "mood_happy_smile",
-        "mood_celebration",   "mood_sad_disappointed",
-    ]}
-
-    with patch(f"{_BASE}.get_mood_photos_for_user", return_value=four_slots), \
+    with patch(f"{_BASE}.get_mood_photos_for_user", return_value={s: None for s in _ALL_SLOTS}), \
          patch(f"{_BASE}.templates") as mock_tpl:
         mock_tpl.TemplateResponse.return_value = MagicMock()
 
@@ -531,3 +523,159 @@ def test_mp_r19_route_passes_lfa_spec_context():
         assert ctx.get("spec_dashboard_icon") == "⚽"
         assert ctx.get("spec_profile_url") == "/profile/lfa-football-player"
         assert ctx.get("spec_profile_icon") == "🪪"
+
+
+# ── MP-R20 ── MOOD_PHOTO_SLOTS contains all 6 valid slot keys ────────────────
+
+def test_mp_r20_mood_photo_slots_has_6_entries():
+    from app.models.user_mood_photos import MOOD_PHOTO_SLOTS
+
+    assert "mood_angry_competitive" in MOOD_PHOTO_SLOTS, (
+        "MOOD_PHOTO_SLOTS missing mood_angry_competitive"
+    )
+    assert "mood_surprised_shocked" in MOOD_PHOTO_SLOTS, (
+        "MOOD_PHOTO_SLOTS missing mood_surprised_shocked"
+    )
+    assert len(MOOD_PHOTO_SLOTS) == 6, (
+        f"MOOD_PHOTO_SLOTS must have 6 entries, got {len(MOOD_PHOTO_SLOTS)}"
+    )
+
+
+# ── MP-R21 ── _SLOT_META has 6 entries each with required keys ───────────────
+
+def test_mp_r21_slot_meta_has_6_entries_with_description():
+    from app.api.web_routes.mood_photos import _SLOT_META
+
+    assert len(_SLOT_META) == 6, (
+        f"_SLOT_META must have 6 entries, got {len(_SLOT_META)}"
+    )
+    slots_in_meta = {m["slot"] for m in _SLOT_META}
+    assert "mood_angry_competitive" in slots_in_meta, (
+        "_SLOT_META missing mood_angry_competitive"
+    )
+    assert "mood_surprised_shocked" in slots_in_meta, (
+        "_SLOT_META missing mood_surprised_shocked"
+    )
+    labels = {m["label"] for m in _SLOT_META}
+    assert "Angry" in labels,    "_SLOT_META missing label 'Angry'"
+    assert "Surprised" in labels, "_SLOT_META missing label 'Surprised'"
+
+    for meta in _SLOT_META:
+        assert "description" in meta, (
+            f"_SLOT_META entry {meta['slot']!r} missing 'description' key"
+        )
+        assert meta["description"], (
+            f"_SLOT_META entry {meta['slot']!r} has empty description"
+        )
+
+
+# ── MP-R22 ── upload to mood_angry_competitive → 303 redirect ────────────────
+
+def test_mp_r22_upload_angry_slot_redirects():
+    from app.api.web_routes.mood_photos import mood_photo_upload
+
+    with patch(f"{_BASE}.save_mood_photo"), \
+         patch(f"{_BASE}.get_mood_photos_for_user", return_value={}):
+        resp = _run(
+            mood_photo_upload(
+                slot    = "mood_angry_competitive",
+                request = _request(),
+                photo   = _mock_photo(),
+                user    = _user(),
+                db      = _db(),
+            )
+        )
+
+    assert isinstance(resp, RedirectResponse)
+    assert resp.status_code == 303
+    assert "/profile/my-mood-photos" in str(resp.headers.get("location", ""))
+
+
+# ── MP-R23 ── upload to mood_surprised_shocked → 303 redirect ────────────────
+
+def test_mp_r23_upload_surprised_slot_redirects():
+    from app.api.web_routes.mood_photos import mood_photo_upload
+
+    with patch(f"{_BASE}.save_mood_photo"), \
+         patch(f"{_BASE}.get_mood_photos_for_user", return_value={}):
+        resp = _run(
+            mood_photo_upload(
+                slot    = "mood_surprised_shocked",
+                request = _request(),
+                photo   = _mock_photo(),
+                user    = _user(),
+                db      = _db(),
+            )
+        )
+
+    assert isinstance(resp, RedirectResponse)
+    assert resp.status_code == 303
+
+
+# ── MP-R24 ── delete mood_angry_competitive → 303 redirect ───────────────────
+
+def test_mp_r24_delete_angry_slot_redirects():
+    from app.api.web_routes.mood_photos import mood_photo_delete_form
+
+    with patch(f"{_BASE}.delete_mood_photo"):
+        resp = _run(
+            mood_photo_delete_form(
+                slot = "mood_angry_competitive",
+                user = _user(),
+                db   = _db(),
+            )
+        )
+
+    assert isinstance(resp, RedirectResponse)
+    assert resp.status_code == 303
+
+
+# ── MP-R25 ── delete mood_surprised_shocked via API → 204 None ───────────────
+
+def test_mp_r25_delete_surprised_slot_api_returns_none():
+    from app.api.web_routes.mood_photos import mood_photo_delete_api
+
+    with patch(f"{_BASE}.delete_mood_photo"):
+        result = _run(
+            mood_photo_delete_api(
+                slot = "mood_surprised_shocked",
+                user = _user(),
+                db   = _db(),
+            )
+        )
+    assert result is None
+
+
+# ── MP-R26 ── template is data-driven — no hardcoded slot name comparisons ───
+
+def test_mp_r26_template_has_no_hardcoded_slot_if_elif():
+    from pathlib import Path
+
+    content = (
+        Path(__file__).resolve()
+        .parent.parent.parent.parent.parent
+        / "app" / "templates" / "lfa_player_mood_photos.html"
+    ).read_text(encoding="utf-8")
+
+    assert "meta.slot == 'mood_intro_neutral'" not in content, (
+        "Template must not hardcode mood_intro_neutral in if/elif — "
+        "use meta.description from _SLOT_META instead"
+    )
+    assert "meta.slot == 'mood_happy_smile'" not in content, (
+        "Template must not hardcode mood_happy_smile in if/elif"
+    )
+    assert "meta.slot == 'mood_celebration'" not in content, (
+        "Template must not hardcode mood_celebration in if/elif"
+    )
+    assert "meta.description" in content, (
+        "Template must render {{ meta.description }} — data-driven slot descriptions"
+    )
+    # Template is data-driven: labels are injected via {{ meta.label }} and
+    # {{ meta.description }} — "Angry"/"Surprised" are NOT literal strings in
+    # the source.  Assert the data-driving variables are present instead.
+    assert "meta.label" in content, (
+        "Template must render {{ meta.label }} so Angry/Surprised appear at runtime"
+    )
+    assert "meta.emoji" in content, (
+        "Template must render {{ meta.emoji }}"
+    )

--- a/tests/unit/api/web_routes/test_mood_photos.py
+++ b/tests/unit/api/web_routes/test_mood_photos.py
@@ -212,7 +212,7 @@ def test_mp_r08_delete_invalid_slot_raises_422():
     assert exc_info.value.status_code == 422
 
 
-# ── MP-R09 ── onboarding Step 7 contains hangulatkep offer block ──────────────
+# ── MP-R09 ── onboarding Step 7 contains English mood photo offer block ───────
 
 def test_mp_r09_onboarding_template_contains_mood_offer():
     from pathlib import Path
@@ -229,10 +229,65 @@ def test_mp_r09_onboarding_template_contains_mood_offer():
     assert "/profile/my-mood-photos" in content, (
         "lfa_player_onboarding.html missing link to /profile/my-mood-photos"
     )
-    assert "Hangulatk" in content, (
-        "lfa_player_onboarding.html missing 'Hangulatkép' text"
+    assert "Mood Photos" in content, (
+        "lfa_player_onboarding.html must use English 'Mood Photos'"
     )
-    # Onboarding completion gate must NOT mention mood in submit handler
-    assert "mood" not in content.split("lfa_player_onboarding_web_submit")[0].lower() \
-        or "onboarding_completed" not in content.split("step7-mood-offer")[0], \
-        "onboarding_completed must not be gated on mood upload"
+    assert "Hangulatk" not in content, (
+        "lfa_player_onboarding.html must not contain Hungarian 'Hangulatkép'"
+    )
+
+
+# ── MP-R10 ── /profile/my-mood-photos renders zero-state (no uploads) ────────
+
+def test_mp_r10_management_page_zero_state_renders():
+    from app.api.web_routes.mood_photos import mood_photos_page
+
+    empty_slots = {
+        "mood_intro_neutral":    None,
+        "mood_happy_smile":      None,
+        "mood_celebration":      None,
+        "mood_sad_disappointed": None,
+    }
+
+    with patch(f"{_BASE}.get_mood_photos_for_user", return_value=empty_slots), \
+         patch(f"{_BASE}.templates") as mock_tpl:
+        mock_tpl.TemplateResponse.return_value = MagicMock()
+
+        _run(mood_photos_page(request=_request(), user=_user(), db=_db()))
+
+        call_kwargs = mock_tpl.TemplateResponse.call_args
+        template_name = call_kwargs[0][0]
+        ctx = call_kwargs[0][1]
+
+        assert template_name == "lfa_player_mood_photos.html"
+        assert all(v is None for v in ctx["mood_photos"].values()), (
+            "zero-state: all slots must be None when nothing uploaded"
+        )
+        assert len(ctx["slots_meta"]) == 4
+
+
+# ── MP-R11 ── mood photo template uses English labels only ───────────────────
+
+def test_mp_r11_management_template_is_english():
+    from pathlib import Path
+
+    template_path = (
+        Path(__file__).resolve()
+        .parent.parent.parent.parent.parent
+        / "app" / "templates" / "lfa_player_mood_photos.html"
+    )
+    content = template_path.read_text(encoding="utf-8")
+
+    hungarian_markers = [
+        "Hangulat", "Feltölt", "Töröl", "Semleges", "Boldog",
+        "Ünneplés", "Szomorú", "Vissza a", "Biztosan", "Nincs feltöltve",
+    ]
+    for marker in hungarian_markers:
+        assert marker not in content, (
+            f"lfa_player_mood_photos.html contains Hungarian text: {marker!r}"
+        )
+
+    assert "Mood Photos" in content
+    assert "Upload" in content
+    assert "Delete" in content
+    assert "Not uploaded" in content

--- a/tests/unit/api/web_routes/test_mood_photos.py
+++ b/tests/unit/api/web_routes/test_mood_photos.py
@@ -425,6 +425,13 @@ def test_mp_r16_template_uses_correct_blocks():
     assert "X-CSRF-Token" in content, (
         "template must include X-CSRF-Token fetch header for CSRF validation"
     )
+    assert "_mpDelete(" in content, (
+        "delete must use _mpDelete() onclick — base.html capture listener fires "
+        "before onsubmit, so confirm() never gets to cancel the request"
+    )
+    assert 'type="button"' in content, (
+        "delete button must be type=button to avoid triggering submit event"
+    )
 
 
 # ── MP-R17 ── spec_subpage_hdr has LFA quicknav strip with all key links ─────
@@ -487,3 +494,40 @@ def test_mp_r18_dashboard_modnav_has_profile_editor_moodphotos():
     for url, label in required:
         assert url in modnav_block, f"dashboard mod-nav missing: {url!r} ({label})"
         assert label in modnav_block, f"dashboard mod-nav missing label: {label!r}"
+
+
+# ── MP-R19 ── mood_photos_page route passes explicit LFA spec context ─────────
+
+def test_mp_r19_route_passes_lfa_spec_context():
+    """
+    mood_photos_page must hardcode LFA spec context, not rely on
+    user.specialization which can be any active spec (e.g. GANCUJU_PLAYER)
+    on multi-spec accounts.
+    """
+    from app.api.web_routes.mood_photos import mood_photos_page
+
+    four_slots = {s: None for s in [
+        "mood_intro_neutral", "mood_happy_smile",
+        "mood_celebration",   "mood_sad_disappointed",
+    ]}
+
+    with patch(f"{_BASE}.get_mood_photos_for_user", return_value=four_slots), \
+         patch(f"{_BASE}.templates") as mock_tpl:
+        mock_tpl.TemplateResponse.return_value = MagicMock()
+
+        # Simulate a multi-spec user whose primary spec is NOT LFA_FOOTBALL_PLAYER
+        multi_spec_user = _user()
+        multi_spec_user.specialization = MagicMock()
+        multi_spec_user.specialization.value = "GANCUJU_PLAYER"
+
+        _run(mood_photos_page(request=_request(), user=multi_spec_user, db=_db()))
+
+        ctx = mock_tpl.TemplateResponse.call_args[0][1]
+
+        assert ctx.get("spec_dashboard_url") == "/dashboard/lfa-football-player", (
+            "mood_photos_page must pass spec_dashboard_url='/dashboard/lfa-football-player' "
+            "regardless of user.specialization — prevents wrong spec in header"
+        )
+        assert ctx.get("spec_dashboard_icon") == "⚽"
+        assert ctx.get("spec_profile_url") == "/profile/lfa-football-player"
+        assert ctx.get("spec_profile_icon") == "🪪"

--- a/tests/unit/services/test_mood_photo_service.py
+++ b/tests/unit/services/test_mood_photo_service.py
@@ -140,7 +140,7 @@ def test_mp_s06_delete_removes_row(tmp_path, monkeypatch):
 
     from app.services.mood_photo_service import delete_mood_photo
 
-    delete_mood_photo(user_id=1, slot="mood_intro_neutral", db=db)
+    delete_mood_photo(user_id=99, slot="mood_intro_neutral", db=db)
 
     db.delete.assert_called_once_with(existing)
     db.flush.assert_called()
@@ -154,7 +154,7 @@ def test_mp_s07_delete_nonexistent_is_noop(tmp_path, monkeypatch):
 
     from app.services.mood_photo_service import delete_mood_photo
 
-    delete_mood_photo(user_id=1, slot="mood_celebration", db=db)
+    delete_mood_photo(user_id=99, slot="mood_celebration", db=db)
 
     db.delete.assert_not_called()
 

--- a/tests/unit/services/test_mood_photo_service.py
+++ b/tests/unit/services/test_mood_photo_service.py
@@ -1,0 +1,184 @@
+"""
+MP-S01..MP-S08 — unit tests for mood_photo_service.
+
+Uses MagicMock for the SQLAlchemy Session; no real DB required.
+Disk I/O is patched via tmp_path / monkeypatch so tests stay hermetic.
+"""
+from __future__ import annotations
+
+import io
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from PIL import Image
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+_SVC = "app.services.mood_photo_service"
+
+
+def _make_jpeg_bytes(width: int = 100, height: int = 100) -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", (width, height), color=(80, 120, 60)).save(buf, "JPEG")
+    return buf.getvalue()
+
+
+def _make_db(existing_row=None):
+    db = MagicMock()
+    db.query.return_value.filter_by.return_value.first.return_value = existing_row
+    return db
+
+
+# ── MP-S01 ── valid upload → DB row created, status='uploaded' ───────────────
+
+def test_mp_s01_valid_upload_creates_row(tmp_path, monkeypatch):
+    monkeypatch.setattr(f"{_SVC}.MOOD_PHOTO_DIR", tmp_path)
+    db = _make_db(existing_row=None)
+
+    from app.services.mood_photo_service import save_mood_photo
+
+    row = save_mood_photo(
+        file_bytes   = _make_jpeg_bytes(),
+        content_type = "image/jpeg",
+        user_id      = 1,
+        slot         = "mood_happy_smile",
+        db           = db,
+    )
+
+    db.add.assert_called_once()
+    db.flush.assert_called()
+    added = db.add.call_args[0][0]
+    assert added.status == "uploaded"
+    assert added.processed_png_url is None
+    assert added.processed_at is None
+    assert "mood_happy_smile" in added.original_url
+
+
+# ── MP-S02 ── invalid slot → ValueError ──────────────────────────────────────
+
+def test_mp_s02_invalid_slot_raises():
+    from app.services.mood_photo_service import save_mood_photo
+
+    with pytest.raises(ValueError, match="Invalid mood photo slot"):
+        save_mood_photo(
+            file_bytes   = _make_jpeg_bytes(),
+            content_type = "image/jpeg",
+            user_id      = 1,
+            slot         = "angry_rage",
+            db           = MagicMock(),
+        )
+
+
+# ── MP-S03 ── file too large → ValueError ────────────────────────────────────
+
+def test_mp_s03_file_too_large_raises():
+    from app.services.mood_photo_service import MAX_BYTES, save_mood_photo
+
+    big = b"x" * (MAX_BYTES + 1)
+    with pytest.raises(ValueError, match="too large"):
+        save_mood_photo(
+            file_bytes   = big,
+            content_type = "image/jpeg",
+            user_id      = 1,
+            slot         = "mood_happy_smile",
+            db           = MagicMock(),
+        )
+
+
+# ── MP-S04 ── invalid MIME → ValueError ──────────────────────────────────────
+
+def test_mp_s04_invalid_mime_raises():
+    from app.services.mood_photo_service import save_mood_photo
+
+    with pytest.raises(ValueError, match="Unsupported content type"):
+        save_mood_photo(
+            file_bytes   = b"GIF89a",
+            content_type = "image/gif",
+            user_id      = 1,
+            slot         = "mood_celebration",
+            db           = MagicMock(),
+        )
+
+
+# ── MP-S05 ── replace: existing row updated in-place ─────────────────────────
+
+def test_mp_s05_replace_updates_existing_row(tmp_path, monkeypatch):
+    monkeypatch.setattr(f"{_SVC}.MOOD_PHOTO_DIR", tmp_path)
+
+    existing = MagicMock()
+    existing.original_url      = "/static/uploads/mood_photos/1_mood_happy_smile_orig_111.png"
+    existing.processed_png_url = "/static/some_old.png"
+    existing.status            = "ready"
+
+    db = _make_db(existing_row=existing)
+
+    from app.services.mood_photo_service import save_mood_photo
+
+    save_mood_photo(
+        file_bytes   = _make_jpeg_bytes(),
+        content_type = "image/jpeg",
+        user_id      = 1,
+        slot         = "mood_happy_smile",
+        db           = db,
+    )
+
+    db.add.assert_not_called()
+    assert existing.status == "uploaded"
+    assert existing.processed_png_url is None
+    assert existing.processed_at is None
+    assert "mood_happy_smile" in existing.original_url
+
+
+# ── MP-S06 ── delete removes row ─────────────────────────────────────────────
+
+def test_mp_s06_delete_removes_row(tmp_path, monkeypatch):
+    monkeypatch.setattr(f"{_SVC}.MOOD_PHOTO_DIR", tmp_path)
+
+    existing = MagicMock()
+    db = _make_db(existing_row=existing)
+
+    from app.services.mood_photo_service import delete_mood_photo
+
+    delete_mood_photo(user_id=1, slot="mood_intro_neutral", db=db)
+
+    db.delete.assert_called_once_with(existing)
+    db.flush.assert_called()
+
+
+# ── MP-S07 ── delete non-existent slot is a no-op ────────────────────────────
+
+def test_mp_s07_delete_nonexistent_is_noop(tmp_path, monkeypatch):
+    monkeypatch.setattr(f"{_SVC}.MOOD_PHOTO_DIR", tmp_path)
+    db = _make_db(existing_row=None)
+
+    from app.services.mood_photo_service import delete_mood_photo
+
+    delete_mood_photo(user_id=1, slot="mood_celebration", db=db)
+
+    db.delete.assert_not_called()
+
+
+# ── MP-S08 ── get_mood_photos_for_user always returns all 4 keys ─────────────
+
+def test_mp_s08_get_returns_all_four_slots():
+    row = MagicMock()
+    row.slot = "mood_happy_smile"
+
+    db = MagicMock()
+    db.query.return_value.filter_by.return_value.all.return_value = [row]
+
+    from app.services.mood_photo_service import get_mood_photos_for_user
+
+    result = get_mood_photos_for_user(user_id=42, db=db)
+
+    assert set(result.keys()) == {
+        "mood_intro_neutral",
+        "mood_happy_smile",
+        "mood_celebration",
+        "mood_sad_disappointed",
+    }
+    assert result["mood_happy_smile"] is row
+    assert result["mood_intro_neutral"] is None
+    assert result["mood_celebration"]   is None
+    assert result["mood_sad_disappointed"] is None

--- a/tests/unit/services/test_mood_photo_service.py
+++ b/tests/unit/services/test_mood_photo_service.py
@@ -159,9 +159,9 @@ def test_mp_s07_delete_nonexistent_is_noop(tmp_path, monkeypatch):
     db.delete.assert_not_called()
 
 
-# ── MP-S08 ── get_mood_photos_for_user always returns all 4 keys ─────────────
+# ── MP-S08 ── get_mood_photos_for_user always returns all 6 keys ─────────────
 
-def test_mp_s08_get_returns_all_four_slots():
+def test_mp_s08_get_returns_all_six_slots():
     row = MagicMock()
     row.slot = "mood_happy_smile"
 
@@ -177,8 +177,12 @@ def test_mp_s08_get_returns_all_four_slots():
         "mood_happy_smile",
         "mood_celebration",
         "mood_sad_disappointed",
+        "mood_angry_competitive",
+        "mood_surprised_shocked",
     }
-    assert result["mood_happy_smile"] is row
-    assert result["mood_intro_neutral"] is None
-    assert result["mood_celebration"]   is None
-    assert result["mood_sad_disappointed"] is None
+    assert result["mood_happy_smile"]       is row
+    assert result["mood_intro_neutral"]     is None
+    assert result["mood_celebration"]       is None
+    assert result["mood_sad_disappointed"]  is None
+    assert result["mood_angry_competitive"] is None
+    assert result["mood_surprised_shocked"] is None


### PR DESCRIPTION
## Summary

- **Hangulatkép (Mood Photos) MVP**: `user_mood_photos` tábla, service, 4 routes (GET/POST upload/POST delete/DELETE), önálló management page (`/profile/my-mood-photos`)
- **4→6 slot bővítés**: `mood_angry_competitive` (Angry 😤) és `mood_surprised_shocked` (Surprised 😲) hozzáadva
- **Data-driven template**: hardcoded `if/elif` eltávolítva → `{{ meta.description }}` (jövőbeli slotbővítés = csak `_SLOT_META` entry)
- **Navigation**: LFA quicknav strip, dashboard mod-nav, profile page Card Media card

## Migrations

- `2026_05_26_1100` — `user_mood_photos` tábla (CheckConstraint, UniqueConstraint)
- `2026_05_26_1200` — 4→6 slot (drop + recreate `ck_mood_photo_slot_valid`)

## Tests

- MP-R01..R26 (26 route unit test) — ✅ PASS
- MP-S01..S08 (8 service unit test) — ✅ PASS
- Teljes unit regresszió: **11239 PASS, 0 FAIL**

## CI

- Run [26471841061](https://github.com/football-investment/practice-booking-system/actions/runs/26471841061) — ✅ `completed success` (20/20 job)

## Scope

Kizárólag mood photos feature. Nem érinti: `player_photo_service`, `CardDraft`, `UserLicense` photo mezők, background removal, camera capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)