### PR TITLE
feat(my-cards): 3D-1 UX polish — CC mock, PC CTA, WC ratios

### DIFF
--- a/app/templates/includes/mc_format_grid.html
+++ b/app/templates/includes/mc_format_grid.html
@@ -130,9 +130,11 @@
   .mfg-btn-download:hover { background: #14532d; }
   .mfg-btn-edit     { background: #1e3a5f; color: #93c5fd; }
   .mfg-btn-edit:hover { background: #1d4ed8; color: #fff; text-decoration: none; }
-  /* Aspect ratio overrides (CC mock) */
+  /* Aspect ratio overrides */
   .mfg-preview-wrap.mfg-ratio-169 { aspect-ratio: 16 / 9; }
   .mfg-preview-wrap.mfg-ratio-916 { aspect-ratio: 9 / 16; }
+  .mfg-preview-wrap.mfg-ratio-45  { aspect-ratio: 4 / 5; }
+  .mfg-preview-wrap.mfg-ratio-11  { aspect-ratio: 1 / 1; }
 
   /* CC mock content */
   .mfg-cc-mock {

--- a/app/templates/my_cards_challenge_card.html
+++ b/app/templates/my_cards_challenge_card.html
@@ -114,11 +114,20 @@
   </div>
   {% endif %}
   {% if flash_error == "credits" %}
-  <div class="mfg-flash mfg-flash-error">Not enough credits to purchase this format.</div>
+  <div class="mfg-flash mfg-flash-error">
+    Not enough credits.
+    <a class="mfg-flash-cta" href="/credits">Get more credits →</a>
+  </div>
   {% elif flash_error == "owned" %}
-  <div class="mfg-flash mfg-flash-error">You already own this format.</div>
+  <div class="mfg-flash mfg-flash-error">
+    You already own this.
+    <a class="mfg-flash-cta" href="/shop/cards/challenge">Browse Challenge Cards →</a>
+  </div>
   {% elif flash_error == "invalid" %}
-  <div class="mfg-flash mfg-flash-error">Unknown format.</div>
+  <div class="mfg-flash mfg-flash-error">
+    This product is no longer available.
+    <a class="mfg-flash-cta" href="/shop/cards">Back to shop →</a>
+  </div>
   {% endif %}
 
   {% if cc_format_rows %}
@@ -134,8 +143,11 @@
     {% for r in cc_format_rows %}
     <div class="mfg-card">
 
-      <div class="mfg-preview-wrap">
-        <div class="mfg-preview-placeholder">{{ r.label[:2] | upper }}</div>
+      <div class="mfg-preview-wrap
+        {% if '9_16' in r.design_id %}mfg-ratio-916{% else %}mfg-ratio-169{% endif %}">
+        <div class="mfg-cc-mock">
+          <span class="mfg-cc-mock-dims">{{ r.dims }}</span>
+        </div>
       </div>
 
       <p class="mfg-style-tag">{{ r.style_tag }}</p>

--- a/app/templates/my_cards_player_card.html
+++ b/app/templates/my_cards_player_card.html
@@ -97,16 +97,26 @@
 
   {# ── Flash messages ── #}
   {% if flash_purchased %}
+  {% set _pl = (design_rows | selectattr('id', 'equalto', flash_purchased) | map(attribute='label') | first) %}
   <div class="mfg-flash mfg-flash-success">
-    ✓ Design unlocked — {{ flash_purchased }} is now in your collection.
+    ✓ Design unlocked — {{ _pl or flash_purchased }} is now in your collection.
   </div>
   {% endif %}
   {% if flash_error == "credits" %}
-  <div class="mfg-flash mfg-flash-error">Not enough credits to purchase this design.</div>
+  <div class="mfg-flash mfg-flash-error">
+    Not enough credits.
+    <a class="mfg-flash-cta" href="/credits">Get more credits →</a>
+  </div>
   {% elif flash_error == "owned" %}
-  <div class="mfg-flash mfg-flash-error">You already own this design.</div>
+  <div class="mfg-flash mfg-flash-error">
+    You already own this.
+    <a class="mfg-flash-cta" href="/shop/cards/player">Browse Player Cards →</a>
+  </div>
   {% elif flash_error == "invalid" %}
-  <div class="mfg-flash mfg-flash-error">Unknown card type or design.</div>
+  <div class="mfg-flash mfg-flash-error">
+    This product is no longer available.
+    <a class="mfg-flash-cta" href="/shop/cards">Back to shop →</a>
+  </div>
   {% endif %}
 
   {% if design_rows %}
@@ -140,7 +150,7 @@
       <span class="mfg-badge mfg-badge-owned">Owned ✓</span>
 
       <div class="mfg-cta">
-        <a href="/dashboard/lfa-football-player/card-editor" class="mfg-btn mfg-btn-edit mfg-btn-download">Edit / Download</a>
+        <a href="/dashboard/lfa-football-player/card-editor" class="mfg-btn mfg-btn-edit">Open Editor →</a>
       </div>
 
     </div>

--- a/app/templates/my_cards_welcome_card.html
+++ b/app/templates/my_cards_welcome_card.html
@@ -102,11 +102,20 @@
   </div>
   {% endif %}
   {% if flash_error == "credits" %}
-  <div class="mfg-flash mfg-flash-error">Not enough credits to purchase this format.</div>
+  <div class="mfg-flash mfg-flash-error">
+    Not enough credits.
+    <a class="mfg-flash-cta" href="/credits">Get more credits →</a>
+  </div>
   {% elif flash_error == "owned" %}
-  <div class="mfg-flash mfg-flash-error">You already own this format.</div>
+  <div class="mfg-flash mfg-flash-error">
+    You already own this.
+    <a class="mfg-flash-cta" href="/shop/cards/welcome">Browse Welcome Cards →</a>
+  </div>
   {% elif flash_error == "invalid" %}
-  <div class="mfg-flash mfg-flash-error">Unknown format.</div>
+  <div class="mfg-flash mfg-flash-error">
+    This product is no longer available.
+    <a class="mfg-flash-cta" href="/shop/cards">Back to shop →</a>
+  </div>
   {% endif %}
 
   {% if format_rows %}
@@ -122,7 +131,12 @@
     {% for r in format_rows %}
     <div class="mfg-card">
 
-      <div class="mfg-preview-wrap">
+      <div class="mfg-preview-wrap
+        {% if r.preview_platform in ('instagram_story', 'tiktok') %}mfg-ratio-916
+        {% elif r.preview_platform == 'instagram_portrait' %}mfg-ratio-45
+        {% elif r.preview_platform in ('instagram_square', 'facebook_square') %}mfg-ratio-11
+        {% elif r.preview_platform in ('facebook_landscape', 'banner_custom') %}mfg-ratio-169
+        {% endif %}">
         <iframe
           class="mfg-preview-iframe"
           src="{{ r.preview_url }}"

--- a/app/templates/shop_welcome_card.html
+++ b/app/templates/shop_welcome_card.html
@@ -126,7 +126,13 @@
     <div class="mfg-card{% if flash_purchased and r.design_id == flash_purchased %} mfg-card-just-purchased{% endif %}">
 
       {# Preview with watermark overlay for unowned #}
-      <div class="mfg-preview-wrap{% if r.state != 'owned' %} mfg-locked{% endif %}">
+      <div class="mfg-preview-wrap
+        {% if r.preview_platform in ('instagram_story', 'tiktok') %}mfg-ratio-916
+        {% elif r.preview_platform == 'instagram_portrait' %}mfg-ratio-45
+        {% elif r.preview_platform in ('instagram_square', 'facebook_square') %}mfg-ratio-11
+        {% elif r.preview_platform in ('facebook_landscape', 'banner_custom') %}mfg-ratio-169
+        {% endif %}
+        {% if r.state != 'owned' %} mfg-locked{% endif %}">
         <iframe
           class="mfg-preview-iframe"
           src="{{ r.preview_url }}"

--- a/tests/unit/api/web_routes/test_my_cards_feedback.py
+++ b/tests/unit/api/web_routes/test_my_cards_feedback.py
@@ -1,0 +1,348 @@
+"""My Cards UX Polish tests — MCF-01..21.
+
+Structural tests (template text assertions):
+  MCF-01..02   CC template uses mfg-cc-mock, not mfg-preview-placeholder
+  MCF-05..06   PC CTA is "Open Editor →", no mfg-btn-download on that button
+  MCF-07       PC purchased flash uses selectattr label resolution
+  MCF-09..11   My Cards error flash blocks contain /credits link
+  MCF-20..21   mc_format_grid.html defines mfg-ratio-45 and mfg-ratio-11
+
+Rendering tests (Jinja2 direct render):
+  MCF-03..04   CC formats render correct aspect-ratio class per design_id
+  MCF-08       PC purchased flash renders human-readable label, not raw design_id
+  MCF-12..17   WC My Cards formats render correct ratio class per preview_platform
+  MCF-18..19   Shop WC formats also render correct ratio classes
+"""
+import pathlib
+from unittest.mock import MagicMock
+
+from jinja2 import Environment, FileSystemLoader, Undefined
+
+_TMPL_DIR = str(pathlib.Path(__file__).resolve().parents[4] / "app" / "templates")
+_TMPL = pathlib.Path(_TMPL_DIR)
+
+_MCC  = (_TMPL / "my_cards_challenge_card.html").read_text()
+_MCP  = (_TMPL / "my_cards_player_card.html").read_text()
+_MCW  = (_TMPL / "my_cards_welcome_card.html").read_text()
+_SWC  = (_TMPL / "shop_welcome_card.html").read_text()
+_GRID = (_TMPL / "includes" / "mc_format_grid.html").read_text()
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _user(balance: int = 500):
+    u = MagicMock()
+    u.id = 1
+    u.credit_balance = balance
+    return u
+
+
+def _render(template_name: str, ctx: dict) -> str:
+    env = Environment(
+        loader=FileSystemLoader(_TMPL_DIR),
+        undefined=Undefined,
+        autoescape=False,
+    )
+    return env.get_template(template_name).render(**ctx)
+
+
+def _mcc_ctx(purchased=None, error=None, rows=None):
+    rows = rows or [
+        {
+            "design_id":   "challenge_post_16_9",
+            "label":       "Post (16:9)",
+            "style_tag":   "POST",
+            "dims":        "1280 × 720",
+            "credit_cost": 100,
+            "state":       "owned",
+        },
+        {
+            "design_id":   "challenge_story_9_16",
+            "label":       "Story (9:16)",
+            "style_tag":   "STORY",
+            "dims":        "1080 × 1920",
+            "credit_cost": 100,
+            "state":       "owned",
+        },
+    ]
+    return {
+        "request":         MagicMock(query_params={}),
+        "user":            _user(),
+        "cc_format_rows":  rows,
+        "cc_owned_count":  len(rows),
+        "cc_total":        len(rows),
+        "flash_purchased": purchased,
+        "flash_error":     error,
+        "spec_dashboard_url": "/dashboard/lfa-football-player",
+    }
+
+
+def _mcp_ctx(purchased=None, error=None, rows=None, balance=500):
+    rows = rows or [
+        {
+            "id":          "lfa_classic_2025",
+            "label":       "LFA Classic 2025",
+            "description": None,
+            "credit_cost": 300,
+            "is_premium":  True,
+            "state":       "owned",
+        },
+    ]
+    return {
+        "request":         MagicMock(query_params={}),
+        "user":            _user(balance),
+        "design_rows":     rows,
+        "owned_count":     len(rows),
+        "total_count":     len(rows),
+        "flash_purchased": purchased,
+        "flash_error":     error,
+        "spec_dashboard_url": "/dashboard/lfa-football-player",
+    }
+
+
+def _mcw_ctx(purchased=None, error=None, rows=None):
+    rows = rows or [
+        {
+            "design_id":        "instagram_story",
+            "label":            "Instagram Story",
+            "style_tag":        "IDENTITY CARD",
+            "dims":             "1080 × 1920",
+            "credit_cost":      75,
+            "preview_platform": "instagram_story",
+            "state":            "owned",
+            "preview_url":      "/x",
+            "export_url":       "/x",
+        },
+    ]
+    return {
+        "request":         MagicMock(query_params={}),
+        "user":            _user(),
+        "format_rows":     rows,
+        "owned_count":     sum(1 for r in rows if r["state"] == "owned"),
+        "total_count":     len(rows),
+        "flash_purchased": purchased,
+        "flash_error":     error,
+        "spec_dashboard_url": "/dashboard/lfa-football-player",
+    }
+
+
+def _swc_ctx(purchased=None, error=None, rows=None):
+    rows = rows or [
+        {
+            "design_id":        "instagram_story",
+            "label":            "Instagram Story",
+            "style_tag":        "IDENTITY CARD",
+            "dims":             "1080 × 1920",
+            "credit_cost":      75,
+            "preview_platform": "instagram_story",
+            "state":            "get_card",
+            "preview_url":      "/x",
+            "export_url":       "/x",
+        },
+    ]
+    return {
+        "request":         MagicMock(query_params={}),
+        "user":            _user(),
+        "format_rows":     rows,
+        "owned_count":     sum(1 for r in rows if r["state"] == "owned"),
+        "total_count":     len(rows),
+        "flash_purchased": purchased,
+        "flash_error":     error,
+        "spec_dashboard_url": "/dashboard/lfa-football-player",
+    }
+
+
+def _wc_row(platform: str, state: str = "owned") -> dict:
+    """Build a single WC format_rows entry for a given preview_platform."""
+    dims_map = {
+        "instagram_portrait": "1080 × 1350",
+        "instagram_story":    "1080 × 1920",
+        "instagram_square":   "1080 × 1080",
+        "tiktok":             "1080 × 1920",
+        "facebook_square":    "1080 × 1080",
+        "facebook_landscape": "1920 × 1080",
+        "banner_custom":      "1584 × 396",
+    }
+    return {
+        "design_id":        platform,
+        "label":            platform.replace("_", " ").title(),
+        "style_tag":        "IDENTITY CARD",
+        "dims":             dims_map.get(platform, "—"),
+        "credit_cost":      75,
+        "preview_platform": platform,
+        "state":            state,
+        "preview_url":      "/x",
+        "export_url":       "/x",
+    }
+
+
+# ── MCF-01..04: CC My Cards mock — no placeholder, correct ratio ──────────────
+
+class TestCCMock:
+
+    def test_mcf01_cc_template_uses_mfg_cc_mock(self):
+        """MCF-01: my_cards_challenge_card.html uses mfg-cc-mock, not placeholder."""
+        assert "mfg-cc-mock" in _MCC
+
+    def test_mcf02_cc_template_has_no_preview_placeholder(self):
+        """MCF-02: mfg-preview-placeholder is removed from CC My Cards template."""
+        assert "mfg-preview-placeholder" not in _MCC
+
+    def test_mcf03_cc_story_renders_ratio_916(self):
+        """MCF-03: challenge_story_9_16 row renders mfg-ratio-916 class."""
+        ctx = _mcc_ctx(rows=[
+            {"design_id": "challenge_story_9_16", "label": "Story (9:16)",
+             "style_tag": "STORY", "dims": "1080 × 1920", "credit_cost": 100, "state": "owned"},
+        ])
+        html = _render("my_cards_challenge_card.html", ctx)
+        assert "mfg-ratio-916" in html
+
+    def test_mcf04_cc_post_renders_ratio_169(self):
+        """MCF-04: challenge_post_16_9 row renders mfg-ratio-169 class."""
+        ctx = _mcc_ctx(rows=[
+            {"design_id": "challenge_post_16_9", "label": "Post (16:9)",
+             "style_tag": "POST", "dims": "1280 × 720", "credit_cost": 100, "state": "owned"},
+        ])
+        html = _render("my_cards_challenge_card.html", ctx)
+        assert "mfg-ratio-169" in html
+
+
+# ── MCF-05..08: PC My Cards CTA + flash label ─────────────────────────────────
+
+class TestPCCTAAndFlash:
+
+    def test_mcf05_pc_cta_text_is_open_editor(self):
+        """MCF-05: my_cards_player_card.html CTA text is 'Open Editor →'."""
+        assert "Open Editor →" in _MCP
+
+    def test_mcf06_pc_cta_has_no_mfg_btn_download(self):
+        """MCF-06: The Open Editor link does not carry mfg-btn-download class."""
+        assert 'mfg-btn-edit mfg-btn-download' not in _MCP
+        assert '"mfg-btn mfg-btn-download"' not in _MCP
+
+    def test_mcf07_pc_flash_has_selectattr_label_resolution(self):
+        """MCF-07: PC My Cards template resolves flash label via selectattr."""
+        assert "selectattr('id', 'equalto', flash_purchased)" in _MCP
+        assert "map(attribute='label')" in _MCP
+        assert "_pl or flash_purchased" in _MCP
+
+    def test_mcf08_pc_flash_renders_label_not_raw_id(self):
+        """MCF-08: PC My Cards flash renders 'LFA Classic 2025', not raw 'lfa_classic_2025'."""
+        ctx = _mcp_ctx(purchased="lfa_classic_2025")
+        html = _render("my_cards_player_card.html", ctx)
+        assert "LFA Classic 2025" in html
+        assert "Design unlocked" in html
+        flash_part = html.split("Design unlocked")[1].split("</div>")[0]
+        assert "lfa_classic_2025" not in flash_part
+
+
+# ── MCF-09..11: error flash CTAs contain /credits link ───────────────────────
+
+class TestErrorFlashCTAs:
+
+    def test_mcf09_pc_credits_error_has_credits_link(self):
+        """MCF-09: PC My Cards credits error block contains /credits."""
+        assert "/credits" in _MCP
+        assert "Get more credits" in _MCP
+
+    def test_mcf10_wc_credits_error_has_credits_link(self):
+        """MCF-10: WC My Cards credits error block contains /credits."""
+        assert "/credits" in _MCW
+        assert "Get more credits" in _MCW
+
+    def test_mcf11_cc_credits_error_has_credits_link(self):
+        """MCF-11: CC My Cards credits error block contains /credits."""
+        assert "/credits" in _MCC
+        assert "Get more credits" in _MCC
+
+    def test_mcf09b_pc_credits_error_renders_link(self):
+        """MCF-09b: PC My Cards credits error renders /credits href."""
+        html = _render("my_cards_player_card.html", _mcp_ctx(error="credits"))
+        assert "/credits" in html
+
+    def test_mcf10b_wc_credits_error_renders_link(self):
+        """MCF-10b: WC My Cards credits error renders /credits href."""
+        html = _render("my_cards_welcome_card.html", _mcw_ctx(error="credits"))
+        assert "/credits" in html
+
+    def test_mcf11b_cc_credits_error_renders_link(self):
+        """MCF-11b: CC My Cards credits error renders /credits href."""
+        html = _render("my_cards_challenge_card.html", _mcc_ctx(error="credits"))
+        assert "/credits" in html
+
+
+# ── MCF-12..17: WC My Cards iframe ratio classes ─────────────────────────────
+
+class TestMCWIframeRatio:
+
+    def test_mcf12_wc_story_renders_ratio_916(self):
+        """MCF-12: WC My Cards instagram_story renders mfg-ratio-916."""
+        html = _render("my_cards_welcome_card.html",
+                       _mcw_ctx(rows=[_wc_row("instagram_story")]))
+        assert "mfg-ratio-916" in html
+
+    def test_mcf13_wc_portrait_renders_ratio_45(self):
+        """MCF-13: WC My Cards instagram_portrait renders mfg-ratio-45."""
+        html = _render("my_cards_welcome_card.html",
+                       _mcw_ctx(rows=[_wc_row("instagram_portrait")]))
+        assert "mfg-ratio-45" in html
+
+    def test_mcf14_wc_square_renders_ratio_11(self):
+        """MCF-14: WC My Cards instagram_square renders mfg-ratio-11."""
+        html = _render("my_cards_welcome_card.html",
+                       _mcw_ctx(rows=[_wc_row("instagram_square")]))
+        assert "mfg-ratio-11" in html
+
+    def test_mcf15_wc_facebook_square_renders_ratio_11(self):
+        """MCF-15: WC My Cards facebook_square renders mfg-ratio-11."""
+        html = _render("my_cards_welcome_card.html",
+                       _mcw_ctx(rows=[_wc_row("facebook_square")]))
+        assert "mfg-ratio-11" in html
+
+    def test_mcf16_wc_landscape_renders_ratio_169(self):
+        """MCF-16: WC My Cards facebook_landscape renders mfg-ratio-169."""
+        html = _render("my_cards_welcome_card.html",
+                       _mcw_ctx(rows=[_wc_row("facebook_landscape")]))
+        assert "mfg-ratio-169" in html
+
+    def test_mcf17_wc_banner_renders_ratio_169(self):
+        """MCF-17: WC My Cards banner_custom renders mfg-ratio-169 (practical fallback)."""
+        html = _render("my_cards_welcome_card.html",
+                       _mcw_ctx(rows=[_wc_row("banner_custom")]))
+        assert "mfg-ratio-169" in html
+
+    def test_mcf17b_wc_tiktok_renders_ratio_916(self):
+        """MCF-17b: WC My Cards tiktok renders mfg-ratio-916."""
+        html = _render("my_cards_welcome_card.html",
+                       _mcw_ctx(rows=[_wc_row("tiktok")]))
+        assert "mfg-ratio-916" in html
+
+
+# ── MCF-18..19: Shop WC also uses ratio classes (E bonus fix) ─────────────────
+
+class TestShopWCRatio:
+
+    def test_mcf18_shop_wc_story_renders_ratio_916(self):
+        """MCF-18: shop_welcome_card.html instagram_story renders mfg-ratio-916."""
+        html = _render("shop_welcome_card.html",
+                       _swc_ctx(rows=[_wc_row("instagram_story", state="get_card")]))
+        assert "mfg-ratio-916" in html
+
+    def test_mcf19_shop_wc_portrait_renders_ratio_45(self):
+        """MCF-19: shop_welcome_card.html instagram_portrait renders mfg-ratio-45."""
+        html = _render("shop_welcome_card.html",
+                       _swc_ctx(rows=[_wc_row("instagram_portrait", state="get_card")]))
+        assert "mfg-ratio-45" in html
+
+
+# ── MCF-20..21: new CSS ratio classes defined in mc_format_grid.html ─────────
+
+class TestGridCSSNewRatioClasses:
+
+    def test_mcf20_grid_css_has_ratio_45(self):
+        """MCF-20: mc_format_grid.html defines .mfg-preview-wrap.mfg-ratio-45."""
+        assert "mfg-ratio-45" in _GRID
+
+    def test_mcf21_grid_css_has_ratio_11(self):
+        """MCF-21: mc_format_grid.html defines .mfg-preview-wrap.mfg-ratio-11."""
+        assert "mfg-ratio-11" in _GRID


### PR DESCRIPTION
## Summary

- **My Cards Challenge**: replace 2-letter `mfg-preview-placeholder` with proper CC mock (`mfg-cc-mock` + dims label); `challenge_post_16_9` → `mfg-ratio-169`, `challenge_story_9_16` → `mfg-ratio-916`; no `mfg-locked` overlay on owned items
- **My Cards Player CTA**: rename "Edit / Download" → "Open Editor →"; remove `mfg-btn-download` class from the button
- **My Cards Player flash label**: resolve `?purchased={design_id}` to human-readable label via Jinja2 `selectattr`/`map`/`first` on `design_rows`; fallback to raw ID
- **My Cards error CTAs**: add `mfg-flash-cta` links to error flash blocks across all 3 My Cards pages (`credits` → `/credits`, `owned` → family shop, `invalid` → `/shop/cards`)
- **Welcome Card iframe ratio fix**: apply correct `aspect-ratio` CSS class per `preview_platform` on both `my_cards_welcome_card.html` and `shop_welcome_card.html`; add `mfg-ratio-45` (4:5) and `mfg-ratio-11` (1:1) to `mc_format_grid.html`

## Scope

- 0 migrations
- 0 new endpoints
- 0 model changes
- 0 service/domain changes
- 0 CardDraftService / active badge (deferred to 3D-2)
- 0 direct PC download button
- 0 export route modifications
- 0 dashboard modifications
- Template + CSS only: 5 files changed, 1 new test file

## Files changed

| File | Change |
|---|---|
| `app/templates/my_cards_challenge_card.html` | CC mock, error CTAs |
| `app/templates/my_cards_player_card.html` | CTA relabel, flash label, error CTAs |
| `app/templates/my_cards_welcome_card.html` | iframe ratio classes, error CTAs |
| `app/templates/shop_welcome_card.html` | iframe ratio classes (E bonus) |
| `app/templates/includes/mc_format_grid.html` | `mfg-ratio-45`, `mfg-ratio-11` CSS |
| `tests/unit/api/web_routes/test_my_cards_feedback.py` | 25 MCF-01..21 tests (new) |

## Test plan

- [x] MCF-01..21: 25/25 pass
- [x] SCF-01..24 (shop feedback): 30/30 pass — 0 regressions
- [x] Full unit suite: 11,509 pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)