### PR TITLE
feat(nav): LFA navigation UX + Spec Dashboard MVP

### DIFF
--- a/app/api/web_routes/dashboard.py
+++ b/app/api/web_routes/dashboard.py
@@ -729,6 +729,11 @@ async def spec_dashboard(
             "social_pending_friends": social_pending_friends,
             "social_pending_challenges": social_pending_challenges,
             "social_active_challenges": social_active_challenges,
+            # Explicit LFA spec context for spec_subpage_hdr.html quicknav
+            "spec_dashboard_url": "/dashboard/lfa-football-player",
+            "spec_dashboard_icon": "⚽",
+            "spec_profile_url": "/profile/lfa-football-player",
+            "spec_profile_icon": "🪪",
         }
     )
 

--- a/app/api/web_routes/dashboard.py
+++ b/app/api/web_routes/dashboard.py
@@ -30,6 +30,7 @@ from ...models.audit_log import AuditLog
 from ...models.coupon import Coupon
 from ...utils.age_requirements import get_available_specializations
 from .helpers import get_lfa_age_category
+from ...services.skill_progression import get_all_skill_keys
 
 # Setup templates
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
@@ -694,6 +695,12 @@ async def spec_dashboard(
             if card_draft else False
         )
 
+    skill_count = len(get_all_skill_keys())
+    has_welcome_card = bool(
+        user_license.onboarding_completed
+        or user_license.football_skills is not None
+    )
+
     return templates.TemplateResponse(
         "dashboard_student_new.html",
         {
@@ -734,6 +741,9 @@ async def spec_dashboard(
             "spec_dashboard_icon": "⚽",
             "spec_profile_url": "/profile/lfa-football-player",
             "spec_profile_icon": "🪪",
+            # MVP dashboard context
+            "skill_count": skill_count,
+            "has_welcome_card": has_welcome_card,
         }
     )
 

--- a/app/api/web_routes/my_cards.py
+++ b/app/api/web_routes/my_cards.py
@@ -44,6 +44,12 @@ async def my_cards_hub(
             "request": request,
             "user": user,
             "card_specs": card_specs,
+            # Explicit LFA spec context — do not rely on user.specialization fallback,
+            # which breaks on multi-spec accounts where the active spec != LFA_FOOTBALL_PLAYER.
+            "spec_dashboard_url": "/dashboard/lfa-football-player",
+            "spec_dashboard_icon": "⚽",
+            "spec_profile_url": "/profile/lfa-football-player",
+            "spec_profile_icon": "🪪",
         },
     )
 

--- a/app/templates/dashboard_card_editor.html
+++ b/app/templates/dashboard_card_editor.html
@@ -2,25 +2,18 @@
 
 {% block title %}My Player Card — LFA{% endblock %}
 
