### PR TITLE
feat(shop): Player Card collection detail page — C1 MVP

### DIFF
--- a/app/api/web_routes/shop.py
+++ b/app/api/web_routes/shop.py
@@ -1,7 +1,7 @@
 """Card shop — browse and purchase card designs and platform formats."""
 from pathlib import Path
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from sqlalchemy.orm import Session
@@ -18,6 +18,7 @@ from ...services.card_design_service import (
     is_design_accessible,
     purchase_design,
 )
+from ...services.card_constants import PC_FORMAT_META
 from ...services.credit_service import InsufficientCreditsError
 
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
@@ -110,6 +111,54 @@ async def shop_player_card(
             "flash_purchased": request.query_params.get("purchased"),
             "flash_error":     request.query_params.get("error"),
             "spec_dashboard_url": "/dashboard/lfa-football-player",
+        },
+    )
+
+
+# ── Player Card collection detail ─────────────────────────────────────────────
+
+@router.get("/shop/cards/player/{collection_id}", response_class=HTMLResponse)
+async def shop_player_card_detail(
+    collection_id: str,
+    request: Request,
+    db: Session = Depends(get_db),
+    user: User  = Depends(get_current_user_web),
+):
+    all_designs = get_all_designs(db)
+    design = next((d for d in all_designs if d.id == collection_id), None)
+    if design is None:
+        raise HTTPException(status_code=404)
+
+    credits = user.credit_balance
+    owned = is_design_accessible(db, user.id, "player_card", collection_id)
+
+    if not design.available or design.credit_cost == 0:
+        state = "not_available"
+    elif owned:
+        state = "owned"
+    elif credits >= design.credit_cost:
+        state = "get_card"
+    else:
+        state = "locked"
+
+    meta_by_bucket = {m["bucket"]: m for m in PC_FORMAT_META}
+    format_rows = [
+        meta_by_bucket[b]
+        for b in design.supported_export_buckets
+        if b in meta_by_bucket
+    ]
+
+    return templates.TemplateResponse(
+        "shop_player_card_detail.html",
+        {
+            "request":         request,
+            "user":            user,
+            "design":          design,
+            "collection_id":   collection_id,
+            "state":           state,
+            "format_rows":     format_rows,
+            "flash_purchased": request.query_params.get("purchased"),
+            "flash_error":     request.query_params.get("error"),
         },
     )
 

--- a/app/services/card_constants.py
+++ b/app/services/card_constants.py
@@ -158,3 +158,19 @@ CARD_GALLERY_PLATFORM_IDS: tuple[str, ...] = (
     "og",
     "banner_custom",
 )
+
+# Player Card format metadata — maps export bucket → display metadata.
+# Used by /shop/cards/player/{collection_id} detail page (C1 collection browsing).
+# Ordering: portrait-first, then vertical formats, then square, then wide/landscape.
+# C2 note: when format-level purchase is introduced, each entry gains a credit_cost
+# and design_id convention (e.g. "fifa_instagram_portrait"). For now, ownership is
+# collection-level (design_id="fifa") and all formats are unlocked together.
+PC_FORMAT_META: list[dict] = [
+    {"bucket": "portrait",  "platform": "instagram_portrait",  "label": "Instagram Portrait", "dims": "1080 × 1350", "ratio": "mfg-ratio-45",  "display_order": 0},
+    {"bucket": "story",     "platform": "instagram_story",     "label": "Instagram Story",    "dims": "1080 × 1920", "ratio": "mfg-ratio-916", "display_order": 1},
+    {"bucket": "tiktok",    "platform": "tiktok",              "label": "TikTok",             "dims": "1080 × 1920", "ratio": "mfg-ratio-916", "display_order": 2},
+    {"bucket": "square",    "platform": "instagram_square",    "label": "Square",             "dims": "1080 × 1080", "ratio": "mfg-ratio-11",  "display_order": 3},
+    {"bucket": "landscape", "platform": "facebook_landscape",  "label": "Landscape",          "dims": "1200 × 630",  "ratio": "mfg-ratio-169", "display_order": 4},
+    {"bucket": "og",        "platform": "og",                  "label": "Open Graph",         "dims": "1200 × 630",  "ratio": "mfg-ratio-169", "display_order": 5},
+    {"bucket": "banner",    "platform": "banner_custom",       "label": "Banner",             "dims": "1500 × 500",  "ratio": "mfg-ratio-169", "display_order": 6},
+]

