### PR TITLE
feat(shop): introduce central card shop and owned-only My Cards

### DIFF
--- a/app/api/web_routes/__init__.py
+++ b/app/api/web_routes/__init__.py
@@ -28,6 +28,7 @@ from . import (
     public_tournament,
     sport_director,
     my_cards,
+    shop,
     friends,
     vt_challenges,
     ws_events,
@@ -65,6 +66,7 @@ router.include_router(public_player.router)      # 🌐 Public player card (no a
 router.include_router(public_tournament.router)  # 🌐 Public event detail page (no auth)
 router.include_router(sport_director.router)     # 🏅 Sport Director team enrollment
 router.include_router(my_cards.router)           # 🃏 My Cards hub (/my-cards)
+router.include_router(shop.router)               # 🛒 Card Shop (/shop)
 router.include_router(friends.router)            # 👥 Friendship system (/friends)
 router.include_router(vt_challenges.router)      # 🎮 VT Challenges (/challenges)
 router.include_router(ws_events.router)           # 🔌 Per-user WS event stream (/ws/events)

--- a/app/api/web_routes/my_cards.py
+++ b/app/api/web_routes/my_cards.py
@@ -1,4 +1,4 @@
-"""My Cards hub — cross-card-type navigation hub and family shop routes."""
+"""My Cards hub — owned-card collection and purchase compat wrapper."""
 from pathlib import Path
 
 from fastapi import APIRouter, Depends, Query, Request
@@ -27,11 +27,11 @@ templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
 
 router = APIRouter(tags=["my-cards"])
 
-# Maps card_type_id → family page path (used for purchase redirect targets)
+# Maps card_type_id → canonical collection path (used for purchase redirect targets)
 _TYPE_TO_FAMILY_PATH: dict[str, str] = {
-    "player_card":    "/my-cards/player-card",
-    "welcome_card":   "/my-cards/welcome-card",
-    "challenge_card": "/my-cards/challenge-card",
+    "player_card":    "/my-cards/player",
+    "welcome_card":   "/my-cards/welcome",
+    "challenge_card": "/my-cards/challenge",
 }
 
 
@@ -43,7 +43,7 @@ async def my_cards_hub(
     db: Session = Depends(get_db),
     user: User  = Depends(get_current_user_web),
 ):
-    """Hub — format-count tiles for all three card families."""
+    """Hub — owned-count tiles for all three card families."""
     all_designs = get_all_designs(db)
     pc_total    = len(all_designs)
     pc_owned_ids = set(get_owned_design_ids(db, user.id, "player_card"))
@@ -84,23 +84,40 @@ async def my_cards_hub(
     )
 
 
-# ── /my-cards/shop — retired, redirect by tab param ──────────────────────────
+# ── /my-cards/shop — retired, redirect to central shop ───────────────────────
 
 @router.get("/my-cards/shop")
 async def my_cards_shop(tab: str | None = Query(default=None)):
-    """Retired shop page — redirects to the appropriate family shop."""
+    """Retired shop page — redirects to the card shop."""
     destinations = {
-        "player":    "/my-cards/player-card",
-        "welcome":   "/my-cards/welcome-card",
-        "challenge": "/my-cards/challenge-card",
+        "player":    "/shop/cards/player",
+        "welcome":   "/shop/cards/welcome",
+        "challenge": "/shop/cards/challenge",
     }
     return RedirectResponse(
-        url=destinations.get(tab or "", "/my-cards"),
-        status_code=302,
+        url=destinations.get(tab or "", "/shop/cards"),
+        status_code=301,
     )
 
 
-# ── Purchase POST ─────────────────────────────────────────────────────────────
+# ── Legacy hyphenated paths → canonical short paths (301) ────────────────────
+
+@router.get("/my-cards/player-card")
+async def my_cards_player_card_legacy():
+    return RedirectResponse(url="/my-cards/player", status_code=301)
+
+
+@router.get("/my-cards/welcome-card")
+async def my_cards_welcome_card_legacy():
+    return RedirectResponse(url="/my-cards/welcome", status_code=301)
+
+
+@router.get("/my-cards/challenge-card")
+async def my_cards_challenge_card_legacy():
+    return RedirectResponse(url="/my-cards/challenge", status_code=301)
+
+
+# ── Purchase POST compat wrapper ──────────────────────────────────────────────
 
 @router.post("/my-cards/designs/{card_type_id}/{design_id}/get")
 async def get_card(
@@ -109,7 +126,7 @@ async def get_card(
     db: Session = Depends(get_db),
     user: User  = Depends(get_current_user_web),
 ):
-    """Purchase a card design entitlement (credit deduction + ownership row)."""
+    """Compat purchase endpoint — delegates to purchase_design(), redirects to collection."""
     family_path = _TYPE_TO_FAMILY_PATH.get(card_type_id, "/my-cards")
     try:
         purchase_design(db, user, card_type_id, design_id)
@@ -127,25 +144,16 @@ async def get_card(
         return RedirectResponse(f"{family_path}?error=invalid", status_code=303)
 
 
-# ── Player Card family shop ───────────────────────────────────────────────────
+# ── Player Card collection (owned-only) — canonical: /my-cards/player ─────────
 
-@router.get("/my-cards/player-card", response_class=HTMLResponse)
+@router.get("/my-cards/player", response_class=HTMLResponse)
 async def my_cards_player_card(
     request: Request,
     db: Session     = Depends(get_db),
     user: User      = Depends(get_current_user_web),
 ):
-    """Player Card format shop — browse and purchase Player Card designs."""
+    """Player Card owned-only collection."""
     all_designs = get_all_designs(db)
-    credits     = user.credit_balance
-
-    def _state(design) -> str:
-        if is_design_accessible(db, user.id, "player_card", design.id):
-            return "owned"
-        # Guard: 0-CR designs are never purchasable — must be granted explicitly.
-        if design.credit_cost == 0:
-            return "not_available"
-        return "get_card" if credits >= design.credit_cost else "locked"
 
     design_rows = [
         {
@@ -154,13 +162,14 @@ async def my_cards_player_card(
             "description": d.description,
             "credit_cost": d.credit_cost,
             "is_premium":  d.is_premium,
-            "state":       _state(d),
+            "state":       "owned",
         }
         for d in all_designs
+        if is_design_accessible(db, user.id, "player_card", d.id)
     ]
 
-    owned_count = sum(1 for r in design_rows if r["state"] == "owned")
-    total_count = len(design_rows)
+    owned_count = len(design_rows)
+    total_count = owned_count
 
     return templates.TemplateResponse(
         "my_cards_player_card.html",
@@ -177,39 +186,33 @@ async def my_cards_player_card(
     )
 
 
-# ── Welcome Card family shop ──────────────────────────────────────────────────
+# ── Welcome Card collection (owned-only) — canonical: /my-cards/welcome ───────
 
-@router.get("/my-cards/welcome-card", response_class=HTMLResponse)
+@router.get("/my-cards/welcome", response_class=HTMLResponse)
 async def my_cards_welcome_card(
     request: Request,
     db: Session     = Depends(get_db),
     user: User      = Depends(get_current_user_web),
 ):
-    """Welcome Card format shop — browse and purchase Welcome Card platform formats."""
-    credits = user.credit_balance
-
-    def _wc_state(fmt) -> str:
-        if is_design_accessible(db, user.id, "welcome_card", fmt.design_id):
-            return "owned"
-        return "get_card" if credits >= fmt.credit_cost else "locked"
-
+    """Welcome Card owned-only format collection."""
     format_rows = [
         {
-            "design_id":       fmt.design_id,
-            "label":           fmt.label,
-            "style_tag":       fmt.style_tag,
-            "dims":            fmt.dims,
-            "credit_cost":     fmt.credit_cost,
+            "design_id":        fmt.design_id,
+            "label":            fmt.label,
+            "style_tag":        fmt.style_tag,
+            "dims":             fmt.dims,
+            "credit_cost":      fmt.credit_cost,
             "preview_platform": fmt.preview_platform,
-            "state":           _wc_state(fmt),
-            "preview_url":     f"/profile/onboarding-card?platform={fmt.preview_platform}",
-            "export_url":      f"/profile/onboarding-card/export?platform={fmt.preview_platform}",
+            "state":            "owned",
+            "preview_url":      f"/profile/onboarding-card?platform={fmt.preview_platform}",
+            "export_url":       f"/profile/onboarding-card/export?platform={fmt.preview_platform}",
         }
         for fmt in WELCOME_CARD_FORMATS
+        if is_design_accessible(db, user.id, "welcome_card", fmt.design_id)
     ]
 
-    owned_count = sum(1 for r in format_rows if r["state"] == "owned")
-    total_count = len(format_rows)
+    owned_count = len(format_rows)
+    total_count = owned_count
 
     return templates.TemplateResponse(
         "my_cards_welcome_card.html",
@@ -226,23 +229,15 @@ async def my_cards_welcome_card(
     )
 
 
+# ── Challenge Card collection (owned-only) — canonical: /my-cards/challenge ───
 
-# ── Challenge Card format shop ─────────────────────────────────────────────────
-
-@router.get("/my-cards/challenge-card", response_class=HTMLResponse)
+@router.get("/my-cards/challenge", response_class=HTMLResponse)
 async def my_cards_challenge_card(
     request: Request,
     db: Session = Depends(get_db),
     user: User  = Depends(get_current_user_web),
 ):
-    """Challenge Card format shop — browse and purchase Challenge Card formats."""
-    credits = user.credit_balance
-
-    def _cc_fmt_state(fmt) -> str:
-        if is_design_accessible(db, user.id, "challenge_card", fmt.design_id):
-            return "owned"
-        return "get_card" if credits >= fmt.credit_cost else "locked"
-
+    """Challenge Card owned-only format collection."""
     cc_format_rows = [
         {
             "design_id":   fmt.design_id,
@@ -250,12 +245,13 @@ async def my_cards_challenge_card(
             "style_tag":   fmt.style_tag,
             "dims":        fmt.dims,
             "credit_cost": fmt.credit_cost,
-            "state":       _cc_fmt_state(fmt),
+            "state":       "owned",
         }
         for fmt in CHALLENGE_CARD_FORMATS
+        if is_design_accessible(db, user.id, "challenge_card", fmt.design_id)
     ]
-    cc_owned_count = sum(1 for r in cc_format_rows if r["state"] == "owned")
-    cc_total       = len(cc_format_rows)
+    cc_owned_count = len(cc_format_rows)
+    cc_total       = cc_owned_count
 
     return templates.TemplateResponse(
         "my_cards_challenge_card.html",

--- a/app/api/web_routes/shop.py
+++ b/app/api/web_routes/shop.py
@@ -1,0 +1,216 @@
+"""Card shop — browse and purchase card designs and platform formats."""
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+from sqlalchemy.orm import Session
+
+from ...database import get_db
+from ...dependencies import get_current_user_web
+from ...models.user import User
+from ...services.card_design_service import (
+    CHALLENGE_CARD_FORMATS,
+    WELCOME_CARD_FORMATS,
+    AlreadyOwnedError,
+    FreeDesignError,
+    get_all_designs,
+    is_design_accessible,
+    purchase_design,
+)
+from ...services.credit_service import InsufficientCreditsError
+
+BASE_DIR = Path(__file__).resolve().parent.parent.parent
+templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
+
+router = APIRouter(tags=["shop"])
+
+_TYPE_TO_SHOP_PATH: dict[str, str] = {
+    "player_card":    "/shop/cards/player",
+    "welcome_card":   "/shop/cards/welcome",
+    "challenge_card": "/shop/cards/challenge",
+}
+
+
+# ── Landing ────────────────────────────────────────────────────────────────────
+
+@router.get("/shop", response_class=HTMLResponse)
+async def shop_landing(
+    request: Request,
+    user: User = Depends(get_current_user_web),
+):
+    return templates.TemplateResponse(
+        "shop_landing.html",
+        {
+            "request": request,
+            "user":    user,
+            "spec_dashboard_url":  "/dashboard/lfa-football-player",
+            "spec_dashboard_icon": "⚽",
+        },
+    )
+
+
+@router.get("/shop/cards", response_class=HTMLResponse)
+async def shop_cards(
+    request: Request,
+    user: User = Depends(get_current_user_web),
+):
+    return templates.TemplateResponse(
+        "shop_cards.html",
+        {
+            "request": request,
+            "user":    user,
+            "spec_dashboard_url":  "/dashboard/lfa-football-player",
+            "spec_dashboard_icon": "⚽",
+        },
+    )
+
+
+# ── Player Card shop ───────────────────────────────────────────────────────────
+
+@router.get("/shop/cards/player", response_class=HTMLResponse)
+async def shop_player_card(
+    request: Request,
+    db: Session = Depends(get_db),
+    user: User  = Depends(get_current_user_web),
+):
+    all_designs = get_all_designs(db)
+    credits = user.credit_balance
+
+    def _state(design) -> str:
+        if is_design_accessible(db, user.id, "player_card", design.id):
+            return "owned"
+        if design.credit_cost == 0:
+            return "not_available"
+        return "get_card" if credits >= design.credit_cost else "locked"
+
+    design_rows = [
+        {
+            "id":          d.id,
+            "label":       d.label,
+            "description": d.description,
+            "credit_cost": d.credit_cost,
+            "is_premium":  d.is_premium,
+            "state":       _state(d),
+        }
+        for d in all_designs
+    ]
+
+    return templates.TemplateResponse(
+        "shop_player_card.html",
+        {
+            "request":         request,
+            "user":            user,
+            "design_rows":     design_rows,
+            "flash_purchased": request.query_params.get("purchased"),
+            "flash_error":     request.query_params.get("error"),
+            "spec_dashboard_url": "/dashboard/lfa-football-player",
+        },
+    )
+
+
+# ── Welcome Card shop ──────────────────────────────────────────────────────────
+
+@router.get("/shop/cards/welcome", response_class=HTMLResponse)
+async def shop_welcome_card(
+    request: Request,
+    db: Session = Depends(get_db),
+    user: User  = Depends(get_current_user_web),
+):
+    credits = user.credit_balance
+
+    def _wc_state(fmt) -> str:
+        if is_design_accessible(db, user.id, "welcome_card", fmt.design_id):
+            return "owned"
+        return "get_card" if credits >= fmt.credit_cost else "locked"
+
+    format_rows = [
+        {
+            "design_id":        fmt.design_id,
+            "label":            fmt.label,
+            "style_tag":        fmt.style_tag,
+            "dims":             fmt.dims,
+            "credit_cost":      fmt.credit_cost,
+            "preview_platform": fmt.preview_platform,
+            "state":            _wc_state(fmt),
+            "preview_url":      f"/profile/onboarding-card?platform={fmt.preview_platform}",
+            "export_url":       f"/profile/onboarding-card/export?platform={fmt.preview_platform}",
+        }
+        for fmt in WELCOME_CARD_FORMATS
+    ]
+
+    return templates.TemplateResponse(
+        "shop_welcome_card.html",
+        {
+            "request":         request,
+            "user":            user,
+            "format_rows":     format_rows,
+            "flash_purchased": request.query_params.get("purchased"),
+            "flash_error":     request.query_params.get("error"),
+            "spec_dashboard_url": "/dashboard/lfa-football-player",
+        },
+    )
+
+
+# ── Challenge Card shop ────────────────────────────────────────────────────────
+
+@router.get("/shop/cards/challenge", response_class=HTMLResponse)
+async def shop_challenge_card(
+    request: Request,
+    db: Session = Depends(get_db),
+    user: User  = Depends(get_current_user_web),
+):
+    credits = user.credit_balance
+
+    def _cc_state(fmt) -> str:
+        if is_design_accessible(db, user.id, "challenge_card", fmt.design_id):
+            return "owned"
+        return "get_card" if credits >= fmt.credit_cost else "locked"
+
+    format_rows = [
+        {
+            "design_id":   fmt.design_id,
+            "label":       fmt.label,
+            "style_tag":   fmt.style_tag,
+            "dims":        fmt.dims,
+            "credit_cost": fmt.credit_cost,
+            "state":       _cc_state(fmt),
+        }
+        for fmt in CHALLENGE_CARD_FORMATS
+    ]
+
+    return templates.TemplateResponse(
+        "shop_challenge_card.html",
+        {
+            "request":         request,
+            "user":            user,
+            "format_rows":     format_rows,
+            "flash_purchased": request.query_params.get("purchased"),
+            "flash_error":     request.query_params.get("error"),
+            "spec_dashboard_url": "/dashboard/lfa-football-player",
+        },
+    )
+
+
+# ── Purchase POST ──────────────────────────────────────────────────────────────
+
+@router.post("/shop/cards/{card_type_id}/buy/{design_id}")
+async def shop_buy(
+    card_type_id: str,
+    design_id: str,
+    db: Session = Depends(get_db),
+    user: User  = Depends(get_current_user_web),
+):
+    """Purchase a card design/format from the shop (credit deduction + ownership row)."""
+    shop_path = _TYPE_TO_SHOP_PATH.get(card_type_id, "/shop/cards")
+    try:
+        purchase_design(db, user, card_type_id, design_id)
+        return RedirectResponse(f"{shop_path}?purchased={design_id}", status_code=303)
+    except FreeDesignError:
+        return RedirectResponse(f"{shop_path}?error=free",    status_code=303)
+    except AlreadyOwnedError:
+        return RedirectResponse(f"{shop_path}?error=owned",   status_code=303)
+    except InsufficientCreditsError:
+        return RedirectResponse(f"{shop_path}?error=credits", status_code=303)
+    except ValueError:
+        return RedirectResponse(f"{shop_path}?error=invalid", status_code=303)

--- a/app/templates/dashboard_student_new.html
+++ b/app/templates/dashboard_student_new.html
@@ -271,6 +271,7 @@
             </div>
             <div class="dc-ctas">
                 <a href="/my-cards" class="dc-cta-primary">My Cards →</a>
+                <a href="/shop/cards/player" class="dc-cta-ghost">Shop →</a>
             </div>
         </div>
 
@@ -289,6 +290,7 @@
             </div>
             <div class="dc-ctas">
                 <a href="/my-cards" class="dc-cta-primary">My Cards →</a>
+                <a href="/shop/cards/welcome" class="dc-cta-ghost">Shop →</a>
             </div>
         </div>
 
@@ -302,6 +304,7 @@
             </div>
             <div class="dc-ctas">
                 <a href="/my-cards" class="dc-cta-primary">My Cards →</a>
+                <a href="/shop/cards/challenge" class="dc-cta-ghost">Shop →</a>
                 <a href="/challenges/send" class="dc-cta-ghost">Send →</a>
             </div>
         </div>

--- a/app/templates/my_cards_challenge_card.html
+++ b/app/templates/my_cards_challenge_card.html
@@ -1,6 +1,6 @@
 {% extends "student_base.html" %}
 
-{% block title %}Challenge Card Shop — LFA Education Center{% endblock %}
+{% block title %}My Challenge Card Formats — LFA Education Center{% endblock %}
 {% block active_page %}lfa-player{% endblock %}
 
 {% block student_header %}
@@ -10,223 +10,162 @@
 {% endblock %}
 
 {% block extra_styles %}
+{% include "includes/mc_format_grid.html" %}
 <style>
-    .cc-shop {
-        max-width: 900px;
-        margin: 0 auto;
-        padding: 1.5rem 1rem 4rem;
-    }
-
-    .cc-back {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.3rem;
-        font-size: 0.8rem;
-        color: var(--app-text-muted);
-        text-decoration: none;
-        margin-bottom: 1.2rem;
-    }
-    .cc-back:hover { color: var(--app-text); }
-
-    .cc-header { margin-bottom: 1.8rem; }
-    .cc-header h1 {
-        font-size: 1.6rem;
-        font-weight: 700;
-        color: var(--app-text);
-        margin: 0 0 0.4rem;
-    }
-    .cc-header p {
-        font-size: 0.9rem;
-        color: var(--app-text-muted);
-        margin: 0;
-        max-width: 560px;
-    }
-
-    /* ── Format grid ── */
-    .cc-format-grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-        gap: 1rem;
-        margin-bottom: 2rem;
-    }
-
-    .cc-format-card {
-        background: #0f172a;
-        border: 1px solid #1e293b;
-        border-radius: 12px;
-        padding: 1rem;
-        display: flex;
-        flex-direction: column;
-        gap: 0.6rem;
-    }
-
-    .cc-format-tag {
-        font-size: 0.63rem;
-        font-weight: 700;
-        letter-spacing: 0.08em;
-        color: #475569;
-        text-transform: uppercase;
-    }
-    .cc-format-label {
-        font-weight: 700;
-        font-size: 0.92rem;
-        color: #f1f5f9;
-    }
-    .cc-format-dims {
-        font-size: 0.72rem;
-        color: #475569;
-    }
-
-    /* State badges */
-    .cc-badge-owned {
-        display: inline-block;
-        padding: 0.18rem 0.5rem;
-        border-radius: 10px;
-        font-size: 0.69rem;
-        font-weight: 700;
-        background: #1e3a5f;
-        color: #93c5fd;
-        align-self: flex-start;
-    }
-    .cc-badge-get {
-        display: inline-block;
-        padding: 0.18rem 0.5rem;
-        border-radius: 10px;
-        font-size: 0.69rem;
-        font-weight: 700;
-        background: #78350f;
-        color: #fde68a;
-        align-self: flex-start;
-    }
-    .cc-badge-locked {
-        display: inline-block;
-        padding: 0.18rem 0.5rem;
-        border-radius: 10px;
-        font-size: 0.69rem;
-        font-weight: 700;
-        background: #1e293b;
-        color: #475569;
-        align-self: flex-start;
-    }
-
-    /* CTAs */
-    .cc-btn-owned {
-        display: block;
-        width: 100%;
-        padding: 0.45rem 0.75rem;
-        border-radius: 8px;
-        font-size: 0.82rem;
-        font-weight: 600;
-        text-align: center;
-        background: #1e3a5f;
-        color: #93c5fd;
-        cursor: default;
-        border: none;
-    }
-    .cc-btn-get {
-        display: block;
-        width: 100%;
-        padding: 0.45rem 0.75rem;
-        border-radius: 8px;
-        font-size: 0.82rem;
-        font-weight: 600;
-        text-align: center;
-        cursor: pointer;
-        border: none;
-        background: #854d0e;
-        color: #fde68a;
-    }
-    .cc-btn-get:hover { opacity: 0.9; }
-    .cc-btn-locked {
-        display: block;
-        width: 100%;
-        padding: 0.45rem 0.75rem;
-        border-radius: 8px;
-        font-size: 0.82rem;
-        font-weight: 600;
-        text-align: center;
-        cursor: not-allowed;
-        border: none;
-        background: #1e293b;
-        color: #334155;
-        opacity: 0.7;
-    }
-
-    /* ── Footer CTA ── */
-    .cc-results-cta {
-        margin-top: 2rem;
-        text-align: center;
-    }
-    .cc-results-cta a {
-        font-size: 0.9rem;
-        font-weight: 600;
-        color: var(--app-accent, #667eea);
-        text-decoration: none;
-    }
-    .cc-results-cta a:hover { opacity: 0.85; }
+  .mcc-wrap {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 1.5rem 1rem 4rem;
+  }
+  .mcc-breadcrumb {
+    font-size: 0.8rem;
+    color: #64748b;
+    margin-bottom: 1.25rem;
+  }
+  .mcc-breadcrumb a { color: #94a3b8; text-decoration: none; }
+  .mcc-breadcrumb a:hover { color: #f1f5f9; }
+  .mcc-breadcrumb span { margin: 0 0.35rem; }
+  .mcc-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+  }
+  .mcc-header h1 { font-size: 1.4rem; font-weight: 700; color: #f8fafc; margin: 0; }
+  .mcc-credits-badge {
+    background: #1e293b;
+    border: 1px solid #334155;
+    border-radius: 20px;
+    padding: 0.35rem 0.9rem;
+    font-size: 0.85rem;
+    color: #94a3b8;
+  }
+  .mcc-credits-badge strong { color: #FFD200; }
+  .mcc-shop-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.82rem;
+    font-weight: 600;
+    color: #FFD200;
+    text-decoration: none;
+    margin-bottom: 1.5rem;
+  }
+  .mcc-shop-link:hover { opacity: 0.85; text-decoration: none; }
+  /* Empty state */
+  .mcc-empty {
+    text-align: center;
+    padding: 3rem 1rem;
+    color: #64748b;
+  }
+  .mcc-empty-icon { font-size: 2.5rem; margin-bottom: 0.75rem; }
+  .mcc-empty h3 { font-size: 1.1rem; font-weight: 600; color: #94a3b8; margin: 0 0 0.5rem; }
+  .mcc-empty p { font-size: 0.88rem; margin: 0 0 1.25rem; }
+  .mcc-empty-cta {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.6rem 1.25rem;
+    border-radius: 8px;
+    font-size: 0.875rem;
+    font-weight: 600;
+    background: #FFD200;
+    color: #0f172a;
+    text-decoration: none;
+    transition: opacity 0.15s;
+  }
+  .mcc-empty-cta:hover { opacity: 0.88; color: #0f172a; text-decoration: none; }
+  /* Results CTA */
+  .mcc-results-cta {
+    margin-top: 2rem;
+    text-align: center;
+  }
+  .mcc-results-cta a {
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--app-accent, #667eea);
+    text-decoration: none;
+  }
+  .mcc-results-cta a:hover { opacity: 0.85; }
 </style>
 {% endblock %}
 
 {% block student_content %}
-<div class="cc-shop">
+<div class="mcc-wrap">
 
-    <a href="/my-cards" class="cc-back">← My Cards</a>
+  <nav class="mcc-breadcrumb" aria-label="Breadcrumb">
+    <a href="/my-cards">My Cards</a>
+    <span>›</span>
+    <span>Challenge Card</span>
+  </nav>
 
-    <div class="cc-header">
-        <h1>⚡ Challenge Card Formats</h1>
-        <p>Purchase a Challenge Card format to download social cards for your completed Virtual Challenges.</p>
+  <div class="mcc-header">
+    <h1>My Challenge Card Formats</h1>
+    <span class="mcc-credits-badge">Balance: <strong>{{ user.credit_balance }} CR</strong></span>
+  </div>
+
+  <a href="/shop/cards/challenge" class="mcc-shop-link">Shop Formats →</a>
+
+  {# ── Flash messages ── #}
+  {% if flash_purchased %}
+  <div class="mfg-flash mfg-flash-success">
+    ✓ Format unlocked — you can now export Challenge Cards in this format.
+  </div>
+  {% endif %}
+  {% if flash_error == "credits" %}
+  <div class="mfg-flash mfg-flash-error">Not enough credits to purchase this format.</div>
+  {% elif flash_error == "owned" %}
+  <div class="mfg-flash mfg-flash-error">You already own this format.</div>
+  {% elif flash_error == "invalid" %}
+  <div class="mfg-flash mfg-flash-error">Unknown format.</div>
+  {% endif %}
+
+  {% if cc_format_rows %}
+
+  {# ── Section header ── #}
+  <div class="mfg-section-hdr">
+    <h2>Owned Formats</h2>
+    <span class="mfg-count-badge">{{ cc_owned_count }} owned</span>
+  </div>
+
+  {# ── Format grid (owned only) ── #}
+  <div class="mfg-grid">
+    {% for r in cc_format_rows %}
+    <div class="mfg-card">
+
+      <div class="mfg-preview-wrap mfg-locked">
+        <div class="mfg-preview-placeholder">{{ r.label[:2] | upper }}</div>
+      </div>
+
+      <p class="mfg-style-tag">{{ r.style_tag }}</p>
+      <p class="mfg-label">{{ r.label }}</p>
+      <p class="mfg-dims">{{ r.dims }}</p>
+
+      <span class="mfg-badge mfg-badge-owned">Owned ✓</span>
+
+      <div class="mfg-cta">
+        <a href="/challenges/results" class="mfg-btn mfg-btn-download">View Results →</a>
+      </div>
+
     </div>
+    {% endfor %}
+  </div>
 
-    {# ── Flash messages ── #}
-    {% if flash_purchased %}
-    <div style="padding:0.7rem 1rem;border-radius:8px;margin-bottom:1rem;font-size:0.85rem;background:#14532d;color:#86efac;border:1px solid #166534;">
-        ✓ Format unlocked — you can now export Challenge Cards in this format.
-    </div>
-    {% endif %}
-    {% if flash_error == "credits" %}
-    <div style="padding:0.7rem 1rem;border-radius:8px;margin-bottom:1rem;font-size:0.85rem;background:#450a0a;color:#fca5a5;border:1px solid #7f1d1d;">Not enough credits.</div>
-    {% elif flash_error == "owned" %}
-    <div style="padding:0.7rem 1rem;border-radius:8px;margin-bottom:1rem;font-size:0.85rem;background:#450a0a;color:#fca5a5;border:1px solid #7f1d1d;">You already own this format.</div>
-    {% elif flash_error == "invalid" %}
-    <div style="padding:0.7rem 1rem;border-radius:8px;margin-bottom:1rem;font-size:0.85rem;background:#450a0a;color:#fca5a5;border:1px solid #7f1d1d;">Unknown format.</div>
-    {% endif %}
+  {% else %}
 
-    {# ── Owned counter ── #}
-    <div style="display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:0.5rem;margin-bottom:0.85rem;">
-        <h2 style="font-size:1rem;font-weight:700;color:var(--app-text);margin:0;">Formats</h2>
-        <span style="font-size:0.75rem;font-weight:600;color:#94a3b8;background:#1e293b;border:1px solid #334155;border-radius:12px;padding:0.18rem 0.6rem;">
-            {{ cc_owned_count }} / {{ cc_total }} owned
-        </span>
-    </div>
+  <div class="mcc-empty">
+    <div class="mcc-empty-icon">⚡</div>
+    <h3>No formats yet</h3>
+    <p>You don't own any Challenge Card formats. Visit the shop to unlock social card exports.</p>
+    <a href="/shop/cards/challenge" class="mcc-empty-cta">Browse Formats →</a>
+  </div>
 
-    {# ── Format cards ── #}
-    <div class="cc-format-grid">
-        {% for r in cc_format_rows %}
-        <div class="cc-format-card">
-            <div class="cc-format-tag">{{ r.style_tag }}</div>
-            <div class="cc-format-label">{{ r.label }}</div>
-            <div class="cc-format-dims">{{ r.dims }}</div>
+  {% endif %}
 
-            {% if r.state == "owned" %}
-                <span class="cc-badge-owned">Owned ✓</span>
-                <button class="cc-btn-owned" disabled>Owned ✓</button>
-            {% elif r.state == "get_card" %}
-                <span class="cc-badge-get">{{ r.credit_cost }} CR</span>
-                <form method="POST" action="/my-cards/designs/challenge_card/{{ r.design_id }}/get">
-                    <button type="submit" class="cc-btn-get">Get Card — {{ r.credit_cost }} CR</button>
-                </form>
-            {% else %}
-                <span class="cc-badge-locked">{{ r.credit_cost }} CR 🔒</span>
-                <button class="cc-btn-locked" disabled>Not enough credits</button>
-            {% endif %}
-        </div>
-        {% endfor %}
-    </div>
-
-    {# ── View Challenge Results CTA ── #}
-    <div class="cc-results-cta">
-        <a href="/challenges/results">View Challenge Results →</a>
-    </div>
+  <div class="mcc-results-cta">
+    <a href="/challenges/results">View Challenge Results →</a>
+  </div>
 
 </div>
 {% endblock %}

--- a/app/templates/my_cards_hub.html
+++ b/app/templates/my_cards_hub.html
@@ -159,7 +159,8 @@
       <span class="mc-count-badge{% if pc_owned_count == pc_total %} mc-count-complete{% endif %}">
         {{ pc_owned_count }} / {{ pc_total }} owned
       </span>
-      <a href="/my-cards/player-card" class="mc-browse-btn">Browse Designs</a>
+      <a href="/my-cards/player" class="mc-browse-btn">My Designs</a>
+      <a href="/shop/cards/player" style="display:flex;align-items:center;justify-content:center;padding:0.45rem 1rem;border-radius:8px;font-size:0.82rem;font-weight:600;text-decoration:none;border:1px solid #334155;color:#94a3b8;transition:border-color 0.15s;" onmouseover="this.style.borderColor='#FFD200';this.style.color='#FFD200'" onmouseout="this.style.borderColor='#334155';this.style.color='#94a3b8'">Shop Designs →</a>
     </div>
 
     {# Welcome Card tile #}
@@ -174,7 +175,8 @@
       <span class="mc-count-badge{% if wc_owned_count == wc_total %} mc-count-complete{% endif %}">
         {{ wc_owned_count }} / {{ wc_total }} owned
       </span>
-      <a href="/my-cards/welcome-card" class="mc-browse-btn">Browse Formats</a>
+      <a href="/my-cards/welcome" class="mc-browse-btn">My Formats</a>
+      <a href="/shop/cards/welcome" style="display:flex;align-items:center;justify-content:center;padding:0.45rem 1rem;border-radius:8px;font-size:0.82rem;font-weight:600;text-decoration:none;border:1px solid #334155;color:#94a3b8;transition:border-color 0.15s;" onmouseover="this.style.borderColor='#FFD200';this.style.color='#FFD200'" onmouseout="this.style.borderColor='#334155';this.style.color='#94a3b8'">Shop Formats →</a>
     </div>
 
     {# Challenge Card tile #}
@@ -189,7 +191,8 @@
       <span class="mc-count-badge{% if cc_owned_count == cc_total %} mc-count-complete{% endif %}">
         {{ cc_owned_count }} / {{ cc_total }} owned
       </span>
-      <a href="/my-cards/challenge-card" class="mc-browse-btn">Browse Formats</a>
+      <a href="/my-cards/challenge" class="mc-browse-btn">My Formats</a>
+      <a href="/shop/cards/challenge" style="display:flex;align-items:center;justify-content:center;padding:0.45rem 1rem;border-radius:8px;font-size:0.82rem;font-weight:600;text-decoration:none;border:1px solid #334155;color:#94a3b8;transition:border-color 0.15s;" onmouseover="this.style.borderColor='#FFD200';this.style.color='#FFD200'" onmouseout="this.style.borderColor='#334155';this.style.color='#94a3b8'">Shop Formats →</a>
     </div>
 
   </div>

--- a/app/templates/my_cards_player_card.html
+++ b/app/templates/my_cards_player_card.html
@@ -1,6 +1,6 @@
 {% extends "student_base.html" %}
 
-{% block title %}Player Card — LFA Education Center{% endblock %}
+{% block title %}My Player Card Designs — LFA Education Center{% endblock %}
 {% block active_page %}lfa-player{% endblock %}
 
 {% block student_header %}
@@ -31,7 +31,7 @@
     justify-content: space-between;
     flex-wrap: wrap;
     gap: 0.5rem;
-    margin-bottom: 1.5rem;
+    margin-bottom: 1rem;
   }
   .mcp-header h1 { font-size: 1.4rem; font-weight: 700; color: #f8fafc; margin: 0; }
   .mcp-credits-badge {
@@ -43,6 +43,39 @@
     color: #94a3b8;
   }
   .mcp-credits-badge strong { color: #FFD200; }
+  .mcp-shop-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.82rem;
+    font-weight: 600;
+    color: #FFD200;
+    text-decoration: none;
+    margin-bottom: 1.5rem;
+  }
+  .mcp-shop-link:hover { opacity: 0.85; text-decoration: none; }
+  /* Empty state */
+  .mcp-empty {
+    text-align: center;
+    padding: 3rem 1rem;
+    color: #64748b;
+  }
+  .mcp-empty-icon { font-size: 2.5rem; margin-bottom: 0.75rem; }
+  .mcp-empty h3 { font-size: 1.1rem; font-weight: 600; color: #94a3b8; margin: 0 0 0.5rem; }
+  .mcp-empty p { font-size: 0.88rem; margin: 0 0 1.25rem; }
+  .mcp-empty-cta {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.6rem 1.25rem;
+    border-radius: 8px;
+    font-size: 0.875rem;
+    font-weight: 600;
+    background: #FFD200;
+    color: #0f172a;
+    text-decoration: none;
+    transition: opacity 0.15s;
+  }
+  .mcp-empty-cta:hover { opacity: 0.88; color: #0f172a; text-decoration: none; }
 </style>
 {% endblock %}
 
@@ -56,9 +89,11 @@
   </nav>
 
   <div class="mcp-header">
-    <h1>Player Card</h1>
+    <h1>My Player Card Designs</h1>
     <span class="mcp-credits-badge">Balance: <strong>{{ user.credit_balance }} CR</strong></span>
   </div>
+
+  <a href="/shop/cards/player" class="mcp-shop-link">Shop Designs →</a>
 
   {# ── Flash messages ── #}
   {% if flash_purchased %}
@@ -74,19 +109,19 @@
   <div class="mfg-flash mfg-flash-error">Unknown card type or design.</div>
   {% endif %}
 
+  {% if design_rows %}
+
   {# ── Section header ── #}
   <div class="mfg-section-hdr">
-    <h2>Designs</h2>
-    <span class="mfg-count-badge">{{ owned_count }} / {{ total_count }} owned</span>
+    <h2>Owned Designs</h2>
+    <span class="mfg-count-badge">{{ owned_count }} owned</span>
   </div>
 
-  {# ── Design grid ── #}
+  {# ── Design grid (owned only) ── #}
   <div class="mfg-grid">
     {% for d in design_rows %}
     <div class="mfg-card">
 
-      {# Preview #}
-      {% if d.state == "owned" %}
       <div class="mfg-preview-wrap">
         <iframe
           class="mfg-preview-iframe"
@@ -96,48 +131,32 @@
           title="{{ d.label }} preview"
         ></iframe>
       </div>
-      {% else %}
-      <div class="mfg-preview-wrap mfg-locked">
-        <div class="mfg-preview-placeholder">{{ d.label[:2] | upper }}</div>
-      </div>
-      {% endif %}
 
-      {# Metadata #}
       <p class="mfg-label">{{ d.label }}</p>
       {% if d.description %}
       <p style="font-size:0.75rem;color:#64748b;margin:0;">{{ d.description }}</p>
       {% endif %}
 
-      {# State badge + CTA #}
-      <div style="display:flex;align-items:center;justify-content:space-between;gap:0.5rem;">
-        {% if d.state == "owned" %}
-          <span class="mfg-badge mfg-badge-owned">Owned ✓</span>
-        {% elif d.state == "get_card" %}
-          <span class="mfg-badge mfg-badge-get">{{ d.credit_cost }} CR</span>
-        {% elif d.state == "not_available" %}
-          <span class="mfg-badge mfg-badge-locked">—</span>
-        {% else %}
-          <span class="mfg-badge mfg-badge-locked">{{ d.credit_cost }} CR 🔒</span>
-        {% endif %}
-      </div>
+      <span class="mfg-badge mfg-badge-owned">Owned ✓</span>
 
       <div class="mfg-cta">
-        {% if d.state == "owned" %}
-          <a href="/dashboard/lfa-football-player/card-editor" class="mfg-btn mfg-btn-edit mfg-btn-download">Edit / Download</a>
-        {% elif d.state == "get_card" %}
-          <form method="POST" action="/my-cards/designs/player_card/{{ d.id }}/get">
-            <button type="submit" class="mfg-btn mfg-btn-get">Get Card — {{ d.credit_cost }} CR</button>
-          </form>
-        {% elif d.state == "not_available" %}
-          <button class="mfg-btn mfg-btn-disabled" disabled>Contact admin</button>
-        {% else %}
-          <button class="mfg-btn mfg-btn-disabled" disabled>Not enough credits</button>
-        {% endif %}
+        <a href="/dashboard/lfa-football-player/card-editor" class="mfg-btn mfg-btn-edit mfg-btn-download">Edit / Download</a>
       </div>
 
     </div>
     {% endfor %}
   </div>
+
+  {% else %}
+
+  <div class="mcp-empty">
+    <div class="mcp-empty-icon">🎴</div>
+    <h3>No designs yet</h3>
+    <p>You don't own any Player Card designs. Visit the shop to get your first design.</p>
+    <a href="/shop/cards/player" class="mcp-empty-cta">Browse Designs →</a>
+  </div>
+
+  {% endif %}
 
 </div>
 {% endblock %}

--- a/app/templates/my_cards_welcome_card.html
+++ b/app/templates/my_cards_welcome_card.html
@@ -1,6 +1,6 @@
 {% extends "student_base.html" %}
 
-{% block title %}Welcome Card — LFA Education Center{% endblock %}
+{% block title %}My Welcome Card Formats — LFA Education Center{% endblock %}
 {% block active_page %}lfa-player{% endblock %}
 
 {% block student_header %}
@@ -31,7 +31,7 @@
     justify-content: space-between;
     flex-wrap: wrap;
     gap: 0.5rem;
-    margin-bottom: 1.5rem;
+    margin-bottom: 1rem;
   }
   .mcw-header h1 { font-size: 1.4rem; font-weight: 700; color: #f8fafc; margin: 0; }
   .mcw-credits-badge {
@@ -43,12 +43,39 @@
     color: #94a3b8;
   }
   .mcw-credits-badge strong { color: #FFD200; }
-  .mcw-desc {
-    font-size: 0.88rem;
-    color: #64748b;
+  .mcw-shop-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.82rem;
+    font-weight: 600;
+    color: #FFD200;
+    text-decoration: none;
     margin-bottom: 1.5rem;
-    max-width: 600px;
   }
+  .mcw-shop-link:hover { opacity: 0.85; text-decoration: none; }
+  /* Empty state */
+  .mcw-empty {
+    text-align: center;
+    padding: 3rem 1rem;
+    color: #64748b;
+  }
+  .mcw-empty-icon { font-size: 2.5rem; margin-bottom: 0.75rem; }
+  .mcw-empty h3 { font-size: 1.1rem; font-weight: 600; color: #94a3b8; margin: 0 0 0.5rem; }
+  .mcw-empty p { font-size: 0.88rem; margin: 0 0 1.25rem; }
+  .mcw-empty-cta {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.6rem 1.25rem;
+    border-radius: 8px;
+    font-size: 0.875rem;
+    font-weight: 600;
+    background: #FFD200;
+    color: #0f172a;
+    text-decoration: none;
+    transition: opacity 0.15s;
+  }
+  .mcw-empty-cta:hover { opacity: 0.88; color: #0f172a; text-decoration: none; }
 </style>
 {% endblock %}
 
@@ -62,14 +89,11 @@
   </nav>
 
   <div class="mcw-header">
-    <h1>Welcome Card</h1>
+    <h1>My Welcome Card Formats</h1>
     <span class="mcw-credits-badge">Balance: <strong>{{ user.credit_balance }} CR</strong></span>
   </div>
 
-  <p class="mcw-desc">
-    Your onboarding milestone card in different platform formats.
-    Purchase a format to unlock its export. Each format is independently owned.
-  </p>
+  <a href="/shop/cards/welcome" class="mcw-shop-link">Shop Formats →</a>
 
   {# ── Flash messages ── #}
   {% if flash_purchased %}
@@ -85,19 +109,20 @@
   <div class="mfg-flash mfg-flash-error">Unknown format.</div>
   {% endif %}
 
+  {% if format_rows %}
+
   {# ── Section header ── #}
   <div class="mfg-section-hdr">
-    <h2>Formats</h2>
-    <span class="mfg-count-badge">{{ owned_count }} / {{ total_count }} owned</span>
+    <h2>Owned Formats</h2>
+    <span class="mfg-count-badge">{{ owned_count }} owned</span>
   </div>
 
-  {# ── Format grid ── #}
+  {# ── Format grid (owned only) ── #}
   <div class="mfg-grid">
     {% for r in format_rows %}
     <div class="mfg-card">
 
-      {# Preview with watermark overlay for unowned #}
-      <div class="mfg-preview-wrap{% if r.state != 'owned' %} mfg-locked{% endif %}">
+      <div class="mfg-preview-wrap">
         <iframe
           class="mfg-preview-iframe"
           src="{{ r.preview_url }}"
@@ -107,36 +132,30 @@
         ></iframe>
       </div>
 
-      {# Metadata #}
       <p class="mfg-style-tag">{{ r.style_tag }}</p>
       <p class="mfg-label">{{ r.label }}</p>
       <p class="mfg-dims">{{ r.dims }}</p>
 
-      {# State badge #}
-      {% if r.state == "owned" %}
-        <span class="mfg-badge mfg-badge-owned">Owned ✓</span>
-      {% elif r.state == "purchasable" %}
-        <span class="mfg-badge mfg-badge-get">{{ r.credit_cost }} CR</span>
-      {% else %}
-        <span class="mfg-badge mfg-badge-locked">{{ r.credit_cost }} CR 🔒</span>
-      {% endif %}
+      <span class="mfg-badge mfg-badge-owned">Owned ✓</span>
 
-      {# CTA #}
       <div class="mfg-cta">
-        {% if r.state == "owned" %}
-          <a href="{{ r.export_url }}" class="mfg-btn mfg-btn-download">Download PNG</a>
-        {% elif r.state == "purchasable" %}
-          <form method="POST" action="/my-cards/designs/welcome_card/{{ r.design_id }}/get">
-            <button type="submit" class="mfg-btn mfg-btn-get">Get Card — {{ r.credit_cost }} CR</button>
-          </form>
-        {% else %}
-          <button class="mfg-btn mfg-btn-disabled" disabled>Not enough credits</button>
-        {% endif %}
+        <a href="{{ r.export_url }}" class="mfg-btn mfg-btn-download">Download PNG</a>
       </div>
 
     </div>
     {% endfor %}
   </div>
+
+  {% else %}
+
+  <div class="mcw-empty">
+    <div class="mcw-empty-icon">👋</div>
+    <h3>No formats yet</h3>
+    <p>You don't own any Welcome Card formats. Visit the shop to unlock platform exports.</p>
+    <a href="/shop/cards/welcome" class="mcw-empty-cta">Browse Formats →</a>
+  </div>
+
+  {% endif %}
 
 </div>
 {% endblock %}

--- a/app/templates/shop_cards.html
+++ b/app/templates/shop_cards.html
@@ -1,0 +1,163 @@
+{% extends "student_base.html" %}
+
+{% block title %}Cards Shop — LFA Education Center{% endblock %}
+{% block active_page %}lfa-player{% endblock %}
+
+{% block student_header %}
+{% set _page_icon = '🛒' %}
+{% set _page_name = 'Cards Shop' %}
+{% include "includes/spec_subpage_hdr.html" %}
+{% endblock %}
+
+{% block extra_styles %}
+<style>
+  .shopc-wrap {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 1.5rem 1rem 4rem;
+  }
+  .shopc-breadcrumb {
+    font-size: 0.8rem;
+    color: #64748b;
+    margin-bottom: 1.25rem;
+  }
+  .shopc-breadcrumb a { color: #94a3b8; text-decoration: none; }
+  .shopc-breadcrumb a:hover { color: #f1f5f9; }
+  .shopc-breadcrumb span { margin: 0 0.35rem; }
+  .shopc-header {
+    margin-bottom: 2rem;
+  }
+  .shopc-header h1 {
+    font-size: 1.4rem;
+    font-weight: 700;
+    color: var(--app-text, #f1f5f9);
+    margin: 0 0 0.35rem;
+  }
+  .shopc-header p {
+    font-size: 0.88rem;
+    color: var(--app-text-muted, #64748b);
+    margin: 0;
+  }
+  .shopc-balance {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    background: #1e293b;
+    border: 1px solid #334155;
+    border-radius: 20px;
+    padding: 0.35rem 0.9rem;
+    font-size: 0.85rem;
+    color: #94a3b8;
+    margin-bottom: 2rem;
+  }
+  .shopc-balance strong { color: #FFD200; }
+
+  .shopc-tiles {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    gap: 1.25rem;
+  }
+  .shopc-tile {
+    background: var(--app-card, #1a1f2e);
+    border: 1px solid var(--app-border, #252d42);
+    border-radius: 14px;
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    transition: border-color 0.15s;
+  }
+  .shopc-tile:hover { border-color: #334155; }
+  .shopc-tile-top {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.85rem;
+  }
+  .shopc-tile-icon { font-size: 2rem; line-height: 1; flex-shrink: 0; }
+  .shopc-tile-meta { flex: 1; min-width: 0; }
+  .shopc-tile-title {
+    font-size: 1.05rem;
+    font-weight: 700;
+    color: var(--app-text, #f1f5f9);
+    margin: 0 0 0.25rem;
+  }
+  .shopc-tile-desc {
+    font-size: 0.78rem;
+    color: var(--app-text-muted, #64748b);
+    margin: 0;
+  }
+  .shopc-browse-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.55rem 1rem;
+    border-radius: 8px;
+    font-size: 0.875rem;
+    font-weight: 600;
+    text-decoration: none;
+    background: #FFD200;
+    color: #0f172a;
+    transition: opacity 0.15s;
+    text-align: center;
+  }
+  .shopc-browse-btn:hover { opacity: 0.88; color: #0f172a; text-decoration: none; }
+</style>
+{% endblock %}
+
+{% block student_content %}
+<div class="shopc-wrap">
+
+  <nav class="shopc-breadcrumb" aria-label="Breadcrumb">
+    <a href="/shop">Shop</a>
+    <span>›</span>
+    <span>Cards</span>
+  </nav>
+
+  <div class="shopc-header">
+    <h1>Cards</h1>
+    <p>Browse all card families — designs and platform export formats.</p>
+  </div>
+
+  <div class="shopc-balance">
+    Balance: <strong>{{ user.credit_balance }} CR</strong>
+  </div>
+
+  <div class="shopc-tiles">
+
+    <div class="shopc-tile">
+      <div class="shopc-tile-top">
+        <span class="shopc-tile-icon">🎴</span>
+        <div class="shopc-tile-meta">
+          <div class="shopc-tile-title">Player Card</div>
+          <p class="shopc-tile-desc">Your LFA player identity card. Choose a design to display on your profile.</p>
+        </div>
+      </div>
+      <a href="/shop/cards/player" class="shopc-browse-btn">Browse Designs →</a>
+    </div>
+
+    <div class="shopc-tile">
+      <div class="shopc-tile-top">
+        <span class="shopc-tile-icon">👋</span>
+        <div class="shopc-tile-meta">
+          <div class="shopc-tile-title">Welcome Card</div>
+          <p class="shopc-tile-desc">Your onboarding milestone card in multiple platform export formats.</p>
+        </div>
+      </div>
+      <a href="/shop/cards/welcome" class="shopc-browse-btn">Browse Formats →</a>
+    </div>
+
+    <div class="shopc-tile">
+      <div class="shopc-tile-top">
+        <span class="shopc-tile-icon">⚡</span>
+        <div class="shopc-tile-meta">
+          <div class="shopc-tile-title">Challenge Card</div>
+          <p class="shopc-tile-desc">Share your Virtual Challenge results as social cards.</p>
+        </div>
+      </div>
+      <a href="/shop/cards/challenge" class="shopc-browse-btn">Browse Formats →</a>
+    </div>
+
+  </div>
+
+</div>
+{% endblock %}

--- a/app/templates/shop_challenge_card.html
+++ b/app/templates/shop_challenge_card.html
@@ -1,0 +1,166 @@
+{% extends "student_base.html" %}
+
+{% block title %}Challenge Card Formats — LFA Card Shop{% endblock %}
+{% block active_page %}lfa-player{% endblock %}
+
+{% block student_header %}
+{% set _page_icon = '⚡' %}
+{% set _page_name = 'Challenge Card Formats' %}
+{% include "includes/spec_subpage_hdr.html" %}
+{% endblock %}
+
+{% block extra_styles %}
+{% include "includes/mc_format_grid.html" %}
+<style>
+  .scc-wrap {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 1.5rem 1rem 4rem;
+  }
+  .scc-breadcrumb {
+    font-size: 0.8rem;
+    color: #64748b;
+    margin-bottom: 1.25rem;
+  }
+  .scc-breadcrumb a { color: #94a3b8; text-decoration: none; }
+  .scc-breadcrumb a:hover { color: #f1f5f9; }
+  .scc-breadcrumb span { margin: 0 0.35rem; }
+  .scc-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+  }
+  .scc-header h1 { font-size: 1.4rem; font-weight: 700; color: #f8fafc; margin: 0; }
+  .scc-credits-badge {
+    background: #1e293b;
+    border: 1px solid #334155;
+    border-radius: 20px;
+    padding: 0.35rem 0.9rem;
+    font-size: 0.85rem;
+    color: #94a3b8;
+  }
+  .scc-credits-badge strong { color: #FFD200; }
+  .scc-desc {
+    font-size: 0.88rem;
+    color: #64748b;
+    margin-bottom: 1rem;
+    max-width: 600px;
+  }
+  .scc-my-collection {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.82rem;
+    font-weight: 600;
+    color: #93c5fd;
+    text-decoration: none;
+    margin-bottom: 1.5rem;
+  }
+  .scc-my-collection:hover { color: #bfdbfe; text-decoration: none; }
+  .scc-results-cta {
+    margin-top: 2rem;
+    text-align: center;
+  }
+  .scc-results-cta a {
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--app-accent, #667eea);
+    text-decoration: none;
+  }
+  .scc-results-cta a:hover { opacity: 0.85; }
+</style>
+{% endblock %}
+
+{% block student_content %}
+<div class="scc-wrap">
+
+  <nav class="scc-breadcrumb" aria-label="Breadcrumb">
+    <a href="/shop">Shop</a>
+    <span>›</span>
+    <a href="/shop/cards">Cards</a>
+    <span>›</span>
+    <span>Challenge Card</span>
+  </nav>
+
+  <div class="scc-header">
+    <h1>Challenge Card Formats</h1>
+    <span class="scc-credits-badge">Balance: <strong>{{ user.credit_balance }} CR</strong></span>
+  </div>
+
+  <p class="scc-desc">
+    Purchase a Challenge Card format to download social cards for your completed Virtual Challenges.
+    Each format is independently owned.
+  </p>
+
+  <a href="/my-cards/challenge" class="scc-my-collection">← My Collection</a>
+
+  {# ── Flash messages ── #}
+  {% if flash_purchased %}
+  <div class="mfg-flash mfg-flash-success">
+    ✓ Format unlocked — you can now export Challenge Cards in this format.
+  </div>
+  {% endif %}
+  {% if flash_error == "credits" %}
+  <div class="mfg-flash mfg-flash-error">Not enough credits to purchase this format.</div>
+  {% elif flash_error == "owned" %}
+  <div class="mfg-flash mfg-flash-error">You already own this format.</div>
+  {% elif flash_error == "free" %}
+  <div class="mfg-flash mfg-flash-error">This format is free — no purchase needed.</div>
+  {% elif flash_error == "invalid" %}
+  <div class="mfg-flash mfg-flash-error">Unknown format.</div>
+  {% endif %}
+
+  {# ── Section header ── #}
+  <div class="mfg-section-hdr">
+    <h2>Formats</h2>
+  </div>
+
+  {# ── Format grid ── #}
+  <div class="mfg-grid">
+    {% for r in format_rows %}
+    <div class="mfg-card">
+
+      {# No iframe preview for challenge card — no generic preview URL #}
+      <div class="mfg-preview-wrap mfg-locked">
+        <div class="mfg-preview-placeholder">{{ r.label[:2] | upper }}</div>
+      </div>
+
+      {# Metadata #}
+      <p class="mfg-style-tag">{{ r.style_tag }}</p>
+      <p class="mfg-label">{{ r.label }}</p>
+      <p class="mfg-dims">{{ r.dims }}</p>
+
+      {# State badge #}
+      {% if r.state == "owned" %}
+        <span class="mfg-badge mfg-badge-owned">Owned ✓</span>
+      {% elif r.state == "get_card" %}
+        <span class="mfg-badge mfg-badge-get">{{ r.credit_cost }} CR</span>
+      {% else %}
+        <span class="mfg-badge mfg-badge-locked">{{ r.credit_cost }} CR 🔒</span>
+      {% endif %}
+
+      <div class="mfg-cta">
+        {% if r.state == "owned" %}
+          <a href="/challenges/results" class="mfg-btn mfg-btn-download">View Results →</a>
+        {% elif r.state == "get_card" %}
+          <form method="POST" action="/shop/cards/challenge_card/buy/{{ r.design_id }}">
+            <button type="submit" class="mfg-btn mfg-btn-get">Get Card — {{ r.credit_cost }} CR</button>
+          </form>
+        {% else %}
+          <button class="mfg-btn mfg-btn-disabled" disabled>Not enough credits</button>
+        {% endif %}
+      </div>
+
+    </div>
+    {% endfor %}
+  </div>
+
+  <div class="scc-results-cta">
+    <a href="/challenges/results">View Challenge Results →</a>
+  </div>
+
+</div>
+{% endblock %}

--- a/app/templates/shop_landing.html
+++ b/app/templates/shop_landing.html
@@ -1,0 +1,154 @@
+{% extends "student_base.html" %}
+
+{% block title %}Card Shop — LFA Education Center{% endblock %}
+{% block active_page %}lfa-player{% endblock %}
+
+{% block student_header %}
+{% set _page_icon = '🛒' %}
+{% set _page_name = 'Card Shop' %}
+{% include "includes/spec_subpage_hdr.html" %}
+{% endblock %}
+
+{% block extra_styles %}
+<style>
+  .shop-wrap {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 1.5rem 1rem 4rem;
+  }
+  .shop-header {
+    margin-bottom: 2rem;
+  }
+  .shop-header h1 {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--app-text, #f1f5f9);
+    margin: 0 0 0.4rem;
+  }
+  .shop-header p {
+    font-size: 0.9rem;
+    color: var(--app-text-muted, #64748b);
+    margin: 0;
+    max-width: 560px;
+  }
+  .shop-balance {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    background: #1e293b;
+    border: 1px solid #334155;
+    border-radius: 20px;
+    padding: 0.4rem 1rem;
+    font-size: 0.88rem;
+    color: #94a3b8;
+    margin-bottom: 2rem;
+  }
+  .shop-balance strong { color: #FFD200; }
+
+  /* ── Category tiles ── */
+  .shop-categories {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    gap: 1.25rem;
+  }
+  .shop-cat-tile {
+    background: var(--app-card, #1a1f2e);
+    border: 1px solid var(--app-border, #252d42);
+    border-radius: 14px;
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    transition: border-color 0.15s;
+    text-decoration: none;
+  }
+  .shop-cat-tile:hover {
+    border-color: #FFD200;
+    text-decoration: none;
+  }
+  .shop-cat-top {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.85rem;
+  }
+  .shop-cat-icon { font-size: 2rem; line-height: 1; flex-shrink: 0; }
+  .shop-cat-meta { flex: 1; min-width: 0; }
+  .shop-cat-title {
+    font-size: 1.05rem;
+    font-weight: 700;
+    color: var(--app-text, #f1f5f9);
+    margin: 0 0 0.25rem;
+  }
+  .shop-cat-desc {
+    font-size: 0.78rem;
+    color: var(--app-text-muted, #64748b);
+    margin: 0;
+  }
+  .shop-cat-cta {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.55rem 1rem;
+    border-radius: 8px;
+    font-size: 0.875rem;
+    font-weight: 600;
+    background: #FFD200;
+    color: #0f172a;
+    transition: opacity 0.15s;
+    text-align: center;
+  }
+  .shop-cat-tile:hover .shop-cat-cta { opacity: 0.88; }
+</style>
+{% endblock %}
+
+{% block student_content %}
+<div class="shop-wrap">
+
+  <div class="shop-header">
+    <h1>Card Shop</h1>
+    <p>Browse and purchase card designs and platform export formats.</p>
+  </div>
+
+  <div class="shop-balance">
+    Balance: <strong>{{ user.credit_balance }} CR</strong>
+  </div>
+
+  <div class="shop-categories">
+
+    <a href="/shop/cards/player" class="shop-cat-tile">
+      <div class="shop-cat-top">
+        <span class="shop-cat-icon">🎴</span>
+        <div class="shop-cat-meta">
+          <div class="shop-cat-title">Player Card Designs</div>
+          <p class="shop-cat-desc">Choose your LFA player card design — FIFA Classic, Compact, Atlas, Pulse and more.</p>
+        </div>
+      </div>
+      <span class="shop-cat-cta">Browse Designs →</span>
+    </a>
+
+    <a href="/shop/cards/welcome" class="shop-cat-tile">
+      <div class="shop-cat-top">
+        <span class="shop-cat-icon">👋</span>
+        <div class="shop-cat-meta">
+          <div class="shop-cat-title">Welcome Card Formats</div>
+          <p class="shop-cat-desc">Export your onboarding milestone card in Instagram, TikTok, Facebook and banner formats.</p>
+        </div>
+      </div>
+      <span class="shop-cat-cta">Browse Formats →</span>
+    </a>
+
+    <a href="/shop/cards/challenge" class="shop-cat-tile">
+      <div class="shop-cat-top">
+        <span class="shop-cat-icon">⚡</span>
+        <div class="shop-cat-meta">
+          <div class="shop-cat-title">Challenge Card Formats</div>
+          <p class="shop-cat-desc">Share your Virtual Challenge results as social cards in 16:9 and 9:16 formats.</p>
+        </div>
+      </div>
+      <span class="shop-cat-cta">Browse Formats →</span>
+    </a>
+
+  </div>
+
+</div>
+{% endblock %}

--- a/app/templates/shop_player_card.html
+++ b/app/templates/shop_player_card.html
@@ -1,0 +1,163 @@
+{% extends "student_base.html" %}
+
+{% block title %}Player Card Designs — LFA Card Shop{% endblock %}
+{% block active_page %}lfa-player{% endblock %}
+
+{% block student_header %}
+{% set _page_icon = '🎴' %}
+{% set _page_name = 'Player Card Designs' %}
+{% include "includes/spec_subpage_hdr.html" %}
+{% endblock %}
+
+{% block extra_styles %}
+{% include "includes/mc_format_grid.html" %}
+<style>
+  .spc-wrap {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 1.5rem 1rem 4rem;
+  }
+  .spc-breadcrumb {
+    font-size: 0.8rem;
+    color: #64748b;
+    margin-bottom: 1.25rem;
+  }
+  .spc-breadcrumb a { color: #94a3b8; text-decoration: none; }
+  .spc-breadcrumb a:hover { color: #f1f5f9; }
+  .spc-breadcrumb span { margin: 0 0.35rem; }
+  .spc-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 1.5rem;
+  }
+  .spc-header h1 { font-size: 1.4rem; font-weight: 700; color: #f8fafc; margin: 0; }
+  .spc-credits-badge {
+    background: #1e293b;
+    border: 1px solid #334155;
+    border-radius: 20px;
+    padding: 0.35rem 0.9rem;
+    font-size: 0.85rem;
+    color: #94a3b8;
+  }
+  .spc-credits-badge strong { color: #FFD200; }
+  .spc-my-collection {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.82rem;
+    font-weight: 600;
+    color: #93c5fd;
+    text-decoration: none;
+    margin-bottom: 1.5rem;
+  }
+  .spc-my-collection:hover { color: #bfdbfe; text-decoration: none; }
+</style>
+{% endblock %}
+
+{% block student_content %}
+<div class="spc-wrap">
+
+  <nav class="spc-breadcrumb" aria-label="Breadcrumb">
+    <a href="/shop">Shop</a>
+    <span>›</span>
+    <a href="/shop/cards">Cards</a>
+    <span>›</span>
+    <span>Player Card</span>
+  </nav>
+
+  <div class="spc-header">
+    <h1>Player Card Designs</h1>
+    <span class="spc-credits-badge">Balance: <strong>{{ user.credit_balance }} CR</strong></span>
+  </div>
+
+  <a href="/my-cards/player" class="spc-my-collection">← My Collection</a>
+
+  {# ── Flash messages ── #}
+  {% if flash_purchased %}
+  <div class="mfg-flash mfg-flash-success">
+    ✓ Design unlocked — {{ flash_purchased }} is now in your collection.
+  </div>
+  {% endif %}
+  {% if flash_error == "credits" %}
+  <div class="mfg-flash mfg-flash-error">Not enough credits to purchase this design.</div>
+  {% elif flash_error == "owned" %}
+  <div class="mfg-flash mfg-flash-error">You already own this design.</div>
+  {% elif flash_error == "free" %}
+  <div class="mfg-flash mfg-flash-error">This design is free — no purchase needed.</div>
+  {% elif flash_error == "invalid" %}
+  <div class="mfg-flash mfg-flash-error">Unknown card type or design.</div>
+  {% endif %}
+
+  {# ── Section header ── #}
+  <div class="mfg-section-hdr">
+    <h2>Designs</h2>
+  </div>
+
+  {# ── Design grid ── #}
+  <div class="mfg-grid">
+    {% for d in design_rows %}
+    <div class="mfg-card">
+
+      {# Preview #}
+      {% if d.state == "owned" %}
+      <div class="mfg-preview-wrap">
+        <iframe
+          class="mfg-preview-iframe"
+          src="/players/{{ user.id }}/card?platform=instagram_portrait&design={{ d.id }}"
+          loading="lazy"
+          scrolling="no"
+          title="{{ d.label }} preview"
+        ></iframe>
+      </div>
+      {% elif d.state == "not_available" %}
+      <div class="mfg-preview-wrap mfg-locked">
+        <div class="mfg-preview-placeholder">{{ d.label[:2] | upper }}</div>
+      </div>
+      {% else %}
+      <div class="mfg-preview-wrap mfg-locked">
+        <div class="mfg-preview-placeholder">{{ d.label[:2] | upper }}</div>
+      </div>
+      {% endif %}
+
+      {# Metadata #}
+      <p class="mfg-label">{{ d.label }}</p>
+      {% if d.description %}
+      <p style="font-size:0.75rem;color:#64748b;margin:0;">{{ d.description }}</p>
+      {% endif %}
+
+      {# State badge #}
+      <div style="display:flex;align-items:center;justify-content:space-between;gap:0.5rem;">
+        {% if d.state == "owned" %}
+          <span class="mfg-badge mfg-badge-owned">Owned ✓</span>
+        {% elif d.state == "get_card" %}
+          <span class="mfg-badge mfg-badge-get">{{ d.credit_cost }} CR</span>
+        {% elif d.state == "not_available" %}
+          <span class="mfg-badge mfg-badge-locked">—</span>
+        {% else %}
+          <span class="mfg-badge mfg-badge-locked">{{ d.credit_cost }} CR 🔒</span>
+        {% endif %}
+      </div>
+
+      <div class="mfg-cta">
+        {% if d.state == "owned" %}
+          <a href="/dashboard/lfa-football-player/card-editor" class="mfg-btn mfg-btn-edit mfg-btn-download">Edit / Download</a>
+        {% elif d.state == "get_card" %}
+          <form method="POST" action="/shop/cards/player_card/buy/{{ d.id }}">
+            <button type="submit" class="mfg-btn mfg-btn-get">Get Card — {{ d.credit_cost }} CR</button>
+          </form>
+        {% elif d.state == "not_available" %}
+          <button class="mfg-btn mfg-btn-disabled" disabled>Contact admin</button>
+        {% else %}
+          <button class="mfg-btn mfg-btn-disabled" disabled>Not enough credits</button>
+        {% endif %}
+      </div>
+
+    </div>
+    {% endfor %}
+  </div>
+
+</div>
+{% endblock %}

--- a/app/templates/shop_welcome_card.html
+++ b/app/templates/shop_welcome_card.html
@@ -1,0 +1,158 @@
+{% extends "student_base.html" %}
+
+{% block title %}Welcome Card Formats — LFA Card Shop{% endblock %}
+{% block active_page %}lfa-player{% endblock %}
+
+{% block student_header %}
+{% set _page_icon = '👋' %}
+{% set _page_name = 'Welcome Card Formats' %}
+{% include "includes/spec_subpage_hdr.html" %}
+{% endblock %}
+
+{% block extra_styles %}
+{% include "includes/mc_format_grid.html" %}
+<style>
+  .swc-wrap {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 1.5rem 1rem 4rem;
+  }
+  .swc-breadcrumb {
+    font-size: 0.8rem;
+    color: #64748b;
+    margin-bottom: 1.25rem;
+  }
+  .swc-breadcrumb a { color: #94a3b8; text-decoration: none; }
+  .swc-breadcrumb a:hover { color: #f1f5f9; }
+  .swc-breadcrumb span { margin: 0 0.35rem; }
+  .swc-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+  }
+  .swc-header h1 { font-size: 1.4rem; font-weight: 700; color: #f8fafc; margin: 0; }
+  .swc-credits-badge {
+    background: #1e293b;
+    border: 1px solid #334155;
+    border-radius: 20px;
+    padding: 0.35rem 0.9rem;
+    font-size: 0.85rem;
+    color: #94a3b8;
+  }
+  .swc-credits-badge strong { color: #FFD200; }
+  .swc-desc {
+    font-size: 0.88rem;
+    color: #64748b;
+    margin-bottom: 1rem;
+    max-width: 600px;
+  }
+  .swc-my-collection {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.82rem;
+    font-weight: 600;
+    color: #93c5fd;
+    text-decoration: none;
+    margin-bottom: 1.5rem;
+  }
+  .swc-my-collection:hover { color: #bfdbfe; text-decoration: none; }
+</style>
+{% endblock %}
+
+{% block student_content %}
+<div class="swc-wrap">
+
+  <nav class="swc-breadcrumb" aria-label="Breadcrumb">
+    <a href="/shop">Shop</a>
+    <span>›</span>
+    <a href="/shop/cards">Cards</a>
+    <span>›</span>
+    <span>Welcome Card</span>
+  </nav>
+
+  <div class="swc-header">
+    <h1>Welcome Card Formats</h1>
+    <span class="swc-credits-badge">Balance: <strong>{{ user.credit_balance }} CR</strong></span>
+  </div>
+
+  <p class="swc-desc">
+    Your onboarding milestone card in different platform formats.
+    Purchase a format to unlock its export. Each format is independently owned.
+  </p>
+
+  <a href="/my-cards/welcome" class="swc-my-collection">← My Collection</a>
+
+  {# ── Flash messages ── #}
+  {% if flash_purchased %}
+  <div class="mfg-flash mfg-flash-success">
+    ✓ Format unlocked — you can now export your Welcome Card in this format.
+  </div>
+  {% endif %}
+  {% if flash_error == "credits" %}
+  <div class="mfg-flash mfg-flash-error">Not enough credits to purchase this format.</div>
+  {% elif flash_error == "owned" %}
+  <div class="mfg-flash mfg-flash-error">You already own this format.</div>
+  {% elif flash_error == "free" %}
+  <div class="mfg-flash mfg-flash-error">This format is free — no purchase needed.</div>
+  {% elif flash_error == "invalid" %}
+  <div class="mfg-flash mfg-flash-error">Unknown format.</div>
+  {% endif %}
+
+  {# ── Section header ── #}
+  <div class="mfg-section-hdr">
+    <h2>Formats</h2>
+  </div>
+
+  {# ── Format grid ── #}
+  <div class="mfg-grid">
+    {% for r in format_rows %}
+    <div class="mfg-card">
+
+      {# Preview with watermark overlay for unowned #}
+      <div class="mfg-preview-wrap{% if r.state != 'owned' %} mfg-locked{% endif %}">
+        <iframe
+          class="mfg-preview-iframe"
+          src="{{ r.preview_url }}"
+          loading="lazy"
+          scrolling="no"
+          title="{{ r.label }} preview"
+        ></iframe>
+      </div>
+
+      {# Metadata #}
+      <p class="mfg-style-tag">{{ r.style_tag }}</p>
+      <p class="mfg-label">{{ r.label }}</p>
+      <p class="mfg-dims">{{ r.dims }}</p>
+
+      {# State badge #}
+      {% if r.state == "owned" %}
+        <span class="mfg-badge mfg-badge-owned">Owned ✓</span>
+      {% elif r.state == "get_card" %}
+        <span class="mfg-badge mfg-badge-get">{{ r.credit_cost }} CR</span>
+      {% else %}
+        <span class="mfg-badge mfg-badge-locked">{{ r.credit_cost }} CR 🔒</span>
+      {% endif %}
+
+      {# CTA #}
+      <div class="mfg-cta">
+        {% if r.state == "owned" %}
+          <a href="{{ r.export_url }}" class="mfg-btn mfg-btn-download">Download PNG</a>
+        {% elif r.state == "get_card" %}
+          <form method="POST" action="/shop/cards/welcome_card/buy/{{ r.design_id }}">
+            <button type="submit" class="mfg-btn mfg-btn-get">Get Card — {{ r.credit_cost }} CR</button>
+          </form>
+        {% else %}
+          <button class="mfg-btn mfg-btn-disabled" disabled>Not enough credits</button>
+        {% endif %}
+      </div>
+
+    </div>
+    {% endfor %}
+  </div>
+
+</div>
+{% endblock %}

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -62774,7 +62774,7 @@
     },
     "/my-cards": {
       "get": {
-        "description": "Hub \u2014 format-count tiles for all three card families.",
+        "description": "Hub \u2014 owned-count tiles for all three card families.",
         "operationId": "my_cards_hub_my_cards_get",
         "responses": {
           "200": {
@@ -62795,10 +62795,10 @@
         ]
       }
     },
-    "/my-cards/challenge-card": {
+    "/my-cards/challenge": {
       "get": {
-        "description": "Challenge Card format shop \u2014 browse and purchase Challenge Card formats.",
-        "operationId": "my_cards_challenge_card_my_cards_challenge_card_get",
+        "description": "Challenge Card owned-only format collection.",
+        "operationId": "my_cards_challenge_card_my_cards_challenge_get",
         "responses": {
           "200": {
             "content": {
@@ -62818,9 +62818,29 @@
         ]
       }
     },
+    "/my-cards/challenge-card": {
+      "get": {
+        "operationId": "my_cards_challenge_card_legacy_my_cards_challenge_card_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "My Cards Challenge Card Legacy",
+        "tags": [
+          "web",
+          "my-cards"
+        ]
+      }
+    },
     "/my-cards/designs/{card_type_id}/{design_id}/get": {
       "post": {
-        "description": "Purchase a card design entitlement (credit deduction + ownership row).",
+        "description": "Compat purchase endpoint \u2014 delegates to purchase_design(), redirects to collection.",
         "operationId": "get_card_my_cards_designs__card_type_id___design_id__get_post",
         "parameters": [
           {
@@ -62869,10 +62889,10 @@
         ]
       }
     },
-    "/my-cards/player-card": {
+    "/my-cards/player": {
       "get": {
-        "description": "Player Card format shop \u2014 browse and purchase Player Card designs.",
-        "operationId": "my_cards_player_card_my_cards_player_card_get",
+        "description": "Player Card owned-only collection.",
+        "operationId": "my_cards_player_card_my_cards_player_get",
         "responses": {
           "200": {
             "content": {
@@ -62892,9 +62912,29 @@
         ]
       }
     },
+    "/my-cards/player-card": {
+      "get": {
+        "operationId": "my_cards_player_card_legacy_my_cards_player_card_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "My Cards Player Card Legacy",
+        "tags": [
+          "web",
+          "my-cards"
+        ]
+      }
+    },
     "/my-cards/shop": {
       "get": {
-        "description": "Retired shop page \u2014 redirects to the appropriate family shop.",
+        "description": "Retired shop page \u2014 redirects to the card shop.",
         "operationId": "my_cards_shop_my_cards_shop_get",
         "parameters": [
           {
@@ -62941,10 +62981,10 @@
         ]
       }
     },
-    "/my-cards/welcome-card": {
+    "/my-cards/welcome": {
       "get": {
-        "description": "Welcome Card format shop \u2014 browse and purchase Welcome Card platform formats.",
-        "operationId": "my_cards_welcome_card_my_cards_welcome_card_get",
+        "description": "Welcome Card owned-only format collection.",
+        "operationId": "my_cards_welcome_card_my_cards_welcome_get",
         "responses": {
           "200": {
             "content": {
@@ -62958,6 +62998,26 @@
           }
         },
         "summary": "My Cards Welcome Card",
+        "tags": [
+          "web",
+          "my-cards"
+        ]
+      }
+    },
+    "/my-cards/welcome-card": {
+      "get": {
+        "operationId": "my_cards_welcome_card_legacy_my_cards_welcome_card_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "My Cards Welcome Card Legacy",
         "tags": [
           "web",
           "my-cards"
@@ -64680,6 +64740,167 @@
         "summary": "Unlock Quiz",
         "tags": [
           "web"
+        ]
+      }
+    },
+    "/shop": {
+      "get": {
+        "operationId": "shop_landing_shop_get",
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Shop Landing",
+        "tags": [
+          "web",
+          "shop"
+        ]
+      }
+    },
+    "/shop/cards": {
+      "get": {
+        "operationId": "shop_cards_shop_cards_get",
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Shop Cards",
+        "tags": [
+          "web",
+          "shop"
+        ]
+      }
+    },
+    "/shop/cards/challenge": {
+      "get": {
+        "operationId": "shop_challenge_card_shop_cards_challenge_get",
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Shop Challenge Card",
+        "tags": [
+          "web",
+          "shop"
+        ]
+      }
+    },
+    "/shop/cards/player": {
+      "get": {
+        "operationId": "shop_player_card_shop_cards_player_get",
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Shop Player Card",
+        "tags": [
+          "web",
+          "shop"
+        ]
+      }
+    },
+    "/shop/cards/welcome": {
+      "get": {
+        "operationId": "shop_welcome_card_shop_cards_welcome_get",
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Shop Welcome Card",
+        "tags": [
+          "web",
+          "shop"
+        ]
+      }
+    },
+    "/shop/cards/{card_type_id}/buy/{design_id}": {
+      "post": {
+        "description": "Purchase a card design/format from the shop (credit deduction + ownership row).",
+        "operationId": "shop_buy_shop_cards__card_type_id__buy__design_id__post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "card_type_id",
+            "required": true,
+            "schema": {
+              "title": "Card Type Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "design_id",
+            "required": true,
+            "schema": {
+              "title": "Design Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Shop Buy",
+        "tags": [
+          "web",
+          "shop"
         ]
       }
     },

--- a/tests/unit/api/web_routes/test_my_cards_hub.py
+++ b/tests/unit/api/web_routes/test_my_cards_hub.py
@@ -250,10 +250,10 @@ class TestMyCardsHubTemplate:
         assert "My Cards" in hub_src
 
     def test_mch13_hub_template_has_three_family_links(self, hub_src):
-        """MCH-13: Hub template has static links for all three card families."""
-        assert "/my-cards/player-card" in hub_src
-        assert "/my-cards/welcome-card" in hub_src
-        assert "/my-cards/challenge-card" in hub_src
+        """MCH-13: Hub template has links for all three card collection pages (short paths)."""
+        assert "/my-cards/player" in hub_src
+        assert "/my-cards/welcome" in hub_src
+        assert "/my-cards/challenge" in hub_src
 
     def test_mch14_hub_context_has_all_count_keys(self):
         """MCH-14: All six count context keys present (pc/wc/cc owned_count+total)."""
@@ -361,7 +361,7 @@ def _theme(tid, label, dot="#667eea", is_premium=False):
 
 class TestMyChallengeCardRoute:
 
-    def _call(self, *, user=None, db=None):
+    def _call(self, *, user=None, db=None, accessible=False):
         from app.api.web_routes.my_cards import my_cards_challenge_card
         user = user or _user()
         db   = db   or _db_mock()
@@ -374,7 +374,7 @@ class TestMyChallengeCardRoute:
             return MagicMock(status_code=200)
 
         with patch(f"{_CC_BASE}.templates") as mock_tmpl, \
-             patch(f"{_CC_BASE}.is_design_accessible", return_value=False):
+             patch(f"{_CC_BASE}.is_design_accessible", return_value=accessible):
             mock_tmpl.TemplateResponse.side_effect = _capture
             _run(my_cards_challenge_card(
                 request=MagicMock(),
@@ -402,19 +402,19 @@ class TestMyChallengeCardRoute:
         assert "cc_total" in ctx
 
     def test_mch_ch04_hub_template_has_challenge_card_static_link(self):
-        """MCH-CH-04: hub template contains static /my-cards/challenge-card link."""
+        """MCH-CH-04: hub template contains /my-cards/challenge collection link."""
         hub_html = _CC_TEMPLATE_PATH.parent.joinpath("my_cards_hub.html").read_text()
-        assert "/my-cards/challenge-card" in hub_html
+        assert "/my-cards/challenge" in hub_html
 
-    def test_mch_ch05_context_contains_post_16_9(self):
-        """MCH-CH-05: route context cc_format_rows includes challenge_post_16_9."""
-        cap = self._call()
+    def test_mch_ch05_context_contains_post_16_9_when_owned(self):
+        """MCH-CH-05: when accessible, cc_format_rows includes challenge_post_16_9."""
+        cap = self._call(accessible=True)
         row_ids = {r["design_id"] for r in cap["context"].get("cc_format_rows", [])}
         assert "challenge_post_16_9" in row_ids
 
-    def test_mch_ch06_context_contains_story_9_16(self):
-        """MCH-CH-06: route context cc_format_rows includes challenge_story_9_16."""
-        cap = self._call()
+    def test_mch_ch06_context_contains_story_9_16_when_owned(self):
+        """MCH-CH-06: when accessible, cc_format_rows includes challenge_story_9_16."""
+        cap = self._call(accessible=True)
         row_ids = {r["design_id"] for r in cap["context"].get("cc_format_rows", [])}
         assert "challenge_story_9_16" in row_ids
 
@@ -430,17 +430,17 @@ class TestMyChallengeCardRoute:
         assert CHALLENGE_CARD_SPEC.theme_compatible is True
         assert CHALLENGE_CARD_SPEC.has_published_state is False
 
-    def test_mch_ch09_context_contains_cc_format_rows_with_both_ids(self):
-        """MCH-CH-09: route context cc_format_rows contains both platform IDs."""
-        cap = self._call()
+    def test_mch_ch09_context_contains_cc_format_rows_with_both_ids_when_owned(self):
+        """MCH-CH-09: when accessible, cc_format_rows contains both platform IDs."""
+        cap = self._call(accessible=True)
         rows = cap["context"].get("cc_format_rows", [])
         row_ids = {r["design_id"] for r in rows}
         assert "challenge_post_16_9"  in row_ids
         assert "challenge_story_9_16" in row_ids
 
-    def test_mch_ch10_context_contains_cc_format_rows(self):
-        """MCH-CH-10: route context contains cc_format_rows with state per format."""
-        cap = self._call()
+    def test_mch_ch10_context_contains_cc_format_rows_when_owned(self):
+        """MCH-CH-10: when accessible, cc_format_rows contains 2 formats with state='owned'."""
+        cap = self._call(accessible=True)
         rows = cap["context"].get("cc_format_rows", [])
         assert len(rows) == 2
         row_ids = {r["design_id"] for r in rows}
@@ -448,11 +448,12 @@ class TestMyChallengeCardRoute:
         assert "challenge_story_9_16" in row_ids
         for r in rows:
             assert "state" in r
+            assert r["state"] == "owned"
             assert "credit_cost" in r
 
     def test_mch_ch11_context_has_no_challenge_list_keys(self):
-        """MCH-CH-11: shop route context must NOT contain challenge_rows, has_challenges,
-        draft, themes, or formats keys — the shop is format-only now."""
+        """MCH-CH-11: collection context must NOT contain challenge_rows, has_challenges,
+        draft, themes, or formats keys — the route is owned-only format collection now."""
         cap = self._call()
         ctx = cap["context"]
         for forbidden in ("challenge_rows", "has_challenges", "draft", "themes", "formats"):
@@ -462,3 +463,47 @@ class TestMyChallengeCardRoute:
         """MCH-CH-12: shop template must not contain cc-preview-iframe (challenge list removed)."""
         html = _CC_TEMPLATE_PATH.read_text()
         assert "cc-preview-iframe" not in html
+
+
+# ── MCH-R: Legacy redirect tests ─────────────────────────────────────────────
+
+class TestMyCardsLegacyRedirects:
+    """MCH-R: Hyphenated legacy paths redirect to canonical short paths (301)."""
+
+    def test_mch_r01_player_card_legacy_redirects_to_canonical(self):
+        """MCH-R01: GET /my-cards/player-card → 301 → /my-cards/player."""
+        from app.api.web_routes.my_cards import my_cards_player_card_legacy
+        resp = asyncio.run(my_cards_player_card_legacy())
+        assert resp.status_code == 301
+        assert resp.headers["location"] == "/my-cards/player"
+
+    def test_mch_r02_welcome_card_legacy_redirects_to_canonical(self):
+        """MCH-R02: GET /my-cards/welcome-card → 301 → /my-cards/welcome."""
+        from app.api.web_routes.my_cards import my_cards_welcome_card_legacy
+        resp = asyncio.run(my_cards_welcome_card_legacy())
+        assert resp.status_code == 301
+        assert resp.headers["location"] == "/my-cards/welcome"
+
+    def test_mch_r03_challenge_card_legacy_redirects_to_canonical(self):
+        """MCH-R03: GET /my-cards/challenge-card → 301 → /my-cards/challenge."""
+        from app.api.web_routes.my_cards import my_cards_challenge_card_legacy
+        resp = asyncio.run(my_cards_challenge_card_legacy())
+        assert resp.status_code == 301
+        assert resp.headers["location"] == "/my-cards/challenge"
+
+    def test_mch_r04_shop_redirect_still_works(self):
+        """MCH-R04: GET /my-cards/shop → 301 → /shop/cards."""
+        from app.api.web_routes.my_cards import my_cards_shop
+        resp = asyncio.run(my_cards_shop(tab=None))
+        assert resp.status_code == 301
+        assert resp.headers["location"] == "/shop/cards"
+
+    def test_mch_r05_canonical_player_has_auth_dependency(self):
+        """MCH-R05: canonical /my-cards/player route has user auth dependency."""
+        sig = inspect.signature(my_cards_player_card)
+        assert "user" in sig.parameters
+
+    def test_mch_r06_canonical_welcome_has_auth_dependency(self):
+        """MCH-R06: canonical /my-cards/welcome route has user auth dependency."""
+        sig = inspect.signature(my_cards_welcome_card)
+        assert "user" in sig.parameters

--- a/tests/unit/api/web_routes/test_my_cards_player_card.py
+++ b/tests/unit/api/web_routes/test_my_cards_player_card.py
@@ -1,17 +1,17 @@
-"""Player Card format shop route tests — MCP-01..MCP-12.
+"""Player Card owned-only collection route tests — MCP-01..MCP-12.
 
 MCP-01  GET /my-cards/player-card renders my_cards_player_card.html
-MCP-02  Context contains design_rows with state for each design
-MCP-03  Non-premium design, no CDO → state='get_card' or 'locked' (no free bypass)
-MCP-04  Premium not owned, credits ≥ cost → state='get_card'
-MCP-05  Premium not owned, credits < cost → state='locked'
-MCP-06  Premium owned → state='owned'
-MCP-07  Context contains owned_count and total_count
+MCP-02  Context contains design_rows with only accessible (owned) designs
+MCP-03  Non-accessible design → not in design_rows
+MCP-04  Accessible design → in design_rows with state='owned'
+MCP-05  Multiple accessible designs → all appear in design_rows
+MCP-06  Premium owned → in design_rows with state='owned'
+MCP-07  Context contains owned_count and total_count (both = len(owned designs))
 MCP-08  Route has auth dependency (get_current_user_web)
 MCP-09  Template file extends student_base and includes spec_subpage_hdr
 MCP-10  Template file breadcrumb links to /my-cards
-MCP-11  Template file contains purchase form POST action pattern
-MCP-12  owned_count = explicitly owned designs only (no free auto-include)
+MCP-11  Template file has Browse Shop CTA linking to /shop/cards/player
+MCP-12  owned_count = explicitly CDO-backed owned designs only
 """
 import asyncio
 import inspect
@@ -92,48 +92,44 @@ class TestPlayerCardShopRoute:
 
     def test_mcp01_renders_player_card_template(self):
         """MCP-01: GET /my-cards/player-card renders my_cards_player_card.html."""
-        cap = _call()
+        cap = _call(accessible_ids={("player_card", "compact")})
         assert cap["template"] == "my_cards_player_card.html"
 
-    def test_mcp02_context_has_design_rows(self):
-        """MCP-02: context contains design_rows with expected keys."""
-        ctx = _call()["context"]
+    def test_mcp02_context_has_design_rows_with_owned_designs(self):
+        """MCP-02: context.design_rows contains only accessible (owned) designs."""
+        ctx = _call(accessible_ids={("player_card", "compact")})["context"]
         rows = ctx["design_rows"]
-        assert len(rows) == 2
-        for r in rows:
-            assert "id" in r
-            assert "state" in r
-            assert "credit_cost" in r
+        assert len(rows) == 1  # only compact is accessible
+        assert rows[0]["id"] == "compact"
+        assert rows[0]["state"] == "owned"
 
-    def test_mcp03_non_premium_no_cdo_not_free(self):
-        """MCP-03: 0-CR design without CDO row → state is 'not_available' (no free/0CR bypass)."""
-        ctx = _call(user=_user(balance=0), accessible_ids=set())["context"]
+    def test_mcp03_non_accessible_design_not_in_rows(self):
+        """MCP-03: design without CDO row → not present in design_rows."""
+        ctx = _call(accessible_ids=set())["context"]
         rows = ctx["design_rows"]
-        fifa = next((r for r in rows if r["id"] == "fifa"), None)
-        if fifa is None:
-            return  # fifa not in mock designs for this test — skip
-        assert fifa["state"] not in ("free", "get_card"), (
-            "0-CR designs must not be purchasable via Get Card flow; expected 'not_available'"
-        )
-        # Either explicitly not_available (if credit_cost=0 in mock) or owned/locked
-        assert fifa["state"] in ("not_available", "owned", "locked")
+        assert len(rows) == 0  # no accessible designs → empty collection
 
-    def test_mcp04_premium_get_card(self):
-        """MCP-04: premium not owned, credits ≥ cost → state='get_card'."""
-        ctx = _call(user=_user(balance=500), accessible_ids=set())["context"]
+    def test_mcp04_accessible_design_in_rows_with_owned_state(self):
+        """MCP-04: accessible design → appears in design_rows with state='owned'."""
+        ctx = _call(
+            user=_user(balance=500),
+            accessible_ids={("player_card", "compact")},
+        )["context"]
         rows = ctx["design_rows"]
-        row = next(r for r in rows if r["id"] == "compact")
-        assert row["state"] == "get_card"
+        row  = next(r for r in rows if r["id"] == "compact")
+        assert row["state"] == "owned"
 
-    def test_mcp05_premium_locked(self):
-        """MCP-05: premium not owned, credits < cost → state='locked'."""
-        ctx = _call(user=_user(balance=50), accessible_ids=set())["context"]
-        rows = ctx["design_rows"]
-        row = next(r for r in rows if r["id"] == "compact")
-        assert row["state"] == "locked"
+    def test_mcp05_multiple_accessible_designs_all_in_rows(self):
+        """MCP-05: multiple accessible designs → all appear in design_rows."""
+        ctx = _call(
+            accessible_ids={("player_card", "fifa"), ("player_card", "compact")},
+        )["context"]
+        ids = {r["id"] for r in ctx["design_rows"]}
+        assert "fifa" in ids
+        assert "compact" in ids
 
-    def test_mcp06_premium_owned(self):
-        """MCP-06: premium owned → state='owned'."""
+    def test_mcp06_premium_owned_in_rows(self):
+        """MCP-06: premium owned → in design_rows with state='owned'."""
         ctx = _call(
             user=_user(balance=500),
             accessible_ids={("player_card", "compact")},
@@ -143,11 +139,12 @@ class TestPlayerCardShopRoute:
         assert row["state"] == "owned"
 
     def test_mcp07_context_has_owned_and_total_counts(self):
-        """MCP-07: context contains owned_count and total_count."""
-        ctx = _call()["context"]
+        """MCP-07: context contains owned_count and total_count (both = owned)."""
+        ctx = _call(accessible_ids={("player_card", "compact")})["context"]
         assert "owned_count" in ctx
         assert "total_count" in ctx
-        assert ctx["total_count"] == 2
+        assert ctx["owned_count"] == 1
+        assert ctx["total_count"] == 1
 
     def test_mcp08_route_has_auth_dependency(self):
         """MCP-08: route declares get_current_user_web dependency."""
@@ -166,11 +163,10 @@ class TestPlayerCardShopRoute:
         src = _TEMPLATE_PATH.read_text()
         assert 'href="/my-cards"' in src
 
-    def test_mcp11_template_has_purchase_form(self):
-        """MCP-11: template contains POST form action for purchasing designs."""
+    def test_mcp11_template_has_browse_shop_cta(self):
+        """MCP-11: template has Browse Shop CTA linking to /shop/cards/player."""
         src = _TEMPLATE_PATH.read_text()
-        assert "/my-cards/designs/player_card/" in src
-        assert 'method="POST"' in src
+        assert "/shop/cards/player" in src
 
     def test_mcp12_owned_count_only_cdo_rows(self):
         """MCP-12: owned_count = only CDO-backed owned designs (no free auto-include)."""
@@ -183,4 +179,4 @@ class TestPlayerCardShopRoute:
             accessible_ids={("player_card", "compact")},
         )["context"]
         assert ctx["owned_count"] == 1  # only owned compact; fifa not auto-included
-        assert ctx["total_count"] == 2
+        assert ctx["total_count"] == 1  # total_count = owned_count in owned-only view

--- a/tests/unit/api/web_routes/test_my_cards_shop.py
+++ b/tests/unit/api/web_routes/test_my_cards_shop.py
@@ -1,13 +1,13 @@
-"""My Cards Shop tests — Phase 2 format-level MVP.
+"""My Cards collection + compat wrapper tests — Phase 2 owned-only refactor.
 
-MCS-01  GET /my-cards/player-card renders without error (200 + template context)
-MCS-02  Player Card non-premium design, no CDO row → state="get_card" or "locked" (never "free")
-MCS-03  Player Card premium, not owned, enough credits → state="get_card"
-MCS-04  Player Card premium, not owned, insufficient credits → state="locked"
-MCS-05  Player Card premium, owned → state="owned"
-MCS-06  Welcome Card format not owned, enough credits → state="get_card"
-MCS-07  Welcome Card format not owned, insufficient credits → state="locked"
-MCS-08  Welcome Card format owned → state="owned"
+MCS-01  GET /my-cards/player-card renders without error (owned-only context)
+MCS-02  Player Card non-accessible design → not in design_rows (owned-only)
+MCS-03  Player Card accessible design → state="owned" in design_rows
+MCS-04  (reserved — shop state tests now in test_shop.py)
+MCS-05  (reserved — shop state tests now in test_shop.py)
+MCS-06  Welcome Card owned format → state="owned" in format_rows
+MCS-07  Welcome Card non-accessible format → not in format_rows
+MCS-08  Welcome Card format owned → state="owned" in format_rows
 MCS-09  All WC and CC format prices > 0 (never free)
 MCS-10  POST /my-cards/designs/{type}/{id}/get → 303 redirect on success to family page;
          ?error=free / ?error=owned / ?error=credits / ?error=invalid on failure
@@ -62,7 +62,7 @@ def _make_design(design_id: str, credit_cost: int, is_premium: bool):
     return d
 
 
-# ── MCS-01..05: Player Card format shop ──────────────────────────────────────
+# ── MCS-01..05: Player Card owned-only collection ─────────────────────────────
 
 class TestPlayerCardShop:
 
@@ -94,46 +94,25 @@ class TestPlayerCardShop:
 
         return captured
 
-    def test_mcs01_renders_player_card_shop(self):
-        """MCS-01: GET /my-cards/player-card returns my_cards_player_card.html with context keys."""
+    def test_mcs01_renders_player_card_collection(self):
+        """MCS-01: GET /my-cards/player-card returns my_cards_player_card.html with owned context."""
         user = _make_user(balance=500)
         db   = _make_db()
-        ctx  = self._call_player_shop(user, db)
+        ctx  = self._call_player_shop(user, db, accessible_ids={("player_card", "compact")})
         assert ctx["template"] == "my_cards_player_card.html"
         for key in ("design_rows", "owned_count", "total_count"):
             assert key in ctx["context"], f"Missing context key: {key}"
 
-    def test_mcs02_non_premium_design_no_cdo_not_free(self):
-        """MCS-02: 0-CR design without CDO row → state='not_available' (no free bypass)."""
-        user = _make_user(balance=0)
-        db   = _make_db()
-        ctx  = self._call_player_shop(user, db, accessible_ids=set())
-        rows = ctx["context"]["design_rows"]
-        fifa_row = next(r for r in rows if r["id"] == "fifa")
-        assert fifa_row["state"] != "free", "free state must not exist — all designs require ownership"
-        # 0-CR mock design is not purchasable — must be 'not_available' (belt-and-suspenders guard)
-        assert fifa_row["state"] == "not_available"
-
-    def test_mcs03_premium_get_card_state(self):
-        """MCS-03: premium design, not owned, credits ≥ cost → state='get_card'."""
+    def test_mcs02_non_accessible_design_not_in_rows(self):
+        """MCS-02: non-accessible design → not in design_rows (owned-only)."""
         user = _make_user(balance=500)
         db   = _make_db()
         ctx  = self._call_player_shop(user, db, accessible_ids=set())
         rows = ctx["context"]["design_rows"]
-        row  = next(r for r in rows if r["id"] == "compact")
-        assert row["state"] == "get_card"
+        assert len(rows) == 0  # no accessible designs → empty
 
-    def test_mcs04_premium_locked_insufficient_credits(self):
-        """MCS-04: premium design, not owned, credits < cost → state='locked'."""
-        user = _make_user(balance=50)
-        db   = _make_db()
-        ctx  = self._call_player_shop(user, db, accessible_ids=set())
-        rows = ctx["context"]["design_rows"]
-        row  = next(r for r in rows if r["id"] == "compact")
-        assert row["state"] == "locked"
-
-    def test_mcs05_premium_owned(self):
-        """MCS-05: premium design, owned → state='owned'."""
+    def test_mcs03_accessible_design_in_rows_with_owned_state(self):
+        """MCS-03: accessible design → in design_rows with state='owned'."""
         user = _make_user(balance=500)
         db   = _make_db()
         ctx  = self._call_player_shop(user, db, accessible_ids={("player_card", "compact")})
@@ -141,8 +120,16 @@ class TestPlayerCardShop:
         row  = next(r for r in rows if r["id"] == "compact")
         assert row["state"] == "owned"
 
+    def test_mcs04_reserved(self):
+        """MCS-04: reserved — shop state tests moved to test_shop.py (SH-04..06)."""
+        pass
 
-# ── MCS-06..08: Welcome Card format shop states ───────────────────────────────
+    def test_mcs05_reserved(self):
+        """MCS-05: reserved — shop state tests moved to test_shop.py (SH-04..06)."""
+        pass
+
+
+# ── MCS-06..08: Welcome Card owned-only collection ───────────────────────────
 
 class TestWelcomeCardShop:
 
@@ -170,24 +157,30 @@ class TestWelcomeCardShop:
 
         return captured
 
-    def test_mcs06_welcome_card_format_get_card(self):
-        """MCS-06: WC format not owned, credits ≥ price → state='get_card'."""
+    def test_mcs06_welcome_card_owned_format_in_rows(self):
+        """MCS-06: owned WC format → in format_rows with state='owned'."""
+        from app.services.card_design_service import WELCOME_CARD_FORMATS
+        first_fmt = WELCOME_CARD_FORMATS[0]
+        user = _make_user(balance=9999)
+        db   = _make_db()
+        ctx  = self._call_welcome_shop(
+            user, db,
+            accessible_ids={("welcome_card", first_fmt.design_id)},
+        )
+        rows = ctx["context"]["format_rows"]
+        row  = next(r for r in rows if r["design_id"] == first_fmt.design_id)
+        assert row["state"] == "owned"
+
+    def test_mcs07_welcome_card_non_accessible_not_in_rows(self):
+        """MCS-07: non-accessible WC format → not in format_rows."""
         user = _make_user(balance=9999)
         db   = _make_db()
         ctx  = self._call_welcome_shop(user, db, accessible_ids=set())
         rows = ctx["context"]["format_rows"]
-        assert all(r["state"] == "get_card" for r in rows)
-
-    def test_mcs07_welcome_card_format_locked(self):
-        """MCS-07: WC format not owned, credits < price → state='locked'."""
-        user = _make_user(balance=0)
-        db   = _make_db()
-        ctx  = self._call_welcome_shop(user, db, accessible_ids=set())
-        rows = ctx["context"]["format_rows"]
-        assert all(r["state"] == "locked" for r in rows)
+        assert len(rows) == 0
 
     def test_mcs08_welcome_card_format_owned(self):
-        """MCS-08: WC format owned → state='owned'."""
+        """MCS-08: WC format owned → state='owned' in format_rows."""
         from app.services.card_design_service import WELCOME_CARD_FORMATS
         first_fmt = WELCOME_CARD_FORMATS[0]
         user = _make_user(balance=9999)
@@ -225,19 +218,19 @@ class TestPurchaseRedirects:
             return _run(get_card(card_type_id=card_type_id, design_id=design_id, db=db, user=user))
 
     def test_mcs10a_success_redirect_to_family_page(self):
-        """MCS-10a: successful purchase → 303 to /my-cards/player-card?purchased=compact."""
+        """MCS-10a: successful purchase → 303 to /my-cards/player?purchased=compact."""
         user = _make_user()
         db   = _make_db()
         resp = self._call_get_card("player_card", "compact", user, db)
         loc  = resp.headers["location"]
         assert resp.status_code == 303
-        assert loc.startswith("/my-cards/player-card?"), f"Expected player-card redirect, got: {loc}"
+        assert loc.startswith("/my-cards/player?"), f"Expected player redirect, got: {loc}"
         assert "purchased=compact" in loc
         assert "/my-cards/shop" not in loc
         assert "/my-cards?" not in loc
 
     def test_mcs10b_free_error_redirect(self):
-        """MCS-10b: FreeDesignError → /my-cards/player-card?error=free."""
+        """MCS-10b: FreeDesignError → /my-cards/player?error=free."""
         from app.services.card_design_service import FreeDesignError
         user = _make_user()
         db   = _make_db()
@@ -245,11 +238,11 @@ class TestPurchaseRedirects:
         loc  = resp.headers["location"]
         assert resp.status_code == 303
         assert "error=free" in loc
-        assert "/my-cards/player-card" in loc
+        assert "/my-cards/player" in loc
         assert "/my-cards/shop" not in loc
 
     def test_mcs10c_already_owned_redirect(self):
-        """MCS-10c: AlreadyOwnedError → /my-cards/player-card?error=owned."""
+        """MCS-10c: AlreadyOwnedError → /my-cards/player?error=owned."""
         from app.services.card_design_service import AlreadyOwnedError
         user = _make_user()
         db   = _make_db()
@@ -257,10 +250,10 @@ class TestPurchaseRedirects:
         loc  = resp.headers["location"]
         assert resp.status_code == 303
         assert "error=owned" in loc
-        assert "/my-cards/player-card" in loc
+        assert "/my-cards/player" in loc
 
     def test_mcs10d_insufficient_credits_redirect(self):
-        """MCS-10d: InsufficientCreditsError → /my-cards/player-card?error=credits."""
+        """MCS-10d: InsufficientCreditsError → /my-cards/player?error=credits."""
         from app.services.credit_service import InsufficientCreditsError
         user = _make_user()
         db   = _make_db()
@@ -268,7 +261,7 @@ class TestPurchaseRedirects:
         loc  = resp.headers["location"]
         assert resp.status_code == 303
         assert "error=credits" in loc
-        assert "/my-cards/player-card" in loc
+        assert "/my-cards/player" in loc
 
     def test_mcs10e_invalid_card_type_redirect(self):
         """MCS-10e: ValueError (unknown card_type_id) → /my-cards?error=invalid."""
@@ -280,23 +273,23 @@ class TestPurchaseRedirects:
         assert "error=invalid" in loc
 
     def test_mcs10f_welcome_card_error_goes_to_welcome_family(self):
-        """MCS-10f: AlreadyOwnedError on welcome_card → /my-cards/welcome-card?error=owned."""
+        """MCS-10f: AlreadyOwnedError on welcome_card → /my-cards/welcome?error=owned."""
         from app.services.card_design_service import AlreadyOwnedError
         user = _make_user()
         db   = _make_db()
         resp = self._call_get_card("welcome_card", "instagram_portrait", user, db, side_effect=AlreadyOwnedError())
         loc  = resp.headers["location"]
-        assert "/my-cards/welcome-card" in loc
+        assert "/my-cards/welcome" in loc
         assert "error=owned" in loc
 
     def test_mcs10g_challenge_card_error_goes_to_challenge_family(self):
-        """MCS-10g: InsufficientCreditsError on challenge_card → /my-cards/challenge-card?error=credits."""
+        """MCS-10g: InsufficientCreditsError on challenge_card → /my-cards/challenge?error=credits."""
         from app.services.credit_service import InsufficientCreditsError
         user = _make_user()
         db   = _make_db()
         resp = self._call_get_card("challenge_card", "challenge_post_16_9", user, db, side_effect=InsufficientCreditsError(100, 0))
         loc  = resp.headers["location"]
-        assert "/my-cards/challenge-card" in loc
+        assert "/my-cards/challenge" in loc
         assert "error=credits" in loc
 
 

--- a/tests/unit/api/web_routes/test_my_cards_welcome_card.py
+++ b/tests/unit/api/web_routes/test_my_cards_welcome_card.py
@@ -1,17 +1,17 @@
-"""Welcome Card format shop route tests — MCW-01..MCW-12.
+"""Welcome Card owned-only collection route tests — MCW-01..MCW-12.
 
 MCW-01  GET /my-cards/welcome-card renders my_cards_welcome_card.html
-MCW-02  Context contains format_rows with 7 entries (WELCOME_CARD_FORMATS)
-MCW-03  Not owned, credits ≥ price → state='get_card'
-MCW-04  Not owned, credits < price → state='locked'
-MCW-05  Owned → state='owned'
-MCW-06  Context contains owned_count and total_count
+MCW-02  Context format_rows contains only owned (accessible) formats
+MCW-03  Not accessible → not in format_rows (empty collection)
+MCW-04  Accessible format → in format_rows with state='owned'
+MCW-05  Multiple accessible formats → all appear in format_rows
+MCW-06  Context contains owned_count and total_count (both = owned)
 MCW-07  Route has auth dependency (get_current_user_web)
 MCW-08  Template extends student_base and includes spec_subpage_hdr
 MCW-09  Template breadcrumb links to /my-cards
 MCW-10  format_rows contain preview_url and export_url
-MCW-11  Download CTA only present for owned state (template check)
-MCW-12  Template contains purchase form POST action pattern
+MCW-11  Template has Download CTA for owned items
+MCW-12  Template has Browse Shop CTA linking to /shop/cards/welcome
 """
 import asyncio
 import inspect
@@ -77,32 +77,26 @@ class TestWelcomeCardShopRoute:
 
     def test_mcw01_renders_welcome_card_template(self):
         """MCW-01: GET /my-cards/welcome-card renders my_cards_welcome_card.html."""
-        cap = _call()
+        cap = _call(accessible_ids={("welcome_card", "instagram_portrait")})
         assert cap["template"] == "my_cards_welcome_card.html"
 
-    def test_mcw02_context_has_7_format_rows(self):
-        """MCW-02: context.format_rows has 7 entries (one per WELCOME_CARD_FORMAT)."""
+    def test_mcw02_context_format_rows_contains_only_owned(self):
+        """MCW-02: context.format_rows contains only accessible (owned) formats."""
         from app.services.card_design_service import WELCOME_CARD_FORMATS
-        ctx = _call()["context"]
+        first_fmt = WELCOME_CARD_FORMATS[0]
+        ctx = _call(accessible_ids={("welcome_card", first_fmt.design_id)})["context"]
         rows = ctx["format_rows"]
-        assert len(rows) == len(WELCOME_CARD_FORMATS)
+        assert len(rows) == 1
+        assert rows[0]["design_id"] == first_fmt.design_id
 
-    def test_mcw03_not_owned_sufficient_credits_get_card(self):
-        """MCW-03: format not owned, credits ≥ price → state='get_card'."""
-        ctx = _call(user=_user(balance=9999), accessible_ids=set())["context"]
-        rows = ctx["format_rows"]
-        for r in rows:
-            assert r["state"] == "get_card", f"{r['design_id']} should be get_card"
+    def test_mcw03_not_accessible_not_in_format_rows(self):
+        """MCW-03: non-accessible format → not in format_rows (empty collection)."""
+        ctx = _call(accessible_ids=set())["context"]
+        assert ctx["format_rows"] == []
+        assert ctx["owned_count"] == 0
 
-    def test_mcw04_not_owned_insufficient_credits_locked(self):
-        """MCW-04: format not owned, credits < price → state='locked'."""
-        ctx = _call(user=_user(balance=0), accessible_ids=set())["context"]
-        rows = ctx["format_rows"]
-        for r in rows:
-            assert r["state"] == "locked", f"{r['design_id']} should be locked"
-
-    def test_mcw05_owned_format_shows_owned_state(self):
-        """MCW-05: owned format → state='owned'."""
+    def test_mcw04_accessible_format_in_rows_with_owned_state(self):
+        """MCW-04: accessible format → in format_rows with state='owned'."""
         from app.services.card_design_service import WELCOME_CARD_FORMATS
         target_fmt = WELCOME_CARD_FORMATS[0]
         ctx = _call(
@@ -113,13 +107,24 @@ class TestWelcomeCardShopRoute:
         row = next(r for r in rows if r["design_id"] == target_fmt.design_id)
         assert row["state"] == "owned"
 
+    def test_mcw05_multiple_accessible_formats_all_in_rows(self):
+        """MCW-05: multiple accessible formats → all appear in format_rows."""
+        from app.services.card_design_service import WELCOME_CARD_FORMATS
+        first_two = {("welcome_card", f.design_id) for f in WELCOME_CARD_FORMATS[:2]}
+        ctx = _call(user=_user(balance=9999), accessible_ids=first_two)["context"]
+        assert len(ctx["format_rows"]) == 2
+        for r in ctx["format_rows"]:
+            assert r["state"] == "owned"
+
     def test_mcw06_context_has_owned_and_total_count(self):
-        """MCW-06: context contains owned_count and total_count."""
-        ctx = _call()["context"]
+        """MCW-06: context contains owned_count and total_count (both = owned)."""
+        from app.services.card_design_service import WELCOME_CARD_FORMATS
+        first_two = {("welcome_card", f.design_id) for f in WELCOME_CARD_FORMATS[:2]}
+        ctx = _call(accessible_ids=first_two)["context"]
         assert "owned_count" in ctx
         assert "total_count" in ctx
-        from app.services.card_design_service import WELCOME_CARD_FORMATS
-        assert ctx["total_count"] == len(WELCOME_CARD_FORMATS)
+        assert ctx["owned_count"] == 2
+        assert ctx["total_count"] == 2  # total_count = owned_count in owned-only view
 
     def test_mcw07_route_has_auth_dependency(self):
         """MCW-07: route declares get_current_user_web dependency."""
@@ -139,24 +144,25 @@ class TestWelcomeCardShopRoute:
         assert 'href="/my-cards"' in src
 
     def test_mcw10_format_rows_contain_preview_and_export_url(self):
-        """MCW-10: every format_row has preview_url and export_url."""
-        ctx = _call()["context"]
+        """MCW-10: every owned format_row has preview_url and export_url."""
+        from app.services.card_design_service import WELCOME_CARD_FORMATS
+        all_ids = {("welcome_card", f.design_id) for f in WELCOME_CARD_FORMATS}
+        ctx = _call(accessible_ids=all_ids)["context"]
         rows = ctx["format_rows"]
+        assert len(rows) > 0
         for r in rows:
             assert "preview_url" in r, f"{r['design_id']} missing preview_url"
             assert "export_url" in r, f"{r['design_id']} missing export_url"
 
-    def test_mcw11_template_has_download_and_purchase_elements(self):
-        """MCW-11: template uses mfg-btn-download for owned and POST form for get."""
+    def test_mcw11_template_has_download_cta_for_owned(self):
+        """MCW-11: template uses mfg-btn-download for owned formats."""
         src = _TEMPLATE_PATH.read_text()
         assert "mfg-btn-download" in src, "Must have download button class for owned state"
-        assert "mfg-btn-get" in src, "Must have get button class for purchasable state"
 
-    def test_mcw12_template_has_purchase_form(self):
-        """MCW-12: template contains POST form for purchasing a WC format."""
+    def test_mcw12_template_has_browse_shop_cta(self):
+        """MCW-12: template has Browse Shop CTA linking to /shop/cards/welcome."""
         src = _TEMPLATE_PATH.read_text()
-        assert "/my-cards/designs/welcome_card/" in src
-        assert 'method="POST"' in src
+        assert "/shop/cards/welcome" in src
 
     def test_mcw_owned_count_correct(self):
         """MCW-owned: owned_count increments per owned format."""

--- a/tests/unit/api/web_routes/test_publish_guard.py
+++ b/tests/unit/api/web_routes/test_publish_guard.py
@@ -124,13 +124,13 @@ class TestPricingGuard:
             captured["context"] = ctx
             return MagicMock(status_code=200)
 
-        _BASE = "app.api.web_routes.my_cards"
+        _BASE = "app.api.web_routes.shop"
         with patch(f"{_BASE}.templates") as mock_tpl, \
              patch(f"{_BASE}.get_all_designs", return_value=[zero_design]), \
              patch(f"{_BASE}.is_design_accessible", return_value=False):
             mock_tpl.TemplateResponse.side_effect = _fake_tmpl
-            from app.api.web_routes.my_cards import my_cards_player_card
-            asyncio.run(my_cards_player_card(request=request, db=db, user=user))
+            from app.api.web_routes.shop import shop_player_card
+            asyncio.run(shop_player_card(request=request, db=db, user=user))
 
         rows  = captured["context"]["design_rows"]
         row   = next(r for r in rows if r["id"] == "hypothetical_zero")

--- a/tests/unit/api/web_routes/test_shop.py
+++ b/tests/unit/api/web_routes/test_shop.py
@@ -1,0 +1,459 @@
+"""Card shop route tests — SH-01..SH-12.
+
+SH-01  GET /shop → 200, shop_landing.html
+SH-02  GET /shop/cards → 200, shop_cards.html
+SH-03  GET /shop/cards/player → 200, shop_player_card.html, design_rows present
+SH-04  Player Card not owned, credits ≥ cost → state='get_card'
+SH-05  Player Card not owned, credits < cost → state='locked'
+SH-06  Player Card owned → state='owned'
+SH-07  GET /shop/cards/welcome → 200, shop_welcome_card.html, format_rows present
+SH-08  GET /shop/cards/challenge → 200, shop_challenge_card.html, format_rows present
+SH-09  POST /shop/cards/{type}/buy/{id} success → 303 to shop family page
+SH-10  POST purchase error → redirects with error param (free/owned/credits/invalid)
+SH-11  All shop routes declare auth dependency
+SH-12  Shop templates: breadcrumb links to /shop, include spec_subpage_hdr
+"""
+import asyncio
+import inspect
+import pathlib
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_BASE = "app.api.web_routes.shop"
+
+_TEMPLATE_BASE = (
+    pathlib.Path(__file__).resolve().parents[4]
+    / "app" / "templates"
+)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _user(balance=500):
+    from app.models.user import UserRole
+    u = MagicMock()
+    u.id = 42
+    u.credit_balance = balance
+    u.role = UserRole.STUDENT
+    return u
+
+
+def _req(path="/shop", query_params=None):
+    r = MagicMock()
+    r.url.path = path
+    params = query_params or {}
+    r.query_params.get = lambda k, default=None: params.get(k, default)
+    return r
+
+
+def _db():
+    return MagicMock()
+
+
+def _design(design_id, credit_cost, is_premium=True, label=None):
+    d = MagicMock()
+    d.id          = design_id
+    d.label       = label or design_id.title()
+    d.description = ""
+    d.credit_cost = credit_cost
+    d.is_premium  = is_premium
+    return d
+
+
+# ── SH-01: /shop landing ──────────────────────────────────────────────────────
+
+class TestShopLanding:
+
+    def test_sh01_landing_renders_shop_landing_html(self):
+        """SH-01: GET /shop → shop_landing.html."""
+        from app.api.web_routes.shop import shop_landing
+
+        captured = {}
+
+        def fake_tmpl(tmpl, ctx):
+            captured["template"] = tmpl
+            captured["context"]  = ctx
+            return MagicMock(status_code=200)
+
+        with patch(f"{_BASE}.templates.TemplateResponse", side_effect=fake_tmpl):
+            _run(shop_landing(request=_req("/shop"), user=_user()))
+
+        assert captured["template"] == "shop_landing.html"
+
+    def test_sh01b_landing_context_has_user(self):
+        """SH-01b: /shop context includes user."""
+        from app.api.web_routes.shop import shop_landing
+
+        captured = {}
+
+        def fake_tmpl(tmpl, ctx):
+            captured["context"] = ctx
+            return MagicMock(status_code=200)
+
+        u = _user(balance=999)
+        with patch(f"{_BASE}.templates.TemplateResponse", side_effect=fake_tmpl):
+            _run(shop_landing(request=_req(), user=u))
+
+        assert captured["context"]["user"] is u
+
+
+# ── SH-02: /shop/cards overview ───────────────────────────────────────────────
+
+class TestShopCards:
+
+    def test_sh02_cards_renders_shop_cards_html(self):
+        """SH-02: GET /shop/cards → shop_cards.html."""
+        from app.api.web_routes.shop import shop_cards
+
+        captured = {}
+
+        def fake_tmpl(tmpl, ctx):
+            captured["template"] = tmpl
+            return MagicMock(status_code=200)
+
+        with patch(f"{_BASE}.templates.TemplateResponse", side_effect=fake_tmpl):
+            _run(shop_cards(request=_req("/shop/cards"), user=_user()))
+
+        assert captured["template"] == "shop_cards.html"
+
+
+# ── SH-03..06: /shop/cards/player ─────────────────────────────────────────────
+
+class TestShopPlayerCard:
+
+    def _call(self, user=None, accessible_ids=None, designs=None, query_params=None):
+        from app.api.web_routes.shop import shop_player_card
+
+        user           = user or _user()
+        accessible_ids = accessible_ids or set()
+        default_designs = [
+            _design("fifa",    credit_cost=0,   is_premium=False),
+            _design("compact", credit_cost=300, is_premium=True),
+        ]
+        captured = {}
+
+        def fake_tmpl(tmpl, ctx):
+            captured["template"] = tmpl
+            captured["context"]  = ctx
+            return MagicMock(status_code=200)
+
+        def fake_accessible(db, uid, card_type_id, design_id):
+            return (card_type_id, design_id) in accessible_ids
+
+        with patch(f"{_BASE}.get_all_designs", return_value=designs or default_designs), \
+             patch(f"{_BASE}.is_design_accessible", side_effect=fake_accessible), \
+             patch(f"{_BASE}.templates.TemplateResponse", side_effect=fake_tmpl):
+            _run(shop_player_card(
+                request=_req("/shop/cards/player", query_params),
+                db=_db(),
+                user=user,
+            ))
+
+        return captured
+
+    def test_sh03_renders_shop_player_card_html(self):
+        """SH-03: GET /shop/cards/player → shop_player_card.html with design_rows."""
+        cap = self._call()
+        assert cap["template"] == "shop_player_card.html"
+        assert "design_rows" in cap["context"]
+        assert len(cap["context"]["design_rows"]) == 2
+
+    def test_sh04_not_owned_enough_credits_get_card(self):
+        """SH-04: not owned, credits ≥ cost → state='get_card'."""
+        ctx = self._call(user=_user(balance=500), accessible_ids=set())["context"]
+        row = next(r for r in ctx["design_rows"] if r["id"] == "compact")
+        assert row["state"] == "get_card"
+
+    def test_sh05_not_owned_insufficient_credits_locked(self):
+        """SH-05: not owned, credits < cost → state='locked'."""
+        ctx = self._call(user=_user(balance=50), accessible_ids=set())["context"]
+        row = next(r for r in ctx["design_rows"] if r["id"] == "compact")
+        assert row["state"] == "locked"
+
+    def test_sh06_owned_design_state_owned(self):
+        """SH-06: owned design → state='owned'."""
+        ctx = self._call(
+            user=_user(balance=500),
+            accessible_ids={("player_card", "compact")},
+        )["context"]
+        row = next(r for r in ctx["design_rows"] if r["id"] == "compact")
+        assert row["state"] == "owned"
+
+    def test_sh06b_zero_cr_design_not_accessible_not_available(self):
+        """SH-06b: 0-CR design without CDO → state='not_available' (no free bypass)."""
+        ctx = self._call(user=_user(balance=9999), accessible_ids=set())["context"]
+        row = next(r for r in ctx["design_rows"] if r["id"] == "fifa")
+        assert row["state"] == "not_available"
+
+    def test_sh06c_flash_query_params_passed(self):
+        """SH-06c: flash_purchased and flash_error query params forwarded to context."""
+        cap = self._call(query_params={"purchased": "compact", "error": None})
+        assert cap["context"]["flash_purchased"] == "compact"
+
+
+# ── SH-07: /shop/cards/welcome ────────────────────────────────────────────────
+
+class TestShopWelcomeCard:
+
+    def _call(self, user=None, accessible_ids=None):
+        from app.api.web_routes.shop import shop_welcome_card
+
+        user           = user or _user()
+        accessible_ids = accessible_ids or set()
+        captured = {}
+
+        def fake_tmpl(tmpl, ctx):
+            captured["template"] = tmpl
+            captured["context"]  = ctx
+            return MagicMock(status_code=200)
+
+        def fake_accessible(db, uid, card_type_id, design_id):
+            return (card_type_id, design_id) in accessible_ids
+
+        with patch(f"{_BASE}.is_design_accessible", side_effect=fake_accessible), \
+             patch(f"{_BASE}.templates.TemplateResponse", side_effect=fake_tmpl):
+            _run(shop_welcome_card(
+                request=_req("/shop/cards/welcome"),
+                db=_db(),
+                user=user,
+            ))
+
+        return captured
+
+    def test_sh07_renders_shop_welcome_card_html(self):
+        """SH-07: GET /shop/cards/welcome → shop_welcome_card.html with format_rows."""
+        from app.services.card_design_service import WELCOME_CARD_FORMATS
+
+        cap = self._call()
+        assert cap["template"] == "shop_welcome_card.html"
+        rows = cap["context"]["format_rows"]
+        assert len(rows) == len(WELCOME_CARD_FORMATS)
+
+    def test_sh07b_not_owned_enough_credits_get_card(self):
+        """SH-07b: WC format not owned, credits ≥ price → state='get_card'."""
+        ctx = self._call(user=_user(balance=9999), accessible_ids=set())["context"]
+        assert all(r["state"] == "get_card" for r in ctx["format_rows"])
+
+    def test_sh07c_not_owned_insufficient_credits_locked(self):
+        """SH-07c: WC format not owned, credits < price → state='locked'."""
+        ctx = self._call(user=_user(balance=0), accessible_ids=set())["context"]
+        assert all(r["state"] == "locked" for r in ctx["format_rows"])
+
+    def test_sh07d_owned_format_state_owned(self):
+        """SH-07d: owned WC format → state='owned'."""
+        from app.services.card_design_service import WELCOME_CARD_FORMATS
+        first_fmt = WELCOME_CARD_FORMATS[0]
+        ctx = self._call(
+            user=_user(balance=9999),
+            accessible_ids={("welcome_card", first_fmt.design_id)},
+        )["context"]
+        row = next(r for r in ctx["format_rows"] if r["design_id"] == first_fmt.design_id)
+        assert row["state"] == "owned"
+
+    def test_sh07e_format_rows_have_preview_and_export_url(self):
+        """SH-07e: each format_row has preview_url and export_url."""
+        ctx = self._call(user=_user(balance=9999))["context"]
+        for r in ctx["format_rows"]:
+            assert "preview_url" in r
+            assert "export_url" in r
+
+
+# ── SH-08: /shop/cards/challenge ──────────────────────────────────────────────
+
+class TestShopChallengeCard:
+
+    def _call(self, user=None, accessible_ids=None):
+        from app.api.web_routes.shop import shop_challenge_card
+
+        user           = user or _user()
+        accessible_ids = accessible_ids or set()
+        captured = {}
+
+        def fake_tmpl(tmpl, ctx):
+            captured["template"] = tmpl
+            captured["context"]  = ctx
+            return MagicMock(status_code=200)
+
+        def fake_accessible(db, uid, card_type_id, design_id):
+            return (card_type_id, design_id) in accessible_ids
+
+        with patch(f"{_BASE}.is_design_accessible", side_effect=fake_accessible), \
+             patch(f"{_BASE}.templates.TemplateResponse", side_effect=fake_tmpl):
+            _run(shop_challenge_card(
+                request=_req("/shop/cards/challenge"),
+                db=_db(),
+                user=user,
+            ))
+
+        return captured
+
+    def test_sh08_renders_shop_challenge_card_html(self):
+        """SH-08: GET /shop/cards/challenge → shop_challenge_card.html with format_rows."""
+        from app.services.card_design_service import CHALLENGE_CARD_FORMATS
+
+        cap = self._call()
+        assert cap["template"] == "shop_challenge_card.html"
+        rows = cap["context"]["format_rows"]
+        assert len(rows) == len(CHALLENGE_CARD_FORMATS)
+        row_ids = {r["design_id"] for r in rows}
+        assert "challenge_post_16_9"  in row_ids
+        assert "challenge_story_9_16" in row_ids
+
+    def test_sh08b_not_owned_enough_credits_get_card(self):
+        """SH-08b: CC format not owned, credits ≥ price → state='get_card'."""
+        ctx = self._call(user=_user(balance=9999), accessible_ids=set())["context"]
+        assert all(r["state"] == "get_card" for r in ctx["format_rows"])
+
+    def test_sh08c_owned_format_state_owned(self):
+        """SH-08c: owned CC format → state='owned'."""
+        ctx = self._call(
+            user=_user(balance=9999),
+            accessible_ids={("challenge_card", "challenge_post_16_9")},
+        )["context"]
+        row = next(r for r in ctx["format_rows"] if r["design_id"] == "challenge_post_16_9")
+        assert row["state"] == "owned"
+
+
+# ── SH-09..10: Purchase POST ──────────────────────────────────────────────────
+
+class TestShopBuy:
+
+    def _call_buy(self, card_type_id, design_id, user=None, side_effect=None):
+        from app.api.web_routes.shop import shop_buy
+
+        with patch(f"{_BASE}.purchase_design", side_effect=side_effect or (lambda *a, **kw: None)):
+            return _run(shop_buy(
+                card_type_id=card_type_id,
+                design_id=design_id,
+                db=_db(),
+                user=user or _user(),
+            ))
+
+    def test_sh09_success_redirects_to_shop_family(self):
+        """SH-09: successful purchase → 303 to /shop/cards/player?purchased=compact."""
+        resp = self._call_buy("player_card", "compact")
+        loc  = resp.headers["location"]
+        assert resp.status_code == 303
+        assert loc.startswith("/shop/cards/player?")
+        assert "purchased=compact" in loc
+
+    def test_sh09b_welcome_card_success_redirects_to_shop_welcome(self):
+        """SH-09b: WC purchase → /shop/cards/welcome?purchased=..."""
+        resp = self._call_buy("welcome_card", "instagram_portrait")
+        loc  = resp.headers["location"]
+        assert "/shop/cards/welcome" in loc
+        assert "purchased=instagram_portrait" in loc
+
+    def test_sh10a_free_error_redirect(self):
+        """SH-10a: FreeDesignError → /shop/cards/player?error=free."""
+        from app.services.card_design_service import FreeDesignError
+        resp = self._call_buy("player_card", "fifa", side_effect=FreeDesignError())
+        loc  = resp.headers["location"]
+        assert resp.status_code == 303
+        assert "error=free" in loc
+        assert "/shop/cards/player" in loc
+
+    def test_sh10b_already_owned_redirect(self):
+        """SH-10b: AlreadyOwnedError → /shop/cards/player?error=owned."""
+        from app.services.card_design_service import AlreadyOwnedError
+        resp = self._call_buy("player_card", "compact", side_effect=AlreadyOwnedError())
+        assert "error=owned" in resp.headers["location"]
+        assert "/shop/cards/player" in resp.headers["location"]
+
+    def test_sh10c_insufficient_credits_redirect(self):
+        """SH-10c: InsufficientCreditsError → /shop/cards/player?error=credits."""
+        from app.services.credit_service import InsufficientCreditsError
+        resp = self._call_buy("player_card", "compact", side_effect=InsufficientCreditsError(300, 0))
+        assert "error=credits" in resp.headers["location"]
+
+    def test_sh10d_unknown_type_fallback(self):
+        """SH-10d: unknown card_type_id → /shop/cards?error=invalid (fallback)."""
+        resp = self._call_buy("bogus_type", "bogus", side_effect=ValueError("x"))
+        loc  = resp.headers["location"]
+        assert "error=invalid" in loc
+
+    def test_sh10e_challenge_card_error_to_shop_challenge(self):
+        """SH-10e: CC AlreadyOwnedError → /shop/cards/challenge?error=owned."""
+        from app.services.card_design_service import AlreadyOwnedError
+        resp = self._call_buy("challenge_card", "challenge_post_16_9", side_effect=AlreadyOwnedError())
+        assert "/shop/cards/challenge" in resp.headers["location"]
+        assert "error=owned" in resp.headers["location"]
+
+
+# ── SH-11: Auth dependencies ──────────────────────────────────────────────────
+
+class TestShopAuthDependencies:
+
+    def test_sh11_all_shop_routes_have_user_dependency(self):
+        """SH-11: all shop routes declare get_current_user_web dependency."""
+        from app.api.web_routes.shop import (
+            shop_landing,
+            shop_cards,
+            shop_player_card,
+            shop_welcome_card,
+            shop_challenge_card,
+            shop_buy,
+        )
+        for fn in (shop_landing, shop_cards, shop_player_card, shop_welcome_card, shop_challenge_card, shop_buy):
+            sig = inspect.signature(fn)
+            assert "user" in sig.parameters, f"{fn.__name__} missing 'user' dependency"
+
+
+# ── SH-12: Template structure ─────────────────────────────────────────────────
+
+class TestShopTemplates:
+
+    @pytest.fixture(scope="class")
+    def player_src(self):
+        return (_TEMPLATE_BASE / "shop_player_card.html").read_text()
+
+    @pytest.fixture(scope="class")
+    def welcome_src(self):
+        return (_TEMPLATE_BASE / "shop_welcome_card.html").read_text()
+
+    @pytest.fixture(scope="class")
+    def challenge_src(self):
+        return (_TEMPLATE_BASE / "shop_challenge_card.html").read_text()
+
+    @pytest.fixture(scope="class")
+    def landing_src(self):
+        return (_TEMPLATE_BASE / "shop_landing.html").read_text()
+
+    def test_sh12a_player_template_extends_student_base(self, player_src):
+        """SH-12a: shop_player_card.html extends student_base."""
+        assert "student_base.html" in player_src
+
+    def test_sh12b_player_template_includes_spec_hdr(self, player_src):
+        """SH-12b: shop_player_card.html includes spec_subpage_hdr."""
+        assert "spec_subpage_hdr.html" in player_src
+
+    def test_sh12c_player_template_has_breadcrumb_to_shop(self, player_src):
+        """SH-12c: shop_player_card.html breadcrumb links to /shop."""
+        assert 'href="/shop"' in player_src
+
+    def test_sh12d_player_template_has_purchase_form(self, player_src):
+        """SH-12d: shop_player_card.html has POST form to /shop/cards/player_card/buy/."""
+        assert "/shop/cards/player_card/buy/" in player_src
+        assert 'method="POST"' in player_src
+
+    def test_sh12e_welcome_template_has_my_collection_link(self, welcome_src):
+        """SH-12e: shop_welcome_card.html has back link to /my-cards/welcome-card."""
+        assert "/my-cards/welcome" in welcome_src
+
+    def test_sh12f_challenge_template_has_results_cta(self, challenge_src):
+        """SH-12f: shop_challenge_card.html has link to /challenges/results."""
+        assert "/challenges/results" in challenge_src
+
+    def test_sh12g_landing_has_three_card_family_links(self, landing_src):
+        """SH-12g: shop_landing.html links to all three shop family pages."""
+        assert "/shop/cards/player" in landing_src
+        assert "/shop/cards/welcome" in landing_src
+        assert "/shop/cards/challenge" in landing_src
+
+    def test_sh12h_welcome_template_purchase_form(self, welcome_src):
+        """SH-12h: shop_welcome_card.html has POST form to /shop/cards/welcome_card/buy/."""
+        assert "/shop/cards/welcome_card/buy/" in welcome_src
+        assert 'method="POST"' in welcome_src


### PR DESCRIPTION
## Summary

- **Phase 1 — Card Shop scaffold**: New `/shop` route family with 6 routes and 5 templates; shows all designs with state badges (owned / get_card / locked / not_available); purchase delegates to `purchase_design()` service
- **Phase 2 — My Cards owned-only**: `/my-cards/{player,welcome,challenge}` as canonical URLs showing only CDO-accessible items; legacy hyphenated paths (`/my-cards/player-card` etc.) 301-redirect to canonical; empty state + Browse Shop CTA when nothing owned
- **No new migrations, models, or service changes** — pure route + template layer

## Route changes

| | Route | Behaviour |
|---|---|---|
| NEW | `GET /shop` | Shop landing |
| NEW | `GET /shop/cards` | Card families overview |
| NEW | `GET /shop/cards/{player,welcome,challenge}` | Family shop (all states) |
| NEW | `POST /shop/cards/{type}/buy/{design}` | Purchase → 303 |
| NEW (canonical) | `GET /my-cards/{player,welcome,challenge}` | Owned-only collection |
| COMPAT (301) | `GET /my-cards/{player,welcome,challenge}-card` | → canonical |
| COMPAT (301) | `GET /my-cards/shop` | → `/shop/cards` |
| COMPAT (POST) | `POST /my-cards/designs/{type}/{id}/get` | Legacy purchase wrapper |

## Test plan

- [x] 34 new `SH-*` shop tests — all states, purchase errors, template structure
- [x] 6 new `MCH-R*` legacy redirect tests
- [x] Updated MCP/MCW/MCH/MCS (owned-only behavior, canonical paths)
- [x] PG-06 updated to test `shop.py` (state computation moved there)
- [x] 11,442 unit tests pass (0 failed)
- [x] OpenAPI snapshot updated: 831 routes
- [x] Runtime QA: CDO insert + CreditTransaction `CARD_DESIGN_UNLOCK` verified against dev DB

## Scope guard

No new migrations · No new models · No payment gateway · No CardProduct/ShopOrder · No backend watermark · No dashboard redesign · No mood pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)