### PR TITLE
feat(mood-photos): Phase 1 background removal pipeline skeleton (NullProcessor)

### DIFF
--- a/app/api/web_routes/mood_photos.py
+++ b/app/api/web_routes/mood_photos.py
@@ -3,14 +3,18 @@ mood_photos — web routes for the mood photo feature.
 
 Routes
 ------
-GET  /profile/my-mood-photos            — management page
-POST /profile/my-mood-photos/{slot}/upload  — upload / replace a slot
-POST /profile/my-mood-photos/{slot}/delete  — HTML-form delete fallback
-DELETE /profile/my-mood-photos/{slot}       — JS-fetch delete endpoint
+GET    /profile/my-mood-photos                        — management page
+POST   /profile/my-mood-photos/{slot}/upload          — upload / replace a slot
+POST   /profile/my-mood-photos/{slot}/delete          — HTML-form delete fallback
+DELETE /profile/my-mood-photos/{slot}                 — JS-fetch delete endpoint
+POST   /profile/my-mood-photos/{slot}/remove-bg       — trigger background removal
+GET    /profile/my-mood-photos/{slot}/status          — JSON status + timeout flag
+POST   /profile/my-mood-photos/{slot}/reset-processing — reset stuck processing
 """
 from __future__ import annotations
 
 import logging
+from datetime import datetime, timezone
 from pathlib import Path
 
 from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile
@@ -18,16 +22,22 @@ from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from sqlalchemy.orm import Session
 
+from ...config import settings
 from ...database import get_db
 from ...dependencies import get_current_user_web
 from ...models.user import User
 from ...models.license import UserLicense
-from ...models.user_mood_photos import MOOD_PHOTO_SLOTS
+from ...models.user_mood_photos import MOOD_PHOTO_SLOTS, MoodPhotoStatus, UserMoodPhoto
 from ...services.mood_photo_service import (
+    MOOD_PHOTO_DIR,
+    apply_removal_failure,
     delete_mood_photo,
     get_mood_photos_for_user,
+    reset_processing,
     save_mood_photo,
+    set_status_processing,
 )
+from ...tasks.mood_photo_tasks import remove_background_task
 
 logger = logging.getLogger(__name__)
 
@@ -90,10 +100,14 @@ async def mood_photos_page(
     return templates.TemplateResponse(
         "lfa_player_mood_photos.html",
         {
-            "request":     request,
-            "user":        user,
-            "mood_photos": mood_photos,
-            "slots_meta":  _SLOT_META,
+            "request":            request,
+            "user":               user,
+            "mood_photos":        mood_photos,
+            "slots_meta":         _SLOT_META,
+            # Drives processor-aware UI:
+            #   "null"  → Remove Background button hidden; no removal claims shown
+            #   "rembg" → Remove Background / Retry / Background Removed enabled (Phase 2)
+            "bg_processor_mode":  settings.BG_REMOVAL_PROCESSOR,
             # Explicit LFA spec context — mood photos is an LFA Football Player
             # feature; do not rely on user.specialization which can be any active
             # spec (e.g. GANCUJU_PLAYER) on multi-spec accounts.
@@ -186,3 +200,141 @@ async def mood_photo_delete_api(
     delete_mood_photo(user.id, slot, db)
     db.commit()
     logger.info("mood_photo_deleted_api", extra={"user": user.email, "slot": slot})
+
+
+# ── POST /profile/my-mood-photos/{slot}/remove-bg ────────────────────────────
+
+@router.post("/profile/my-mood-photos/{slot}/remove-bg")
+async def mood_photo_remove_bg(
+    slot: str,
+    user: User    = Depends(get_current_user_web),
+    db:   Session = Depends(get_db),
+):
+    """
+    Trigger background removal for a slot.
+
+    State machine:
+      uploaded | failed → set processing → enqueue task → 303
+      processing | ready → 303 no-op (no double enqueue / no re-trigger)
+
+    Fast-fail: if the original file is missing from disk, status is set to
+    'failed' immediately without enqueueing the task.
+
+    Auth: get_current_user_web; filter_by(user_id=user.id) enforces own record only.
+    CSRF: caller must supply X-CSRF-Token header (JS fetch, same as delete).
+    """
+    if slot not in MOOD_PHOTO_SLOTS:
+        raise HTTPException(status_code=422, detail=f"Invalid slot: {slot!r}")
+
+    record = (
+        db.query(UserMoodPhoto)
+        .filter_by(user_id=user.id, slot=slot)
+        .first()
+    )
+    if record is None:
+        raise HTTPException(status_code=404, detail="No uploaded photo for this slot")
+
+    if record.status in (
+        MoodPhotoStatus.processing.value,
+        MoodPhotoStatus.ready.value,
+    ):
+        return RedirectResponse(url="/profile/my-mood-photos", status_code=303)
+
+    # Fast-fail: original file missing from disk
+    orig_path = MOOD_PHOTO_DIR / Path(record.original_url).name
+    if not orig_path.exists():
+        apply_removal_failure(user.id, slot, db)
+        logger.warning(
+            "bg_removal_missing_original",
+            extra={"user": user.email, "slot": slot},
+        )
+        return RedirectResponse(url="/profile/my-mood-photos", status_code=303)
+
+    set_status_processing(user.id, slot, db)
+    db.commit()
+    remove_background_task.delay(user.id, slot, record.original_url)
+    logger.info("bg_removal_triggered", extra={"user": user.email, "slot": slot})
+    return RedirectResponse(url="/profile/my-mood-photos", status_code=303)
+
+
+# ── GET /profile/my-mood-photos/{slot}/status ────────────────────────────────
+
+@router.get("/profile/my-mood-photos/{slot}/status")
+async def mood_photo_status(
+    slot: str,
+    user: User    = Depends(get_current_user_web),
+    db:   Session = Depends(get_db),
+):
+    """
+    Return JSON status for a slot.  Used by the template JS polling loop when
+    status='processing'.
+
+    Response shape:
+      {status, processed_png_url, updated_at, processing_timed_out}
+
+    processing_timed_out=True when status='processing' and updated_at is older
+    than settings.PROCESSING_TIMEOUT_SECONDS — signals a stuck worker to the UI.
+
+    Auth: filter_by(user_id=user.id) — own record only; no cross-user leakage.
+    """
+    if slot not in MOOD_PHOTO_SLOTS:
+        raise HTTPException(status_code=422, detail=f"Invalid slot: {slot!r}")
+
+    record = (
+        db.query(UserMoodPhoto)
+        .filter_by(user_id=user.id, slot=slot)
+        .first()
+    )
+    if record is None:
+        return JSONResponse({
+            "status":               "not_uploaded",
+            "processed_png_url":    None,
+            "updated_at":           None,
+            "processing_timed_out": False,
+        })
+
+    timed_out = (
+        record.status == MoodPhotoStatus.processing.value
+        and record.updated_at is not None
+        and (
+            datetime.now(timezone.utc) - record.updated_at
+        ).total_seconds() > settings.PROCESSING_TIMEOUT_SECONDS
+    )
+    return JSONResponse({
+        "status":               record.status,
+        "processed_png_url":    record.processed_png_url,
+        "updated_at":           record.updated_at.isoformat() if record.updated_at else None,
+        "processing_timed_out": timed_out,
+    })
+
+
+# ── POST /profile/my-mood-photos/{slot}/reset-processing ─────────────────────
+
+@router.post("/profile/my-mood-photos/{slot}/reset-processing")
+async def mood_photo_reset_processing(
+    slot: str,
+    user: User    = Depends(get_current_user_web),
+    db:   Session = Depends(get_db),
+):
+    """
+    Reset a stuck 'processing' record back to 'uploaded'.
+
+    Idempotent: no-op if status != 'processing' or no record exists.
+    Auth: filter_by(user_id=user.id) in reset_processing — own record only.
+    CSRF: caller must supply X-CSRF-Token header (JS fetch).
+    """
+    if slot not in MOOD_PHOTO_SLOTS:
+        raise HTTPException(status_code=422, detail=f"Invalid slot: {slot!r}")
+
+    record = (
+        db.query(UserMoodPhoto)
+        .filter_by(user_id=user.id, slot=slot)
+        .first()
+    )
+    if record is None:
+        raise HTTPException(status_code=404, detail="No mood photo record for this slot")
+
+    reset_processing(user.id, slot, db)
+    db.commit()
+    logger.info("bg_processing_reset", extra={"user": user.email, "slot": slot})
+    return RedirectResponse(url="/profile/my-mood-photos", status_code=303)

--- a/app/celery_app.py
+++ b/app/celery_app.py
@@ -29,6 +29,7 @@ def create_celery() -> Celery:
         backend=settings.CELERY_RESULT_BACKEND,
         include=[
             "app.tasks.tournament_tasks",
+            "app.tasks.mood_photo_tasks",
         ],
     )
 
@@ -59,15 +60,17 @@ def create_celery() -> Celery:
             "socket_connect_timeout": 10,   # seconds to establish Redis connection
             "retry_on_timeout": True,       # re-issue timed-out Redis commands
         },
-        # Routing: large tournament generation goes to dedicated queue
+        # Routing
         task_routes={
             "app.tasks.tournament_tasks.generate_sessions_task": {"queue": "tournaments"},
+            "app.tasks.mood_photo_tasks.remove_background_task": {"queue": "mood_photos"},
         },
         # Queues
         task_default_queue="default",
         task_queues={
-            "default": {},
+            "default":     {},
             "tournaments": {},
+            "mood_photos": {},
         },
         # Rate limiting (protect DB under heavy load)
         task_annotations={

--- a/app/config.py
+++ b/app/config.py
@@ -262,6 +262,14 @@ class Settings(BaseSettings):
     # giving up.  0 = unlimited (not recommended for long broker outages).
     CELERY_BROKER_CONNECTION_MAX_RETRIES: int = 10
 
+    # ── Background removal ─────────────────────────────────────────────────────
+    # "null"  → NullProcessor (Phase 1 skeleton; no real removal; button hidden)
+    # "rembg" → RembgProcessor (Phase 2; requires rembg + onnxruntime-cpu)
+    BG_REMOVAL_PROCESSOR: str = "null"
+    # Seconds after which a stuck 'processing' record is flagged timed-out in
+    # the status endpoint so the user can reset it back to 'uploaded'.
+    PROCESSING_TIMEOUT_SECONDS: int = 300
+
     # ── Slow-query monitoring ──────────────────────────────────────────────────
     # Queries slower than SLOW_QUERY_THRESHOLD_MS are logged to app.slow_query
     # and counted in the slow_queries_total metric.  Raise this value if normal

--- a/app/services/background_removal/__init__.py
+++ b/app/services/background_removal/__init__.py
@@ -1,0 +1,26 @@
+"""
+background_removal package — processor factory + public interface.
+
+get_processor() returns the active BackgroundProcessor based on
+settings.BG_REMOVAL_PROCESSOR:
+  "null"  → NullProcessor  (Phase 1 default; no real removal)
+  "rembg" → RembgProcessor (Phase 2; requires rembg + onnxruntime-cpu)
+
+The RembgProcessor import is deferred so that Phase 1 code never imports
+rembg or onnxruntime, even if those packages happen to be installed.
+"""
+from __future__ import annotations
+
+from app.config import settings
+
+from .processor import BackgroundProcessor, NullProcessor
+
+__all__ = ["BackgroundProcessor", "NullProcessor", "get_processor"]
+
+
+def get_processor() -> BackgroundProcessor:
+    """Return the processor configured by BG_REMOVAL_PROCESSOR."""
+    if settings.BG_REMOVAL_PROCESSOR == "rembg":
+        from .rembg_processor import RembgProcessor  # Phase 2 — deferred import
+        return RembgProcessor()
+    return NullProcessor()

--- a/app/services/background_removal/processor.py
+++ b/app/services/background_removal/processor.py
@@ -1,0 +1,38 @@
+"""
+Background removal processor interface.
+
+Phase 1: NullProcessor — returns the input image unchanged.
+         The Remove Background button is hidden from users when this processor
+         is active (BG_REMOVAL_PROCESSOR="null").
+
+Phase 2: RembgProcessor (rembg_processor.py) — real U2Net background removal.
+         Only used when BG_REMOVAL_PROCESSOR="rembg" and rembg + onnxruntime
+         are installed.
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class BackgroundProcessor(ABC):
+    @abstractmethod
+    def remove(self, input_png_bytes: bytes) -> bytes:
+        """
+        Accept PNG bytes, return PNG bytes with background removed (or unchanged).
+        Input is already a valid PNG (converted and resized by save_mood_photo).
+        """
+        ...
+
+
+class NullProcessor(BackgroundProcessor):
+    """
+    Phase 1 passthrough processor.  Returns the input image without any
+    modification.  Used when BG_REMOVAL_PROCESSOR="null" (default).
+
+    The user-facing "Remove Background" button is hidden when this processor
+    is active — the pipeline is wired end-to-end for testing but no removal
+    claim is shown to users.
+    """
+
+    def remove(self, input_png_bytes: bytes) -> bytes:
+        return input_png_bytes