-{# ── Spec header: utility bar only — mirrors /dashboard/lfa-football-player ── #}
+{# ── Studio header — minimal, spec-pg-hdr aligned, no quicknav ── #}
 {% block student_header %}
 <div class="student-header spec-pg-hdr">
     <div class="student-header-inner">
-        <a href="/dashboard" class="s-hdr-btn" title="Back to Hub">🏠</a>
-        <div class="student-brand">⚽ LFA Football Player</div>
+        <a href="/dashboard" class="s-hdr-btn" title="Hub">🏠</a>
+        <a href="/dashboard/lfa-football-player" class="s-hdr-btn" title="LFA Dashboard">⚽</a>
+        <div class="student-brand">🎴 My Player Card</div>
         <div class="student-header-actions">
             <span class="credit-pill">💰 {{ user.credit_balance if user else 0 }}</span>
             <a href="/credits" class="s-hdr-btn" title="Credits">💳</a>
-            <div class="badge-wrap">
-                <a href="/messages" class="s-hdr-btn" title="Messages" aria-label="Messages">✉️</a>
-                <span class="badge-dot" id="hdr-msg-badge">0</span>
-            </div>
-            <div class="badge-wrap">
-                <a href="/notifications" class="s-hdr-btn" title="Notifications" aria-label="Notifications">🔔</a>
-                <span class="badge-dot" id="hdr-notif-badge">0</span>
-            </div>
             <a href="/my-cards" class="s-hdr-btn" title="My Cards">🃏</a>
-            <a href="/logout"  class="s-hdr-btn" title="Logout">🚪</a>
+            <a href="/logout"   class="s-hdr-btn" title="Logout">🚪</a>
         </div>
     </div>
 </div>

--- a/app/templates/dashboard_card_editor.html
+++ b/app/templates/dashboard_card_editor.html
@@ -19,7 +19,7 @@
                 <a href="/notifications" class="s-hdr-btn" title="Notifications" aria-label="Notifications">🔔</a>
                 <span class="badge-dot" id="hdr-notif-badge">0</span>
             </div>
-            <a href="/profile/lfa-football-player" class="s-hdr-btn" title="Profile">🪪</a>
+            <a href="/my-cards" class="s-hdr-btn" title="My Cards">🃏</a>
             <a href="/logout"  class="s-hdr-btn" title="Logout">🚪</a>
         </div>
     </div>

--- a/app/templates/dashboard_student_new.html
+++ b/app/templates/dashboard_student_new.html
@@ -95,6 +95,14 @@
         box-shadow: 0 4px 12px rgba(0,0,0,0.08);
         margin-bottom: 1.5rem;
     }
+    .mod-nav-section-label {
+        font-size: 0.72rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: var(--app-text-muted);
+        margin: 0 0 0.6rem 0.25rem;
+    }
 
     /* ── Player Card live preview (compact thumbnail) ────────────────────────── */
     .player-card-embed-wrap { border-radius: 12px; overflow: hidden; box-shadow: 0 4px 24px rgba(0,0,0,0.13); max-height: 240px; }
@@ -246,6 +254,7 @@
     {# 2×3 grid: 6 primary domains                                                  #}
     {# Sessions / Progress / Skills accessible via footer + cross-links             #}
     <section class="mod-nav-section">
+        <p class="mod-nav-section-label">Tools &amp; Quick Access</p>
         <div class="mod-nav-grid">
             {# Row 1 #}
             <a href="/events" class="mod-nav-card">

--- a/app/templates/dashboard_student_new.html
+++ b/app/templates/dashboard_student_new.html
@@ -2,31 +2,10 @@
 
 {% block title %}{{ spec_config.name }} Dashboard - LFA{% endblock %}
 
-{# ── Spec header: utility bar only — navbar = global actions, mod-nav cards = feature nav ── #}
 {% block student_header %}
-<div class="student-header spec-pg-hdr">
-    <div class="student-header-inner">
-        <a href="/dashboard" class="s-hdr-btn" title="Back to Hub">🏠</a>
-        <div class="student-brand">{{ spec_config.icon }} {{ spec_config.name }}</div>
-        <nav class="student-nav" id="student-nav" aria-label="Student navigation">
-            <a href="/dashboard/lfa-football-player" class="nav-item active">⚽ LFA Player</a>
-        </nav>
-        <div class="student-header-actions">
-            <span class="credit-pill">💰 {{ user.credit_balance if user else 0 }}</span>
-            <a href="/credits" class="s-hdr-btn" title="Credits">💳</a>
-            <div class="badge-wrap">
-                <a href="/messages" class="s-hdr-btn" title="Messages" aria-label="Messages">✉️</a>
-                <span class="badge-dot" id="hdr-msg-badge">0</span>
-            </div>
-            <div class="badge-wrap">
-                <a href="/notifications" class="s-hdr-btn" title="Notifications" aria-label="Notifications">🔔</a>
-                <span class="badge-dot" id="hdr-notif-badge">0</span>
-            </div>
-            <a href="{% if specialization == 'LFA_FOOTBALL_PLAYER' %}/profile/lfa-football-player{% else %}/profile{% endif %}" class="s-hdr-btn" title="Profile">{% if specialization == 'LFA_FOOTBALL_PLAYER' %}🪪{% else %}👤{% endif %}</a>
-            <a href="/logout"  class="s-hdr-btn" title="Logout">🚪</a>
-        </div>
-    </div>
-</div>
+{% set _page_icon = '⚽' %}
+{% set _page_name = 'LFA Football Player' %}
+{% include "includes/spec_subpage_hdr.html" %}
 {% endblock %}
 
 {% block extra_styles %}

--- a/app/templates/dashboard_student_new.html
+++ b/app/templates/dashboard_student_new.html
@@ -429,7 +429,7 @@
         <a href="/progress">📊 Progress</a>
         <a href="/skills">⚡ Skills</a>
         <a href="/credits">💳 Credits</a>
-        <a href="/profile">👤 Profile</a>
+        <a href="/profile/lfa-football-player">👤 Profile</a>
     </div>
 
 </div>

--- a/app/templates/dashboard_student_new.html
+++ b/app/templates/dashboard_student_new.html
@@ -22,22 +22,25 @@
         padding: 0 0 2rem;
     }
 
-    /* ── Top Card Preview Zone ──────────────────────────────────────────────── */
+    /* ── Top Card Preview Zone — 3 equal tiles, fixed row height ───────────── */
     .dc-card-zone {
         display: grid;
-        grid-template-columns: 1.6fr 1fr 1fr;
+        grid-template-columns: repeat(3, 1fr);
+        grid-auto-rows: 300px;
         gap: 1rem;
         margin-bottom: 1.5rem;
-        align-items: start;
+        align-items: stretch;
     }
     .dc-hero {
         background: #0f172a;
         border-radius: 16px;
-        padding: 1.25rem 1.5rem 1.5rem;
+        padding: 1.25rem 1.5rem 1.4rem;
         display: flex;
         flex-direction: column;
-        gap: 0.75rem;
-        min-height: 200px;
+        gap: 0.6rem;
+        height: 100%;
+        overflow: hidden;
+        box-sizing: border-box;
     }
     .dc-hero-label {
         font-size: 0.72rem;
@@ -46,15 +49,18 @@
         letter-spacing: 0.1em;
         color: rgba(255,255,255,0.45);
         margin: 0;
+        flex-shrink: 0;
     }
 
-    /* Player Card hero */
+    /* Player Card hero — thumbnail preview, not full-height iframe */
     .dc-hero-player { border-top: 3px solid #FFD200; }
     .dc-player-wrap {
-        border-radius: 10px;
+        height: 160px;          /* fixed thumbnail — CSS controls, not JS */
+        border-radius: 8px;
         overflow: hidden;
-        box-shadow: 0 4px 24px rgba(0,0,0,0.35);
-        flex: 1;
+        flex-shrink: 0;
+        box-shadow: 0 2px 16px rgba(0,0,0,0.4);
+        background: #1e293b;    /* placeholder colour while iframe loads */
     }
     .dc-player-wrap iframe { display: block; border: none; }
     .dc-cta-primary {
@@ -71,6 +77,7 @@
         align-self: flex-start;
     }
     .dc-cta-primary:hover { opacity: 0.85; }
+    .dc-ctas { display: flex; gap: 0.5rem; flex-wrap: wrap; flex-shrink: 0; margin-top: auto; }
     .dc-cta-ghost {
         display: inline-block;
         background: rgba(255,255,255,0.08);
@@ -86,16 +93,16 @@
         align-self: flex-start;
     }
     .dc-cta-ghost:hover { background: rgba(255,255,255,0.14); }
-    .dc-ctas { display: flex; gap: 0.5rem; flex-wrap: wrap; }
 
     /* Welcome Card hero */
     .dc-hero-welcome { border-top: 3px solid #818cf8; }
     .dc-welcome-status {
-        flex: 1;
+        flex: 1;                /* fills space between label and CTA */
         display: flex;
         flex-direction: column;
-        justify-content: center;
-        gap: 0.5rem;
+        justify-content: flex-end;
+        gap: 0.45rem;
+        padding-bottom: 0.25rem;
     }
     .dc-wc-title { font-size: 1rem; font-weight: 800; color: #fff; }
     .dc-wc-sub { font-size: 0.82rem; color: rgba(255,255,255,0.5); }
@@ -116,16 +123,20 @@
         flex: 1;
         display: flex;
         flex-direction: column;
-        justify-content: center;
-        gap: 0.5rem;
+        justify-content: flex-end;
+        gap: 0.3rem;
+        padding-bottom: 0.25rem;
     }
-    .dc-chall-count { font-size: 2rem; font-weight: 800; color: #f87171; line-height: 1; }
+    .dc-chall-count { font-size: 2.4rem; font-weight: 800; color: #f87171; line-height: 1; }
     .dc-chall-lbl { font-size: 0.82rem; color: rgba(255,255,255,0.5); }
 
     /* ── Responsive: stack card zone on mobile ──────────────────────────────── */
     @media (max-width: 768px) {
-        .dc-card-zone { grid-template-columns: 1fr; }
-        .dc-hero { min-height: unset; }
+        .dc-card-zone {
+            grid-template-columns: 1fr;
+            grid-auto-rows: unset;
+        }
+        .dc-hero { height: auto; overflow: visible; }
         .s-kpi-row { grid-template-columns: repeat(2, 1fr); }
         .container { padding: 1rem; }
         .mod-nav-section { padding: 1rem 1rem 0.25rem; }
@@ -158,31 +169,36 @@
     .s-kpi-row .s-kpi-card:nth-child(4) .s-kpi-val { color: #2b6cb0; }
     .s-kpi-lbl { font-size: 0.82rem; color: var(--app-text-muted); margin-top: 0.25rem; }
 
-    /* ── Section block ───────────────────────────────────────────────────────── */
+    /* ── Section block — premium card treatment ─────────────────────────────── */
     .section-block {
         background: var(--app-card);
         border-radius: 16px;
-        padding: 1.75rem 2rem;
-        box-shadow: 0 4px 12px rgba(0,0,0,0.08);
-        margin-bottom: 1.5rem;
+        padding: 1.5rem 1.75rem;
+        box-shadow: 0 2px 8px rgba(0,0,0,0.06), 0 0 0 1px rgba(0,0,0,0.04);
+        margin-bottom: 1.25rem;
+        border-top: 2px solid var(--app-border);
     }
-    .section-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1.25rem; }
+    .section-block.dc-social-block   { border-top-color: #22d3ee; }
+    .section-block.dc-pp-block       { border-top-color: #818cf8; }
+    .section-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem; }
+    .section-title { font-size: 0.85rem; font-weight: 800; text-transform: uppercase; letter-spacing: 0.06em; color: var(--app-text-muted); }
 
-    /* ── Standalone mod-nav section ──────────────────────────────────────────── */
+    /* ── Quick Access mod-nav section ───────────────────────────────────────── */
     .mod-nav-section {
         background: var(--app-card);
         border-radius: 16px;
-        padding: 1.1rem 1.1rem 0.6rem;
-        box-shadow: 0 4px 12px rgba(0,0,0,0.08);
-        margin-bottom: 1.5rem;
+        padding: 1rem 1rem 0.75rem;
+        box-shadow: 0 2px 8px rgba(0,0,0,0.06), 0 0 0 1px rgba(0,0,0,0.04);
+        margin-bottom: 1.25rem;
+        border-top: 2px solid #FFD200;
     }
     .mod-nav-section-label {
         font-size: 0.72rem;
-        font-weight: 700;
+        font-weight: 800;
         text-transform: uppercase;
         letter-spacing: 0.1em;
         color: var(--app-text-muted);
-        margin: 0 0 0.6rem 0.25rem;
+        margin: 0 0 0.75rem 0.25rem;
     }
 
     /* ── Public Profile entry point ──────────────────────────────────────────── */
@@ -202,12 +218,21 @@
     .s-pp-btn-edit { background: #0B0B0B; color: #FFD200; }
 
     /* ── Social section ──────────────────────────────────────────────────────── */
-    .mod-social-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1rem; }
-    .mod-social-card { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 0.4rem; background: var(--app-card-alt); border-radius: 12px; padding: 1.2rem 0.75rem; text-decoration: none; color: var(--app-text); position: relative; transition: box-shadow 0.2s, transform 0.2s; border: 1px solid var(--app-border); }
-    .mod-social-card:hover { box-shadow: 0 4px 16px rgba(0,0,0,0.1); transform: translateY(-2px); }
-    .mod-social-icon  { font-size: 1.6rem; line-height: 1; }
-    .mod-social-title { font-size: 0.82rem; font-weight: 700; color: var(--app-text-muted); }
-    .mod-social-badge { position: absolute; top: 0.5rem; right: 0.5rem; background: #ef4444; color: white; border-radius: 999px; font-size: 0.7rem; font-weight: 700; padding: 0.1rem 0.45rem; line-height: 1.4; }
+    .mod-social-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 0.75rem; }
+    .mod-social-card {
+        display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 0.35rem;
+        background: #0f172a; border-radius: 12px; padding: 1.25rem 0.75rem;
+        text-decoration: none; color: #fff; position: relative;
+        transition: box-shadow 0.2s, transform 0.2s;
+        border-top: 2px solid rgba(255,255,255,0.1);
+    }
+    .mod-social-card:nth-child(1) { border-top-color: #22d3ee; }
+    .mod-social-card:nth-child(2) { border-top-color: #f87171; }
+    .mod-social-card:nth-child(3) { border-top-color: #fb923c; }
+    .mod-social-card:hover { box-shadow: 0 4px 20px rgba(0,0,0,0.25); transform: translateY(-2px); }
+    .mod-social-icon  { font-size: 1.5rem; line-height: 1; }
+    .mod-social-title { font-size: 0.78rem; font-weight: 700; color: rgba(255,255,255,0.6); }
+    .mod-social-badge { position: absolute; top: 0.45rem; right: 0.45rem; background: #ef4444; color: white; border-radius: 999px; font-size: 0.68rem; font-weight: 700; padding: 0.1rem 0.4rem; line-height: 1.4; }
     @media (max-width: 480px) {
         .mod-social-grid { grid-template-columns: 1fr; }
         .s-kpi-row { grid-template-columns: 1fr 1fr; }
@@ -288,9 +313,9 @@
     {% endif %}
 
     {# ── 2. Social ─────────────────────────────────────────────────────────────── #}
-    <section class="section-block">
+    <section class="section-block dc-social-block">
         <div class="section-header">
-            <span class="section-title" style="font-weight:800;font-size:1rem;">Social</span>
+            <span class="section-title">Social</span>
         </div>
         <div class="mod-social-grid">
             <a href="/friends" class="mod-social-card">
@@ -316,9 +341,9 @@
 
     {# ── 3. Public Profile entry point (LFA_FOOTBALL_PLAYER only) ─────────────── #}
     {% if specialization == "LFA_FOOTBALL_PLAYER" %}
-    <section class="section-block">
+    <section class="section-block dc-pp-block">
         <div class="section-header">
-            <span class="section-title" style="font-weight:800;font-size:1rem;">Public Profile</span>
+            <span class="section-title">Public Profile</span>
         </div>
         <div class="s-pp-section">
             <div class="s-pp-info">
@@ -394,7 +419,8 @@
 (function () {
     'use strict';
 
-    // ── Player Card iframe scale ──────────────────────────────────────────────
+    // ── Player Card thumbnail scale — CSS controls wrapper height (160px) ────
+    // JS only sets iframe intrinsic size + scale-to-fit; never touches wrap height.
     (function () {
         var _CANVAS = {
             instagram_square:   [1080, 1080],
@@ -414,8 +440,8 @@
             var wrap   = document.getElementById('dc-player-wrap');
             if (!iframe || !wrap) return;
             var cw = dims[0], ch = dims[1];
-            var availW   = wrap.clientWidth || 640;
-            var maxH     = window.innerWidth < 700 ? 160 : 240;
+            var availW   = wrap.clientWidth || 300;
+            var maxH     = 160;           /* matches .dc-player-wrap CSS height */
             var scaleByW = availW / cw;
             var scaleByH = maxH / ch;
             var scale    = Math.min(scaleByW, scaleByH);
@@ -423,7 +449,7 @@
             iframe.style.height          = ch + 'px';
             iframe.style.transform       = 'scale(' + scale + ')';
             iframe.style.transformOrigin = 'top left';
-            wrap.style.height            = Math.round(ch * scale) + 'px';
+            /* wrap height is CSS-controlled — do NOT set wrap.style.height */
         });
     })();
 

--- a/app/templates/dashboard_student_new.html
+++ b/app/templates/dashboard_student_new.html
@@ -2,6 +2,9 @@
 
 {% block title %}{{ spec_config.name }} Dashboard - LFA{% endblock %}
 
+{# Platform for Player Card preview — root-level so accessible in both student_content and scripts blocks #}
+{% set _prev = active_card_platform if (active_card_platform and active_card_platform != 'default') else 'instagram_portrait' %}
+
 {% block student_header %}
 {% set _page_icon = '⚽' %}
 {% set _page_name = 'LFA Football Player' %}
@@ -10,29 +13,123 @@
 
 {% block extra_styles %}
 <style>
-    /* spec-pg-hdr + mod-nav-* → student.css v5 */
-
-    /* ── Spec dashboard: 3-column module nav grid (2×3 — 6 primary domains) */
-    .mod-nav-grid { grid-template-columns: repeat(3, 1fr); }
-    @media (max-width: 768px) { .mod-nav-grid { grid-template-columns: repeat(3, 1fr); } }
-    @media (max-width: 480px) { .mod-nav-grid { grid-template-columns: repeat(3, 1fr); } }
-
-    /* ── Width overrides: break out of global max-width chain ───────────────── */
+    /* ── Width overrides ─────────────────────────────────────────────────────── */
     .main-content  { max-width: none; padding: 0; }
     .student-main  { max-width: 1440px; padding: 0.75rem 1.5rem 1.5rem; }
-
-    /* ── Container ────────────────────────────────────────────────────────────── */
     .container {
         max-width: 1400px;
         margin: 0 auto;
         padding: 0 0 2rem;
     }
 
-    .page-title    { font-size: 1.4rem; color: var(--app-text); margin: 0; }
-    .page-subtitle { color: var(--app-text-muted); font-size: 0.95rem; margin-bottom: 1.5rem; }
+    /* ── Top Card Preview Zone ──────────────────────────────────────────────── */
+    .dc-card-zone {
+        display: grid;
+        grid-template-columns: 1.6fr 1fr 1fr;
+        gap: 1rem;
+        margin-bottom: 1.5rem;
+        align-items: start;
+    }
+    .dc-hero {
+        background: #0f172a;
+        border-radius: 16px;
+        padding: 1.25rem 1.5rem 1.5rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        min-height: 200px;
+    }
+    .dc-hero-label {
+        font-size: 0.72rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: rgba(255,255,255,0.45);
+        margin: 0;
+    }
 
-    .info-banner { background: #e6f7ff; border-left: 4px solid #1890ff; padding: 1rem 1.5rem; border-radius: 8px; margin-bottom: 2rem; }
-    .info-banner p { color: #0050b3; margin: 0; }
+    /* Player Card hero */
+    .dc-hero-player { border-top: 3px solid #FFD200; }
+    .dc-player-wrap {
+        border-radius: 10px;
+        overflow: hidden;
+        box-shadow: 0 4px 24px rgba(0,0,0,0.35);
+        flex: 1;
+    }
+    .dc-player-wrap iframe { display: block; border: none; }
+    .dc-cta-primary {
+        display: inline-block;
+        background: #FFD200;
+        color: #0B0B0B;
+        font-weight: 700;
+        font-size: 0.82rem;
+        padding: 0.45rem 1.1rem;
+        border-radius: 8px;
+        text-decoration: none;
+        text-align: center;
+        transition: opacity 0.18s;
+        align-self: flex-start;
+    }
+    .dc-cta-primary:hover { opacity: 0.85; }
+    .dc-cta-ghost {
+        display: inline-block;
+        background: rgba(255,255,255,0.08);
+        color: rgba(255,255,255,0.75);
+        font-weight: 600;
+        font-size: 0.82rem;
+        padding: 0.45rem 1.1rem;
+        border-radius: 8px;
+        text-decoration: none;
+        text-align: center;
+        border: 1px solid rgba(255,255,255,0.15);
+        transition: background 0.18s;
+        align-self: flex-start;
+    }
+    .dc-cta-ghost:hover { background: rgba(255,255,255,0.14); }
+    .dc-ctas { display: flex; gap: 0.5rem; flex-wrap: wrap; }
+
+    /* Welcome Card hero */
+    .dc-hero-welcome { border-top: 3px solid #818cf8; }
+    .dc-welcome-status {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        gap: 0.5rem;
+    }
+    .dc-wc-title { font-size: 1rem; font-weight: 800; color: #fff; }
+    .dc-wc-sub { font-size: 0.82rem; color: rgba(255,255,255,0.5); }
+    .dc-wc-chip {
+        display: inline-block;
+        font-size: 0.75rem;
+        font-weight: 700;
+        padding: 0.2rem 0.65rem;
+        border-radius: 20px;
+        align-self: flex-start;
+    }
+    .dc-wc-chip-ready { background: rgba(129,140,248,0.2); color: #818cf8; border: 1px solid rgba(129,140,248,0.3); }
+    .dc-wc-chip-empty { background: rgba(255,255,255,0.07); color: rgba(255,255,255,0.45); border: 1px solid rgba(255,255,255,0.12); }
+
+    /* Challenge Card hero */
+    .dc-hero-chall { border-top: 3px solid #f87171; }
+    .dc-chall-status {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        gap: 0.5rem;
+    }
+    .dc-chall-count { font-size: 2rem; font-weight: 800; color: #f87171; line-height: 1; }
+    .dc-chall-lbl { font-size: 0.82rem; color: rgba(255,255,255,0.5); }
+
+    /* ── Responsive: stack card zone on mobile ──────────────────────────────── */
+    @media (max-width: 768px) {
+        .dc-card-zone { grid-template-columns: 1fr; }
+        .dc-hero { min-height: unset; }
+        .s-kpi-row { grid-template-columns: repeat(2, 1fr); }
+        .container { padding: 1rem; }
+        .mod-nav-section { padding: 1rem 1rem 0.25rem; }
+    }
 
     /* ── KPI Row ─────────────────────────────────────────────────────────────── */
     .s-kpi-row {
@@ -41,7 +138,6 @@
         gap: 1rem;
         margin-bottom: 1.5rem;
     }
-
     .s-kpi-card {
         background: var(--app-card);
         border-radius: 8px;
@@ -51,12 +147,10 @@
         transition: box-shadow 0.2s, transform 0.2s;
     }
     .s-kpi-card:hover { box-shadow: 0 6px 20px rgba(0,0,0,0.12); transform: translateY(-2px); }
-
     .s-kpi-row .s-kpi-card:nth-child(1) { border-top-color: #48bb78; }
     .s-kpi-row .s-kpi-card:nth-child(2) { border-top-color: #9b59b6; }
     .s-kpi-row .s-kpi-card:nth-child(3) { border-top-color: #f59e0b; }
     .s-kpi-row .s-kpi-card:nth-child(4) { border-top-color: #4299e1; }
-
     .s-kpi-val { font-size: 2rem; font-weight: 700; color: var(--app-text); line-height: 1.1; }
     .s-kpi-row .s-kpi-card:nth-child(1) .s-kpi-val { color: #276749; }
     .s-kpi-row .s-kpi-card:nth-child(2) .s-kpi-val { color: #553c9a; }
@@ -73,19 +167,6 @@
         margin-bottom: 1.5rem;
     }
     .section-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1.25rem; }
-    .section-link { color: #667eea; font-size: 0.88rem; text-decoration: none; font-weight: 600; white-space: nowrap; }
-    .section-link:hover { text-decoration: underline; }
-
-    /* ── Skill Snapshot (fallback, no LFA license) ───────────────────────────── */
-    .s-snapshot-row { display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.65rem; }
-    .s-snap-label   { width: 130px; font-size: 0.85rem; color: var(--app-text-muted); text-transform: capitalize; flex-shrink: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-    .s-snap-bar-wrap { flex: 1; height: 10px; background: var(--app-border); border-radius: 5px; overflow: hidden; }
-    .s-snap-bar     { height: 100%; border-radius: 5px; transition: width 0.4s ease; }
-    .s-snap-val     { width: 38px; text-align: right; font-size: 0.82rem; font-weight: 600; color: var(--app-text); flex-shrink: 0; }
-
-    /* ── Stacked hero layout ─────────────────────────────────────────────────── */
-    .dash-hero-block { padding: 1.25rem 1.5rem 1.5rem; }
-    .dash-hero-block .section-header { margin-bottom: 1rem; }
 
     /* ── Standalone mod-nav section ──────────────────────────────────────────── */
     .mod-nav-section {
@@ -104,31 +185,6 @@
         margin: 0 0 0.6rem 0.25rem;
     }
 
-    /* ── Player Card live preview (compact thumbnail) ────────────────────────── */
-    .player-card-embed-wrap { border-radius: 12px; overflow: hidden; box-shadow: 0 4px 24px rgba(0,0,0,0.13); max-height: 240px; }
-    .player-card-embed-wrap iframe { display: block; border: none; }
-
-    /* ── Last Result ─────────────────────────────────────────────────────────── */
-    .s-last-result-card { background: var(--app-card); border-left: 4px solid #667eea; border-radius: 0 10px 10px 0; padding: 1rem 1.25rem; display: flex; align-items: center; gap: 1rem; flex-wrap: wrap; }
-    .s-result-name     { font-weight: 700; color: var(--app-text); font-size: 1rem; flex: 1; min-width: 140px; }
-    .s-placement-badge { padding: 0.3rem 0.8rem; border-radius: 20px; font-weight: 700; font-size: 0.85rem; white-space: nowrap; }
-    .s-place-1     { background: #fff3cd; color: #856404; }
-    .s-place-2     { background: #e2e3e5; color: #383d41; }
-    .s-place-3     { background: #fde7c7; color: #7a4200; }
-    .s-place-other { background: var(--app-card-alt); color: var(--app-text-muted); }
-    .s-delta-pos   { color: var(--app-success); font-weight: 700; font-size: 0.95rem; }
-    .s-delta-neg   { color: var(--app-error); font-weight: 700; font-size: 0.95rem; }
-    .s-delta-zero  { color: var(--app-text-muted); font-size: 0.95rem; }
-    .s-result-meta { color: var(--app-text-muted); font-size: 0.82rem; }
-
-    /* ── Footer ──────────────────────────────────────────────────────────────── */
-    .footer-links { text-align: center; margin-top: 2rem; padding-top: 1.5rem; border-top: 1px solid #e2e8f0; }
-    .footer-links a { color: #667eea; text-decoration: none; margin: 0 1rem; font-weight: 600; }
-    .footer-links a:hover { text-decoration: underline; }
-
-    /* ── Loading ─────────────────────────────────────────────────────────────── */
-    .s-loading { color: #a0aec0; font-size: 0.9rem; padding: 0.5rem 0; }
-
     /* ── Public Profile entry point ──────────────────────────────────────────── */
     .s-pp-section { display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 1rem; }
     .s-pp-info { display: flex; flex-direction: column; gap: 0.3rem; }
@@ -145,21 +201,6 @@
     .s-pp-btn-view { background: #e8f0fe; color: #1a56db; }
     .s-pp-btn-edit { background: #0B0B0B; color: #FFD200; }
 
-    /* ── My Card Media section ───────────────────────────────────────────────── */
-    .s-cm-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1rem; }
-    @media (max-width: 520px) { .s-cm-grid { grid-template-columns: 1fr; } }
-    .s-cm-tile {
-        display: flex; flex-direction: column; align-items: flex-start; gap: 0.3rem;
-        background: var(--app-card-alt); border: 1px solid var(--app-border);
-        border-radius: 12px; padding: 1rem 1.1rem;
-        text-decoration: none; color: var(--app-text);
-        transition: box-shadow 0.18s, transform 0.18s;
-    }
-    .s-cm-tile:hover { box-shadow: 0 4px 16px rgba(0,0,0,0.18); transform: translateY(-2px); }
-    .s-cm-icon  { font-size: 1.5rem; }
-    .s-cm-title { font-size: 0.88rem; font-weight: 700; }
-    .s-cm-sub   { font-size: 0.75rem; color: var(--app-text-muted, #94a3b8); }
-
     /* ── Social section ──────────────────────────────────────────────────────── */
     .mod-social-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1rem; }
     .mod-social-card { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 0.4rem; background: var(--app-card-alt); border-radius: 12px; padding: 1.2rem 0.75rem; text-decoration: none; color: var(--app-text); position: relative; transition: box-shadow 0.2s, transform 0.2s; border: 1px solid var(--app-border); }
@@ -167,25 +208,16 @@
     .mod-social-icon  { font-size: 1.6rem; line-height: 1; }
     .mod-social-title { font-size: 0.82rem; font-weight: 700; color: var(--app-text-muted); }
     .mod-social-badge { position: absolute; top: 0.5rem; right: 0.5rem; background: #ef4444; color: white; border-radius: 999px; font-size: 0.7rem; font-weight: 700; padding: 0.1rem 0.45rem; line-height: 1.4; }
-    @media (max-width: 480px) { .mod-social-grid { grid-template-columns: 1fr; } }
-
-    /* ── Responsive ──────────────────────────────────────────────────────────── */
-    @media (max-width: 768px) {
-        .s-kpi-row      { grid-template-columns: repeat(2, 1fr); }
-        .container      { padding: 1rem; }
-        .mod-nav-section { padding: 1rem 1rem 0.25rem; }
-        .mod-nav-grid   { grid-template-columns: repeat(3, 1fr); gap: 0.6rem; }
-    }
-
     @media (max-width: 480px) {
-        .s-kpi-row      { grid-template-columns: 1fr 1fr; }
-        .s-snap-label   { width: 85px; }
-        .mod-nav-grid   { gap: 0.5rem; }
-        .mod-nav-card   { padding: 0.85rem 0.5rem; }
-        .mod-nav-icon   { font-size: 1.4rem; }
-        .mod-nav-title  { font-size: 0.76rem; }
+        .mod-social-grid { grid-template-columns: 1fr; }
+        .s-kpi-row { grid-template-columns: 1fr 1fr; }
+        .mod-nav-card { padding: 0.85rem 0.5rem; }
+        .mod-nav-icon { font-size: 1.4rem; }
+        .mod-nav-title { font-size: 0.76rem; }
     }
 
+    /* ── Loading ─────────────────────────────────────────────────────────────── */
+    .s-loading { color: #a0aec0; font-size: 0.9rem; padding: 0.5rem 0; }
 </style>
 {% endblock %}
 
@@ -200,161 +232,62 @@
 
 <div class="container">
 
-    {# ── Hero: My Player Card (LFA license, full-width) ───────────────────────── #}
+    {# ── 1. Top Card Preview Zone ──────────────────────────────────────────────── #}
     {% if user_license %}
-    <section class="section-block dash-hero-block">
-        <div class="section-header">
-            <h2 class="page-title">🃏 My Cards</h2>
-            <a href="/my-cards/player-card" class="section-link">✏️ Edit →</a>
-        </div>
-        <div class="player-card-embed-wrap" id="spec-card-wrap">
-            {# default platform previews instagram_portrait — same as card editor P-1 fix #}
-            {% set _preview_platform = active_card_platform if (active_card_platform and active_card_platform != 'default') else 'instagram_portrait' %}
-            <iframe id="spec-player-card-iframe"
-                    src="/players/{{ user.id }}/card?platform={{ _preview_platform }}&export=1"
-                    scrolling="no" title="My Player Card"></iframe>
-        </div>
-    </section>
-    <script>
-    (function() {
-        var _SPEC_CANVAS = {
-            instagram_square:   [1080, 1080],
-            instagram_portrait: [1080, 1350],
-            instagram_story:    [1080, 1920],
-            tiktok:             [1080, 1920],
-            facebook_square:    [1080, 1080],
-            facebook_landscape: [1200,  630],
-            og:                 [1200,  630],
-            banner_custom:      [1500,  500],
-        };
-        var _previewPlatform = '{{ _preview_platform }}';
-        document.addEventListener('DOMContentLoaded', function() {
-            var dims = _SPEC_CANVAS[_previewPlatform];
-            if (!dims) return;
-            var iframe = document.getElementById('spec-player-card-iframe');
-            var wrap   = document.getElementById('spec-card-wrap');
-            if (!iframe || !wrap) return;
-            var cw = dims[0], ch = dims[1];
-            var availW   = wrap.clientWidth || 840;
-            var maxH     = window.innerWidth < 700 ? 160 : 240;
-            var scaleByW = availW / cw;
-            var scaleByH = maxH / ch;
-            var scale    = Math.min(scaleByW, scaleByH);
-            iframe.style.width           = cw + 'px';
-            iframe.style.height          = ch + 'px';
-            iframe.style.transform       = 'scale(' + scale + ')';
-            iframe.style.transformOrigin = 'top left';
-            wrap.style.height            = Math.round(ch * scale) + 'px';
-        });
-    })();
-    </script>
-    {% endif %}
+    <div class="dc-card-zone">
 
-    {# ── Module Navigation (full-width, below card) ────────────────────────────── #}
-    {# 2×3 grid: 6 primary domains                                                  #}
-    {# Sessions / Progress / Skills accessible via footer + cross-links             #}
-    <section class="mod-nav-section">
-        <p class="mod-nav-section-label">Tools &amp; Quick Access</p>
-        <div class="mod-nav-grid">
-            {# Row 1 #}
-            <a href="/events" class="mod-nav-card">
-                <span class="mod-nav-icon">📅</span>
-                <span class="mod-nav-title">Events</span>
-            </a>
-            <a href="/my-cards" class="mod-nav-card">
-                <span class="mod-nav-icon">🃏</span>
-                <span class="mod-nav-title">My Cards</span>
-            </a>
-            <a href="/training" class="mod-nav-card">
-                <span class="mod-nav-icon">🎓</span>
-                <span class="mod-nav-title">Training</span>
-            </a>
-            {# Row 2 #}
-            <a href="/skills/history?skill=passing" class="mod-nav-card">
-                <span class="mod-nav-icon">📈</span>
-                <span class="mod-nav-title">Skill History</span>
-            </a>
-            <a href="/calendar" class="mod-nav-card">
-                <span class="mod-nav-icon">📆</span>
-                <span class="mod-nav-title">Calendar</span>
-            </a>
-            <a href="/achievements" class="mod-nav-card">
-                <span class="mod-nav-icon">🏅</span>
-                <span class="mod-nav-title">Achievements</span>
-            </a>
-            {# Row 3 — profile + card tools #}
-            <a href="/profile/lfa-football-player" class="mod-nav-card">
-                <span class="mod-nav-icon">🪪</span>
-                <span class="mod-nav-title">Profile</span>
-            </a>
-            <a href="/dashboard/lfa-football-player/card-editor" class="mod-nav-card">
-                <span class="mod-nav-icon">🎴</span>
-                <span class="mod-nav-title">Card Editor</span>
-            </a>
-            <a href="/profile/my-mood-photos" class="mod-nav-card">
-                <span class="mod-nav-icon">📸</span>
-                <span class="mod-nav-title">Mood Photos</span>
-            </a>
-        </div>
-    </section>
-
-    {# ── Public Profile entry point (LFA_FOOTBALL_PLAYER only) ───────────────── #}
-    {% if specialization == "LFA_FOOTBALL_PLAYER" %}
-    <section class="section-block">
-        <div class="section-header">
-            <span class="section-title" style="font-weight:800;font-size:1rem;">Public Profile</span>
-        </div>
-        <div class="s-pp-section">
-            <div class="s-pp-info">
-                <div class="s-pp-title">Your public player profile</div>
-                <div class="s-pp-meta">
-                    {% if is_profile_published %}
-                    <span class="s-pp-chip s-pp-chip-pub">✓ Published</span>
-                    {% else %}
-                    <span class="s-pp-chip s-pp-chip-unpub">Unpublished</span>
-                    {% endif %}
-                    <span class="s-pp-chip s-pp-chip-grid">Grid {{ profile_grid_filled_slots }}/{{ profile_grid_total_slots }}</span>
-                    {% if has_published_highlight_video %}
-                    <span class="s-pp-chip s-pp-chip-hv">▶ Highlight video</span>
-                    {% endif %}
-                </div>
+        {# Player Card #}
+        <div class="dc-hero dc-hero-player">
+            <p class="dc-hero-label">🃏 Player Card</p>
+            <div class="dc-player-wrap" id="dc-player-wrap">
+                <iframe id="dc-player-iframe"
+                        src="/players/{{ user.id }}/card?platform={{ _prev }}&export=1"
+                        scrolling="no" title="My Player Card"></iframe>
             </div>
-            <div class="s-pp-actions">
-                <a href="{{ public_profile_url }}" target="_blank" class="s-pp-btn s-pp-btn-view">View Profile ↗</a>
-                <a href="{{ grid_editor_url }}" class="s-pp-btn s-pp-btn-edit">Edit Grid</a>
+            <div class="dc-ctas">
+                <a href="/my-cards/player-card" class="dc-cta-primary">✏️ Edit Card</a>
+                <a href="/my-cards" class="dc-cta-ghost">All Cards →</a>
             </div>
         </div>
-    </section>
 
-    {# ── My Card Media (LFA_FOOTBALL_PLAYER only) ─────────────────────────────── #}
-    <section class="section-block">
-        <div class="section-header">
-            <span class="section-title" style="font-weight:800;font-size:1rem;">My Card Media</span>
+        {# Welcome Card #}
+        <div class="dc-hero dc-hero-welcome">
+            <p class="dc-hero-label">🎫 Welcome Card</p>
+            <div class="dc-welcome-status">
+                <div class="dc-wc-title">Welcome Card</div>
+                {% if has_welcome_card %}
+                <span class="dc-wc-chip dc-wc-chip-ready">✓ Ready</span>
+                <div class="dc-wc-sub">Your onboarding card is set up.</div>
+                {% else %}
+                <span class="dc-wc-chip dc-wc-chip-empty">Not created</span>
+                <div class="dc-wc-sub">Complete onboarding to unlock your Welcome Card.</div>
+                {% endif %}
+            </div>
+            <div class="dc-ctas">
+                <a href="/profile/onboarding-card" class="dc-cta-primary">View →</a>
+            </div>
         </div>
-        <p style="font-size:0.82rem;color:var(--app-text-muted,#94a3b8);margin-bottom:1rem;">
-            Photos used in your Player Cards, Welcome Cards, and Challenge Cards.
-        </p>
-        <div class="s-cm-grid">
-            <a href="/dashboard/lfa-football-player/card-editor#media" class="s-cm-tile">
-                <span class="s-cm-icon">📷</span>
-                <span class="s-cm-title">Card Photos</span>
-                <span class="s-cm-sub">Player &amp; Welcome Card photos (Media tab)</span>
-            </a>
-            <a href="/profile/my-mood-photos" class="s-cm-tile">
-                <span class="s-cm-icon">📸</span>
-                <span class="s-cm-title">Mood Photos</span>
-                <span class="s-cm-sub">4 expression slots for future card use</span>
-            </a>
-            <a href="/dashboard/lfa-football-player/card-editor" class="s-cm-tile">
-                <span class="s-cm-icon">🎴</span>
-                <span class="s-cm-title">Card Editor</span>
-                <span class="s-cm-sub">Full card design &amp; export tools</span>
-            </a>
+
+        {# Challenge Card #}
+        <div class="dc-hero dc-hero-chall">
+            <p class="dc-hero-label">⚔ Challenge Card</p>
+            {% set challenge_card_total = social_pending_challenges + social_active_challenges %}
+            <div class="dc-chall-status">
+                <div class="dc-chall-count">{{ challenge_card_total }}</div>
+                <div class="dc-chall-lbl">active &amp; pending challenges</div>
+            </div>
+            <div class="dc-ctas">
+                <a href="/challenges" class="dc-cta-primary">
+                    {%- if challenge_card_total > 0 %}View Challenges{% else %}New Challenge{% endif -%}
+                </a>
+                <a href="/challenges/send" class="dc-cta-ghost">Send →</a>
+            </div>
         </div>
-    </section>
+
+    </div>
     {% endif %}
 
-    {# ── Social ─────────────────────────────────────────────────────────────────── #}
+    {# ── 2. Social ─────────────────────────────────────────────────────────────── #}
     <section class="section-block">
         <div class="section-header">
             <span class="section-title" style="font-weight:800;font-size:1rem;">Social</span>
@@ -381,7 +314,36 @@
         </div>
     </section>
 
-    {# ── KPI Row ───────────────────────────────────────────────────────────────── #}
+    {# ── 3. Public Profile entry point (LFA_FOOTBALL_PLAYER only) ─────────────── #}
+    {% if specialization == "LFA_FOOTBALL_PLAYER" %}
+    <section class="section-block">
+        <div class="section-header">
+            <span class="section-title" style="font-weight:800;font-size:1rem;">Public Profile</span>
+        </div>
+        <div class="s-pp-section">
+            <div class="s-pp-info">
+                <div class="s-pp-title">Your public player profile</div>
+                <div class="s-pp-meta">
+                    {% if is_profile_published %}
+                    <span class="s-pp-chip s-pp-chip-pub">✓ Published</span>
+                    {% else %}
+                    <span class="s-pp-chip s-pp-chip-unpub">Unpublished</span>
+                    {% endif %}
+                    <span class="s-pp-chip s-pp-chip-grid">Grid {{ profile_grid_filled_slots }}/{{ profile_grid_total_slots }}</span>
+                    {% if has_published_highlight_video %}
+                    <span class="s-pp-chip s-pp-chip-hv">▶ Highlight video</span>
+                    {% endif %}
+                </div>
+            </div>
+            <div class="s-pp-actions">
+                <a href="{{ public_profile_url }}" target="_blank" class="s-pp-btn s-pp-btn-view">View Profile ↗</a>
+                <a href="{{ grid_editor_url }}" class="s-pp-btn s-pp-btn-edit">Edit Grid</a>
+            </div>
+        </div>
+    </section>
+    {% endif %}
+
+    {# ── 4. KPI Row ────────────────────────────────────────────────────────────── #}
     <div class="s-kpi-row">
         <div class="s-kpi-card">
             <div class="s-kpi-val" id="kpi-avg">—</div>
@@ -401,36 +363,28 @@
         </div>
     </div>
 
-    {# ── Skill Snapshot ────────────────────────────────────────────────────────── #}
-    <section class="section-block">
-        <div class="section-header">
-            <h2 class="page-title">📊 Skill Snapshot</h2>
-            <a href="/skills" class="section-link">View all 29 skills →</a>
-        </div>
-        <div id="s-snapshot">
-            <div class="s-loading"><span class="s-spinner"></span> Loading…</div>
+    {# ── 5. Tools & Quick Access (4 tiles: Calendar, Achievements, Sessions, Progress) #}
+    <section class="mod-nav-section">
+        <p class="mod-nav-section-label">Tools &amp; Quick Access</p>
+        <div class="mod-nav-grid">
+            <a href="/calendar" class="mod-nav-card">
+                <span class="mod-nav-icon">📆</span>
+                <span class="mod-nav-title">Calendar</span>
+            </a>
+            <a href="/achievements" class="mod-nav-card">
+                <span class="mod-nav-icon">🏅</span>
+                <span class="mod-nav-title">Achievements</span>
+            </a>
+            <a href="/sessions" class="mod-nav-card">
+                <span class="mod-nav-icon">📋</span>
+                <span class="mod-nav-title">Sessions</span>
+            </a>
+            <a href="/progress" class="mod-nav-card">
+                <span class="mod-nav-icon">📊</span>
+                <span class="mod-nav-title">Progress</span>
+            </a>
         </div>
     </section>
-
-    {# ── Last Skill Event ──────────────────────────────────────────────────────── #}
-    <section class="section-block">
-        <div class="section-header">
-            <h2 class="page-title">📈 Last Skill Event</h2>
-            <a href="/skills/history?skill=passing" class="section-link">Full event history →</a>
-        </div>
-        <div id="s-last-result">
-            <div class="s-loading"><span class="s-spinner"></span> Loading…</div>
-        </div>
-    </section>
-
-    <div class="footer-links">
-        <a href="/dashboard">🏠 Hub</a>
-        <a href="/sessions">📋 Sessions</a>
-        <a href="/progress">📊 Progress</a>
-        <a href="/skills">⚡ Skills</a>
-        <a href="/credits">💳 Credits</a>
-        <a href="/profile/lfa-football-player">👤 Profile</a>
-    </div>
 
 </div>
 {% endblock %}
@@ -440,113 +394,58 @@
 (function () {
     'use strict';
 
-    const TIER_COLORS = {
-        BEGINNER:     '#6b7280',
-        DEVELOPING:   '#3b82f6',
-        INTERMEDIATE: '#f59e0b',
-        ADVANCED:     '#dc2626',
-        MASTER:       '#9333ea',
-    };
+    // ── Player Card iframe scale ──────────────────────────────────────────────
+    (function () {
+        var _CANVAS = {
+            instagram_square:   [1080, 1080],
+            instagram_portrait: [1080, 1350],
+            instagram_story:    [1080, 1920],
+            tiktok:             [1080, 1920],
+            facebook_square:    [1080, 1080],
+            facebook_landscape: [1200,  630],
+            og:                 [1200,  630],
+            banner_custom:      [1500,  500],
+        };
+        var _platform = '{{ _prev }}';
+        document.addEventListener('DOMContentLoaded', function () {
+            var dims = _CANVAS[_platform];
+            if (!dims) return;
+            var iframe = document.getElementById('dc-player-iframe');
+            var wrap   = document.getElementById('dc-player-wrap');
+            if (!iframe || !wrap) return;
+            var cw = dims[0], ch = dims[1];
+            var availW   = wrap.clientWidth || 640;
+            var maxH     = window.innerWidth < 700 ? 160 : 240;
+            var scaleByW = availW / cw;
+            var scaleByH = maxH / ch;
+            var scale    = Math.min(scaleByW, scaleByH);
+            iframe.style.width           = cw + 'px';
+            iframe.style.height          = ch + 'px';
+            iframe.style.transform       = 'scale(' + scale + ')';
+            iframe.style.transformOrigin = 'top left';
+            wrap.style.height            = Math.round(ch * scale) + 'px';
+        });
+    })();
 
-    function barWidth(level) {
-        return Math.max(0, Math.min(100, ((level - 40) / 59) * 100)).toFixed(1);
-    }
-
+    // ── KPI data ─────────────────────────────────────────────────────────────
     async function loadSkillsData() {
         try {
             const resp = await fetch('/skills/data');
             if (!resp.ok) throw new Error('HTTP ' + resp.status);
             const data = await resp.json();
-
             document.getElementById('kpi-avg').textContent =
                 data.average_level !== undefined ? data.average_level.toFixed(1) : '—';
             document.getElementById('kpi-tournaments').textContent =
                 data.total_tournaments !== undefined ? data.total_tournaments : '—';
-
-            // Fallback snapshot (only rendered when no LFA license)
-            const snapEl = document.getElementById('s-snapshot');
-            if (!snapEl) return;
-
-            const sorted = Object.entries(data.skills || {})
-                .sort((a, b) => b[1].current_level - a[1].current_level)
-                .slice(0, 5);
-
-            if (sorted.length === 0) {
-                snapEl.innerHTML = '<p style="color:#a0aec0;font-size:0.9rem;">No skill data available yet.</p>';
-                return;
-            }
-
-            snapEl.innerHTML = sorted.map(([key, s]) => {
-                const color = TIER_COLORS[s.tier] || '#667eea';
-                const width = barWidth(s.current_level);
-                return `<div class="s-snapshot-row">
-                    <span class="s-snap-label">${key.replace(/_/g, ' ')}</span>
-                    <div class="s-snap-bar-wrap">
-                        <div class="s-snap-bar" style="width:${width}%;background:${color};"></div>
-                    </div>
-                    <span class="s-snap-val">${s.current_level.toFixed(2)}</span>
-                </div>`;
-            }).join('');
-
         } catch (err) {
             document.getElementById('kpi-avg').textContent = '—';
             document.getElementById('kpi-tournaments').textContent = '—';
-            const snapEl = document.getElementById('s-snapshot');
-            if (snapEl) snapEl.innerHTML = '<p style="color:#e74c3c;font-size:0.85rem;">Could not load skill data.</p>';
-        }
-    }
-
-    async function loadLastResult() {
-        const el = document.getElementById('s-last-result');
-        try {
-            const resp = await fetch('/skills/history/data?skill=passing');
-            if (!resp.ok) throw new Error('HTTP ' + resp.status);
-            const data = await resp.json();
-
-            const timeline = data.timeline || [];
-            if (timeline.length === 0) {
-                el.innerHTML = `<p style="color:#718096;font-size:0.9rem;">
-                    No skill events yet — enroll in an event to start your journey.</p>`;
-                return;
-            }
-
-            const last = timeline[timeline.length - 1];
-
-            let badgeHtml = '';
-            if      (last.placement === 1) badgeHtml = '<span class="s-placement-badge s-place-1">🥇 1st</span>';
-            else if (last.placement === 2) badgeHtml = '<span class="s-placement-badge s-place-2">🥈 2nd</span>';
-            else if (last.placement === 3) badgeHtml = '<span class="s-placement-badge s-place-3">🥉 3rd</span>';
-            else if (last.placement)       badgeHtml = `<span class="s-placement-badge s-place-other">${last.placement}th</span>`;
-            else                           badgeHtml = '<span class="s-placement-badge s-place-other">● Participant</span>';
-
-            const delta = last.delta_from_previous;
-            let deltaHtml = '';
-            if (delta !== null && delta !== undefined) {
-                if      (delta >  0.005) deltaHtml = `<span class="s-delta-pos">+${delta.toFixed(2)} ↑</span>`;
-                else if (delta < -0.005) deltaHtml = `<span class="s-delta-neg">${delta.toFixed(2)} ↓</span>`;
-                else                     deltaHtml = `<span class="s-delta-zero">±0.00</span>`;
-            }
-
-            const playersInfo = last.total_players
-                ? `<span class="s-result-meta">of ${last.total_players} players</span>` : '';
-
-            el.innerHTML = `<div class="s-last-result-card">
-                <span class="s-result-name">${last.event_name || last.tournament_name || 'Event'}</span>
-                ${badgeHtml}
-                ${playersInfo}
-                ${deltaHtml}
-            </div>`;
-
-        } catch (err) {
-            el.innerHTML = '<p style="color:#e74c3c;font-size:0.85rem;">Could not load last result.</p>';
         }
     }
 
     document.addEventListener('DOMContentLoaded', function () {
         loadSkillsData();
-        loadLastResult();
     });
 })();
 </script>
-
 {% endblock %}

--- a/app/templates/includes/spec_subpage_hdr.html
+++ b/app/templates/includes/spec_subpage_hdr.html
@@ -54,6 +54,9 @@
 {# ── LFA Football Player quicknav strip ─────────────────────────────────────
    Shown on all LFA sub-pages. Horizontal scroll on mobile (no wrapping).
    Active item highlighted by matching request path. #}
+{# _lfa_qn — dual trigger so multi-spec users always see LFA quicknav:
+   1. user.specialization is currently LFA_FOOTBALL_PLAYER (single-spec common case)
+   2. route passed explicit spec_dashboard_url (multi-spec safe: my-cards, dashboard, etc.) #}
 {% set _lfa_qn = (
     ((user.specialization.value if user.specialization else '') if user else '') == 'LFA_FOOTBALL_PLAYER'
     or (spec_dashboard_url | default('')) == '/dashboard/lfa-football-player'

--- a/app/templates/includes/spec_subpage_hdr.html
+++ b/app/templates/includes/spec_subpage_hdr.html
@@ -72,6 +72,12 @@
     scrollbar-width: none;
 }
 .spec-quicknav::-webkit-scrollbar { display: none; }
+@media (max-width: 640px) {
+    .spec-quicknav {
+        -webkit-mask-image: linear-gradient(to right, black 75%, transparent 100%);
+        mask-image: linear-gradient(to right, black 75%, transparent 100%);
+    }
+}
 .spec-qn-item {
     flex-shrink: 0;
     padding: 0.28rem 0.7rem;

--- a/app/templates/lfa_player_mood_photos.html
+++ b/app/templates/lfa_player_mood_photos.html
@@ -238,7 +238,6 @@ function _mpDelete(url) {
                 Player Card photos.
             </p>
         </div>
-        <a class="btn btn-secondary btn-sm" href="/profile/lfa-football-player">← Back to profile</a>
     </div>
 
     <div class="mp-grid">

--- a/app/templates/lfa_player_profile.html
+++ b/app/templates/lfa_player_profile.html
@@ -213,17 +213,6 @@
         margin-top: 1rem;
     }
 
-    /* Back link */
-    .back-link {
-        display: inline-block;
-        font-size: 0.85rem;
-        color: var(--hub-text-muted);
-        text-decoration: none;
-        margin-bottom: 1.5rem;
-    }
-
-    .back-link:hover { color: var(--hub-text-secondary); }
-
     /* ── Positions card — view / edit modes ───────────────────────────────── */
     .pos-view-badges  { display: flex; flex-direction: column; gap: 0.35rem; margin-bottom: 1rem; }
     .pos-view-section { display: flex; flex-wrap: wrap; align-items: center; gap: 0.4rem; }
@@ -297,8 +286,6 @@
 {% block student_content %}
 <div class="container">
 
-    <a class="back-link" href="/profile">← Back to Profile</a>
-
     <div class="page-header">
         <div>
             <h2 class="page-title">🪪 LFA Player Profile</h2>
@@ -306,7 +293,7 @@
         </div>
         <div class="page-header-actions">
             <a href="/profile/lfa-football-player/edit" class="btn btn-primary">✏️ Edit Profile</a>
-            <a href="/dashboard/lfa-football-player" class="btn btn-secondary">⚽ Dashboard</a>
+            <a href="/dashboard/lfa-football-player" class="btn btn-secondary">⚽ LFA Dashboard</a>
         </div>
     </div>
 

--- a/app/templates/training_hub.html
+++ b/app/templates/training_hub.html
@@ -217,9 +217,7 @@
     </div>
 
     <div class="trn-footer">
-        <a href="/dashboard/lfa-football-player">⚽ Dashboard</a>
-        <a href="/progress">📊 Progress</a>
-        <a href="/events">📅 Events</a>
+        <a href="/progress">📊 View Progress</a>
     </div>
 
 </div>

--- a/cypress/cypress/e2e/web/student/student_journey.cy.js
+++ b/cypress/cypress/e2e/web/student/student_journey.cy.js
@@ -199,19 +199,20 @@ describe('A. Student Core Journey — Skill Progression', {
     });
   });
 
-  // ── STU-JOURNEY-08 — Spec dashboard structure: student nav + breadcrumb + sections present ──
-  it('STU-JOURNEY-08: /dashboard/LFA_FOOTBALL_PLAYER — student nav present, breadcrumb correct, dashboard sections visible', () => {
+  // ── STU-JOURNEY-08 — Spec dashboard structure: spec header + breadcrumb + sections present ──
+  it('STU-JOURNEY-08: /dashboard/LFA_FOOTBALL_PLAYER — spec header + quicknav + breadcrumb + sections visible', () => {
     cy.visit('/dashboard/LFA_FOOTBALL_PLAYER');
 
-    // Student nav must be rendered by student_base.html (not the old base.html header)
+    // Student base header rendered by spec_subpage_hdr.html include
     cy.get('.student-header').should('exist');
 
-    // Nav has LFA Player link — Hub is in footer, not header nav
-    cy.get('.student-nav a[href="/dashboard/lfa-football-player"]').should('contain.text', 'LFA Player');
-    cy.get('.student-nav a[href="/dashboard/lfa-football-player"]').should('have.class', 'active');
-    cy.get('.student-nav a[href="/dashboard"]').should('not.exist');
-    // Hub link is in footer
-    cy.get('.footer-links a[href="/dashboard"]').should('exist');
+    // Spec dashboard link present as s-hdr-btn (replaces old student-nav pattern)
+    cy.get('a.s-hdr-btn[href="/dashboard/lfa-football-player"]').should('exist');
+    // Hub link also present as s-hdr-btn in header
+    cy.get('a.s-hdr-btn[href="/dashboard"]').should('exist');
+
+    // Quicknav contains My Cards link
+    cy.get('.spec-qn-item[href="/my-cards"]').should('exist');
 
     // Breadcrumb must contain the spec name — proves student is on spec dashboard, not hub
     cy.get('.s-breadcrumb').should('exist');
@@ -222,43 +223,31 @@ describe('A. Student Core Journey — Skill Progression', {
     cy.get('.s-kpi-row').should('exist');
     cy.get('.s-kpi-card').should('have.length', 4);
 
-    // Skill Snapshot + Last Result sections visible
-    cy.contains('h2', 'Skill Snapshot').should('be.visible');
-    cy.contains('h2', 'Last Skill Event').should('be.visible');
-
-    // 2×3 mod-nav: 6 primary domain cards must be present
-    cy.get('.mod-nav-card[href="/events"]').should('exist');
-    cy.get('.mod-nav-card[href="/my-cards"]').should('exist');
-    cy.get('.mod-nav-card[href="/training"]').should('exist');
-    cy.get('.mod-nav-card[href="/skills/history?skill=passing"]').should('exist');
+    // Quick Access: 4 mod-nav tiles (Calendar, Achievements, Sessions, Progress)
     cy.get('.mod-nav-card[href="/calendar"]').should('exist');
     cy.get('.mod-nav-card[href="/achievements"]').should('exist');
+    cy.get('.mod-nav-card[href="/sessions"]').should('exist');
+    cy.get('.mod-nav-card[href="/progress"]').should('exist');
 
-    // Secondary nav in footer: Sessions / Progress / Skills accessible
+    // Sessions and Progress accessible via mod-nav
     cy.get('a[href="/sessions"]').should('exist');
     cy.get('a[href="/progress"]').should('exist');
-    cy.get('a[href="/skills"]').should('exist');
 
     // Page must not show any server error
     cy.get('body').should('not.contain.text', 'Internal Server Error');
     cy.get('body').should('not.contain.text', '400 Bad Request');
   });
 
-  // ── STU-JOURNEY-09 — Dashboard KPI lazy-loads + snapshot bars + last result ──
-  it('STU-JOURNEY-09: spec dashboard KPI row + skill snapshot + last result load', () => {
+  // ── STU-JOURNEY-09 — Dashboard KPI lazy-loads ──
+  it('STU-JOURNEY-09: spec dashboard KPI row lazy-loads avg skill and tournament count', () => {
     cy.visit('/dashboard/LFA_FOOTBALL_PLAYER');
 
     // KPI avg should fill in from /skills/data (not stay as —)
     cy.get('#kpi-avg', { timeout: 10000 }).should('not.contain.text', '—');
     cy.get('#kpi-tournaments').should('contain.text', '2');
 
-    // Skill snapshot renders at least 1 bar
-    cy.get('#s-snapshot .s-snapshot-row', { timeout: 8000 }).should('have.length.gte', 1);
-
-    // Last skill event shows the most recent event (T2: placed 1st, positive delta)
-    cy.get('#s-last-result', { timeout: 8000 }).should('not.contain.text', 'No skill events yet');
-    cy.get('#s-last-result').should('contain.text', 'E2E History Tournament 2');
-    cy.get('#s-last-result .s-delta-pos').should('exist');
+    // KPI row must have 4 cards after data loads
+    cy.get('.s-kpi-card').should('have.length', 4);
   });
 
 });

--- a/tests/unit/api/web_routes/test_lfa_dashboard_mvp.py
+++ b/tests/unit/api/web_routes/test_lfa_dashboard_mvp.py
@@ -181,3 +181,59 @@ class TestSpecDashboardTemplate:
         src = self._src()
         assert 'dc-cta-primary' in src
         assert 'dc-cta-ghost'   in src
+
+    # ── DS-17b..DS-17g: layout-oriented tile-card assertions ─────────────────
+
+    def test_ds17b_card_zone_equal_columns(self):
+        """DS-17b: .dc-card-zone uses repeat(3, 1fr) — no 1.6fr asymmetry."""
+        src = self._src()
+        assert 'repeat(3, 1fr)' in src
+        assert '1.6fr'          not in src
+
+    def test_ds17c_card_zone_align_stretch(self):
+        """DS-17c: .dc-card-zone uses align-items: stretch for equal tile heights."""
+        src = self._src()
+        assert 'align-items: stretch' in src
+
+    def test_ds17d_card_zone_explicit_row_height(self):
+        """DS-17d: .dc-card-zone has grid-auto-rows to control row height."""
+        src = self._src()
+        assert 'grid-auto-rows' in src
+
+    def test_ds17e_player_wrap_no_flex1(self):
+        """DS-17e: .dc-player-wrap does NOT use flex: 1 (would expand layout)."""
+        src = self._src()
+        # Find dc-player-wrap CSS block and check no flex: 1 inside it
+        start = src.index('.dc-player-wrap {')
+        end   = src.index('}', start)
+        wrap_block = src[start:end]
+        assert 'flex: 1' not in wrap_block
+
+    def test_ds17f_player_wrap_has_fixed_height(self):
+        """DS-17f: .dc-player-wrap has an explicit height (thumbnail constraint)."""
+        src = self._src()
+        start = src.index('.dc-player-wrap {')
+        end   = src.index('}', start)
+        wrap_block = src[start:end]
+        assert 'height:' in wrap_block
+
+    def test_ds17g_mobile_card_zone_single_column(self):
+        """DS-17g: @media (max-width: 768px) sets .dc-card-zone to 1fr (stack)."""
+        src = self._src()
+        media_start = src.index('@media (max-width: 768px)')
+        media_block = src[media_start:media_start + 500]
+        assert 'grid-template-columns: 1fr' in media_block
+        assert 'grid-auto-rows: unset'      in media_block
+
+    def test_ds17h_dc_hero_full_height(self):
+        """DS-17h: .dc-hero uses height: 100% to fill the fixed grid row."""
+        src = self._src()
+        start = src.index('.dc-hero {')
+        end   = src.index('}', start)
+        hero_block = src[start:end]
+        assert 'height: 100%' in hero_block
+
+    def test_ds17i_js_no_wrap_height_override(self):
+        """DS-17i: JS does NOT assign wrap.style.height (CSS controls wrapper height)."""
+        src = self._src()
+        assert 'wrap.style.height =' not in src

--- a/tests/unit/api/web_routes/test_lfa_dashboard_mvp.py
+++ b/tests/unit/api/web_routes/test_lfa_dashboard_mvp.py
@@ -1,0 +1,183 @@
+"""LFA Spec Dashboard MVP — DS-01..DS-18 template + route context tests.
+
+DS-01  route context exposes skill_count key
+DS-02  skill_count == len(get_all_skill_keys())
+DS-03  route context exposes has_welcome_card key
+DS-04  template source contains .dc-card-zone
+DS-05  template source contains .dc-hero-player
+DS-06  template source contains .dc-hero-welcome
+DS-07  template source contains .dc-hero-chall
+DS-08  s-cm-grid NOT in template (My Card Media section removed)
+DS-09  s-snapshot NOT in template (Skill Snapshot section removed)
+DS-10  s-last-result NOT in template (Last Skill Event section removed)
+DS-11  "29 skills" NOT in template
+DS-12  /skills/history?skill=passing NOT in template
+DS-13  footer-links NOT in template
+DS-14  mod-nav contains Calendar, Achievements, Sessions, Progress
+DS-15  mod-nav does NOT contain Events, Training, My Cards, Card Editor, Mood Photos tiles
+DS-16  Social section appears after .dc-card-zone in source
+DS-17  @media (max-width: 768px) contains .dc-card-zone override
+DS-18  dc-cta-primary and dc-cta-ghost classes present
+"""
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from app.services.skill_progression import get_all_skill_keys
+
+_T = Path(__file__).resolve().parents[4] / "app" / "templates"
+
+
+def _read(rel):
+    return (_T / rel).read_text(encoding="utf-8")
+
+
+# ── DS-01..03: route context ──────────────────────────────────────────────────
+
+class TestSpecDashboardContext:
+
+    def _mock_spec_dashboard(self):
+        """Build minimal mock objects that spec_dashboard() would pass to the template."""
+        user_license = MagicMock()
+        user_license.onboarding_completed = True
+        user_license.football_skills = {"passing": 65.0}
+        user_license.public_card_platform = "instagram_portrait"
+
+        skill_count = len(get_all_skill_keys())
+        has_welcome_card = bool(
+            user_license.onboarding_completed
+            or user_license.football_skills is not None
+        )
+        return {
+            "skill_count": skill_count,
+            "has_welcome_card": has_welcome_card,
+            "user_license": user_license,
+        }
+
+    def test_ds01_context_has_skill_count(self):
+        """DS-01: context dict contains skill_count key."""
+        ctx = self._mock_spec_dashboard()
+        assert "skill_count" in ctx
+
+    def test_ds02_skill_count_matches_config(self):
+        """DS-02: skill_count equals len(get_all_skill_keys())."""
+        ctx = self._mock_spec_dashboard()
+        assert ctx["skill_count"] == len(get_all_skill_keys())
+
+    def test_ds03_context_has_has_welcome_card(self):
+        """DS-03: context dict contains has_welcome_card key."""
+        ctx = self._mock_spec_dashboard()
+        assert "has_welcome_card" in ctx
+
+    def test_ds03b_has_welcome_card_true_when_onboarding_complete(self):
+        """DS-03b: has_welcome_card is True when onboarding_completed is True."""
+        ctx = self._mock_spec_dashboard()
+        assert ctx["has_welcome_card"] is True
+
+    def test_ds03c_has_welcome_card_false_when_no_onboarding(self):
+        """DS-03c: has_welcome_card is False when neither flag nor skills present."""
+        ul = MagicMock()
+        ul.onboarding_completed = False
+        ul.football_skills = None
+        has_welcome_card = bool(ul.onboarding_completed or ul.football_skills is not None)
+        assert has_welcome_card is False
+
+
+# ── DS-04..18: template source ────────────────────────────────────────────────
+
+class TestSpecDashboardTemplate:
+
+    def _src(self):
+        return _read("dashboard_student_new.html")
+
+    # Card zone structure
+
+    def test_ds04_dc_card_zone_present(self):
+        """DS-04: template contains .dc-card-zone class."""
+        assert 'dc-card-zone' in self._src()
+
+    def test_ds05_dc_hero_player_present(self):
+        """DS-05: template contains .dc-hero-player class."""
+        assert 'dc-hero-player' in self._src()
+
+    def test_ds06_dc_hero_welcome_present(self):
+        """DS-06: template contains .dc-hero-welcome class."""
+        assert 'dc-hero-welcome' in self._src()
+
+    def test_ds07_dc_hero_chall_present(self):
+        """DS-07: template contains .dc-hero-chall class."""
+        assert 'dc-hero-chall' in self._src()
+
+    # Removed sections
+
+    def test_ds08_no_s_cm_grid(self):
+        """DS-08: My Card Media section (s-cm-grid) removed."""
+        assert 's-cm-grid' not in self._src()
+
+    def test_ds09_no_s_snapshot(self):
+        """DS-09: Skill Snapshot section (s-snapshot) removed."""
+        assert 's-snapshot' not in self._src()
+
+    def test_ds10_no_s_last_result(self):
+        """DS-10: Last Skill Event section (s-last-result) removed."""
+        assert 's-last-result' not in self._src()
+
+    def test_ds11_no_hardcoded_29_skills(self):
+        """DS-11: hardcoded '29 skills' text removed."""
+        assert '29 skills' not in self._src()
+
+    def test_ds12_no_skill_history_passing_link(self):
+        """DS-12: /skills/history?skill=passing link removed."""
+        assert '/skills/history?skill=passing' not in self._src()
+
+    def test_ds13_no_footer_links(self):
+        """DS-13: footer-links strip removed."""
+        assert 'footer-links' not in self._src()
+
+    # Quick Access mod-nav tiles
+
+    def test_ds14_mod_nav_has_required_tiles(self):
+        """DS-14: mod-nav section contains Calendar, Achievements, Sessions, Progress."""
+        src = self._src()
+        start = src.index('class="mod-nav-section"')
+        end = src.index('</section>', start) + len('</section>')
+        nav = src[start:end]
+        assert 'href="/calendar"'      in nav
+        assert 'href="/achievements"'  in nav
+        assert 'href="/sessions"'      in nav
+        assert 'href="/progress"'      in nav
+
+    def test_ds15_mod_nav_no_quicknav_duplicates(self):
+        """DS-15: mod-nav section does not contain quicknav-duplicated tiles."""
+        src = self._src()
+        start = src.index('class="mod-nav-section"')
+        end = src.index('</section>', start) + len('</section>')
+        nav = src[start:end]
+        assert 'href="/events"'                             not in nav
+        assert 'href="/training"'                           not in nav
+        assert 'href="/my-cards"'                           not in nav
+        assert '/profile/my-mood-photos'                    not in nav
+        assert 'card-editor'                                not in nav
+
+    # Source order
+
+    def test_ds16_social_after_card_zone(self):
+        """DS-16: Social section appears after .dc-card-zone in template source."""
+        src = self._src()
+        assert src.index('dc-card-zone') < src.index('mod-social-grid')
+
+    # Responsive override
+
+    def test_ds17_media_768_has_dc_card_zone(self):
+        """DS-17: @media (max-width: 768px) block overrides .dc-card-zone layout."""
+        src = self._src()
+        media_start = src.index('@media (max-width: 768px)')
+        media_block = src[media_start:media_start + 400]
+        assert 'dc-card-zone' in media_block
+
+    # CTA classes
+
+    def test_ds18_cta_classes_present(self):
+        """DS-18: dc-cta-primary and dc-cta-ghost classes defined in template."""
+        src = self._src()
+        assert 'dc-cta-primary' in src
+        assert 'dc-cta-ghost'   in src

--- a/tests/unit/api/web_routes/test_lfa_nav.py
+++ b/tests/unit/api/web_routes/test_lfa_nav.py
@@ -1,0 +1,190 @@
+"""LFA spec navigation context tests — NAV-01..NAV-08.
+
+NAV-01  /my-cards route passes explicit spec_dashboard_url (multi-spec safe)
+NAV-02  /my-cards route passes explicit spec_profile_url (multi-spec safe)
+NAV-03  /dashboard/lfa-football-player route passes explicit spec_dashboard_url
+NAV-04  /dashboard/lfa-football-player route passes explicit spec_profile_url
+NAV-05  spec_subpage_hdr.html renders quicknav when _lfa_qn via spec_dashboard_url
+NAV-06  spec_subpage_hdr.html renders quicknav when _lfa_qn via user.specialization
+NAV-07  spec_subpage_hdr.html does NOT render quicknav for GānCuju spec
+NAV-08  dashboard_card_editor.html back link points to /my-cards (not /profile/lfa-football-player)
+"""
+import asyncio
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+_TEMPLATES_DIR = Path(__file__).resolve().parents[4] / "app" / "templates"
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _make_lfa_student(user_id=1):
+    from app.models.user import UserRole
+    u = MagicMock()
+    u.id = user_id
+    u.role = UserRole.STUDENT
+    u.onboarding_completed = True
+    u.credit_balance = 0
+    u.specialization = MagicMock()
+    u.specialization.value = "LFA_FOOTBALL_PLAYER"
+    return u
+
+
+def _make_gancuju_student(user_id=2):
+    from app.models.user import UserRole
+    u = MagicMock()
+    u.id = user_id
+    u.role = UserRole.STUDENT
+    u.onboarding_completed = True
+    u.credit_balance = 0
+    u.specialization = MagicMock()
+    u.specialization.value = "GANCUJU_PLAYER"
+    return u
+
+
+def _make_request(path="/my-cards"):
+    r = MagicMock()
+    r.url.path = path
+    return r
+
+
+def _make_db():
+    db = MagicMock()
+    q = MagicMock()
+    q.filter.return_value = q
+    q.filter_by.return_value = q
+    q.first.return_value = None
+    q.all.return_value = []
+    q.count.return_value = 0
+    q.limit.return_value = q
+    q.order_by.return_value = q
+    db.query.return_value = q
+    return db
+
+
+# ── NAV-01..02: /my-cards explicit spec context ────────────────────────────────
+
+class TestMyCardsSpecContext:
+
+    def _call_my_cards(self):
+        from app.api.web_routes.my_cards import my_cards_hub
+        from app.services.card_system import card_registry
+
+        user = _make_lfa_student()
+        request = _make_request("/my-cards")
+        captured = {}
+
+        def capture(*args, **kwargs):
+            captured.update(args[1] if len(args) > 1 else kwargs.get("context", {}))
+            resp = MagicMock()
+            resp.status_code = 200
+            return resp
+
+        with patch("app.api.web_routes.my_cards.card_registry") as mock_reg, \
+             patch("app.api.web_routes.my_cards.templates") as mock_tmpl:
+            mock_reg.list_card_type_ids.return_value = []
+            mock_reg.get_card_type_spec.return_value = MagicMock()
+            mock_tmpl.TemplateResponse.side_effect = capture
+            _run(my_cards_hub(request=request, user=user))
+
+        return captured
+
+    def test_nav01_my_cards_passes_spec_dashboard_url(self):
+        """NAV-01: /my-cards route passes spec_dashboard_url='/dashboard/lfa-football-player'."""
+        ctx = self._call_my_cards()
+        assert ctx.get("spec_dashboard_url") == "/dashboard/lfa-football-player"
+
+    def test_nav02_my_cards_passes_spec_profile_url(self):
+        """NAV-02: /my-cards route passes spec_profile_url='/profile/lfa-football-player'."""
+        ctx = self._call_my_cards()
+        assert ctx.get("spec_profile_url") == "/profile/lfa-football-player"
+
+
+# ── NAV-03..04: /dashboard/lfa-football-player explicit spec context ───────────
+
+_DASHBOARD_PY = (
+    Path(__file__).resolve().parents[4] / "app" / "api" / "web_routes" / "dashboard.py"
+)
+
+
+class TestDashboardSpecContext:
+
+    def _read_dashboard_route(self):
+        return _DASHBOARD_PY.read_text(encoding="utf-8")
+
+    def test_nav03_dashboard_passes_spec_dashboard_url(self):
+        """NAV-03: dashboard.py TemplateResponse context contains spec_dashboard_url key."""
+        src = self._read_dashboard_route()
+        assert '"spec_dashboard_url": "/dashboard/lfa-football-player"' in src
+
+    def test_nav04_dashboard_passes_spec_profile_url(self):
+        """NAV-04: dashboard.py TemplateResponse context contains spec_profile_url key."""
+        src = self._read_dashboard_route()
+        assert '"spec_profile_url": "/profile/lfa-football-player"' in src
+
+
+# ── NAV-05..07: spec_subpage_hdr.html quicknav rendering ─────────────────────
+
+class TestSpecSubpageHdrTemplate:
+
+    def _read(self):
+        return (_TEMPLATES_DIR / "includes" / "spec_subpage_hdr.html").read_text(encoding="utf-8")
+
+    def test_nav05_quicknav_triggered_by_spec_dashboard_url(self):
+        """NAV-05: spec_subpage_hdr.html renders quicknav via spec_dashboard_url trigger."""
+        html = self._read()
+        # The second branch of _lfa_qn checks spec_dashboard_url
+        assert "(spec_dashboard_url | default('')) == '/dashboard/lfa-football-player'" in html
+
+    def test_nav06_quicknav_triggered_by_user_specialization(self):
+        """NAV-06: spec_subpage_hdr.html renders quicknav via user.specialization trigger."""
+        html = self._read()
+        assert "LFA_FOOTBALL_PLAYER" in html
+        assert "spec-quicknav" in html
+
+    def test_nav07_quicknav_gated_by_lfa_qn(self):
+        """NAV-07: spec_subpage_hdr.html quicknav <nav> element is inside {% if _lfa_qn %} — not rendered for GānCuju."""
+        html = self._read()
+        assert "{% if _lfa_qn %}" in html
+        # The <nav> element must appear after the gate, not the CSS .spec-quicknav selector
+        gate_idx = html.index("{% if _lfa_qn %}")
+        nav_elem_idx = html.index('<nav class="spec-quicknav"')
+        assert nav_elem_idx > gate_idx, "<nav class='spec-quicknav'> must appear after {% if _lfa_qn %} gate"
+
+
+# ── NAV-08: card editor back link ─────────────────────────────────────────────
+
+class TestCardEditorBackLink:
+
+    def _read_editor(self):
+        return (_TEMPLATES_DIR / "dashboard_card_editor.html").read_text(encoding="utf-8")
+
+    def test_nav08_card_editor_back_link_points_to_my_cards(self):
+        """NAV-08: dashboard_card_editor.html back link is /my-cards (not /profile/lfa-football-player)."""
+        html = self._read_editor()
+        assert 'href="/my-cards"' in html
+        assert 'href="/profile/lfa-football-player"' not in html
+
+
+# ── NAV bonus: dashboard template uses spec_subpage_hdr include ───────────────
+
+class TestDashboardHeaderUnification:
+
+    def _read_dashboard(self):
+        return (_TEMPLATES_DIR / "dashboard_student_new.html").read_text(encoding="utf-8")
+
+    def test_dashboard_header_uses_spec_subpage_hdr_include(self):
+        """dashboard_student_new.html student_header block uses spec_subpage_hdr include."""
+        html = self._read_dashboard()
+        assert 'includes/spec_subpage_hdr.html' in html
+
+    def test_dashboard_header_no_redundant_student_nav(self):
+        """dashboard_student_new.html no longer has redundant student-nav element."""
+        html = self._read_dashboard()
+        # The old inline student-nav with hardcoded LFA Player link should be gone
+        assert '<nav class="student-nav"' not in html
+        assert 'href="/dashboard/lfa-football-player" class="nav-item active"' not in html

--- a/tests/unit/api/web_routes/test_lfa_nav_phase_a.py
+++ b/tests/unit/api/web_routes/test_lfa_nav_phase_a.py
@@ -1,0 +1,141 @@
+"""LFA Navigation Phase A — PA-01..PA-12 template source tests.
+
+PA-01  training_hub.html — dashboard link removed from footer
+PA-02  training_hub.html — events link removed from footer
+PA-03  training_hub.html — Progress link preserved as "📊 View Progress"
+PA-04  lfa_player_mood_photos.html — no back-to-profile button link
+PA-05  lfa_player_profile.html — no .back-link CSS class defined
+PA-06  lfa_player_profile.html — no href="/profile" back link element
+PA-07  lfa_player_profile.html — dashboard CTA text is "⚽ LFA Dashboard"
+PA-08  dashboard_card_editor.html — ⚽ LFA Dashboard button present
+PA-09  dashboard_card_editor.html — brand is "🎴 My Player Card"
+PA-10  dashboard_card_editor.html — messages badge-wrap removed
+PA-11  spec_subpage_hdr.html — mask-image mobile scroll fade CSS present
+PA-12  dashboard_student_new.html — "Tools & Quick Access" label present
+"""
+from pathlib import Path
+
+_T = Path(__file__).resolve().parents[4] / "app" / "templates"
+
+
+def _read(rel):
+    return (_T / rel).read_text(encoding="utf-8")
+
+
+# ── PA-01..03: training_hub.html footer ───────────────────────────────────────
+
+class TestTrainingHubFooter:
+
+    def _src(self):
+        return _read("training_hub.html")
+
+    def test_pa01_dashboard_link_removed(self):
+        """PA-01: training footer no longer links to /dashboard/lfa-football-player."""
+        src = self._src()
+        footer_start = src.index('class="trn-footer"')
+        footer_block = src[footer_start:]
+        assert '/dashboard/lfa-football-player' not in footer_block
+
+    def test_pa02_events_link_removed(self):
+        """PA-02: training footer no longer links to /events."""
+        src = self._src()
+        footer_start = src.index('class="trn-footer"')
+        footer_block = src[footer_start:]
+        assert 'href="/events"' not in footer_block
+
+    def test_pa03_progress_link_preserved(self):
+        """PA-03: training footer still contains the Progress link labelled '📊 View Progress'."""
+        src = self._src()
+        assert 'href="/progress"' in src
+        assert '📊 View Progress' in src
+
+
+# ── PA-04: lfa_player_mood_photos.html ────────────────────────────────────────
+
+class TestMoodPhotosBackLink:
+
+    def _src(self):
+        return _read("lfa_player_mood_photos.html")
+
+    def test_pa04_no_back_to_profile_button(self):
+        """PA-04: mood photos page has no back-to-profile button link."""
+        src = self._src()
+        assert 'href="/profile/lfa-football-player"' not in src
+
+
+# ── PA-05..07: lfa_player_profile.html ────────────────────────────────────────
+
+class TestLfaPlayerProfileBackLink:
+
+    def _src(self):
+        return _read("lfa_player_profile.html")
+
+    def test_pa05_no_back_link_css(self):
+        """PA-05: .back-link CSS class definition removed from profile page."""
+        src = self._src()
+        assert '.back-link' not in src
+
+    def test_pa06_no_href_profile_back_link(self):
+        """PA-06: href="/profile" back link element removed from profile page."""
+        src = self._src()
+        assert 'href="/profile"' not in src
+
+    def test_pa07_dashboard_cta_renamed(self):
+        """PA-07: dashboard CTA text is '⚽ LFA Dashboard' (not bare '⚽ Dashboard')."""
+        src = self._src()
+        assert '⚽ LFA Dashboard' in src
+
+
+# ── PA-08..10: dashboard_card_editor.html ────────────────────────────────────
+
+class TestCardEditorHeader:
+
+    def _src(self):
+        return _read("dashboard_card_editor.html")
+
+    def test_pa08_lfa_dashboard_button_present(self):
+        """PA-08: card editor header has ⚽ link pointing to /dashboard/lfa-football-player."""
+        src = self._src()
+        assert 'href="/dashboard/lfa-football-player"' in src
+
+    def test_pa09_brand_is_my_player_card(self):
+        """PA-09: card editor header brand text is '🎴 My Player Card'."""
+        src = self._src()
+        assert '🎴 My Player Card' in src
+
+    def test_pa10_no_messages_badge_wrap(self):
+        """PA-10: messages badge-wrap removed from card editor header."""
+        src = self._src()
+        # The old pattern had an <a> wrapping a messages button with a badge span
+        # Check both the messages route and the badge pattern are gone from header block
+        assert 'href="/messages"' not in src
+
+
+# ── PA-11: spec_subpage_hdr.html mask-image ───────────────────────────────────
+
+class TestSpecSubpageHdrMaskImage:
+
+    def _src(self):
+        return _read("includes/spec_subpage_hdr.html")
+
+    def test_pa11_mask_image_mobile_css_present(self):
+        """PA-11: spec_subpage_hdr has mask-image fade CSS for mobile quicknav scroll."""
+        src = self._src()
+        assert 'mask-image' in src
+        assert '-webkit-mask-image' in src
+        assert 'linear-gradient(to right' in src
+
+
+# ── PA-12: dashboard_student_new.html label ───────────────────────────────────
+
+class TestDashboardModNavLabel:
+
+    def _src(self):
+        return _read("dashboard_student_new.html")
+
+    def test_pa12_tools_quick_access_label_present(self):
+        """PA-12: mod-nav grid has 'Tools & Quick Access' section label."""
+        src = self._src()
+        assert 'mod-nav-section-label' in src
+        assert 'Tools' in src
+        assert 'Quick Access' in src

--- a/tests/unit/api/web_routes/test_lfa_nav_phase_a.py
+++ b/tests/unit/api/web_routes/test_lfa_nav_phase_a.py
@@ -12,6 +12,11 @@ PA-09  dashboard_card_editor.html — brand is "🎴 My Player Card"
 PA-10  dashboard_card_editor.html — messages badge-wrap removed
 PA-11  spec_subpage_hdr.html — mask-image mobile scroll fade CSS present
 PA-12  dashboard_student_new.html — "Tools & Quick Access" label present
+
+Phase A-fix: spec dashboard profile link regression
+PF-01  dashboard_student_new.html — footer Profile link → /profile/lfa-football-player
+PF-02  dashboard_student_new.html — no bare href="/profile" footer link remains
+PF-03  dashboard_student_new.html — mod-nav Profile tile → /profile/lfa-football-player
 """
 from pathlib import Path
 
@@ -139,3 +144,30 @@ class TestDashboardModNavLabel:
         assert 'mod-nav-section-label' in src
         assert 'Tools' in src
         assert 'Quick Access' in src
+
+
+# ── PF-01..03: spec dashboard profile link regression fix ─────────────────────
+
+class TestSpecDashboardProfileLinks:
+    """Profile links on the LFA spec dashboard must point to the spec profile, not hub."""
+
+    def _src(self):
+        return _read("dashboard_student_new.html")
+
+    def test_pf01_footer_profile_link_is_spec(self):
+        """PF-01: footer Profile link is /profile/lfa-football-player."""
+        src = self._src()
+        assert 'href="/profile/lfa-football-player"' in src
+
+    def test_pf02_no_bare_profile_footer_link(self):
+        """PF-02: no bare href="/profile" link in footer-links section."""
+        src = self._src()
+        footer_start = src.index('class="footer-links"')
+        footer_block = src[footer_start:footer_start + 500]
+        assert 'href="/profile"' not in footer_block
+
+    def test_pf03_mod_nav_profile_tile_is_spec(self):
+        """PF-03: mod-nav Profile tile already points to /profile/lfa-football-player."""
+        src = self._src()
+        # Both mod-nav tile and footer link should use spec URL
+        assert src.count('href="/profile/lfa-football-player"') >= 2

--- a/tests/unit/api/web_routes/test_lfa_nav_phase_a.py
+++ b/tests/unit/api/web_routes/test_lfa_nav_phase_a.py
@@ -147,27 +147,26 @@ class TestDashboardModNavLabel:
 
 
 # ── PF-01..03: spec dashboard profile link regression fix ─────────────────────
+# After MVP refactor: footer-links + mod-nav Profile tile removed from dashboard.
+# Profile access via spec_subpage_hdr quicknav (include file).
 
 class TestSpecDashboardProfileLinks:
-    """Profile links on the LFA spec dashboard must point to the spec profile, not hub."""
+    """Profile link regression: dashboard must not route to bare /profile hub."""
 
     def _src(self):
         return _read("dashboard_student_new.html")
 
-    def test_pf01_footer_profile_link_is_spec(self):
-        """PF-01: footer Profile link is /profile/lfa-football-player."""
-        src = self._src()
-        assert 'href="/profile/lfa-football-player"' in src
+    def test_pf01_quicknav_include_has_spec_profile(self):
+        """PF-01: spec_subpage_hdr.html (quicknav include) contains /profile/lfa-football-player."""
+        quicknav = _read("includes/spec_subpage_hdr.html")
+        assert 'href="/profile/lfa-football-player"' in quicknav
 
-    def test_pf02_no_bare_profile_footer_link(self):
-        """PF-02: no bare href="/profile" link in footer-links section."""
+    def test_pf02_footer_links_strip_removed(self):
+        """PF-02: footer-links strip has been removed from the spec dashboard template."""
         src = self._src()
-        footer_start = src.index('class="footer-links"')
-        footer_block = src[footer_start:footer_start + 500]
-        assert 'href="/profile"' not in footer_block
+        assert 'class="footer-links"' not in src
 
-    def test_pf03_mod_nav_profile_tile_is_spec(self):
-        """PF-03: mod-nav Profile tile already points to /profile/lfa-football-player."""
+    def test_pf03_no_bare_profile_href_in_dashboard(self):
+        """PF-03: no bare href="/profile" (hub profile) hardcoded in the dashboard template."""
         src = self._src()
-        # Both mod-nav tile and footer link should use spec URL
-        assert src.count('href="/profile/lfa-football-player"') >= 2
+        assert 'href="/profile"' not in src

--- a/tests/unit/api/web_routes/test_lfa_player_profile.py
+++ b/tests/unit/api/web_routes/test_lfa_player_profile.py
@@ -330,8 +330,8 @@ class TestLfaPlayerProfileTemplate:
 
     # ── Navigation ─────────────────────────────────────────────────────────
 
-    def test_back_link_to_global_profile(self, tpl_src):
-        assert 'href="/profile"' in tpl_src
+    def test_no_redundant_back_link(self, tpl_src):
+        assert 'class="back-link"' not in tpl_src
 
     def test_dashboard_link_to_lfa_dashboard(self, tpl_src):
         assert '/dashboard/lfa-football-player' in tpl_src

--- a/tests/unit/api/web_routes/test_lfa_player_profile.py
+++ b/tests/unit/api/web_routes/test_lfa_player_profile.py
@@ -856,26 +856,23 @@ class TestLfaNavigationCTAs:
         assert match is not None, "btn-go-profile element not found"
         assert match.group(1) == "/profile/lfa-football-player"
 
-    # ── Card editor header Profile button ────────────────────────────────────
+    # ── Card editor header My Cards button (P2: was Profile, now My Cards) ──────
 
-    def test_card_editor_header_profile_btn_points_to_lfa_profile(self, card_editor_src):
-        """Card editor is LFA-specific; its header Profile button targets spec profile."""
-        assert 'href="/profile/lfa-football-player"' in card_editor_src
+    def test_card_editor_header_my_cards_btn_points_to_my_cards(self, card_editor_src):
+        """Card editor header back button (P2) now targets /my-cards (not /profile/lfa-football-player)."""
+        assert 'href="/my-cards"' in card_editor_src
+        assert 'href="/profile/lfa-football-player"' not in card_editor_src
 
-    def test_card_editor_header_profile_btn_uses_id_card_icon(self, card_editor_src):
-        """Card editor Profile button must use 🪪 (LFA spec-profile link)."""
+    def test_card_editor_header_my_cards_btn_uses_joker_card_icon(self, card_editor_src):
+        """Card editor My Cards button must use 🃏 icon."""
         import re
-        match = re.search(r'href="/profile/lfa-football-player"[^>]*>([^<]+)', card_editor_src)
-        assert match is not None, "Profile link not found in card editor"
-        assert '🪪' in match.group(1)
+        match = re.search(r'href="/my-cards"[^>]*>([^<]+)', card_editor_src)
+        assert match is not None, "My Cards link not found in card editor"
+        assert '🃏' in match.group(1)
 
-    def test_card_editor_header_profile_btn_not_global(self, card_editor_src):
+    def test_card_editor_header_btn_not_global_profile(self, card_editor_src):
         """Card editor must not have a plain s-hdr-btn pointing to /profile."""
-        import re
-        # There should be no s-hdr-btn with href="/profile" (the plain global route)
         assert 'href="/profile" class="s-hdr-btn"' not in card_editor_src
-        assert 'href="/profile"' not in card_editor_src or \
-               'href="/profile/lfa-football-player"' in card_editor_src
 
     # ── My Cards tile icon — Phase 4B: 🃏, hero title: My Cards ─────────────
 
@@ -891,12 +888,12 @@ class TestLfaNavigationCTAs:
         """Card editor page title must contain My Player Card."""
         assert 'My Player Card' in card_editor_src
 
-    def test_card_editor_profile_cta_still_uses_id_card_icon(self, card_editor_src):
-        """Profile CTA in card editor must still be 🪪 (unchanged)."""
+    def test_card_editor_my_cards_cta_uses_joker_icon(self, card_editor_src):
+        """My Cards CTA in card editor must use 🃏 (P2: replaced Profile 🪪 → My Cards 🃏)."""
         import re
-        match = re.search(r'href="/profile/lfa-football-player"[^>]*>([^<]+)', card_editor_src)
-        assert match is not None
-        assert '🪪' in match.group(1)
+        match = re.search(r'href="/my-cards"[^>]*>([^<]+)', card_editor_src)
+        assert match is not None, "My Cards link not found in card editor"
+        assert '🃏' in match.group(1)
 
     # ── Regression: student_base.html global nav stays on /profile ───────────
 

--- a/tests/unit/api/web_routes/test_lfa_player_profile.py
+++ b/tests/unit/api/web_routes/test_lfa_player_profile.py
@@ -820,9 +820,13 @@ class TestLfaNavigationCTAs:
 
     # ── Dashboard footer links — must remain global ───────────────────────────
 
-    def test_dashboard_footer_profile_link_remains_global(self, dashboard_src):
-        """Footer nav is a utility strip; it stays /profile regardless of spec."""
-        assert 'href="/profile"' in dashboard_src
+    def test_dashboard_footer_profile_link_is_spec(self, dashboard_src):
+        """Spec dashboard footer Profile link points to LFA spec profile, not hub."""
+        assert 'href="/profile/lfa-football-player"' in dashboard_src
+        # bare /profile must not appear in the footer-links utility strip
+        footer_start = dashboard_src.index('class="footer-links"')
+        footer_block = dashboard_src[footer_start:footer_start + 500]
+        assert 'href="/profile"' not in footer_block
 
     # ── LFA dashboard Profile button icon ────────────────────────────────────
 

--- a/tests/unit/api/web_routes/test_lfa_player_profile.py
+++ b/tests/unit/api/web_routes/test_lfa_player_profile.py
@@ -75,6 +75,10 @@ _STUDENT_BASE_TPL_PATH = (
     pathlib.Path(__file__).resolve().parents[4]
     / "app" / "templates" / "student_base.html"
 )
+_QUICKNAV_TPL_PATH = (
+    pathlib.Path(__file__).resolve().parents[4]
+    / "app" / "templates" / "includes" / "spec_subpage_hdr.html"
+)
 
 
 # ── Shared helpers ─────────────────────────────────────────────────────────────
@@ -805,8 +809,10 @@ class TestLfaNavigationCTAs:
     # ── LFA dashboard header Profile button ──────────────────────────────────
 
     def test_dashboard_header_profile_btn_points_to_lfa_profile(self, dashboard_src):
-        """Header Profile button in LFA dashboard conditionally targets spec profile."""
-        assert "/profile/lfa-football-player" in dashboard_src
+        """Header Profile button: dashboard includes spec_subpage_hdr which has spec profile link."""
+        assert "includes/spec_subpage_hdr.html" in dashboard_src
+        quicknav_src = _QUICKNAV_TPL_PATH.read_text()
+        assert 'href="/profile/lfa-football-player"' in quicknav_src
 
     def test_dashboard_header_profile_btn_is_conditional_on_specialization(self, dashboard_src):
         """Conditional branch must check for LFA_FOOTBALL_PLAYER so other specs keep /profile."""
@@ -820,23 +826,22 @@ class TestLfaNavigationCTAs:
 
     # ── Dashboard footer links — must remain global ───────────────────────────
 
-    def test_dashboard_footer_profile_link_is_spec(self, dashboard_src):
-        """Spec dashboard footer Profile link points to LFA spec profile, not hub."""
-        assert 'href="/profile/lfa-football-player"' in dashboard_src
-        # bare /profile must not appear in the footer-links utility strip
-        footer_start = dashboard_src.index('class="footer-links"')
-        footer_block = dashboard_src[footer_start:footer_start + 500]
-        assert 'href="/profile"' not in footer_block
+    def test_dashboard_footer_links_removed_no_bare_profile(self, dashboard_src):
+        """Footer-links strip removed in MVP; no bare href='/profile' in dashboard template."""
+        assert 'class="footer-links"' not in dashboard_src
+        assert 'href="/profile"' not in dashboard_src
 
     # ── LFA dashboard Profile button icon ────────────────────────────────────
 
     def test_dashboard_lfa_profile_btn_uses_id_card_icon(self, dashboard_src):
-        """When specialization == LFA_FOOTBALL_PLAYER the Profile btn must show 🪪."""
-        assert '🪪' in dashboard_src
+        """LFA spec navigation (via quicknav include) uses 🪪 icon for the profile link."""
+        quicknav_src = _QUICKNAV_TPL_PATH.read_text()
+        assert '🪪' in quicknav_src
 
     def test_dashboard_non_lfa_profile_btn_uses_person_icon(self, dashboard_src):
-        """The else branch (non-LFA) must show 👤."""
-        assert '👤' in dashboard_src
+        """Non-LFA spec navigation (via quicknav include) falls back to 👤 icon."""
+        quicknav_src = _QUICKNAV_TPL_PATH.read_text()
+        assert '👤' in quicknav_src
 
     # ── Onboarding Step 7 "Go to Profile" button ─────────────────────────────
 
@@ -885,8 +890,9 @@ class TestLfaNavigationCTAs:
         assert '🃏' in dashboard_src
 
     def test_dashboard_my_cards_hero_title_updated(self, dashboard_src):
-        """My Cards hero section title must reflect Phase 4B rename."""
-        assert '🃏 My Cards' in dashboard_src
+        """Player Card dc-hero uses 🃏 icon; All Cards link goes to /my-cards."""
+        assert '🃏' in dashboard_src
+        assert 'href="/my-cards"' in dashboard_src
 
     def test_card_editor_page_title_uses_playing_card_icon(self, card_editor_src):
         """Card editor page title must contain My Player Card."""

--- a/tests/unit/api/web_routes/test_mood_photos.py
+++ b/tests/unit/api/web_routes/test_mood_photos.py
@@ -406,7 +406,9 @@ def test_mp_r16_template_uses_correct_blocks():
     assert "mp-grid" in content, "template must contain mp-grid class for 2×2 slot layout"
     assert "mp-card" in content, "template must contain mp-card class for slot cards"
     assert "btn btn-primary" in content, "template must use btn btn-primary for upload button"
-    assert "btn btn-secondary" in content, "template must use btn btn-secondary for back link"
+    assert 'href="/profile/lfa-football-player"' not in content, (
+        "redundant back-to-profile link removed in Phase A nav cleanup"
+    )
     assert "btn btn-danger" in content, "template must use btn btn-danger for delete button"
     assert "spec_subpage_hdr.html" in content, (
         "template must include spec_subpage_hdr.html for platform header"

--- a/tests/unit/api/web_routes/test_mood_photos.py
+++ b/tests/unit/api/web_routes/test_mood_photos.py
@@ -290,24 +290,24 @@ def test_mp_r11_management_template_is_english():
     assert "Not uploaded" in content
 
 
-# ── MP-R12 ── dashboard has My Card Media section + correct links ─────────────
+# ── MP-R12 ── dashboard My Card Media section removed; access via quicknav ─────
 
 def test_mp_r12_dashboard_has_card_media_section():
     from pathlib import Path
 
-    content = (
-        Path(__file__).resolve()
-        .parent.parent.parent.parent.parent
-        / "app" / "templates" / "dashboard_student_new.html"
-    ).read_text(encoding="utf-8")
+    _tpl = Path(__file__).resolve().parent.parent.parent.parent.parent / "app" / "templates"
+    dashboard = (_tpl / "dashboard_student_new.html").read_text(encoding="utf-8")
+    quicknav  = (_tpl / "includes" / "spec_subpage_hdr.html").read_text(encoding="utf-8")
 
-    assert "My Card Media" in content, "dashboard missing 'My Card Media' section title"
-    assert "/profile/my-mood-photos" in content, "dashboard missing /profile/my-mood-photos link"
-    assert "/dashboard/lfa-football-player/card-editor#media" in content, (
-        "dashboard missing card editor #media deep link"
+    # My Card Media section removed in MVP refactor — now lives in quicknav
+    assert "My Card Media" not in dashboard, (
+        "My Card Media section should be removed from dashboard (MVP refactor)"
     )
-    assert "/dashboard/lfa-football-player/card-editor" in content, (
-        "dashboard missing card editor link"
+    assert "/profile/my-mood-photos" in quicknav, (
+        "quicknav should still link to /profile/my-mood-photos"
+    )
+    assert "/dashboard/lfa-football-player/card-editor" in quicknav, (
+        "quicknav should still link to card-editor"
     )
 
 
@@ -463,36 +463,29 @@ def test_mp_r17_spec_subpage_hdr_has_lfa_quicknav():
     assert "spec-qn-item" in content, "quicknav items must use spec-qn-item class"
 
 
-# ── MP-R18 ── dashboard mod-nav has 9 items including Profile/Editor/Mood ────
+# ── MP-R18 ── dashboard mod-nav has 4 Quick Access tiles; quicknav has Mood ───
+# After MVP refactor: 9-tile mod-nav replaced with 4-tile Quick Access.
+# Profile/Editor/Mood Photos moved to spec_subpage_hdr.html quicknav.
 
 def test_mp_r18_dashboard_modnav_has_profile_editor_moodphotos():
     from pathlib import Path
 
-    content = (
-        Path(__file__).resolve()
-        .parent.parent.parent.parent.parent
-        / "app" / "templates" / "dashboard_student_new.html"
-    ).read_text(encoding="utf-8")
+    _tpl = Path(__file__).resolve().parent.parent.parent.parent.parent / "app" / "templates"
+    content = (_tpl / "dashboard_student_new.html").read_text(encoding="utf-8")
+    quicknav = (_tpl / "includes" / "spec_subpage_hdr.html").read_text(encoding="utf-8")
 
-    # All 9 mod-nav destinations must be present
-    required = [
-        ("/events",                                    "Events"),
-        ("/my-cards",                                  "My Cards"),
-        ("/training",                                  "Training"),
-        ("/skills/history",                            "Skill History"),
-        ("/calendar",                                  "Calendar"),
-        ("/achievements",                              "Achievements"),
-        ("/profile/lfa-football-player",               "Profile"),
-        ("/dashboard/lfa-football-player/card-editor", "Card Editor"),
-        ("/profile/my-mood-photos",                    "Mood Photos"),
-    ]
+    # Dashboard mod-nav: 4 Quick Access tiles
     modnav_start = content.find('<section class="mod-nav-section">')
     modnav_end   = content.find("</section>", modnav_start)
     modnav_block = content[modnav_start:modnav_end] if modnav_start != -1 else content
 
-    for url, label in required:
-        assert url in modnav_block, f"dashboard mod-nav missing: {url!r} ({label})"
-        assert label in modnav_block, f"dashboard mod-nav missing label: {label!r}"
+    for url in ("/calendar", "/achievements", "/sessions", "/progress"):
+        assert url in modnav_block, f"dashboard mod-nav missing Quick Access tile: {url!r}"
+
+    # Mood Photos, Card Editor, Profile accessible via quicknav (not mod-nav)
+    assert "/profile/my-mood-photos"                    in quicknav
+    assert "/dashboard/lfa-football-player/card-editor" in quicknav
+    assert "/profile/lfa-football-player"               in quicknav
 
 
 # ── MP-R19 ── mood_photos_page route passes explicit LFA spec context ─────────

--- a/tests/unit/api/web_routes/test_training_hub.py
+++ b/tests/unit/api/web_routes/test_training_hub.py
@@ -154,9 +154,9 @@ class TestDashboardModNav:
         return (_TEMPLATES_DIR / "dashboard_student_new.html").read_text(encoding="utf-8")
 
     def test_trn04_dashboard_contains_training_card(self):
-        """TRN-04: dashboard_student_new.html mod-nav contains /training link."""
-        html = self._read_dashboard()
-        assert 'href="/training"' in html
+        """TRN-04: /training link accessible from dashboard via spec quicknav include."""
+        quicknav = (_TEMPLATES_DIR / "includes" / "spec_subpage_hdr.html").read_text(encoding="utf-8")
+        assert 'href="/training"' in quicknav
 
     def test_trn05_dashboard_no_direct_adaptive_learning_card(self):
         """TRN-05: dashboard_student_new.html mod-nav does NOT contain direct /adaptive-learning card."""

--- a/tests/unit/api/web_routes/test_welcome_card.py
+++ b/tests/unit/api/web_routes/test_welcome_card.py
@@ -905,7 +905,7 @@ class TestWelcomeCardProfileSection:
 
     def test_dashboard_player_card_link_unchanged(self, dashboard_src):
         assert '/players/{{ user.id }}/card' in dashboard_src
-        assert 'spec-player-card-iframe' in dashboard_src
+        assert 'dc-player-iframe' in dashboard_src
 
 
 # ── 10. Preview / export rendering fixes (Fix A, B, C) ───────────────────────


### PR DESCRIPTION
## Summary

- Multi-spec safe quicknav — LFA spec navigation context fixes (sidebar, mobile nav, quicknav active state)
- Phase A LFA navigation UX cleanup — active state tracking, breadcrumb, mobile nav polish
- Spec dashboard footer Profile link → correct `/profile/lfa-football-player` route
- LFA Spec Dashboard MVP — card preview zone (`.dc-card-zone`), 4-tile Quick Access (Calendar/Achievements/Sessions/Progress), KPI row
- Tile-card layout polish — equal 3-col grid, 160px thumbnail

## New context keys

`skill_count`, `has_welcome_card`, `spec_dashboard_url` added to dashboard route context.

## New CSS class

`dc-cta-primary` introduced in `theme.css` — required by PR-B (My Cards Hub).

## New test files

`tests/unit/api/web_routes/test_lfa_nav.py`, `test_lfa_nav_phase_a.py`, `test_lfa_dashboard_mvp.py`

## Merge order

Merge after **PR-A0** (#183). PR-B bases on this branch.

## Test plan

- [ ] Unit Tests (incl. test_lfa_nav.py, test_lfa_nav_phase_a.py, test_lfa_dashboard_mvp.py)
- [ ] API Smoke Tests green
- [ ] `card-unlock-apply-gate` path-filtered check triggers (dashboard.py changed)
- [ ] Dashboard renders correctly for LFA spec student

🤖 Generated with [Claude Code](https://claude.com/claude-code)