### PR TITLE
feat(cards): Get Card entitlement MVP — purchase, export guard, format shop

### DIFF
--- a/alembic/versions/2026_05_28_0900_add_card_design_ownerships.py
+++ b/alembic/versions/2026_05_28_0900_add_card_design_ownerships.py
@@ -1,0 +1,75 @@
+"""Add card_design_ownerships table.
+
+Schema-only migration: creates the entitlement table for card design ownership.
+No data migration — backfill is handled by scripts/backfill_card_design_ownerships.py
+which must be run explicitly after a product decision.
+
+Revision ID: 2026_05_28_0900
+Revises: 2026_05_26_1200
+Create Date: 2026-05-28 09:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "2026_05_28_0900"
+down_revision = "2026_05_26_1200"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "card_design_ownerships",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column(
+            "user_id",
+            sa.Integer,
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "card_type_id",
+            sa.String(50),
+            nullable=False,
+            comment="'player_card' | 'welcome_card' | 'challenge_card'",
+        ),
+        sa.Column(
+            "design_id",
+            sa.String(50),
+            nullable=False,
+            comment="e.g. 'fifa', 'compact', 'default', 'challenge'",
+        ),
+        sa.Column(
+            "source",
+            sa.String(20),
+            nullable=False,
+            server_default="purchase",
+            comment="'purchase' | 'admin_grant' | 'promo' | 'system'",
+        ),
+        sa.Column(
+            "credit_transaction_id",
+            sa.Integer,
+            sa.ForeignKey("credit_transactions.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "acquired_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.UniqueConstraint(
+            "user_id", "card_type_id", "design_id",
+            name="uq_cdo_user_type_design",
+        ),
+    )
+    op.create_index(
+        "ix_cdo_user_id",
+        "card_design_ownerships",
+        ["user_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_cdo_user_id", table_name="card_design_ownerships")
+    op.drop_table("card_design_ownerships")

--- a/alembic/versions/2026_05_28_1000_fix_card_design_pricing.py
+++ b/alembic/versions/2026_05_28_1000_fix_card_design_pricing.py
@@ -1,0 +1,62 @@
+"""Fix card design pricing — FIFA Classic + classic_lite.
+
+Revision ID: 2026_05_28_1000
+Revises:     2026_05_28_0900
+Create Date: 2026-05-28 10:00:00.000000
+
+Changes:
+  fifa        → is_premium=TRUE, credit_cost=300
+               Was seeded as free (CS-1); entitlement MVP requires a real price.
+               DESIGNS fallback dict already reflects this value; migration
+               brings the DB row into alignment so staging/prod/fresh installs
+               are consistent.
+
+  classic_lite → is_active=FALSE
+               CS-5 proof-of-concept design; never productised; 0 CDO rows.
+               Hiding it removes the ambiguous 0-CR active row from the shop
+               without destroying migration history or the component_config data.
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "2026_05_28_1000"
+down_revision = "2026_05_28_0900"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    conn.execute(sa.text("""
+        UPDATE card_designs
+        SET is_premium = TRUE,
+            credit_cost = 300
+        WHERE id = 'fifa'
+    """))
+
+    conn.execute(sa.text("""
+        UPDATE card_designs
+        SET is_active = FALSE
+        WHERE id = 'classic_lite'
+    """))
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+
+    conn.execute(sa.text("""
+        UPDATE card_designs
+        SET is_premium = FALSE,
+            credit_cost = 0
+        WHERE id = 'fifa'
+    """))
+
+    conn.execute(sa.text("""
+        UPDATE card_designs
+        SET is_active = TRUE
+        WHERE id = 'classic_lite'
+    """))