--- a/app/services/mood_photo_service.py
+++ b/app/services/mood_photo_service.py
@@ -5,13 +5,17 @@ Completely independent from player_photo_service.  Never reads or writes
 player_card_photo_url, wc_photo_url, or any other UserLicense photo field.
 No fallback in either direction.
 
-Background removal (processed_png_url) is NOT implemented in this module —
-that is a future phase requiring separate approval.
+Background removal pipeline (Phase 1):
+  set_status_processing / apply_removal_result / apply_removal_failure /
+  reset_processing handle DB state transitions.  The actual image processing
+  is done by app.services.background_removal (NullProcessor in Phase 1).
+  Real background removal remains Phase 2.
 """
 from __future__ import annotations
 
 import io
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 
 from PIL import Image
@@ -102,9 +106,9 @@ def get_mood_photos_for_user(
     user_id: int, db: Session
 ) -> dict[str, UserMoodPhoto | None]:
     """
-    Return {slot: record_or_None} for all 4 MOOD_PHOTO_SLOTS.
+    Return {slot: record_or_None} for all 6 MOOD_PHOTO_SLOTS.
 
-    Always returns all 4 keys so callers can iterate predictably.
+    Always returns all 6 keys so callers can iterate predictably.
     """
     rows = (
         db.query(UserMoodPhoto)
@@ -167,3 +171,75 @@ def _delete_files_for_slot(user_id: int, slot: str) -> None:
             f.unlink(missing_ok=True)
         except OSError:
             pass
+
+
+# ── Background removal pipeline — Phase 1 ────────────────────────────────────
+# These functions manage DB state transitions only.  Actual image processing
+# is handled by the Celery task in app.tasks.mood_photo_tasks.
+# Real background removal remains Phase 2 (rembg + onnxruntime-cpu).
+
+def set_status_processing(user_id: int, slot: str, db: Session) -> UserMoodPhoto:
+    """Set status='processing' before the Celery task is enqueued."""
+    record = (
+        db.query(UserMoodPhoto)
+        .filter_by(user_id=user_id, slot=slot)
+        .first()
+    )
+    if record is None:
+        raise ValueError(
+            f"No mood photo record for user_id={user_id} slot={slot!r}"
+        )
+    record.status = MoodPhotoStatus.processing.value
+    db.flush()
+    return record
+
+
+def apply_removal_result(
+    user_id: int, slot: str, processed_url: str, db: Session
+) -> None:
+    """Called by the Celery task on success. Commits the DB session."""
+    record = (
+        db.query(UserMoodPhoto)
+        .filter_by(user_id=user_id, slot=slot)
+        .first()
+    )
+    if record is None:
+        return
+    record.processed_png_url = processed_url
+    record.status            = MoodPhotoStatus.ready.value
+    record.processed_at      = datetime.now(timezone.utc)
+    db.commit()
+
+
+def apply_removal_failure(user_id: int, slot: str, db: Session) -> None:
+    """Called by the Celery task on failure (including max retries). Commits."""
+    record = (
+        db.query(UserMoodPhoto)
+        .filter_by(user_id=user_id, slot=slot)
+        .first()
+    )
+    if record is None:
+        return
+    record.status       = MoodPhotoStatus.failed.value
+    record.processed_at = datetime.now(timezone.utc)
+    db.commit()
+
+
+def reset_processing(user_id: int, slot: str, db: Session) -> None:
+    """
+    Reset a stuck 'processing' record back to 'uploaded'.
+
+    Idempotent: no-op if the record does not exist or status != 'processing'.
+    Only operates on the record belonging to user_id (own record guard).
+    """
+    record = (
+        db.query(UserMoodPhoto)
+        .filter_by(user_id=user_id, slot=slot)
+        .first()
+    )
+    if record is None or record.status != MoodPhotoStatus.processing.value:
+        return
+    record.status            = MoodPhotoStatus.uploaded.value
+    record.processed_png_url = None
+    record.processed_at      = None
+    db.flush()

--- a/app/tasks/mood_photo_tasks.py
+++ b/app/tasks/mood_photo_tasks.py
@@ -1,0 +1,99 @@
+"""
+Mood photo background removal Celery task.
+
+State flow (managed by mood_photo_service helpers):
+  uploaded → processing  (set by the /remove-bg route before enqueue)
+           → ready       (set by this task on success)
+           → failed      (set by this task on max-retries exceeded or missing file)
+
+Phase 1: NullProcessor is used — no real background removal occurs.
+         The "Remove Background" button is hidden from users when
+         BG_REMOVAL_PROCESSOR="null", so this task is not reachable from
+         the UI in Phase 1.  It is fully exercised by the test suite.
+
+Real background removal remains Phase 2 (rembg + onnxruntime-cpu).
+"""
+from __future__ import annotations
+
+import logging
+import time
+from pathlib import Path
+
+from app.celery_app import celery_app
+from app.database import SessionLocal
+from app.services.background_removal import get_processor
+from app.services.mood_photo_service import (
+    MOOD_PHOTO_DIR,
+    apply_removal_failure,
+    apply_removal_result,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@celery_app.task(
+    bind=True,
+    max_retries=2,
+    default_retry_delay=10,
+    queue="mood_photos",
+    name="app.tasks.mood_photo_tasks.remove_background_task",
+)
+def remove_background_task(
+    self,
+    user_id: int,
+    slot: str,
+    original_url: str,
+) -> dict:
+    """
+    Load the original PNG, run the background processor, save the result,
+    update the DB record.
+
+    original_url is passed from the route so the task can locate the file
+    without an extra DB read.  The task opens its own SessionLocal for the
+    write-back; it does not share the web worker's DB session.
+    """
+    db = SessionLocal()
+    try:
+        filename  = Path(original_url).name
+        orig_path = MOOD_PHOTO_DIR / filename
+
+        if not orig_path.exists():
+            apply_removal_failure(user_id, slot, db)
+            logger.warning(
+                "bg_removal_missing_file",
+                extra={"user_id": user_id, "slot": slot, "path": str(orig_path)},
+            )
+            return {"status": "failed", "reason": "missing_file"}
+
+        input_bytes  = orig_path.read_bytes()
+        processor    = get_processor()
+        output_bytes = processor.remove(input_bytes)
+
+        # Remove any previous processed file for this slot before writing
+        for old in MOOD_PHOTO_DIR.glob(f"{user_id}_mood_{slot}_proc_*.png"):
+            old.unlink(missing_ok=True)
+
+        ts            = int(time.time())
+        proc_filename = f"{user_id}_mood_{slot}_proc_{ts}.png"
+        (MOOD_PHOTO_DIR / proc_filename).write_bytes(output_bytes)
+
+        processed_url = f"/static/uploads/mood_photos/{proc_filename}"
+        apply_removal_result(user_id, slot, processed_url, db)
+        logger.info(
+            "bg_removal_done",
+            extra={"user_id": user_id, "slot": slot, "processor": type(processor).__name__},
+        )
+        return {"status": "ready", "processed_url": processed_url}
+
+    except Exception as exc:
+        logger.warning(
+            "bg_removal_error",
+            extra={"user_id": user_id, "slot": slot, "error": str(exc)},
+        )
+        try:
+            raise self.retry(exc=exc)
+        except self.MaxRetriesExceededError:
+            apply_removal_failure(user_id, slot, db)
+            return {"status": "failed", "reason": str(exc)}
+    finally:
+        db.close()

--- a/app/templates/lfa_player_mood_photos.html
+++ b/app/templates/lfa_player_mood_photos.html
@@ -39,7 +39,7 @@
         margin: 0;
     }
 
-    /* ── Back link as secondary button ── */
+    /* ── Buttons ── */
     .btn {
         padding: 0.75rem 1.4rem;
         border: none;
@@ -65,6 +65,11 @@
         color: var(--hub-btn-text, #fff);
         border: none;
     }
+    .btn-accent {
+        background: var(--hub-accent-bg, #d97706);
+        color: #fff;
+        border: none;
+    }
     .btn-danger {
         background: transparent;
         color: #f87171;
@@ -73,7 +78,7 @@
     .btn-danger:hover { background: rgba(248,113,113,0.1); }
     .btn-sm { padding: 0.45rem 0.9rem; font-size: 0.85rem; }
 
-    /* ── 2×2 mood grid ── */
+    /* ── 2-column mood grid ── */
     .mp-grid {
         display: grid;
         grid-template-columns: repeat(2, 1fr);
@@ -108,7 +113,7 @@
         flex: 1;
     }
 
-    /* ── Status badge ── */
+    /* ── Status badges ── */
     .mp-badge {
         display: inline-block;
         font-size: 0.72rem;
@@ -123,6 +128,23 @@
     .mp-badge-uploaded {
         background: rgba(134,239,172,0.15);
         color: #86efac;
+    }
+    .mp-badge-processing {
+        background: rgba(251,191,36,0.15);
+        color: #fbbf24;
+        animation: mp-pulse 1.5s ease-in-out infinite;
+    }
+    .mp-badge-ready {
+        background: rgba(96,165,250,0.15);
+        color: #60a5fa;
+    }
+    .mp-badge-failed {
+        background: rgba(248,113,113,0.15);
+        color: #f87171;
+    }
+    @keyframes mp-pulse {
+        0%, 100% { opacity: 1; }
+        50%       { opacity: 0.55; }
     }
 
     /* ── Instruction text ── */
@@ -151,6 +173,7 @@
         object-fit: contain;
         border-radius: 8px;
     }
+    .mp-preview img.mp-img-dimmed { opacity: 0.5; }
     .mp-preview-placeholder {
         text-align: center;
         color: var(--hub-text-muted, #94a3b8);
@@ -166,62 +189,119 @@
         align-items: center;
     }
 
-    /* ── Timestamp hint ── */
+    /* ── Timestamp / hint text ── */
     .mp-hint {
         font-size: 0.75rem;
         color: var(--hub-text-muted, #94a3b8);
         margin: 0;
+    }
+    .mp-hint-warn {
+        color: #fbbf24;
     }
 </style>
 {% endblock %}
 
 {% block extra_scripts %}
 <script>
-/* Mood photo upload: must use fetch() + X-CSRF-Token header.
-   form.submit() skips the submit event so base.html CSRF interceptor never fires.
-   Using FormData (not URLSearchParams) preserves the file as multipart/form-data. */
+/* ── CSRF helper ── */
 function _mpCsrfToken() {
     var m = document.cookie.match(/(?:^|;\s*)csrf_token=([^;]+)/);
     return m ? decodeURIComponent(m[1]) : null;
 }
 
-/* Upload: form.submit() bypasses submit event so base.html CSRF interceptor
-   never fires. Sending FormData directly preserves the file as multipart. */
+/* ── Upload / Replace ──
+   Must use fetch() + X-CSRF-Token; form.submit() skips the submit event so
+   the base.html CSRF interceptor never fires.  FormData preserves the file
+   as multipart/form-data. */
 function _mpUpload(input) {
     var form = input.closest('form');
     var tok  = _mpCsrfToken();
     if (!tok || !input.files || !input.files[0]) return;
-
     fetch(form.action, {
         method:      'POST',
         headers:     { 'X-CSRF-Token': tok },
         body:        new FormData(form),
         credentials: 'include',
         redirect:    'follow',
-    }).then(function (r) {
+    }).then(function(r) {
         window.location.href = r.redirected ? r.url : '/profile/my-mood-photos';
-    }).catch(function () {
-        window.location.reload();
-    });
+    }).catch(function() { window.location.reload(); });
 }
 
-/* Delete: type="button" avoids submit event entirely; confirm() runs first so
-   the user can cancel before the request is sent. */
+/* ── Delete ── */
 function _mpDelete(url) {
     if (!confirm('Delete this mood photo?')) return;
     var tok = _mpCsrfToken();
     if (!tok) { window.location.reload(); return; }
-
     fetch(url, {
         method:      'POST',
         headers:     { 'X-CSRF-Token': tok, 'Content-Type': 'application/x-www-form-urlencoded' },
         credentials: 'include',
         redirect:    'follow',
-    }).then(function (r) {
+    }).then(function(r) {
         window.location.href = r.redirected ? r.url : '/profile/my-mood-photos';
-    }).catch(function () {
-        window.location.reload();
+    }).catch(function() { window.location.reload(); });
+}
+
+/* ── Remove Background / Retry ──
+   Only wired when bg_processor_mode == "rembg" (Phase 2).
+   In Phase 1 (null processor) the button is not rendered. */
+function _mpRemoveBg(slot) {
+    var tok = _mpCsrfToken();
+    if (!tok) { window.location.reload(); return; }
+    fetch('/profile/my-mood-photos/' + slot + '/remove-bg', {
+        method:      'POST',
+        headers:     { 'X-CSRF-Token': tok },
+        credentials: 'include',
+        redirect:    'follow',
+    }).then(function(r) {
+        window.location.href = r.redirected ? r.url : '/profile/my-mood-photos';
+    }).catch(function() { window.location.reload(); });
+}
+
+/* ── Reset stuck processing ── */
+function _mpResetProcessing(slot) {
+    var tok = _mpCsrfToken();
+    if (!tok) { window.location.reload(); return; }
+    fetch('/profile/my-mood-photos/' + slot + '/reset-processing', {
+        method:      'POST',
+        headers:     { 'X-CSRF-Token': tok },
+        credentials: 'include',
+        redirect:    'follow',
+    }).then(function(r) {
+        window.location.href = r.redirected ? r.url : '/profile/my-mood-photos';
+    }).catch(function() { window.location.reload(); });
+}
+
+/* ── Status polling ──
+   Started for every slot whose badge carries data-poll-slot.
+   Polls GET /{slot}/status every 3 s.
+   Stops when status != 'processing', then reloads the page.
+   On processing_timed_out=true: reveals the Reset button and warning text. */
+document.addEventListener('DOMContentLoaded', function() {
+    document.querySelectorAll('[data-poll-slot]').forEach(function(el) {
+        _mpStartPolling(el.dataset.pollSlot);
     });
+});
+
+function _mpStartPolling(slot) {
+    var interval = setInterval(function() {
+        fetch('/profile/my-mood-photos/' + slot + '/status', { credentials: 'include' })
+            .then(function(r) { return r.json(); })
+            .then(function(data) {
+                if (data.processing_timed_out) {
+                    clearInterval(interval);
+                    var btn = document.getElementById('btn-reset-' + slot);
+                    var msg = document.getElementById('timeout-msg-' + slot);
+                    if (btn) btn.style.display = '';
+                    if (msg) msg.style.display = '';
+                } else if (data.status !== 'processing') {
+                    clearInterval(interval);
+                    window.location.reload();
+                }
+            })
+            .catch(function() { clearInterval(interval); });
+    }, 3000);
 }
 </script>
 {% endblock %}
@@ -250,10 +330,23 @@ function _mpDelete(url) {
             <div class="mp-card-header">
                 <span class="mp-card-emoji">{{ meta.emoji }}</span>
                 <span class="mp-card-title">{{ meta.label }}</span>
-                {% if record %}
-                <span class="mp-badge mp-badge-uploaded">✓ Uploaded</span>
-                {% else %}
-                <span class="mp-badge">Not uploaded</span>
+
+                {% if not record %}
+                    <span class="mp-badge">Not uploaded</span>
+                {% elif record.status == 'uploaded' %}
+                    <span class="mp-badge mp-badge-uploaded">✓ Uploaded</span>
+                {% elif record.status == 'processing' %}
+                    {# data-poll-slot triggers JS polling loop #}
+                    <span class="mp-badge mp-badge-processing"
+                          data-poll-slot="{{ meta.slot }}">⏳ Processing...</span>
+                {% elif record.status == 'ready' %}
+                    {% if bg_processor_mode == 'rembg' %}
+                        <span class="mp-badge mp-badge-ready">✨ Background Removed</span>
+                    {% else %}
+                        <span class="mp-badge mp-badge-ready">✓ Processed</span>
+                    {% endif %}
+                {% elif record.status == 'failed' %}
+                    <span class="mp-badge mp-badge-failed">⚠ Processing Failed</span>
                 {% endif %}
             </div>
 
@@ -263,22 +356,35 @@ function _mpDelete(url) {
             <!-- Photo preview -->
             <div class="mp-preview">
                 {% if record %}
-                <img src="{{ record.original_url }}" alt="Mood photo — {{ meta.label }}">
+                    {# Show processed PNG if ready; fall back to original on img error #}
+                    {% if record.status == 'ready' and record.processed_png_url %}
+                        <img src="{{ record.processed_png_url }}"
+                             alt="Processed mood photo — {{ meta.label }}"
+                             onerror="this.src='{{ record.original_url }}'">
+                    {% else %}
+                        <img src="{{ record.original_url }}"
+                             alt="Mood photo — {{ meta.label }}"
+                             {% if record.status == 'processing' %}class="mp-img-dimmed"{% endif %}>
+                    {% endif %}
                 {% else %}
-                <div class="mp-preview-placeholder">
-                    No photo uploaded yet<br>
-                    <small>JPEG · PNG · WebP · max 5 MB</small>
-                </div>
+                    <div class="mp-preview-placeholder">
+                        No photo uploaded yet<br>
+                        <small>JPEG · PNG · WebP · max 5 MB</small>
+                    </div>
                 {% endif %}
             </div>
 
-            <!-- Actions: Upload/Replace + Delete -->
+            <!-- Actions -->
             <div class="mp-actions">
+
+                <!-- Upload / Replace: always available -->
                 <form method="post"
                       action="/profile/my-mood-photos/{{ meta.slot }}/upload"
                       enctype="multipart/form-data"
                       style="display:contents;">
-                    <label class="btn btn-primary btn-sm" for="file-{{ meta.slot }}" style="cursor:pointer;">
+                    <label class="btn btn-primary btn-sm"
+                           for="file-{{ meta.slot }}"
+                           style="cursor:pointer;">
                         {% if record %}🔄 Replace{% else %}📷 Upload{% endif %}
                     </label>
                     <input id="file-{{ meta.slot }}"
@@ -289,6 +395,7 @@ function _mpDelete(url) {
                            onchange="_mpUpload(this)">
                 </form>
 
+                <!-- Delete: if record exists -->
                 {% if record %}
                 <button type="button"
                         class="btn btn-danger btn-sm"
@@ -296,9 +403,51 @@ function _mpDelete(url) {
                     🗑 Delete
                 </button>
                 {% endif %}
+
+                <!-- Remove Background: ONLY when rembg processor is active AND status=uploaded.
+                     Phase 1 (null processor): this button is never rendered.
+                     No background removal claim is shown to users with NullProcessor. -->
+                {% if bg_processor_mode == 'rembg' and record and record.status == 'uploaded' %}
+                <button type="button"
+                        class="btn btn-accent btn-sm"
+                        onclick="_mpRemoveBg('{{ meta.slot }}')">
+                    ✂ Remove Background
+                </button>
+                {% endif %}
+
+                <!-- Retry Remove Background: ONLY rembg + status=failed -->
+                {% if bg_processor_mode == 'rembg' and record and record.status == 'failed' %}
+                <button type="button"
+                        class="btn btn-accent btn-sm"
+                        onclick="_mpRemoveBg('{{ meta.slot }}')">
+                    ↺ Retry Remove Background
+                </button>
+                {% endif %}
+
+                <!-- Reset processing: shown when status=processing; initially hidden.
+                     JS polling reveals it when processing_timed_out=True. -->
+                {% if record and record.status == 'processing' %}
+                <button type="button"
+                        id="btn-reset-{{ meta.slot }}"
+                        class="btn btn-secondary btn-sm"
+                        style="display:none;"
+                        onclick="_mpResetProcessing('{{ meta.slot }}')">
+                    ↺ Reset
+                </button>
+                {% endif %}
+
             </div>
 
-            <!-- Timestamp hint if photo exists -->
+            <!-- Timeout warning: hidden until JS polling detects processing_timed_out -->
+            {% if record and record.status == 'processing' %}
+            <p id="timeout-msg-{{ meta.slot }}"
+               class="mp-hint mp-hint-warn"
+               style="display:none;">
+                Processing is taking longer than expected. You can reset and re-upload.
+            </p>
+            {% endif %}
+
+            <!-- Timestamp hint -->
             {% if record %}
             <p class="mp-hint">
                 Uploaded {{ record.created_at.strftime('%Y-%m-%d %H:%M') if record.created_at else '—' }}

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -63557,6 +63557,129 @@
         ]
       }
     },
+    "/profile/my-mood-photos/{slot}/remove-bg": {
+      "post": {
+        "description": "Trigger background removal for a slot.\n\nState machine:\n  uploaded | failed \u2192 set processing \u2192 enqueue task \u2192 303\n  processing | ready \u2192 303 no-op (no double enqueue / no re-trigger)\n\nFast-fail: if the original file is missing from disk, status is set to\n'failed' immediately without enqueueing the task.\n\nAuth: get_current_user_web; filter_by(user_id=user.id) enforces own record only.\nCSRF: caller must supply X-CSRF-Token header (JS fetch, same as delete).",
+        "operationId": "mood_photo_remove_bg_profile_my_mood_photos__slot__remove_bg_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slot",
+            "required": true,
+            "schema": {
+              "title": "Slot",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Mood Photo Remove Bg",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/profile/my-mood-photos/{slot}/reset-processing": {
+      "post": {
+        "description": "Reset a stuck 'processing' record back to 'uploaded'.\n\nIdempotent: no-op if status != 'processing' or no record exists.\nAuth: filter_by(user_id=user.id) in reset_processing \u2014 own record only.\nCSRF: caller must supply X-CSRF-Token header (JS fetch).",
+        "operationId": "mood_photo_reset_processing_profile_my_mood_photos__slot__reset_processing_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slot",
+            "required": true,
+            "schema": {
+              "title": "Slot",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Mood Photo Reset Processing",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/profile/my-mood-photos/{slot}/status": {
+      "get": {
+        "description": "Return JSON status for a slot.  Used by the template JS polling loop when\nstatus='processing'.\n\nResponse shape:\n  {status, processed_png_url, updated_at, processing_timed_out}\n\nprocessing_timed_out=True when status='processing' and updated_at is older\nthan settings.PROCESSING_TIMEOUT_SECONDS \u2014 signals a stuck worker to the UI.\n\nAuth: filter_by(user_id=user.id) \u2014 own record only; no cross-user leakage.",
+        "operationId": "mood_photo_status_profile_my_mood_photos__slot__status_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slot",
+            "required": true,
+            "schema": {
+              "title": "Slot",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Mood Photo Status",
+        "tags": [
+          "web"
+        ]
+      }
+    },
     "/profile/my-mood-photos/{slot}/upload": {
       "post": {
         "operationId": "mood_photo_upload_profile_my_mood_photos__slot__upload_post",

--- a/tests/unit/api/web_routes/test_mood_photos.py
+++ b/tests/unit/api/web_routes/test_mood_photos.py
@@ -1,5 +1,5 @@
 """
