### PR TITLE
feat(vt): stabilize VT reference data + bootstrap guard

### DIFF
--- a/.github/workflows/e2e-clean-db-bootstrap.yml
+++ b/.github/workflows/e2e-clean-db-bootstrap.yml
@@ -10,9 +10,11 @@ on:
     paths:
       - 'scripts/bootstrap_clean.py'
       - 'scripts/validate_seed_state.py'
+      - 'scripts/seed_virtual_training_games.py'
       - 'scripts/e2e_matrix_test.py'
       - 'scripts/e2e_promo_flow_test.py'
       - 'app/api/web_routes/admin.py'
+      - 'app/models/virtual_training.py'
       - 'alembic/versions/**'
       - '.github/workflows/e2e-clean-db-bootstrap.yml'
   workflow_dispatch:

--- a/README_STUDENT_RESET.md
+++ b/README_STUDENT_RESET.md
@@ -1,0 +1,90 @@
+# Dev DB Reset Checklist
+
+Use this checklist every time you run a destructive DB reset in development.
+
+---
+
+## 1. Full Reset + Bootstrap (single command)
+
+```bash
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/lfa_intern_system" \
+  PYTHONPATH=. python scripts/reset_and_bootstrap.py --yes
+```
+
+This runs automatically:
+- `DROP SCHEMA public CASCADE` + `CREATE SCHEMA public`
+- `alembic upgrade head` — recreates all tables
+- `bootstrap_clean.py` Steps 1–8:
+  - TournamentType (4 rows), GamePreset (5 rows), Location + Campus, Pitches, Admin, Instructor, Bootstrap Club
+  - **Step 8: VirtualTrainingGame (12 rows, 6 active)** — included since 2026-05-27
+- Post-reset validation: hard fail if `virtual_training_games` is empty
+
+No manual seed step required for VT data.
+
+---
+
+## 2. Validate Seed State
+
+```bash
+PYTHONPATH=. python scripts/validate_seed_state.py
+```
+
+Checks (7 total):
+1. TournamentType ≥ 4 rows
+2. GamePreset ≥ 3 rows
+3. Campus ≥ 1 active row
+4. Admin user present
+5. Instructor user present
+6. Club with active teams + players
+7. **VirtualTrainingGame: ≥ 1 active, memory_sequence + target_tracking both active**
+
+Exits 0 on success, 1 with details on failure.
+
+---
+
+## 3. Optional: Dev Friendship Seed
+
+Creates ACCEPTED friendship pairs between bootstrap LFA Adult players.
+Required for testing the Friends + Challenge flow in a clean environment.
+
+```bash
+PYTHONPATH=. python scripts/seed_dev_friendships.py
+```
+
+- Idempotent: safe to run multiple times
+- 4 pairs from LFA Adult bootstrap team
+- PENDING → ACCEPTED upgrade, DECLINED → ACCEPTED replace
+- Output: `N created, N upgraded, N skipped`
+
+---
+
+## 4. Start the App
+
+```bash
+# Terminal 1 — FastAPI
+BG_REMOVAL_PROCESSOR=rembg uvicorn app.main:app \
+  --host 0.0.0.0 --port 8000 --reload --reload-dir app
+
+# Terminal 2 — Celery (if using rembg background removal)
+BG_REMOVAL_PROCESSOR=rembg celery -A app.celery_app worker \
+  -Q mood_photos -c 1 -l info --pool=solo
+```
+
+---
+
+## 5. Quick Sanity Checks
+
+| URL | Expected |
+|-----|----------|
+| `/training` | Virtual Games link visible under Adaptive Learning |
+| `/virtual-training` | 6 game cards (Color Reaction, Go/No-Go, etc.) |
+| `/challenges/send` | memory_sequence + target_tracking selectable; friend list populated (after friendship seed) |
+| `/friends` | ACCEPTED pairs visible (after friendship seed) |
+
+---
+
+## Notes
+
+- `virtual_training_games` is **reference data** — same as `TournamentType` or `GamePreset`. The app cannot function without it.
+- If the Virtual Games link is missing on `/training`, run `validate_seed_state.py` — it will tell you exactly what is missing.
+- The friendship seed uses only bootstrap-guaranteed users. It does NOT require `rdias@manchestercity.com` or other dev-only seeds.

--- a/app/core/startup_checks.py
+++ b/app/core/startup_checks.py
@@ -1,0 +1,35 @@
+"""Startup reference-data integrity checks — WARNING only, non-fatal."""
+import logging
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+_CHALLENGE_COMPATIBLE = frozenset({"memory_sequence", "target_tracking"})
+
+
+def check_reference_data_integrity(db: Session) -> None:
+    """Warn if VT reference data is missing. Does not raise."""
+    try:
+        from app.models.virtual_training import VirtualTrainingGame  # lazy — avoids circular import
+        vt_total = db.query(VirtualTrainingGame).count()
+        if vt_total == 0:
+            logger.warning(
+                "STARTUP: virtual_training_games is empty — "
+                "Virtual Games hub and Challenge flow will not work. "
+                "Fix: PYTHONPATH=. python scripts/seed_virtual_training_games.py"
+            )
+            return
+        vt_compat = db.query(VirtualTrainingGame).filter(
+            VirtualTrainingGame.code.in_(_CHALLENGE_COMPATIBLE),
+            VirtualTrainingGame.is_active == True,  # noqa: E712
+        ).count()
+        if vt_compat < len(_CHALLENGE_COMPATIBLE):
+            logger.warning(
+                "STARTUP: Only %d/%d challenge-compatible VT games are active "
+                "(expected: memory_sequence, target_tracking). "
+                "/challenges/send will show no games.",
+                vt_compat,
+                len(_CHALLENGE_COMPATIBLE),
+            )
+    except Exception:
+        logger.warning("STARTUP: VT reference-data check failed — continuing anyway", exc_info=True)