--- a/app/templates/shop_player_card.html
+++ b/app/templates/shop_player_card.html
@@ -54,6 +54,15 @@
     margin-bottom: 1.5rem;
   }
   .spc-my-collection:hover { color: #bfdbfe; text-decoration: none; }
+  .spc-browse-formats {
+    display: block;
+    text-align: center;
+    font-size: 0.78rem;
+    color: #64748b;
+    text-decoration: none;
+    margin-top: 0.25rem;
+  }
+  .spc-browse-formats:hover { color: #94a3b8; text-decoration: none; }
 </style>
 {% endblock %}
 
@@ -174,6 +183,7 @@
         {% else %}
           <button class="mfg-btn mfg-btn-disabled" disabled>Not enough credits</button>
         {% endif %}
+        <a href="/shop/cards/player/{{ d.id }}" class="spc-browse-formats">Browse formats →</a>
       </div>
 
     </div>

--- a/app/templates/shop_player_card_detail.html
+++ b/app/templates/shop_player_card_detail.html
@@ -1,0 +1,219 @@
+{% extends "student_base.html" %}
+
+{% block title %}{{ design.label }} — LFA Card Shop{% endblock %}
+{% block active_page %}lfa-player{% endblock %}
+
+{% block student_header %}
+{% set _page_icon = '🎴' %}
+{% set _page_name = design.label %}
+{% include "includes/spec_subpage_hdr.html" %}
+{% endblock %}
+
+{% block extra_styles %}
+{% include "includes/mc_format_grid.html" %}
+<style>
+  .spd-wrap {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 1.5rem 1rem 4rem;
+  }
+  .spd-breadcrumb {
+    font-size: 0.8rem;
+    color: #64748b;
+    margin-bottom: 1.25rem;
+  }
+  .spd-breadcrumb a { color: #94a3b8; text-decoration: none; }
+  .spd-breadcrumb a:hover { color: #f1f5f9; }
+  .spd-breadcrumb span { margin: 0 0.35rem; }
+  .spd-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 0.75rem;
+  }
+  .spd-header h1 { font-size: 1.4rem; font-weight: 700; color: #f8fafc; margin: 0; }
+  .spd-credits-badge {
+    background: #1e293b;
+    border: 1px solid #334155;
+    border-radius: 20px;
+    padding: 0.35rem 0.9rem;
+    font-size: 0.85rem;
+    color: #94a3b8;
+  }
+  .spd-credits-badge strong { color: #FFD200; }
+  .spd-desc {
+    font-size: 0.88rem;
+    color: #64748b;
+    margin-bottom: 0.75rem;
+    max-width: 600px;
+  }
+  .spd-back {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.82rem;
+    font-weight: 600;
+    color: #93c5fd;
+    text-decoration: none;
+    margin-bottom: 1.5rem;
+  }
+  .spd-back:hover { color: #bfdbfe; text-decoration: none; }
+  /* Collection CTA block */
+  .spd-collection-cta {
+    background: #0f172a;
+    border: 1px solid #1e293b;
+    border-radius: 12px;
+    padding: 1rem 1.25rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-bottom: 2rem;
+  }
+  .spd-collection-cta-info {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+  .spd-collection-cta-label {
+    font-size: 0.78rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: #475569;
+  }
+  .spd-collection-cta-price {
+    font-size: 1rem;
+    font-weight: 700;
+    color: #f1f5f9;
+  }
+  .spd-collection-cta-price.owned { color: #86efac; }
+  /* Format grid section */
+  .spd-section-hdr {
+    margin-bottom: 0.75rem;
+  }
+  .spd-section-hdr h2 {
+    font-size: 1rem;
+    font-weight: 700;
+    color: #f1f5f9;
+    margin: 0 0 0.2rem;
+  }
+  .spd-section-sub {
+    font-size: 0.78rem;
+    color: #475569;
+  }
+  /* "Included in this collection" badge override — reuse mfg-badge-free */
+</style>
+{% endblock %}
+
+{% block student_content %}
+<div class="spd-wrap">
+
+  <nav class="spd-breadcrumb" aria-label="Breadcrumb">
+    <a href="/shop">Shop</a>
+    <span>›</span>
+    <a href="/shop/cards">Cards</a>
+    <span>›</span>
+    <a href="/shop/cards/player">Player Card</a>
+    <span>›</span>
+    <span>{{ design.label }}</span>
+  </nav>
+
+  <div class="spd-header">
+    <h1>{{ design.label }}</h1>
+    <span class="spd-credits-badge">Balance: <strong>{{ user.credit_balance }} CR</strong></span>
+  </div>
+
+  {% if design.description %}
+  <p class="spd-desc">{{ design.description }}</p>
+  {% endif %}
+
+  <a href="/shop/cards/player" class="spd-back">← Player Card Designs</a>
+
+  {# ── Flash messages ── #}
+  {% if flash_purchased %}
+  <div class="mfg-flash mfg-flash-success">
+    ✓ {{ design.label }} unlocked — all formats are now available for export.
+  </div>
+  {% endif %}
+  {% if flash_error == "credits" %}
+  <div class="mfg-flash mfg-flash-error">
+    Not enough credits.
+    <a class="mfg-flash-cta" href="/credits">Get more credits →</a>
+  </div>
+  {% elif flash_error == "owned" %}
+  <div class="mfg-flash mfg-flash-error">
+    You already own this collection.
+    <a class="mfg-flash-cta" href="/my-cards/player">View in My Cards →</a>
+  </div>
+  {% elif flash_error == "invalid" %}
+  <div class="mfg-flash mfg-flash-error">
+    This product is no longer available.
+    <a class="mfg-flash-cta" href="/shop/cards">Back to shop →</a>
+  </div>
+  {% endif %}
+
+  {# ── Collection-level CTA ── #}
+  <div class="spd-collection-cta">
+    <div class="spd-collection-cta-info">
+      <span class="spd-collection-cta-label">Collection</span>
+      {% if state == "owned" %}
+        <span class="spd-collection-cta-price owned">{{ design.label }} — Owned ✓</span>
+      {% elif state == "not_available" %}
+        <span class="spd-collection-cta-price">{{ design.label }} — Not available</span>
+      {% else %}
+        <span class="spd-collection-cta-price">{{ design.label }} — {{ design.credit_cost }} CR</span>
+      {% endif %}
+    </div>
+
+    <div>
+      {% if state == "owned" %}
+        <a href="/dashboard/lfa-football-player/card-editor" class="mfg-btn mfg-btn-edit" style="width:auto;display:inline-block;padding:0.5rem 1.25rem;">Open Editor →</a>
+      {% elif state == "get_card" %}
+        <form method="POST" action="/shop/cards/player_card/buy/{{ collection_id }}">
+          <button type="submit" class="mfg-btn mfg-btn-get" style="width:auto;padding:0.5rem 1.25rem;">
+            Buy {{ design.label }} — {{ design.credit_cost }} CR
+          </button>
+        </form>
+      {% elif state == "not_available" %}
+        <button class="mfg-btn mfg-btn-disabled" style="width:auto;padding:0.5rem 1.25rem;" disabled>Not available</button>
+      {% else %}
+        <button class="mfg-btn mfg-btn-disabled" style="width:auto;padding:0.5rem 1.25rem;" disabled>Not enough credits</button>
+      {% endif %}
+    </div>
+  </div>
+
+  {# ── Format grid ── #}
+  <div class="spd-section-hdr">
+    <h2>Formats included in this collection</h2>
+    <p class="spd-section-sub">All {{ format_rows | length }} formats are unlocked together with one purchase.</p>
+  </div>
+
+  <div class="mfg-grid">
+    {% for r in format_rows %}
+    <div class="mfg-card">
+
+      <div class="mfg-preview-wrap {{ r.ratio }}{% if state != 'owned' %} mfg-locked{% endif %}">
+        <iframe
+          class="mfg-preview-iframe"
+          src="/players/{{ user.id }}/card?platform={{ r.platform }}&design={{ collection_id }}"
+          loading="lazy"
+          scrolling="no"
+          title="{{ r.label }} preview"
+        ></iframe>
+      </div>
+
+      <p class="mfg-label">{{ r.label }}</p>
+      <p class="mfg-dims">{{ r.dims }}</p>
+
+      <span class="mfg-badge mfg-badge-free">Included in this collection</span>
+
+    </div>
+    {% endfor %}
+  </div>
+
+</div>
+{% endblock %}

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -64831,6 +64831,49 @@
         ]
       }
     },
+    "/shop/cards/player/{collection_id}": {
+      "get": {
+        "operationId": "shop_player_card_detail_shop_cards_player__collection_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "collection_id",
+            "required": true,
+            "schema": {
+              "title": "Collection Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Shop Player Card Detail",
+        "tags": [
+          "web",
+          "shop"
+        ]
+      }
+    },
     "/shop/cards/welcome": {
       "get": {
         "operationId": "shop_welcome_card_shop_cards_welcome_get",

--- a/tests/unit/api/web_routes/test_shop_player_detail.py
+++ b/tests/unit/api/web_routes/test_shop_player_detail.py
@@ -1,0 +1,368 @@
+"""Player Card collection detail page tests — PCID-01..12.
+
+PCID-01  GET /shop/cards/player/fifa → 200, shop_player_card_detail.html
+PCID-02  GET /shop/cards/player/unknown_xyz → 404
+PCID-03  Detail page context contains collection title (design.label)
+PCID-04  format_rows contains exactly the 7 FIFA buckets
+PCID-05  portrait bucket → mfg-ratio-45 ratio class
+PCID-06  story and tiktok buckets → mfg-ratio-916 ratio class
+PCID-07  square bucket → mfg-ratio-11 ratio class
+PCID-08  landscape / og / banner buckets → mfg-ratio-169 ratio class
+PCID-09  Unowned state → preview wrappers carry mfg-locked class
+PCID-10  Owned state → preview wrappers do NOT carry mfg-locked class
+PCID-11  Unowned state → collection buy form targets /shop/cards/player_card/buy/fifa
+PCID-12  No per-format buy form present in rendered HTML
+PCID-BF  Browse formats → link present on /shop/cards/player list page
+"""
+import asyncio
+import pathlib
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+_BASE = "app.api.web_routes.shop"
+
+_TEMPLATE_BASE = (
+    pathlib.Path(__file__).resolve().parents[4]
+    / "app" / "templates"
+)
+
+_FIFA_BUCKETS = ("square", "portrait", "story", "tiktok", "landscape", "og", "banner")
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _user(balance=500):
+    from app.models.user import UserRole
+    u = MagicMock()
+    u.id = 42
+    u.credit_balance = balance
+    u.role = UserRole.STUDENT
+    return u
+
+
+def _req(path="/shop/cards/player/fifa", query_params=None):
+    r = MagicMock()
+    r.url.path = path
+    params = query_params or {}
+    r.query_params.get = lambda k, default=None: params.get(k, default)
+    return r
+
+
+def _db():
+    return MagicMock()
+
+
+def _fifa_design(available=True, credit_cost=300):
+    d = MagicMock()
+    d.id = "fifa"
+    d.label = "FIFA Classic"
+    d.description = "The original LFA player card."
+    d.credit_cost = credit_cost
+    d.is_premium = True
+    d.available = available
+    d.supported_export_buckets = _FIFA_BUCKETS
+    return d
+
+
+def _call_detail(
+    collection_id="fifa",
+    user=None,
+    owned=False,
+    designs=None,
+    query_params=None,
+):
+    """Helper: call shop_player_card_detail and return captured template name + context."""
+    from app.api.web_routes.shop import shop_player_card_detail
+    from app.services.card_constants import PC_FORMAT_META
+
+    user = user or _user()
+    if designs is None:
+        designs = [_fifa_design()]
+
+    captured = {}
+
+    def fake_tmpl(tmpl, ctx):
+        captured["template"] = tmpl
+        captured["context"] = ctx
+        return MagicMock(status_code=200)
+
+    with patch(f"{_BASE}.get_all_designs", return_value=designs), \
+         patch(f"{_BASE}.is_design_accessible", return_value=owned), \
+         patch(f"{_BASE}.templates.TemplateResponse", side_effect=fake_tmpl):
+        _run(shop_player_card_detail(
+            collection_id=collection_id,
+            request=_req(f"/shop/cards/player/{collection_id}", query_params),
+            db=_db(),
+            user=user,
+        ))
+
+    return captured
+
+
+def _render_detail(state="get_card", owned=False):
+    """Render shop_player_card_detail.html via Jinja2 and return the HTML string."""
+    from jinja2 import Environment, FileSystemLoader
+
+    env = Environment(loader=FileSystemLoader(str(_TEMPLATE_BASE)), autoescape=True)
+
+    from app.services.card_constants import PC_FORMAT_META
+    meta_by_bucket = {m["bucket"]: m for m in PC_FORMAT_META}
+    format_rows = [meta_by_bucket[b] for b in _FIFA_BUCKETS if b in meta_by_bucket]
+
+    user = MagicMock()
+    user.id = 42
+    user.credit_balance = 500
+
+    design = MagicMock()
+    design.label = "FIFA Classic"
+    design.description = "The original LFA player card."
+    design.credit_cost = 300
+    design.supported_export_buckets = _FIFA_BUCKETS
+
+    ctx = {
+        "request": MagicMock(),
+        "user": user,
+        "design": design,
+        "collection_id": "fifa",
+        "state": state,
+        "format_rows": format_rows,
+        "flash_purchased": None,
+        "flash_error": None,
+    }
+    tmpl = env.get_template("shop_player_card_detail.html")
+    return tmpl.render(**ctx)
+
+
+def _render_player_list():
+    """Render shop_player_card.html and return HTML."""
+    from jinja2 import Environment, FileSystemLoader
+
+    env = Environment(loader=FileSystemLoader(str(_TEMPLATE_BASE)), autoescape=True)
+
+    user = MagicMock()
+    user.id = 42
+    user.credit_balance = 500
+
+    design_rows = [
+        {"id": "fifa", "label": "FIFA Classic", "description": "", "credit_cost": 300, "is_premium": True, "state": "get_card"},
+        {"id": "compact", "label": "Compact", "description": "", "credit_cost": 300, "is_premium": True, "state": "locked"},
+    ]
+
+    ctx = {
+        "request": MagicMock(),
+        "user": user,
+        "design_rows": design_rows,
+        "owned_count": 0,
+        "total_count": 2,
+        "flash_purchased": None,
+        "flash_error": None,
+        "spec_dashboard_url": "/dashboard/lfa-football-player",
+    }
+    tmpl = env.get_template("shop_player_card.html")
+    return tmpl.render(**ctx)
+
+
+# ── PCID-01: route → 200 ─────────────────────────────────────────────────────
+
+class TestPCID01RouteSuccess:
+
+    def test_pcid01_fifa_returns_200_with_correct_template(self):
+        """PCID-01: GET /shop/cards/player/fifa → 200, shop_player_card_detail.html."""
+        cap = _call_detail(collection_id="fifa")
+        assert cap["template"] == "shop_player_card_detail.html"
+
+
+# ── PCID-02: unknown collection_id → 404 ─────────────────────────────────────
+
+class TestPCID02UnknownCollection:
+
+    def test_pcid02_unknown_collection_id_raises_404(self):
+        """PCID-02: GET /shop/cards/player/unknown_xyz → HTTPException 404."""
+        from app.api.web_routes.shop import shop_player_card_detail
+
+        with patch(f"{_BASE}.get_all_designs", return_value=[_fifa_design()]), \
+             patch(f"{_BASE}.is_design_accessible", return_value=False):
+            with pytest.raises(HTTPException) as exc_info:
+                _run(shop_player_card_detail(
+                    collection_id="unknown_xyz",
+                    request=_req("/shop/cards/player/unknown_xyz"),
+                    db=_db(),
+                    user=_user(),
+                ))
+        assert exc_info.value.status_code == 404
+
+
+# ── PCID-03: context contains collection title ────────────────────────────────
+
+class TestPCID03CollectionTitle:
+
+    def test_pcid03_context_contains_design_with_correct_label(self):
+        """PCID-03: context design.label == 'FIFA Classic'."""
+        cap = _call_detail(collection_id="fifa")
+        assert cap["context"]["design"].label == "FIFA Classic"
+
+    def test_pcid03_rendered_html_contains_collection_title(self):
+        """PCID-03b: rendered HTML contains 'FIFA Classic'."""
+        html = _render_detail()
+        assert "FIFA Classic" in html
+
+
+# ── PCID-04: 7 format rows ───────────────────────────────────────────────────
+
+class TestPCID04FormatCount:
+
+    def test_pcid04_context_has_7_format_rows(self):
+        """PCID-04: format_rows contains exactly 7 entries for FIFA Classic."""
+        cap = _call_detail(collection_id="fifa")
+        assert len(cap["context"]["format_rows"]) == 7
+
+    def test_pcid04_rendered_html_contains_all_7_format_labels(self):
+        """PCID-04b: rendered HTML contains all 7 platform labels."""
+        html = _render_detail()
+        expected = [
+            "Instagram Portrait", "Instagram Story", "TikTok",
+            "Square", "Landscape", "Open Graph", "Banner",
+        ]
+        for label in expected:
+            assert label in html, f"Missing format label: {label}"
+
+
+# ── PCID-05..08: ratio class mapping ─────────────────────────────────────────
+
+class TestPCID05to08RatioClasses:
+
+    def _get_ratio(self, bucket):
+        from app.services.card_constants import PC_FORMAT_META
+        return next(m["ratio"] for m in PC_FORMAT_META if m["bucket"] == bucket)
+
+    def test_pcid05_portrait_ratio_45(self):
+        """PCID-05: portrait bucket → mfg-ratio-45."""
+        assert self._get_ratio("portrait") == "mfg-ratio-45"
+
+    def test_pcid06_story_ratio_916(self):
+        """PCID-06a: story bucket → mfg-ratio-916."""
+        assert self._get_ratio("story") == "mfg-ratio-916"
+
+    def test_pcid06_tiktok_ratio_916(self):
+        """PCID-06b: tiktok bucket → mfg-ratio-916."""
+        assert self._get_ratio("tiktok") == "mfg-ratio-916"
+
+    def test_pcid07_square_ratio_11(self):
+        """PCID-07: square bucket → mfg-ratio-11."""
+        assert self._get_ratio("square") == "mfg-ratio-11"
+
+    def test_pcid08_landscape_ratio_169(self):
+        """PCID-08a: landscape bucket → mfg-ratio-169."""
+        assert self._get_ratio("landscape") == "mfg-ratio-169"
+
+    def test_pcid08_og_ratio_169(self):
+        """PCID-08b: og bucket → mfg-ratio-169."""
+        assert self._get_ratio("og") == "mfg-ratio-169"
+
+    def test_pcid08_banner_ratio_169(self):
+        """PCID-08c: banner bucket → mfg-ratio-169."""
+        assert self._get_ratio("banner") == "mfg-ratio-169"
+
+    def test_pcid08_rendered_html_contains_ratio_classes(self):
+        """PCID-08d: rendered HTML contains all 4 ratio CSS classes."""
+        html = _render_detail(state="get_card")
+        for ratio in ("mfg-ratio-45", "mfg-ratio-916", "mfg-ratio-11", "mfg-ratio-169"):
+            assert ratio in html, f"Missing ratio class: {ratio}"
+
+
+# ── PCID-09: unowned → mfg-locked ─────────────────────────────────────────────
+
+class TestPCID09UnownedLocked:
+
+    def test_pcid09_unowned_preview_has_mfg_locked_class(self):
+        """PCID-09: unowned state → mfg-locked appears as a CSS class on preview wrappers.
+
+        We check for ' mfg-locked' (space-prefixed) to distinguish the class
+        attribute value from the CSS selector text (.mfg-locked) in mc_format_grid.html.
+        """
+        html = _render_detail(state="get_card", owned=False)
+        assert " mfg-locked" in html
+
+    def test_pcid09_locked_state_also_has_mfg_locked(self):
+        """PCID-09b: locked state → mfg-locked class present on preview wrappers."""
+        html = _render_detail(state="locked", owned=False)
+        assert " mfg-locked" in html
+
+
+# ── PCID-10: owned → no mfg-locked ───────────────────────────────────────────
+
+class TestPCID10OwnedClean:
+
+    def test_pcid10_owned_preview_has_no_mfg_locked(self):
+        """PCID-10: owned state → mfg-locked not present as a class attribute value.
+
+        The CSS selector .mfg-locked still appears in <style> — we check for the
+        space-prefixed form ' mfg-locked' which only appears in class="..." attributes.
+        """
+        html = _render_detail(state="owned", owned=True)
+        assert " mfg-locked" not in html
+
+
+# ── PCID-11: collection buy form ─────────────────────────────────────────────
+
+class TestPCID11CollectionBuyForm:
+
+    def test_pcid11_unowned_buy_form_targets_correct_endpoint(self):
+        """PCID-11: unowned → buy form action = /shop/cards/player_card/buy/fifa."""
+        html = _render_detail(state="get_card")
+        assert 'action="/shop/cards/player_card/buy/fifa"' in html
+
+    def test_pcid11_buy_form_not_present_when_owned(self):
+        """PCID-11b: owned state → no buy form rendered."""
+        html = _render_detail(state="owned")
+        assert 'action="/shop/cards/player_card/buy/fifa"' not in html
+
+
+# ── PCID-12: no per-format buy forms ─────────────────────────────────────────
+
+class TestPCID12NoPerFormatBuy:
+
+    def test_pcid12_no_per_format_buy_buttons_in_format_grid(self):
+        """PCID-12: format grid has no per-format purchase forms.
+
+        The buy action URL should appear exactly once (the collection-level CTA).
+        If per-format buy forms were present we would see it 7 times (once per bucket).
+        """
+        html = _render_detail(state="get_card")
+        buy_action_count = html.count('action="/shop/cards/player_card/buy/fifa"')
+        assert buy_action_count == 1, (
+            f"Expected exactly 1 collection buy form action, found {buy_action_count}"
+        )
+
+    def test_pcid12_format_cards_contain_included_badge(self):
+        """PCID-12b: format cards show 'Included in this collection' badge, not CR price.
+
+        mfg-badge-get as a CSS rule is always in the stylesheet — we check for its
+        use as a class attribute value (space-prefixed) which only appears on rendered
+        elements.
+        """
+        html = _render_detail(state="get_card")
+        assert "Included in this collection" in html
+        # No per-format CR badge rendered as an element (mfg-badge-get in class attr)
+        assert ' mfg-badge-get"' not in html
+
+
+# ── PCID-BF: Browse formats → on list page ───────────────────────────────────
+
+class TestPCIDBrowseFormats:
+
+    def test_pcid_bf_browse_formats_link_present_in_list(self):
+        """PCID-BF: /shop/cards/player list — each card has 'Browse formats →' link."""
+        html = _render_player_list()
+        assert "Browse formats →" in html
+        assert "/shop/cards/player/fifa" in html
+        assert "/shop/cards/player/compact" in html
+
+    def test_pcid_bf_browse_formats_link_count_matches_design_count(self):
+        """PCID-BF-2: number of 'Browse formats →' links equals number of designs."""
+        html = _render_player_list()
+        assert html.count("Browse formats →") == 2


### PR DESCRIPTION
## Summary

- Adds `GET /shop/cards/player/{collection_id}` — collection detail page showing all platform formats included in a Player Card design (e.g. FIFA Classic with 6–7 formats)
- Adds `PC_FORMAT_META` to `card_constants.py` — 7-entry registry mapping export buckets → display metadata (label, dims, aspect-ratio CSS class)
- Updates `shop_player_card.html` — "Browse formats →" secondary link on each collection card
- New template `shop_player_card_detail.html` — breadcrumb, collection-level buy CTA, format grid with locked/owned previews, "Included in this collection" badges
- Unknown `collection_id` returns 404
- 0 migration, 0 new model, 0 CDO change — C1 collection-level ownership only

## Scope guard

**Out of scope (C2 — later monetisation decision):**
format-level `design_id` convention (`fifa_instagram_portrait` etc.), legacy FIFA owner backfill migration, per-format pricing, editor export guard per platform, bundle purchase logic, My Cards player detail route.

## Test plan

- [ ] 23 PCID-01..12 + BF tests — all pass
- [ ] Existing SH-01..12 shop tests — unaffected
- [ ] Full unit suite: 11507 passed, 0 failed
- [ ] OpenAPI snapshot updated (832 routes)
- [ ] Manual QA: /shop/cards/player + /shop/cards/player/fifa verified on live server

🤖 Generated with [Claude Code](https://claude.com/claude-code)