-MP-R01..MP-R09 — unit tests for mood_photos web routes.
+MP-R01..MP-R46 — unit tests for mood_photos web routes.
 
 Tests call route functions directly (asyncio.run) with patched
 dependencies — no TestClient, no real DB, no disk I/O.
@@ -678,4 +678,367 @@ def test_mp_r26_template_has_no_hardcoded_slot_if_elif():
     )
     assert "meta.emoji" in content, (
         "Template must render {{ meta.emoji }}"
+    )
+
+
+# ── MP-R27..R46 — background removal pipeline routes ─────────────────────────
+
+_TASK = "app.tasks.mood_photo_tasks.remove_background_task"
+
+
+def _record(status: str = "uploaded", original_url: str = "/static/uploads/mood_photos/42_mood_happy_smile_orig_1.png"):
+    r = MagicMock()
+    r.status       = status
+    r.original_url = original_url
+    return r
+
+
+def _db_with(record):
+    db = MagicMock()
+    db.query.return_value.filter_by.return_value.first.return_value = record
+    return db
+
+
+# ── MP-R27 ── POST /remove-bg uploaded + file exists → 303, task enqueued ────
+
+def test_mp_r27_remove_bg_uploaded_enqueues_task(tmp_path, monkeypatch):
+    from app.api.web_routes.mood_photos import mood_photo_remove_bg
+
+    orig_file = tmp_path / "42_mood_happy_smile_orig_1.png"
+    orig_file.write_bytes(b"PNG")
+    monkeypatch.setattr("app.api.web_routes.mood_photos.MOOD_PHOTO_DIR", tmp_path)
+
+    rec = _record(status="uploaded", original_url=f"/static/uploads/mood_photos/{orig_file.name}")
+    db  = _db_with(rec)
+
+    with patch(f"{_BASE}.set_status_processing") as mock_set, \
+         patch(f"{_BASE}.apply_removal_failure") as mock_fail, \
+         patch(f"{_TASK}.delay") as mock_delay:
+        resp = _run(mood_photo_remove_bg(slot="mood_happy_smile", user=_user(42), db=db))
+
+    assert resp.status_code == 303
+    mock_set.assert_called_once()
+    mock_delay.assert_called_once()
+    mock_fail.assert_not_called()
+
+
+# ── MP-R28 ── POST /remove-bg failed (Retry) + file exists → 303, task ───────
+
+def test_mp_r28_remove_bg_failed_retry_enqueues_task(tmp_path, monkeypatch):
+    from app.api.web_routes.mood_photos import mood_photo_remove_bg
+
+    orig_file = tmp_path / "42_mood_happy_smile_orig_1.png"
+    orig_file.write_bytes(b"PNG")
+    monkeypatch.setattr("app.api.web_routes.mood_photos.MOOD_PHOTO_DIR", tmp_path)
+
+    rec = _record(status="failed", original_url=f"/static/uploads/mood_photos/{orig_file.name}")
+    db  = _db_with(rec)
+
+    with patch(f"{_BASE}.set_status_processing"), \
+         patch(f"{_TASK}.delay") as mock_delay:
+        resp = _run(mood_photo_remove_bg(slot="mood_happy_smile", user=_user(42), db=db))
+
+    assert resp.status_code == 303
+    mock_delay.assert_called_once()
+
+
+# ── MP-R29 ── POST /remove-bg status=processing → 303 no-op, no enqueue ──────
+
+def test_mp_r29_remove_bg_processing_no_double_enqueue(tmp_path, monkeypatch):
+    from app.api.web_routes.mood_photos import mood_photo_remove_bg
+
+    monkeypatch.setattr("app.api.web_routes.mood_photos.MOOD_PHOTO_DIR", tmp_path)
+    rec = _record(status="processing")
+    db  = _db_with(rec)
+
+    with patch(f"{_TASK}.delay") as mock_delay:
+        resp = _run(mood_photo_remove_bg(slot="mood_happy_smile", user=_user(42), db=db))
+
+    assert resp.status_code == 303
+    mock_delay.assert_not_called()
+
+
+# ── MP-R30 ── POST /remove-bg status=ready → 303 no-op, no re-trigger ────────
+
+def test_mp_r30_remove_bg_ready_no_retrigger(tmp_path, monkeypatch):
+    from app.api.web_routes.mood_photos import mood_photo_remove_bg
+
+    monkeypatch.setattr("app.api.web_routes.mood_photos.MOOD_PHOTO_DIR", tmp_path)
+    rec = _record(status="ready")
+    db  = _db_with(rec)
+
+    with patch(f"{_TASK}.delay") as mock_delay:
+        resp = _run(mood_photo_remove_bg(slot="mood_happy_smile", user=_user(42), db=db))
+
+    assert resp.status_code == 303
+    mock_delay.assert_not_called()
+
+
+# ── MP-R31 ── POST /remove-bg invalid slot → 422 ─────────────────────────────
+
+def test_mp_r31_remove_bg_invalid_slot_raises_422():
+    from app.api.web_routes.mood_photos import mood_photo_remove_bg
+
+    with pytest.raises(HTTPException) as exc:
+        _run(mood_photo_remove_bg(slot="not_a_slot", user=_user(42), db=_db()))
+
+    assert exc.value.status_code == 422
+
+
+# ── MP-R32 ── POST /remove-bg no record → 404 ────────────────────────────────
+
+def test_mp_r32_remove_bg_no_record_raises_404():
+    from app.api.web_routes.mood_photos import mood_photo_remove_bg
+
+    db = _db_with(None)
+    with pytest.raises(HTTPException) as exc:
+        _run(mood_photo_remove_bg(slot="mood_happy_smile", user=_user(42), db=db))
+
+    assert exc.value.status_code == 404
+
+
+# ── MP-R33 ── POST /remove-bg missing file → 303, status=failed, no enqueue ──
+
+def test_mp_r33_remove_bg_missing_file_fast_fail(tmp_path, monkeypatch):
+    from app.api.web_routes.mood_photos import mood_photo_remove_bg
+
+    monkeypatch.setattr("app.api.web_routes.mood_photos.MOOD_PHOTO_DIR", tmp_path)
+    # original_url points to a file that does NOT exist
+    rec = _record(status="uploaded", original_url="/static/uploads/mood_photos/missing.png")
+    db  = _db_with(rec)
+
+    with patch(f"{_BASE}.apply_removal_failure") as mock_fail, \
+         patch(f"{_TASK}.delay") as mock_delay:
+        resp = _run(mood_photo_remove_bg(slot="mood_happy_smile", user=_user(42), db=db))
+
+    assert resp.status_code == 303
+    mock_fail.assert_called_once()
+    mock_delay.assert_not_called()
+
+
+# ── MP-R34 ── GET /status uploaded → JSON, processing_timed_out=False ─────────
+
+def test_mp_r34_status_uploaded():
+    from app.api.web_routes.mood_photos import mood_photo_status
+
+    rec = _record(status="uploaded")
+    rec.updated_at        = None
+    rec.processed_png_url = None
+    db  = _db_with(rec)
+
+    resp    = _run(mood_photo_status(slot="mood_happy_smile", user=_user(42), db=db))
+    payload = resp.body if hasattr(resp, "body") else resp.body
+
+    import json
+    data = json.loads(resp.body)
+    assert data["status"] == "uploaded"
+    assert data["processing_timed_out"] is False
+
+
+# ── MP-R35 ── GET /status processing, fresh → processing_timed_out=False ──────
+
+def test_mp_r35_status_processing_fresh():
+    from datetime import datetime, timezone
+
+    from app.api.web_routes.mood_photos import mood_photo_status
+
+    rec = _record(status="processing")
+    rec.updated_at        = datetime.now(timezone.utc)
+    rec.processed_png_url = None
+    db  = _db_with(rec)
+
+    import json
+    resp = _run(mood_photo_status(slot="mood_happy_smile", user=_user(42), db=db))
+    data = json.loads(resp.body)
+    assert data["status"] == "processing"
+    assert data["processing_timed_out"] is False
+
+
+# ── MP-R36 ── GET /status processing, stale → processing_timed_out=True ───────
+
+def test_mp_r36_status_processing_timed_out():
+    from datetime import datetime, timedelta, timezone
+
+    from app.api.web_routes.mood_photos import mood_photo_status
+
+    rec = _record(status="processing")
+    rec.updated_at        = datetime.now(timezone.utc) - timedelta(seconds=400)
+    rec.processed_png_url = None
+    db  = _db_with(rec)
+
+    import json
+    with patch("app.api.web_routes.mood_photos.settings") as mock_settings:
+        mock_settings.MOOD_PHOTO_SLOTS   = None   # not used in this route
+        mock_settings.PROCESSING_TIMEOUT_SECONDS = 300
+        resp = _run(mood_photo_status(slot="mood_happy_smile", user=_user(42), db=db))
+
+    data = json.loads(resp.body)
+    assert data["status"] == "processing"
+    assert data["processing_timed_out"] is True
+
+
+# ── MP-R37 ── GET /status ready → processed_png_url in response ───────────────
+
+def test_mp_r37_status_ready():
+    from datetime import datetime, timezone
+
+    from app.api.web_routes.mood_photos import mood_photo_status
+
+    import json
+    rec = _record(status="ready")
+    rec.updated_at        = datetime.now(timezone.utc)
+    rec.processed_png_url = "/static/uploads/mood_photos/42_mood_happy_smile_proc_1.png"
+    db  = _db_with(rec)
+
+    resp = _run(mood_photo_status(slot="mood_happy_smile", user=_user(42), db=db))
+    data = json.loads(resp.body)
+    assert data["status"] == "ready"
+    assert data["processed_png_url"] is not None
+
+
+# ── MP-R38 ── GET /status no record → not_uploaded ────────────────────────────
+
+def test_mp_r38_status_no_record():
+    import json
+    from app.api.web_routes.mood_photos import mood_photo_status
+
+    db = _db_with(None)
+    resp = _run(mood_photo_status(slot="mood_happy_smile", user=_user(42), db=db))
+    data = json.loads(resp.body)
+    assert data["status"] == "not_uploaded"
+    assert data["processing_timed_out"] is False
+
+
+# ── MP-R39 ── POST /reset-processing: processing → uploaded ───────────────────
+
+def test_mp_r39_reset_processing_resets_to_uploaded():
+    from app.api.web_routes.mood_photos import mood_photo_reset_processing
+
+    rec = _record(status="processing")
+    db  = _db_with(rec)
+
+    with patch(f"{_BASE}.reset_processing") as mock_reset:
+        resp = _run(mood_photo_reset_processing(
+            slot="mood_happy_smile", user=_user(42), db=db
+        ))
+
+    assert resp.status_code == 303
+    mock_reset.assert_called_once_with(42, "mood_happy_smile", db)
+
+
+# ── MP-R40 ── POST /reset-processing: status=uploaded → no-op (idempotent) ────
+
+def test_mp_r40_reset_processing_noop_when_not_processing():
+    from app.api.web_routes.mood_photos import mood_photo_reset_processing
+
+    rec = _record(status="uploaded")
+    db  = _db_with(rec)
+
+    with patch(f"{_BASE}.reset_processing") as mock_reset:
+        resp = _run(mood_photo_reset_processing(
+            slot="mood_happy_smile", user=_user(42), db=db
+        ))
+
+    assert resp.status_code == 303
+    mock_reset.assert_called_once()   # called; service handles no-op internally
+
+
+# ── MP-R41 ── POST /reset-processing: invalid slot → 422 ─────────────────────
+
+def test_mp_r41_reset_processing_invalid_slot():
+    from app.api.web_routes.mood_photos import mood_photo_reset_processing
+
+    with pytest.raises(HTTPException) as exc:
+        _run(mood_photo_reset_processing(slot="bad_slot", user=_user(42), db=_db()))
+
+    assert exc.value.status_code == 422
+
+
+# ── MP-R42 ── POST /reset-processing: no record → 404 ────────────────────────
+
+def test_mp_r42_reset_processing_no_record_raises_404():
+    from app.api.web_routes.mood_photos import mood_photo_reset_processing
+
+    db = _db_with(None)
+    with pytest.raises(HTTPException) as exc:
+        _run(mood_photo_reset_processing(
+            slot="mood_happy_smile", user=_user(42), db=db
+        ))
+
+    assert exc.value.status_code == 404
+
+
+# ── MP-R43..R46 ── Template processor-aware assertions ───────────────────────
+
+def _tpl():
+    from pathlib import Path
+    return (
+        Path(__file__).resolve()
+        .parent.parent.parent.parent.parent
+        / "app" / "templates" / "lfa_player_mood_photos.html"
+    ).read_text(encoding="utf-8")
+
+
+# ── MP-R43 ── null mode: "Remove Background" not in template source ───────────
+
+def test_mp_r43_null_mode_remove_bg_button_gated():
+    """
+    The Remove Background button must be inside a
+    {% if bg_processor_mode == 'rembg' ... %} guard so it is
+    never rendered when BG_REMOVAL_PROCESSOR="null".
+    """
+    content = _tpl()
+    assert "bg_processor_mode == 'rembg'" in content, (
+        "Template must gate Remove Background on bg_processor_mode == 'rembg'"
+    )
+    # Verify the button text exists but is inside the guard
+    assert "Remove Background" in content
+    # "Background Removed" label must also be inside the rembg guard
+    assert "Background Removed" in content
+
+
+# ── MP-R44 ── null mode ready badge says "Processed", not "Background Removed" ─
+
+def test_mp_r44_null_mode_ready_badge_no_removal_claim():
+    """
+    When bg_processor_mode != 'rembg' and status == 'ready', the template
+    must show "Processed" not "Background Removed".
+    The check: template has both labels but gates "Background Removed"
+    behind bg_processor_mode == 'rembg'.
+    """
+    content = _tpl()
+    # "Processed" badge must exist for null processor path
+    assert "✓ Processed" in content, (
+        "Template must show '✓ Processed' badge when bg_processor_mode != 'rembg'"
+    )
+    # "Background Removed" must be inside rembg guard
+    rembg_block_start = content.find("bg_processor_mode == 'rembg'")
+    bg_removed_pos    = content.find("Background Removed")
+    assert rembg_block_start < bg_removed_pos, (
+        "'Background Removed' text must appear after the rembg processor mode guard"
+    )
+
+
+# ── MP-R45 ── processing badge has data-poll-slot for JS polling ──────────────
+
+def test_mp_r45_processing_badge_has_poll_slot():
+    content = _tpl()
+    assert "data-poll-slot" in content, (
+        "Template must attach data-poll-slot to the processing badge "
+        "so the JS polling loop can target the correct slot"
+    )
+
+
+# ── MP-R46 ── reset button initially hidden, timeout message present ──────────
+
+def test_mp_r46_reset_button_and_timeout_message_present():
+    content = _tpl()
+    assert "btn-reset-" in content, (
+        "Template must render a reset button (id=btn-reset-{slot}) for stuck processing"
+    )
+    assert "Processing is taking longer than expected" in content, (
+        "Template must contain the timeout warning message"
+    )
+    assert "style=\"display:none;\"" in content or "style='display:none;'" in content, (
+        "Reset button and timeout message must be initially hidden (display:none)"
     )

