### PR TITLE
fix(shop): 3A+3B — CC/PC preview bugfixes and watermark upgrade

### DIFF
--- a/app/templates/includes/mc_format_grid.html
+++ b/app/templates/includes/mc_format_grid.html
@@ -130,6 +130,53 @@
   .mfg-btn-download:hover { background: #14532d; }
   .mfg-btn-edit     { background: #1e3a5f; color: #93c5fd; }
   .mfg-btn-edit:hover { background: #1d4ed8; color: #fff; text-decoration: none; }
+  /* Aspect ratio overrides (CC mock) */
+  .mfg-preview-wrap.mfg-ratio-169 { aspect-ratio: 16 / 9; }
+  .mfg-preview-wrap.mfg-ratio-916 { aspect-ratio: 9 / 16; }
+
+  /* CC mock content */
+  .mfg-cc-mock {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.4rem;
+    border-radius: 8px;
+  }
+  .mfg-cc-mock-dims {
+    font-size: 0.72rem;
+    color: #334155;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+  }
+
+  /* Unavailable state — diagonal stripes, no iframe */
+  .mfg-preview-wrap.mfg-unavailable {
+    background: repeating-linear-gradient(
+      45deg,
+      #0d1117,
+      #0d1117 6px,
+      #131b25 6px,
+      #131b25 12px
+    );
+  }
+  .mfg-unavailable-inner {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .mfg-na-label {
+    font-size: 0.68rem;
+    color: #334155;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
   /* Flash messages */
   .mfg-flash {
     padding: 0.75rem 1rem;

--- a/app/templates/my_cards_challenge_card.html
+++ b/app/templates/my_cards_challenge_card.html
@@ -134,7 +134,7 @@
     {% for r in cc_format_rows %}
     <div class="mfg-card">
 
-      <div class="mfg-preview-wrap mfg-locked">
+      <div class="mfg-preview-wrap">
         <div class="mfg-preview-placeholder">{{ r.label[:2] | upper }}</div>
       </div>
 

--- a/app/templates/shop_challenge_card.html
+++ b/app/templates/shop_challenge_card.html
@@ -123,9 +123,13 @@
     {% for r in format_rows %}
     <div class="mfg-card">
 
-      {# No iframe preview for challenge card — no generic preview URL #}
-      <div class="mfg-preview-wrap mfg-locked">
-        <div class="mfg-preview-placeholder">{{ r.label[:2] | upper }}</div>
+      {# CC aspect-ratio mock — no iframe (no generic preview URL) #}
+      <div class="mfg-preview-wrap
+        {% if '9_16' in r.design_id %}mfg-ratio-916{% else %}mfg-ratio-169{% endif %}
+        {% if r.state != 'owned' %} mfg-locked{% endif %}">
+        <div class="mfg-cc-mock">
+          <span class="mfg-cc-mock-dims">{{ r.dims }}</span>
+        </div>
       </div>
 
       {# Metadata #}
@@ -144,7 +148,7 @@
 
       <div class="mfg-cta">
         {% if r.state == "owned" %}
-          <a href="/challenges/results" class="mfg-btn mfg-btn-download">View Results →</a>
+          <a href="/challenges/results" class="mfg-btn mfg-btn-edit">View Challenges →</a>
         {% elif r.state == "get_card" %}
           <form method="POST" action="/shop/cards/challenge_card/buy/{{ r.design_id }}">
             <button type="submit" class="mfg-btn mfg-btn-get">Get Card — {{ r.credit_cost }} CR</button>

--- a/app/templates/shop_player_card.html
+++ b/app/templates/shop_player_card.html
@@ -113,12 +113,20 @@
         ></iframe>
       </div>
       {% elif d.state == "not_available" %}
-      <div class="mfg-preview-wrap mfg-locked">
-        <div class="mfg-preview-placeholder">{{ d.label[:2] | upper }}</div>
+      <div class="mfg-preview-wrap mfg-unavailable">
+        <div class="mfg-unavailable-inner">
+          <span class="mfg-na-label">Not available</span>
+        </div>
       </div>
       {% else %}
       <div class="mfg-preview-wrap mfg-locked">
-        <div class="mfg-preview-placeholder">{{ d.label[:2] | upper }}</div>
+        <iframe
+          class="mfg-preview-iframe"
+          src="/players/{{ user.id }}/card?platform=instagram_portrait&design={{ d.id }}"
+          loading="lazy"
+          scrolling="no"
+          title="{{ d.label }} preview"
+        ></iframe>
       </div>
       {% endif %}
 

--- a/tests/unit/api/web_routes/test_shop_preview.py
+++ b/tests/unit/api/web_routes/test_shop_preview.py
@@ -1,0 +1,138 @@
+"""Shop preview / watermark 3A+3B structural tests — SUX-01..12.
+
+SUX-01  mc_format_grid.html defines .mfg-unavailable
+SUX-02  mc_format_grid.html defines .mfg-cc-mock
+SUX-03  mc_format_grid.html defines .mfg-ratio-916
+SUX-04  mc_format_grid.html defines .mfg-ratio-169
+SUX-05  shop_player_card.html not_available state uses mfg-unavailable (not mfg-locked)
+SUX-06  shop_player_card.html get_card/locked branch uses mfg-preview-iframe
+SUX-07  shop_player_card.html does not contain mfg-preview-placeholder anywhere
+SUX-08  shop_challenge_card.html mfg-locked is conditional (state != 'owned')
+SUX-09  shop_challenge_card.html mfg-cc-mock present, mfg-preview-placeholder absent
+SUX-10  shop_challenge_card.html owned CTA uses mfg-btn-edit, not mfg-btn-download
+SUX-11  shop_challenge_card.html mfg-ratio-916 present (9:16 format mock)
+SUX-12  my_cards_challenge_card.html does not contain mfg-locked (owned-only collection)
+"""
+import pathlib
+
+_TMPL = (
+    pathlib.Path(__file__).resolve().parents[4]
+    / "app" / "templates"
+)
+_GRID  = (_TMPL / "includes" / "mc_format_grid.html").read_text()
+_SPC   = (_TMPL / "shop_player_card.html").read_text()
+_SCC   = (_TMPL / "shop_challenge_card.html").read_text()
+_MCC   = (_TMPL / "my_cards_challenge_card.html").read_text()
+
+
+# ── SUX-01..04: mc_format_grid.html CSS definitions ───────────────────────────
+
+class TestFormatGridCSS:
+
+    def test_sux01_mfg_unavailable_defined(self):
+        """SUX-01: mc_format_grid.html defines mfg-unavailable."""
+        assert "mfg-unavailable" in _GRID, (
+            "mc_format_grid.html must define .mfg-unavailable for not_available state"
+        )
+
+    def test_sux02_mfg_cc_mock_defined(self):
+        """SUX-02: mc_format_grid.html defines mfg-cc-mock."""
+        assert "mfg-cc-mock" in _GRID, (
+            "mc_format_grid.html must define .mfg-cc-mock for Challenge Card aspect-ratio mock"
+        )
+
+    def test_sux03_mfg_ratio_916_defined(self):
+        """SUX-03: mc_format_grid.html defines mfg-ratio-916 (9:16 aspect ratio)."""
+        assert "mfg-ratio-916" in _GRID, (
+            "mc_format_grid.html must define .mfg-ratio-916 for 9:16 Challenge Card story format"
+        )
+
+    def test_sux04_mfg_ratio_169_defined(self):
+        """SUX-04: mc_format_grid.html defines mfg-ratio-169 (16:9 aspect ratio)."""
+        assert "mfg-ratio-169" in _GRID, (
+            "mc_format_grid.html must define .mfg-ratio-169 for 16:9 Challenge Card post format"
+        )
+
+
+# ── SUX-05..07: shop_player_card.html preview logic ───────────────────────────
+
+class TestPlayerCardShopPreview:
+
+    def test_sux05_not_available_uses_mfg_unavailable(self):
+        """SUX-05: shop_player_card.html not_available state uses mfg-unavailable, not mfg-locked."""
+        assert "mfg-unavailable" in _SPC, (
+            "shop_player_card.html must use mfg-unavailable class for not_available state"
+        )
+        # not_available branch must reference mfg-unavailable — verified by its presence
+        # additionally confirm mfg-na-label is used (inner content)
+        assert "mfg-na-label" in _SPC
+
+    def test_sux06_get_card_locked_uses_iframe(self):
+        """SUX-06: shop_player_card.html get_card/locked branch uses mfg-preview-iframe."""
+        assert "mfg-preview-iframe" in _SPC, (
+            "shop_player_card.html must render iframe for get_card/locked states (not placeholder)"
+        )
+        # The else branch (get_card + locked) must have mfg-locked + iframe
+        assert "mfg-locked" in _SPC, (
+            "shop_player_card.html must still apply mfg-locked overlay for locked/get_card states"
+        )
+
+    def test_sux07_no_placeholder_in_player_shop(self):
+        """SUX-07: shop_player_card.html does not use mfg-preview-placeholder anywhere."""
+        assert "mfg-preview-placeholder" not in _SPC, (
+            "shop_player_card.html must not use 2-letter placeholder — "
+            "locked/get_card now use iframe; not_available uses mfg-unavailable"
+        )
+
+
+# ── SUX-08..11: shop_challenge_card.html preview + CTA ────────────────────────
+
+class TestChallengeCardShopPreview:
+
+    def test_sux08_mfg_locked_is_conditional(self):
+        """SUX-08: shop_challenge_card.html mfg-locked only when state != 'owned'."""
+        assert "state != 'owned'" in _SCC, (
+            "shop_challenge_card.html must conditionally apply mfg-locked "
+            "only when state != 'owned' — owned CC must not show locked overlay"
+        )
+
+    def test_sux09_cc_mock_present_placeholder_absent(self):
+        """SUX-09: shop_challenge_card.html has mfg-cc-mock, no mfg-preview-placeholder."""
+        assert "mfg-cc-mock" in _SCC, (
+            "shop_challenge_card.html must use mfg-cc-mock for CC preview (aspect-ratio mock)"
+        )
+        assert "mfg-preview-placeholder" not in _SCC, (
+            "shop_challenge_card.html must not use 2-letter placeholder — "
+            "CC mock replaces it for all states"
+        )
+
+    def test_sux10_owned_cta_is_edit_not_download(self):
+        """SUX-10: shop_challenge_card.html owned CTA uses mfg-btn-edit, not mfg-btn-download."""
+        assert "mfg-btn-edit" in _SCC, (
+            "shop_challenge_card.html owned CTA must use mfg-btn-edit (navigate style)"
+        )
+        assert "View Challenges" in _SCC, (
+            "shop_challenge_card.html owned CTA text must be 'View Challenges →'"
+        )
+        assert "mfg-btn-download" not in _SCC, (
+            "shop_challenge_card.html must not use mfg-btn-download — "
+            "CC owned CTA navigates to results, does not download"
+        )
+
+    def test_sux11_ratio_916_present(self):
+        """SUX-11: shop_challenge_card.html uses mfg-ratio-916 for 9:16 story format."""
+        assert "mfg-ratio-916" in _SCC, (
+            "shop_challenge_card.html must apply mfg-ratio-916 for challenge_story_9_16 format"
+        )
+
+
+# ── SUX-12: my_cards_challenge_card.html — no mfg-locked on owned ─────────────
+
+class TestMyCardsChallengeCardNoBug:
+
+    def test_sux12_owned_cc_no_mfg_locked(self):
+        """SUX-12: my_cards_challenge_card.html (owned-only) must not contain mfg-locked."""
+        assert "mfg-locked" not in _MCC, (
+            "my_cards_challenge_card.html is owned-only — no format should appear locked. "
+            "BUG-1 fix: remove mfg-locked class from preview div."
+        )


### PR DESCRIPTION
## Summary

- **BUG-1**: `my_cards_challenge_card.html` — remove `mfg-locked` from owned CC preview; owned Challenge Card formats no longer appear locked in My Cards collection
- **BUG-2**: `shop_challenge_card.html` — `mfg-locked` is now conditional (`state != 'owned'`); owned CC shows clean aspect-ratio mock; owned CTA changed from `mfg-btn-download` to `mfg-btn-edit` ("View Challenges →")
- **BUG-3**: `shop_player_card.html` — `not_available` state gets `mfg-unavailable` (diagonal stripe pattern), visually distinct from `locked`; `get_card`/`locked` now use iframe + watermark overlay instead of 2-letter placeholder
- **3B**: `mc_format_grid.html` — new CSS classes: `mfg-ratio-169`, `mfg-ratio-916`, `mfg-cc-mock`, `mfg-cc-mock-dims`, `mfg-unavailable`, `mfg-unavailable-inner`, `mfg-na-label`

## Scope

5 files only: 4 templates + 1 new test file. No migration, no model, no new endpoint, no backend change.

## Test plan

- [x] SUX-01..12: 12 new structural tests — all pass
- [x] 110 affected tests (shop + my-cards + publish-guard) — all pass
- [x] Full unit suite: 11 454 passed, 0 failed
- [x] Jinja2 template parse: 0 syntax errors
- [x] 19/19 programmatic QA invariants: all PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)