--- a/app/main.py
+++ b/app/main.py
@@ -47,6 +47,18 @@ async def lifespan(app: FastAPI):
     logger.info("🚀 Application startup initiated")
     create_initial_admin()
 
+    # Reference-data integrity check (WARNING only, non-fatal)
+    try:
+        from .core.startup_checks import check_reference_data_integrity
+        from .database import SessionLocal
+        _startup_db = SessionLocal()
+        try:
+            check_reference_data_integrity(_startup_db)
+        finally:
+            _startup_db.close()
+    except Exception:
+        logger.warning("Startup reference-data check failed — continuing", exc_info=True)
+
     # Start background scheduler for periodic tasks
     scheduler = None
     try:

--- a/app/templates/training_hub.html
+++ b/app/templates/training_hub.html
@@ -140,6 +140,19 @@
         font-size: 0.9rem;
     }
 
+    .trn-submodule-unavailable {
+        padding: 0.55rem 0.85rem;
+        border: 1px dashed var(--app-border, #e5e7eb);
+        border-radius: 8px;
+        color: var(--app-text-muted);
+        font-size: 0.82rem;
+        line-height: 1.5;
+    }
+
+    .trn-submodule-unavailable p {
+        margin: 0;
+    }
+
     /* ── Footer ──────────────────────────────────────────────────────────────── */
     .trn-footer {
         text-align: center;
@@ -210,6 +223,11 @@
                     <span>Virtual Games</span>
                     <span class="trn-sub-arrow">→</span>
                 </a>
+                {% else %}
+                <div class="trn-submodule-unavailable">
+                    <p>🎮 Virtual Games — not available.</p>
+                    <p>Contact your administrator to enable virtual game modules.</p>
+                </div>
                 {% endif %}
             </div>
         </div>

--- a/scripts/bootstrap_clean.py
+++ b/scripts/bootstrap_clean.py
@@ -17,6 +17,7 @@ What it creates (skips existing rows):
   6. Instructor user     instructor@lfa.com / instructor123
   7. Bootstrap Club      LFA_BOOTSTRAP_CLUB — 3 teams × 12 UK-named players, all LFA-licensed
                          LFA U15 (63.0), LFA U18 (68.0), LFA Adult (72.0)
+  8. VirtualTrainingGame (12 rows: 6 active incl. memory_sequence + target_tracking)
 """
 import json
 import os
@@ -638,6 +639,20 @@ def run():
                 db.commit()
                 print(f"       → patched {len(null_preset_cfgs)} GameConfiguration(s) with NULL game_preset_id")
 
+        # Step 8: Virtual Training game presets (reference data)
+        _step(8, "Virtual Training game presets (reference data)")
+        from scripts.seed_virtual_training_games import seed_virtual_training_games as _seed_vt  # noqa: E402
+        _seed_vt()
+        db.expire_all()  # refresh session after external commit from _seed_vt()
+        from app.models.virtual_training import VirtualTrainingGame  # noqa: E402
+        _vt_total  = db.query(VirtualTrainingGame).count()
+        _vt_active = db.query(VirtualTrainingGame).filter(
+            VirtualTrainingGame.is_active == True  # noqa: E712
+        ).count()
+        print(f"  → VirtualTrainingGame total: {_vt_total} ({_vt_active} active)")
+        if _vt_total == 0:
+            print("  ❌ WARNING: VT seed produced 0 rows — challenge flow will not work!")
+
         # Summary
         print("\n" + "="*70)
         print("  Bootstrap complete")
@@ -649,6 +664,10 @@ def run():
         instr_u = db.query(User).filter(User.email == "instructor@lfa.com").first()
         boot_club = db.query(Club).filter(Club.code == _CLUB_CODE).first()
         team_count = db.query(Team).filter(Team.club_id == boot_club.id).count() if boot_club else 0
+        vt_total_s  = db.query(VirtualTrainingGame).count()
+        vt_active_s = db.query(VirtualTrainingGame).filter(
+            VirtualTrainingGame.is_active == True  # noqa: E712
+        ).count()
         print(f"  TournamentType : {tt_count} rows")
         print(f"  GamePreset     : {gp_count} rows")
         print(f"  Campus         : {campus_count} (id={campus.id}, '{campus.name}')")
@@ -661,6 +680,7 @@ def run():
         ) if boot_club else 0
         print(f"  Teams          : {team_count} (LFA U15 / LFA U18 / LFA Adult, 12 players each)")
         print(f"  Players        : {player_count} total (UK English names)")
+        print(f"  VT Games       : {vt_total_s} rows ({vt_active_s} active)")
         print()
         print("  Run validate:  PYTHONPATH=. python scripts/validate_seed_state.py")
         print("="*70 + "\n")

--- a/scripts/reset_and_bootstrap.py
+++ b/scripts/reset_and_bootstrap.py
@@ -85,6 +85,27 @@ def main() -> None:
     from scripts.bootstrap_clean import run as bootstrap_run  # noqa: E402
     bootstrap_run()
 
+    print("\n--- Step 4: Post-reset VT reference data validation ---")
+    from app.database import SessionLocal as _SL       # noqa: E402
+    from app.models.virtual_training import VirtualTrainingGame as _VTG  # noqa: E402
+    _vdb = _SL()
+    try:
+        _vt_total  = _vdb.query(_VTG).count()
+        _vt_compat = _vdb.query(_VTG).filter(
+            _VTG.code.in_(["memory_sequence", "target_tracking"]),
+            _VTG.is_active == True,  # noqa: E712
+        ).count()
+    finally:
+        _vdb.close()
+
+    if _vt_total == 0:
+        print("❌ FATAL: virtual_training_games is EMPTY after bootstrap.")
+        print("   bootstrap_clean.py Step 8 did not complete correctly.")
+        print("   Fix: PYTHONPATH=. python scripts/seed_virtual_training_games.py")
+        sys.exit(1)
+
+    print(f"✅ VirtualTrainingGame: {_vt_total} rows ({_vt_compat}/2 challenge-compatible active)")
+
     print("\n" + "=" * 60)
     print("  ✅  Reset complete. DB is in a clean bootstrapped state.")
     print("=" * 60)

--- a/scripts/seed_dev_friendships.py
+++ b/scripts/seed_dev_friendships.py
@@ -1,0 +1,116 @@
+"""Seed accepted friendships between bootstrap LFA Adult player pairs.
+
+Idempotent: skips existing ACCEPTED pairs, upgrades PENDING → ACCEPTED,
+replaces DECLINED with ACCEPTED. Safe to run multiple times.
+
+All pairs use bootstrap-guaranteed users (seeded by bootstrap_clean.py LFA Adult team),
+so this script is safe to run immediately after any fresh bootstrap.
+
+Usage:
+    PYTHONPATH=. python scripts/seed_dev_friendships.py
+"""
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+os.environ.setdefault(
+    "DATABASE_URL",
+    "postgresql://postgres:postgres@localhost:5432/lfa_intern_system",
+)
+
+from app.database import SessionLocal                       # noqa: E402
+from app.models.friendship import Friendship, FriendshipStatus  # noqa: E402
+from app.models.user import User                            # noqa: E402
+
+# Bootstrap-guaranteed pairs — all seeded by bootstrap_clean.py LFA Adult team.
+# Passwords: Bootstrap#123
+_DEV_PAIRS: list[tuple[str, str]] = [
+    ("lfa-adult-robert.adams@lfa.com",     "lfa-adult-michael.baker@lfa.com"),
+    ("lfa-adult-christopher.cole@lfa.com", "lfa-adult-andrew.davis@lfa.com"),
+    ("lfa-adult-jonathan.evans@lfa.com",   "lfa-adult-matthew.fisher@lfa.com"),
+    ("lfa-adult-benjamin.gray@lfa.com",    "lfa-adult-nicholas.hall@lfa.com"),
+]
+
+
+def _find_user(db, email: str) -> User | None:
+    return db.query(User).filter(User.email == email).first()
+
+
+def _find_existing(db, user_a_id: int, user_b_id: int) -> Friendship | None:
+    return (
+        db.query(Friendship)
+        .filter(
+            (
+                (Friendship.requester_id == user_a_id) & (Friendship.addressee_id == user_b_id)
+            ) | (
+                (Friendship.requester_id == user_b_id) & (Friendship.addressee_id == user_a_id)
+            )
+        )
+        .first()
+    )
+
+
+def seed_dev_friendships() -> dict:
+    """Create/upgrade friendship pairs. Returns summary dict."""
+    db = SessionLocal()
+    created = upgraded = skipped = 0
+    try:
+        for email_a, email_b in _DEV_PAIRS:
+            user_a = _find_user(db, email_a)
+            user_b = _find_user(db, email_b)
+
+            if user_a is None:
+                print(f"  ⚠️  Skip — user not found: {email_a}")
+                skipped += 1
+                continue
+            if user_b is None:
+                print(f"  ⚠️  Skip — user not found: {email_b}")
+                skipped += 1
+                continue
+
+            existing = _find_existing(db, user_a.id, user_b.id)
+
+            if existing is None:
+                db.add(Friendship(
+                    requester_id=user_a.id,
+                    addressee_id=user_b.id,
+                    status=FriendshipStatus.ACCEPTED,
+                ))
+                db.flush()
+                created += 1
+                print(f"  +  ACCEPTED  {email_a}  ↔  {email_b}")
+
+            elif existing.status == FriendshipStatus.ACCEPTED:
+                skipped += 1
+                print(f"  ⏭️  Already ACCEPTED  {email_a}  ↔  {email_b}")
+
+            elif existing.status in (FriendshipStatus.PENDING, FriendshipStatus.DECLINED):
+                old_status = existing.status.value
+                existing.status = FriendshipStatus.ACCEPTED
+                db.flush()
+                upgraded += 1
+                print(f"  ↑  {old_status} → ACCEPTED  {email_a}  ↔  {email_b}")
+
+            else:
+                # BLOCKED — leave untouched
+                skipped += 1
+                print(f"  ⏭️  Skip (BLOCKED)  {email_a}  ↔  {email_b}")
+
+        db.commit()
+        print(
+            f"\nDone. {created} created, {upgraded} upgraded, {skipped} skipped."
+        )
+        return {"created": created, "upgraded": upgraded, "skipped": skipped}
+
+    except Exception as exc:
+        db.rollback()
+        print(f"Error: {exc}")
+        raise
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    seed_dev_friendships()

--- a/scripts/seed_virtual_training_games.py
+++ b/scripts/seed_virtual_training_games.py
@@ -1,8 +1,14 @@
 """Seed Virtual Training game presets.
 
 Safe to run multiple times: new games are inserted, existing games have their
-config/skill_targets/base_xp/description/name updated in-place (idempotent UPDATE).
-All non-color_reaction presets remain is_active=False until an admin toggle.
+config/skill_targets/base_xp/description/name/is_active updated in-place (idempotent UPDATE).
+
+Active after seed: color_reaction, go_no_go, direction_swipe, number_color_conflict,
+memory_sequence, target_tracking.
+Inactive after seed: stroop_challenge, peripheral_vision, dual_task, fake_target,
+audio_visual_reaction, pattern_break.
+
+memory_sequence and target_tracking are challenge-compatible (CHALLENGE_COMPATIBLE_GAMES).
 
 show_in_hub=False in config → game excluded from the Virtual Games hub display.
 """

--- a/scripts/validate_seed_state.py
+++ b/scripts/validate_seed_state.py
@@ -23,6 +23,7 @@ from app.models.game_preset import GamePreset  # noqa: E402
 from app.models.team import Team, TeamMember  # noqa: E402
 from app.models.tournament_type import TournamentType  # noqa: E402
 from app.models.user import User, UserRole  # noqa: E402
+from app.models.virtual_training import VirtualTrainingGame  # noqa: E402
 
 
 def run():
@@ -131,6 +132,28 @@ def run():
             failures.append(
                 "No Club with active teams and players. The promotion wizard will create empty tournaments. "
                 "Run: python scripts/bootstrap_clean.py"
+            )
+
+        # 7. VirtualTrainingGame reference data
+        _CHALLENGE_COMPAT = {"memory_sequence", "target_tracking"}
+        vt_active_games = (
+            db.query(VirtualTrainingGame)
+            .filter(VirtualTrainingGame.is_active == True)  # noqa: E712
+            .all()
+        )
+        vt_compat_count = sum(1 for g in vt_active_games if g.code in _CHALLENGE_COMPAT)
+        if len(vt_active_games) >= 1 and vt_compat_count >= 2:
+            vt_codes = [g.code for g in vt_active_games]
+            print(f"  ✅ VirtualTrainingGame: {len(vt_active_games)} active ({', '.join(vt_codes)})")
+        else:
+            print(
+                f"  ❌ VirtualTrainingGame: {len(vt_active_games)} active, "
+                f"{vt_compat_count}/2 challenge-compatible (need memory_sequence + target_tracking)"
+            )
+            failures.append(
+                f"VirtualTrainingGame: {len(vt_active_games)} active games, "
+                f"{vt_compat_count}/2 challenge-compatible. "
+                "Run: PYTHONPATH=. python scripts/seed_virtual_training_games.py"
             )
 
         print("-" * 50)

--- a/tests/unit/api/web_routes/test_training_hub.py
+++ b/tests/unit/api/web_routes/test_training_hub.py
@@ -180,3 +180,84 @@ class TestAdaptiveLearningRegression:
         from app.api.web_routes import router
         paths = [r.path for r in router.routes]
         assert "/adaptive-learning" in paths
+
+
+# ── TRN-07..09: vt_active gate + empty state ─────────────────────────────────
+
+class TestVirtualTrainingGate:
+    """
+    TRN-07  vt_active=True when VirtualTrainingService.get_games returns games
+    TRN-08  vt_active=False when VirtualTrainingService.get_games returns []
+    TRN-09  training_hub.html template contains trn-submodule-unavailable class (empty state)
+    TRN-10  training_hub.html template contains Virtual Games link inside {% if vt_active %}
+    TRN-11  Adaptive Learning link always present — not gated by vt_active
+    """
+
+    def _read(self):
+        return (_TEMPLATES_DIR / "training_hub.html").read_text(encoding="utf-8")
+
+    def test_trn07_vt_active_true_when_games_exist(self):
+        """TRN-07: vt_active=True is passed to template when get_games returns a non-empty list."""
+        from app.api.web_routes.training import training_hub_page
+
+        user = _make_student()
+        request = _make_request()
+        db = _make_db()
+        fake_game = MagicMock()
+        fake_response = MagicMock()
+
+        with patch(f"{_ROUTES}.require_student_onboarding", return_value=None), \
+             patch(f"{_ROUTES}._spec_ctx", return_value={}), \
+             patch(f"{_ROUTES}.VirtualTrainingService.get_games", return_value=[fake_game]), \
+             patch(f"{_ROUTES}.templates") as mock_tmpl:
+            mock_tmpl.TemplateResponse.return_value = fake_response
+            _run(training_hub_page(request=request, db=db, user=user))
+
+        ctx = mock_tmpl.TemplateResponse.call_args[0][1]
+        assert ctx["vt_active"] is True
+
+    def test_trn08_vt_active_false_when_no_games(self):
+        """TRN-08: vt_active=False is passed to template when get_games returns []."""
+        from app.api.web_routes.training import training_hub_page
+
+        user = _make_student()
+        request = _make_request()
+        db = _make_db()
+        fake_response = MagicMock()
+
+        with patch(f"{_ROUTES}.require_student_onboarding", return_value=None), \
+             patch(f"{_ROUTES}._spec_ctx", return_value={}), \
+             patch(f"{_ROUTES}.VirtualTrainingService.get_games", return_value=[]), \
+             patch(f"{_ROUTES}.templates") as mock_tmpl:
+            mock_tmpl.TemplateResponse.return_value = fake_response
+            _run(training_hub_page(request=request, db=db, user=user))
+
+        ctx = mock_tmpl.TemplateResponse.call_args[0][1]
+        assert ctx["vt_active"] is False
+
+    def test_trn09_template_has_empty_state_class(self):
+        """TRN-09: training_hub.html contains trn-submodule-unavailable CSS class (empty state)."""
+        html = self._read()
+        assert "trn-submodule-unavailable" in html
+
+    def test_trn10_template_virtual_games_link_inside_if_block(self):
+        """TRN-10: Virtual Games link exists and is inside an {% if vt_active %} conditional."""
+        html = self._read()
+        assert 'href="/virtual-training"' in html
+        # Both the link and empty state must exist in the template source
+        assert "trn-submodule-unavailable" in html
+        # The if block must be present
+        assert "vt_active" in html
+
+    def test_trn11_adaptive_learning_not_gated(self):
+        """TRN-11: Adaptive Learning link is not inside an {% if %} block — always rendered."""
+        html = self._read()
+        # Find the adaptive-learning href line
+        al_idx = html.find('href="/adaptive-learning"')
+        assert al_idx != -1, "Adaptive Learning link missing from template"
+        # The nearest preceding {% if %} should be the outer if vt_active, not an adaptive-specific gate
+        preceding = html[:al_idx]
+        # No {% if ... %} block should directly wrap the adaptive-learning link
+        # (it appears before the vt_active check)
+        vt_if_idx = html.find("{% if vt_active %}")
+        assert al_idx < vt_if_idx, "Adaptive Learning link must appear before the {% if vt_active %} block"

--- a/tests/unit/core/test_startup_checks.py
+++ b/tests/unit/core/test_startup_checks.py
@@ -1,0 +1,82 @@
+"""Unit tests for app/core/startup_checks.py
+
+SC-01  WARNING logged when virtual_training_games is empty
+SC-02  WARNING logged when no challenge-compatible games are active
+SC-03  No WARNING when memory_sequence + target_tracking are both active
+SC-04  Function does not raise even when db.query raises an exception
+"""
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+
+_MODULE = "app.core.startup_checks"
+
+
+def _make_query_mock(total: int, compat: int):
+    """Return a mock db where .count() returns the given values in sequence."""
+    db = MagicMock()
+
+    def query_side_effect(model):
+        q = MagicMock()
+        q.count.return_value = total
+        filtered = MagicMock()
+        filtered.count.return_value = compat
+        q.filter.return_value = filtered
+        return q
+
+    db.query.side_effect = query_side_effect
+    return db
+
+
+class TestStartupChecks:
+
+    def test_sc01_warns_when_vt_empty(self, caplog):
+        """SC-01: WARNING when virtual_training_games count == 0."""
+        from app.core.startup_checks import check_reference_data_integrity
+
+        db = _make_query_mock(total=0, compat=0)
+
+        with caplog.at_level(logging.WARNING, logger=_MODULE):
+            check_reference_data_integrity(db)
+
+        assert any("virtual_training_games is empty" in r.message for r in caplog.records)
+
+    def test_sc02_warns_when_no_challenge_compat(self, caplog):
+        """SC-02: WARNING when total > 0 but no challenge-compatible games active."""
+        from app.core.startup_checks import check_reference_data_integrity
+
+        db = _make_query_mock(total=3, compat=0)
+
+        with caplog.at_level(logging.WARNING, logger=_MODULE):
+            check_reference_data_integrity(db)
+
+        assert any("challenge-compatible" in r.message for r in caplog.records)
+
+    def test_sc03_silent_when_all_ok(self, caplog):
+        """SC-03: No WARNING when both challenge-compatible games are active."""
+        from app.core.startup_checks import check_reference_data_integrity
+
+        db = _make_query_mock(total=6, compat=2)
+
+        with caplog.at_level(logging.WARNING, logger=_MODULE):
+            check_reference_data_integrity(db)
+
+        warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert len(warnings) == 0
+
+    def test_sc04_does_not_raise_on_db_exception(self, caplog):
+        """SC-04: Exception from db.query() is caught — function returns without raising."""
+        from app.core.startup_checks import check_reference_data_integrity
+
+        db = MagicMock()
+        db.query.side_effect = Exception("DB connection error")
+
+        # Must not raise
+        with caplog.at_level(logging.WARNING, logger=_MODULE):
+            check_reference_data_integrity(db)
+
+        # Should log a warning about the failure
+        assert any("check failed" in r.message.lower() or r.levelno >= logging.WARNING
+                   for r in caplog.records)

--- a/tests/unit/scripts/test_seed_dev_friendships.py
+++ b/tests/unit/scripts/test_seed_dev_friendships.py
@@ -1,0 +1,175 @@
+"""Unit tests for scripts/seed_dev_friendships.py
+
+SDF-01  _DEV_PAIRS is non-empty
+SDF-02  _DEV_PAIRS contains no duplicate pairs
+SDF-03  All _DEV_PAIRS emails follow lfa-adult-*.@lfa.com pattern
+SDF-04  DB: seed creates ACCEPTED friendships for existing user pairs
+SDF-05  DB: seed is idempotent — second call produces same count
+SDF-06  DB: seed skips gracefully when a user is not found
+SDF-07  DB: seed upgrades PENDING → ACCEPTED
+SDF-08  DB: seed replaces DECLINED with ACCEPTED
+SDF-09  summary dict keys: created, upgraded, skipped
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+
+# ── Data-definition tests (no DB) ────────────────────────────────────────────
+
+class TestDevPairsDefinition:
+
+    def setup_method(self):
+        from scripts.seed_dev_friendships import _DEV_PAIRS
+        self._pairs = _DEV_PAIRS
+
+    def test_sdf01_pairs_not_empty(self):
+        """SDF-01: _DEV_PAIRS is not empty."""
+        assert len(self._pairs) > 0
+
+    def test_sdf02_no_duplicate_pairs(self):
+        """SDF-02: No duplicate (a, b) pairs."""
+        normalised = {tuple(sorted(pair)) for pair in self._pairs}
+        assert len(normalised) == len(self._pairs)
+
+    def test_sdf03_all_emails_bootstrap_pattern(self):
+        """SDF-03: All emails follow lfa-adult-*@lfa.com (bootstrap-guaranteed)."""
+        for email_a, email_b in self._pairs:
+            assert email_a.startswith("lfa-adult-") and email_a.endswith("@lfa.com"), \
+                f"Email {email_a!r} is not a bootstrap adult player"
+            assert email_b.startswith("lfa-adult-") and email_b.endswith("@lfa.com"), \
+                f"Email {email_b!r} is not a bootstrap adult player"
+
+
+# ── DB logic tests ────────────────────────────────────────────────────────────
+# Use test-specific emails to avoid clashing with bootstrap data already in the real DB.
+
+_TEST_EMAIL_A = "test-frd-alpha@unit-test.lfa"
+_TEST_EMAIL_B = "test-frd-beta@unit-test.lfa"
+_TEST_PAIRS   = [(_TEST_EMAIL_A, _TEST_EMAIL_B)]
+
+
+def _wrap_no_close(test_db):
+    """Wrap test_db so .close() is a no-op (preserves SAVEPOINT isolation)."""
+    wrapper = MagicMock(wraps=test_db)
+    wrapper.close = MagicMock()
+    return wrapper
+
+
+def _create_user(test_db, email: str):
+    from app.models.user import User, UserRole
+    from app.core.security import get_password_hash
+    u = User(
+        name=email,
+        email=email,
+        password_hash=get_password_hash("Test#123"),
+        role=UserRole.STUDENT,
+        is_active=True,
+        onboarding_completed=True,
+    )
+    test_db.add(u)
+    test_db.flush()
+    return u
+
+
+def _run_seed(test_db, pairs=None):
+    patch_pairs = pairs if pairs is not None else _TEST_PAIRS
+    patch = __import__("unittest.mock", fromlist=["patch"]).patch
+    with patch("scripts.seed_dev_friendships.SessionLocal", return_value=_wrap_no_close(test_db)), \
+         patch("scripts.seed_dev_friendships._DEV_PAIRS", patch_pairs):
+        from scripts.seed_dev_friendships import seed_dev_friendships
+        return seed_dev_friendships()
+
+
+class TestSeedDevFriendshipsDB:
+
+    def test_sdf04_creates_accepted_friendships(self, test_db):
+        """SDF-04: Seed creates ACCEPTED friendships for known user pairs."""
+        from app.models.friendship import Friendship, FriendshipStatus
+
+        _create_user(test_db, _TEST_EMAIL_A)
+        _create_user(test_db, _TEST_EMAIL_B)
+
+        result = _run_seed(test_db)
+
+        accepted = test_db.query(Friendship).filter(
+            Friendship.status == FriendshipStatus.ACCEPTED
+        ).all()
+        assert len(accepted) >= 1
+        assert result["created"] >= 1
+
+    def test_sdf05_idempotent_second_call(self, test_db):
+        """SDF-05: Second call produces same friendship count — no duplicates."""
+        from app.models.friendship import Friendship
+
+        _create_user(test_db, _TEST_EMAIL_A)
+        _create_user(test_db, _TEST_EMAIL_B)
+
+        _run_seed(test_db)
+        count_after_first = test_db.query(Friendship).count()
+
+        result2 = _run_seed(test_db)
+        count_after_second = test_db.query(Friendship).count()
+
+        assert count_after_first == count_after_second
+        assert result2["created"] == 0
+        assert result2["skipped"] >= 1
+
+    def test_sdf06_skips_missing_user(self, test_db):
+        """SDF-06: Missing user → pair skipped without error (users not in DB)."""
+        # _TEST_PAIRS users are NOT created → all pairs skipped
+        result = _run_seed(test_db)
+
+        assert result["created"] == 0
+        assert result["skipped"] >= 1
+
+    def test_sdf07_upgrades_pending_to_accepted(self, test_db):
+        """SDF-07: Existing PENDING friendship → upgraded to ACCEPTED."""
+        from app.models.friendship import Friendship, FriendshipStatus
+
+        user_a = _create_user(test_db, _TEST_EMAIL_A)
+        user_b = _create_user(test_db, _TEST_EMAIL_B)
+
+        test_db.add(Friendship(
+            requester_id=user_a.id,
+            addressee_id=user_b.id,
+            status=FriendshipStatus.PENDING,
+        ))
+        test_db.flush()
+
+        result = _run_seed(test_db)
+
+        assert result["upgraded"] >= 1
+        row = test_db.query(Friendship).filter_by(
+            requester_id=user_a.id, addressee_id=user_b.id
+        ).first()
+        assert row.status == FriendshipStatus.ACCEPTED
+
+    def test_sdf08_replaces_declined_with_accepted(self, test_db):
+        """SDF-08: Existing DECLINED friendship → replaced with ACCEPTED."""
+        from app.models.friendship import Friendship, FriendshipStatus
+
+        user_a = _create_user(test_db, _TEST_EMAIL_A)
+        user_b = _create_user(test_db, _TEST_EMAIL_B)
+
+        test_db.add(Friendship(
+            requester_id=user_a.id,
+            addressee_id=user_b.id,
+            status=FriendshipStatus.DECLINED,
+        ))
+        test_db.flush()
+
+        result = _run_seed(test_db)
+
+        assert result["upgraded"] >= 1
+        row = test_db.query(Friendship).filter_by(
+            requester_id=user_a.id, addressee_id=user_b.id
+        ).first()
+        assert row.status == FriendshipStatus.ACCEPTED
+
+    def test_sdf09_summary_keys_present(self, test_db):
+        """SDF-09: Return dict contains created, upgraded, skipped."""
+        result = _run_seed(test_db)
+        assert "created" in result
+        assert "upgraded" in result
+        assert "skipped" in result

--- a/tests/unit/scripts/test_seed_virtual_training_games.py
+++ b/tests/unit/scripts/test_seed_virtual_training_games.py
@@ -1,0 +1,133 @@
+"""Unit tests for scripts/seed_virtual_training_games.py
+
+SVT-01  _GAMES defines exactly 12 game presets
+SVT-02  All game codes are unique in _GAMES
+SVT-03  memory_sequence is defined with is_active=True
+SVT-04  target_tracking is defined with is_active=True
+SVT-05  color_reaction is defined with is_active=True
+SVT-06  stroop_challenge is defined with is_active=False
+SVT-07  _UPDATE_FIELDS includes is_active (seed overrides admin toggles intentionally)
+SVT-08  _UPDATE_FIELDS includes config, name, skill_targets, base_xp, description
+SVT-09  All _CHALLENGE_COMPATIBLE codes exist in _GAMES and are active
+SVT-10  DB seed: first run inserts all 12 games
+SVT-11  DB seed: second run (idempotent) — count unchanged, no duplicates
+SVT-12  DB seed: idempotent UPDATE preserves existing row data with new values from _GAMES
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+
+# ── Data-definition tests (no DB) ────────────────────────────────────────────
+
+class TestSeedGameDefinitions:
+
+    def setup_method(self):
+        from scripts.seed_virtual_training_games import _GAMES, _UPDATE_FIELDS
+        self._games = _GAMES
+        self._update_fields = _UPDATE_FIELDS
+
+    def test_svt01_game_count(self):
+        """SVT-01: 12 game definitions in _GAMES."""
+        assert len(self._games) == 12
+
+    def test_svt02_codes_unique(self):
+        """SVT-02: All game codes are unique."""
+        codes = [g["code"] for g in self._games]
+        assert len(codes) == len(set(codes))
+
+    def test_svt03_memory_sequence_active(self):
+        """SVT-03: memory_sequence is_active=True."""
+        game = next(g for g in self._games if g["code"] == "memory_sequence")
+        assert game["is_active"] is True
+
+    def test_svt04_target_tracking_active(self):
+        """SVT-04: target_tracking is_active=True."""
+        game = next(g for g in self._games if g["code"] == "target_tracking")
+        assert game["is_active"] is True
+
+    def test_svt05_color_reaction_active(self):
+        """SVT-05: color_reaction is_active=True."""
+        game = next(g for g in self._games if g["code"] == "color_reaction")
+        assert game["is_active"] is True
+
+    def test_svt06_stroop_inactive(self):
+        """SVT-06: stroop_challenge is_active=False."""
+        game = next(g for g in self._games if g["code"] == "stroop_challenge")
+        assert game["is_active"] is False
+
+    def test_svt07_update_fields_includes_is_active(self):
+        """SVT-07: _UPDATE_FIELDS includes is_active."""
+        assert "is_active" in self._update_fields
+
+    def test_svt08_update_fields_complete(self):
+        """SVT-08: _UPDATE_FIELDS covers all mutable fields."""
+        for field in ("config", "name", "skill_targets", "base_xp", "description"):
+            assert field in self._update_fields, f"Missing field in _UPDATE_FIELDS: {field}"
+
+    def test_svt09_challenge_compatible_games_all_active(self):
+        """SVT-09: CHALLENGE_COMPATIBLE_GAMES codes exist in _GAMES and are active."""
+        from app.models.vt_challenge import CHALLENGE_COMPATIBLE_GAMES
+        game_map = {g["code"]: g for g in self._games}
+        for code in CHALLENGE_COMPATIBLE_GAMES:
+            assert code in game_map, f"Challenge-compatible game '{code}' missing from _GAMES"
+            assert game_map[code]["is_active"] is True, f"Game '{code}' must be active"
+
+
+# ── DB logic tests (test_db fixture + mocked SessionLocal) ───────────────────
+
+def _wrap_no_close(test_db):
+    """Wrap test_db so .close() is a no-op (preserves SAVEPOINT isolation)."""
+    wrapper = MagicMock(wraps=test_db)
+    wrapper.close = MagicMock()
+    return wrapper
+
+
+class TestSeedVTGamesDB:
+
+    def _run_seed(self, db_wrapper):
+        with __import__("unittest.mock", fromlist=["patch"]).patch(
+            "scripts.seed_virtual_training_games.SessionLocal",
+            return_value=db_wrapper,
+        ):
+            from scripts.seed_virtual_training_games import seed_virtual_training_games
+            seed_virtual_training_games()
+
+    def test_svt10_first_run_inserts_all_games(self, test_db):
+        """SVT-10: First seed inserts all 12 game rows."""
+        from app.models.virtual_training import VirtualTrainingGame
+        from scripts.seed_virtual_training_games import _GAMES
+
+        self._run_seed(_wrap_no_close(test_db))
+
+        count = test_db.query(VirtualTrainingGame).count()
+        assert count == len(_GAMES)
+
+    def test_svt11_second_run_idempotent(self, test_db):
+        """SVT-11: Second seed call produces same count, no duplicates."""
+        from app.models.virtual_training import VirtualTrainingGame
+
+        self._run_seed(_wrap_no_close(test_db))
+        count_after_first = test_db.query(VirtualTrainingGame).count()
+
+        self._run_seed(_wrap_no_close(test_db))
+        count_after_second = test_db.query(VirtualTrainingGame).count()
+
+        assert count_after_first == count_after_second
+
+    def test_svt12_seed_updates_existing_name(self, test_db):
+        """SVT-12: Re-running seed overwrites name field of existing rows."""
+        from app.models.virtual_training import VirtualTrainingGame
+
+        # First seed
+        self._run_seed(_wrap_no_close(test_db))
+
+        # Manually corrupt the name
+        game = test_db.query(VirtualTrainingGame).filter_by(code="memory_sequence").first()
+        game.name = "CORRUPTED_NAME"
+        test_db.flush()
+
+        # Second seed — should restore correct name
+        self._run_seed(_wrap_no_close(test_db))
+        game = test_db.query(VirtualTrainingGame).filter_by(code="memory_sequence").first()
+        assert game.name != "CORRUPTED_NAME"

--- a/tests/unit/scripts/test_validate_seed_state.py
+++ b/tests/unit/scripts/test_validate_seed_state.py
@@ -1,0 +1,120 @@
+"""Unit tests for scripts/validate_seed_state.py — VT reference data check
+
+VSS-01  validate fails (exit 1) when virtual_training_games is empty
+VSS-02  validate fails (exit 1) when no challenge-compatible games are active
+VSS-03  validate passes when memory_sequence + target_tracking are active
+
+Note: validate_seed_state.run() calls sys.exit(). Tests capture SystemExit.
+These tests patch the DB query to isolate the VT check logic.
+"""
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_db_with_counts(**table_counts):
+    """
+    Build a mock db where db.query(Model).count() or .all() returns preset values.
+    table_counts keys are model class names (str).
+    """
+    db = MagicMock()
+
+    def query_side_effect(model):
+        name = getattr(model, "__name__", str(model))
+        q = MagicMock()
+        q.count.return_value = table_counts.get(name, 0)
+        q.all.return_value = table_counts.get(name + "__all", [])
+        filtered = MagicMock()
+        filtered.count.return_value = table_counts.get(name + "__filtered", 0)
+        filtered.all.return_value = table_counts.get(name + "__filtered_all", [])
+        q.filter.return_value = filtered
+        return q
+
+    db.query.side_effect = query_side_effect
+    return db
+
+
+class TestValidateSeedStateVTCheck:
+    """Patch SessionLocal to inject controlled DB state."""
+
+    def _run(self, db_mock):
+        with patch("scripts.validate_seed_state.SessionLocal", return_value=db_mock):
+            from importlib import reload
+            import scripts.validate_seed_state as _mod
+            reload(_mod)
+            return _mod.run
+
+    def test_vss01_fails_when_vt_empty(self, test_db):
+        """VSS-01: validate exits 1 when virtual_training_games has 0 active rows.
+
+        bootstrap_clean Step 8 seeds VT games, so we delete them first to
+        create the "empty VT" scenario this test is designed to verify.
+        """
+        from app.models.virtual_training import VirtualTrainingGame
+        from scripts.validate_seed_state import run as validate_run
+
+        # Clear the VT games that bootstrap seeded
+        test_db.query(VirtualTrainingGame).delete()
+        test_db.flush()
+
+        with patch("scripts.validate_seed_state.SessionLocal", return_value=test_db):
+            with pytest.raises(SystemExit) as exc:
+                validate_run()
+        assert exc.value.code != 0
+
+    def test_vss02_fails_when_no_compat_games_active(self, test_db):
+        """VSS-02: validate exits 1 when VT games exist but none are challenge-compatible.
+
+        Delete all bootstrap VT games, then insert only a non-compatible game
+        so the challenge-compatible count stays at 0.
+        """
+        from app.models.virtual_training import VirtualTrainingGame
+
+        # Remove bootstrap VT games, then insert only a non-compat one
+        test_db.query(VirtualTrainingGame).delete()
+        test_db.flush()
+        test_db.add(VirtualTrainingGame(
+            code="color_reaction",
+            name="Color Reaction",
+            game_type="reaction_time",
+            is_active=True,
+            base_xp=20,
+            max_daily_attempts=5,
+            skill_targets={},
+            config={},
+        ))
+        test_db.flush()
+
+        # memory_sequence and target_tracking absent → compat count = 0
+        with patch("scripts.validate_seed_state.SessionLocal", return_value=test_db):
+            with pytest.raises(SystemExit) as exc:
+                from importlib import reload
+                import scripts.validate_seed_state as _mod
+                _mod.run()
+        assert exc.value.code != 0
+
+    def test_vss03_vt_check_logic_passes_with_compat_games(self, test_db):
+        """VSS-03: VT check logic passes when memory_sequence + target_tracking are active.
+
+        bootstrap_clean Step 8 already seeds all 12 games (including both
+        challenge-compatible ones), so we just verify the filter directly.
+        """
+        from app.models.virtual_training import VirtualTrainingGame
+
+        _CHALLENGE_COMPAT = {"memory_sequence", "target_tracking"}
+
+        # Games are already present from bootstrap — no inserts needed
+        vt_active_games = (
+            test_db.query(VirtualTrainingGame)
+            .filter(VirtualTrainingGame.is_active == True)  # noqa: E712
+            .all()
+        )
+        vt_compat_count = sum(1 for g in vt_active_games if g.code in _CHALLENGE_COMPAT)
+
+        assert len(vt_active_games) >= 1, "Expected at least 1 active VT game"
+        assert vt_compat_count >= 2, (
+            f"Expected 2 challenge-compatible games, got {vt_compat_count}"
+        )


### PR DESCRIPTION
## Summary

- `bootstrap_clean.py`: Step 8 seeds 12 VT games (6 active) — prevents VT routes failing after DB reset
- `reset_and_bootstrap.py`: hard-fail (sys.exit 1) if VT table empty after reset
- `app/core/startup_checks.py`: WARNING on empty/missing challenge-compatible VT games at startup
- `app/main.py`: lifespan calls `check_reference_data_integrity()` on startup
- `training_hub.html`: `{% if vt_active %}` gate + empty-state div — VT section never silently disappears
- `scripts/seed_dev_friendships.py`: idempotent ACCEPTED friendship seed for 4 LFA Adult pairs

## Merge order

**PR-A0 → main first**, then PR-A bases on main.

## Test plan

- [ ] `pytest` passes (unit tests)
- [ ] API Smoke Tests green
- [ ] `bootstrap_clean.py` runs without error; VT games seeded
- [ ] `reset_and_bootstrap.py` fails cleanly if VT table empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)