--- a/tests/unit/services/test_mood_photo_service.py
+++ b/tests/unit/services/test_mood_photo_service.py
@@ -1,5 +1,5 @@
 """
-MP-S01..MP-S08 — unit tests for mood_photo_service.
+MP-S01..MP-S13 — unit tests for mood_photo_service.
 
 Uses MagicMock for the SQLAlchemy Session; no real DB required.
 Disk I/O is patched via tmp_path / monkeypatch so tests stay hermetic.
@@ -186,3 +186,88 @@ def test_mp_s08_get_returns_all_six_slots():
     assert result["mood_sad_disappointed"]  is None
     assert result["mood_angry_competitive"] is None
     assert result["mood_surprised_shocked"] is None
+
+
+# ── MP-S09 ── set_status_processing sets status and calls flush ───────────────
+
+def test_mp_s09_set_status_processing():
+    record = MagicMock()
+    record.status = "uploaded"
+    db = _make_db(existing_row=record)
+
+    from app.services.mood_photo_service import set_status_processing
+
+    result = set_status_processing(user_id=42, slot="mood_happy_smile", db=db)
+
+    assert record.status == "processing"
+    db.flush.assert_called()
+    assert result is record
+
+
+# ── MP-S10 ── apply_removal_result sets ready + url + timestamp ───────────────
+
+def test_mp_s10_apply_removal_result():
+    from datetime import datetime, timezone
+
+    record = MagicMock()
+    db = _make_db(existing_row=record)
+
+    from app.services.mood_photo_service import apply_removal_result
+
+    apply_removal_result(
+        user_id=42,
+        slot="mood_happy_smile",
+        processed_url="/static/uploads/mood_photos/42_mood_happy_smile_proc_999.png",
+        db=db,
+    )
+
+    assert record.status == "ready"
+    assert record.processed_png_url == "/static/uploads/mood_photos/42_mood_happy_smile_proc_999.png"
+    assert record.processed_at is not None
+    db.commit.assert_called()
+
+
+# ── MP-S11 ── apply_removal_failure sets failed, clears processed_at ─────────
+
+def test_mp_s11_apply_removal_failure():
+    record = MagicMock()
+    db = _make_db(existing_row=record)
+
+    from app.services.mood_photo_service import apply_removal_failure
+
+    apply_removal_failure(user_id=42, slot="mood_happy_smile", db=db)
+
+    assert record.status == "failed"
+    assert record.processed_at is not None
+    db.commit.assert_called()
+
+
+# ── MP-S12 ── reset_processing: status=processing → uploaded, cleared ────────
+
+def test_mp_s12_reset_processing_from_processing():
+    record = MagicMock()
+    record.status = "processing"
+    db = _make_db(existing_row=record)
+
+    from app.services.mood_photo_service import reset_processing
+
+    reset_processing(user_id=42, slot="mood_happy_smile", db=db)
+
+    assert record.status == "uploaded"
+    assert record.processed_png_url is None
+    assert record.processed_at is None
+    db.flush.assert_called()
+
+
+# ── MP-S13 ── reset_processing: status != processing → no-op ─────────────────
+
+def test_mp_s13_reset_processing_noop_when_not_processing():
+    record = MagicMock()
+    record.status = "uploaded"
+    db = _make_db(existing_row=record)
+
+    from app.services.mood_photo_service import reset_processing
+
+    reset_processing(user_id=42, slot="mood_happy_smile", db=db)
+
+    db.flush.assert_not_called()

--- a/tests/unit/tasks/test_mood_photo_tasks.py
+++ b/tests/unit/tasks/test_mood_photo_tasks.py
@@ -1,0 +1,155 @@
+"""
+MP-T01..MP-T06 — unit tests for mood_photo_tasks (background removal Celery task).
+
+All tests use MagicMock / patch — no real Celery worker, no real DB,
+no rembg/onnxruntime required.
+
+Phase 1 invariants tested:
+  - NullProcessor returns bytes unchanged
+  - get_processor() returns NullProcessor when BG_REMOVAL_PROCESSOR="null"
+  - Task writes processed file and calls apply_removal_result on success
+  - Task calls apply_removal_failure when original file is missing (no retry)
+  - Task calls apply_removal_failure when max retries are exhausted
+  - apply_removal_failure is NOT called on a successful run
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+_TASK_MOD = "app.tasks.mood_photo_tasks"
+
+
+# ── MP-T01 ── NullProcessor.remove() returns input unchanged ─────────────────
+
+def test_mp_t01_null_processor_passthrough():
+    from app.services.background_removal.processor import NullProcessor
+
+    data = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+    assert NullProcessor().remove(data) == data
+
+
+# ── MP-T02 ── get_processor() with null config → NullProcessor ────────────────
+
+def test_mp_t02_get_processor_null_mode():
+    from app.services.background_removal.processor import NullProcessor
+
+    with patch("app.services.background_removal.settings") as mock_cfg:
+        mock_cfg.BG_REMOVAL_PROCESSOR = "null"
+        from app.services.background_removal import get_processor
+        proc = get_processor()
+
+    assert isinstance(proc, NullProcessor)
+
+
+# ── MP-T03 ── Task success: proc file written, apply_removal_result called ────
+
+def test_mp_t03_task_success_writes_proc_file(tmp_path):
+    orig_file = tmp_path / "42_mood_happy_smile_orig_1.png"
+    orig_file.write_bytes(b"FAKEDATA")
+    original_url = f"/static/uploads/mood_photos/{orig_file.name}"
+
+    fake_proc = MagicMock()
+    fake_proc.remove.return_value = b"PROCESSED"
+
+    with patch(f"{_TASK_MOD}.MOOD_PHOTO_DIR", new=tmp_path), \
+         patch(f"{_TASK_MOD}.get_processor", return_value=fake_proc), \
+         patch(f"{_TASK_MOD}.apply_removal_result") as mock_ok, \
+         patch(f"{_TASK_MOD}.apply_removal_failure") as mock_fail, \
+         patch(f"{_TASK_MOD}.SessionLocal", return_value=MagicMock()):
+
+        from app.tasks.mood_photo_tasks import remove_background_task
+        result = remove_background_task.run(
+            user_id=42, slot="mood_happy_smile", original_url=original_url
+        )
+
+    assert result["status"] == "ready"
+    mock_ok.assert_called_once()
+    mock_fail.assert_not_called()
+
+    # Slot names start with "mood_" and the filename template adds "_mood_" prefix,
+    # so the actual pattern is: 42_mood_{slot}_proc_*.png = 42_mood_mood_happy_smile_proc_*.png
+    proc_files = list(tmp_path.glob(f"42_mood_mood_happy_smile_proc_*.png"))
+    assert len(proc_files) == 1
+    assert proc_files[0].read_bytes() == b"PROCESSED"
+
+
+# ── MP-T04 ── Task: max retries exhausted → apply_removal_failure called ──────
+
+def test_mp_t04_task_max_retries_calls_failure(tmp_path):
+    orig_file = tmp_path / "42_mood_happy_smile_orig_1.png"
+    orig_file.write_bytes(b"FAKEDATA")
+    original_url = f"/static/uploads/mood_photos/{orig_file.name}"
+
+    failing_proc = MagicMock()
+    failing_proc.remove.side_effect = RuntimeError("boom")
+
+    with patch(f"{_TASK_MOD}.MOOD_PHOTO_DIR", new=tmp_path), \
+         patch(f"{_TASK_MOD}.get_processor", return_value=failing_proc), \
+         patch(f"{_TASK_MOD}.apply_removal_result") as mock_ok, \
+         patch(f"{_TASK_MOD}.apply_removal_failure") as mock_fail, \
+         patch(f"{_TASK_MOD}.SessionLocal", return_value=MagicMock()):
+
+        from app.tasks.mood_photo_tasks import remove_background_task
+
+        # Simulate max retries exhausted: task.retry raises MaxRetriesExceededError
+        mock_self = MagicMock()
+        mock_self.MaxRetriesExceededError = RuntimeError
+        mock_self.retry.side_effect = RuntimeError("max retries exceeded")
+
+        # Invoke the underlying function directly with a mock self
+        result = remove_background_task.run.__func__(
+            mock_self,
+            user_id=42,
+            slot="mood_happy_smile",
+            original_url=original_url,
+        )
+
+    assert result["status"] == "failed"
+    mock_fail.assert_called_once()
+    mock_ok.assert_not_called()
+
+
+# ── MP-T05 ── Task: missing original file → failed immediately, no retry ───────
+
+def test_mp_t05_task_missing_file_immediate_failure(tmp_path):
+    # original_url points to a file that does NOT exist
+    original_url = "/static/uploads/mood_photos/nonexistent.png"
+
+    with patch(f"{_TASK_MOD}.MOOD_PHOTO_DIR", new=tmp_path), \
+         patch(f"{_TASK_MOD}.apply_removal_failure") as mock_fail, \
+         patch(f"{_TASK_MOD}.apply_removal_result") as mock_ok, \
+         patch(f"{_TASK_MOD}.SessionLocal", return_value=MagicMock()):
+
+        from app.tasks.mood_photo_tasks import remove_background_task
+        result = remove_background_task.run(
+            user_id=42, slot="mood_happy_smile", original_url=original_url
+        )
+
+    assert result["status"] == "failed"
+    assert result.get("reason") == "missing_file"
+    mock_fail.assert_called_once()
+    mock_ok.assert_not_called()
+
+
+# ── MP-T06 ── apply_removal_failure NOT called on success ────────────────────
+
+def test_mp_t06_no_failure_call_on_success(tmp_path):
+    orig_file = tmp_path / "99_mood_celebration_orig_1.png"
+    orig_file.write_bytes(b"DATA")
+    original_url = f"/static/uploads/mood_photos/{orig_file.name}"
+
+    fake_proc = MagicMock()
+    fake_proc.remove.return_value = b"OUTPUT"
+
+    with patch(f"{_TASK_MOD}.MOOD_PHOTO_DIR", new=tmp_path), \
+         patch(f"{_TASK_MOD}.get_processor", return_value=fake_proc), \
+         patch(f"{_TASK_MOD}.apply_removal_result"), \
+         patch(f"{_TASK_MOD}.apply_removal_failure") as mock_fail, \
+         patch(f"{_TASK_MOD}.SessionLocal", return_value=MagicMock()):
+
+        from app.tasks.mood_photo_tasks import remove_background_task
+        remove_background_task.run(
+            user_id=99, slot="mood_celebration", original_url=original_url
+        )
+
+    mock_fail.assert_not_called()