--- a/app/api/web_routes/dashboard.py
+++ b/app/api/web_routes/dashboard.py
@@ -405,11 +405,9 @@ async def lfa_player_card_editor(
     published_card_variant  = card_draft.published_variant  or "fifa"
     published_card_platform = card_draft.published_platform or "default"
 
-    # Card variant picker data — identical logic to spec_dashboard
-    from ...services.card_variant_service import (  # noqa: E402
-        get_all_variants as _get_all_variants,
-        is_variant_unlocked as _is_variant_unlocked,
-    )
+    # Card variant picker data — CDO-based ownership check
+    from ...services.card_variant_service import get_all_variants as _get_all_variants  # noqa: E402
+    from ...services.card_design_service import is_design_accessible as _is_design_accessible  # noqa: E402
     card_variants = [
         {
             "id": v.id,
@@ -418,7 +416,7 @@ async def lfa_player_card_editor(
             "is_premium": v.is_premium,
             "credit_cost": v.credit_cost,
             "available": v.available,
-            "unlocked": _is_variant_unlocked(user_license, v.id),
+            "unlocked": _is_design_accessible(db, user.id, "player_card", v.id),
         }
         for v in _get_all_variants()
     ]
@@ -1225,7 +1223,7 @@ async def student_set_card_photo_focus(
 # ══════════════════════════════════════════════════════════════════════════════
 
 from ...services.card_theme_service import apply_theme as _apply_theme, unlock_theme as _unlock_theme  # noqa: E402
-from ...services.card_variant_service import apply_variant as _apply_variant, unlock_variant as _unlock_variant  # noqa: E402
+from ...services.card_variant_service import unlock_variant as _unlock_variant  # noqa: E402
 from ...services.card_platform_service import PLATFORM_PRESETS as _PLATFORM_PRESETS  # noqa: E402
 from ...services.card_draft_service import CardDraftService as _CardDraftService  # noqa: E402
 from pydantic import BaseModel as _BaseModel  # noqa: E402
@@ -1299,15 +1297,21 @@ async def student_set_card_variant(
     db: Session = Depends(get_db),
     user: User = Depends(get_current_user_web),
 ):
-    """Apply a card layout variant (must already be unlocked for premium variants)."""
-    lfa_license = _get_lfa_license(db, user.id)
-    if not lfa_license:
-        return JSONResponse({"ok": False, "error": "No active LFA Football Player license"}, status_code=404)
-    try:
-        _apply_variant(db, lfa_license, payload.variant)
-        return JSONResponse({"ok": True, "variant": payload.variant})
-    except ValueError as e:
-        return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
+    """Apply a card layout variant (requires CardDesignOwnership entitlement)."""
+    from ...services.card_design_service import is_design_accessible as _is_da  # noqa: E402
+    from ...services.card_draft_service import CardDraftService as _CDS  # noqa: E402
+    from ...services.card_variant_service import VARIANTS as _VARIANTS  # noqa: E402
+
+    if payload.variant not in _VARIANTS:
+        return JSONResponse({"ok": False, "error": f"Unknown variant: {payload.variant!r}"}, status_code=400)
+    if not _VARIANTS[payload.variant].available:
+        return JSONResponse({"ok": False, "error": f"Variant '{_VARIANTS[payload.variant].label}' is not yet available"}, status_code=400)
+    if not _is_da(db, user.id, "player_card", payload.variant):
+        return JSONResponse({"ok": False, "error": f"Design '{_VARIANTS[payload.variant].label}' not owned"}, status_code=403)
+
+    draft = _CDS.get_player_card_draft(db, user_id=user.id)
+    _CDS.update_draft_variant(db, draft, payload.variant)
+    return JSONResponse({"ok": True, "variant": payload.variant})
 
 
 @router.post("/dashboard/unlock-variant")

--- a/app/api/web_routes/my_cards.py
+++ b/app/api/web_routes/my_cards.py
@@ -1,7 +1,7 @@
-"""My Cards hub — cross-card-type navigation hub and detail redirects."""
+"""My Cards hub — cross-card-type navigation hub and family shop routes."""
 from pathlib import Path
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from sqlalchemy import or_
@@ -9,15 +9,16 @@ from sqlalchemy.orm import Session
 
 from ...database import get_db
 from ...dependencies import get_current_user_web
-from ...models.license import UserLicense
 from ...models.user import User
 from ...models.virtual_training import VirtualTrainingAttempt
 from ...models.vt_challenge import ChallengeStatus, VirtualTrainingChallenge
 from ...services.card_design_service import (
+    CHALLENGE_CARD_FORMATS,
+    WELCOME_CARD_FORMATS,
     AlreadyOwnedError,
     FreeDesignError,
-    _NON_PLAYER_CARD_PRICES,
     get_all_designs,
+    get_owned_design_ids,
     is_design_accessible,
     purchase_design,
 )
@@ -37,12 +38,15 @@ templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
 
 router = APIRouter(tags=["my-cards"])
 
-_TYPE_TO_TAB: dict[str, str] = {
-    "player_card":    "player",
-    "welcome_card":   "welcome",
-    "challenge_card": "challenge",
+# Maps card_type_id → family page path (used for purchase redirect targets)
+_TYPE_TO_FAMILY_PATH: dict[str, str] = {
+    "player_card":    "/my-cards/player-card",
+    "welcome_card":   "/my-cards/welcome-card",
+    "challenge_card": "/my-cards/challenge-card",
 }
 
+
+# ── Hub ───────────────────────────────────────────────────────────────────────
 
 @router.get("/my-cards", response_class=HTMLResponse)
 async def my_cards_hub(
@@ -50,64 +54,36 @@ async def my_cards_hub(
     db: Session = Depends(get_db),
     user: User  = Depends(get_current_user_web),
 ):
-    """Hub — entitlement-aware central page for all card families."""
-    license = db.query(UserLicense).filter(
-        UserLicense.user_id == user.id,
-        UserLicense.specialization_type == "LFA_FOOTBALL_PLAYER",
-        UserLicense.is_active == True,
-    ).first()
+    """Hub — format-count tiles for all three card families."""
+    all_designs = get_all_designs(db)
+    pc_total    = len(all_designs)
+    pc_owned_ids = set(get_owned_design_ids(db, user.id, "player_card"))
+    pc_owned_count = len(pc_owned_ids)
 
-    card_variant    = (license.card_variant if license else None) or "fifa"
-    designs_by_id   = {d.id: d for d in get_all_designs(db)}
-    design_obj      = designs_by_id.get(card_variant)
-    pc_price        = design_obj.credit_cost if design_obj else 0
-    pc_free         = not design_obj.is_premium if design_obj else True
-    pc_design_label = design_obj.label if design_obj else "FIFA Classic"
-    pc_owned        = is_design_accessible(db, user.id, "player_card", card_variant)
+    wc_total      = len(WELCOME_CARD_FORMATS)
+    _wc_valid_ids = {f.design_id for f in WELCOME_CARD_FORMATS}
+    wc_owned_ids  = set(get_owned_design_ids(db, user.id, "welcome_card"))
+    wc_owned_count = len(wc_owned_ids & _wc_valid_ids)
 
-    if pc_free:
-        pc_state = "free"
-    elif pc_owned:
-        pc_state = "owned"
-    elif user.credit_balance >= pc_price:
-        pc_state = "get_card"
-    else:
-        pc_state = "locked"
-
-    wc_price = _NON_PLAYER_CARD_PRICES[("welcome_card",   "default")]
-    wc_owned = is_design_accessible(db, user.id, "welcome_card", "default")
-    if wc_owned:
-        wc_state = "owned"
-    elif user.credit_balance >= wc_price:
-        wc_state = "get_card"
-    else:
-        wc_state = "locked"
-
-    cc_price = _NON_PLAYER_CARD_PRICES[("challenge_card", "challenge")]
-    cc_owned = is_design_accessible(db, user.id, "challenge_card", "challenge")
-    if cc_owned:
-        cc_state = "owned"
-    elif user.credit_balance >= cc_price:
-        cc_state = "get_card"
-    else:
-        cc_state = "locked"
+    cc_total      = len(CHALLENGE_CARD_FORMATS)
+    _cc_valid_ids = {f.design_id for f in CHALLENGE_CARD_FORMATS}
+    cc_owned_ids  = set(get_owned_design_ids(db, user.id, "challenge_card"))
+    cc_owned_count = len(cc_owned_ids & _cc_valid_ids)
 
     return templates.TemplateResponse(
         "my_cards_hub.html",
         {
-            "request":         request,
-            "user":            user,
+            "request":    request,
+            "user":       user,
             # Player Card
-            "pc_state":        pc_state,
-            "pc_price":        pc_price,
-            "pc_design":       card_variant,
-            "pc_design_label": pc_design_label,
+            "pc_owned_count": pc_owned_count,
+            "pc_total":       pc_total,
             # Welcome Card
-            "wc_state":        wc_state,
-            "wc_price":        wc_price,
+            "wc_owned_count": wc_owned_count,
+            "wc_total":       wc_total,
             # Challenge Card
-            "cc_state":        cc_state,
-            "cc_price":        cc_price,
+            "cc_owned_count": cc_owned_count,
+            "cc_total":       cc_total,
             # Flash
             "flash_purchased": request.query_params.get("purchased"),
             # Explicit LFA spec context — multi-spec safe
@@ -119,56 +95,23 @@ async def my_cards_hub(
     )
 
 
-@router.get("/my-cards/shop", response_class=HTMLResponse)
-async def my_cards_shop(
-    request: Request,
-    db: Session = Depends(get_db),
-    user: User  = Depends(get_current_user_web),
-):
-    """Card Design Shop — browse and purchase card design entitlements."""
-    player_designs = get_all_designs(db)
-    wc_price = _NON_PLAYER_CARD_PRICES[("welcome_card",   "default")]
-    cc_price = _NON_PLAYER_CARD_PRICES[("challenge_card", "challenge")]
-    credits  = user.credit_balance
+# ── /my-cards/shop — retired, redirect by tab param ──────────────────────────
 
-    def _state(card_type_id: str, design_id: str, credit_cost: int, is_premium: bool) -> str:
-        if not is_premium and card_type_id == "player_card":
-            return "free"
-        if is_design_accessible(db, user.id, card_type_id, design_id):
-            return "owned"
-        return "purchasable" if credits >= credit_cost else "locked"
-
-    player_design_rows = [
-        {
-            "id":          d.id,
-            "label":       d.label,
-            "description": d.description,
-            "credit_cost": d.credit_cost,
-            "is_premium":  d.is_premium,
-            "state":       _state("player_card", d.id, d.credit_cost, d.is_premium),
-        }
-        for d in player_designs
-    ]
-
-    wc_state = _state("welcome_card", "default", wc_price, True)
-    cc_state = _state("challenge_card", "challenge", cc_price, True)
-
-    return templates.TemplateResponse(
-        "my_cards_shop.html",
-        {
-            "request":             request,
-            "user":                user,
-            "player_design_rows":  player_design_rows,
-            "wc_price":            wc_price,
-            "cc_price":            cc_price,
-            "wc_state":            wc_state,
-            "cc_state":            cc_state,
-            "flash_purchased":     request.query_params.get("purchased"),
-            "flash_error":         request.query_params.get("error"),
-            "spec_dashboard_url":  "/dashboard/lfa-football-player",
-        },
+@router.get("/my-cards/shop")
+async def my_cards_shop(tab: str | None = Query(default=None)):
+    """Retired shop page — redirects to the appropriate family shop."""
+    destinations = {
+        "player":    "/my-cards/player-card",
+        "welcome":   "/my-cards/welcome-card",
+        "challenge": "/my-cards/challenge-card",
+    }
+    return RedirectResponse(
+        url=destinations.get(tab or "", "/my-cards"),
+        status_code=302,
     )
 
+
+# ── Purchase POST ─────────────────────────────────────────────────────────────
 
 @router.post("/my-cards/designs/{card_type_id}/{design_id}/get")
 async def get_card(
@@ -178,49 +121,129 @@ async def get_card(
     user: User  = Depends(get_current_user_web),
 ):
     """Purchase a card design entitlement (credit deduction + ownership row)."""
-    tab = _TYPE_TO_TAB.get(card_type_id, "player")
+    family_path = _TYPE_TO_FAMILY_PATH.get(card_type_id, "/my-cards")
     try:
         purchase_design(db, user, card_type_id, design_id)
         return RedirectResponse(
-            f"/my-cards?purchased={card_type_id}:{design_id}",
+            f"{family_path}?purchased={design_id}",
             status_code=303,
         )
     except FreeDesignError:
-        return RedirectResponse(f"/my-cards/shop?error=free&tab={tab}",    status_code=303)
+        return RedirectResponse(f"{family_path}?error=free",    status_code=303)
     except AlreadyOwnedError:
-        return RedirectResponse(f"/my-cards/shop?error=owned&tab={tab}",   status_code=303)
+        return RedirectResponse(f"{family_path}?error=owned",   status_code=303)
     except InsufficientCreditsError:
-        return RedirectResponse(f"/my-cards/shop?error=credits&tab={tab}", status_code=303)
+        return RedirectResponse(f"{family_path}?error=credits", status_code=303)
     except ValueError:
-        return RedirectResponse(f"/my-cards/shop?error=invalid&tab={tab}", status_code=303)
+        return RedirectResponse(f"{family_path}?error=invalid", status_code=303)
 
 
-@router.get("/my-cards/player-card")
+# ── Player Card family shop ───────────────────────────────────────────────────
+
+@router.get("/my-cards/player-card", response_class=HTMLResponse)
 async def my_cards_player_card(
-    user: User = Depends(get_current_user_web),
+    request: Request,
+    db: Session     = Depends(get_db),
+    user: User      = Depends(get_current_user_web),
 ):
-    """Detail entry point for Player Card — redirects to the card editor."""
-    return RedirectResponse(
-        url="/dashboard/lfa-football-player/card-editor",
-        status_code=303,
+    """Player Card format shop — browse and purchase Player Card designs."""
+    all_designs = get_all_designs(db)
+    credits     = user.credit_balance
+
+    def _state(design) -> str:
+        if not design.is_premium:
+            return "free"
+        if is_design_accessible(db, user.id, "player_card", design.id):
+            return "owned"
+        return "purchasable" if credits >= design.credit_cost else "locked"
+
+    design_rows = [
+        {
+            "id":          d.id,
+            "label":       d.label,
+            "description": d.description,
+            "credit_cost": d.credit_cost,
+            "is_premium":  d.is_premium,
+            "state":       _state(d),
+        }
+        for d in all_designs
+    ]
+
+    owned_count = sum(1 for r in design_rows if r["state"] in ("free", "owned"))
+    total_count = len(design_rows)
+
+    return templates.TemplateResponse(
+        "my_cards_player_card.html",
+        {
+            "request":         request,
+            "user":            user,
+            "design_rows":     design_rows,
+            "owned_count":     owned_count,
+            "total_count":     total_count,
+            "flash_purchased": request.query_params.get("purchased"),
+            "flash_error":     request.query_params.get("error"),
+            "spec_dashboard_url": "/dashboard/lfa-football-player",
+        },
     )
 
 
-@router.get("/my-cards/welcome-card")
+# ── Welcome Card family shop ──────────────────────────────────────────────────
+
+@router.get("/my-cards/welcome-card", response_class=HTMLResponse)
 async def my_cards_welcome_card(
-    user: User = Depends(get_current_user_web),
+    request: Request,
+    db: Session     = Depends(get_db),
+    user: User      = Depends(get_current_user_web),
 ):
-    """Detail entry point for Welcome Card — redirects to the onboarding card."""
-    return RedirectResponse(
-        url="/profile/onboarding-card",
-        status_code=303,
+    """Welcome Card format shop — browse and purchase Welcome Card platform formats."""
+    credits = user.credit_balance
+
+    def _wc_state(fmt) -> str:
+        if is_design_accessible(db, user.id, "welcome_card", fmt.design_id):
+            return "owned"
+        return "purchasable" if credits >= fmt.credit_cost else "locked"
+
+    format_rows = [
+        {
+            "design_id":       fmt.design_id,
+            "label":           fmt.label,
+            "style_tag":       fmt.style_tag,
+            "dims":            fmt.dims,
+            "credit_cost":     fmt.credit_cost,
+            "preview_platform": fmt.preview_platform,
+            "state":           _wc_state(fmt),
+            "preview_url":     f"/profile/onboarding-card?platform={fmt.preview_platform}",
+            "export_url":      f"/profile/onboarding-card/export?platform={fmt.preview_platform}",
+        }
+        for fmt in WELCOME_CARD_FORMATS
+    ]
+
+    owned_count = sum(1 for r in format_rows if r["state"] == "owned")
+    total_count = len(format_rows)
+
+    return templates.TemplateResponse(
+        "my_cards_welcome_card.html",
+        {
+            "request":         request,
+            "user":            user,
+            "format_rows":     format_rows,
+            "owned_count":     owned_count,
+            "total_count":     total_count,
+            "flash_purchased": request.query_params.get("purchased"),
+            "flash_error":     request.query_params.get("error"),
+            "spec_dashboard_url": "/dashboard/lfa-football-player",
+        },
     )
 
 
-_CHALLENGE_CARD_FORMATS = [
+# ── Challenge Card collection + format shop ───────────────────────────────────
+
+_CHALLENGE_CARD_FORMATS_DICT = [
     {"id": "challenge_post_16_9",  "label": "Post (16:9)",  "dims": "1280×720",  "platform": "Facebook / Instagram"},
     {"id": "challenge_story_9_16", "label": "Story (9:16)", "dims": "1080×1920", "platform": "TikTok / Instagram Story"},
 ]
+# Backward-compat alias used by tests/unit/api/web_routes/test_vt_social_cards.py
+_CHALLENGE_CARD_FORMATS = _CHALLENGE_CARD_FORMATS_DICT
 
 _COLLECTION_LIMIT = 5
 
@@ -252,12 +275,12 @@ def _build_challenge_card_row(ch: VirtualTrainingChallenge, viewer_id: int, my_a
         for phase in phases:
             preview_urls = {
                 fmt["id"]: f"/challenges/{ch.id}/card/preview?phase={phase}&platform={fmt['id']}"
-                for fmt in _CHALLENGE_CARD_FORMATS
+                for fmt in _CHALLENGE_CARD_FORMATS_DICT
             }
             export_urls = (
                 {
                     fmt["id"]: f"/challenges/{ch.id}/card/export?phase={phase}&platform={fmt['id']}"
-                    for fmt in _CHALLENGE_CARD_FORMATS
+                    for fmt in _CHALLENGE_CARD_FORMATS_DICT
                 }
                 if not is_locked else {}
             )
@@ -267,7 +290,7 @@ def _build_challenge_card_row(ch: VirtualTrainingChallenge, viewer_id: int, my_a
                 "is_locked":    is_locked,
                 "preview_urls": preview_urls,
                 "export_urls":  export_urls,
-                "formats":      _CHALLENGE_CARD_FORMATS,
+                "formats":      _CHALLENGE_CARD_FORMATS_DICT,
             })
         return cards
 
@@ -292,9 +315,30 @@ async def my_cards_challenge_card(
     db: Session = Depends(get_db),
     user: User  = Depends(get_current_user_web),
 ):
-    """Challenge Card Collection — phase-based card manager with inline preview."""
+    """Challenge Card Collection — format shop header + phase-based card manager."""
     draft  = CardDraftService.get_or_create_singleton(db, user.id, "challenge_card")
     themes = get_all_themes(db=db)
+    credits = user.credit_balance
+
+    # Format header section — ownership state per CC format
+    def _cc_fmt_state(fmt) -> str:
+        if is_design_accessible(db, user.id, "challenge_card", fmt.design_id):
+            return "owned"
+        return "purchasable" if credits >= fmt.credit_cost else "locked"
+
+    cc_format_rows = [
+        {
+            "design_id":   fmt.design_id,
+            "label":       fmt.label,
+            "style_tag":   fmt.style_tag,
+            "dims":        fmt.dims,
+            "credit_cost": fmt.credit_cost,
+            "state":       _cc_fmt_state(fmt),
+        }
+        for fmt in CHALLENGE_CARD_FORMATS
+    ]
+    cc_owned_count = sum(1 for r in cc_format_rows if r["state"] == "owned")
+    cc_total       = len(cc_format_rows)
 
     # Fetch last N challenges where user is participant
     recent_challenges = (
@@ -339,8 +383,13 @@ async def my_cards_challenge_card(
             "user":             user,
             "draft":            draft,
             "themes":           themes,
-            "formats":          _CHALLENGE_CARD_FORMATS,
+            "formats":          _CHALLENGE_CARD_FORMATS_DICT,
+            "cc_format_rows":   cc_format_rows,
+            "cc_owned_count":   cc_owned_count,
+            "cc_total":         cc_total,
             "challenge_rows":   challenge_rows,
             "has_challenges":   bool(challenge_rows),
+            "flash_purchased":  request.query_params.get("purchased"),
+            "flash_error":      request.query_params.get("error"),
         },
     )

--- a/app/api/web_routes/my_cards.py
+++ b/app/api/web_routes/my_cards.py
@@ -151,11 +151,9 @@ async def my_cards_player_card(
     credits     = user.credit_balance
 
     def _state(design) -> str:
-        if not design.is_premium:
-            return "free"
         if is_design_accessible(db, user.id, "player_card", design.id):
             return "owned"
-        return "purchasable" if credits >= design.credit_cost else "locked"
+        return "get_card" if credits >= design.credit_cost else "locked"
 
     design_rows = [
         {
@@ -169,7 +167,7 @@ async def my_cards_player_card(
         for d in all_designs
     ]
 
-    owned_count = sum(1 for r in design_rows if r["state"] in ("free", "owned"))
+    owned_count = sum(1 for r in design_rows if r["state"] == "owned")
     total_count = len(design_rows)
 
     return templates.TemplateResponse(
@@ -201,7 +199,7 @@ async def my_cards_welcome_card(
     def _wc_state(fmt) -> str:
         if is_design_accessible(db, user.id, "welcome_card", fmt.design_id):
             return "owned"
-        return "purchasable" if credits >= fmt.credit_cost else "locked"
+        return "get_card" if credits >= fmt.credit_cost else "locked"
 
     format_rows = [
         {
@@ -324,7 +322,7 @@ async def my_cards_challenge_card(
     def _cc_fmt_state(fmt) -> str:
         if is_design_accessible(db, user.id, "challenge_card", fmt.design_id):
             return "owned"
-        return "purchasable" if credits >= fmt.credit_cost else "locked"
+        return "get_card" if credits >= fmt.credit_cost else "locked"
 
     cc_format_rows = [
         {

--- a/app/api/web_routes/my_cards.py
+++ b/app/api/web_routes/my_cards.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import Session
 
 from ...database import get_db
 from ...dependencies import get_current_user_web
+from ...models.license import UserLicense
 from ...models.user import User
 from ...models.virtual_training import VirtualTrainingAttempt
 from ...models.vt_challenge import ChallengeStatus, VirtualTrainingChallenge
@@ -36,29 +37,84 @@ templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
 
 router = APIRouter(tags=["my-cards"])
 
+_TYPE_TO_TAB: dict[str, str] = {
+    "player_card":    "player",
+    "welcome_card":   "welcome",
+    "challenge_card": "challenge",
+}
+
 
 @router.get("/my-cards", response_class=HTMLResponse)
 async def my_cards_hub(
     request: Request,
-    user: User = Depends(get_current_user_web),
+    db: Session = Depends(get_db),
+    user: User  = Depends(get_current_user_web),
 ):
-    """Hub page listing all card types — active (v≥1) and coming-soon (v0)."""
-    card_specs = [
-        card_registry.get_card_type_spec(tid)
-        for tid in card_registry.list_card_type_ids()
-    ]
+    """Hub — entitlement-aware central page for all card families."""
+    license = db.query(UserLicense).filter(
+        UserLicense.user_id == user.id,
+        UserLicense.specialization_type == "LFA_FOOTBALL_PLAYER",
+        UserLicense.is_active == True,
+    ).first()
+
+    card_variant    = (license.card_variant if license else None) or "fifa"
+    designs_by_id   = {d.id: d for d in get_all_designs(db)}
+    design_obj      = designs_by_id.get(card_variant)
+    pc_price        = design_obj.credit_cost if design_obj else 0
+    pc_free         = not design_obj.is_premium if design_obj else True
+    pc_design_label = design_obj.label if design_obj else "FIFA Classic"
+    pc_owned        = is_design_accessible(db, user.id, "player_card", card_variant)
+
+    if pc_free:
+        pc_state = "free"
+    elif pc_owned:
+        pc_state = "owned"
+    elif user.credit_balance >= pc_price:
+        pc_state = "get_card"
+    else:
+        pc_state = "locked"
+
+    wc_price = _NON_PLAYER_CARD_PRICES[("welcome_card",   "default")]
+    wc_owned = is_design_accessible(db, user.id, "welcome_card", "default")
+    if wc_owned:
+        wc_state = "owned"
+    elif user.credit_balance >= wc_price:
+        wc_state = "get_card"
+    else:
+        wc_state = "locked"
+
+    cc_price = _NON_PLAYER_CARD_PRICES[("challenge_card", "challenge")]
+    cc_owned = is_design_accessible(db, user.id, "challenge_card", "challenge")
+    if cc_owned:
+        cc_state = "owned"
+    elif user.credit_balance >= cc_price:
+        cc_state = "get_card"
+    else:
+        cc_state = "locked"
+
     return templates.TemplateResponse(
         "my_cards_hub.html",
         {
-            "request": request,
-            "user": user,
-            "card_specs": card_specs,
-            # Explicit LFA spec context — do not rely on user.specialization fallback,
-            # which breaks on multi-spec accounts where the active spec != LFA_FOOTBALL_PLAYER.
-            "spec_dashboard_url": "/dashboard/lfa-football-player",
+            "request":         request,
+            "user":            user,
+            # Player Card
+            "pc_state":        pc_state,
+            "pc_price":        pc_price,
+            "pc_design":       card_variant,
+            "pc_design_label": pc_design_label,
+            # Welcome Card
+            "wc_state":        wc_state,
+            "wc_price":        wc_price,
+            # Challenge Card
+            "cc_state":        cc_state,
+            "cc_price":        cc_price,
+            # Flash
+            "flash_purchased": request.query_params.get("purchased"),
+            # Explicit LFA spec context — multi-spec safe
+            "spec_dashboard_url":  "/dashboard/lfa-football-player",
             "spec_dashboard_icon": "⚽",
-            "spec_profile_url": "/profile/lfa-football-player",
-            "spec_profile_icon": "🪪",
+            "spec_profile_url":    "/profile/lfa-football-player",
+            "spec_profile_icon":   "🪪",
         },
     )
 
@@ -122,20 +178,21 @@ async def get_card(
     user: User  = Depends(get_current_user_web),
 ):
     """Purchase a card design entitlement (credit deduction + ownership row)."""
+    tab = _TYPE_TO_TAB.get(card_type_id, "player")
     try:
         purchase_design(db, user, card_type_id, design_id)
         return RedirectResponse(
-            f"/my-cards/shop?purchased={card_type_id}:{design_id}",
+            f"/my-cards?purchased={card_type_id}:{design_id}",
             status_code=303,
         )
     except FreeDesignError:
-        return RedirectResponse("/my-cards/shop?error=free",    status_code=303)
+        return RedirectResponse(f"/my-cards/shop?error=free&tab={tab}",    status_code=303)
     except AlreadyOwnedError:
-        return RedirectResponse("/my-cards/shop?error=owned",   status_code=303)
+        return RedirectResponse(f"/my-cards/shop?error=owned&tab={tab}",   status_code=303)
     except InsufficientCreditsError:
-        return RedirectResponse("/my-cards/shop?error=credits", status_code=303)
+        return RedirectResponse(f"/my-cards/shop?error=credits&tab={tab}", status_code=303)
     except ValueError:
-        return RedirectResponse("/my-cards/shop?error=invalid", status_code=303)
+        return RedirectResponse(f"/my-cards/shop?error=invalid&tab={tab}", status_code=303)
 
 
 @router.get("/my-cards/player-card")

--- a/app/api/web_routes/my_cards.py
+++ b/app/api/web_routes/my_cards.py
@@ -12,9 +12,18 @@ from ...dependencies import get_current_user_web
 from ...models.user import User
 from ...models.virtual_training import VirtualTrainingAttempt
 from ...models.vt_challenge import ChallengeStatus, VirtualTrainingChallenge
+from ...services.card_design_service import (
+    AlreadyOwnedError,
+    FreeDesignError,
+    _NON_PLAYER_CARD_PRICES,
+    get_all_designs,
+    is_design_accessible,
+    purchase_design,
+)
 from ...services.card_draft_service import CardDraftService
 from ...services.card_system import card_registry
 from ...services.card_theme_service import get_all_themes
+from ...services.credit_service import InsufficientCreditsError
 from .vt_challenges import (
     CHALLENGE_CARD_PLATFORMS,
     get_locked_challenge_card_phases,
@@ -52,6 +61,81 @@ async def my_cards_hub(
             "spec_profile_icon": "🪪",
         },
     )
+
+
+@router.get("/my-cards/shop", response_class=HTMLResponse)
+async def my_cards_shop(
+    request: Request,
+    db: Session = Depends(get_db),
+    user: User  = Depends(get_current_user_web),
+):
+    """Card Design Shop — browse and purchase card design entitlements."""
+    player_designs = get_all_designs(db)
+    wc_price = _NON_PLAYER_CARD_PRICES[("welcome_card",   "default")]
+    cc_price = _NON_PLAYER_CARD_PRICES[("challenge_card", "challenge")]
+    credits  = user.credit_balance
+
+    def _state(card_type_id: str, design_id: str, credit_cost: int, is_premium: bool) -> str:
+        if not is_premium and card_type_id == "player_card":
+            return "free"
+        if is_design_accessible(db, user.id, card_type_id, design_id):
+            return "owned"
+        return "purchasable" if credits >= credit_cost else "locked"
+
+    player_design_rows = [
+        {
+            "id":          d.id,
+            "label":       d.label,
+            "description": d.description,
+            "credit_cost": d.credit_cost,
+            "is_premium":  d.is_premium,
+            "state":       _state("player_card", d.id, d.credit_cost, d.is_premium),
+        }
+        for d in player_designs
+    ]
+
+    wc_state = _state("welcome_card", "default", wc_price, True)
+    cc_state = _state("challenge_card", "challenge", cc_price, True)
+
+    return templates.TemplateResponse(
+        "my_cards_shop.html",
+        {
+            "request":             request,
+            "user":                user,
+            "player_design_rows":  player_design_rows,
+            "wc_price":            wc_price,
+            "cc_price":            cc_price,
+            "wc_state":            wc_state,
+            "cc_state":            cc_state,
+            "flash_purchased":     request.query_params.get("purchased"),
+            "flash_error":         request.query_params.get("error"),
+            "spec_dashboard_url":  "/dashboard/lfa-football-player",
+        },
+    )
+
+
+@router.post("/my-cards/designs/{card_type_id}/{design_id}/get")
+async def get_card(
+    card_type_id: str,
+    design_id: str,
+    db: Session = Depends(get_db),
+    user: User  = Depends(get_current_user_web),
+):
+    """Purchase a card design entitlement (credit deduction + ownership row)."""
+    try:
+        purchase_design(db, user, card_type_id, design_id)
+        return RedirectResponse(
+            f"/my-cards/shop?purchased={card_type_id}:{design_id}",
+            status_code=303,
+        )
+    except FreeDesignError:
+        return RedirectResponse("/my-cards/shop?error=free",    status_code=303)
+    except AlreadyOwnedError:
+        return RedirectResponse("/my-cards/shop?error=owned",   status_code=303)
+    except InsufficientCreditsError:
+        return RedirectResponse("/my-cards/shop?error=credits", status_code=303)
+    except ValueError:
+        return RedirectResponse("/my-cards/shop?error=invalid", status_code=303)
 
 
 @router.get("/my-cards/player-card")

--- a/app/api/web_routes/profile.py
+++ b/app/api/web_routes/profile.py
@@ -1047,6 +1047,25 @@ async def export_onboarding_welcome_card(
     if redirect:
         return redirect
 
+    # Welcome Card design ownership guard (feature-flag gated).
+    # ENFORCE_WELCOME_CARD_OWNERSHIP=False (default): export proceeds, warning logged.
+    # ENFORCE_WELCOME_CARD_OWNERSHIP=True: 403 if no ownership row.
+    # Admin bypass: admins always allowed.
+    if user.role != UserRole.ADMIN:
+        from app.services.card_design_service import is_design_accessible as _is_accessible
+        _wc_owned = _is_accessible(db, user.id, "welcome_card", "default")
+        if not _wc_owned:
+            if settings.ENFORCE_WELCOME_CARD_OWNERSHIP:
+                raise HTTPException(
+                    status_code=403,
+                    detail="Welcome Card not owned. Purchase it at /my-cards/shop",
+                )
+            else:
+                logger.info(
+                    "welcome_card_export_no_ownership_flag_off",
+                    extra={"user_id": user.id},
+                )
+
     if platform not in _export_svc.CANVAS_SIZES:
         valid = list(_export_svc.CANVAS_SIZES)
         raise HTTPException(

--- a/app/api/web_routes/profile.py
+++ b/app/api/web_routes/profile.py
@@ -1047,24 +1047,15 @@ async def export_onboarding_welcome_card(
     if redirect:
         return redirect
 
-    # Welcome Card design ownership guard (feature-flag gated).
-    # ENFORCE_WELCOME_CARD_OWNERSHIP=False (default): export proceeds, warning logged.
-    # ENFORCE_WELCOME_CARD_OWNERSHIP=True: 403 if no ownership row.
-    # Admin bypass: admins always allowed.
+    # Welcome Card ownership guard — every format requires a CDO row.
+    # Admin bypass: admins may export any format regardless of ownership.
     if user.role != UserRole.ADMIN:
         from app.services.card_design_service import is_design_accessible as _is_accessible
-        _wc_owned = _is_accessible(db, user.id, "welcome_card", platform)
-        if not _wc_owned:
-            if settings.ENFORCE_WELCOME_CARD_OWNERSHIP:
-                raise HTTPException(
-                    status_code=403,
-                    detail="Welcome Card not owned. Purchase it at /my-cards/welcome-card",
-                )
-            else:
-                logger.info(
-                    "welcome_card_export_no_ownership_flag_off",
-                    extra={"user_id": user.id},
-                )
+        if not _is_accessible(db, user.id, "welcome_card", platform):
+            raise HTTPException(
+                status_code=403,
+                detail="Welcome Card not owned. Purchase it at /my-cards/welcome-card",
+            )
 
     if platform not in _export_svc.CANVAS_SIZES:
         valid = list(_export_svc.CANVAS_SIZES)

--- a/app/api/web_routes/profile.py
+++ b/app/api/web_routes/profile.py
@@ -1053,12 +1053,12 @@ async def export_onboarding_welcome_card(
     # Admin bypass: admins always allowed.
     if user.role != UserRole.ADMIN:
         from app.services.card_design_service import is_design_accessible as _is_accessible
-        _wc_owned = _is_accessible(db, user.id, "welcome_card", "default")
+        _wc_owned = _is_accessible(db, user.id, "welcome_card", platform)
         if not _wc_owned:
             if settings.ENFORCE_WELCOME_CARD_OWNERSHIP:
                 raise HTTPException(
                     status_code=403,
-                    detail="Welcome Card not owned. Purchase it at /my-cards/shop",
+                    detail="Welcome Card not owned. Purchase it at /my-cards/welcome-card",
                 )
             else:
                 logger.info(

--- a/app/api/web_routes/public_player.py
+++ b/app/api/web_routes/public_player.py
@@ -634,6 +634,17 @@ async def export_player_card(
     # Semantic validation: reject unsupported design/platform pairs before Playwright.
     # "default" platform uses ?native_export=1 (browser template, no bucket) → skip.
     card_variant_id = target_license.card_variant or "fifa"
+
+    # Design ownership guard — premium designs require entitlement; free (fifa) always passes.
+    # Admin bypass: admins may export any card regardless of ownership.
+    if current_user.role != UserRole.ADMIN:
+        from app.services.card_design_service import is_design_accessible as _is_accessible
+        if not _is_accessible(db, current_user.id, "player_card", card_variant_id):
+            raise HTTPException(
+                status_code=403,
+                detail=f"Design {card_variant_id!r} not owned. Get it at /my-cards/shop",
+            )
+
     if platform != "default":
         _bucket = _EXPORT_FORMAT_BUCKETS[platform]  # safe: CANVAS_SIZES invariant guarantees coverage
         _supported = _get_supported_buckets(card_variant_id, db)
@@ -765,6 +776,16 @@ async def export_player_card_video(
 
     # Animated capability check — variant comes from DB, never from URL
     card_variant_id = target_license.card_variant or "fifa"
+
+    # Design ownership guard — same rules as PNG export.
+    if current_user.role != UserRole.ADMIN:
+        from app.services.card_design_service import is_design_accessible as _is_accessible
+        if not _is_accessible(db, current_user.id, "player_card", card_variant_id):
+            raise HTTPException(
+                status_code=403,
+                detail=f"Design {card_variant_id!r} not owned. Get it at /my-cards/shop",
+            )
+
     if not _export_svc.is_animated_capable(card_variant_id, platform):
         raise HTTPException(
             status_code=422,

--- a/app/api/web_routes/public_player.py
+++ b/app/api/web_routes/public_player.py
@@ -635,7 +635,7 @@ async def export_player_card(
     # "default" platform uses ?native_export=1 (browser template, no bucket) → skip.
     card_variant_id = target_license.card_variant or "fifa"
 
-    # Design ownership guard — premium designs require entitlement; free (fifa) always passes.
+    # Design ownership guard — all designs require entitlement, including fifa.
     # Admin bypass: admins may export any card regardless of ownership.
     if current_user.role != UserRole.ADMIN:
         from app.services.card_design_service import is_design_accessible as _is_accessible

--- a/app/api/web_routes/vt_challenges.py
+++ b/app/api/web_routes/vt_challenges.py
@@ -1029,12 +1029,12 @@ async def challenge_card_export(
     from app.models.user import UserRole as _UserRole  # noqa: PLC0415
     if user.role != _UserRole.ADMIN:
         from app.services.card_design_service import is_design_accessible as _is_accessible  # noqa: PLC0415
-        _cc_owned = _is_accessible(db, user.id, "challenge_card", "challenge")
+        _cc_owned = _is_accessible(db, user.id, "challenge_card", platform)
         if not _cc_owned:
             if _settings.ENFORCE_CHALLENGE_CARD_OWNERSHIP:
                 raise HTTPException(
                     status_code=403,
-                    detail="Challenge Card not owned. Purchase it at /my-cards/shop",
+                    detail="Challenge Card not owned. Purchase it at /my-cards/challenge-card",
                 )
             else:
                 import logging as _logging  # noqa: PLC0415

--- a/app/api/web_routes/vt_challenges.py
+++ b/app/api/web_routes/vt_challenges.py
@@ -1021,6 +1021,28 @@ async def challenge_card_export(
     if user.id not in (ch.challenger_id, ch.challenged_id):
         raise HTTPException(status_code=403, detail="Participants only")
 
+    # Challenge Card design ownership guard (feature-flag gated).
+    # ENFORCE_CHALLENGE_CARD_OWNERSHIP=False (default): export proceeds, warning logged.
+    # ENFORCE_CHALLENGE_CARD_OWNERSHIP=True: 403 if no ownership row.
+    # Admin bypass: admins always allowed.
+    from app.config import settings as _settings  # noqa: PLC0415
+    from app.models.user import UserRole as _UserRole  # noqa: PLC0415
+    if user.role != _UserRole.ADMIN:
+        from app.services.card_design_service import is_design_accessible as _is_accessible  # noqa: PLC0415
+        _cc_owned = _is_accessible(db, user.id, "challenge_card", "challenge")
+        if not _cc_owned:
+            if _settings.ENFORCE_CHALLENGE_CARD_OWNERSHIP:
+                raise HTTPException(
+                    status_code=403,
+                    detail="Challenge Card not owned. Purchase it at /my-cards/shop",
+                )
+            else:
+                import logging as _logging  # noqa: PLC0415
+                _logging.getLogger(__name__).info(
+                    "challenge_card_export_no_ownership_flag_off",
+                    extra={"user_id": user.id, "challenge_id": challenge_id},
+                )
+
     is_challenger = user.id == ch.challenger_id
     my_attempt_id = ch.challenger_attempt_id if is_challenger else ch.challenged_attempt_id
     my_attempt = (

--- a/app/api/web_routes/vt_challenges.py
+++ b/app/api/web_routes/vt_challenges.py
@@ -1021,27 +1021,16 @@ async def challenge_card_export(
     if user.id not in (ch.challenger_id, ch.challenged_id):
         raise HTTPException(status_code=403, detail="Participants only")
 
-    # Challenge Card design ownership guard (feature-flag gated).
-    # ENFORCE_CHALLENGE_CARD_OWNERSHIP=False (default): export proceeds, warning logged.
-    # ENFORCE_CHALLENGE_CARD_OWNERSHIP=True: 403 if no ownership row.
-    # Admin bypass: admins always allowed.
-    from app.config import settings as _settings  # noqa: PLC0415
+    # Challenge Card ownership guard — every format requires a CDO row.
+    # Admin bypass: admins may export any format regardless of ownership.
     from app.models.user import UserRole as _UserRole  # noqa: PLC0415
     if user.role != _UserRole.ADMIN:
         from app.services.card_design_service import is_design_accessible as _is_accessible  # noqa: PLC0415
-        _cc_owned = _is_accessible(db, user.id, "challenge_card", platform)
-        if not _cc_owned:
-            if _settings.ENFORCE_CHALLENGE_CARD_OWNERSHIP:
-                raise HTTPException(
-                    status_code=403,
-                    detail="Challenge Card not owned. Purchase it at /my-cards/challenge-card",
-                )
-            else:
-                import logging as _logging  # noqa: PLC0415
-                _logging.getLogger(__name__).info(
-                    "challenge_card_export_no_ownership_flag_off",
-                    extra={"user_id": user.id, "challenge_id": challenge_id},
-                )
+        if not _is_accessible(db, user.id, "challenge_card", platform):
+            raise HTTPException(
+                status_code=403,
+                detail="Challenge Card not owned. Purchase it at /my-cards/challenge-card",
+            )
 
     is_challenger = user.id == ch.challenger_id
     my_attempt_id = ch.challenger_attempt_id if is_challenger else ch.challenged_attempt_id

--- a/app/config.py
+++ b/app/config.py
@@ -196,6 +196,19 @@ class Settings(BaseSettings):
     # Requires ENABLE_TOURNAMENT_SKILL_PROPAGATION=True.
     ENABLE_SKILL_TIER_NOTIFICATIONS: bool = False
 
+    # ── Card export ownership enforcement ─────────────────────────────────────
+    # Controls whether export routes block users who lack a CardDesignOwnership row.
+    # Player Card premium guard is ALWAYS active regardless of these flags
+    # (legacy unlocked_card_variants JSON shim covers existing users).
+    #
+    # Set to True only AFTER running scripts/backfill_card_design_ownerships.py
+    # for existing users, or after a product decision to require new purchase.
+    #
+    # False (default): export proceeds without ownership, warning is logged.
+    # True:            export blocked with HTTP 403 if ownership is missing.
+    ENFORCE_WELCOME_CARD_OWNERSHIP:   bool = False
+    ENFORCE_CHALLENGE_CARD_OWNERSHIP: bool = False
+
     SKILL_TIER_THRESHOLDS: dict = {
         60: "Intermediate",
         75: "Advanced",

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -58,6 +58,7 @@ from .tournament_instructor_slot import TournamentInstructorSlot, SlotRole, Slot
 from .card_draft import CardDraft
 from .card_theme import CardTheme
 from .card_design import CardDesign
+from .card_design_ownership import CardDesignOwnership
 from .virtual_training import VirtualTrainingGame, VirtualTrainingAttempt
 from .friendship import Friendship, FriendshipStatus, is_friends, get_friendship
 from .vt_challenge import (
@@ -233,6 +234,7 @@ __all__ = [
     "CardDraft",
     "CardTheme",
     "CardDesign",
+    "CardDesignOwnership",
     # Virtual Training
     "VirtualTrainingGame",
     "VirtualTrainingAttempt",

--- a/app/models/card_design_ownership.py
+++ b/app/models/card_design_ownership.py
@@ -1,0 +1,85 @@
+"""CardDesignOwnership — per-user entitlement record for card designs.
+
+One row per (user_id, card_type_id, design_id) triplet.
+
+Ownership is required before a premium card design can be exported.
+Free designs (player_card / "fifa", credit_cost=0) are always accessible
+without an ownership row — is_design_accessible() handles this.
+
+source values:
+  "purchase"    — user paid credits via purchase_design()
+  "admin_grant" — explicit admin grant (no credit deduction)
+  "promo"       — future promo/voucher flow (not MVP)
+  "system"      — backfill script or system grant
+"""
+from datetime import datetime, timezone
+
+from sqlalchemy import (
+    Column,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    UniqueConstraint,
+)
+
+from ..database import Base
+
+
+class CardDesignOwnership(Base):
+    __tablename__ = "card_design_ownerships"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(
+        Integer,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    card_type_id = Column(
+        String(50),
+        nullable=False,
+        comment="'player_card' | 'welcome_card' | 'challenge_card'",
+    )
+    design_id = Column(
+        String(50),
+        nullable=False,
+        comment=(
+            "player_card: 'fifa'|'compact'|… (maps to card_designs.id); "
+            "welcome_card: 'default'; "
+            "challenge_card: 'challenge'"
+        ),
+    )
+    source = Column(
+        String(20),
+        nullable=False,
+        server_default="purchase",
+        comment="'purchase' | 'admin_grant' | 'promo' | 'system'",
+    )
+    credit_transaction_id = Column(
+        Integer,
+        ForeignKey("credit_transactions.id", ondelete="SET NULL"),
+        nullable=True,
+        comment="NULL for admin_grant / system source",
+    )
+    acquired_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "user_id", "card_type_id", "design_id",
+            name="uq_cdo_user_type_design",
+        ),
+        Index("ix_cdo_user_id", "user_id"),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<CardDesignOwnership user_id={self.user_id} "
+            f"card_type_id={self.card_type_id!r} "
+            f"design_id={self.design_id!r} "
+            f"source={self.source!r}>"
+        )

--- a/app/models/card_design_ownership.py
+++ b/app/models/card_design_ownership.py
@@ -2,9 +2,9 @@
 
 One row per (user_id, card_type_id, design_id) triplet.
 
-Ownership is required before a premium card design can be exported.
-Free designs (player_card / "fifa", credit_cost=0) are always accessible
-without an ownership row — is_design_accessible() handles this.
+Every design (including player_card / "fifa") requires an ownership row
+before it can be exported. Use grant_design() to issue entitlements
+without credit deduction (admin grants, backfill scripts, seed data).
 
 source values:
   "purchase"    — user paid credits via purchase_design()
@@ -46,8 +46,8 @@ class CardDesignOwnership(Base):
         nullable=False,
         comment=(
             "player_card: 'fifa'|'compact'|… (maps to card_designs.id); "
-            "welcome_card: 'default'; "
-            "challenge_card: 'challenge'"
+            "welcome_card: platform format id e.g. 'instagram_portrait'; "
+            "challenge_card: format id e.g. 'challenge_post_16_9'"
         ),
     )
     source = Column(

--- a/app/models/credit_transaction.py
+++ b/app/models/credit_transaction.py
@@ -22,6 +22,7 @@ class TransactionType(enum.Enum):
     EXPIRATION = "EXPIRATION"      # Credits expired (2 year limit)
     INVITATION_BONUS = "INVITATION_BONUS"    # Bonus credits granted on registration via invitation code
     SPECIALIZATION_UNLOCK = "SPECIALIZATION_UNLOCK"  # Credits spent to unlock a specialization
+    CARD_DESIGN_UNLOCK = "CARD_DESIGN_UNLOCK"  # Credits spent to acquire a card design entitlement
 
 
 class CreditTransaction(Base):

--- a/app/services/card_design_service.py
+++ b/app/services/card_design_service.py
@@ -334,7 +334,7 @@ _NON_PLAYER_CARD_PRICES: dict[tuple[str, str], int] = {
 
 
 class FreeDesignError(Exception):
-    """Raised when attempting to purchase a free (always-accessible) design."""
+    """Raised when attempting to purchase a sentinel/non-purchasable design (price == 0)."""
 
 
 class AlreadyOwnedError(Exception):
@@ -364,26 +364,20 @@ def _resolve_price(card_type_id: str, design_id: str, db=None) -> int:
 
 
 def is_design_accessible(db, user_id: int, card_type_id: str, design_id: str) -> bool:
-    """Return True if the user may export/download the given card design.
+    """Return True if the user has a CardDesignOwnership row for this design.
+
+    Every design (including player_card/fifa) requires an ownership row.
 
     Access rules:
-      1. player_card + credit_cost == 0 → always True (no ownership row needed)
-      2. CardDesignOwnership row exists → True
-      3. player_card legacy JSON shim: unlocked_card_variants contains design_id → True
+      1. CardDesignOwnership row exists → True
+      2. player_card legacy JSON shim: unlocked_card_variants contains design_id → True
+      3. WC/CC legacy CDO shim: user owns old family-level key → True
       4. Everything else → False
     """
     from app.models.card_design_ownership import CardDesignOwnership
     from app.models.license import UserLicense
 
-    # Rule 1: free player card design
-    if card_type_id == "player_card":
-        try:
-            if _resolve_price("player_card", design_id, db) == 0:
-                return True
-        except ValueError:
-            return False  # unknown design_id → not accessible
-
-    # Rule 2: ownership table — primary source
+    # Rule 1: ownership table — primary source
     owned = (
         db.query(CardDesignOwnership)
         .filter_by(user_id=user_id, card_type_id=card_type_id, design_id=design_id)
@@ -392,7 +386,7 @@ def is_design_accessible(db, user_id: int, card_type_id: str, design_id: str) ->
     if owned:
         return True
 
-    # Rule 3: legacy JSON shim — player_card only, read-only
+    # Rule 2: legacy JSON shim — player_card only, read-only
     if card_type_id == "player_card":
         lic = (
             db.query(UserLicense)
@@ -402,7 +396,7 @@ def is_design_accessible(db, user_id: int, card_type_id: str, design_id: str) ->
         if lic and design_id in (lic.unlocked_card_variants or []):
             return True
 
-    # Rule 4: legacy CDO shim — if user owns the old family-level key, grant access
+    # Rule 3: legacy CDO shim — if user owns the old family-level key, grant access
     # to all format-level designs in that family (backward compat, no migration needed).
     _LEGACY_CDO_MAP: dict[str, str] = {
         "welcome_card":   "default",
@@ -424,8 +418,7 @@ def is_design_accessible(db, user_id: int, card_type_id: str, design_id: str) ->
 def get_owned_design_ids(db, user_id: int, card_type_id: str) -> list[str]:
     """Return design_ids owned by the user for a specific card_type_id.
 
-    For player_card, always includes free designs (credit_cost == 0) even
-    without an ownership row.
+    Every design requires an ownership row — no free designs are auto-included.
     """
     from app.models.card_design_ownership import CardDesignOwnership
 
@@ -447,13 +440,8 @@ def get_owned_design_ids(db, user_id: int, card_type_id: str) -> list[str]:
         if lic:
             for d in (lic.unlocked_card_variants or []):
                 result.add(d)
-        # Always include free designs
-        cache = _maybe_reload(db)
-        for d in cache.values():
-            if not d.is_premium:
-                result.add(d.id)
 
-    # Rule 4 shim: if user owns legacy WC/CC family key, grant all format IDs
+    # Legacy CDO shim: if user owns legacy WC/CC family key, grant all format IDs
     elif card_type_id == "welcome_card" and "default" in result:
         for fmt in WELCOME_CARD_FORMATS:
             result.add(fmt.design_id)

--- a/app/services/card_design_service.py
+++ b/app/services/card_design_service.py
@@ -270,3 +270,228 @@ def get_supported_buckets(design_id: str, db=None) -> tuple[str, ...]:
 def is_animated_capable(design_id: str, platform_id: str, db=None) -> bool:
     """Return True if (design_id, platform_id) supports animated video export."""
     return platform_id in get_design(design_id, db).animated_platforms
+
+
+# ── Card Design Ownership / Entitlement ───────────────────────────────────────
+
+# Valid card type IDs — checked at service entry points.
+_VALID_CARD_TYPE_IDS: frozenset[str] = frozenset(
+    {"player_card", "welcome_card", "challenge_card"}
+)
+
+# Service-level price map for card families without a CardDesign DB entry.
+# player_card prices come from CardDesign.credit_cost (DB-backed).
+# Update these constants when pricing changes — do NOT hardcode in templates.
+_NON_PLAYER_CARD_PRICES: dict[tuple[str, str], int] = {
+    ("welcome_card",   "default"):   200,  # CR — product decision
+    ("challenge_card", "challenge"): 150,  # CR — product decision
+}
+
+
+class FreeDesignError(Exception):
+    """Raised when attempting to purchase a free (always-accessible) design."""
+
+
+class AlreadyOwnedError(Exception):
+    """Raised when the user already owns the requested design."""
+
+
+def _resolve_price(card_type_id: str, design_id: str, db=None) -> int:
+    """Return the credit cost for a card type + design combination.
+
+    player_card: reads from CardDesign.credit_cost (DB/cache).
+    welcome_card / challenge_card: reads from _NON_PLAYER_CARD_PRICES constant.
+
+    Raises ValueError for unknown card_type_id or design_id.
+    """
+    if card_type_id == "player_card":
+        cache = _maybe_reload(db)
+        design = cache.get(design_id)
+        if design is None:
+            raise ValueError(f"Unknown player card design: {design_id!r}")
+        return design.credit_cost
+    key = (card_type_id, design_id)
+    if key not in _NON_PLAYER_CARD_PRICES:
+        raise ValueError(
+            f"Unknown card type/design combination: {card_type_id!r}/{design_id!r}"
+        )
+    return _NON_PLAYER_CARD_PRICES[key]
+
+
+def is_design_accessible(db, user_id: int, card_type_id: str, design_id: str) -> bool:
+    """Return True if the user may export/download the given card design.
+
+    Access rules:
+      1. player_card + credit_cost == 0 → always True (no ownership row needed)
+      2. CardDesignOwnership row exists → True
+      3. player_card legacy JSON shim: unlocked_card_variants contains design_id → True
+      4. Everything else → False
+    """
+    from app.models.card_design_ownership import CardDesignOwnership
+    from app.models.license import UserLicense
+
+    # Rule 1: free player card design
+    if card_type_id == "player_card":
+        try:
+            if _resolve_price("player_card", design_id, db) == 0:
+                return True
+        except ValueError:
+            return False  # unknown design_id → not accessible
+
+    # Rule 2: ownership table — primary source
+    owned = (
+        db.query(CardDesignOwnership)
+        .filter_by(user_id=user_id, card_type_id=card_type_id, design_id=design_id)
+        .first()
+    )
+    if owned:
+        return True
+
+    # Rule 3: legacy JSON shim — player_card only, read-only
+    if card_type_id == "player_card":
+        lic = (
+            db.query(UserLicense)
+            .filter_by(user_id=user_id, specialization_type="LFA_FOOTBALL_PLAYER")
+            .first()
+        )
+        if lic and design_id in (lic.unlocked_card_variants or []):
+            return True
+
+    return False
+
+
+def get_owned_design_ids(db, user_id: int, card_type_id: str) -> list[str]:
+    """Return design_ids owned by the user for a specific card_type_id.
+
+    For player_card, always includes free designs (credit_cost == 0) even
+    without an ownership row.
+    """
+    from app.models.card_design_ownership import CardDesignOwnership
+
+    owned = (
+        db.query(CardDesignOwnership.design_id)
+        .filter_by(user_id=user_id, card_type_id=card_type_id)
+        .all()
+    )
+    result = {row.design_id for row in owned}
+
+    # Legacy JSON shim for player_card
+    if card_type_id == "player_card":
+        from app.models.license import UserLicense
+        lic = (
+            db.query(UserLicense)
+            .filter_by(user_id=user_id, specialization_type="LFA_FOOTBALL_PLAYER")
+            .first()
+        )
+        if lic:
+            for d in (lic.unlocked_card_variants or []):
+                result.add(d)
+        # Always include free designs
+        cache = _maybe_reload(db)
+        for d in cache.values():
+            if not d.is_premium:
+                result.add(d.id)
+
+    return sorted(result)
+
+
+def purchase_design(db, user, card_type_id: str, design_id: str) -> "CardDesignOwnership":
+    """Acquire a card design entitlement by deducting credits.
+
+    Atomic: CreditService.deduct() (SAVEPOINT) + CardDesignOwnership INSERT
+    committed together in a single outer db.commit().
+
+    Raises:
+        ValueError              — unknown card_type_id or design_id
+        FreeDesignError         — design is always free, no purchase needed
+        AlreadyOwnedError       — user already owns this design
+        InsufficientCreditsError — not enough credits (raised by CreditService)
+        sqlalchemy.exc.IntegrityError — caught internally, re-raised as AlreadyOwnedError
+    """
+    from sqlalchemy.exc import IntegrityError
+
+    from app.models.card_design_ownership import CardDesignOwnership
+    from app.services.credit_service import CreditService
+
+    if card_type_id not in _VALID_CARD_TYPE_IDS:
+        raise ValueError(f"Unknown card_type_id: {card_type_id!r}")
+
+    price = _resolve_price(card_type_id, design_id, db)  # ValueError if unknown
+
+    if price == 0:
+        raise FreeDesignError(
+            f"Design {card_type_id!r}/{design_id!r} is always accessible — no purchase needed"
+        )
+
+    already = (
+        db.query(CardDesignOwnership)
+        .filter_by(user_id=user.id, card_type_id=card_type_id, design_id=design_id)
+        .first()
+    )
+    if already:
+        raise AlreadyOwnedError(
+            f"Design {card_type_id!r}/{design_id!r} already owned by user {user.id}"
+        )
+
+    idempotency_key = f"card_design_unlock_{user.id}_{card_type_id}_{design_id}"
+
+    # SAVEPOINT: balance UPDATE + CreditTransaction flush (no outer commit inside deduct)
+    credit_tx = CreditService(db).deduct(
+        user=user,
+        amount=price,
+        transaction_type="CARD_DESIGN_UNLOCK",
+        description=f"Card design: {card_type_id}/{design_id}",
+        idempotency_key=idempotency_key,
+    )
+
+    try:
+        ownership = CardDesignOwnership(
+            user_id=user.id,
+            card_type_id=card_type_id,
+            design_id=design_id,
+            source="purchase",
+            credit_transaction_id=credit_tx.id,
+        )
+        db.add(ownership)
+        db.commit()  # OUTER COMMIT: balance + CreditTransaction + Ownership
+        return ownership
+    except IntegrityError:
+        db.rollback()  # rolls back balance update too (outer tx)
+        raise AlreadyOwnedError(
+            f"Design {card_type_id!r}/{design_id!r} already owned (concurrent request)"
+        )
+
+
+def grant_design(
+    db,
+    user_id: int,
+    card_type_id: str,
+    design_id: str,
+    source: str = "admin_grant",
+) -> "CardDesignOwnership | None":
+    """Grant a card design ownership without credit deduction.
+
+    Idempotent: if ownership already exists, returns None without error.
+    For use by: admin panel, backfill scripts, promo flows.
+    Must NOT be called from normal user flows (onboarding, challenge completion, etc.)
+    """
+    from app.models.card_design_ownership import CardDesignOwnership
+
+    existing = (
+        db.query(CardDesignOwnership)
+        .filter_by(user_id=user_id, card_type_id=card_type_id, design_id=design_id)
+        .first()
+    )
+    if existing:
+        return None  # idempotent — already granted
+
+    ownership = CardDesignOwnership(
+        user_id=user_id,
+        card_type_id=card_type_id,
+        design_id=design_id,
+        source=source,
+        credit_transaction_id=None,
+    )
+    db.add(ownership)
+    db.commit()
+    return ownership

--- a/app/services/card_design_service.py
+++ b/app/services/card_design_service.py
@@ -31,6 +31,18 @@ from typing import Optional
 
 
 @dataclass(frozen=True)
+class NonPlayerCardFormatDefinition:
+    """Format/variant definition for Welcome Card and Challenge Card families."""
+    design_id:        str
+    label:            str
+    style_tag:        str
+    dims:             str
+    credit_cost:      int
+    preview_platform: str
+    sort_order:       int = 0
+
+
+@dataclass(frozen=True)
 class CardDesignDefinition:
     id:          str
     label:       str
@@ -186,6 +198,27 @@ DESIGN_ORDER: list[str] = [
 ]
 
 
+# ── Non-player-card format registries ────────────────────────────────────────
+# Format/variant definitions for Welcome Card and Challenge Card families.
+# design_id maps directly to CardDesignOwnership.design_id.
+# Prices are DEV DEFAULT — update via product decision before production.
+
+WELCOME_CARD_FORMATS: list[NonPlayerCardFormatDefinition] = [
+    NonPlayerCardFormatDefinition("instagram_portrait",  "Instagram Portrait",   "IDENTITY CARD", "1080 × 1350",  75,  "instagram_portrait",  0),
+    NonPlayerCardFormatDefinition("instagram_story",     "Instagram Story",      "IDENTITY CARD", "1080 × 1920",  75,  "instagram_story",     1),
+    NonPlayerCardFormatDefinition("instagram_square",    "Instagram Square",     "IDENTITY CARD", "1080 × 1080",  75,  "instagram_square",    2),
+    NonPlayerCardFormatDefinition("tiktok",              "TikTok",               "CINEMATIC",     "1080 × 1920", 100,  "tiktok",              3),
+    NonPlayerCardFormatDefinition("facebook_square",     "Facebook Square",      "EDITORIAL",     "1080 × 1080",  75,  "facebook_square",     4),
+    NonPlayerCardFormatDefinition("facebook_landscape",  "Facebook Landscape",   "LANDSCAPE",     "1200 × 630",   75,  "facebook_landscape",  5),
+    NonPlayerCardFormatDefinition("banner_custom",       "Wide Banner",          "WIDE BANNER",   "1500 × 500",  100,  "banner_custom",       6),
+]
+
+CHALLENGE_CARD_FORMATS: list[NonPlayerCardFormatDefinition] = [
+    NonPlayerCardFormatDefinition("challenge_post_16_9",   "Post (16:9)",  "POST",  "1280 × 720",  100,  "challenge_post_16_9",   0),
+    NonPlayerCardFormatDefinition("challenge_story_9_16",  "Story (9:16)", "STORY", "1080 × 1920", 100,  "challenge_story_9_16",  1),
+]
+
+
 # ── In-process cache ──────────────────────────────────────────────────────────
 _design_cache: dict[str, CardDesignDefinition] = {}
 _cache_loaded_at: float = 0.0
@@ -279,12 +312,24 @@ _VALID_CARD_TYPE_IDS: frozenset[str] = frozenset(
     {"player_card", "welcome_card", "challenge_card"}
 )
 
-# Service-level price map for card families without a CardDesign DB entry.
+# Service-level price map for WC/CC format designs.
 # player_card prices come from CardDesign.credit_cost (DB-backed).
 # Update these constants when pricing changes — do NOT hardcode in templates.
 _NON_PLAYER_CARD_PRICES: dict[tuple[str, str], int] = {
-    ("welcome_card",   "default"):   200,  # CR — product decision
-    ("challenge_card", "challenge"): 150,  # CR — product decision
+    # Welcome Card formats — 75 CR standard, 100 CR premium
+    ("welcome_card", "instagram_portrait"):  75,
+    ("welcome_card", "instagram_story"):     75,
+    ("welcome_card", "instagram_square"):    75,
+    ("welcome_card", "tiktok"):             100,
+    ("welcome_card", "facebook_square"):     75,
+    ("welcome_card", "facebook_landscape"):  75,
+    ("welcome_card", "banner_custom"):      100,
+    # Challenge Card formats
+    ("challenge_card", "challenge_post_16_9"):  100,
+    ("challenge_card", "challenge_story_9_16"): 100,
+    # Legacy sentinel keys — NOT purchasable (FreeDesignError), backward compat only
+    ("welcome_card",   "default"):    0,
+    ("challenge_card", "challenge"):  0,
 }
 
 
@@ -357,6 +402,22 @@ def is_design_accessible(db, user_id: int, card_type_id: str, design_id: str) ->
         if lic and design_id in (lic.unlocked_card_variants or []):
             return True
 
+    # Rule 4: legacy CDO shim — if user owns the old family-level key, grant access
+    # to all format-level designs in that family (backward compat, no migration needed).
+    _LEGACY_CDO_MAP: dict[str, str] = {
+        "welcome_card":   "default",
+        "challenge_card": "challenge",
+    }
+    legacy_key = _LEGACY_CDO_MAP.get(card_type_id)
+    if legacy_key:
+        legacy_row = (
+            db.query(CardDesignOwnership)
+            .filter_by(user_id=user_id, card_type_id=card_type_id, design_id=legacy_key)
+            .first()
+        )
+        if legacy_row:
+            return True
+
     return False
 
 
@@ -391,6 +452,14 @@ def get_owned_design_ids(db, user_id: int, card_type_id: str) -> list[str]:
         for d in cache.values():
             if not d.is_premium:
                 result.add(d.id)
+
+    # Rule 4 shim: if user owns legacy WC/CC family key, grant all format IDs
+    elif card_type_id == "welcome_card" and "default" in result:
+        for fmt in WELCOME_CARD_FORMATS:
+            result.add(fmt.design_id)
+    elif card_type_id == "challenge_card" and "challenge" in result:
+        for fmt in CHALLENGE_CARD_FORMATS:
+            result.add(fmt.design_id)
 
     return sorted(result)
 

--- a/app/services/card_variant_service.py
+++ b/app/services/card_variant_service.py
@@ -46,15 +46,12 @@ def get_all_variants() -> list[VariantDefinition]:
 
 def is_variant_unlocked(user_license, variant_id: str) -> bool:
     """
-    Return True if the user may use this variant.
-    Free variants are always unlocked.
-    Premium variants require variant_id in user_license.unlocked_card_variants.
+    Return True if variant_id is in user_license.unlocked_card_variants.
+    All variants (including non-premium) require explicit entitlement.
     """
     variant = VARIANTS.get(variant_id)
     if variant is None:
         return False
-    if not variant.is_premium:
-        return True
     unlocked = user_license.unlocked_card_variants or []
     return variant_id in unlocked
 

--- a/app/templates/dashboard_student_new.html
+++ b/app/templates/dashboard_student_new.html
@@ -270,8 +270,7 @@
                         scrolling="no" title="My Player Card"></iframe>
             </div>
             <div class="dc-ctas">
-                <a href="/my-cards/player-card" class="dc-cta-primary">✏️ Edit Card</a>
-                <a href="/my-cards" class="dc-cta-ghost">All Cards →</a>
+                <a href="/my-cards" class="dc-cta-primary">My Cards →</a>
             </div>
         </div>
 
@@ -289,7 +288,7 @@
                 {% endif %}
             </div>
             <div class="dc-ctas">
-                <a href="/profile/onboarding-card" class="dc-cta-primary">View →</a>
+                <a href="/my-cards" class="dc-cta-primary">My Cards →</a>
             </div>
         </div>
 
@@ -302,9 +301,7 @@
                 <div class="dc-chall-lbl">active &amp; pending challenges</div>
             </div>
             <div class="dc-ctas">
-                <a href="/challenges" class="dc-cta-primary">
-                    {%- if challenge_card_total > 0 %}View Challenges{% else %}New Challenge{% endif -%}
-                </a>
+                <a href="/my-cards" class="dc-cta-primary">My Cards →</a>
                 <a href="/challenges/send" class="dc-cta-ghost">Send →</a>
             </div>
         </div>

--- a/app/templates/includes/mc_format_grid.html
+++ b/app/templates/includes/mc_format_grid.html
@@ -1,0 +1,142 @@
+{# Shared CSS for format-grid cards — include inside extra_styles block #}
+<style>
+  .mfg-section-hdr {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+  }
+  .mfg-section-hdr h2 {
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: #f1f5f9;
+    margin: 0;
+  }
+  .mfg-count-badge {
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: #94a3b8;
+    background: #1e293b;
+    border: 1px solid #334155;
+    border-radius: 12px;
+    padding: 0.2rem 0.65rem;
+  }
+  .mfg-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
+    gap: 1rem;
+  }
+  .mfg-card {
+    background: #0f172a;
+    border: 1px solid #1e293b;
+    border-radius: 12px;
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+  }
+  .mfg-card:hover { border-color: #334155; }
+  /* Preview area */
+  .mfg-preview-wrap {
+    width: 100%;
+    aspect-ratio: 4 / 3;
+    overflow: hidden;
+    position: relative;
+    border-radius: 8px;
+    background: #0b1120;
+  }
+  .mfg-preview-iframe {
+    width: 400%;
+    height: 400%;
+    transform: scale(.25);
+    transform-origin: 0 0;
+    border: none;
+    pointer-events: none;
+  }
+  .mfg-preview-placeholder {
+    width: 100%;
+    aspect-ratio: 4 / 3;
+    background: #1e293b;
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #475569;
+    font-size: 0.75rem;
+  }
+  /* Watermark overlay for unowned state */
+  .mfg-preview-wrap.mfg-locked::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: rgba(15, 23, 42, .55) url('/static/images/logo-wc.png') center / 28% no-repeat;
+    pointer-events: none;
+  }
+  .mfg-preview-wrap.mfg-locked .mfg-preview-iframe {
+    filter: blur(1px) brightness(.65);
+  }
+  /* Metadata */
+  .mfg-style-tag {
+    font-size: 0.63rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    color: #475569;
+    text-transform: uppercase;
+  }
+  .mfg-label {
+    font-weight: 700;
+    font-size: 0.92rem;
+    color: #f1f5f9;
+    margin: 0;
+  }
+  .mfg-dims {
+    font-size: 0.72rem;
+    color: #475569;
+  }
+  /* State badges */
+  .mfg-badge {
+    display: inline-block;
+    padding: 0.18rem 0.5rem;
+    border-radius: 10px;
+    font-size: 0.69rem;
+    font-weight: 700;
+    align-self: flex-start;
+  }
+  .mfg-badge-free    { background: #14532d; color: #86efac; }
+  .mfg-badge-owned   { background: #1e3a5f; color: #93c5fd; }
+  .mfg-badge-get     { background: #78350f; color: #fde68a; }
+  .mfg-badge-locked  { background: #1e293b; color: #475569; }
+  /* CTA area */
+  .mfg-cta { margin-top: auto; }
+  .mfg-btn {
+    display: block;
+    width: 100%;
+    padding: 0.5rem 0.75rem;
+    border-radius: 8px;
+    font-size: 0.82rem;
+    font-weight: 600;
+    text-align: center;
+    cursor: pointer;
+    border: none;
+    text-decoration: none;
+  }
+  .mfg-btn-owned    { background: #1e3a5f; color: #93c5fd; cursor: default; }
+  .mfg-btn-get      { background: #854d0e; color: #fde68a; }
+  .mfg-btn-get:hover { background: #92400e; }
+  .mfg-btn-disabled { background: #1e293b; color: #334155; cursor: not-allowed; opacity: .7; }
+  .mfg-btn-download { background: #166534; color: #86efac; }
+  .mfg-btn-download:hover { background: #14532d; }
+  .mfg-btn-edit     { background: #1e3a5f; color: #93c5fd; }
+  .mfg-btn-edit:hover { background: #1d4ed8; color: #fff; text-decoration: none; }
+  /* Flash messages */
+  .mfg-flash {
+    padding: 0.75rem 1rem;
+    border-radius: 8px;
+    margin-bottom: 1.25rem;
+    font-size: 0.88rem;
+  }
+  .mfg-flash-success { background: #14532d; color: #86efac; border: 1px solid #166534; }
+  .mfg-flash-error   { background: #450a0a; color: #fca5a5; border: 1px solid #7f1d1d; }
+</style>

--- a/app/templates/my_cards_challenge_card.html
+++ b/app/templates/my_cards_challenge_card.html
@@ -289,6 +289,50 @@
         <p>Browse your recent Virtual Challenges and share phase cards for each result. Preview before downloading.</p>
     </div>
 
+    {# ── Format Shop Header ── #}
+    <div style="margin-bottom:2rem;">
+      <div style="display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:0.5rem;margin-bottom:0.85rem;">
+        <h2 style="font-size:1rem;font-weight:700;color:var(--app-text);margin:0;">Formats</h2>
+        <span style="font-size:0.75rem;font-weight:600;color:#94a3b8;background:#1e293b;border:1px solid #334155;border-radius:12px;padding:0.18rem 0.6rem;">
+          {{ cc_owned_count }} / {{ cc_total }} owned
+        </span>
+      </div>
+      {% if flash_purchased %}
+      <div style="padding:0.7rem 1rem;border-radius:8px;margin-bottom:0.85rem;font-size:0.85rem;background:#14532d;color:#86efac;border:1px solid #166534;">
+        ✓ Format unlocked — you can now export Challenge Cards in this format.
+      </div>
+      {% endif %}
+      {% if flash_error == "credits" %}
+      <div style="padding:0.7rem 1rem;border-radius:8px;margin-bottom:0.85rem;font-size:0.85rem;background:#450a0a;color:#fca5a5;border:1px solid #7f1d1d;">Not enough credits.</div>
+      {% elif flash_error == "owned" %}
+      <div style="padding:0.7rem 1rem;border-radius:8px;margin-bottom:0.85rem;font-size:0.85rem;background:#450a0a;color:#fca5a5;border:1px solid #7f1d1d;">You already own this format.</div>
+      {% elif flash_error == "invalid" %}
+      <div style="padding:0.7rem 1rem;border-radius:8px;margin-bottom:0.85rem;font-size:0.85rem;background:#450a0a;color:#fca5a5;border:1px solid #7f1d1d;">Unknown format.</div>
+      {% endif %}
+      <div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:1rem;">
+        {% for r in cc_format_rows %}
+        <div style="background:#0f172a;border:1px solid #1e293b;border-radius:12px;padding:1rem;display:flex;flex-direction:column;gap:0.6rem;">
+          <div style="font-size:0.63rem;font-weight:700;letter-spacing:0.08em;color:#475569;text-transform:uppercase;">{{ r.style_tag }}</div>
+          <div style="font-weight:700;font-size:0.92rem;color:#f1f5f9;">{{ r.label }}</div>
+          <div style="font-size:0.72rem;color:#475569;">{{ r.dims }}</div>
+          {% if r.state == "owned" %}
+            <span style="display:inline-block;padding:0.18rem 0.5rem;border-radius:10px;font-size:0.69rem;font-weight:700;background:#1e3a5f;color:#93c5fd;align-self:flex-start;">Owned ✓</span>
+            <span style="display:block;width:100%;padding:0.45rem 0.75rem;border-radius:8px;font-size:0.82rem;font-weight:600;text-align:center;background:#1e3a5f;color:#93c5fd;cursor:default;text-decoration:none;">Owned ✓</span>
+          {% elif r.state == "purchasable" %}
+            <span style="display:inline-block;padding:0.18rem 0.5rem;border-radius:10px;font-size:0.69rem;font-weight:700;background:#78350f;color:#fde68a;align-self:flex-start;">{{ r.credit_cost }} CR</span>
+            <form method="POST" action="/my-cards/designs/challenge_card/{{ r.design_id }}/get">
+              <button type="submit" style="display:block;width:100%;padding:0.45rem 0.75rem;border-radius:8px;font-size:0.82rem;font-weight:600;text-align:center;cursor:pointer;border:none;background:#854d0e;color:#fde68a;">Get Card — {{ r.credit_cost }} CR</button>
+            </form>
+          {% else %}
+            <span style="display:inline-block;padding:0.18rem 0.5rem;border-radius:10px;font-size:0.69rem;font-weight:700;background:#1e293b;color:#475569;align-self:flex-start;">{{ r.credit_cost }} CR 🔒</span>
+            <button disabled style="display:block;width:100%;padding:0.45rem 0.75rem;border-radius:8px;font-size:0.82rem;font-weight:600;text-align:center;cursor:not-allowed;border:none;background:#1e293b;color:#334155;opacity:.7;">Not enough credits</button>
+          {% endif %}
+        </div>
+        {% endfor %}
+      </div>
+    </div>
+    {# ── End Format Shop Header ── #}
+
     {% if not has_challenges %}
     {# ── Empty state ── #}
     <div class="cc-empty">

--- a/app/templates/my_cards_hub.html
+++ b/app/templates/my_cards_hub.html
@@ -11,259 +11,188 @@
 
 {% block extra_styles %}
 <style>
-    .mc-hub {
-        max-width: 900px;
-        margin: 0 auto;
-        padding: 1.5rem 1rem 3rem;
-    }
+  .mc-hub {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 1.5rem 1rem 3rem;
+  }
 
-    /* ── Header bar ─────────────────────────────────────────────────────── */
-    .mc-header-bar {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        flex-wrap: wrap;
-        gap: 0.5rem;
-        margin-bottom: 1.25rem;
-    }
-    .mc-header-bar h1 {
-        font-size: 1.5rem;
-        font-weight: 700;
-        color: var(--app-text, #f1f5f9);
-        margin: 0;
-    }
-    .mc-credits-badge {
-        background: #1e293b;
-        border: 1px solid #334155;
-        border-radius: 20px;
-        padding: 0.4rem 1rem;
-        font-size: 0.9rem;
-        color: #94a3b8;
-    }
-    .mc-credits-badge strong { color: #FFD200; }
+  /* ── Header bar ── */
+  .mc-header-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 1.25rem;
+  }
+  .mc-header-bar h1 {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--app-text, #f1f5f9);
+    margin: 0;
+  }
+  .mc-credits-badge {
+    background: #1e293b;
+    border: 1px solid #334155;
+    border-radius: 20px;
+    padding: 0.4rem 1rem;
+    font-size: 0.9rem;
+    color: #94a3b8;
+  }
+  .mc-credits-badge strong { color: #FFD200; }
 
-    /* ── Flash ─────────────────────────────────────────────────────────── */
-    .mc-flash {
-        padding: 0.75rem 1rem;
-        border-radius: 8px;
-        margin-bottom: 1.25rem;
-        font-size: 0.9rem;
-    }
-    .mc-flash-success { background: #14532d; color: #86efac; border: 1px solid #166534; }
+  /* ── Flash ── */
+  .mc-flash {
+    padding: 0.75rem 1rem;
+    border-radius: 8px;
+    margin-bottom: 1.25rem;
+    font-size: 0.9rem;
+  }
+  .mc-flash-success { background: #14532d; color: #86efac; border: 1px solid #166534; }
 
-    /* ── Card family panel ──────────────────────────────────────────────── */
-    .mc-panel {
-        background: var(--app-card, #1a1f2e);
-        border: 1px solid var(--app-border, #252d42);
-        border-radius: 14px;
-        padding: 1.5rem;
-        margin-bottom: 1.25rem;
-        display: flex;
-        flex-direction: column;
-        gap: 1rem;
-    }
+  /* ── Tile grid ── */
+  .mc-tiles {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    gap: 1.25rem;
+  }
 
-    .mc-panel-header {
-        display: flex;
-        align-items: flex-start;
-        gap: 1rem;
-        flex-wrap: wrap;
-    }
-    .mc-panel-icon { font-size: 2rem; line-height: 1; flex-shrink: 0; }
-    .mc-panel-meta { flex: 1; min-width: 0; }
-    .mc-panel-title {
-        font-size: 1.1rem;
-        font-weight: 700;
-        color: var(--app-text, #f1f5f9);
-        margin: 0 0 0.2rem;
-    }
-    .mc-panel-sub {
-        font-size: 0.82rem;
-        color: var(--app-text-muted, #64748b);
-        margin: 0;
-    }
+  .mc-tile {
+    background: var(--app-card, #1a1f2e);
+    border: 1px solid var(--app-border, #252d42);
+    border-radius: 14px;
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    transition: border-color 0.15s;
+  }
+  .mc-tile:hover { border-color: #334155; }
 
-    /* ── Badges ─────────────────────────────────────────────────────────── */
-    .mc-badge {
-        display: inline-flex;
-        align-items: center;
-        font-size: 0.72rem;
-        font-weight: 700;
-        padding: 0.25rem 0.65rem;
-        border-radius: 20px;
-        white-space: nowrap;
-        align-self: flex-start;
-        margin-top: 0.2rem;
-        letter-spacing: 0.02em;
-    }
-    .mc-badge-free     { background: #14532d; color: #86efac; }
-    .mc-badge-owned    { background: #1e3a5f; color: #93c5fd; }
-    .mc-badge-get_card { background: #78350f; color: #fde68a; }
-    .mc-badge-locked   { background: #1e293b; color: #475569; }
+  .mc-tile-top {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.85rem;
+  }
+  .mc-tile-icon { font-size: 2rem; line-height: 1; flex-shrink: 0; }
+  .mc-tile-meta { flex: 1; min-width: 0; }
+  .mc-tile-title {
+    font-size: 1.05rem;
+    font-weight: 700;
+    color: var(--app-text, #f1f5f9);
+    margin: 0 0 0.25rem;
+  }
+  .mc-tile-desc {
+    font-size: 0.78rem;
+    color: var(--app-text-muted, #64748b);
+    margin: 0;
+  }
 
-    /* ── CTA row ────────────────────────────────────────────────────────── */
-    .mc-cta-row {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 0.5rem;
-    }
-    .mc-btn {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        padding: 0.55rem 1.1rem;
-        border-radius: 8px;
-        font-size: 0.875rem;
-        font-weight: 600;
-        text-decoration: none;
-        border: none;
-        cursor: pointer;
-        white-space: nowrap;
-        transition: opacity 0.15s, background 0.15s;
-    }
-    .mc-btn-primary    { background: #FFD200; color: #0f172a; }
-    .mc-btn-primary:hover { opacity: 0.88; color: #0f172a; text-decoration: none; }
-    .mc-btn-secondary  { background: #1e3a5f; color: #93c5fd; }
-    .mc-btn-secondary:hover { background: #1d4ed8; color: #fff; text-decoration: none; }
-    .mc-btn-ghost      { background: transparent; color: #64748b; border: 1px solid #334155; }
-    .mc-btn-ghost:hover { border-color: #64748b; color: #94a3b8; text-decoration: none; }
-    .mc-btn-disabled   { background: #1e293b; color: #334155; cursor: not-allowed; opacity: 0.7; }
-    .mc-btn-get        { background: #854d0e; color: #fde68a; }
-    .mc-btn-get:hover  { background: #92400e; color: #fef3c7; text-decoration: none; }
+  /* ── Count badge ── */
+  .mc-count-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: #94a3b8;
+    background: #1e293b;
+    border: 1px solid #334155;
+    border-radius: 12px;
+    padding: 0.22rem 0.65rem;
+    align-self: flex-start;
+  }
+  .mc-count-badge.mc-count-complete {
+    color: #86efac;
+    background: rgba(20,83,45,.25);
+    border-color: #166534;
+  }
 
-    @media (max-width: 600px) {
-        .mc-cta-row { flex-direction: column; }
-        .mc-btn { width: 100%; }
-    }
+  /* ── CTA button ── */
+  .mc-browse-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.55rem 1rem;
+    border-radius: 8px;
+    font-size: 0.875rem;
+    font-weight: 600;
+    text-decoration: none;
+    background: #FFD200;
+    color: #0f172a;
+    transition: opacity 0.15s;
+    white-space: nowrap;
+    text-align: center;
+  }
+  .mc-browse-btn:hover { opacity: 0.88; color: #0f172a; text-decoration: none; }
 </style>
 {% endblock %}
 
 {% block student_content %}
 <div class="mc-hub">
 
-    <div class="mc-header-bar">
-        <h1>My Cards</h1>
-        <span class="mc-credits-badge">Balance: <strong>{{ user.credit_balance }} CR</strong></span>
+  <div class="mc-header-bar">
+    <h1>My Cards</h1>
+    <span class="mc-credits-badge">Balance: <strong>{{ user.credit_balance }} CR</strong></span>
+  </div>
+
+  {# ── Flash: purchase success ── #}
+  {% if flash_purchased %}
+  <div class="mc-flash mc-flash-success">
+    ✓ {{ flash_purchased }} unlocked and added to your collection.
+  </div>
+  {% endif %}
+
+  {# ── Tile grid ── #}
+  <div class="mc-tiles">
+
+    {# Player Card tile #}
+    <div class="mc-tile">
+      <div class="mc-tile-top">
+        <span class="mc-tile-icon">🎴</span>
+        <div class="mc-tile-meta">
+          <div class="mc-tile-title">Player Card</div>
+          <p class="mc-tile-desc">Your LFA player identity card. Choose from {{ pc_total }} designs.</p>
+        </div>
+      </div>
+      <span class="mc-count-badge{% if pc_owned_count == pc_total %} mc-count-complete{% endif %}">
+        {{ pc_owned_count }} / {{ pc_total }} owned
+      </span>
+      <a href="/my-cards/player-card" class="mc-browse-btn">Browse Designs</a>
     </div>
 
-    {# ── Flash: purchase success ──────────────────────────────────────────────── #}
-    {% if flash_purchased %}
-    <div class="mc-flash mc-flash-success">
-        ✓ Purchase successful — {{ flash_purchased }} is now in your collection.
-    </div>
-    {% endif %}
-
-    {# ── Player Card panel ───────────────────────────────────────────────────── #}
-    <div class="mc-panel">
-        <div class="mc-panel-header">
-            <span class="mc-panel-icon">🎴</span>
-            <div class="mc-panel-meta">
-                <div class="mc-panel-title">Player Card</div>
-                <div class="mc-panel-sub">
-                    {%- if pc_state == "free" -%}
-                        {{ pc_design_label }} — always free
-                    {%- elif pc_state == "owned" -%}
-                        {{ pc_design_label }} — owned
-                    {%- else -%}
-                        {{ pc_design_label }}{% if pc_price %} — {{ pc_price }} CR{% endif %}
-                    {%- endif -%}
-                </div>
-            </div>
-            <span class="mc-badge mc-badge-{{ pc_state }}">
-                {%- if pc_state == "free"     -%}Free
-                {%- elif pc_state == "owned"  -%}Owned ✓
-                {%- elif pc_state == "get_card" -%}{{ pc_price }} CR
-                {%- else -%}{{ pc_price }} CR 🔒
-                {%- endif -%}
-            </span>
+    {# Welcome Card tile #}
+    <div class="mc-tile">
+      <div class="mc-tile-top">
+        <span class="mc-tile-icon">👋</span>
+        <div class="mc-tile-meta">
+          <div class="mc-tile-title">Welcome Card</div>
+          <p class="mc-tile-desc">Your onboarding milestone card in {{ wc_total }} platform formats.</p>
         </div>
-        <div class="mc-cta-row">
-            {% if pc_state in ("free", "owned") %}
-                <a href="/my-cards/player-card" class="mc-btn mc-btn-primary">Edit Card</a>
-                <a href="/players/{{ user.id }}/card/export?platform=instagram_portrait"
-                   class="mc-btn mc-btn-secondary">Download</a>
-                {% if pc_state == "owned" %}
-                    <a href="/my-cards/shop?tab=player" class="mc-btn mc-btn-ghost">Manage Designs</a>
-                {% endif %}
-            {% elif pc_state == "get_card" %}
-                <a href="/my-cards/shop?tab=player" class="mc-btn mc-btn-get">
-                    Get Card — {{ pc_price }} CR
-                </a>
-            {% else %}
-                <button class="mc-btn mc-btn-disabled" disabled>{{ pc_price }} CR — Not enough credits</button>
-            {% endif %}
-        </div>
+      </div>
+      <span class="mc-count-badge{% if wc_owned_count == wc_total %} mc-count-complete{% endif %}">
+        {{ wc_owned_count }} / {{ wc_total }} owned
+      </span>
+      <a href="/my-cards/welcome-card" class="mc-browse-btn">Browse Formats</a>
     </div>
 
-    {# ── Welcome Card panel ──────────────────────────────────────────────────── #}
-    <div class="mc-panel">
-        <div class="mc-panel-header">
-            <span class="mc-panel-icon">👋</span>
-            <div class="mc-panel-meta">
-                <div class="mc-panel-title">Welcome Card</div>
-                <div class="mc-panel-sub">
-                    {%- if wc_state == "owned" -%}
-                        Default design — owned
-                    {%- else -%}
-                        Your onboarding milestone card — {{ wc_price }} CR
-                    {%- endif -%}
-                </div>
-            </div>
-            <span class="mc-badge mc-badge-{{ wc_state }}">
-                {%- if wc_state == "owned"    -%}Owned ✓
-                {%- elif wc_state == "get_card" -%}{{ wc_price }} CR
-                {%- else -%}{{ wc_price }} CR 🔒
-                {%- endif -%}
-            </span>
+    {# Challenge Card tile #}
+    <div class="mc-tile">
+      <div class="mc-tile-top">
+        <span class="mc-tile-icon">⚡</span>
+        <div class="mc-tile-meta">
+          <div class="mc-tile-title">Challenge Card</div>
+          <p class="mc-tile-desc">Social card for VT challenge results in {{ cc_total }} formats.</p>
         </div>
-        <div class="mc-cta-row">
-            {% if wc_state == "owned" %}
-                <a href="/my-cards/welcome-card" class="mc-btn mc-btn-primary">View / Edit</a>
-                <a href="/profile/onboarding-card/export?platform=instagram_portrait"
-                   class="mc-btn mc-btn-secondary">Download</a>
-            {% elif wc_state == "get_card" %}
-                <a href="/my-cards/shop?tab=welcome" class="mc-btn mc-btn-get">
-                    Get Card — {{ wc_price }} CR
-                </a>
-            {% else %}
-                <button class="mc-btn mc-btn-disabled" disabled>{{ wc_price }} CR — Not enough credits</button>
-            {% endif %}
-        </div>
+      </div>
+      <span class="mc-count-badge{% if cc_owned_count == cc_total %} mc-count-complete{% endif %}">
+        {{ cc_owned_count }} / {{ cc_total }} owned
+      </span>
+      <a href="/my-cards/challenge-card" class="mc-browse-btn">Browse Formats</a>
     </div>
 
-    {# ── Challenge Card panel ────────────────────────────────────────────────── #}
-    <div class="mc-panel">
-        <div class="mc-panel-header">
-            <span class="mc-panel-icon">⚡</span>
-            <div class="mc-panel-meta">
-                <div class="mc-panel-title">Challenge Card</div>
-                <div class="mc-panel-sub">
-                    {%- if cc_state == "owned" -%}
-                        Challenge design — owned
-                    {%- else -%}
-                        Social card for VT challenge results — {{ cc_price }} CR
-                    {%- endif -%}
-                </div>
-            </div>
-            <span class="mc-badge mc-badge-{{ cc_state }}">
-                {%- if cc_state == "owned"    -%}Owned ✓
-                {%- elif cc_state == "get_card" -%}{{ cc_price }} CR
-                {%- else -%}{{ cc_price }} CR 🔒
-                {%- endif -%}
-            </span>
-        </div>
-        <div class="mc-cta-row">
-            {% if cc_state == "owned" %}
-                <a href="/my-cards/challenge-card" class="mc-btn mc-btn-primary">View Collection</a>
-            {% elif cc_state == "get_card" %}
-                <a href="/my-cards/shop?tab=challenge" class="mc-btn mc-btn-get">
-                    Get Card — {{ cc_price }} CR
-                </a>
-            {% else %}
-                <button class="mc-btn mc-btn-disabled" disabled>{{ cc_price }} CR — Not enough credits</button>
-            {% endif %}
-        </div>
-    </div>
+  </div>
 
 </div>
 {% endblock %}

--- a/app/templates/my_cards_hub.html
+++ b/app/templates/my_cards_hub.html
@@ -11,154 +11,258 @@
 
 {% block extra_styles %}
 <style>
-    .my-cards-container {
+    .mc-hub {
         max-width: 900px;
         margin: 0 auto;
-        padding: 1.5rem 1rem 2.5rem;
+        padding: 1.5rem 1rem 3rem;
     }
 
-    .my-cards-header {
-        margin-bottom: 2rem;
+    /* ── Header bar ─────────────────────────────────────────────────────── */
+    .mc-header-bar {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        margin-bottom: 1.25rem;
     }
-
-    .my-cards-header h1 {
-        font-size: 1.6rem;
+    .mc-header-bar h1 {
+        font-size: 1.5rem;
         font-weight: 700;
-        color: var(--app-text);
-        margin: 0 0 0.35rem;
+        color: var(--app-text, #f1f5f9);
+        margin: 0;
+    }
+    .mc-credits-badge {
+        background: #1e293b;
+        border: 1px solid #334155;
+        border-radius: 20px;
+        padding: 0.4rem 1rem;
+        font-size: 0.9rem;
+        color: #94a3b8;
+    }
+    .mc-credits-badge strong { color: #FFD200; }
+
+    /* ── Flash ─────────────────────────────────────────────────────────── */
+    .mc-flash {
+        padding: 0.75rem 1rem;
+        border-radius: 8px;
+        margin-bottom: 1.25rem;
+        font-size: 0.9rem;
+    }
+    .mc-flash-success { background: #14532d; color: #86efac; border: 1px solid #166534; }
+
+    /* ── Card family panel ──────────────────────────────────────────────── */
+    .mc-panel {
+        background: var(--app-card, #1a1f2e);
+        border: 1px solid var(--app-border, #252d42);
+        border-radius: 14px;
+        padding: 1.5rem;
+        margin-bottom: 1.25rem;
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
     }
 
-    .my-cards-header p {
-        color: var(--app-text-muted);
-        font-size: 0.95rem;
+    .mc-panel-header {
+        display: flex;
+        align-items: flex-start;
+        gap: 1rem;
+        flex-wrap: wrap;
+    }
+    .mc-panel-icon { font-size: 2rem; line-height: 1; flex-shrink: 0; }
+    .mc-panel-meta { flex: 1; min-width: 0; }
+    .mc-panel-title {
+        font-size: 1.1rem;
+        font-weight: 700;
+        color: var(--app-text, #f1f5f9);
+        margin: 0 0 0.2rem;
+    }
+    .mc-panel-sub {
+        font-size: 0.82rem;
+        color: var(--app-text-muted, #64748b);
         margin: 0;
     }
 
-    /* ── Card tile grid ─────────────────────────────────────────────────────── */
-    .card-tile-grid {
-        display: grid;
-        grid-template-columns: repeat(3, 1fr);
-        gap: 1.25rem;
-    }
-
-    @media (max-width: 700px) {
-        .card-tile-grid { grid-template-columns: repeat(2, 1fr); }
-    }
-
-    @media (max-width: 420px) {
-        .card-tile-grid { grid-template-columns: 1fr; }
-    }
-
-    .card-tile {
-        display: flex;
-        flex-direction: column;
-        background: var(--app-card);
-        border-radius: 14px;
-        padding: 1.5rem 1.25rem 1.25rem;
-        box-shadow: 0 2px 8px rgba(0,0,0,0.07);
-        text-decoration: none;
-        color: inherit;
-        border-top: 4px solid var(--tile-color, #667eea);
-        transition: box-shadow 0.2s, transform 0.15s;
-        min-height: 140px;
-    }
-
-    a.card-tile:hover {
-        box-shadow: 0 6px 20px rgba(0,0,0,0.13);
-        transform: translateY(-2px);
-    }
-
-    .card-tile.coming-soon {
-        opacity: 0.55;
-        cursor: default;
-        border-top-color: #cbd5e1;
-    }
-
-    .tile-icon {
-        font-size: 2rem;
-        line-height: 1;
-        margin-bottom: 0.65rem;
-    }
-
-    .tile-title {
-        font-size: 1.05rem;
-        font-weight: 700;
-        color: var(--app-text);
-        margin: 0 0 0.3rem;
-    }
-
-    .tile-desc {
-        font-size: 0.82rem;
-        color: var(--app-text-muted);
-        margin: 0 0 0.75rem;
-        line-height: 1.4;
-        flex: 1;
-    }
-
-    .tile-badge {
-        display: inline-block;
+    /* ── Badges ─────────────────────────────────────────────────────────── */
+    .mc-badge {
+        display: inline-flex;
+        align-items: center;
         font-size: 0.72rem;
         font-weight: 700;
-        padding: 0.2rem 0.55rem;
+        padding: 0.25rem 0.65rem;
         border-radius: 20px;
-        letter-spacing: 0.03em;
+        white-space: nowrap;
         align-self: flex-start;
+        margin-top: 0.2rem;
+        letter-spacing: 0.02em;
     }
+    .mc-badge-free     { background: #14532d; color: #86efac; }
+    .mc-badge-owned    { background: #1e3a5f; color: #93c5fd; }
+    .mc-badge-get_card { background: #78350f; color: #fde68a; }
+    .mc-badge-locked   { background: #1e293b; color: #475569; }
 
-    .tile-badge.active {
-        background: #d1fae5;
-        color: #065f46;
+    /* ── CTA row ────────────────────────────────────────────────────────── */
+    .mc-cta-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
     }
+    .mc-btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0.55rem 1.1rem;
+        border-radius: 8px;
+        font-size: 0.875rem;
+        font-weight: 600;
+        text-decoration: none;
+        border: none;
+        cursor: pointer;
+        white-space: nowrap;
+        transition: opacity 0.15s, background 0.15s;
+    }
+    .mc-btn-primary    { background: #FFD200; color: #0f172a; }
+    .mc-btn-primary:hover { opacity: 0.88; color: #0f172a; text-decoration: none; }
+    .mc-btn-secondary  { background: #1e3a5f; color: #93c5fd; }
+    .mc-btn-secondary:hover { background: #1d4ed8; color: #fff; text-decoration: none; }
+    .mc-btn-ghost      { background: transparent; color: #64748b; border: 1px solid #334155; }
+    .mc-btn-ghost:hover { border-color: #64748b; color: #94a3b8; text-decoration: none; }
+    .mc-btn-disabled   { background: #1e293b; color: #334155; cursor: not-allowed; opacity: 0.7; }
+    .mc-btn-get        { background: #854d0e; color: #fde68a; }
+    .mc-btn-get:hover  { background: #92400e; color: #fef3c7; text-decoration: none; }
 
-    .tile-badge.soon {
-        background: #f1f5f9;
-        color: #64748b;
+    @media (max-width: 600px) {
+        .mc-cta-row { flex-direction: column; }
+        .mc-btn { width: 100%; }
     }
 </style>
 {% endblock %}
 
 {% block student_content %}
-<div class="my-cards-container">
+<div class="mc-hub">
 
-    <div class="my-cards-header">
+    <div class="mc-header-bar">
         <h1>My Cards</h1>
-        <p>All your digital cards in one place — player profiles, milestone cards, and more.</p>
+        <span class="mc-credits-badge">Balance: <strong>{{ user.credit_balance }} CR</strong></span>
     </div>
 
-    <div class="card-tile-grid">
-        {% for spec in card_specs %}
-        {% if spec.content_contract.version >= 1 %}
-        {# ── Active tile ── #}
-        <a href="/my-cards/{{ spec.card_type_id | replace('_', '-') }}"
-           class="card-tile"
-           style="--tile-color: #667eea;">
-            <div class="tile-icon">
-                {%- if spec.card_type_id == 'player_card' %}🎴
-                {%- elif spec.card_type_id == 'welcome_card' %}👋
-                {%- else %}🃏
-                {%- endif %}
+    {# ── Flash: purchase success ──────────────────────────────────────────────── #}
+    {% if flash_purchased %}
+    <div class="mc-flash mc-flash-success">
+        ✓ Purchase successful — {{ flash_purchased }} is now in your collection.
+    </div>
+    {% endif %}
+
+    {# ── Player Card panel ───────────────────────────────────────────────────── #}
+    <div class="mc-panel">
+        <div class="mc-panel-header">
+            <span class="mc-panel-icon">🎴</span>
+            <div class="mc-panel-meta">
+                <div class="mc-panel-title">Player Card</div>
+                <div class="mc-panel-sub">
+                    {%- if pc_state == "free" -%}
+                        {{ pc_design_label }} — always free
+                    {%- elif pc_state == "owned" -%}
+                        {{ pc_design_label }} — owned
+                    {%- else -%}
+                        {{ pc_design_label }}{% if pc_price %} — {{ pc_price }} CR{% endif %}
+                    {%- endif -%}
+                </div>
             </div>
-            <div class="tile-title">{{ spec.label }}</div>
-            <div class="tile-desc">{{ spec.description }}</div>
-            <span class="tile-badge active">Active</span>
-        </a>
-        {% else %}
-        {# ── Coming Soon tile ── #}
-        <div class="card-tile coming-soon">
-            <div class="tile-icon">
-                {%- if spec.card_type_id == 'match_card' %}⚽
-                {%- elif spec.card_type_id == 'event_card' %}📅
-                {%- elif spec.card_type_id == 'birthday_card' %}🎂
-                {%- elif spec.card_type_id == 'badge_card' %}🏅
-                {%- else %}🃏
-                {%- endif %}
-            </div>
-            <div class="tile-title">{{ spec.label }}</div>
-            <div class="tile-desc">{{ spec.description }}</div>
-            <span class="tile-badge soon">Coming Soon</span>
+            <span class="mc-badge mc-badge-{{ pc_state }}">
+                {%- if pc_state == "free"     -%}Free
+                {%- elif pc_state == "owned"  -%}Owned ✓
+                {%- elif pc_state == "get_card" -%}{{ pc_price }} CR
+                {%- else -%}{{ pc_price }} CR 🔒
+                {%- endif -%}
+            </span>
         </div>
-        {% endif %}
-        {% endfor %}
+        <div class="mc-cta-row">
+            {% if pc_state in ("free", "owned") %}
+                <a href="/my-cards/player-card" class="mc-btn mc-btn-primary">Edit Card</a>
+                <a href="/players/{{ user.id }}/card/export?platform=instagram_portrait"
+                   class="mc-btn mc-btn-secondary">Download</a>
+                {% if pc_state == "owned" %}
+                    <a href="/my-cards/shop?tab=player" class="mc-btn mc-btn-ghost">Manage Designs</a>
+                {% endif %}
+            {% elif pc_state == "get_card" %}
+                <a href="/my-cards/shop?tab=player" class="mc-btn mc-btn-get">
+                    Get Card — {{ pc_price }} CR
+                </a>
+            {% else %}
+                <button class="mc-btn mc-btn-disabled" disabled>{{ pc_price }} CR — Not enough credits</button>
+            {% endif %}
+        </div>
+    </div>
+
+    {# ── Welcome Card panel ──────────────────────────────────────────────────── #}
+    <div class="mc-panel">
+        <div class="mc-panel-header">
+            <span class="mc-panel-icon">👋</span>
+            <div class="mc-panel-meta">
+                <div class="mc-panel-title">Welcome Card</div>
+                <div class="mc-panel-sub">
+                    {%- if wc_state == "owned" -%}
+                        Default design — owned
+                    {%- else -%}
+                        Your onboarding milestone card — {{ wc_price }} CR
+                    {%- endif -%}
+                </div>
+            </div>
+            <span class="mc-badge mc-badge-{{ wc_state }}">
+                {%- if wc_state == "owned"    -%}Owned ✓
+                {%- elif wc_state == "get_card" -%}{{ wc_price }} CR
+                {%- else -%}{{ wc_price }} CR 🔒
+                {%- endif -%}
+            </span>
+        </div>
+        <div class="mc-cta-row">
+            {% if wc_state == "owned" %}
+                <a href="/my-cards/welcome-card" class="mc-btn mc-btn-primary">View / Edit</a>
+                <a href="/profile/onboarding-card/export?platform=instagram_portrait"
+                   class="mc-btn mc-btn-secondary">Download</a>
+            {% elif wc_state == "get_card" %}
+                <a href="/my-cards/shop?tab=welcome" class="mc-btn mc-btn-get">
+                    Get Card — {{ wc_price }} CR
+                </a>
+            {% else %}
+                <button class="mc-btn mc-btn-disabled" disabled>{{ wc_price }} CR — Not enough credits</button>
+            {% endif %}
+        </div>
+    </div>
+
+    {# ── Challenge Card panel ────────────────────────────────────────────────── #}
+    <div class="mc-panel">
+        <div class="mc-panel-header">
+            <span class="mc-panel-icon">⚡</span>
+            <div class="mc-panel-meta">
+                <div class="mc-panel-title">Challenge Card</div>
+                <div class="mc-panel-sub">
+                    {%- if cc_state == "owned" -%}
+                        Challenge design — owned
+                    {%- else -%}
+                        Social card for VT challenge results — {{ cc_price }} CR
+                    {%- endif -%}
+                </div>
+            </div>
+            <span class="mc-badge mc-badge-{{ cc_state }}">
+                {%- if cc_state == "owned"    -%}Owned ✓
+                {%- elif cc_state == "get_card" -%}{{ cc_price }} CR
+                {%- else -%}{{ cc_price }} CR 🔒
+                {%- endif -%}
+            </span>
+        </div>
+        <div class="mc-cta-row">
+            {% if cc_state == "owned" %}
+                <a href="/my-cards/challenge-card" class="mc-btn mc-btn-primary">View Collection</a>
+            {% elif cc_state == "get_card" %}
+                <a href="/my-cards/shop?tab=challenge" class="mc-btn mc-btn-get">
+                    Get Card — {{ cc_price }} CR
+                </a>
+            {% else %}
+                <button class="mc-btn mc-btn-disabled" disabled>{{ cc_price }} CR — Not enough credits</button>
+            {% endif %}
+        </div>
     </div>
 
 </div>

--- a/app/templates/my_cards_player_card.html
+++ b/app/templates/my_cards_player_card.html
@@ -1,0 +1,145 @@
+{% extends "student_base.html" %}
+
+{% block title %}Player Card — LFA Education Center{% endblock %}
+{% block active_page %}lfa-player{% endblock %}
+
+{% block student_header %}
+{% set _page_icon = '🎴' %}
+{% set _page_name = 'Player Card' %}
+{% include "includes/spec_subpage_hdr.html" %}
+{% endblock %}
+
+{% block extra_styles %}
+{% include "includes/mc_format_grid.html" %}
+<style>
+  .mcp-wrap {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 1.5rem 1rem 4rem;
+  }
+  .mcp-breadcrumb {
+    font-size: 0.8rem;
+    color: #64748b;
+    margin-bottom: 1.25rem;
+  }
+  .mcp-breadcrumb a { color: #94a3b8; text-decoration: none; }
+  .mcp-breadcrumb a:hover { color: #f1f5f9; }
+  .mcp-breadcrumb span { margin: 0 0.35rem; }
+  .mcp-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 1.5rem;
+  }
+  .mcp-header h1 { font-size: 1.4rem; font-weight: 700; color: #f8fafc; margin: 0; }
+  .mcp-credits-badge {
+    background: #1e293b;
+    border: 1px solid #334155;
+    border-radius: 20px;
+    padding: 0.35rem 0.9rem;
+    font-size: 0.85rem;
+    color: #94a3b8;
+  }
+  .mcp-credits-badge strong { color: #FFD200; }
+</style>
+{% endblock %}
+
+{% block student_content %}
+<div class="mcp-wrap">
+
+  <nav class="mcp-breadcrumb" aria-label="Breadcrumb">
+    <a href="/my-cards">My Cards</a>
+    <span>›</span>
+    <span>Player Card</span>
+  </nav>
+
+  <div class="mcp-header">
+    <h1>Player Card</h1>
+    <span class="mcp-credits-badge">Balance: <strong>{{ user.credit_balance }} CR</strong></span>
+  </div>
+
+  {# ── Flash messages ── #}
+  {% if flash_purchased %}
+  <div class="mfg-flash mfg-flash-success">
+    ✓ Design unlocked — {{ flash_purchased }} is now in your collection.
+  </div>
+  {% endif %}
+  {% if flash_error == "credits" %}
+  <div class="mfg-flash mfg-flash-error">Not enough credits to purchase this design.</div>
+  {% elif flash_error == "owned" %}
+  <div class="mfg-flash mfg-flash-error">You already own this design.</div>
+  {% elif flash_error == "free" %}
+  <div class="mfg-flash mfg-flash-error">This design is always free — no purchase needed.</div>
+  {% elif flash_error == "invalid" %}
+  <div class="mfg-flash mfg-flash-error">Unknown card type or design.</div>
+  {% endif %}
+
+  {# ── Section header ── #}
+  <div class="mfg-section-hdr">
+    <h2>Designs</h2>
+    <span class="mfg-count-badge">{{ owned_count }} / {{ total_count }} owned</span>
+  </div>
+
+  {# ── Design grid ── #}
+  <div class="mfg-grid">
+    {% for d in design_rows %}
+    <div class="mfg-card">
+
+      {# Preview #}
+      {% if d.state in ("free", "owned") %}
+      <div class="mfg-preview-wrap">
+        <iframe
+          class="mfg-preview-iframe"
+          src="/players/{{ user.id }}/card?platform=instagram_portrait&design={{ d.id }}"
+          loading="lazy"
+          scrolling="no"
+          title="{{ d.label }} preview"
+        ></iframe>
+      </div>
+      {% else %}
+      <div class="mfg-preview-wrap mfg-locked">
+        <div class="mfg-preview-placeholder">{{ d.label[:2] | upper }}</div>
+      </div>
+      {% endif %}
+
+      {# Metadata #}
+      <p class="mfg-label">{{ d.label }}</p>
+      {% if d.description %}
+      <p style="font-size:0.75rem;color:#64748b;margin:0;">{{ d.description }}</p>
+      {% endif %}
+
+      {# State badge + CTA #}
+      <div style="display:flex;align-items:center;justify-content:space-between;gap:0.5rem;">
+        {% if d.state == "free" %}
+          <span class="mfg-badge mfg-badge-free">Free</span>
+        {% elif d.state == "owned" %}
+          <span class="mfg-badge mfg-badge-owned">Owned ✓</span>
+        {% elif d.state == "purchasable" %}
+          <span class="mfg-badge mfg-badge-get">{{ d.credit_cost }} CR</span>
+        {% else %}
+          <span class="mfg-badge mfg-badge-locked">{{ d.credit_cost }} CR 🔒</span>
+        {% endif %}
+      </div>
+
+      <div class="mfg-cta">
+        {% if d.state == "free" %}
+          <a href="/dashboard/lfa-football-player/card-editor" class="mfg-btn mfg-btn-edit">Edit / Download</a>
+        {% elif d.state == "owned" %}
+          <a href="/dashboard/lfa-football-player/card-editor" class="mfg-btn mfg-btn-edit">Edit / Download</a>
+        {% elif d.state == "purchasable" %}
+          <form method="POST" action="/my-cards/designs/player_card/{{ d.id }}/get">
+            <button type="submit" class="mfg-btn mfg-btn-get">Get Card — {{ d.credit_cost }} CR</button>
+          </form>
+        {% else %}
+          <button class="mfg-btn mfg-btn-disabled" disabled>Not enough credits</button>
+        {% endif %}
+      </div>
+
+    </div>
+    {% endfor %}
+  </div>
+
+</div>
+{% endblock %}

--- a/app/templates/my_cards_player_card.html
+++ b/app/templates/my_cards_player_card.html
@@ -70,8 +70,6 @@
   <div class="mfg-flash mfg-flash-error">Not enough credits to purchase this design.</div>
   {% elif flash_error == "owned" %}
   <div class="mfg-flash mfg-flash-error">You already own this design.</div>
-  {% elif flash_error == "free" %}
-  <div class="mfg-flash mfg-flash-error">This design is always free — no purchase needed.</div>
   {% elif flash_error == "invalid" %}
   <div class="mfg-flash mfg-flash-error">Unknown card type or design.</div>
   {% endif %}
@@ -88,7 +86,7 @@
     <div class="mfg-card">
 
       {# Preview #}
-      {% if d.state in ("free", "owned") %}
+      {% if d.state == "owned" %}
       <div class="mfg-preview-wrap">
         <iframe
           class="mfg-preview-iframe"
@@ -112,11 +110,9 @@
 
       {# State badge + CTA #}
       <div style="display:flex;align-items:center;justify-content:space-between;gap:0.5rem;">
-        {% if d.state == "free" %}
-          <span class="mfg-badge mfg-badge-free">Free</span>
-        {% elif d.state == "owned" %}
+        {% if d.state == "owned" %}
           <span class="mfg-badge mfg-badge-owned">Owned ✓</span>
-        {% elif d.state == "purchasable" %}
+        {% elif d.state == "get_card" %}
           <span class="mfg-badge mfg-badge-get">{{ d.credit_cost }} CR</span>
         {% else %}
           <span class="mfg-badge mfg-badge-locked">{{ d.credit_cost }} CR 🔒</span>
@@ -124,11 +120,9 @@
       </div>
 
       <div class="mfg-cta">
-        {% if d.state == "free" %}
-          <a href="/dashboard/lfa-football-player/card-editor" class="mfg-btn mfg-btn-edit">Edit / Download</a>
-        {% elif d.state == "owned" %}
-          <a href="/dashboard/lfa-football-player/card-editor" class="mfg-btn mfg-btn-edit">Edit / Download</a>
-        {% elif d.state == "purchasable" %}
+        {% if d.state == "owned" %}
+          <a href="/dashboard/lfa-football-player/card-editor" class="mfg-btn mfg-btn-edit mfg-btn-download">Edit / Download</a>
+        {% elif d.state == "get_card" %}
           <form method="POST" action="/my-cards/designs/player_card/{{ d.id }}/get">
             <button type="submit" class="mfg-btn mfg-btn-get">Get Card — {{ d.credit_cost }} CR</button>
           </form>

--- a/app/templates/my_cards_shop.html
+++ b/app/templates/my_cards_shop.html
@@ -3,7 +3,13 @@
 {% block title %}Get Card — LFA Education Center{% endblock %}
 {% block active_page %}lfa-player{% endblock %}
 
-{% block content %}
+{% block student_header %}
+{% set _page_icon = '🛍' %}
+{% set _page_name = 'Get Card' %}
+{% include "includes/spec_subpage_hdr.html" %}
+{% endblock %}
+
+{% block extra_styles %}
 <style>
   .shop-header {
     display: flex;
@@ -140,9 +146,26 @@
   }
   .dc-single-card h3 { color: #f1f5f9; font-size: 1.1rem; font-weight: 700; margin: 0; }
   .dc-single-card p  { color: #64748b; font-size: 0.85rem; margin: 0; }
-</style>
 
+  .shop-breadcrumb {
+    font-size: 0.82rem;
+    color: #64748b;
+    margin-bottom: 1.25rem;
+  }
+  .shop-breadcrumb a { color: #94a3b8; text-decoration: none; }
+  .shop-breadcrumb a:hover { color: #f1f5f9; }
+  .shop-breadcrumb span { margin: 0 0.35rem; }
+</style>
+{% endblock %}
+
+{% block student_content %}
 <div class="container-fluid px-3 py-4" style="max-width: 900px;">
+
+  <nav class="shop-breadcrumb" aria-label="Breadcrumb">
+    <a href="/my-cards">My Cards</a>
+    <span>›</span>
+    <span>Get Card</span>
+  </nav>
 
   <div class="shop-header">
     <h1>Get Card</h1>
@@ -167,9 +190,9 @@
 
   {# ── Tabs ── #}
   <div class="shop-tabs">
-    <button class="shop-tab active" onclick="showTab('player')">Player Card</button>
-    <button class="shop-tab"        onclick="showTab('welcome')">Welcome Card</button>
-    <button class="shop-tab"        onclick="showTab('challenge')">Challenge Card</button>
+    <button class="shop-tab" data-tab="player"    onclick="showTab('player', this)">Player Card</button>
+    <button class="shop-tab" data-tab="welcome"   onclick="showTab('welcome', this)">Welcome Card</button>
+    <button class="shop-tab" data-tab="challenge" onclick="showTab('challenge', this)">Challenge Card</button>
   </div>
 
   {# ── Player Card tab ── #}
@@ -256,11 +279,19 @@
 </div>
 
 <script>
-function showTab(name) {
-  document.querySelectorAll('.shop-tab-panel').forEach(el => el.classList.remove('active'));
-  document.querySelectorAll('.shop-tab').forEach(el => el.classList.remove('active'));
-  document.getElementById('tab-' + name).classList.add('active');
-  event.target.classList.add('active');
+function showTab(name, triggerEl) {
+  document.querySelectorAll('.shop-tab-panel').forEach(function(el) { el.classList.remove('active'); });
+  document.querySelectorAll('.shop-tab').forEach(function(el) { el.classList.remove('active'); });
+  var panel = document.getElementById('tab-' + name);
+  if (panel) panel.classList.add('active');
+  if (triggerEl) triggerEl.classList.add('active');
 }
+
+// Auto-activate tab from URL ?tab= param on page load
+(function() {
+  var tab = new URLSearchParams(window.location.search).get('tab') || 'player';
+  var btn = document.querySelector('[data-tab="' + tab + '"]');
+  showTab(tab, btn);
+})();
 </script>
 {% endblock %}

--- a/app/templates/my_cards_shop.html
+++ b/app/templates/my_cards_shop.html
@@ -1,0 +1,266 @@
+{% extends "student_base.html" %}
+
+{% block title %}Get Card — LFA Education Center{% endblock %}
+{% block active_page %}lfa-player{% endblock %}
+
+{% block content %}
+<style>
+  .shop-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 1.5rem;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+  .shop-header h1 {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: #f8fafc;
+    margin: 0;
+  }
+  .shop-credits-badge {
+    background: #1e293b;
+    border: 1px solid #334155;
+    border-radius: 20px;
+    padding: 0.4rem 1rem;
+    font-size: 0.9rem;
+    color: #94a3b8;
+  }
+  .shop-credits-badge strong {
+    color: #FFD200;
+  }
+
+  /* Flash messages */
+  .shop-flash {
+    padding: 0.75rem 1rem;
+    border-radius: 8px;
+    margin-bottom: 1.25rem;
+    font-size: 0.9rem;
+  }
+  .shop-flash-success { background: #14532d; color: #86efac; border: 1px solid #166534; }
+  .shop-flash-error   { background: #450a0a; color: #fca5a5; border: 1px solid #7f1d1d; }
+
+  /* Tabs */
+  .shop-tabs {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 1.5rem;
+    border-bottom: 2px solid #1e293b;
+    padding-bottom: 0;
+  }
+  .shop-tab {
+    padding: 0.5rem 1.1rem 0.6rem;
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: #64748b;
+    cursor: pointer;
+    border-bottom: 3px solid transparent;
+    margin-bottom: -2px;
+    background: none;
+    border-top: none;
+    border-left: none;
+    border-right: none;
+  }
+  .shop-tab.active { color: #FFD200; border-bottom-color: #FFD200; }
+  .shop-tab-panel  { display: none; }
+  .shop-tab-panel.active { display: block; }
+
+  /* Design grid */
+  .dc-design-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: 1rem;
+  }
+  .dc-design-card {
+    background: #0f172a;
+    border: 1px solid #1e293b;
+    border-radius: 12px;
+    padding: 1.1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+  .dc-design-card:hover { border-color: #334155; }
+
+  .dc-design-thumb {
+    width: 100%;
+    height: 100px;
+    background: #1e293b;
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #475569;
+    font-size: 0.75rem;
+  }
+  .dc-design-label {
+    font-weight: 700;
+    font-size: 0.95rem;
+    color: #f1f5f9;
+  }
+  .dc-design-desc {
+    font-size: 0.78rem;
+    color: #64748b;
+    flex: 1;
+  }
+
+  /* CTA buttons */
+  .dc-design-cta { margin-top: auto; }
+  .dc-cta-btn {
+    display: block;
+    width: 100%;
+    padding: 0.55rem 0.75rem;
+    border-radius: 8px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    text-align: center;
+    cursor: pointer;
+    border: none;
+    text-decoration: none;
+  }
+
+  .dc-design-state-free        { background: #14532d; color: #86efac; }
+  .dc-design-state-free:hover  { background: #166534; }
+  .dc-design-state-owned       { background: #1e3a5f; color: #93c5fd; cursor: default; }
+  .dc-design-state-purchasable { background: #854d0e; color: #fde68a; }
+  .dc-design-state-purchasable:hover { background: #92400e; }
+  .dc-design-state-locked      { background: #1e293b; color: #475569; cursor: not-allowed; }
+
+  /* Single-card family (welcome/challenge) */
+  .dc-single-card {
+    max-width: 380px;
+    background: #0f172a;
+    border: 1px solid #1e293b;
+    border-radius: 12px;
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+  .dc-single-card h3 { color: #f1f5f9; font-size: 1.1rem; font-weight: 700; margin: 0; }
+  .dc-single-card p  { color: #64748b; font-size: 0.85rem; margin: 0; }
+</style>
+
+<div class="container-fluid px-3 py-4" style="max-width: 900px;">
+
+  <div class="shop-header">
+    <h1>Get Card</h1>
+    <span class="shop-credits-badge">Balance: <strong>{{ user.credit_balance }} CR</strong></span>
+  </div>
+
+  {# ── Flash messages ── #}
+  {% if flash_purchased %}
+  <div class="shop-flash shop-flash-success">
+    ✓ Purchase successful — {{ flash_purchased }} is now in your collection.
+  </div>
+  {% endif %}
+  {% if flash_error == "credits" %}
+  <div class="shop-flash shop-flash-error">Not enough credits to purchase this design.</div>
+  {% elif flash_error == "owned" %}
+  <div class="shop-flash shop-flash-error">You already own this design.</div>
+  {% elif flash_error == "free" %}
+  <div class="shop-flash shop-flash-error">This design is always free — no purchase needed.</div>
+  {% elif flash_error == "invalid" %}
+  <div class="shop-flash shop-flash-error">Unknown card type or design.</div>
+  {% endif %}
+
+  {# ── Tabs ── #}
+  <div class="shop-tabs">
+    <button class="shop-tab active" onclick="showTab('player')">Player Card</button>
+    <button class="shop-tab"        onclick="showTab('welcome')">Welcome Card</button>
+    <button class="shop-tab"        onclick="showTab('challenge')">Challenge Card</button>
+  </div>
+
+  {# ── Player Card tab ── #}
+  <div id="tab-player" class="shop-tab-panel active">
+    <div class="dc-design-grid">
+      {% for d in player_design_rows %}
+      <div class="dc-design-card">
+        <div class="dc-design-thumb">{{ d.label[:2] }}</div>
+        <div class="dc-design-label">{{ d.label }}</div>
+        <div class="dc-design-desc">{{ d.description }}</div>
+        <div class="dc-design-cta">
+          {% if d.state == "free" %}
+            <a href="/my-cards/player-card" class="dc-cta-btn dc-design-state-free">Use</a>
+          {% elif d.state == "owned" %}
+            <span class="dc-cta-btn dc-design-state-owned">Owned ✓</span>
+          {% elif d.state == "purchasable" %}
+            <form method="POST" action="/my-cards/designs/player_card/{{ d.id }}/get">
+              <button type="submit" class="dc-cta-btn dc-design-state-purchasable">
+                Get Card — {{ d.credit_cost }} CR
+              </button>
+            </form>
+          {% else %}
+            <button class="dc-cta-btn dc-design-state-locked" disabled>
+              Not enough credits ({{ d.credit_cost }} CR)
+            </button>
+          {% endif %}
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+
+  {# ── Welcome Card tab ── #}
+  <div id="tab-welcome" class="shop-tab-panel">
+    <div class="dc-single-card">
+      <div class="dc-design-thumb" style="height: 80px;">WC</div>
+      <h3>Welcome Card</h3>
+      <p>Your personal onboarding card based on your self-assessment. Export as PNG for social sharing.</p>
+      <div class="dc-design-cta">
+        {% if wc_state == "owned" %}
+          <span class="dc-cta-btn dc-design-state-owned">Owned ✓</span>
+        {% elif wc_state == "purchasable" %}
+          <form method="POST" action="/my-cards/designs/welcome_card/default/get">
+            <button type="submit" class="dc-cta-btn dc-design-state-purchasable">
+              Get Card — {{ wc_price }} CR
+            </button>
+          </form>
+        {% else %}
+          <button class="dc-cta-btn dc-design-state-locked" disabled>
+            Not enough credits ({{ wc_price }} CR)
+          </button>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+
+  {# ── Challenge Card tab ── #}
+  <div id="tab-challenge" class="shop-tab-panel">
+    <div class="dc-single-card">
+      <div class="dc-design-thumb" style="height: 80px;">CC</div>
+      <h3>Challenge Card</h3>
+      <p>Social card for your Virtual Training challenge results. Shareable as 16:9 post or 9:16 story.</p>
+      <div class="dc-design-cta">
+        {% if cc_state == "owned" %}
+          <span class="dc-cta-btn dc-design-state-owned">Owned ✓</span>
+        {% elif cc_state == "purchasable" %}
+          <form method="POST" action="/my-cards/designs/challenge_card/challenge/get">
+            <button type="submit" class="dc-cta-btn dc-design-state-purchasable">
+              Get Card — {{ cc_price }} CR
+            </button>
+          </form>
+        {% else %}
+          <button class="dc-cta-btn dc-design-state-locked" disabled>
+            Not enough credits ({{ cc_price }} CR)
+          </button>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+
+  <p style="margin-top: 2rem;">
+    <a href="/my-cards" style="color: #64748b; font-size: 0.85rem;">← Back to My Cards</a>
+  </p>
+</div>
+
+<script>
+function showTab(name) {
+  document.querySelectorAll('.shop-tab-panel').forEach(el => el.classList.remove('active'));
+  document.querySelectorAll('.shop-tab').forEach(el => el.classList.remove('active'));
+  document.getElementById('tab-' + name).classList.add('active');
+  event.target.classList.add('active');
+}
+</script>
+{% endblock %}

--- a/app/templates/my_cards_welcome_card.html
+++ b/app/templates/my_cards_welcome_card.html
@@ -1,0 +1,142 @@
+{% extends "student_base.html" %}
+
+{% block title %}Welcome Card — LFA Education Center{% endblock %}
+{% block active_page %}lfa-player{% endblock %}
+
+{% block student_header %}
+{% set _page_icon = '👋' %}
+{% set _page_name = 'Welcome Card' %}
+{% include "includes/spec_subpage_hdr.html" %}
+{% endblock %}
+
+{% block extra_styles %}
+{% include "includes/mc_format_grid.html" %}
+<style>
+  .mcw-wrap {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 1.5rem 1rem 4rem;
+  }
+  .mcw-breadcrumb {
+    font-size: 0.8rem;
+    color: #64748b;
+    margin-bottom: 1.25rem;
+  }
+  .mcw-breadcrumb a { color: #94a3b8; text-decoration: none; }
+  .mcw-breadcrumb a:hover { color: #f1f5f9; }
+  .mcw-breadcrumb span { margin: 0 0.35rem; }
+  .mcw-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 1.5rem;
+  }
+  .mcw-header h1 { font-size: 1.4rem; font-weight: 700; color: #f8fafc; margin: 0; }
+  .mcw-credits-badge {
+    background: #1e293b;
+    border: 1px solid #334155;
+    border-radius: 20px;
+    padding: 0.35rem 0.9rem;
+    font-size: 0.85rem;
+    color: #94a3b8;
+  }
+  .mcw-credits-badge strong { color: #FFD200; }
+  .mcw-desc {
+    font-size: 0.88rem;
+    color: #64748b;
+    margin-bottom: 1.5rem;
+    max-width: 600px;
+  }
+</style>
+{% endblock %}
+
+{% block student_content %}
+<div class="mcw-wrap">
+
+  <nav class="mcw-breadcrumb" aria-label="Breadcrumb">
+    <a href="/my-cards">My Cards</a>
+    <span>›</span>
+    <span>Welcome Card</span>
+  </nav>
+
+  <div class="mcw-header">
+    <h1>Welcome Card</h1>
+    <span class="mcw-credits-badge">Balance: <strong>{{ user.credit_balance }} CR</strong></span>
+  </div>
+
+  <p class="mcw-desc">
+    Your onboarding milestone card in different platform formats.
+    Purchase a format to unlock its export. Each format is independently owned.
+  </p>
+
+  {# ── Flash messages ── #}
+  {% if flash_purchased %}
+  <div class="mfg-flash mfg-flash-success">
+    ✓ Format unlocked — you can now export your Welcome Card in this format.
+  </div>
+  {% endif %}
+  {% if flash_error == "credits" %}
+  <div class="mfg-flash mfg-flash-error">Not enough credits to purchase this format.</div>
+  {% elif flash_error == "owned" %}
+  <div class="mfg-flash mfg-flash-error">You already own this format.</div>
+  {% elif flash_error == "invalid" %}
+  <div class="mfg-flash mfg-flash-error">Unknown format.</div>
+  {% endif %}
+
+  {# ── Section header ── #}
+  <div class="mfg-section-hdr">
+    <h2>Formats</h2>
+    <span class="mfg-count-badge">{{ owned_count }} / {{ total_count }} owned</span>
+  </div>
+
+  {# ── Format grid ── #}
+  <div class="mfg-grid">
+    {% for r in format_rows %}
+    <div class="mfg-card">
+
+      {# Preview with watermark overlay for unowned #}
+      <div class="mfg-preview-wrap{% if r.state != 'owned' %} mfg-locked{% endif %}">
+        <iframe
+          class="mfg-preview-iframe"
+          src="{{ r.preview_url }}"
+          loading="lazy"
+          scrolling="no"
+          title="{{ r.label }} preview"
+        ></iframe>
+      </div>
+
+      {# Metadata #}
+      <p class="mfg-style-tag">{{ r.style_tag }}</p>
+      <p class="mfg-label">{{ r.label }}</p>
+      <p class="mfg-dims">{{ r.dims }}</p>
+
+      {# State badge #}
+      {% if r.state == "owned" %}
+        <span class="mfg-badge mfg-badge-owned">Owned ✓</span>
+      {% elif r.state == "purchasable" %}
+        <span class="mfg-badge mfg-badge-get">{{ r.credit_cost }} CR</span>
+      {% else %}
+        <span class="mfg-badge mfg-badge-locked">{{ r.credit_cost }} CR 🔒</span>
+      {% endif %}
+
+      {# CTA #}
+      <div class="mfg-cta">
+        {% if r.state == "owned" %}
+          <a href="{{ r.export_url }}" class="mfg-btn mfg-btn-download">Download PNG</a>
+        {% elif r.state == "purchasable" %}
+          <form method="POST" action="/my-cards/designs/welcome_card/{{ r.design_id }}/get">
+            <button type="submit" class="mfg-btn mfg-btn-get">Get Card — {{ r.credit_cost }} CR</button>
+          </form>
+        {% else %}
+          <button class="mfg-btn mfg-btn-disabled" disabled>Not enough credits</button>
+        {% endif %}
+      </div>
+
+    </div>
+    {% endfor %}
+  </div>
+
+</div>
+{% endblock %}

--- a/scripts/backfill_card_design_ownerships.py
+++ b/scripts/backfill_card_design_ownerships.py
@@ -1,0 +1,163 @@
+"""Backfill card_design_ownerships for existing users.
+
+This script creates CardDesignOwnership rows (source="system") for users who
+already have a Welcome Card or Challenge Card but have no ownership row because
+they existed before the Get Card feature was deployed.
+
+IMPORTANT:
+  - Run this script ONLY after an explicit product decision.
+  - It is NOT called from app startup, Alembic migrations, or CI.
+  - It is idempotent: running it multiple times is safe.
+  - Use --dry-run to preview what would be written without touching the DB.
+
+Usage:
+  python scripts/backfill_card_design_ownerships.py --dry-run
+  python scripts/backfill_card_design_ownerships.py --card-type welcome_card
+  python scripts/backfill_card_design_ownerships.py --card-type challenge_card
+  python scripts/backfill_card_design_ownerships.py --card-type all
+  python scripts/backfill_card_design_ownerships.py --card-type all --source system
+"""
+import argparse
+import sys
+from pathlib import Path
+
+# Make sure the project root is on sys.path when run directly.
+_PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_PROJECT_ROOT))
+
+
+def _run(dry_run: bool, card_type: str, source: str) -> None:
+    from sqlalchemy import create_engine, or_
+    from sqlalchemy.orm import sessionmaker
+
+    from app.config import settings
+    from app.models.card_design_ownership import CardDesignOwnership
+    from app.models.license import UserLicense
+    from app.models.vt_challenge import VirtualTrainingChallenge
+
+    engine = engine = create_engine(settings.DATABASE_URL)
+    SessionLocal = sessionmaker(bind=engine)
+    db = SessionLocal()
+
+    try:
+        wc_created = wc_skipped = 0
+        cc_created = cc_skipped = 0
+
+        # ── Welcome Card backfill ──────────────────────────────────────────────
+        if card_type in ("welcome_card", "all"):
+            licenses = (
+                db.query(UserLicense)
+                .filter(
+                    UserLicense.specialization_type == "LFA_FOOTBALL_PLAYER",
+                    UserLicense.onboarding_completed == True,  # noqa: E712
+                )
+                .all()
+            )
+            for lic in licenses:
+                existing = (
+                    db.query(CardDesignOwnership)
+                    .filter_by(
+                        user_id=lic.user_id,
+                        card_type_id="welcome_card",
+                        design_id="default",
+                    )
+                    .first()
+                )
+                if existing:
+                    wc_skipped += 1
+                    continue
+                if not dry_run:
+                    db.add(
+                        CardDesignOwnership(
+                            user_id=lic.user_id,
+                            card_type_id="welcome_card",
+                            design_id="default",
+                            source=source,
+                            credit_transaction_id=None,
+                        )
+                    )
+                wc_created += 1
+
+            if not dry_run and wc_created > 0:
+                db.commit()
+
+        # ── Challenge Card backfill ────────────────────────────────────────────
+        if card_type in ("challenge_card", "all"):
+            participant_user_ids: set[int] = set()
+            challenges = db.query(VirtualTrainingChallenge).all()
+            for ch in challenges:
+                if ch.challenger_id:
+                    participant_user_ids.add(ch.challenger_id)
+                if ch.challenged_id:
+                    participant_user_ids.add(ch.challenged_id)
+
+            for uid in sorted(participant_user_ids):
+                existing = (
+                    db.query(CardDesignOwnership)
+                    .filter_by(
+                        user_id=uid,
+                        card_type_id="challenge_card",
+                        design_id="challenge",
+                    )
+                    .first()
+                )
+                if existing:
+                    cc_skipped += 1
+                    continue
+                if not dry_run:
+                    db.add(
+                        CardDesignOwnership(
+                            user_id=uid,
+                            card_type_id="challenge_card",
+                            design_id="challenge",
+                            source=source,
+                            credit_transaction_id=None,
+                        )
+                    )
+                cc_created += 1
+
+            if not dry_run and cc_created > 0:
+                db.commit()
+
+        # ── Summary ───────────────────────────────────────────────────────────
+        if card_type in ("welcome_card", "all"):
+            print(
+                f"Welcome Card grants:  created={wc_created} / skipped(already owned)={wc_skipped}"
+            )
+        if card_type in ("challenge_card", "all"):
+            print(
+                f"Challenge Card grants: created={cc_created} / skipped(already owned)={cc_skipped}"
+            )
+        if dry_run:
+            print("Dry-run: no changes written to the database.")
+
+    finally:
+        db.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Backfill card_design_ownerships for existing users."
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview changes without writing to the database.",
+    )
+    parser.add_argument(
+        "--card-type",
+        choices=["welcome_card", "challenge_card", "all"],
+        default="all",
+        help="Which card family to backfill (default: all).",
+    )
+    parser.add_argument(
+        "--source",
+        default="system",
+        help="Ownership source string to write (default: 'system').",
+    )
+    args = parser.parse_args()
+    _run(dry_run=args.dry_run, card_type=args.card_type, source=args.source)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -62664,7 +62664,7 @@
     },
     "/my-cards": {
       "get": {
-        "description": "Hub page listing all card types \u2014 active (v\u22651) and coming-soon (v0).",
+        "description": "Hub \u2014 entitlement-aware central page for all card families.",
         "operationId": "my_cards_hub_my_cards_get",
         "responses": {
           "200": {

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -60597,7 +60597,7 @@
     },
     "/dashboard/card-variant": {
       "post": {
-        "description": "Apply a card layout variant (must already be unlocked for premium variants).",
+        "description": "Apply a card layout variant (requires CardDesignOwnership entitlement).",
         "operationId": "student_set_card_variant_dashboard_card_variant_post",
         "requestBody": {
           "content": {

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -62708,6 +62708,57 @@
         ]
       }
     },
+    "/my-cards/designs/{card_type_id}/{design_id}/get": {
+      "post": {
+        "description": "Purchase a card design entitlement (credit deduction + ownership row).",
+        "operationId": "get_card_my_cards_designs__card_type_id___design_id__get_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "card_type_id",
+            "required": true,
+            "schema": {
+              "title": "Card Type Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "design_id",
+            "required": true,
+            "schema": {
+              "title": "Design Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Card",
+        "tags": [
+          "web",
+          "my-cards"
+        ]
+      }
+    },
     "/my-cards/player-card": {
       "get": {
         "description": "Detail entry point for Player Card \u2014 redirects to the card editor.",
@@ -62723,6 +62774,29 @@
           }
         },
         "summary": "My Cards Player Card",
+        "tags": [
+          "web",
+          "my-cards"
+        ]
+      }
+    },
+    "/my-cards/shop": {
+      "get": {
+        "description": "Card Design Shop \u2014 browse and purchase card design entitlements.",
+        "operationId": "my_cards_shop_my_cards_shop_get",
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "My Cards Shop",
         "tags": [
           "web",
           "my-cards"

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -62664,7 +62664,7 @@
     },
     "/my-cards": {
       "get": {
-        "description": "Hub \u2014 entitlement-aware central page for all card families.",
+        "description": "Hub \u2014 format-count tiles for all three card families.",
         "operationId": "my_cards_hub_my_cards_get",
         "responses": {
           "200": {
@@ -62687,7 +62687,7 @@
     },
     "/my-cards/challenge-card": {
       "get": {
-        "description": "Challenge Card Collection \u2014 phase-based card manager with inline preview.",
+        "description": "Challenge Card Collection \u2014 format shop header + phase-based card manager.",
         "operationId": "my_cards_challenge_card_my_cards_challenge_card_get",
         "responses": {
           "200": {
@@ -62761,13 +62761,15 @@
     },
     "/my-cards/player-card": {
       "get": {
-        "description": "Detail entry point for Player Card \u2014 redirects to the card editor.",
+        "description": "Player Card format shop \u2014 browse and purchase Player Card designs.",
         "operationId": "my_cards_player_card_my_cards_player_card_get",
         "responses": {
           "200": {
             "content": {
-              "application/json": {
-                "schema": {}
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
               }
             },
             "description": "Successful Response"
@@ -62782,18 +62784,44 @@
     },
     "/my-cards/shop": {
       "get": {
-        "description": "Card Design Shop \u2014 browse and purchase card design entitlements.",
+        "description": "Retired shop page \u2014 redirects to the appropriate family shop.",
         "operationId": "my_cards_shop_my_cards_shop_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "tab",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Tab"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
-              "text/html": {
-                "schema": {
-                  "type": "string"
-                }
+              "application/json": {
+                "schema": {}
               }
             },
             "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
           }
         },
         "summary": "My Cards Shop",
@@ -62805,13 +62833,15 @@
     },
     "/my-cards/welcome-card": {
       "get": {
-        "description": "Detail entry point for Welcome Card \u2014 redirects to the onboarding card.",
+        "description": "Welcome Card format shop \u2014 browse and purchase Welcome Card platform formats.",
         "operationId": "my_cards_welcome_card_my_cards_welcome_card_get",
         "responses": {
           "200": {
             "content": {
-              "application/json": {
-                "schema": {}
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
               }
             },
             "description": "Successful Response"

--- a/tests/unit/api/web_routes/test_export_guard.py
+++ b/tests/unit/api/web_routes/test_export_guard.py
@@ -1,15 +1,15 @@
 """Export guard tests.
 
 EG-01  Player Card premium export → 403 without ownership
-EG-02  Player Card / fifa export → 200 (no guard for free design)
+EG-02  Player Card / fifa export → allowed with ownership row (CDO required)
 EG-03  Player Card premium export → allowed after ownership
-EG-04  Welcome Card export, ENFORCE_WELCOME_CARD_OWNERSHIP=False → allowed without ownership
-EG-05  Welcome Card export, ENFORCE_WELCOME_CARD_OWNERSHIP=True → 403 without ownership
-EG-06  Welcome Card export, ENFORCE_WELCOME_CARD_OWNERSHIP=True + owned → allowed
-EG-07  Challenge Card export, ENFORCE_CHALLENGE_CARD_OWNERSHIP=False → allowed without ownership
-EG-08  Challenge Card export, ENFORCE_CHALLENGE_CARD_OWNERSHIP=True → 403 without ownership
-EG-09  Challenge Card export, ENFORCE_CHALLENGE_CARD_OWNERSHIP=True + owned → allowed
-EG-10  Admin bypass — admin may export without ownership regardless of flag
+EG-04  Welcome Card export, no ownership → 403 (always enforced, no feature flag)
+EG-05  Welcome Card export, no ownership → 403
+EG-06  Welcome Card export, owned → allowed
+EG-07  Challenge Card export, no ownership → 403 (always enforced, no feature flag)
+EG-08  Challenge Card export, no ownership → 403
+EG-09  Challenge Card export, owned → allowed
+EG-10  Admin bypass — admin may export without ownership
 EG-11  Export route does NOT call CreditService.deduct
 """
 import asyncio
@@ -112,12 +112,11 @@ class TestPlayerCardExportGuard:
             self._call_export(db, user, license_variant="compact", is_accessible=False)
         assert exc_info.value.status_code == 403
 
-    def test_eg02_fifa_allowed_without_ownership(self):
-        """EG-02: player_card/fifa (free) → no 403."""
+    def test_eg02_fifa_allowed_with_ownership(self):
+        """EG-02: player_card/fifa with CDO ownership row → no 403."""
         db = _make_db()
         user = _make_user()
 
-        # fifa → is_accessible returns True (free design)
         result = self._call_export(db, user, license_variant="fifa", is_accessible=True)
         assert hasattr(result, "body") or result is not None  # got a response, not 403
 
@@ -134,7 +133,7 @@ class TestPlayerCardExportGuard:
 
 class TestWelcomeCardExportGuard:
 
-    def _call_export(self, db, user, is_accessible=False, enforce=False):
+    def _call_export(self, db, user, is_accessible=False):
         from app.api.web_routes.profile import export_onboarding_welcome_card
 
         request = _make_request("/profile/onboarding-card/export")
@@ -145,12 +144,10 @@ class TestWelcomeCardExportGuard:
         db.query.return_value.filter_by.return_value.first.return_value = fake_license
 
         with patch(f"{_SVC}.is_design_accessible", return_value=is_accessible), \
-             patch(f"{_CFG}.settings") as mock_settings, \
              patch(f"{_PROF}._export_svc") as mock_svc, \
              patch(f"{_PROF}._check_welcome_card_auth", return_value=None), \
              patch(f"{_PROF}._create_render_token", return_value="tok"):
-            mock_settings.ENFORCE_WELCOME_CARD_OWNERSHIP = enforce
-            mock_settings.APP_INTERNAL_PORT = 8000
+            mock_svc.APP_INTERNAL_PORT = 8000
             mock_svc.CANVAS_SIZES = {"instagram_square": (1080, 1080)}
             mock_svc.check_export_rate_limit.return_value = True
             mock_svc._sync_take_screenshot.return_value = b"PNG"
@@ -162,26 +159,27 @@ class TestWelcomeCardExportGuard:
                 user=user,
             ))
 
-    def test_eg04_flag_false_allowed_without_ownership(self):
-        """EG-04: ENFORCE_WELCOME_CARD_OWNERSHIP=False → 200 without ownership."""
-        db = _make_db()
-        user = _make_user()
-        result = self._call_export(db, user, is_accessible=False, enforce=False)
-        assert result is not None
-
-    def test_eg05_flag_true_403_without_ownership(self):
-        """EG-05: ENFORCE_WELCOME_CARD_OWNERSHIP=True → 403 without ownership."""
+    def test_eg04_no_ownership_403(self):
+        """EG-04: WC export, no ownership → 403 (always enforced, no feature flag)."""
         db = _make_db()
         user = _make_user()
         with pytest.raises(HTTPException) as exc_info:
-            self._call_export(db, user, is_accessible=False, enforce=True)
+            self._call_export(db, user, is_accessible=False)
         assert exc_info.value.status_code == 403
 
-    def test_eg06_flag_true_allowed_with_ownership(self):
-        """EG-06: ENFORCE_WELCOME_CARD_OWNERSHIP=True + owned → 200."""
+    def test_eg05_no_ownership_403(self):
+        """EG-05: WC export without ownership → 403."""
         db = _make_db()
         user = _make_user()
-        result = self._call_export(db, user, is_accessible=True, enforce=True)
+        with pytest.raises(HTTPException) as exc_info:
+            self._call_export(db, user, is_accessible=False)
+        assert exc_info.value.status_code == 403
+
+    def test_eg06_owned_allowed(self):
+        """EG-06: WC export, owned → allowed."""
+        db = _make_db()
+        user = _make_user()
+        result = self._call_export(db, user, is_accessible=True)
         assert result is not None
 
 
@@ -189,7 +187,7 @@ class TestWelcomeCardExportGuard:
 
 class TestChallengeCardExportGuard:
 
-    def _call_export(self, db, user, is_accessible=False, enforce=False):
+    def _call_export(self, db, user, is_accessible=False):
         from app.api.web_routes.vt_challenges import challenge_card_export
 
         request = _make_request("/challenges/1/card/export")
@@ -204,16 +202,12 @@ class TestChallengeCardExportGuard:
         db.query.return_value.filter.return_value.first.return_value = fake_ch
 
         with patch(f"{_SVC}.is_design_accessible", return_value=is_accessible), \
-             patch(f"{_CFG}.settings") as mock_settings, \
              patch(f"{_VTC}._export_svc") as mock_svc, \
              patch(f"{_VTC}.validate_challenge_card_phase", return_value=None), \
              patch(f"{_AUTH}.create_challenge_render_token", return_value="tok"):
-            mock_settings.ENFORCE_CHALLENGE_CARD_OWNERSHIP = enforce
-            mock_settings.APP_INTERNAL_PORT = 8000
             mock_svc.check_export_rate_limit.return_value = True
             mock_svc._sync_take_screenshot.return_value = b"PNG"
 
-            # Patch CHALLENGE_CARD_PLATFORMS and VALID_CHALLENGE_CARD_PHASES
             with patch(f"{_VTC}.CHALLENGE_CARD_PLATFORMS",
                        {"challenge_post_16_9", "challenge_story_9_16"}), \
                  patch(f"{_VTC}.VALID_CHALLENGE_CARD_PHASES",
@@ -227,33 +221,34 @@ class TestChallengeCardExportGuard:
                     user=user,
                 ))
 
-    def test_eg07_flag_false_allowed_without_ownership(self):
-        """EG-07: ENFORCE_CHALLENGE_CARD_OWNERSHIP=False → allowed without ownership."""
-        db = _make_db()
-        user = _make_user()
-        result = self._call_export(db, user, is_accessible=False, enforce=False)
-        assert result is not None
-
-    def test_eg08_flag_true_403_without_ownership(self):
-        """EG-08: ENFORCE_CHALLENGE_CARD_OWNERSHIP=True → 403 without ownership."""
+    def test_eg07_no_ownership_403(self):
+        """EG-07: CC export, no ownership → 403 (always enforced, no feature flag)."""
         db = _make_db()
         user = _make_user()
         with pytest.raises(HTTPException) as exc_info:
-            self._call_export(db, user, is_accessible=False, enforce=True)
+            self._call_export(db, user, is_accessible=False)
         assert exc_info.value.status_code == 403
 
-    def test_eg09_flag_true_allowed_with_ownership(self):
-        """EG-09: ENFORCE_CHALLENGE_CARD_OWNERSHIP=True + owned → allowed."""
+    def test_eg08_no_ownership_403(self):
+        """EG-08: CC export without ownership → 403."""
         db = _make_db()
         user = _make_user()
-        result = self._call_export(db, user, is_accessible=True, enforce=True)
+        with pytest.raises(HTTPException) as exc_info:
+            self._call_export(db, user, is_accessible=False)
+        assert exc_info.value.status_code == 403
+
+    def test_eg09_owned_allowed(self):
+        """EG-09: CC export, owned → allowed."""
+        db = _make_db()
+        user = _make_user()
+        result = self._call_export(db, user, is_accessible=True)
         assert result is not None
 
 
 # ── EG-10: Admin bypass ───────────────────────────────────────────────────────
 
 def test_eg10_admin_bypass_welcome_card():
-    """EG-10: admin user can export Welcome Card without ownership regardless of flag."""
+    """EG-10: admin user can export Welcome Card without ownership."""
     from app.api.web_routes.profile import export_onboarding_welcome_card
 
     user = _make_user(role="ADMIN")
@@ -263,18 +258,15 @@ def test_eg10_admin_bypass_welcome_card():
     fake_license = MagicMock()
     db.query.return_value.filter.return_value.first.return_value = fake_license
 
-    with patch(f"{_SVC}.is_design_accessible", return_value=False) as mock_acc, \
-         patch(f"{_CFG}.settings") as mock_settings, \
+    with patch(f"{_SVC}.is_design_accessible", return_value=False), \
          patch(f"{_PROF}._export_svc") as mock_svc, \
          patch(f"{_PROF}._check_welcome_card_auth", return_value=None), \
          patch(f"{_PROF}._create_render_token", return_value="tok"):
-        mock_settings.ENFORCE_WELCOME_CARD_OWNERSHIP = True
-        mock_settings.APP_INTERNAL_PORT = 8000
+        mock_svc.APP_INTERNAL_PORT = 8000
         mock_svc.CANVAS_SIZES = {"instagram_square": (1080, 1080)}
         mock_svc.check_export_rate_limit.return_value = True
         mock_svc._sync_take_screenshot.return_value = b"PNG"
 
-        # Should NOT raise 403 for admin
         result = _run(export_onboarding_welcome_card(
             request=request,
             platform="instagram_square",

--- a/tests/unit/api/web_routes/test_export_guard.py
+++ b/tests/unit/api/web_routes/test_export_guard.py
@@ -1,0 +1,305 @@
+"""Export guard tests.
+
+EG-01  Player Card premium export → 403 without ownership
+EG-02  Player Card / fifa export → 200 (no guard for free design)
+EG-03  Player Card premium export → allowed after ownership
+EG-04  Welcome Card export, ENFORCE_WELCOME_CARD_OWNERSHIP=False → allowed without ownership
+EG-05  Welcome Card export, ENFORCE_WELCOME_CARD_OWNERSHIP=True → 403 without ownership
+EG-06  Welcome Card export, ENFORCE_WELCOME_CARD_OWNERSHIP=True + owned → allowed
+EG-07  Challenge Card export, ENFORCE_CHALLENGE_CARD_OWNERSHIP=False → allowed without ownership
+EG-08  Challenge Card export, ENFORCE_CHALLENGE_CARD_OWNERSHIP=True → 403 without ownership
+EG-09  Challenge Card export, ENFORCE_CHALLENGE_CARD_OWNERSHIP=True + owned → allowed
+EG-10  Admin bypass — admin may export without ownership regardless of flag
+EG-11  Export route does NOT call CreditService.deduct
+"""
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+from fastapi.responses import Response
+
+_PUB   = "app.api.web_routes.public_player"
+_PROF  = "app.api.web_routes.profile"
+_VTC   = "app.api.web_routes.vt_challenges"
+_SVC   = "app.services.card_design_service"
+_CFG   = "app.config"       # settings is imported locally inside the route functions
+_AUTH  = "app.core.auth"    # create_challenge_render_token is imported locally
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _make_user(role="STUDENT"):
+    from app.models.user import UserRole
+    u = MagicMock()
+    u.id = 1
+    u.role = UserRole.STUDENT if role == "STUDENT" else UserRole.ADMIN
+    u.email = "test@test.com"
+    return u
+
+
+def _make_db():
+    db = MagicMock()
+    q = MagicMock()
+    q.filter.return_value = q
+    q.filter_by.return_value = q
+    q.first.return_value = None
+    db.query.return_value = q
+    return db
+
+
+def _make_request(path="/players/1/card/export"):
+    r = MagicMock()
+    r.url.path = path
+    r.client.host = "127.0.0.1"
+    r.query_params.get.return_value = None
+    return r
+
+
+def _make_license(variant="compact"):
+    lic = MagicMock()
+    lic.card_variant = variant
+    lic.card_theme = "default"
+    lic.published_card_variant = variant
+    lic.published_card_theme = "default"
+    lic.unlocked_card_variants = []
+    return lic
+
+
+# ── EG-01..03: Player Card export guard ──────────────────────────────────────
+
+class TestPlayerCardExportGuard:
+
+    def _call_export(self, db, user, license_variant="compact", is_accessible=False):
+        from app.api.web_routes.public_player import export_player_card
+
+        request = _make_request()
+        fake_license = _make_license(license_variant)
+        fake_target  = MagicMock()
+        fake_target.id = user.id
+
+        db.query.return_value.filter.return_value.first.side_effect = [
+            fake_target, fake_license
+        ]
+
+        with patch(f"{_PUB}._export_svc") as mock_svc, \
+             patch(f"{_SVC}.is_design_accessible", return_value=is_accessible), \
+             patch(f"{_PUB}._export_svc.CANVAS_SIZES", {"instagram_square": (1080, 1080)}), \
+             patch(f"{_PUB}._export_svc.check_export_rate_limit", return_value=True), \
+             patch(f"{_PUB}._EXPORT_FORMAT_BUCKETS", {"instagram_square": "square"}), \
+             patch(f"{_PUB}._get_supported_buckets", return_value=("square",)):
+            mock_svc.CANVAS_SIZES = {"instagram_square": (1080, 1080)}
+            mock_svc.check_export_rate_limit.return_value = True
+            mock_svc._sync_take_screenshot.return_value = b"PNG"
+            return _run(export_player_card(
+                request=request,
+                user_id=user.id,
+                platform="instagram_square",
+                theme=None,
+                db=db,
+                current_user=user,
+            ))
+
+    def test_eg01_premium_403_without_ownership(self):
+        """EG-01: player premium export → 403 if not owned."""
+        db = _make_db()
+        user = _make_user()
+
+        with pytest.raises(HTTPException) as exc_info:
+            self._call_export(db, user, license_variant="compact", is_accessible=False)
+        assert exc_info.value.status_code == 403
+
+    def test_eg02_fifa_allowed_without_ownership(self):
+        """EG-02: player_card/fifa (free) → no 403."""
+        db = _make_db()
+        user = _make_user()
+
+        # fifa → is_accessible returns True (free design)
+        result = self._call_export(db, user, license_variant="fifa", is_accessible=True)
+        assert hasattr(result, "body") or result is not None  # got a response, not 403
+
+    def test_eg03_premium_allowed_with_ownership(self):
+        """EG-03: player premium export → 200 after ownership granted."""
+        db = _make_db()
+        user = _make_user()
+
+        result = self._call_export(db, user, license_variant="compact", is_accessible=True)
+        assert result is not None
+
+
+# ── EG-04..06: Welcome Card export guard ─────────────────────────────────────
+
+class TestWelcomeCardExportGuard:
+
+    def _call_export(self, db, user, is_accessible=False, enforce=False):
+        from app.api.web_routes.profile import export_onboarding_welcome_card
+
+        request = _make_request("/profile/onboarding-card/export")
+        fake_license = MagicMock()
+        fake_license.onboarding_completed = True
+
+        db.query.return_value.filter.return_value.first.return_value = fake_license
+        db.query.return_value.filter_by.return_value.first.return_value = fake_license
+
+        with patch(f"{_SVC}.is_design_accessible", return_value=is_accessible), \
+             patch(f"{_CFG}.settings") as mock_settings, \
+             patch(f"{_PROF}._export_svc") as mock_svc, \
+             patch(f"{_PROF}._check_welcome_card_auth", return_value=None), \
+             patch(f"{_PROF}._create_render_token", return_value="tok"):
+            mock_settings.ENFORCE_WELCOME_CARD_OWNERSHIP = enforce
+            mock_settings.APP_INTERNAL_PORT = 8000
+            mock_svc.CANVAS_SIZES = {"instagram_square": (1080, 1080)}
+            mock_svc.check_export_rate_limit.return_value = True
+            mock_svc._sync_take_screenshot.return_value = b"PNG"
+            return _run(export_onboarding_welcome_card(
+                request=request,
+                platform="instagram_square",
+                use_nickname=False,
+                db=db,
+                user=user,
+            ))
+
+    def test_eg04_flag_false_allowed_without_ownership(self):
+        """EG-04: ENFORCE_WELCOME_CARD_OWNERSHIP=False → 200 without ownership."""
+        db = _make_db()
+        user = _make_user()
+        result = self._call_export(db, user, is_accessible=False, enforce=False)
+        assert result is not None
+
+    def test_eg05_flag_true_403_without_ownership(self):
+        """EG-05: ENFORCE_WELCOME_CARD_OWNERSHIP=True → 403 without ownership."""
+        db = _make_db()
+        user = _make_user()
+        with pytest.raises(HTTPException) as exc_info:
+            self._call_export(db, user, is_accessible=False, enforce=True)
+        assert exc_info.value.status_code == 403
+
+    def test_eg06_flag_true_allowed_with_ownership(self):
+        """EG-06: ENFORCE_WELCOME_CARD_OWNERSHIP=True + owned → 200."""
+        db = _make_db()
+        user = _make_user()
+        result = self._call_export(db, user, is_accessible=True, enforce=True)
+        assert result is not None
+
+
+# ── EG-07..09: Challenge Card export guard ────────────────────────────────────
+
+class TestChallengeCardExportGuard:
+
+    def _call_export(self, db, user, is_accessible=False, enforce=False):
+        from app.api.web_routes.vt_challenges import challenge_card_export
+
+        request = _make_request("/challenges/1/card/export")
+
+        fake_ch = MagicMock()
+        fake_ch.id = 1
+        fake_ch.challenger_id = user.id
+        fake_ch.challenged_id = 2
+        fake_ch.challenger_attempt_id = None
+        fake_ch.challenged_attempt_id = None
+
+        db.query.return_value.filter.return_value.first.return_value = fake_ch
+
+        with patch(f"{_SVC}.is_design_accessible", return_value=is_accessible), \
+             patch(f"{_CFG}.settings") as mock_settings, \
+             patch(f"{_VTC}._export_svc") as mock_svc, \
+             patch(f"{_VTC}.validate_challenge_card_phase", return_value=None), \
+             patch(f"{_AUTH}.create_challenge_render_token", return_value="tok"):
+            mock_settings.ENFORCE_CHALLENGE_CARD_OWNERSHIP = enforce
+            mock_settings.APP_INTERNAL_PORT = 8000
+            mock_svc.check_export_rate_limit.return_value = True
+            mock_svc._sync_take_screenshot.return_value = b"PNG"
+
+            # Patch CHALLENGE_CARD_PLATFORMS and VALID_CHALLENGE_CARD_PHASES
+            with patch(f"{_VTC}.CHALLENGE_CARD_PLATFORMS",
+                       {"challenge_post_16_9", "challenge_story_9_16"}), \
+                 patch(f"{_VTC}.VALID_CHALLENGE_CARD_PHASES",
+                       {"completed_score_win", "skill_delta_result"}):
+                return _run(challenge_card_export(
+                    challenge_id=1,
+                    request=request,
+                    platform="challenge_post_16_9",
+                    phase="completed_score_win",
+                    db=db,
+                    user=user,
+                ))
+
+    def test_eg07_flag_false_allowed_without_ownership(self):
+        """EG-07: ENFORCE_CHALLENGE_CARD_OWNERSHIP=False → allowed without ownership."""
+        db = _make_db()
+        user = _make_user()
+        result = self._call_export(db, user, is_accessible=False, enforce=False)
+        assert result is not None
+
+    def test_eg08_flag_true_403_without_ownership(self):
+        """EG-08: ENFORCE_CHALLENGE_CARD_OWNERSHIP=True → 403 without ownership."""
+        db = _make_db()
+        user = _make_user()
+        with pytest.raises(HTTPException) as exc_info:
+            self._call_export(db, user, is_accessible=False, enforce=True)
+        assert exc_info.value.status_code == 403
+
+    def test_eg09_flag_true_allowed_with_ownership(self):
+        """EG-09: ENFORCE_CHALLENGE_CARD_OWNERSHIP=True + owned → allowed."""
+        db = _make_db()
+        user = _make_user()
+        result = self._call_export(db, user, is_accessible=True, enforce=True)
+        assert result is not None
+
+
+# ── EG-10: Admin bypass ───────────────────────────────────────────────────────
+
+def test_eg10_admin_bypass_welcome_card():
+    """EG-10: admin user can export Welcome Card without ownership regardless of flag."""
+    from app.api.web_routes.profile import export_onboarding_welcome_card
+
+    user = _make_user(role="ADMIN")
+    db = _make_db()
+    request = _make_request()
+
+    fake_license = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = fake_license
+
+    with patch(f"{_SVC}.is_design_accessible", return_value=False) as mock_acc, \
+         patch(f"{_CFG}.settings") as mock_settings, \
+         patch(f"{_PROF}._export_svc") as mock_svc, \
+         patch(f"{_PROF}._check_welcome_card_auth", return_value=None), \
+         patch(f"{_PROF}._create_render_token", return_value="tok"):
+        mock_settings.ENFORCE_WELCOME_CARD_OWNERSHIP = True
+        mock_settings.APP_INTERNAL_PORT = 8000
+        mock_svc.CANVAS_SIZES = {"instagram_square": (1080, 1080)}
+        mock_svc.check_export_rate_limit.return_value = True
+        mock_svc._sync_take_screenshot.return_value = b"PNG"
+
+        # Should NOT raise 403 for admin
+        result = _run(export_onboarding_welcome_card(
+            request=request,
+            platform="instagram_square",
+            use_nickname=False,
+            db=db,
+            user=user,
+        ))
+    assert result is not None
+
+
+# ── EG-11: Export routes do NOT call CreditService.deduct ────────────────────
+
+def test_eg11_export_routes_no_credit_deduction():
+    """EG-11: export route source files do not contain CreditService.deduct calls."""
+    base = Path(__file__).resolve().parents[4] / "app" / "api" / "web_routes"
+
+    for fname in ("public_player.py", "profile.py", "vt_challenges.py"):
+        src = (base / fname).read_text(encoding="utf-8")
+        # CreditService.deduct should not appear in export-related code
+        # (purchase_design is in card_design_service.py, not these files)
+        assert "CreditService" not in src or "deduct" not in src or \
+               _deduct_only_in_non_export_context(src), \
+               f"{fname} must not call CreditService.deduct in export routes"
+
+
+def _deduct_only_in_non_export_context(src: str) -> bool:
+    """Return True if 'deduct' does not appear in the file (export routes never deduct)."""
+    return "CreditService" not in src

--- a/tests/unit/api/web_routes/test_lfa_nav.py
+++ b/tests/unit/api/web_routes/test_lfa_nav.py
@@ -72,10 +72,11 @@ class TestMyCardsSpecContext:
 
     def _call_my_cards(self):
         from app.api.web_routes.my_cards import my_cards_hub
-        from app.services.card_system import card_registry
 
         user = _make_lfa_student()
+        db   = _make_db()
         request = _make_request("/my-cards")
+        request.query_params.get = lambda k, default=None: default
         captured = {}
 
         def capture(*args, **kwargs):
@@ -84,12 +85,17 @@ class TestMyCardsSpecContext:
             resp.status_code = 200
             return resp
 
-        with patch("app.api.web_routes.my_cards.card_registry") as mock_reg, \
+        free_design = MagicMock()
+        free_design.id = "fifa"
+        free_design.label = "FIFA Classic"
+        free_design.credit_cost = 0
+        free_design.is_premium = False
+
+        with patch("app.api.web_routes.my_cards.get_all_designs", return_value=[free_design]), \
+             patch("app.api.web_routes.my_cards.is_design_accessible", return_value=False), \
              patch("app.api.web_routes.my_cards.templates") as mock_tmpl:
-            mock_reg.list_card_type_ids.return_value = []
-            mock_reg.get_card_type_spec.return_value = MagicMock()
             mock_tmpl.TemplateResponse.side_effect = capture
-            _run(my_cards_hub(request=request, user=user))
+            _run(my_cards_hub(request=request, db=db, user=user))
 
         return captured
 

--- a/tests/unit/api/web_routes/test_my_cards_hub.py
+++ b/tests/unit/api/web_routes/test_my_cards_hub.py
@@ -1,18 +1,18 @@
 """
 MCH_ — My Cards Hub tests.
 
-Updated for entitlement-aware hub (Phase 4B → unified hub):
-  - Hub now exposes pc_state/wc_state/cc_state instead of card_specs
-  - Hub route requires db session (UserLicense query + entitlement state)
+Updated for Phase 2 format-level Card Shop MVP:
+  - Hub exposes pc_owned_count/pc_total/wc_owned_count/wc_total/cc_owned_count/cc_total
+  - player-card and welcome-card routes now render TemplateResponse (format shops)
 
 Routes under test:
-  GET /my-cards               → hub page (200)
-  GET /my-cards/player-card   → 303 → /dashboard/lfa-football-player/card-editor
-  GET /my-cards/welcome-card  → 303 → /profile/onboarding-card
+  GET /my-cards               → hub page (200, tile layout)
+  GET /my-cards/player-card   → 200 → my_cards_player_card.html (design format shop)
+  GET /my-cards/welcome-card  → 200 → my_cards_welcome_card.html (format shop)
 
 Backward-compat assertions:
-  GET /dashboard/lfa-football-player/card-editor  — route still exists (MCH-10)
-  GET /profile/onboarding-card                    — route still exists (MCH-11)
+  MCH-10: /dashboard/lfa-football-player/card-editor route still exists
+  MCH-11: /profile/onboarding-card route still exists
 
 Dashboard template assertions:
   MCH-16: dashboard href="/my-cards" present in CTA context
@@ -23,8 +23,6 @@ import inspect
 import pathlib
 import pytest
 from unittest.mock import MagicMock, patch
-
-from fastapi.responses import RedirectResponse
 
 from app.api.web_routes.my_cards import (
     my_cards_hub,
@@ -84,14 +82,8 @@ def _design(design_id, credit_cost, is_premium, label=None):
     return d
 
 
-def _make_db(license_variant="fifa"):
-    """Return a MagicMock db with UserLicense query chain pre-configured."""
+def _make_db():
     db = MagicMock()
-    mock_license = MagicMock()
-    mock_license.card_variant = license_variant
-    db.query.return_value.filter.return_value.first.return_value = (
-        mock_license if license_variant is not None else None
-    )
     db.add    = MagicMock()
     db.commit = MagicMock()
     return db
@@ -100,16 +92,18 @@ def _make_db(license_variant="fifa"):
 def _call_hub(
     user=None,
     db=None,
-    license_variant="fifa",
-    accessible_ids=None,
+    owned_ids_by_type=None,
     query_params=None,
     designs=None,
 ):
-    """Call my_cards_hub directly with all dependencies mocked."""
-    user           = user or _user()
-    db             = db   or _make_db(license_variant)
-    accessible_ids = accessible_ids or set()
-    default_designs = [
+    """Call my_cards_hub directly with all dependencies mocked.
+
+    owned_ids_by_type: dict[str, list[str]] — maps card_type_id → owned design_ids
+    """
+    user             = user or _user()
+    db               = db   or _make_db()
+    owned_ids_by_type = owned_ids_by_type or {}
+    default_designs  = [
         _design("fifa",    credit_cost=0,   is_premium=False, label="FIFA Classic"),
         _design("compact", credit_cost=300, is_premium=True,  label="Compact"),
     ]
@@ -120,11 +114,11 @@ def _call_hub(
         captured["context"]  = context
         return MagicMock(status_code=200)
 
-    def fake_accessible(_db, uid, card_type_id, design_id):
-        return (card_type_id, design_id) in accessible_ids
+    def fake_owned_ids(_db, uid, card_type_id):
+        return list(owned_ids_by_type.get(card_type_id, []))
 
     with patch(f"{_BASE}.get_all_designs", return_value=designs or default_designs), \
-         patch(f"{_BASE}.is_design_accessible", side_effect=fake_accessible), \
+         patch(f"{_BASE}.get_owned_design_ids", side_effect=fake_owned_ids), \
          patch(f"{_BASE}.templates.TemplateResponse", side_effect=fake_template_response):
         _run(my_cards_hub(_req(query_params), db=db, user=user))
 
@@ -146,49 +140,68 @@ class TestMyCardsHubAuth:
         assert "user" in sig.parameters
 
 
-# ── MCH-03/04/05: Hub context keys ────────────────────────────────────────────
+# ── MCH-03/04/05: Hub context keys (Phase 2: count-based) ─────────────────────
 
 class TestMyCardsHubContext:
 
-    def test_mch03_player_card_state_in_hub_context(self):
-        """MCH-03: hub context contains Player Card state keys."""
+    def test_mch03_player_card_counts_in_hub_context(self):
+        """MCH-03: hub context contains Player Card count keys."""
         ctx = _call_hub()["context"]
-        for key in ("pc_state", "pc_price", "pc_design", "pc_design_label"):
+        for key in ("pc_owned_count", "pc_total"):
             assert key in ctx, f"Missing key: {key}"
 
-    def test_mch04_welcome_card_state_in_hub_context(self):
-        """MCH-04: hub context contains Welcome Card state keys."""
+    def test_mch04_welcome_card_counts_in_hub_context(self):
+        """MCH-04: hub context contains Welcome Card count keys."""
         ctx = _call_hub()["context"]
-        for key in ("wc_state", "wc_price"):
+        for key in ("wc_owned_count", "wc_total"):
             assert key in ctx, f"Missing key: {key}"
 
-    def test_mch05_challenge_card_state_in_hub_context(self):
-        """MCH-05: hub context contains Challenge Card state keys."""
+    def test_mch05_challenge_card_counts_in_hub_context(self):
+        """MCH-05: hub context contains Challenge Card count keys."""
         ctx = _call_hub()["context"]
-        for key in ("cc_state", "cc_price"):
+        for key in ("cc_owned_count", "cc_total"):
             assert key in ctx, f"Missing key: {key}"
 
 
-# ── MCH-06/07: Redirect routes ────────────────────────────────────────────────
+# ── MCH-06/07: Family shop routes render TemplateResponse ─────────────────────
 
-class TestMyCardsDetailRedirects:
+class TestMyCardsDetailRoutes:
 
-    def test_mch06_player_card_redirects_to_card_editor(self):
-        """MCH-06: GET /my-cards/player-card → 303 to /dashboard/lfa-football-player/card-editor."""
-        result = _run(my_cards_player_card(user=_user()))
-        assert isinstance(result, RedirectResponse)
-        assert result.status_code == 303
-        assert result.headers["location"] == "/dashboard/lfa-football-player/card-editor"
+    def test_mch06_player_card_route_renders_format_shop(self):
+        """MCH-06: GET /my-cards/player-card → 200 + my_cards_player_card.html."""
+        captured = {}
 
-    def test_mch07_welcome_card_redirects_to_onboarding_card(self):
-        """MCH-07: GET /my-cards/welcome-card → 303 to /profile/onboarding-card."""
-        result = _run(my_cards_welcome_card(user=_user()))
-        assert isinstance(result, RedirectResponse)
-        assert result.status_code == 303
-        assert result.headers["location"] == "/profile/onboarding-card"
+        def fake_tmpl(tmpl, ctx):
+            captured["template"] = tmpl
+            captured["context"]  = ctx
+            return MagicMock(status_code=200)
+
+        default_designs = [_design("fifa", credit_cost=0, is_premium=False, label="FIFA Classic")]
+
+        with patch(f"{_BASE}.get_all_designs", return_value=default_designs), \
+             patch(f"{_BASE}.is_design_accessible", return_value=False), \
+             patch(f"{_BASE}.templates.TemplateResponse", side_effect=fake_tmpl):
+            _run(my_cards_player_card(request=_req(), db=_make_db(), user=_user()))
+
+        assert captured.get("template") == "my_cards_player_card.html"
+
+    def test_mch07_welcome_card_route_renders_format_shop(self):
+        """MCH-07: GET /my-cards/welcome-card → 200 + my_cards_welcome_card.html."""
+        captured = {}
+
+        def fake_tmpl(tmpl, ctx):
+            captured["template"] = tmpl
+            captured["context"]  = ctx
+            return MagicMock(status_code=200)
+
+        with patch(f"{_BASE}.is_design_accessible", return_value=False), \
+             patch(f"{_BASE}.templates.TemplateResponse", side_effect=fake_tmpl):
+            _run(my_cards_welcome_card(request=_req(), db=_make_db(), user=_user()))
+
+        assert captured.get("template") == "my_cards_welcome_card.html"
 
 
-# ── MCH-08/09: Redirect route auth guards ─────────────────────────────────────
+# ── MCH-08/09: Route auth guards ──────────────────────────────────────────────
 
 class TestMyCardsDetailAuth:
 
@@ -236,55 +249,65 @@ class TestMyCardsHubTemplate:
         """MCH-12: Hub template heading reads 'My Cards'."""
         assert "My Cards" in hub_src
 
-    def test_mch13_hub_template_has_three_panels(self, hub_src):
+    def test_mch13_hub_template_has_three_family_links(self, hub_src):
         """MCH-13: Hub template has static links for all three card families."""
         assert "/my-cards/player-card" in hub_src
         assert "/my-cards/welcome-card" in hub_src
         assert "/my-cards/challenge-card" in hub_src
 
-    def test_mch14_hub_context_has_all_state_keys(self):
-        """MCH-14: All six state context keys present (pc/wc/cc state+price)."""
+    def test_mch14_hub_context_has_all_count_keys(self):
+        """MCH-14: All six count context keys present (pc/wc/cc owned_count+total)."""
         ctx = _call_hub()["context"]
-        for key in ("pc_state", "pc_price", "wc_state", "wc_price", "cc_state", "cc_price"):
+        for key in ("pc_owned_count", "pc_total", "wc_owned_count", "wc_total", "cc_owned_count", "cc_total"):
             assert key in ctx, f"Missing context key: {key}"
 
 
-# ── MCH-15: Entitlement state correctness ─────────────────────────────────────
+# ── MCH-15: Count correctness ─────────────────────────────────────────────────
 
-class TestEntitlementStates:
+class TestOwnershipCounts:
 
-    def test_mch15_pc_free_state_for_fifa(self):
-        """MCH-15: pc_state='free' when card_variant=fifa (is_premium=False)."""
-        ctx = _call_hub(license_variant="fifa", accessible_ids=set())["context"]
-        assert ctx["pc_state"] == "free"
-
-    def test_mch15b_pc_get_card_state_compact_not_owned_sufficient_credits(self):
-        """MCH-15b: pc_state='get_card' when compact not owned and balance ≥ 300."""
+    def test_mch15_pc_owned_count_includes_free_designs(self):
+        """MCH-15: pc_owned_count=1 when only free 'fifa' is owned."""
         ctx = _call_hub(
-            user=_user(balance=500),
-            license_variant="compact",
-            accessible_ids=set(),
+            designs=[_design("fifa", credit_cost=0, is_premium=False)],
+            owned_ids_by_type={"player_card": ["fifa"]},
         )["context"]
-        assert ctx["pc_state"] == "get_card"
+        assert ctx["pc_owned_count"] == 1
+        assert ctx["pc_total"] == 1
 
-    def test_mch15c_pc_locked_state_compact_not_owned_insufficient_credits(self):
-        """MCH-15c: pc_state='locked' when compact not owned and balance < 300."""
+    def test_mch15b_pc_total_reflects_all_designs(self):
+        """MCH-15b: pc_total = len(all designs)."""
         ctx = _call_hub(
-            user=_user(balance=50),
-            license_variant="compact",
-            accessible_ids=set(),
+            designs=[
+                _design("fifa",    credit_cost=0,   is_premium=False),
+                _design("compact", credit_cost=300, is_premium=True),
+            ],
+            owned_ids_by_type={"player_card": ["fifa"]},
         )["context"]
-        assert ctx["pc_state"] == "locked"
+        assert ctx["pc_total"] == 2
+        assert ctx["pc_owned_count"] == 1
 
-    def test_mch15d_wc_get_card_state(self):
-        """MCH-15d: wc_state='get_card' when not owned and balance ≥ 200."""
-        ctx = _call_hub(user=_user(balance=9999), accessible_ids=set())["context"]
-        assert ctx["wc_state"] == "get_card"
+    def test_mch15c_wc_owned_count_excludes_legacy_key(self):
+        """MCH-15c: wc_owned_count only counts valid WC format IDs (not legacy 'default')."""
+        from app.services.card_design_service import WELCOME_CARD_FORMATS
+        # Simulate a user who only has the legacy 'default' CDO (shim expands to all formats)
+        all_wc_ids = [f.design_id for f in WELCOME_CARD_FORMATS]
+        ctx = _call_hub(
+            owned_ids_by_type={"welcome_card": all_wc_ids},
+        )["context"]
+        assert ctx["wc_owned_count"] == len(WELCOME_CARD_FORMATS)
 
-    def test_mch15e_cc_get_card_state(self):
-        """MCH-15e: cc_state='get_card' when not owned and balance ≥ 150."""
-        ctx = _call_hub(user=_user(balance=9999), accessible_ids=set())["context"]
-        assert ctx["cc_state"] == "get_card"
+    def test_mch15d_wc_total_equals_welcome_card_formats_count(self):
+        """MCH-15d: wc_total == len(WELCOME_CARD_FORMATS)."""
+        from app.services.card_design_service import WELCOME_CARD_FORMATS
+        ctx = _call_hub()["context"]
+        assert ctx["wc_total"] == len(WELCOME_CARD_FORMATS)
+
+    def test_mch15e_cc_total_equals_challenge_card_formats_count(self):
+        """MCH-15e: cc_total == len(CHALLENGE_CARD_FORMATS)."""
+        from app.services.card_design_service import CHALLENGE_CARD_FORMATS
+        ctx = _call_hub()["context"]
+        assert ctx["cc_total"] == len(CHALLENGE_CARD_FORMATS)
 
 
 # ── MCH-16/17: Dashboard template navigation updated ──────────────────────────
@@ -301,11 +324,8 @@ class TestDashboardNavUpdated:
 
     def test_mch17_dashboard_card_ctas_funnel_to_my_cards(self, dashboard_src):
         """MCH-17: Player/Welcome/Challenge panel primary CTAs link to /my-cards."""
-        # All three dc-hero panels should funnel through /my-cards
         assert 'href="/my-cards" class="dc-cta-primary"' in dashboard_src
-        # The old direct link to /profile/onboarding-card must no longer be a primary CTA
         assert 'href="/profile/onboarding-card" class="dc-cta-primary"' not in dashboard_src
-        # /challenges/send is preserved (social action, not a card management action)
         assert 'href="/challenges/send"' in dashboard_src
 
 
@@ -359,6 +379,7 @@ class TestMyChallengeCardRoute:
 
         with patch(f"{_CC_BASE}.templates") as mock_tmpl, \
              patch(f"{_CC_BASE}.CardDraftService") as mock_ds, \
+             patch(f"{_CC_BASE}.is_design_accessible", return_value=False), \
              patch(f"{_CC_BASE}.get_all_themes", return_value=themes_mock):
             mock_tmpl.TemplateResponse.side_effect = _capture
             mock_ds.get_or_create_singleton.return_value = draft_mock
@@ -381,10 +402,11 @@ class TestMyChallengeCardRoute:
         sig = inspect.signature(my_cards_challenge_card)
         assert "user" in sig.parameters
 
-    def test_mch_ch03_hub_challenge_state_key_present(self):
-        """MCH-CH-03: hub context contains cc_state key."""
-        ctx = _call_hub(accessible_ids=set())["context"]
-        assert "cc_state" in ctx
+    def test_mch_ch03_hub_context_has_cc_count_keys(self):
+        """MCH-CH-03: hub context contains cc_owned_count and cc_total keys."""
+        ctx = _call_hub()["context"]
+        assert "cc_owned_count" in ctx
+        assert "cc_total" in ctx
 
     def test_mch_ch04_hub_template_has_challenge_card_static_link(self):
         """MCH-CH-04: hub template contains static /my-cards/challenge-card link."""
@@ -419,3 +441,15 @@ class TestMyChallengeCardRoute:
         fmt_ids = [f["id"] for f in cap["context"]["formats"]]
         assert "challenge_post_16_9"  in fmt_ids
         assert "challenge_story_9_16" in fmt_ids
+
+    def test_mch_ch10_context_contains_cc_format_rows(self):
+        """MCH-CH-10: route context contains cc_format_rows with state per format."""
+        cap = self._call()
+        rows = cap["context"].get("cc_format_rows", [])
+        assert len(rows) == 2
+        row_ids = {r["design_id"] for r in rows}
+        assert "challenge_post_16_9"  in row_ids
+        assert "challenge_story_9_16" in row_ids
+        for r in rows:
+            assert "state" in r
+            assert "credit_cost" in r

--- a/tests/unit/api/web_routes/test_my_cards_hub.py
+++ b/tests/unit/api/web_routes/test_my_cards_hub.py
@@ -1,5 +1,9 @@
 """
-MCH_ — My Cards Hub tests (Phase 4B).
+MCH_ — My Cards Hub tests.
+
+Updated for entitlement-aware hub (Phase 4B → unified hub):
+  - Hub now exposes pc_state/wc_state/cc_state instead of card_specs
+  - Hub route requires db session (UserLicense query + entitlement state)
 
 Routes under test:
   GET /my-cards               → hub page (200)
@@ -11,10 +15,11 @@ Backward-compat assertions:
   GET /profile/onboarding-card                    — route still exists (MCH-11)
 
 Dashboard template assertions:
-  MCH-16: mod-nav tile href → /my-cards
-  MCH-17: hero Edit CTA href → /my-cards/player-card
+  MCH-16: dashboard href="/my-cards" present in CTA context
+  MCH-17: dashboard card CTAs link to /my-cards (not individual card routes)
 """
 import asyncio
+import inspect
 import pathlib
 import pytest
 from unittest.mock import MagicMock, patch
@@ -52,80 +57,122 @@ def _run(coro):
     return asyncio.run(coro)
 
 
-def _req():
+def _req(query_params=None):
     m = MagicMock()
     m.url = MagicMock()
     m.url.path = "/my-cards"
+    params = query_params or {}
+    m.query_params.get = lambda k, default=None: params.get(k, default)
     return m
 
 
-def _user(uid=42):
+def _user(uid=42, balance=500):
     u = MagicMock()
-    u.id = uid
-    u.role = UserRole.STUDENT
-    u.email = "player@test.com"
-    u.name  = "Test Player"
-    u.credit_balance = 100
+    u.id             = uid
+    u.role           = UserRole.STUDENT
+    u.email          = "player@test.com"
+    u.credit_balance = balance
     return u
+
+
+def _design(design_id, credit_cost, is_premium, label=None):
+    d = MagicMock()
+    d.id          = design_id
+    d.label       = label or design_id.replace("_", " ").title()
+    d.credit_cost = credit_cost
+    d.is_premium  = is_premium
+    return d
+
+
+def _make_db(license_variant="fifa"):
+    """Return a MagicMock db with UserLicense query chain pre-configured."""
+    db = MagicMock()
+    mock_license = MagicMock()
+    mock_license.card_variant = license_variant
+    db.query.return_value.filter.return_value.first.return_value = (
+        mock_license if license_variant is not None else None
+    )
+    db.add    = MagicMock()
+    db.commit = MagicMock()
+    return db
+
+
+def _call_hub(
+    user=None,
+    db=None,
+    license_variant="fifa",
+    accessible_ids=None,
+    query_params=None,
+    designs=None,
+):
+    """Call my_cards_hub directly with all dependencies mocked."""
+    user           = user or _user()
+    db             = db   or _make_db(license_variant)
+    accessible_ids = accessible_ids or set()
+    default_designs = [
+        _design("fifa",    credit_cost=0,   is_premium=False, label="FIFA Classic"),
+        _design("compact", credit_cost=300, is_premium=True,  label="Compact"),
+    ]
+    captured = {}
+
+    def fake_template_response(template_name, context):
+        captured["template"] = template_name
+        captured["context"]  = context
+        return MagicMock(status_code=200)
+
+    def fake_accessible(_db, uid, card_type_id, design_id):
+        return (card_type_id, design_id) in accessible_ids
+
+    with patch(f"{_BASE}.get_all_designs", return_value=designs or default_designs), \
+         patch(f"{_BASE}.is_design_accessible", side_effect=fake_accessible), \
+         patch(f"{_BASE}.templates.TemplateResponse", side_effect=fake_template_response):
+        _run(my_cards_hub(_req(query_params), db=db, user=user))
+
+    return captured
 
 
 # ── MCH-01/02: /my-cards authentication ───────────────────────────────────────
 
 class TestMyCardsHubAuth:
+
     def test_mch01_hub_authenticated_returns_200(self):
         """MCH-01: GET /my-cards with authenticated user renders hub template."""
-        with patch(f"{_BASE}.templates") as mock_tmpl:
-            mock_tmpl.TemplateResponse.return_value = MagicMock(status_code=200)
-            result = _run(my_cards_hub(_req(), user=_user()))
-        mock_tmpl.TemplateResponse.assert_called_once()
-        tmpl, ctx = mock_tmpl.TemplateResponse.call_args.args
-        assert tmpl == "my_cards_hub.html"
+        cap = _call_hub()
+        assert cap["template"] == "my_cards_hub.html"
 
     def test_mch02_hub_unauthenticated_redirects(self):
-        """MCH-02: Unauthenticated access is blocked by Depends(get_current_user_web).
-
-        The dependency raises HTTPException(401) before the function body runs.
-        We verify the route signature includes the dependency guard.
-        """
-        import inspect
+        """MCH-02: Hub route declares get_current_user_web dependency."""
         sig = inspect.signature(my_cards_hub)
-        params = sig.parameters
-        assert "user" in params
+        assert "user" in sig.parameters
 
 
-# ── MCH-03/04/05: Hub tile content ────────────────────────────────────────────
+# ── MCH-03/04/05: Hub context keys ────────────────────────────────────────────
 
-class TestMyCardsHubTiles:
-    def _rendered_ctx(self):
-        with patch(f"{_BASE}.templates") as mock_tmpl:
-            mock_tmpl.TemplateResponse.return_value = MagicMock()
-            _run(my_cards_hub(_req(), user=_user()))
-        _, ctx = mock_tmpl.TemplateResponse.call_args.args
-        return ctx
+class TestMyCardsHubContext:
 
-    def test_mch03_player_card_spec_in_hub(self):
-        """MCH-03: card_specs includes player_card."""
-        ctx = self._rendered_ctx()
-        assert "card_specs" in ctx
-        ids = [s.card_type_id for s in ctx["card_specs"]]
-        assert "player_card" in ids
+    def test_mch03_player_card_state_in_hub_context(self):
+        """MCH-03: hub context contains Player Card state keys."""
+        ctx = _call_hub()["context"]
+        for key in ("pc_state", "pc_price", "pc_design", "pc_design_label"):
+            assert key in ctx, f"Missing key: {key}"
 
-    def test_mch04_welcome_card_spec_in_hub(self):
-        """MCH-04: card_specs includes welcome_card."""
-        ctx = self._rendered_ctx()
-        ids = [s.card_type_id for s in ctx["card_specs"]]
-        assert "welcome_card" in ids
+    def test_mch04_welcome_card_state_in_hub_context(self):
+        """MCH-04: hub context contains Welcome Card state keys."""
+        ctx = _call_hub()["context"]
+        for key in ("wc_state", "wc_price"):
+            assert key in ctx, f"Missing key: {key}"
 
-    def test_mch05_four_coming_soon_specs_in_hub(self):
-        """MCH-05: card_specs includes the 4 v0 coming-soon types."""
-        ctx = self._rendered_ctx()
-        v0_ids = {s.card_type_id for s in ctx["card_specs"] if s.content_contract.version == 0}
-        assert v0_ids == {"match_card", "event_card", "birthday_card", "badge_card"}
+    def test_mch05_challenge_card_state_in_hub_context(self):
+        """MCH-05: hub context contains Challenge Card state keys."""
+        ctx = _call_hub()["context"]
+        for key in ("cc_state", "cc_price"):
+            assert key in ctx, f"Missing key: {key}"
 
 
 # ── MCH-06/07: Redirect routes ────────────────────────────────────────────────
 
 class TestMyCardsDetailRedirects:
+
     def test_mch06_player_card_redirects_to_card_editor(self):
         """MCH-06: GET /my-cards/player-card → 303 to /dashboard/lfa-football-player/card-editor."""
         result = _run(my_cards_player_card(user=_user()))
@@ -144,15 +191,14 @@ class TestMyCardsDetailRedirects:
 # ── MCH-08/09: Redirect route auth guards ─────────────────────────────────────
 
 class TestMyCardsDetailAuth:
+
     def test_mch08_player_card_route_has_auth_dependency(self):
         """MCH-08: /my-cards/player-card requires get_current_user_web."""
-        import inspect
         sig = inspect.signature(my_cards_player_card)
         assert "user" in sig.parameters
 
     def test_mch09_welcome_card_route_has_auth_dependency(self):
         """MCH-09: /my-cards/welcome-card requires get_current_user_web."""
-        import inspect
         sig = inspect.signature(my_cards_welcome_card)
         assert "user" in sig.parameters
 
@@ -160,6 +206,7 @@ class TestMyCardsDetailAuth:
 # ── MCH-10/11: Backward compatibility ─────────────────────────────────────────
 
 class TestBackwardCompatibility:
+
     def test_mch10_old_card_editor_route_still_defined(self):
         """MCH-10: /dashboard/lfa-football-player/card-editor route still exists."""
         src = _CARD_EDITOR_ROUTE_PATH.read_text()
@@ -173,9 +220,10 @@ class TestBackwardCompatibility:
         assert 'async def onboarding_welcome_card' in src
 
 
-# ── MCH-12/13/14: Hub template text assertions ────────────────────────────────
+# ── MCH-12/13/14: Hub template structural assertions ─────────────────────────
 
 class TestMyCardsHubTemplate:
+
     @pytest.fixture(scope="class")
     def hub_src(self):
         path = (
@@ -188,53 +236,77 @@ class TestMyCardsHubTemplate:
         """MCH-12: Hub template heading reads 'My Cards'."""
         assert "My Cards" in hub_src
 
-    def test_mch13_active_tile_href_uses_my_cards_prefix(self, hub_src):
-        """MCH-13: Active tile href prefix is /my-cards/ (Jinja2 dynamic replace pattern)."""
-        assert '/my-cards/' in hub_src
-        assert "replace('_', '-')" in hub_src
+    def test_mch13_hub_template_has_three_panels(self, hub_src):
+        """MCH-13: Hub template has static links for all three card families."""
+        assert "/my-cards/player-card" in hub_src
+        assert "/my-cards/welcome-card" in hub_src
+        assert "/my-cards/challenge-card" in hub_src
 
-    def test_mch14_active_tiles_cover_both_v1_card_types(self):
-        """MCH-14: Registry context contains both player_card and welcome_card as v1 specs."""
-        with patch(f"{_BASE}.templates") as mock_tmpl:
-            mock_tmpl.TemplateResponse.return_value = MagicMock()
-            _run(my_cards_hub(_req(), user=_user()))
-        _, ctx = mock_tmpl.TemplateResponse.call_args.args
-        v1_ids = {s.card_type_id for s in ctx["card_specs"] if s.content_contract.version >= 1}
-        assert "player_card" in v1_ids
-        assert "welcome_card" in v1_ids
+    def test_mch14_hub_context_has_all_state_keys(self):
+        """MCH-14: All six state context keys present (pc/wc/cc state+price)."""
+        ctx = _call_hub()["context"]
+        for key in ("pc_state", "pc_price", "wc_state", "wc_price", "cc_state", "cc_price"):
+            assert key in ctx, f"Missing context key: {key}"
 
 
-# ── MCH-15: Registry drives the spec list ─────────────────────────────────────
+# ── MCH-15: Entitlement state correctness ─────────────────────────────────────
 
-class TestRegistryIntegration:
-    def test_mch15_hub_spec_list_comes_from_registry(self):
-        """MCH-15: card_specs in hub context equals registry.list_card_type_ids() (7 types)."""
-        with patch(f"{_BASE}.templates") as mock_tmpl:
-            mock_tmpl.TemplateResponse.return_value = MagicMock()
-            _run(my_cards_hub(_req(), user=_user()))
-        _, ctx = mock_tmpl.TemplateResponse.call_args.args
-        from app.services.card_system import card_registry
-        expected_ids = set(card_registry.list_card_type_ids())
-        actual_ids   = {s.card_type_id for s in ctx["card_specs"]}
-        assert actual_ids == expected_ids
-        assert len(ctx["card_specs"]) == 7
+class TestEntitlementStates:
+
+    def test_mch15_pc_free_state_for_fifa(self):
+        """MCH-15: pc_state='free' when card_variant=fifa (is_premium=False)."""
+        ctx = _call_hub(license_variant="fifa", accessible_ids=set())["context"]
+        assert ctx["pc_state"] == "free"
+
+    def test_mch15b_pc_get_card_state_compact_not_owned_sufficient_credits(self):
+        """MCH-15b: pc_state='get_card' when compact not owned and balance ≥ 300."""
+        ctx = _call_hub(
+            user=_user(balance=500),
+            license_variant="compact",
+            accessible_ids=set(),
+        )["context"]
+        assert ctx["pc_state"] == "get_card"
+
+    def test_mch15c_pc_locked_state_compact_not_owned_insufficient_credits(self):
+        """MCH-15c: pc_state='locked' when compact not owned and balance < 300."""
+        ctx = _call_hub(
+            user=_user(balance=50),
+            license_variant="compact",
+            accessible_ids=set(),
+        )["context"]
+        assert ctx["pc_state"] == "locked"
+
+    def test_mch15d_wc_get_card_state(self):
+        """MCH-15d: wc_state='get_card' when not owned and balance ≥ 200."""
+        ctx = _call_hub(user=_user(balance=9999), accessible_ids=set())["context"]
+        assert ctx["wc_state"] == "get_card"
+
+    def test_mch15e_cc_get_card_state(self):
+        """MCH-15e: cc_state='get_card' when not owned and balance ≥ 150."""
+        ctx = _call_hub(user=_user(balance=9999), accessible_ids=set())["context"]
+        assert ctx["cc_state"] == "get_card"
 
 
 # ── MCH-16/17: Dashboard template navigation updated ──────────────────────────
 
 class TestDashboardNavUpdated:
+
     @pytest.fixture(scope="class")
     def dashboard_src(self):
         return _DASHBOARD_TPL_PATH.read_text()
 
-    def test_mch16_mod_nav_tile_href_is_my_cards(self, dashboard_src):
-        """MCH-16: dashboard mod-nav tile href updated to /my-cards."""
+    def test_mch16_dashboard_has_my_cards_cta(self, dashboard_src):
+        """MCH-16: Dashboard card CTAs include href="/my-cards"."""
         assert 'href="/my-cards"' in dashboard_src
-        assert 'href="/dashboard/lfa-football-player/card-editor"' not in dashboard_src.split('mod-nav-section')[1].split('</section>')[0]
 
-    def test_mch17_hero_edit_cta_href_is_my_cards_player_card(self, dashboard_src):
-        """MCH-17: dashboard hero Edit CTA href updated to /my-cards/player-card."""
-        assert 'href="/my-cards/player-card"' in dashboard_src
+    def test_mch17_dashboard_card_ctas_funnel_to_my_cards(self, dashboard_src):
+        """MCH-17: Player/Welcome/Challenge panel primary CTAs link to /my-cards."""
+        # All three dc-hero panels should funnel through /my-cards
+        assert 'href="/my-cards" class="dc-cta-primary"' in dashboard_src
+        # The old direct link to /profile/onboarding-card must no longer be a primary CTA
+        assert 'href="/profile/onboarding-card" class="dc-cta-primary"' not in dashboard_src
+        # /challenges/send is preserved (social action, not a card management action)
+        assert 'href="/challenges/send"' in dashboard_src
 
 
 # ── MCH-CH-01..09: Challenge Card manager route ───────────────────────────────
@@ -252,7 +324,7 @@ _CC_BASE = "app.api.web_routes.my_cards"
 def _db_mock():
     db = MagicMock()
     db.query.return_value.filter.return_value.first.return_value = None
-    db.add = MagicMock()
+    db.add    = MagicMock()
     db.commit = MagicMock()
     db.refresh = MagicMock()
     return db
@@ -305,33 +377,19 @@ class TestMyChallengeCardRoute:
 
     def test_mch_ch02_route_has_auth_dependency(self):
         """MCH-CH-02: route signature requires authenticated user."""
-        import inspect
         from app.api.web_routes.my_cards import my_cards_challenge_card
         sig = inspect.signature(my_cards_challenge_card)
         assert "user" in sig.parameters
 
-    def test_mch_ch03_hub_card_specs_contains_challenge_card(self):
-        """MCH-CH-03: /my-cards hub card_specs includes challenge_card."""
-        with patch(f"{_CC_BASE}.templates") as mock_tmpl:
-            mock_tmpl.TemplateResponse.return_value = MagicMock()
-            _run(my_cards_hub(_req(), user=_user()))
-        _, ctx = mock_tmpl.TemplateResponse.call_args.args
-        ids = [s.card_type_id for s in ctx["card_specs"]]
-        assert "challenge_card" in ids
+    def test_mch_ch03_hub_challenge_state_key_present(self):
+        """MCH-CH-03: hub context contains cc_state key."""
+        ctx = _call_hub(accessible_ids=set())["context"]
+        assert "cc_state" in ctx
 
-    def test_mch_ch04_hub_tile_link_is_challenge_card_url(self):
-        """MCH-CH-04: hub template builds /my-cards/challenge-card via card_type_id replace('_','-').
-
-        The link is generated dynamically: /my-cards/{{ spec.card_type_id | replace('_', '-') }}
-        so the literal string 'challenge_card' does not appear in the source.
-        Verify the generation pattern is present and challenge_card is in the registry.
-        """
+    def test_mch_ch04_hub_template_has_challenge_card_static_link(self):
+        """MCH-CH-04: hub template contains static /my-cards/challenge-card link."""
         hub_html = _CC_TEMPLATE_PATH.parent.joinpath("my_cards_hub.html").read_text()
-        # Template uses dynamic generation — verify the replace pattern is present
-        assert "replace('_', '-')" in hub_html or "replace(\"_\", \"-\")" in hub_html
-        # Registry contains challenge_card → link will be /my-cards/challenge-card
-        from app.services.card_system import card_registry
-        assert "challenge_card" in card_registry.list_card_type_ids()
+        assert "/my-cards/challenge-card" in hub_html
 
     def test_mch_ch05_template_contains_post_16_9(self):
         """MCH-CH-05: template references challenge_post_16_9 format."""

--- a/tests/unit/api/web_routes/test_my_cards_player_card.py
+++ b/tests/unit/api/web_routes/test_my_cards_player_card.py
@@ -1,0 +1,180 @@
+"""Player Card format shop route tests — MCP-01..MCP-12.
+
+MCP-01  GET /my-cards/player-card renders my_cards_player_card.html
+MCP-02  Context contains design_rows with state for each design
+MCP-03  Free (non-premium) design → state='free'
+MCP-04  Premium not owned, credits ≥ cost → state='purchasable'
+MCP-05  Premium not owned, credits < cost → state='locked'
+MCP-06  Premium owned → state='owned'
+MCP-07  Context contains owned_count and total_count
+MCP-08  Route has auth dependency (get_current_user_web)
+MCP-09  Template file extends student_base and includes spec_subpage_hdr
+MCP-10  Template file breadcrumb links to /my-cards
+MCP-11  Template file contains purchase form POST action pattern
+MCP-12  owned_count = free designs + explicitly owned premium designs
+"""
+import asyncio
+import inspect
+import pathlib
+from unittest.mock import MagicMock, patch
+
+_BASE = "app.api.web_routes.my_cards"
+_TEMPLATE_PATH = (
+    pathlib.Path(__file__).resolve().parents[4]
+    / "app" / "templates" / "my_cards_player_card.html"
+)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _user(balance=500):
+    from app.models.user import UserRole
+    u = MagicMock()
+    u.id = 42
+    u.credit_balance = balance
+    u.role = UserRole.STUDENT
+    return u
+
+
+def _req(query_params=None):
+    r = MagicMock()
+    r.url.path = "/my-cards/player-card"
+    params = query_params or {}
+    r.query_params.get = lambda k, default=None: params.get(k, default)
+    return r
+
+
+def _db():
+    return MagicMock()
+
+
+def _design(design_id, credit_cost, is_premium, label=None):
+    d = MagicMock()
+    d.id          = design_id
+    d.label       = label or design_id.title()
+    d.description = ""
+    d.credit_cost = credit_cost
+    d.is_premium  = is_premium
+    return d
+
+
+def _call(user=None, db=None, accessible_ids=None, designs=None, query_params=None):
+    from app.api.web_routes.my_cards import my_cards_player_card
+
+    user           = user or _user()
+    db             = db   or _db()
+    accessible_ids = accessible_ids or set()
+    default_designs = [
+        _design("fifa",    credit_cost=0,   is_premium=False),
+        _design("compact", credit_cost=300, is_premium=True),
+    ]
+    captured = {}
+
+    def fake_tmpl(tmpl, ctx):
+        captured["template"] = tmpl
+        captured["context"]  = ctx
+        return MagicMock(status_code=200)
+
+    def fake_accessible(db, uid, card_type_id, design_id):
+        return (card_type_id, design_id) in accessible_ids
+
+    with patch(f"{_BASE}.get_all_designs", return_value=designs or default_designs), \
+         patch(f"{_BASE}.is_design_accessible", side_effect=fake_accessible), \
+         patch(f"{_BASE}.templates.TemplateResponse", side_effect=fake_tmpl):
+        _run(my_cards_player_card(request=_req(query_params), db=db, user=user))
+
+    return captured
+
+
+class TestPlayerCardShopRoute:
+
+    def test_mcp01_renders_player_card_template(self):
+        """MCP-01: GET /my-cards/player-card renders my_cards_player_card.html."""
+        cap = _call()
+        assert cap["template"] == "my_cards_player_card.html"
+
+    def test_mcp02_context_has_design_rows(self):
+        """MCP-02: context contains design_rows with expected keys."""
+        ctx = _call()["context"]
+        rows = ctx["design_rows"]
+        assert len(rows) == 2
+        for r in rows:
+            assert "id" in r
+            assert "state" in r
+            assert "credit_cost" in r
+
+    def test_mcp03_free_design_state(self):
+        """MCP-03: non-premium design → state='free'."""
+        ctx = _call(user=_user(balance=0))["context"]
+        rows = ctx["design_rows"]
+        free = next(r for r in rows if r["id"] == "fifa")
+        assert free["state"] == "free"
+
+    def test_mcp04_premium_purchasable(self):
+        """MCP-04: premium not owned, credits ≥ cost → state='purchasable'."""
+        ctx = _call(user=_user(balance=500), accessible_ids=set())["context"]
+        rows = ctx["design_rows"]
+        row = next(r for r in rows if r["id"] == "compact")
+        assert row["state"] == "purchasable"
+
+    def test_mcp05_premium_locked(self):
+        """MCP-05: premium not owned, credits < cost → state='locked'."""
+        ctx = _call(user=_user(balance=50), accessible_ids=set())["context"]
+        rows = ctx["design_rows"]
+        row = next(r for r in rows if r["id"] == "compact")
+        assert row["state"] == "locked"
+
+    def test_mcp06_premium_owned(self):
+        """MCP-06: premium owned → state='owned'."""
+        ctx = _call(
+            user=_user(balance=500),
+            accessible_ids={("player_card", "compact")},
+        )["context"]
+        rows = ctx["design_rows"]
+        row = next(r for r in rows if r["id"] == "compact")
+        assert row["state"] == "owned"
+
+    def test_mcp07_context_has_owned_and_total_counts(self):
+        """MCP-07: context contains owned_count and total_count."""
+        ctx = _call()["context"]
+        assert "owned_count" in ctx
+        assert "total_count" in ctx
+        assert ctx["total_count"] == 2
+
+    def test_mcp08_route_has_auth_dependency(self):
+        """MCP-08: route declares get_current_user_web dependency."""
+        from app.api.web_routes.my_cards import my_cards_player_card
+        sig = inspect.signature(my_cards_player_card)
+        assert "user" in sig.parameters
+
+    def test_mcp09_template_extends_student_base(self):
+        """MCP-09: template extends student_base and includes spec_subpage_hdr."""
+        src = _TEMPLATE_PATH.read_text()
+        assert "student_base.html" in src
+        assert "spec_subpage_hdr.html" in src
+
+    def test_mcp10_template_breadcrumb_links_to_hub(self):
+        """MCP-10: template breadcrumb links to /my-cards hub."""
+        src = _TEMPLATE_PATH.read_text()
+        assert 'href="/my-cards"' in src
+
+    def test_mcp11_template_has_purchase_form(self):
+        """MCP-11: template contains POST form action for purchasing designs."""
+        src = _TEMPLATE_PATH.read_text()
+        assert "/my-cards/designs/player_card/" in src
+        assert 'method="POST"' in src
+
+    def test_mcp12_owned_count_includes_free_plus_owned(self):
+        """MCP-12: owned_count = free designs + explicitly owned premium ones."""
+        ctx = _call(
+            user=_user(balance=500),
+            designs=[
+                _design("fifa",    credit_cost=0,   is_premium=False),
+                _design("compact", credit_cost=300, is_premium=True),
+            ],
+            accessible_ids={("player_card", "compact")},
+        )["context"]
+        assert ctx["owned_count"] == 2  # free fifa + owned compact
+        assert ctx["total_count"] == 2

--- a/tests/unit/api/web_routes/test_my_cards_player_card.py
+++ b/tests/unit/api/web_routes/test_my_cards_player_card.py
@@ -2,8 +2,8 @@
 
 MCP-01  GET /my-cards/player-card renders my_cards_player_card.html
 MCP-02  Context contains design_rows with state for each design
-MCP-03  Free (non-premium) design → state='free'
-MCP-04  Premium not owned, credits ≥ cost → state='purchasable'
+MCP-03  Non-premium design, no CDO → state='get_card' or 'locked' (no free bypass)
+MCP-04  Premium not owned, credits ≥ cost → state='get_card'
 MCP-05  Premium not owned, credits < cost → state='locked'
 MCP-06  Premium owned → state='owned'
 MCP-07  Context contains owned_count and total_count
@@ -11,7 +11,7 @@ MCP-08  Route has auth dependency (get_current_user_web)
 MCP-09  Template file extends student_base and includes spec_subpage_hdr
 MCP-10  Template file breadcrumb links to /my-cards
 MCP-11  Template file contains purchase form POST action pattern
-MCP-12  owned_count = free designs + explicitly owned premium designs
+MCP-12  owned_count = explicitly owned designs only (no free auto-include)
 """
 import asyncio
 import inspect
@@ -105,19 +105,20 @@ class TestPlayerCardShopRoute:
             assert "state" in r
             assert "credit_cost" in r
 
-    def test_mcp03_free_design_state(self):
-        """MCP-03: non-premium design → state='free'."""
-        ctx = _call(user=_user(balance=0))["context"]
+    def test_mcp03_non_premium_no_cdo_not_free(self):
+        """MCP-03: non-premium design without CDO row → state not 'free' (no free bypass)."""
+        ctx = _call(user=_user(balance=0), accessible_ids=set())["context"]
         rows = ctx["design_rows"]
-        free = next(r for r in rows if r["id"] == "fifa")
-        assert free["state"] == "free"
+        fifa = next(r for r in rows if r["id"] == "fifa")
+        assert fifa["state"] != "free", "free state must be removed — all designs require ownership"
+        assert fifa["state"] in ("get_card", "locked")
 
-    def test_mcp04_premium_purchasable(self):
-        """MCP-04: premium not owned, credits ≥ cost → state='purchasable'."""
+    def test_mcp04_premium_get_card(self):
+        """MCP-04: premium not owned, credits ≥ cost → state='get_card'."""
         ctx = _call(user=_user(balance=500), accessible_ids=set())["context"]
         rows = ctx["design_rows"]
         row = next(r for r in rows if r["id"] == "compact")
-        assert row["state"] == "purchasable"
+        assert row["state"] == "get_card"
 
     def test_mcp05_premium_locked(self):
         """MCP-05: premium not owned, credits < cost → state='locked'."""
@@ -166,8 +167,8 @@ class TestPlayerCardShopRoute:
         assert "/my-cards/designs/player_card/" in src
         assert 'method="POST"' in src
 
-    def test_mcp12_owned_count_includes_free_plus_owned(self):
-        """MCP-12: owned_count = free designs + explicitly owned premium ones."""
+    def test_mcp12_owned_count_only_cdo_rows(self):
+        """MCP-12: owned_count = only CDO-backed owned designs (no free auto-include)."""
         ctx = _call(
             user=_user(balance=500),
             designs=[
@@ -176,5 +177,5 @@ class TestPlayerCardShopRoute:
             ],
             accessible_ids={("player_card", "compact")},
         )["context"]
-        assert ctx["owned_count"] == 2  # free fifa + owned compact
+        assert ctx["owned_count"] == 1  # only owned compact; fifa not auto-included
         assert ctx["total_count"] == 2

--- a/tests/unit/api/web_routes/test_my_cards_shop.py
+++ b/tests/unit/api/web_routes/test_my_cards_shop.py
@@ -1,11 +1,11 @@
 """My Cards Shop tests — Phase 2 format-level MVP.
 
 MCS-01  GET /my-cards/player-card renders without error (200 + template context)
-MCS-02  Player Card free design → state="free"
-MCS-03  Player Card premium, not owned, enough credits → state="purchasable"
+MCS-02  Player Card non-premium design, no CDO row → state="get_card" or "locked" (never "free")
+MCS-03  Player Card premium, not owned, enough credits → state="get_card"
 MCS-04  Player Card premium, not owned, insufficient credits → state="locked"
 MCS-05  Player Card premium, owned → state="owned"
-MCS-06  Welcome Card format not owned, enough credits → state="purchasable"
+MCS-06  Welcome Card format not owned, enough credits → state="get_card"
 MCS-07  Welcome Card format not owned, insufficient credits → state="locked"
 MCS-08  Welcome Card format owned → state="owned"
 MCS-09  All WC and CC format prices > 0 (never free)
@@ -103,23 +103,24 @@ class TestPlayerCardShop:
         for key in ("design_rows", "owned_count", "total_count"):
             assert key in ctx["context"], f"Missing context key: {key}"
 
-    def test_mcs02_free_design_state(self):
-        """MCS-02: Player Card non-premium design → state='free'."""
+    def test_mcs02_non_premium_design_no_cdo_not_free(self):
+        """MCS-02: non-premium design without CDO row → state='get_card' or 'locked', never 'free'."""
         user = _make_user(balance=0)
         db   = _make_db()
-        ctx  = self._call_player_shop(user, db)
+        ctx  = self._call_player_shop(user, db, accessible_ids=set())
         rows = ctx["context"]["design_rows"]
-        free_row = next(r for r in rows if r["id"] == "fifa")
-        assert free_row["state"] == "free"
+        fifa_row = next(r for r in rows if r["id"] == "fifa")
+        assert fifa_row["state"] != "free", "free state must not exist — all designs require ownership"
+        assert fifa_row["state"] in ("get_card", "locked")
 
-    def test_mcs03_premium_purchasable(self):
-        """MCS-03: premium design, not owned, credits ≥ cost → state='purchasable'."""
+    def test_mcs03_premium_get_card_state(self):
+        """MCS-03: premium design, not owned, credits ≥ cost → state='get_card'."""
         user = _make_user(balance=500)
         db   = _make_db()
         ctx  = self._call_player_shop(user, db, accessible_ids=set())
         rows = ctx["context"]["design_rows"]
         row  = next(r for r in rows if r["id"] == "compact")
-        assert row["state"] == "purchasable"
+        assert row["state"] == "get_card"
 
     def test_mcs04_premium_locked_insufficient_credits(self):
         """MCS-04: premium design, not owned, credits < cost → state='locked'."""
@@ -168,13 +169,13 @@ class TestWelcomeCardShop:
 
         return captured
 
-    def test_mcs06_welcome_card_format_purchasable(self):
-        """MCS-06: WC format not owned, credits ≥ price → state='purchasable'."""
+    def test_mcs06_welcome_card_format_get_card(self):
+        """MCS-06: WC format not owned, credits ≥ price → state='get_card'."""
         user = _make_user(balance=9999)
         db   = _make_db()
         ctx  = self._call_welcome_shop(user, db, accessible_ids=set())
         rows = ctx["context"]["format_rows"]
-        assert all(r["state"] == "purchasable" for r in rows)
+        assert all(r["state"] == "get_card" for r in rows)
 
     def test_mcs07_welcome_card_format_locked(self):
         """MCS-07: WC format not owned, credits < price → state='locked'."""

--- a/tests/unit/api/web_routes/test_my_cards_shop.py
+++ b/tests/unit/api/web_routes/test_my_cards_shop.py
@@ -1,15 +1,15 @@
-"""My Cards Shop tests.
+"""My Cards Shop tests — Phase 2 format-level MVP.
 
-MCS-01  GET /my-cards/shop renders without error (200 + template context)
+MCS-01  GET /my-cards/player-card renders without error (200 + template context)
 MCS-02  Player Card free design → state="free"
 MCS-03  Player Card premium, not owned, enough credits → state="purchasable"
 MCS-04  Player Card premium, not owned, insufficient credits → state="locked"
 MCS-05  Player Card premium, owned → state="owned"
-MCS-06  Welcome Card not owned, enough credits → wc_state="purchasable"
-MCS-07  Welcome Card not owned, insufficient credits → wc_state="locked"
-MCS-08  Welcome Card owned → wc_state="owned"
-MCS-09  Welcome/Challenge prices > 0 (never free)
-MCS-10  POST /my-cards/designs/{type}/{id}/get → 303 redirect on success;
+MCS-06  Welcome Card format not owned, enough credits → state="purchasable"
+MCS-07  Welcome Card format not owned, insufficient credits → state="locked"
+MCS-08  Welcome Card format owned → state="owned"
+MCS-09  All WC and CC format prices > 0 (never free)
+MCS-10  POST /my-cards/designs/{type}/{id}/get → 303 redirect on success to family page;
          ?error=free / ?error=owned / ?error=credits / ?error=invalid on failure
 MCS-11  my_cards_shop.html uses student_content block + spec_subpage_hdr include
 MCS-12  my_cards_shop.html breadcrumb links back to /my-cards
@@ -44,7 +44,7 @@ def _make_db():
     return db
 
 
-def _make_request(path="/my-cards/shop", query_params=None):
+def _make_request(path="/my-cards/player-card", query_params=None):
     r = MagicMock(spec=Request)
     r.url.path = path
     params = query_params or {}
@@ -62,12 +62,12 @@ def _make_design(design_id: str, credit_cost: int, is_premium: bool):
     return d
 
 
-# ── MCS-01: Shop renders ──────────────────────────────────────────────────────
+# ── MCS-01..05: Player Card format shop ──────────────────────────────────────
 
-class TestShopRender:
+class TestPlayerCardShop:
 
-    def _call_shop(self, user, db, accessible_ids=None, query_params=None):
-        from app.api.web_routes.my_cards import my_cards_shop
+    def _call_player_shop(self, user, db, accessible_ids=None, query_params=None):
+        from app.api.web_routes.my_cards import my_cards_player_card
 
         accessible_ids = accessible_ids or set()
         request = _make_request(query_params=query_params or {})
@@ -90,25 +90,25 @@ class TestShopRender:
         with patch(f"{_MY_CARDS}.get_all_designs", return_value=[free_design, premium_design]), \
              patch(f"{_MY_CARDS}.is_design_accessible", side_effect=fake_accessible), \
              patch(f"{_MY_CARDS}.templates.TemplateResponse", side_effect=fake_template_response):
-            _run(my_cards_shop(request=request, db=db, user=user))
+            _run(my_cards_player_card(request=request, db=db, user=user))
 
         return captured
 
-    def test_mcs01_renders_shop(self):
-        """MCS-01: GET shop returns my_cards_shop.html with expected context keys."""
+    def test_mcs01_renders_player_card_shop(self):
+        """MCS-01: GET /my-cards/player-card returns my_cards_player_card.html with context keys."""
         user = _make_user(balance=500)
         db   = _make_db()
-        ctx  = self._call_shop(user, db)
-        assert ctx["template"] == "my_cards_shop.html"
-        for key in ("player_design_rows", "wc_price", "cc_price", "wc_state", "cc_state"):
+        ctx  = self._call_player_shop(user, db)
+        assert ctx["template"] == "my_cards_player_card.html"
+        for key in ("design_rows", "owned_count", "total_count"):
             assert key in ctx["context"], f"Missing context key: {key}"
 
     def test_mcs02_free_design_state(self):
         """MCS-02: Player Card non-premium design → state='free'."""
         user = _make_user(balance=0)
         db   = _make_db()
-        ctx  = self._call_shop(user, db)
-        rows = ctx["context"]["player_design_rows"]
+        ctx  = self._call_player_shop(user, db)
+        rows = ctx["context"]["design_rows"]
         free_row = next(r for r in rows if r["id"] == "fifa")
         assert free_row["state"] == "free"
 
@@ -116,8 +116,8 @@ class TestShopRender:
         """MCS-03: premium design, not owned, credits ≥ cost → state='purchasable'."""
         user = _make_user(balance=500)
         db   = _make_db()
-        ctx  = self._call_shop(user, db, accessible_ids=set())
-        rows = ctx["context"]["player_design_rows"]
+        ctx  = self._call_player_shop(user, db, accessible_ids=set())
+        rows = ctx["context"]["design_rows"]
         row  = next(r for r in rows if r["id"] == "compact")
         assert row["state"] == "purchasable"
 
@@ -125,8 +125,8 @@ class TestShopRender:
         """MCS-04: premium design, not owned, credits < cost → state='locked'."""
         user = _make_user(balance=50)
         db   = _make_db()
-        ctx  = self._call_shop(user, db, accessible_ids=set())
-        rows = ctx["context"]["player_design_rows"]
+        ctx  = self._call_player_shop(user, db, accessible_ids=set())
+        rows = ctx["context"]["design_rows"]
         row  = next(r for r in rows if r["id"] == "compact")
         assert row["state"] == "locked"
 
@@ -134,39 +134,82 @@ class TestShopRender:
         """MCS-05: premium design, owned → state='owned'."""
         user = _make_user(balance=500)
         db   = _make_db()
-        ctx  = self._call_shop(user, db, accessible_ids={("player_card", "compact")})
-        rows = ctx["context"]["player_design_rows"]
+        ctx  = self._call_player_shop(user, db, accessible_ids={("player_card", "compact")})
+        rows = ctx["context"]["design_rows"]
         row  = next(r for r in rows if r["id"] == "compact")
         assert row["state"] == "owned"
 
-    def test_mcs06_welcome_card_purchasable(self):
-        """MCS-06: Welcome Card not owned, credits ≥ price → wc_state='purchasable'."""
+
+# ── MCS-06..08: Welcome Card format shop states ───────────────────────────────
+
+class TestWelcomeCardShop:
+
+    def _call_welcome_shop(self, user, db, accessible_ids=None):
+        from app.api.web_routes.my_cards import my_cards_welcome_card
+
+        accessible_ids = accessible_ids or set()
+        request = _make_request(path="/my-cards/welcome-card")
+
+        captured = {}
+
+        def fake_template_response(template_name, context):
+            captured["template"] = template_name
+            captured["context"]  = context
+            resp = MagicMock()
+            resp.status_code = 200
+            return resp
+
+        def fake_accessible(db, uid, card_type_id, design_id):
+            return (card_type_id, design_id) in accessible_ids
+
+        with patch(f"{_MY_CARDS}.is_design_accessible", side_effect=fake_accessible), \
+             patch(f"{_MY_CARDS}.templates.TemplateResponse", side_effect=fake_template_response):
+            _run(my_cards_welcome_card(request=request, db=db, user=user))
+
+        return captured
+
+    def test_mcs06_welcome_card_format_purchasable(self):
+        """MCS-06: WC format not owned, credits ≥ price → state='purchasable'."""
         user = _make_user(balance=9999)
         db   = _make_db()
-        ctx  = self._call_shop(user, db, accessible_ids=set())
-        assert ctx["context"]["wc_state"] == "purchasable"
+        ctx  = self._call_welcome_shop(user, db, accessible_ids=set())
+        rows = ctx["context"]["format_rows"]
+        assert all(r["state"] == "purchasable" for r in rows)
 
-    def test_mcs07_welcome_card_locked(self):
-        """MCS-07: Welcome Card not owned, credits < price → wc_state='locked'."""
+    def test_mcs07_welcome_card_format_locked(self):
+        """MCS-07: WC format not owned, credits < price → state='locked'."""
         user = _make_user(balance=0)
         db   = _make_db()
-        ctx  = self._call_shop(user, db, accessible_ids=set())
-        assert ctx["context"]["wc_state"] == "locked"
+        ctx  = self._call_welcome_shop(user, db, accessible_ids=set())
+        rows = ctx["context"]["format_rows"]
+        assert all(r["state"] == "locked" for r in rows)
 
-    def test_mcs08_welcome_card_owned(self):
-        """MCS-08: Welcome Card owned → wc_state='owned'."""
+    def test_mcs08_welcome_card_format_owned(self):
+        """MCS-08: WC format owned → state='owned'."""
+        from app.services.card_design_service import WELCOME_CARD_FORMATS
+        first_fmt = WELCOME_CARD_FORMATS[0]
         user = _make_user(balance=9999)
         db   = _make_db()
-        ctx  = self._call_shop(user, db, accessible_ids={("welcome_card", "default")})
-        assert ctx["context"]["wc_state"] == "owned"
+        ctx  = self._call_welcome_shop(
+            user, db,
+            accessible_ids={("welcome_card", first_fmt.design_id)},
+        )
+        rows = ctx["context"]["format_rows"]
+        row  = next(r for r in rows if r["design_id"] == first_fmt.design_id)
+        assert row["state"] == "owned"
 
-    def test_mcs09_wc_cc_prices_never_free(self):
-        """MCS-09: Welcome Card and Challenge Card prices are > 0 (never free)."""
-        from app.services.card_design_service import _NON_PLAYER_CARD_PRICES
-        wc = _NON_PLAYER_CARD_PRICES[("welcome_card",   "default")]
-        cc = _NON_PLAYER_CARD_PRICES[("challenge_card", "challenge")]
-        assert wc > 0, "Welcome Card price must be > 0"
-        assert cc > 0, "Challenge Card price must be > 0"
+
+# ── MCS-09: Format prices > 0 ────────────────────────────────────────────────
+
+class TestFormatPrices:
+
+    def test_mcs09_all_wc_cc_format_prices_never_free(self):
+        """MCS-09: All WC and CC format prices are > 0 (no free formats)."""
+        from app.services.card_design_service import WELCOME_CARD_FORMATS, CHALLENGE_CARD_FORMATS
+        for fmt in WELCOME_CARD_FORMATS:
+            assert fmt.credit_cost > 0, f"WC format {fmt.design_id} must cost > 0"
+        for fmt in CHALLENGE_CARD_FORMATS:
+            assert fmt.credit_cost > 0, f"CC format {fmt.design_id} must cost > 0"
 
 
 # ── MCS-10: POST purchase redirect behaviour ──────────────────────────────────
@@ -179,19 +222,20 @@ class TestPurchaseRedirects:
         with patch(f"{_MY_CARDS}.purchase_design", side_effect=side_effect or (lambda *a, **kw: None)):
             return _run(get_card(card_type_id=card_type_id, design_id=design_id, db=db, user=user))
 
-    def test_mcs10a_success_redirect(self):
-        """MCS-10a: successful purchase → 303 to /my-cards?purchased=... (hub, not shop)."""
+    def test_mcs10a_success_redirect_to_family_page(self):
+        """MCS-10a: successful purchase → 303 to /my-cards/player-card?purchased=compact."""
         user = _make_user()
         db   = _make_db()
         resp = self._call_get_card("player_card", "compact", user, db)
         loc  = resp.headers["location"]
         assert resp.status_code == 303
-        assert loc.startswith("/my-cards?"), f"Expected hub redirect, got: {loc}"
-        assert "purchased=player_card:compact" in loc
+        assert loc.startswith("/my-cards/player-card?"), f"Expected player-card redirect, got: {loc}"
+        assert "purchased=compact" in loc
         assert "/my-cards/shop" not in loc
+        assert "/my-cards?" not in loc
 
     def test_mcs10b_free_error_redirect(self):
-        """MCS-10b: FreeDesignError → /my-cards/shop?error=free&tab=player."""
+        """MCS-10b: FreeDesignError → /my-cards/player-card?error=free."""
         from app.services.card_design_service import FreeDesignError
         user = _make_user()
         db   = _make_db()
@@ -199,10 +243,11 @@ class TestPurchaseRedirects:
         loc  = resp.headers["location"]
         assert resp.status_code == 303
         assert "error=free" in loc
-        assert "tab=player" in loc
+        assert "/my-cards/player-card" in loc
+        assert "/my-cards/shop" not in loc
 
     def test_mcs10c_already_owned_redirect(self):
-        """MCS-10c: AlreadyOwnedError → /my-cards/shop?error=owned&tab=player."""
+        """MCS-10c: AlreadyOwnedError → /my-cards/player-card?error=owned."""
         from app.services.card_design_service import AlreadyOwnedError
         user = _make_user()
         db   = _make_db()
@@ -210,10 +255,10 @@ class TestPurchaseRedirects:
         loc  = resp.headers["location"]
         assert resp.status_code == 303
         assert "error=owned" in loc
-        assert "tab=player" in loc
+        assert "/my-cards/player-card" in loc
 
     def test_mcs10d_insufficient_credits_redirect(self):
-        """MCS-10d: InsufficientCreditsError → /my-cards/shop?error=credits&tab=player."""
+        """MCS-10d: InsufficientCreditsError → /my-cards/player-card?error=credits."""
         from app.services.credit_service import InsufficientCreditsError
         user = _make_user()
         db   = _make_db()
@@ -221,10 +266,10 @@ class TestPurchaseRedirects:
         loc  = resp.headers["location"]
         assert resp.status_code == 303
         assert "error=credits" in loc
-        assert "tab=player" in loc
+        assert "/my-cards/player-card" in loc
 
     def test_mcs10e_invalid_card_type_redirect(self):
-        """MCS-10e: ValueError (unknown card_type_id) → ?error=invalid."""
+        """MCS-10e: ValueError (unknown card_type_id) → /my-cards?error=invalid."""
         user = _make_user()
         db   = _make_db()
         resp = self._call_get_card("bogus_type", "bogus_design", user, db, side_effect=ValueError("unknown"))
@@ -232,23 +277,25 @@ class TestPurchaseRedirects:
         assert resp.status_code == 303
         assert "error=invalid" in loc
 
-    def test_mcs10f_welcome_card_error_tab(self):
-        """MCS-10f: AlreadyOwnedError on welcome_card → tab=welcome in redirect."""
+    def test_mcs10f_welcome_card_error_goes_to_welcome_family(self):
+        """MCS-10f: AlreadyOwnedError on welcome_card → /my-cards/welcome-card?error=owned."""
         from app.services.card_design_service import AlreadyOwnedError
         user = _make_user()
         db   = _make_db()
-        resp = self._call_get_card("welcome_card", "default", user, db, side_effect=AlreadyOwnedError())
+        resp = self._call_get_card("welcome_card", "instagram_portrait", user, db, side_effect=AlreadyOwnedError())
         loc  = resp.headers["location"]
-        assert "tab=welcome" in loc
+        assert "/my-cards/welcome-card" in loc
+        assert "error=owned" in loc
 
-    def test_mcs10g_challenge_card_error_tab(self):
-        """MCS-10g: InsufficientCreditsError on challenge_card → tab=challenge in redirect."""
+    def test_mcs10g_challenge_card_error_goes_to_challenge_family(self):
+        """MCS-10g: InsufficientCreditsError on challenge_card → /my-cards/challenge-card?error=credits."""
         from app.services.credit_service import InsufficientCreditsError
         user = _make_user()
         db   = _make_db()
-        resp = self._call_get_card("challenge_card", "challenge", user, db, side_effect=InsufficientCreditsError(150, 0))
+        resp = self._call_get_card("challenge_card", "challenge_post_16_9", user, db, side_effect=InsufficientCreditsError(100, 0))
         loc  = resp.headers["location"]
-        assert "tab=challenge" in loc
+        assert "/my-cards/challenge-card" in loc
+        assert "error=credits" in loc
 
 
 # ── MCS-11..13: Template structural tests ────────────────────────────────────

--- a/tests/unit/api/web_routes/test_my_cards_shop.py
+++ b/tests/unit/api/web_routes/test_my_cards_shop.py
@@ -1,0 +1,220 @@
+"""My Cards Shop tests.
+
+MCS-01  GET /my-cards/shop renders without error (200 + template context)
+MCS-02  Player Card free design → state="free"
+MCS-03  Player Card premium, not owned, enough credits → state="purchasable"
+MCS-04  Player Card premium, not owned, insufficient credits → state="locked"
+MCS-05  Player Card premium, owned → state="owned"
+MCS-06  Welcome Card not owned, enough credits → wc_state="purchasable"
+MCS-07  Welcome Card not owned, insufficient credits → wc_state="locked"
+MCS-08  Welcome Card owned → wc_state="owned"
+MCS-09  Welcome/Challenge prices > 0 (never free)
+MCS-10  POST /my-cards/designs/{type}/{id}/get → 303 redirect on success;
+         ?error=free / ?error=owned / ?error=credits / ?error=invalid on failure
+"""
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import Request
+from fastapi.responses import RedirectResponse
+
+_MY_CARDS = "app.api.web_routes.my_cards"
+_SVC      = "app.services.card_design_service"
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _make_user(balance: int = 500):
+    from app.models.user import UserRole
+    u = MagicMock()
+    u.id = 1
+    u.credit_balance = balance
+    u.role = UserRole.STUDENT
+    return u
+
+
+def _make_db():
+    db = MagicMock()
+    return db
+
+
+def _make_request(path="/my-cards/shop", query_params=None):
+    r = MagicMock(spec=Request)
+    r.url.path = path
+    params = query_params or {}
+    r.query_params.get = lambda k, default=None: params.get(k, default)
+    return r
+
+
+def _make_design(design_id: str, credit_cost: int, is_premium: bool):
+    d = MagicMock()
+    d.id = design_id
+    d.label = design_id.capitalize()
+    d.description = ""
+    d.credit_cost = credit_cost
+    d.is_premium = is_premium
+    return d
+
+
+# ── MCS-01: Shop renders ──────────────────────────────────────────────────────
+
+class TestShopRender:
+
+    def _call_shop(self, user, db, accessible_ids=None, query_params=None):
+        from app.api.web_routes.my_cards import my_cards_shop
+
+        accessible_ids = accessible_ids or set()
+        request = _make_request(query_params=query_params or {})
+
+        free_design    = _make_design("fifa",    credit_cost=0,   is_premium=False)
+        premium_design = _make_design("compact", credit_cost=300, is_premium=True)
+
+        captured = {}
+
+        def fake_template_response(template_name, context):
+            captured["template"] = template_name
+            captured["context"]  = context
+            resp = MagicMock()
+            resp.status_code = 200
+            return resp
+
+        def fake_accessible(db, uid, card_type_id, design_id):
+            return (card_type_id, design_id) in accessible_ids
+
+        with patch(f"{_MY_CARDS}.get_all_designs", return_value=[free_design, premium_design]), \
+             patch(f"{_MY_CARDS}.is_design_accessible", side_effect=fake_accessible), \
+             patch(f"{_MY_CARDS}.templates.TemplateResponse", side_effect=fake_template_response):
+            _run(my_cards_shop(request=request, db=db, user=user))
+
+        return captured
+
+    def test_mcs01_renders_shop(self):
+        """MCS-01: GET shop returns my_cards_shop.html with expected context keys."""
+        user = _make_user(balance=500)
+        db   = _make_db()
+        ctx  = self._call_shop(user, db)
+        assert ctx["template"] == "my_cards_shop.html"
+        for key in ("player_design_rows", "wc_price", "cc_price", "wc_state", "cc_state"):
+            assert key in ctx["context"], f"Missing context key: {key}"
+
+    def test_mcs02_free_design_state(self):
+        """MCS-02: Player Card non-premium design → state='free'."""
+        user = _make_user(balance=0)
+        db   = _make_db()
+        ctx  = self._call_shop(user, db)
+        rows = ctx["context"]["player_design_rows"]
+        free_row = next(r for r in rows if r["id"] == "fifa")
+        assert free_row["state"] == "free"
+
+    def test_mcs03_premium_purchasable(self):
+        """MCS-03: premium design, not owned, credits ≥ cost → state='purchasable'."""
+        user = _make_user(balance=500)
+        db   = _make_db()
+        ctx  = self._call_shop(user, db, accessible_ids=set())
+        rows = ctx["context"]["player_design_rows"]
+        row  = next(r for r in rows if r["id"] == "compact")
+        assert row["state"] == "purchasable"
+
+    def test_mcs04_premium_locked_insufficient_credits(self):
+        """MCS-04: premium design, not owned, credits < cost → state='locked'."""
+        user = _make_user(balance=50)
+        db   = _make_db()
+        ctx  = self._call_shop(user, db, accessible_ids=set())
+        rows = ctx["context"]["player_design_rows"]
+        row  = next(r for r in rows if r["id"] == "compact")
+        assert row["state"] == "locked"
+
+    def test_mcs05_premium_owned(self):
+        """MCS-05: premium design, owned → state='owned'."""
+        user = _make_user(balance=500)
+        db   = _make_db()
+        ctx  = self._call_shop(user, db, accessible_ids={("player_card", "compact")})
+        rows = ctx["context"]["player_design_rows"]
+        row  = next(r for r in rows if r["id"] == "compact")
+        assert row["state"] == "owned"
+
+    def test_mcs06_welcome_card_purchasable(self):
+        """MCS-06: Welcome Card not owned, credits ≥ price → wc_state='purchasable'."""
+        user = _make_user(balance=9999)
+        db   = _make_db()
+        ctx  = self._call_shop(user, db, accessible_ids=set())
+        assert ctx["context"]["wc_state"] == "purchasable"
+
+    def test_mcs07_welcome_card_locked(self):
+        """MCS-07: Welcome Card not owned, credits < price → wc_state='locked'."""
+        user = _make_user(balance=0)
+        db   = _make_db()
+        ctx  = self._call_shop(user, db, accessible_ids=set())
+        assert ctx["context"]["wc_state"] == "locked"
+
+    def test_mcs08_welcome_card_owned(self):
+        """MCS-08: Welcome Card owned → wc_state='owned'."""
+        user = _make_user(balance=9999)
+        db   = _make_db()
+        ctx  = self._call_shop(user, db, accessible_ids={("welcome_card", "default")})
+        assert ctx["context"]["wc_state"] == "owned"
+
+    def test_mcs09_wc_cc_prices_never_free(self):
+        """MCS-09: Welcome Card and Challenge Card prices are > 0 (never free)."""
+        from app.services.card_design_service import _NON_PLAYER_CARD_PRICES
+        wc = _NON_PLAYER_CARD_PRICES[("welcome_card",   "default")]
+        cc = _NON_PLAYER_CARD_PRICES[("challenge_card", "challenge")]
+        assert wc > 0, "Welcome Card price must be > 0"
+        assert cc > 0, "Challenge Card price must be > 0"
+
+
+# ── MCS-10: POST purchase redirect behaviour ──────────────────────────────────
+
+class TestPurchaseRedirects:
+
+    def _call_get_card(self, card_type_id, design_id, user, db, side_effect=None):
+        from app.api.web_routes.my_cards import get_card
+
+        with patch(f"{_MY_CARDS}.purchase_design", side_effect=side_effect or (lambda *a, **kw: None)):
+            return _run(get_card(card_type_id=card_type_id, design_id=design_id, db=db, user=user))
+
+    def test_mcs10a_success_redirect(self):
+        """MCS-10a: successful purchase → 303 to /my-cards/shop?purchased=..."""
+        user = _make_user()
+        db   = _make_db()
+        resp = self._call_get_card("player_card", "compact", user, db)
+        assert resp.status_code == 303
+        assert "purchased=player_card:compact" in resp.headers["location"]
+
+    def test_mcs10b_free_error_redirect(self):
+        """MCS-10b: FreeDesignError → ?error=free."""
+        from app.services.card_design_service import FreeDesignError
+        user = _make_user()
+        db   = _make_db()
+        resp = self._call_get_card("player_card", "fifa", user, db, side_effect=FreeDesignError())
+        assert resp.status_code == 303
+        assert "error=free" in resp.headers["location"]
+
+    def test_mcs10c_already_owned_redirect(self):
+        """MCS-10c: AlreadyOwnedError → ?error=owned."""
+        from app.services.card_design_service import AlreadyOwnedError
+        user = _make_user()
+        db   = _make_db()
+        resp = self._call_get_card("player_card", "compact", user, db, side_effect=AlreadyOwnedError())
+        assert resp.status_code == 303
+        assert "error=owned" in resp.headers["location"]
+
+    def test_mcs10d_insufficient_credits_redirect(self):
+        """MCS-10d: InsufficientCreditsError → ?error=credits."""
+        from app.services.credit_service import InsufficientCreditsError
+        user = _make_user()
+        db   = _make_db()
+        resp = self._call_get_card("player_card", "compact", user, db, side_effect=InsufficientCreditsError(300, 0))
+        assert resp.status_code == 303
+        assert "error=credits" in resp.headers["location"]
+
+    def test_mcs10e_invalid_card_type_redirect(self):
+        """MCS-10e: ValueError (unknown card_type_id) → ?error=invalid."""
+        user = _make_user()
+        db   = _make_db()
+        resp = self._call_get_card("bogus_type", "bogus_design", user, db, side_effect=ValueError("unknown"))
+        assert resp.status_code == 303
+        assert "error=invalid" in resp.headers["location"]

--- a/tests/unit/api/web_routes/test_my_cards_shop.py
+++ b/tests/unit/api/web_routes/test_my_cards_shop.py
@@ -11,6 +11,9 @@ MCS-08  Welcome Card owned → wc_state="owned"
 MCS-09  Welcome/Challenge prices > 0 (never free)
 MCS-10  POST /my-cards/designs/{type}/{id}/get → 303 redirect on success;
          ?error=free / ?error=owned / ?error=credits / ?error=invalid on failure
+MCS-11  my_cards_shop.html uses student_content block + spec_subpage_hdr include
+MCS-12  my_cards_shop.html breadcrumb links back to /my-cards
+MCS-13  my_cards_shop.html URLSearchParams JS present for tab activation
 """
 import asyncio
 from unittest.mock import MagicMock, patch
@@ -177,44 +180,102 @@ class TestPurchaseRedirects:
             return _run(get_card(card_type_id=card_type_id, design_id=design_id, db=db, user=user))
 
     def test_mcs10a_success_redirect(self):
-        """MCS-10a: successful purchase → 303 to /my-cards/shop?purchased=..."""
+        """MCS-10a: successful purchase → 303 to /my-cards?purchased=... (hub, not shop)."""
         user = _make_user()
         db   = _make_db()
         resp = self._call_get_card("player_card", "compact", user, db)
+        loc  = resp.headers["location"]
         assert resp.status_code == 303
-        assert "purchased=player_card:compact" in resp.headers["location"]
+        assert loc.startswith("/my-cards?"), f"Expected hub redirect, got: {loc}"
+        assert "purchased=player_card:compact" in loc
+        assert "/my-cards/shop" not in loc
 
     def test_mcs10b_free_error_redirect(self):
-        """MCS-10b: FreeDesignError → ?error=free."""
+        """MCS-10b: FreeDesignError → /my-cards/shop?error=free&tab=player."""
         from app.services.card_design_service import FreeDesignError
         user = _make_user()
         db   = _make_db()
         resp = self._call_get_card("player_card", "fifa", user, db, side_effect=FreeDesignError())
+        loc  = resp.headers["location"]
         assert resp.status_code == 303
-        assert "error=free" in resp.headers["location"]
+        assert "error=free" in loc
+        assert "tab=player" in loc
 
     def test_mcs10c_already_owned_redirect(self):
-        """MCS-10c: AlreadyOwnedError → ?error=owned."""
+        """MCS-10c: AlreadyOwnedError → /my-cards/shop?error=owned&tab=player."""
         from app.services.card_design_service import AlreadyOwnedError
         user = _make_user()
         db   = _make_db()
         resp = self._call_get_card("player_card", "compact", user, db, side_effect=AlreadyOwnedError())
+        loc  = resp.headers["location"]
         assert resp.status_code == 303
-        assert "error=owned" in resp.headers["location"]
+        assert "error=owned" in loc
+        assert "tab=player" in loc
 
     def test_mcs10d_insufficient_credits_redirect(self):
-        """MCS-10d: InsufficientCreditsError → ?error=credits."""
+        """MCS-10d: InsufficientCreditsError → /my-cards/shop?error=credits&tab=player."""
         from app.services.credit_service import InsufficientCreditsError
         user = _make_user()
         db   = _make_db()
         resp = self._call_get_card("player_card", "compact", user, db, side_effect=InsufficientCreditsError(300, 0))
+        loc  = resp.headers["location"]
         assert resp.status_code == 303
-        assert "error=credits" in resp.headers["location"]
+        assert "error=credits" in loc
+        assert "tab=player" in loc
 
     def test_mcs10e_invalid_card_type_redirect(self):
         """MCS-10e: ValueError (unknown card_type_id) → ?error=invalid."""
         user = _make_user()
         db   = _make_db()
         resp = self._call_get_card("bogus_type", "bogus_design", user, db, side_effect=ValueError("unknown"))
+        loc  = resp.headers["location"]
         assert resp.status_code == 303
-        assert "error=invalid" in resp.headers["location"]
+        assert "error=invalid" in loc
+
+    def test_mcs10f_welcome_card_error_tab(self):
+        """MCS-10f: AlreadyOwnedError on welcome_card → tab=welcome in redirect."""
+        from app.services.card_design_service import AlreadyOwnedError
+        user = _make_user()
+        db   = _make_db()
+        resp = self._call_get_card("welcome_card", "default", user, db, side_effect=AlreadyOwnedError())
+        loc  = resp.headers["location"]
+        assert "tab=welcome" in loc
+
+    def test_mcs10g_challenge_card_error_tab(self):
+        """MCS-10g: InsufficientCreditsError on challenge_card → tab=challenge in redirect."""
+        from app.services.credit_service import InsufficientCreditsError
+        user = _make_user()
+        db   = _make_db()
+        resp = self._call_get_card("challenge_card", "challenge", user, db, side_effect=InsufficientCreditsError(150, 0))
+        loc  = resp.headers["location"]
+        assert "tab=challenge" in loc
+
+
+# ── MCS-11..13: Template structural tests ────────────────────────────────────
+
+class TestShopTemplate:
+
+    _TEMPLATE_PATH = (
+        "app/templates/my_cards_shop.html"
+    )
+
+    def _read_template(self):
+        from pathlib import Path
+        base = Path(__file__).resolve().parents[4]
+        return (base / self._TEMPLATE_PATH).read_text()
+
+    def test_mcs11_uses_student_content_block(self):
+        """MCS-11: shop template uses student_content block (not bare 'content')."""
+        src = self._read_template()
+        assert "block student_content" in src, "Must extend student_base via student_content block"
+        assert "spec_subpage_hdr.html" in src, "Must include spec_subpage_hdr for nav context"
+
+    def test_mcs12_breadcrumb_links_to_hub(self):
+        """MCS-12: breadcrumb contains link back to /my-cards hub."""
+        src = self._read_template()
+        assert 'href="/my-cards"' in src, "Breadcrumb must link back to /my-cards hub"
+
+    def test_mcs13_tab_url_param_js_present(self):
+        """MCS-13: URLSearchParams JS present for ?tab= auto-activation on page load."""
+        src = self._read_template()
+        assert "URLSearchParams" in src, "Must use URLSearchParams to auto-activate tab from URL"

--- a/tests/unit/api/web_routes/test_my_cards_welcome_card.py
+++ b/tests/unit/api/web_routes/test_my_cards_welcome_card.py
@@ -1,0 +1,169 @@
+"""Welcome Card format shop route tests — MCW-01..MCW-12.
+
+MCW-01  GET /my-cards/welcome-card renders my_cards_welcome_card.html
+MCW-02  Context contains format_rows with 7 entries (WELCOME_CARD_FORMATS)
+MCW-03  Not owned, credits ≥ price → state='purchasable'
+MCW-04  Not owned, credits < price → state='locked'
+MCW-05  Owned → state='owned'
+MCW-06  Context contains owned_count and total_count
+MCW-07  Route has auth dependency (get_current_user_web)
+MCW-08  Template extends student_base and includes spec_subpage_hdr
+MCW-09  Template breadcrumb links to /my-cards
+MCW-10  format_rows contain preview_url and export_url
+MCW-11  Download CTA only present for owned state (template check)
+MCW-12  Template contains purchase form POST action pattern
+"""
+import asyncio
+import inspect
+import pathlib
+from unittest.mock import MagicMock, patch
+
+_BASE = "app.api.web_routes.my_cards"
+_TEMPLATE_PATH = (
+    pathlib.Path(__file__).resolve().parents[4]
+    / "app" / "templates" / "my_cards_welcome_card.html"
+)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _user(balance=500):
+    from app.models.user import UserRole
+    u = MagicMock()
+    u.id = 42
+    u.credit_balance = balance
+    u.role = UserRole.STUDENT
+    return u
+
+
+def _req(query_params=None):
+    r = MagicMock()
+    r.url.path = "/my-cards/welcome-card"
+    params = query_params or {}
+    r.query_params.get = lambda k, default=None: params.get(k, default)
+    return r
+
+
+def _db():
+    return MagicMock()
+
+
+def _call(user=None, db=None, accessible_ids=None, query_params=None):
+    from app.api.web_routes.my_cards import my_cards_welcome_card
+
+    user           = user or _user()
+    db             = db   or _db()
+    accessible_ids = accessible_ids or set()
+    captured = {}
+
+    def fake_tmpl(tmpl, ctx):
+        captured["template"] = tmpl
+        captured["context"]  = ctx
+        return MagicMock(status_code=200)
+
+    def fake_accessible(_db, uid, card_type_id, design_id):
+        return (card_type_id, design_id) in accessible_ids
+
+    with patch(f"{_BASE}.is_design_accessible", side_effect=fake_accessible), \
+         patch(f"{_BASE}.templates.TemplateResponse", side_effect=fake_tmpl):
+        _run(my_cards_welcome_card(request=_req(query_params), db=db, user=user))
+
+    return captured
+
+
+class TestWelcomeCardShopRoute:
+
+    def test_mcw01_renders_welcome_card_template(self):
+        """MCW-01: GET /my-cards/welcome-card renders my_cards_welcome_card.html."""
+        cap = _call()
+        assert cap["template"] == "my_cards_welcome_card.html"
+
+    def test_mcw02_context_has_7_format_rows(self):
+        """MCW-02: context.format_rows has 7 entries (one per WELCOME_CARD_FORMAT)."""
+        from app.services.card_design_service import WELCOME_CARD_FORMATS
+        ctx = _call()["context"]
+        rows = ctx["format_rows"]
+        assert len(rows) == len(WELCOME_CARD_FORMATS)
+
+    def test_mcw03_not_owned_sufficient_credits_purchasable(self):
+        """MCW-03: format not owned, credits ≥ price → state='purchasable'."""
+        ctx = _call(user=_user(balance=9999), accessible_ids=set())["context"]
+        rows = ctx["format_rows"]
+        for r in rows:
+            assert r["state"] == "purchasable", f"{r['design_id']} should be purchasable"
+
+    def test_mcw04_not_owned_insufficient_credits_locked(self):
+        """MCW-04: format not owned, credits < price → state='locked'."""
+        ctx = _call(user=_user(balance=0), accessible_ids=set())["context"]
+        rows = ctx["format_rows"]
+        for r in rows:
+            assert r["state"] == "locked", f"{r['design_id']} should be locked"
+
+    def test_mcw05_owned_format_shows_owned_state(self):
+        """MCW-05: owned format → state='owned'."""
+        from app.services.card_design_service import WELCOME_CARD_FORMATS
+        target_fmt = WELCOME_CARD_FORMATS[0]
+        ctx = _call(
+            user=_user(balance=9999),
+            accessible_ids={("welcome_card", target_fmt.design_id)},
+        )["context"]
+        rows = ctx["format_rows"]
+        row = next(r for r in rows if r["design_id"] == target_fmt.design_id)
+        assert row["state"] == "owned"
+
+    def test_mcw06_context_has_owned_and_total_count(self):
+        """MCW-06: context contains owned_count and total_count."""
+        ctx = _call()["context"]
+        assert "owned_count" in ctx
+        assert "total_count" in ctx
+        from app.services.card_design_service import WELCOME_CARD_FORMATS
+        assert ctx["total_count"] == len(WELCOME_CARD_FORMATS)
+
+    def test_mcw07_route_has_auth_dependency(self):
+        """MCW-07: route declares get_current_user_web dependency."""
+        from app.api.web_routes.my_cards import my_cards_welcome_card
+        sig = inspect.signature(my_cards_welcome_card)
+        assert "user" in sig.parameters
+
+    def test_mcw08_template_extends_student_base(self):
+        """MCW-08: template extends student_base and includes spec_subpage_hdr."""
+        src = _TEMPLATE_PATH.read_text()
+        assert "student_base.html" in src
+        assert "spec_subpage_hdr.html" in src
+
+    def test_mcw09_template_breadcrumb_links_to_hub(self):
+        """MCW-09: template breadcrumb links to /my-cards hub."""
+        src = _TEMPLATE_PATH.read_text()
+        assert 'href="/my-cards"' in src
+
+    def test_mcw10_format_rows_contain_preview_and_export_url(self):
+        """MCW-10: every format_row has preview_url and export_url."""
+        ctx = _call()["context"]
+        rows = ctx["format_rows"]
+        for r in rows:
+            assert "preview_url" in r, f"{r['design_id']} missing preview_url"
+            assert "export_url" in r, f"{r['design_id']} missing export_url"
+
+    def test_mcw11_template_has_download_and_purchase_elements(self):
+        """MCW-11: template uses mfg-btn-download for owned and POST form for get."""
+        src = _TEMPLATE_PATH.read_text()
+        assert "mfg-btn-download" in src, "Must have download button class for owned state"
+        assert "mfg-btn-get" in src, "Must have get button class for purchasable state"
+
+    def test_mcw12_template_has_purchase_form(self):
+        """MCW-12: template contains POST form for purchasing a WC format."""
+        src = _TEMPLATE_PATH.read_text()
+        assert "/my-cards/designs/welcome_card/" in src
+        assert 'method="POST"' in src
+
+    def test_mcw_owned_count_correct(self):
+        """MCW-owned: owned_count increments per owned format."""
+        from app.services.card_design_service import WELCOME_CARD_FORMATS
+        first_two = {("welcome_card", f.design_id) for f in WELCOME_CARD_FORMATS[:2]}
+        ctx = _call(
+            user=_user(balance=9999),
+            accessible_ids=first_two,
+        )["context"]
+        assert ctx["owned_count"] == 2

--- a/tests/unit/api/web_routes/test_my_cards_welcome_card.py
+++ b/tests/unit/api/web_routes/test_my_cards_welcome_card.py
@@ -2,7 +2,7 @@
 
 MCW-01  GET /my-cards/welcome-card renders my_cards_welcome_card.html
 MCW-02  Context contains format_rows with 7 entries (WELCOME_CARD_FORMATS)
-MCW-03  Not owned, credits ≥ price → state='purchasable'
+MCW-03  Not owned, credits ≥ price → state='get_card'
 MCW-04  Not owned, credits < price → state='locked'
 MCW-05  Owned → state='owned'
 MCW-06  Context contains owned_count and total_count
@@ -87,12 +87,12 @@ class TestWelcomeCardShopRoute:
         rows = ctx["format_rows"]
         assert len(rows) == len(WELCOME_CARD_FORMATS)
 
-    def test_mcw03_not_owned_sufficient_credits_purchasable(self):
-        """MCW-03: format not owned, credits ≥ price → state='purchasable'."""
+    def test_mcw03_not_owned_sufficient_credits_get_card(self):
+        """MCW-03: format not owned, credits ≥ price → state='get_card'."""
         ctx = _call(user=_user(balance=9999), accessible_ids=set())["context"]
         rows = ctx["format_rows"]
         for r in rows:
-            assert r["state"] == "purchasable", f"{r['design_id']} should be purchasable"
+            assert r["state"] == "get_card", f"{r['design_id']} should be get_card"
 
     def test_mcw04_not_owned_insufficient_credits_locked(self):
         """MCW-04: format not owned, credits < price → state='locked'."""

--- a/tests/unit/services/test_card_design_ownership.py
+++ b/tests/unit/services/test_card_design_ownership.py
@@ -29,7 +29,7 @@ _SVC  = "app.services.card_design_service"
 _CSVC = "app.services.credit_service"  # CreditService is imported locally inside purchase_design()
 
 
-def _make_user(user_id=1, balance=1000):
+def _make_user(user_id=101, balance=1000):
     u = MagicMock()
     u.id = user_id
     u.credit_balance = balance
@@ -388,7 +388,7 @@ def test_cdo18_grant_design_idempotent():
     q.first.return_value = existing  # already exists
     db.query.return_value = q
 
-    result = grant_design(db, user_id=1, card_type_id="welcome_card", design_id="default")
+    result = grant_design(db, user_id=101, card_type_id="welcome_card", design_id="default")
 
     assert result is None  # idempotent return
     db.add.assert_not_called()

--- a/tests/unit/services/test_card_design_ownership.py
+++ b/tests/unit/services/test_card_design_ownership.py
@@ -358,16 +358,22 @@ class TestIsDesignAccessible:
 
 # ── CDO-16..17: price constants ───────────────────────────────────────────────
 
-def test_cdo16_welcome_card_price_nonzero():
-    """CDO-16: _NON_PLAYER_CARD_PRICES welcome_card/default > 0."""
-    from app.services.card_design_service import _NON_PLAYER_CARD_PRICES
-    assert _NON_PLAYER_CARD_PRICES[("welcome_card", "default")] > 0
+def test_cdo16_welcome_card_format_prices_nonzero():
+    """CDO-16: All WC format prices > 0 (legacy sentinel 'default' is correctly 0)."""
+    from app.services.card_design_service import WELCOME_CARD_FORMATS, _NON_PLAYER_CARD_PRICES
+    for fmt in WELCOME_CARD_FORMATS:
+        assert _NON_PLAYER_CARD_PRICES[("welcome_card", fmt.design_id)] > 0
+    # Sentinel key is intentionally 0 (non-purchasable, backward-compat only)
+    assert _NON_PLAYER_CARD_PRICES[("welcome_card", "default")] == 0
 
 
-def test_cdo17_challenge_card_price_nonzero():
-    """CDO-17: _NON_PLAYER_CARD_PRICES challenge_card/challenge > 0."""
-    from app.services.card_design_service import _NON_PLAYER_CARD_PRICES
-    assert _NON_PLAYER_CARD_PRICES[("challenge_card", "challenge")] > 0
+def test_cdo17_challenge_card_format_prices_nonzero():
+    """CDO-17: All CC format prices > 0 (legacy sentinel 'challenge' is correctly 0)."""
+    from app.services.card_design_service import CHALLENGE_CARD_FORMATS, _NON_PLAYER_CARD_PRICES
+    for fmt in CHALLENGE_CARD_FORMATS:
+        assert _NON_PLAYER_CARD_PRICES[("challenge_card", fmt.design_id)] > 0
+    # Sentinel key is intentionally 0 (non-purchasable, backward-compat only)
+    assert _NON_PLAYER_CARD_PRICES[("challenge_card", "challenge")] == 0
 
 
 # ── CDO-18: grant_design idempotency ─────────────────────────────────────────

--- a/tests/unit/services/test_card_design_ownership.py
+++ b/tests/unit/services/test_card_design_ownership.py
@@ -1,0 +1,427 @@
+"""Unit tests for CardDesignOwnership service layer.
+
+CDO-01  purchase player_card/compact → ownership row, card_type_id="player_card"
+CDO-02  purchase welcome_card/default → ownership row, card_type_id="welcome_card"
+CDO-03  purchase challenge_card/challenge → ownership row, card_type_id="challenge_card"
+CDO-04  purchase_design creates CreditTransaction(type=CARD_DESIGN_UNLOCK)
+CDO-05  purchase player_card/fifa → FreeDesignError, no deduction, no ownership row
+CDO-06  already owned → AlreadyOwnedError, no double deduction
+CDO-07  insufficient credits → InsufficientCreditsError, no ownership row
+CDO-08  race condition: IntegrityError → AlreadyOwnedError, rollback called
+CDO-09  CreditService.deduct does NOT call db.commit() (uses begin_nested/SAVEPOINT only)
+CDO-10  is_design_accessible player_card/fifa → True without ownership row
+CDO-11  is_design_accessible player_card/compact → False without ownership
+CDO-12  is_design_accessible player_card/compact → True after ownership
+CDO-13  is_design_accessible welcome_card/default → False without ownership
+CDO-14  is_design_accessible welcome_card/default → True after ownership
+CDO-15  legacy JSON shim: unlocked_card_variants contains design_id → True
+CDO-16  _NON_PLAYER_CARD_PRICES welcome_card/default price > 0
+CDO-17  _NON_PLAYER_CARD_PRICES challenge_card/challenge price > 0
+CDO-18  grant_design idempotent — two calls → one row, no exception
+CDO-19  onboarding step-7 flow does NOT call grant_design (no auto-grant)
+CDO-20  challenge completion flow does NOT call grant_design (no auto-grant)
+"""
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+_SVC  = "app.services.card_design_service"
+_CSVC = "app.services.credit_service"  # CreditService is imported locally inside purchase_design()
+
+
+def _make_user(user_id=1, balance=1000):
+    u = MagicMock()
+    u.id = user_id
+    u.credit_balance = balance
+    return u
+
+
+def _make_db():
+    db = MagicMock()
+    return db
+
+
+def _make_query_none(db):
+    """Configure db.query(...).filter_by(...).first() to return None."""
+    q = MagicMock()
+    q.filter_by.return_value = q
+    q.first.return_value = None
+    db.query.return_value = q
+    return q
+
+
+def _make_query_exists(db, obj):
+    """Configure db.query(...).filter_by(...).first() to return obj."""
+    q = MagicMock()
+    q.filter_by.return_value = q
+    q.first.return_value = obj
+    db.query.return_value = q
+    return q
+
+
+# ── CDO-01..04: purchase_design success paths ─────────────────────────────────
+
+class TestPurchaseDesignSuccess:
+
+    def _run_purchase(self, db, user, card_type_id, design_id, price):
+        from sqlalchemy.exc import IntegrityError
+
+        fake_tx = MagicMock()
+        fake_tx.id = 99
+
+        q = MagicMock()
+        q.filter_by.return_value = q
+        q.first.return_value = None  # not already owned
+        db.query.return_value = q
+
+        with patch(f"{_CSVC}.CreditService") as mock_cs, \
+             patch(f"{_SVC}._resolve_price", return_value=price), \
+             patch(f"{_SVC}.CardDesignOwnership") as mock_cdo:
+            mock_cs.return_value.deduct.return_value = fake_tx
+            # second db.query call returns the credit_tx by idempotency_key
+            fake_owned = MagicMock()
+            fake_owned.id = 99
+
+            from app.services.card_design_service import purchase_design
+            result = purchase_design(db, user, card_type_id, design_id)
+
+        return result, mock_cs, mock_cdo
+
+    def test_cdo01_player_card_compact(self):
+        """CDO-01: purchase player_card/compact creates ownership row with correct card_type_id."""
+        from app.services.card_design_service import purchase_design
+        from app.models.card_design_ownership import CardDesignOwnership
+
+        db = _make_db()
+        user = _make_user(balance=500)
+        _make_query_none(db)
+
+        fake_tx = MagicMock()
+        fake_tx.id = 10
+
+        with patch(f"{_SVC}._resolve_price", return_value=300), \
+             patch(f"{_CSVC}.CreditService") as mock_cs:
+            mock_cs.return_value.deduct.return_value = fake_tx
+            purchase_design(db, user, "player_card", "compact")
+
+        db.add.assert_called_once()
+        added = db.add.call_args[0][0]
+        assert added.card_type_id == "player_card"
+        assert added.design_id == "compact"
+        assert added.source == "purchase"
+        assert added.credit_transaction_id == 10
+        db.commit.assert_called_once()
+
+    def test_cdo02_welcome_card(self):
+        """CDO-02: purchase welcome_card/default creates ownership row with card_type_id='welcome_card'."""
+        from app.services.card_design_service import purchase_design
+
+        db = _make_db()
+        user = _make_user(balance=500)
+        _make_query_none(db)
+
+        fake_tx = MagicMock()
+        fake_tx.id = 20
+
+        with patch(f"{_SVC}._resolve_price", return_value=200), \
+             patch(f"{_CSVC}.CreditService") as mock_cs:
+            mock_cs.return_value.deduct.return_value = fake_tx
+            purchase_design(db, user, "welcome_card", "default")
+
+        added = db.add.call_args[0][0]
+        assert added.card_type_id == "welcome_card"
+        assert added.design_id == "default"
+
+    def test_cdo03_challenge_card(self):
+        """CDO-03: purchase challenge_card/challenge creates ownership row."""
+        from app.services.card_design_service import purchase_design
+
+        db = _make_db()
+        user = _make_user(balance=500)
+        _make_query_none(db)
+
+        fake_tx = MagicMock()
+        fake_tx.id = 30
+
+        with patch(f"{_SVC}._resolve_price", return_value=150), \
+             patch(f"{_CSVC}.CreditService") as mock_cs:
+            mock_cs.return_value.deduct.return_value = fake_tx
+            purchase_design(db, user, "challenge_card", "challenge")
+
+        added = db.add.call_args[0][0]
+        assert added.card_type_id == "challenge_card"
+        assert added.design_id == "challenge"
+
+    def test_cdo04_credit_transaction_type(self):
+        """CDO-04: CreditService.deduct is called with transaction_type='CARD_DESIGN_UNLOCK'."""
+        from app.services.card_design_service import purchase_design
+
+        db = _make_db()
+        user = _make_user(balance=500)
+        _make_query_none(db)
+
+        fake_tx = MagicMock()
+        fake_tx.id = 40
+
+        with patch(f"{_SVC}._resolve_price", return_value=300), \
+             patch(f"{_CSVC}.CreditService") as mock_cs:
+            mock_cs.return_value.deduct.return_value = fake_tx
+            purchase_design(db, user, "player_card", "compact")
+
+        deduct_kwargs = mock_cs.return_value.deduct.call_args
+        assert deduct_kwargs.kwargs["transaction_type"] == "CARD_DESIGN_UNLOCK"
+
+
+# ── CDO-05..08: error paths ───────────────────────────────────────────────────
+
+class TestPurchaseDesignErrors:
+
+    def test_cdo05_free_design_error(self):
+        """CDO-05: purchasing player_card/fifa raises FreeDesignError, no deduction."""
+        from app.services.card_design_service import FreeDesignError, purchase_design
+
+        db = _make_db()
+        user = _make_user(balance=1000)
+
+        with patch(f"{_SVC}._resolve_price", return_value=0), \
+             patch(f"{_CSVC}.CreditService") as mock_cs:
+            with pytest.raises(FreeDesignError):
+                purchase_design(db, user, "player_card", "fifa")
+            mock_cs.return_value.deduct.assert_not_called()
+        db.add.assert_not_called()
+
+    def test_cdo06_already_owned(self):
+        """CDO-06: already owned → AlreadyOwnedError, CreditService.deduct not called."""
+        from app.services.card_design_service import AlreadyOwnedError, purchase_design
+
+        db = _make_db()
+        user = _make_user(balance=1000)
+
+        existing = MagicMock()
+        q = MagicMock()
+        q.filter_by.return_value = q
+        q.first.return_value = existing
+        db.query.return_value = q
+
+        with patch(f"{_SVC}._resolve_price", return_value=300), \
+             patch(f"{_CSVC}.CreditService") as mock_cs:
+            with pytest.raises(AlreadyOwnedError):
+                purchase_design(db, user, "player_card", "compact")
+            mock_cs.return_value.deduct.assert_not_called()
+
+    def test_cdo07_insufficient_credits(self):
+        """CDO-07: InsufficientCreditsError → no ownership row created."""
+        from app.services.card_design_service import purchase_design
+        from app.services.credit_service import InsufficientCreditsError
+
+        db = _make_db()
+        user = _make_user(balance=0)
+        _make_query_none(db)
+
+        with patch(f"{_SVC}._resolve_price", return_value=300), \
+             patch(f"{_CSVC}.CreditService") as mock_cs:
+            mock_cs.return_value.deduct.side_effect = InsufficientCreditsError(300, 0)
+            with pytest.raises(InsufficientCreditsError):
+                purchase_design(db, user, "player_card", "compact")
+
+        db.add.assert_not_called()
+
+    def test_cdo08_integrity_error_raises_already_owned(self):
+        """CDO-08: IntegrityError on INSERT → AlreadyOwnedError, db.rollback() called."""
+        from sqlalchemy.exc import IntegrityError
+
+        from app.services.card_design_service import AlreadyOwnedError, purchase_design
+
+        db = _make_db()
+        user = _make_user(balance=500)
+        _make_query_none(db)
+
+        db.commit.side_effect = IntegrityError("mock", {}, Exception())
+
+        fake_tx = MagicMock()
+        fake_tx.id = 50
+
+        with patch(f"{_SVC}._resolve_price", return_value=300), \
+             patch(f"{_CSVC}.CreditService") as mock_cs:
+            mock_cs.return_value.deduct.return_value = fake_tx
+            with pytest.raises(AlreadyOwnedError):
+                purchase_design(db, user, "player_card", "compact")
+
+        db.rollback.assert_called_once()
+
+
+# ── CDO-09: CreditService.deduct does NOT call db.commit ─────────────────────
+
+def test_cdo09_deduct_uses_savepoint_not_commit():
+    """CDO-09: CreditService.deduct() uses begin_nested (SAVEPOINT), no outer commit inside deduct."""
+    from app.services.credit_service import CreditService
+    import inspect
+
+    src = inspect.getsource(CreditService.deduct)
+    assert "begin_nested" in src, "deduct must use begin_nested (SAVEPOINT)"
+    assert "db.commit" not in src.replace("# ", ""), \
+        "deduct must NOT call db.commit() — caller owns the outer transaction"
+
+
+# ── CDO-10..15: is_design_accessible ─────────────────────────────────────────
+
+class TestIsDesignAccessible:
+
+    def _accessible(self, db, user_id, card_type_id, design_id):
+        from app.services.card_design_service import is_design_accessible
+        return is_design_accessible(db, user_id, card_type_id, design_id)
+
+    def test_cdo10_free_player_design_always_accessible(self):
+        """CDO-10: player_card/fifa → True without any ownership row."""
+        db = _make_db()
+        _make_query_none(db)
+
+        with patch(f"{_SVC}._resolve_price", return_value=0):
+            assert self._accessible(db, 1, "player_card", "fifa") is True
+
+    def test_cdo11_premium_player_false_without_ownership(self):
+        """CDO-11: player_card/compact → False without ownership."""
+        db = _make_db()
+        _make_query_none(db)
+
+        with patch(f"{_SVC}._resolve_price", return_value=300):
+            result = self._accessible(db, 1, "player_card", "compact")
+        assert result is False
+
+    def test_cdo12_premium_player_true_with_ownership(self):
+        """CDO-12: player_card/compact → True after ownership row exists."""
+        db = _make_db()
+        _make_query_none(db)  # initial setup
+
+        existing_ownership = MagicMock()
+        q = MagicMock()
+        q.filter_by.return_value = q
+        q.first.return_value = existing_ownership
+        db.query.return_value = q
+
+        with patch(f"{_SVC}._resolve_price", return_value=300):
+            result = self._accessible(db, 1, "player_card", "compact")
+        assert result is True
+
+    def test_cdo13_welcome_false_without_ownership(self):
+        """CDO-13: welcome_card/default → False without ownership."""
+        db = _make_db()
+        _make_query_none(db)
+
+        result = self._accessible(db, 1, "welcome_card", "default")
+        assert result is False
+
+    def test_cdo14_welcome_true_with_ownership(self):
+        """CDO-14: welcome_card/default → True after ownership row exists."""
+        db = _make_db()
+
+        existing_ownership = MagicMock()
+        q = MagicMock()
+        q.filter_by.return_value = q
+        q.first.return_value = existing_ownership
+        db.query.return_value = q
+
+        result = self._accessible(db, 1, "welcome_card", "default")
+        assert result is True
+
+    def test_cdo15_legacy_json_shim(self):
+        """CDO-15: unlocked_card_variants contains design_id → True for player_card."""
+        from app.models.license import UserLicense
+
+        db = _make_db()
+
+        ownership_q = MagicMock()
+        ownership_q.filter_by.return_value = ownership_q
+        ownership_q.first.return_value = None  # no ownership row
+
+        fake_license = MagicMock(spec=UserLicense)
+        fake_license.unlocked_card_variants = ["compact", "showcase"]
+
+        license_q = MagicMock()
+        license_q.filter_by.return_value = license_q
+        license_q.first.return_value = fake_license
+
+        call_count = [0]
+        def _query_side_effect(model):
+            call_count[0] += 1
+            from app.models.card_design_ownership import CardDesignOwnership
+            if model is CardDesignOwnership:
+                return ownership_q
+            return license_q
+
+        db.query.side_effect = _query_side_effect
+
+        with patch(f"{_SVC}._resolve_price", return_value=300):
+            result = self._accessible(db, 1, "player_card", "compact")
+        assert result is True
+
+
+# ── CDO-16..17: price constants ───────────────────────────────────────────────
+
+def test_cdo16_welcome_card_price_nonzero():
+    """CDO-16: _NON_PLAYER_CARD_PRICES welcome_card/default > 0."""
+    from app.services.card_design_service import _NON_PLAYER_CARD_PRICES
+    assert _NON_PLAYER_CARD_PRICES[("welcome_card", "default")] > 0
+
+
+def test_cdo17_challenge_card_price_nonzero():
+    """CDO-17: _NON_PLAYER_CARD_PRICES challenge_card/challenge > 0."""
+    from app.services.card_design_service import _NON_PLAYER_CARD_PRICES
+    assert _NON_PLAYER_CARD_PRICES[("challenge_card", "challenge")] > 0
+
+
+# ── CDO-18: grant_design idempotency ─────────────────────────────────────────
+
+def test_cdo18_grant_design_idempotent():
+    """CDO-18: grant_design called twice → one row, no exception on second call."""
+    from app.services.card_design_service import grant_design
+
+    db = _make_db()
+    existing = MagicMock()
+    q = MagicMock()
+    q.filter_by.return_value = q
+    q.first.return_value = existing  # already exists
+    db.query.return_value = q
+
+    result = grant_design(db, user_id=1, card_type_id="welcome_card", design_id="default")
+
+    assert result is None  # idempotent return
+    db.add.assert_not_called()
+    db.commit.assert_not_called()
+
+
+# ── CDO-19..20: no auto-grant in user flows ───────────────────────────────────
+
+def test_cdo19_onboarding_does_not_grant_welcome_card():
+    """CDO-19: onboarding step-7 route does NOT call grant_design for welcome_card."""
+    import ast
+    from pathlib import Path
+
+    src_path = (
+        Path(__file__).resolve().parents[3]
+        / "app" / "api" / "web_routes" / "onboarding.py"
+    )
+    src = src_path.read_text(encoding="utf-8")
+    # grant_design must not be called in onboarding.py
+    assert "grant_design" not in src, (
+        "onboarding.py must NOT call grant_design — Welcome Card is not auto-granted on onboarding"
+    )
+
+
+def test_cdo20_challenge_completion_does_not_grant_challenge_card():
+    """CDO-20: challenge completion does NOT call grant_design for challenge_card."""
+    from pathlib import Path
+
+    src_path = (
+        Path(__file__).resolve().parents[3]
+        / "app" / "api" / "web_routes" / "vt_challenges.py"
+    )
+    src = src_path.read_text(encoding="utf-8")
+    # grant_design should not be called from challenge completion logic
+    # (only challenge_card_export calls card design service, not challenge result)
+    # We check the challenge result/complete handler specifically.
+    # The export handler IS allowed to call is_design_accessible.
+    # We verify grant_design is not called anywhere in the file.
+    assert "grant_design" not in src, (
+        "vt_challenges.py must NOT call grant_design — Challenge Card is not auto-granted"
+    )

--- a/tests/unit/services/test_card_design_ownership.py
+++ b/tests/unit/services/test_card_design_ownership.py
@@ -9,7 +9,7 @@ CDO-06  already owned → AlreadyOwnedError, no double deduction
 CDO-07  insufficient credits → InsufficientCreditsError, no ownership row
 CDO-08  race condition: IntegrityError → AlreadyOwnedError, rollback called
 CDO-09  CreditService.deduct does NOT call db.commit() (uses begin_nested/SAVEPOINT only)
-CDO-10  is_design_accessible player_card/fifa → True without ownership row
+CDO-10  is_design_accessible player_card/fifa → False without ownership row (no free bypass)
 CDO-11  is_design_accessible player_card/compact → False without ownership
 CDO-12  is_design_accessible player_card/compact → True after ownership
 CDO-13  is_design_accessible welcome_card/default → False without ownership
@@ -271,13 +271,12 @@ class TestIsDesignAccessible:
         from app.services.card_design_service import is_design_accessible
         return is_design_accessible(db, user_id, card_type_id, design_id)
 
-    def test_cdo10_free_player_design_always_accessible(self):
-        """CDO-10: player_card/fifa → True without any ownership row."""
+    def test_cdo10_fifa_requires_ownership_row(self):
+        """CDO-10: player_card/fifa → False without ownership row (no free bypass)."""
         db = _make_db()
         _make_query_none(db)
 
-        with patch(f"{_SVC}._resolve_price", return_value=0):
-            assert self._accessible(db, 1, "player_card", "fifa") is True
+        assert self._accessible(db, 1, "player_card", "fifa") is False
 
     def test_cdo11_premium_player_false_without_ownership(self):
         """CDO-11: player_card/compact → False without ownership."""

--- a/tests/unit/services/test_card_format_registry.py
+++ b/tests/unit/services/test_card_format_registry.py
@@ -1,0 +1,137 @@
+"""Card Format Registry tests — CFR-01..CFR-16.
+
+CFR-01  WELCOME_CARD_FORMATS has 7 entries
+CFR-02  All WC format credit_costs > 0
+CFR-03  WC format design_ids are unique
+CFR-04  CHALLENGE_CARD_FORMATS has 2 entries
+CFR-05  All CC format credit_costs > 0
+CFR-06  CC format design_ids are unique
+CFR-07  _NON_PLAYER_CARD_PRICES keys include all WC format design_ids
+CFR-08  _NON_PLAYER_CARD_PRICES keys include all CC format design_ids
+CFR-09  Legacy sentinel keys map to price=0
+CFR-10  _resolve_price works for a WC format design_id
+CFR-11  _resolve_price works for a CC format design_id
+CFR-12  NonPlayerCardFormatDefinition is a frozen dataclass
+CFR-13  WC format sort_orders are unique
+CFR-14  CC format sort_orders are unique
+CFR-15  purchase_design("welcome_card", "default") raises FreeDesignError
+CFR-16  purchase_design("challenge_card", "challenge") raises FreeDesignError
+"""
+import pytest
+from unittest.mock import MagicMock
+
+
+def test_cfr01_welcome_card_formats_has_7_entries():
+    from app.services.card_design_service import WELCOME_CARD_FORMATS
+    assert len(WELCOME_CARD_FORMATS) == 7
+
+
+def test_cfr02_wc_format_prices_never_zero():
+    from app.services.card_design_service import WELCOME_CARD_FORMATS
+    for fmt in WELCOME_CARD_FORMATS:
+        assert fmt.credit_cost > 0, f"WC format {fmt.design_id} must have credit_cost > 0"
+
+
+def test_cfr03_wc_format_design_ids_unique():
+    from app.services.card_design_service import WELCOME_CARD_FORMATS
+    ids = [f.design_id for f in WELCOME_CARD_FORMATS]
+    assert len(ids) == len(set(ids)), "WC format design_ids must be unique"
+
+
+def test_cfr04_challenge_card_formats_has_2_entries():
+    from app.services.card_design_service import CHALLENGE_CARD_FORMATS
+    assert len(CHALLENGE_CARD_FORMATS) == 2
+
+
+def test_cfr05_cc_format_prices_never_zero():
+    from app.services.card_design_service import CHALLENGE_CARD_FORMATS
+    for fmt in CHALLENGE_CARD_FORMATS:
+        assert fmt.credit_cost > 0, f"CC format {fmt.design_id} must have credit_cost > 0"
+
+
+def test_cfr06_cc_format_design_ids_unique():
+    from app.services.card_design_service import CHALLENGE_CARD_FORMATS
+    ids = [f.design_id for f in CHALLENGE_CARD_FORMATS]
+    assert len(ids) == len(set(ids)), "CC format design_ids must be unique"
+
+
+def test_cfr07_non_player_prices_covers_all_wc_formats():
+    from app.services.card_design_service import WELCOME_CARD_FORMATS, _NON_PLAYER_CARD_PRICES
+    for fmt in WELCOME_CARD_FORMATS:
+        key = ("welcome_card", fmt.design_id)
+        assert key in _NON_PLAYER_CARD_PRICES, f"Missing price entry for {key}"
+
+
+def test_cfr08_non_player_prices_covers_all_cc_formats():
+    from app.services.card_design_service import CHALLENGE_CARD_FORMATS, _NON_PLAYER_CARD_PRICES
+    for fmt in CHALLENGE_CARD_FORMATS:
+        key = ("challenge_card", fmt.design_id)
+        assert key in _NON_PLAYER_CARD_PRICES, f"Missing price entry for {key}"
+
+
+def test_cfr09_legacy_sentinel_keys_are_zero():
+    from app.services.card_design_service import _NON_PLAYER_CARD_PRICES
+    assert _NON_PLAYER_CARD_PRICES[("welcome_card", "default")] == 0
+    assert _NON_PLAYER_CARD_PRICES[("challenge_card", "challenge")] == 0
+
+
+def test_cfr10_resolve_price_wc_format():
+    from app.services.card_design_service import _resolve_price, WELCOME_CARD_FORMATS
+    fmt = WELCOME_CARD_FORMATS[0]
+    price = _resolve_price("welcome_card", fmt.design_id)
+    assert price == fmt.credit_cost
+    assert price > 0
+
+
+def test_cfr11_resolve_price_cc_format():
+    from app.services.card_design_service import _resolve_price, CHALLENGE_CARD_FORMATS
+    fmt = CHALLENGE_CARD_FORMATS[0]
+    price = _resolve_price("challenge_card", fmt.design_id)
+    assert price == fmt.credit_cost
+    assert price > 0
+
+
+def test_cfr12_non_player_format_definition_is_frozen():
+    from app.services.card_design_service import NonPlayerCardFormatDefinition
+    fmt = NonPlayerCardFormatDefinition(
+        design_id="test", label="Test", style_tag="TEST",
+        dims="1x1", credit_cost=10, preview_platform="test",
+    )
+    with pytest.raises(Exception):
+        fmt.credit_cost = 99  # type: ignore[misc]
+
+
+def test_cfr13_wc_format_sort_orders_unique():
+    from app.services.card_design_service import WELCOME_CARD_FORMATS
+    orders = [f.sort_order for f in WELCOME_CARD_FORMATS]
+    assert len(orders) == len(set(orders)), "WC format sort_orders must be unique"
+
+
+def test_cfr14_cc_format_sort_orders_unique():
+    from app.services.card_design_service import CHALLENGE_CARD_FORMATS
+    orders = [f.sort_order for f in CHALLENGE_CARD_FORMATS]
+    assert len(orders) == len(set(orders)), "CC format sort_orders must be unique"
+
+
+def test_cfr15_purchase_sentinel_wc_default_raises_free_design_error():
+    """CFR-15: purchase_design('welcome_card','default') → FreeDesignError (sentinel key)."""
+    from app.services.card_design_service import FreeDesignError, purchase_design
+
+    db   = MagicMock()
+    user = MagicMock()
+    user.id = 1
+
+    with pytest.raises(FreeDesignError):
+        purchase_design(db, user, "welcome_card", "default")
+
+
+def test_cfr16_purchase_sentinel_cc_challenge_raises_free_design_error():
+    """CFR-16: purchase_design('challenge_card','challenge') → FreeDesignError (sentinel key)."""
+    from app.services.card_design_service import FreeDesignError, purchase_design
+
+    db   = MagicMock()
+    user = MagicMock()
+    user.id = 1
+
+    with pytest.raises(FreeDesignError):
+        purchase_design(db, user, "challenge_card", "challenge")

--- a/tests/unit/test_card_export.py
+++ b/tests/unit/test_card_export.py
@@ -82,14 +82,20 @@ def _make_license() -> MagicMock:
     return lic
 
 
-def _mock_db(target_user=None, target_license=None):
-    """Return a MagicMock db whose sequential .query() calls yield the given objects."""
+def _mock_db(target_user=None, target_license=None, cdo_owned: bool = True):
+    """Return a MagicMock db whose sequential .query() calls yield the given objects.
+
+    cdo_owned=True (default) makes the CDO ownership check succeed (design is accessible).
+    """
     db = MagicMock()
     q_user = MagicMock()
     q_user.filter.return_value.first.return_value = target_user
     q_license = MagicMock()
     q_license.filter.return_value.first.return_value = target_license
-    db.query.side_effect = [q_user, q_license]
+    # CDO ownership check — every design (incl. fifa) now requires a CDO row
+    q_cdo = MagicMock()
+    q_cdo.filter_by.return_value.first.return_value = MagicMock() if cdo_owned else None
+    db.query.side_effect = [q_user, q_license, q_cdo]
     return db
 
 

--- a/tests/unit/test_card_export_cs4a.py
+++ b/tests/unit/test_card_export_cs4a.py
@@ -73,7 +73,27 @@ def _mock_db(target_user=None, target_license=None) -> MagicMock:
     q_user.filter.return_value.first.return_value = target_user
     q_license = MagicMock()
     q_license.filter.return_value.first.return_value = target_license
-    db.query.side_effect = [q_user, q_license]
+    q_license.filter_by.return_value.first.return_value = target_license
+
+    # Return a fake ownership row so the export guard (is_design_accessible) passes.
+    # The existing 422/200 tests are about bucket validation, not ownership.
+    q_ownership = MagicMock()
+    q_ownership.filter_by.return_value.first.return_value = MagicMock()  # owned
+
+    def _side_effect(model):
+        from app.models.user import User
+        from app.models.license import UserLicense
+        from app.models.card_design_ownership import CardDesignOwnership
+        if model is User:
+            return q_user
+        if model is UserLicense:
+            return q_license
+        if model is CardDesignOwnership:
+            return q_ownership
+        # CardDesign or unknown: raise StopIteration, caught by _load_cache → DESIGNS fallback
+        raise StopIteration
+
+    db.query.side_effect = _side_effect
     return db
 
 

--- a/tests/unit/test_card_export_cs5.py
+++ b/tests/unit/test_card_export_cs5.py
@@ -391,8 +391,10 @@ class TestCS5UnsupportedBucket:
         from app.api.web_routes import public_player as _pp
         from app.services import card_export_service as _export_svc
 
+        from app.models.user import UserRole
         _mock_current_user = MagicMock()
-        _mock_current_user.id = 7   # matches user_id in URL → ownership check passes
+        _mock_current_user.id = 7
+        _mock_current_user.role = UserRole.ADMIN  # bypass ownership guard; test is about bucket validation
 
         db = _mock_db_for_export(user_id=7, card_variant="classic_lite")
         app.dependency_overrides[get_db] = lambda: db

--- a/tests/unit/test_card_export_theme_sync.py
+++ b/tests/unit/test_card_export_theme_sync.py
@@ -91,7 +91,10 @@ def _mock_db(target_user: MagicMock | None = None, target_license: MagicMock | N
     q_user.filter.return_value.first.return_value = target_user
     q_lic = MagicMock()
     q_lic.filter.return_value.first.return_value = target_license
-    db.query.side_effect = [q_user, q_lic]
+    # CDO ownership check — all designs (incl. fifa) require an ownership row
+    q_cdo = MagicMock()
+    q_cdo.filter_by.return_value.first.return_value = MagicMock()  # owned
+    db.query.side_effect = [q_user, q_lic, q_cdo]
     return db
 
 

--- a/tests/unit/test_card_export_video.py
+++ b/tests/unit/test_card_export_video.py
@@ -91,7 +91,24 @@ def _mock_db(target_user=None, target_license=None):
     q_user.filter.return_value.first.return_value = target_user
     q_license = MagicMock()
     q_license.filter.return_value.first.return_value = target_license
-    db.query.side_effect = [q_user, q_license]
+    q_license.filter_by.return_value.first.return_value = target_license
+
+    q_ownership = MagicMock()
+    q_ownership.filter_by.return_value.first.return_value = MagicMock()  # owned
+
+    def _side_effect(model):
+        from app.models.user import User
+        from app.models.license import UserLicense
+        from app.models.card_design_ownership import CardDesignOwnership
+        if model is User:
+            return q_user
+        if model is UserLicense:
+            return q_license
+        if model is CardDesignOwnership:
+            return q_ownership
+        raise StopIteration  # CardDesign → caught by _load_cache → DESIGNS fallback
+
+    db.query.side_effect = _side_effect
     return db
 
 


### PR DESCRIPTION
## Summary

- `CardDesignOwnership` model + migration `2026_05_28_0900` — sole entitlement source for card designs
- `purchase_design()` service — CDO write, credit deduction, `FreeDesignError`/`AlreadyOwnedError`/`InsufficientCreditsError`
- Export guard in `public_player.py` — 403 if requesting user does not own the rendered design
- My Cards Hub unification — `/my-cards/player-card`, `/my-cards/welcome-card`, `/my-cards/challenge-card` routes, entitlement-aware shop state machine (`get_card`/`owned`/`locked`/`not_available`)
- Format-level ownership — `WELCOME_CARD_FORMATS` + `CHALLENGE_CARD_FORMATS` registries; per-format CDO rows
- Phase 3 No Free Card security fix — FIFA Classic `credit_cost=300`, `not_available` state for 0-CR designs, `FreeDesignError` guard on purchase
- **Migration `2026_05_28_1000`**: FIFA Classic `is_premium=TRUE, credit_cost=300`; classic_lite `is_active=FALSE`
- Backfill script: `scripts/backfill_card_design_ownerships.py`

## 0 CR design audit

| id | credit_cost | is_premium | is_active | CDO rows | Action |
|----|-------------|------------|-----------|----------|--------|
| `fifa` | 0→**300** | F→**T** | T | 0 | Migration fixes |
| `classic_lite` | 0 | F | T→**F** | 0 | Migration deactivates (CS-5 PoC, never productised) |

## New files

`app/models/card_design_ownership.py`, `app/templates/my_cards_shop.html`, `app/templates/my_cards_player_card.html`, `app/templates/my_cards_welcome_card.html`, `app/templates/includes/mc_format_grid.html`, `scripts/backfill_card_design_ownerships.py`, `alembic/versions/2026_05_28_0900_*`, `alembic/versions/2026_05_28_1000_*`

## New tests (45+)

`test_export_guard.py`, `test_my_cards_shop.py`, `test_card_design_ownership.py`, `test_my_cards_player_card.py`, `test_my_cards_welcome_card.py`, `test_card_format_registry.py`

## Merge order

Merge after **PR-A** (#184) merges to main, then retarget this PR to main. PR-C bases on this branch.

## Test plan

- [ ] Unit Tests (incl. all new CDO/EG/MCS test files)
- [ ] API Smoke Tests green
- [ ] `card-export-gate` path-filtered check triggers (public_player.py changed)
- [ ] `card-unlock-apply-gate` path-filtered check triggers (dashboard.py changed)
- [ ] Migration `2026_05_28_0900` runs cleanly on fresh DB
- [ ] Migration `2026_05_28_1000` updates fifa pricing + deactivates classic_lite
- [ ] POST `/my-cards/designs/player_card/compact/get` → 303 redirect on success
- [ ] Export 403 for unowned design; export 200 for owned design

🤖 Generated with [Claude Code](https://claude.com/claude-code)