### PR DESCRIPTION
## Summary

- Wires the background removal pipeline end-to-end with `NullProcessor` — no real BG removal occurs
- `BG_REMOVAL_PROCESSOR="null"` (default): "Remove Background" button hidden; "Background Removed" label hidden
- Adds `BackgroundProcessor` ABC + `NullProcessor` (Phase 1 passthrough), deferred `RembgProcessor` import (Phase 2)
- Adds `remove_background_task` Celery task on `mood_photos` queue with state machine: uploaded→processing→ready|failed
- Adds 3 new routes: `POST /remove-bg`, `GET /status`, `POST /reset-processing`
- Adds 4 new service functions: `set_status_processing`, `apply_removal_result`, `apply_removal_failure`, `reset_processing`
- Template is processor-aware: `bg_processor_mode` context variable drives all labels/buttons
- 65 mood photo tests (MP-S01..S13, MP-R01..R46, MP-T01..T06) — 11 239/11 239 local PASS

## Phase 1 status

> Background removal pipeline skeleton implemented with NullProcessor. Real background removal remains Phase 2.

## Scope guard

- `requirements.txt` **unchanged** — no `rembg`, no `onnxruntime-cpu`
- No real background removal
- No camera capture / face manipulation / card system / navbar changes
- `player_photo_service.py`, `UserLicense` photo fields, `CardDraft` — untouched
- Mood slot definitions — untouched

## Phase 2 prerequisites (gated — separate approval)

`rembg_processor.py` (single new file) + `requirements.txt` + `BG_REMOVAL_PROCESSOR="rembg"` default flip

🤖 Generated with [Claude Code](https://claude.com/claude-code)