### PR TITLE
feat(card-editor): WCE-1 Welcome Card Customizer — preview + export wrapper

### DIFF
--- a/app/api/web_routes/__init__.py
+++ b/app/api/web_routes/__init__.py
@@ -28,6 +28,7 @@ from . import (
     public_tournament,
     sport_director,
     my_cards,
+    card_editor,
     shop,
     friends,
     vt_challenges,
@@ -66,6 +67,7 @@ router.include_router(public_player.router)      # 🌐 Public player card (no a
 router.include_router(public_tournament.router)  # 🌐 Public event detail page (no auth)
 router.include_router(sport_director.router)     # 🏅 Sport Director team enrollment
 router.include_router(my_cards.router)           # 🃏 My Cards hub (/my-cards)
+router.include_router(card_editor.router)        # ✏️  Card Editor (/card-editor)
 router.include_router(shop.router)               # 🛒 Card Shop (/shop)
 router.include_router(friends.router)            # 👥 Friendship system (/friends)
 router.include_router(vt_challenges.router)      # 🎮 VT Challenges (/challenges)

--- a/app/api/web_routes/card_editor.py
+++ b/app/api/web_routes/card_editor.py
@@ -1,0 +1,101 @@
+"""Card Editor routes — family-specific customizer/export pages.
+
+Phase WCE-1: Welcome Card Customizer (preview + export wrapper, no draft).
+Future: /card-editor/player/{collection_id}, /card-editor/challenge/{id}
+"""
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+from sqlalchemy.orm import Session
+
+from ...database import get_db
+from ...dependencies import get_current_user_web
+from ...models.user import User, UserRole
+from ...models.license import UserLicense
+from ...services.card_design_service import (
+    WELCOME_CARD_FORMATS,
+    is_design_accessible,
+)
+
+BASE_DIR = Path(__file__).resolve().parent.parent.parent
+templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
+
+router = APIRouter(tags=["card-editor"])
+
+# Lookup map: design_id → NonPlayerCardFormatDefinition
+_WC_FORMAT_BY_ID = {f.design_id: f for f in WELCOME_CARD_FORMATS}
+
+# Aspect-ratio CSS class per preview_platform
+_WC_RATIO: dict[str, str] = {
+    "instagram_portrait":  "mfg-ratio-45",
+    "instagram_story":     "mfg-ratio-916",
+    "instagram_square":    "mfg-ratio-11",
+    "tiktok":              "mfg-ratio-916",
+    "facebook_square":     "mfg-ratio-11",
+    "facebook_landscape":  "mfg-ratio-169",
+    "banner_custom":       "mfg-ratio-169",
+}
+
+
+# ── Welcome Card Customizer ───────────────────────────────────────────────────
+
+@router.get("/card-editor/welcome/{format_id}", response_class=HTMLResponse)
+async def welcome_card_editor(
+    format_id: str,
+    request: Request,
+    db: Session = Depends(get_db),
+    user: User  = Depends(get_current_user_web),
+):
+    """Welcome Card Customizer — preview + export wrapper for an owned format.
+
+    Guards (in order):
+      1. Authenticated (get_current_user_web)
+      2. LFA_FOOTBALL_PLAYER license + onboarding complete
+      3. format_id in WELCOME_CARD_FORMATS → 404 otherwise
+      4. CDO ownership (is_design_accessible) → redirect shop if not owned
+         Admin bypass: skipped for UserRole.ADMIN
+    """
+    # ── Guard 2: license + onboarding ────────────────────────────────────────
+    license = db.query(UserLicense).filter(
+        UserLicense.user_id == user.id,
+        UserLicense.specialization_type == "LFA_FOOTBALL_PLAYER",
+    ).first()
+    if not license:
+        return RedirectResponse(
+            url="/dashboard?info=complete_lfa_onboarding_first", status_code=303
+        )
+    if not license.onboarding_completed:
+        return RedirectResponse(
+            url="/specialization/lfa-player/onboarding", status_code=303
+        )
+
+    # ── Guard 3: known format ─────────────────────────────────────────────────
+    fmt = _WC_FORMAT_BY_ID.get(format_id)
+    if fmt is None:
+        raise HTTPException(status_code=404, detail=f"Unknown Welcome Card format: {format_id!r}")
+
+    # ── Guard 4: ownership ────────────────────────────────────────────────────
+    if user.role != UserRole.ADMIN:
+        if not is_design_accessible(db, user.id, "welcome_card", format_id):
+            return RedirectResponse(
+                url="/shop/cards/welcome?error=not_owned", status_code=303
+            )
+
+    ratio_class = _WC_RATIO.get(fmt.preview_platform, "mfg-ratio-11")
+    preview_url = f"/profile/onboarding-card?platform={fmt.preview_platform}"
+    export_url  = f"/profile/onboarding-card/export?platform={fmt.preview_platform}"
+
+    return templates.TemplateResponse(
+        "card_editor_welcome.html",
+        {
+            "request":     request,
+            "user":        user,
+            "fmt":         fmt,
+            "format_id":   format_id,
+            "ratio_class": ratio_class,
+            "preview_url": preview_url,
+            "export_url":  export_url,
+        },
+    )

--- a/app/templates/card_editor_welcome.html
+++ b/app/templates/card_editor_welcome.html
@@ -1,0 +1,214 @@
+{% extends "student_base.html" %}
+
+{% block title %}Welcome Card Customizer — {{ fmt.label }} — LFA Education Center{% endblock %}
+{% block active_page %}lfa-player{% endblock %}
+
+{% block student_header %}
+{% set _page_icon = '👋' %}
+{% set _page_name = 'Welcome Card Customizer' %}
+{% include "includes/spec_subpage_hdr.html" %}
+{% endblock %}
+
+{% block extra_styles %}
+{% include "includes/mc_format_grid.html" %}
+<style>
+  .wce-wrap {
+    max-width: 820px;
+    margin: 0 auto;
+    padding: 1.5rem 1rem 4rem;
+  }
+  .wce-breadcrumb {
+    font-size: 0.8rem;
+    color: #64748b;
+    margin-bottom: 1.25rem;
+  }
+  .wce-breadcrumb a { color: #94a3b8; text-decoration: none; }
+  .wce-breadcrumb a:hover { color: #f1f5f9; }
+  .wce-breadcrumb span { margin: 0 0.35rem; }
+  .wce-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 0.75rem;
+  }
+  .wce-header h1 { font-size: 1.4rem; font-weight: 700; color: #f8fafc; margin: 0; }
+  .wce-credits-badge {
+    background: #1e293b;
+    border: 1px solid #334155;
+    border-radius: 20px;
+    padding: 0.35rem 0.9rem;
+    font-size: 0.85rem;
+    color: #94a3b8;
+  }
+  .wce-credits-badge strong { color: #FFD200; }
+  /* Meta row */
+  .wce-meta {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    margin-bottom: 1.5rem;
+  }
+  .wce-style-tag {
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #64748b;
+  }
+  .wce-dims {
+    font-size: 0.8rem;
+    color: #475569;
+  }
+  .wce-owned-badge {
+    font-size: 0.75rem;
+    font-weight: 700;
+    color: #86efac;
+    background: rgba(134,239,172,.12);
+    border: 1px solid rgba(134,239,172,.25);
+    border-radius: 20px;
+    padding: 0.2rem 0.65rem;
+  }
+  /* Preview panel */
+  .wce-preview-panel {
+    background: #0f172a;
+    border: 1px solid #1e293b;
+    border-radius: 14px;
+    padding: 1.25rem;
+    margin-bottom: 1.5rem;
+  }
+  .wce-preview-label {
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+    color: #475569;
+    margin-bottom: 0.75rem;
+  }
+  .wce-preview-container {
+    display: flex;
+    justify-content: center;
+  }
+  /* Constrain tall formats so the preview doesn't dominate the page */
+  .wce-preview-wrap {
+    width: 100%;
+    max-width: 320px;
+    position: relative;
+    border-radius: 8px;
+    overflow: hidden;
+    background: #0b1120;
+  }
+  /* Export panel */
+  .wce-export-panel {
+    background: #0f172a;
+    border: 1px solid #1e293b;
+    border-radius: 14px;
+    padding: 1.25rem 1.5rem;
+    margin-bottom: 1.5rem;
+  }
+  .wce-export-title {
+    font-size: 1rem;
+    font-weight: 700;
+    color: #f1f5f9;
+    margin: 0 0 0.35rem;
+  }
+  .wce-export-sub {
+    font-size: 0.8rem;
+    color: #475569;
+    margin: 0 0 1rem;
+  }
+  .wce-btn-download {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.6rem 1.4rem;
+    background: #FFD200;
+    color: #0f172a;
+    font-size: 0.875rem;
+    font-weight: 700;
+    border-radius: 8px;
+    text-decoration: none;
+    transition: opacity 0.15s;
+  }
+  .wce-btn-download:hover { opacity: 0.88; color: #0f172a; text-decoration: none; }
+  /* Nav links */
+  .wce-nav {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+    margin-top: 2rem;
+  }
+  .wce-nav-back {
+    font-size: 0.82rem;
+    font-weight: 600;
+    color: #93c5fd;
+    text-decoration: none;
+  }
+  .wce-nav-back:hover { color: #bfdbfe; text-decoration: none; }
+  .wce-nav-shop {
+    font-size: 0.82rem;
+    font-weight: 600;
+    color: #FFD200;
+    text-decoration: none;
+  }
+  .wce-nav-shop:hover { opacity: 0.85; text-decoration: none; }
+</style>
+{% endblock %}
+
+{% block student_content %}
+<div class="wce-wrap">
+
+  <nav class="wce-breadcrumb" aria-label="Breadcrumb">
+    <a href="/my-cards">My Cards</a>
+    <span>›</span>
+    <a href="/my-cards/welcome">Welcome Card</a>
+    <span>›</span>
+    <span>{{ fmt.label }}</span>
+  </nav>
+
+  <div class="wce-header">
+    <h1>{{ fmt.label }}</h1>
+    <span class="wce-credits-badge">Balance: <strong>{{ user.credit_balance }} CR</strong></span>
+  </div>
+
+  <div class="wce-meta">
+    <span class="wce-style-tag">{{ fmt.style_tag }}</span>
+    <span class="wce-dims">{{ fmt.dims }}</span>
+    <span class="wce-owned-badge">Owned ✓</span>
+  </div>
+
+  {# ── Preview panel ── #}
+  <div class="wce-preview-panel">
+    <p class="wce-preview-label">Preview</p>
+    <div class="wce-preview-container">
+      <div class="wce-preview-wrap mfg-preview-wrap {{ ratio_class }}">
+        <iframe
+          class="mfg-preview-iframe"
+          src="{{ preview_url }}"
+          loading="lazy"
+          scrolling="no"
+          title="{{ fmt.label }} Welcome Card preview"
+        ></iframe>
+      </div>
+    </div>
+  </div>
+
+  {# ── Export panel ── #}
+  <div class="wce-export-panel">
+    <p class="wce-export-title">Download your Welcome Card</p>
+    <p class="wce-export-sub">Exports a full-resolution PNG at {{ fmt.dims }} using your current player data.</p>
+    <a href="{{ export_url }}" class="wce-btn-download" download>
+      ↓ Download PNG
+    </a>
+  </div>
+
+  {# ── Navigation ── #}
+  <div class="wce-nav">
+    <a href="/my-cards/welcome" class="wce-nav-back">← Back to My Welcome Cards</a>
+    <a href="/shop/cards/welcome" class="wce-nav-shop">Browse Welcome Cards →</a>
+  </div>
+
+</div>
+{% endblock %}

--- a/app/templates/my_cards_welcome_card.html
+++ b/app/templates/my_cards_welcome_card.html
@@ -153,7 +153,7 @@
       <span class="mfg-badge mfg-badge-owned">Owned ✓</span>
 
       <div class="mfg-cta">
-        <a href="{{ r.export_url }}" class="mfg-btn mfg-btn-download">Download PNG</a>
+        <a href="/card-editor/welcome/{{ r.design_id }}" class="mfg-btn mfg-btn-edit">Customize / Export →</a>
       </div>
 
     </div>

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -59833,6 +59833,50 @@
         ]
       }
     },
+    "/card-editor/welcome/{format_id}": {
+      "get": {
+        "description": "Welcome Card Customizer \u2014 preview + export wrapper for an owned format.\n\nGuards (in order):\n  1. Authenticated (get_current_user_web)\n  2. LFA_FOOTBALL_PLAYER license + onboarding complete\n  3. format_id in WELCOME_CARD_FORMATS \u2192 404 otherwise\n  4. CDO ownership (is_design_accessible) \u2192 redirect shop if not owned\n     Admin bypass: skipped for UserRole.ADMIN",
+        "operationId": "welcome_card_editor_card_editor_welcome__format_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "format_id",
+            "required": true,
+            "schema": {
+              "title": "Format Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Welcome Card Editor",
+        "tags": [
+          "web",
+          "card-editor"
+        ]
+      }
+    },
     "/challenges": {
       "get": {
         "operationId": "challenge_inbox_challenges_get",

--- a/tests/unit/api/web_routes/test_my_cards_welcome_card.py
+++ b/tests/unit/api/web_routes/test_my_cards_welcome_card.py
@@ -154,10 +154,11 @@ class TestWelcomeCardShopRoute:
             assert "preview_url" in r, f"{r['design_id']} missing preview_url"
             assert "export_url" in r, f"{r['design_id']} missing export_url"
 
-    def test_mcw11_template_has_download_cta_for_owned(self):
-        """MCW-11: template uses mfg-btn-download for owned formats."""
+    def test_mcw11_template_has_editor_cta_for_owned(self):
+        """MCW-11: template uses mfg-btn-edit (editor link) for owned formats, not direct download."""
         src = _TEMPLATE_PATH.read_text()
-        assert "mfg-btn-download" in src, "Must have download button class for owned state"
+        assert "mfg-btn-edit" in src, "Must have editor button class for owned state"
+        assert "mfg-btn-download" not in src, "Direct download button must be absent — editor link replaces it"
 
     def test_mcw12_template_has_browse_shop_cta(self):
         """MCW-12: template has Browse Shop CTA linking to /shop/cards/welcome."""

--- a/tests/unit/api/web_routes/test_welcome_card_editor.py
+++ b/tests/unit/api/web_routes/test_welcome_card_editor.py
@@ -1,0 +1,479 @@
+"""Welcome Card Editor route tests — WCE-01..WCE-10.
+
+WCE-01  Owned user GET /card-editor/welcome/instagram_portrait → 200, correct template
+WCE-02  Unowned user (no CDO) → redirect /shop/cards/welcome?error=not_owned
+WCE-03  Unknown format_id → 404
+WCE-04  Template contains preview iframe with correct platform param
+WCE-05  Template contains Download PNG link with correct export URL
+WCE-06  Template contains Back to My Cards link (/my-cards/welcome)
+WCE-07  My Cards Welcome CTA is "Customize / Export →" (not "Download PNG")
+WCE-08  My Cards Welcome grid has no direct "Download PNG" CTA
+WCE-09  Admin bypass: admin user with no CDO → 200 (ownership guard skipped)
+WCE-10  No-license user → redirect (no LFA_FOOTBALL_PLAYER license)
+"""
+from __future__ import annotations
+
+import asyncio
+import pathlib
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+_BASE    = "app.api.web_routes.card_editor"
+_MYCARDS = "app.api.web_routes.my_cards"
+
+_TEMPLATE_BASE = (
+    pathlib.Path(__file__).resolve().parents[4]
+    / "app" / "templates"
+)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _user(balance=500, role=None):
+    from app.models.user import UserRole
+    u = MagicMock()
+    u.id = 42
+    u.credit_balance = balance
+    u.role = role or UserRole.STUDENT
+    return u
+
+
+def _admin_user():
+    from app.models.user import UserRole
+    return _user(role=UserRole.ADMIN)
+
+
+def _license(onboarding_completed=True):
+    lic = MagicMock()
+    lic.onboarding_completed = onboarding_completed
+    return lic
+
+
+def _db():
+    return MagicMock()
+
+
+def _req(path="/card-editor/welcome/instagram_portrait"):
+    r = MagicMock()
+    r.url.path = path
+    return r
+
+
+def _call_editor(format_id="instagram_portrait", user=None, owned=True, license=None):
+    """Call welcome_card_editor and return captured template name + context dict."""
+    from app.api.web_routes.card_editor import welcome_card_editor
+
+    user    = user    or _user()
+    license = license or _license()
+
+    captured = {}
+
+    def _fake_tmpl(tmpl, ctx):
+        captured["template"] = tmpl
+        captured["context"]  = ctx
+        return MagicMock(status_code=200)
+
+    with patch(f"{_BASE}.templates.TemplateResponse", side_effect=_fake_tmpl), \
+         patch(f"{_BASE}.is_design_accessible", return_value=owned), \
+         patch(
+             f"{_BASE}.db.query",
+             side_effect=lambda m: MagicMock(
+                 filter=lambda *a, **kw: MagicMock(first=lambda: license)
+             ),
+         ) if False else patch(f"{_BASE}.db", create=True):
+
+        # Patch the DB query inside the route via dependency injection
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = license
+
+        with patch(f"{_BASE}.templates.TemplateResponse", side_effect=_fake_tmpl), \
+             patch(f"{_BASE}.is_design_accessible", return_value=owned):
+            result = _run(welcome_card_editor(
+                format_id=format_id,
+                request=_req(f"/card-editor/welcome/{format_id}"),
+                db=db,
+                user=user,
+            ))
+
+    return captured, result
+
+
+# ── WCE-01  Owned user → 200 + correct template ───────────────────────────────
+
+class TestWCE01OwnedSuccess:
+
+    def test_wce01_owned_returns_correct_template(self):
+        """WCE-01: owned user → template card_editor_welcome.html."""
+        cap, _ = _call_editor(format_id="instagram_portrait", owned=True)
+        assert cap["template"] == "card_editor_welcome.html"
+
+    def test_wce01_context_contains_fmt(self):
+        """WCE-01b: context fmt.design_id matches requested format_id."""
+        cap, _ = _call_editor(format_id="instagram_portrait", owned=True)
+        assert cap["context"]["fmt"].design_id == "instagram_portrait"
+
+    def test_wce01_context_contains_preview_url(self):
+        """WCE-01c: context preview_url contains the correct platform param."""
+        cap, _ = _call_editor(format_id="instagram_portrait", owned=True)
+        assert "platform=instagram_portrait" in cap["context"]["preview_url"]
+
+    def test_wce01_context_contains_export_url(self):
+        """WCE-01d: context export_url points to the export endpoint."""
+        cap, _ = _call_editor(format_id="instagram_portrait", owned=True)
+        assert "/profile/onboarding-card/export" in cap["context"]["export_url"]
+        assert "platform=instagram_portrait" in cap["context"]["export_url"]
+
+    def test_wce01_all_7_formats_return_200(self):
+        """WCE-01e: all 7 valid Welcome Card format IDs resolve to 200."""
+        from app.services.card_design_service import WELCOME_CARD_FORMATS
+        for fmt in WELCOME_CARD_FORMATS:
+            cap, _ = _call_editor(format_id=fmt.design_id, owned=True)
+            assert cap["template"] == "card_editor_welcome.html", \
+                f"Format {fmt.design_id!r} did not return the expected template"
+
+
+# ── WCE-02  Unowned user → redirect shop ─────────────────────────────────────
+
+class TestWCE02UnownedRedirect:
+
+    def test_wce02_unowned_redirects_to_shop(self):
+        """WCE-02: unowned user → 303 redirect to /shop/cards/welcome?error=not_owned."""
+        from fastapi.responses import RedirectResponse
+        db  = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = _license()
+
+        with patch(f"{_BASE}.is_design_accessible", return_value=False):
+            from app.api.web_routes.card_editor import welcome_card_editor
+            result = _run(welcome_card_editor(
+                format_id="instagram_portrait",
+                request=_req(),
+                db=db,
+                user=_user(),
+            ))
+
+        assert isinstance(result, RedirectResponse)
+        assert result.status_code == 303
+        assert "error=not_owned" in result.headers["location"]
+        assert "/shop/cards/welcome" in result.headers["location"]
+
+
+# ── WCE-03  Unknown format_id → 404 ──────────────────────────────────────────
+
+class TestWCE03UnknownFormat:
+
+    def test_wce03_unknown_format_raises_404(self):
+        """WCE-03: unknown format_id → HTTPException 404."""
+        db  = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = _license()
+
+        from app.api.web_routes.card_editor import welcome_card_editor
+        with pytest.raises(HTTPException) as exc_info:
+            _run(welcome_card_editor(
+                format_id="nonexistent_format_xyz",
+                request=_req("/card-editor/welcome/nonexistent_format_xyz"),
+                db=db,
+                user=_user(),
+            ))
+        assert exc_info.value.status_code == 404
+
+    def test_wce03_empty_string_raises_404(self):
+        """WCE-03b: empty-like string not in WELCOME_CARD_FORMATS → 404."""
+        db  = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = _license()
+
+        from app.api.web_routes.card_editor import welcome_card_editor
+        with pytest.raises(HTTPException) as exc_info:
+            _run(welcome_card_editor(
+                format_id="challenge_post_16_9",  # valid challenge format, wrong family
+                request=_req("/card-editor/welcome/challenge_post_16_9"),
+                db=db,
+                user=_user(),
+            ))
+        assert exc_info.value.status_code == 404
+
+
+# ── WCE-04  Template preview iframe ──────────────────────────────────────────
+
+class TestWCE04PreviewIframe:
+
+    def _render(self, format_id="instagram_portrait"):
+        from jinja2 import Environment, FileSystemLoader
+        env = Environment(loader=FileSystemLoader(str(_TEMPLATE_BASE)), autoescape=True)
+
+        from app.services.card_design_service import WELCOME_CARD_FORMATS
+        _wc = {f.design_id: f for f in WELCOME_CARD_FORMATS}
+        fmt = _wc[format_id]
+
+        user = MagicMock()
+        user.credit_balance = 500
+
+        ctx = {
+            "request":     MagicMock(),
+            "user":        user,
+            "fmt":         fmt,
+            "format_id":   format_id,
+            "ratio_class": "mfg-ratio-45",
+            "preview_url": f"/profile/onboarding-card?platform={format_id}",
+            "export_url":  f"/profile/onboarding-card/export?platform={format_id}",
+        }
+        return env.get_template("card_editor_welcome.html").render(**ctx)
+
+    def test_wce04_preview_iframe_present(self):
+        """WCE-04: rendered template contains an iframe element."""
+        html = self._render()
+        assert "<iframe" in html
+
+    def test_wce04_preview_iframe_src_has_platform_param(self):
+        """WCE-04b: iframe src contains correct platform param."""
+        html = self._render(format_id="instagram_story")
+        assert "platform=instagram_story" in html
+
+    def test_wce04_preview_url_points_to_onboarding_card(self):
+        """WCE-04c: preview src points to /profile/onboarding-card."""
+        html = self._render()
+        assert "/profile/onboarding-card" in html
+
+
+# ── WCE-05  Export CTA URL ────────────────────────────────────────────────────
+
+class TestWCE05ExportCTA:
+
+    def _render(self, format_id="tiktok"):
+        from jinja2 import Environment, FileSystemLoader
+        env = Environment(loader=FileSystemLoader(str(_TEMPLATE_BASE)), autoescape=True)
+
+        from app.services.card_design_service import WELCOME_CARD_FORMATS
+        _wc = {f.design_id: f for f in WELCOME_CARD_FORMATS}
+        fmt = _wc[format_id]
+        user = MagicMock(); user.credit_balance = 500
+        ctx = {
+            "request": MagicMock(), "user": user, "fmt": fmt,
+            "format_id": format_id, "ratio_class": "mfg-ratio-916",
+            "preview_url": f"/profile/onboarding-card?platform={format_id}",
+            "export_url":  f"/profile/onboarding-card/export?platform={format_id}",
+        }
+        return env.get_template("card_editor_welcome.html").render(**ctx)
+
+    def test_wce05_download_link_present(self):
+        """WCE-05: rendered template contains 'Download PNG' text."""
+        html = self._render()
+        assert "Download PNG" in html
+
+    def test_wce05_export_href_correct(self):
+        """WCE-05b: export href points to /profile/onboarding-card/export."""
+        html = self._render(format_id="tiktok")
+        assert "/profile/onboarding-card/export" in html
+        assert "platform=tiktok" in html
+
+
+# ── WCE-06  Back to My Cards link ─────────────────────────────────────────────
+
+class TestWCE06BackLink:
+
+    def _render(self):
+        from jinja2 import Environment, FileSystemLoader
+        env = Environment(loader=FileSystemLoader(str(_TEMPLATE_BASE)), autoescape=True)
+        from app.services.card_design_service import WELCOME_CARD_FORMATS
+        fmt = WELCOME_CARD_FORMATS[0]
+        user = MagicMock(); user.credit_balance = 500
+        ctx = {
+            "request": MagicMock(), "user": user, "fmt": fmt,
+            "format_id": fmt.design_id, "ratio_class": "mfg-ratio-45",
+            "preview_url": f"/profile/onboarding-card?platform={fmt.design_id}",
+            "export_url":  f"/profile/onboarding-card/export?platform={fmt.design_id}",
+        }
+        return env.get_template("card_editor_welcome.html").render(**ctx)
+
+    def test_wce06_back_link_present(self):
+        """WCE-06: template contains a link to /my-cards/welcome."""
+        html = self._render()
+        assert "/my-cards/welcome" in html
+
+    def test_wce06_back_link_text(self):
+        """WCE-06b: template contains 'Back to My' text."""
+        html = self._render()
+        assert "Back to My" in html
+
+    def test_wce06_shop_link_present(self):
+        """WCE-06c: template contains Browse Welcome Cards link."""
+        html = self._render()
+        assert "/shop/cards/welcome" in html
+        assert "Browse Welcome Cards" in html
+
+
+# ── WCE-07  My Cards Welcome CTA text ────────────────────────────────────────
+
+class TestWCE07MyCardsCTA:
+
+    def _render_my_cards(self):
+        from jinja2 import Environment, FileSystemLoader
+        env = Environment(loader=FileSystemLoader(str(_TEMPLATE_BASE)), autoescape=True)
+
+        user = MagicMock(); user.credit_balance = 500
+        format_rows = [
+            {
+                "design_id":        "instagram_portrait",
+                "label":            "Instagram Portrait",
+                "style_tag":        "IDENTITY CARD",
+                "dims":             "1080 × 1350",
+                "credit_cost":      75,
+                "preview_platform": "instagram_portrait",
+                "state":            "owned",
+                "preview_url":      "/profile/onboarding-card?platform=instagram_portrait",
+                "export_url":       "/profile/onboarding-card/export?platform=instagram_portrait",
+            }
+        ]
+        ctx = {
+            "request": MagicMock(), "user": user,
+            "format_rows": format_rows, "owned_count": 1, "total_count": 1,
+            "flash_purchased": None, "flash_error": None,
+            "spec_dashboard_url": "/dashboard/lfa-football-player",
+        }
+        return env.get_template("my_cards_welcome_card.html").render(**ctx)
+
+    def test_wce07_customize_export_cta_present(self):
+        """WCE-07: My Cards WC grid shows 'Customize / Export →' CTA."""
+        html = self._render_my_cards()
+        assert "Customize / Export" in html
+
+    def test_wce07_cta_href_points_to_editor(self):
+        """WCE-07b: CTA href targets /card-editor/welcome/{design_id}."""
+        html = self._render_my_cards()
+        assert "/card-editor/welcome/instagram_portrait" in html
+
+
+# ── WCE-08  No direct Download PNG in My Cards grid ──────────────────────────
+
+class TestWCE08NoDirectDownload:
+
+    def _render_my_cards(self):
+        from jinja2 import Environment, FileSystemLoader
+        env = Environment(loader=FileSystemLoader(str(_TEMPLATE_BASE)), autoescape=True)
+
+        user = MagicMock(); user.credit_balance = 500
+        format_rows = [
+            {
+                "design_id": "instagram_story", "label": "Instagram Story",
+                "style_tag": "IDENTITY CARD",   "dims": "1080 × 1920",
+                "credit_cost": 75, "preview_platform": "instagram_story",
+                "state": "owned",
+                "preview_url": "/profile/onboarding-card?platform=instagram_story",
+                "export_url":  "/profile/onboarding-card/export?platform=instagram_story",
+            }
+        ]
+        ctx = {
+            "request": MagicMock(), "user": user,
+            "format_rows": format_rows, "owned_count": 1, "total_count": 1,
+            "flash_purchased": None, "flash_error": None,
+            "spec_dashboard_url": "/dashboard/lfa-football-player",
+        }
+        return env.get_template("my_cards_welcome_card.html").render(**ctx)
+
+    def test_wce08_no_direct_download_png_cta(self):
+        """WCE-08: My Cards WC grid CTA does NOT read 'Download PNG'."""
+        html = self._render_my_cards()
+        # Check element attribute usage — CSS definition of .mfg-btn-download is still
+        # present in mc_format_grid.html's <style> block, but no element should carry it.
+        assert 'mfg-btn-download"' not in html, \
+            "mfg-btn-download class should not appear on any element in the My Cards WC grid"
+
+    def test_wce08_export_url_not_direct_cta(self):
+        """WCE-08b: the direct export URL is not an href on a CTA button in the grid."""
+        html = self._render_my_cards()
+        # The export URL should not be a direct button href — it's now inside the editor
+        assert 'href="/profile/onboarding-card/export' not in html
+
+
+# ── WCE-09  Admin bypass ──────────────────────────────────────────────────────
+
+class TestWCE09AdminBypass:
+
+    def test_wce09_admin_no_cdo_returns_200(self):
+        """WCE-09: admin user with no CDO ownership → 200 (guard skipped)."""
+        from app.api.web_routes.card_editor import welcome_card_editor
+
+        db  = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = _license()
+
+        captured = {}
+        def _fake_tmpl(tmpl, ctx):
+            captured["template"] = tmpl
+            return MagicMock(status_code=200)
+
+        with patch(f"{_BASE}.templates.TemplateResponse", side_effect=_fake_tmpl), \
+             patch(f"{_BASE}.is_design_accessible", return_value=False):
+            _run(welcome_card_editor(
+                format_id="instagram_portrait",
+                request=_req(),
+                db=db,
+                user=_admin_user(),
+            ))
+
+        assert captured.get("template") == "card_editor_welcome.html"
+
+    def test_wce09_is_design_accessible_not_called_for_admin(self):
+        """WCE-09b: is_design_accessible is NOT called when user is ADMIN."""
+        from app.api.web_routes.card_editor import welcome_card_editor
+
+        db  = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = _license()
+
+        with patch(f"{_BASE}.templates.TemplateResponse", return_value=MagicMock()), \
+             patch(f"{_BASE}.is_design_accessible") as mock_check:
+            _run(welcome_card_editor(
+                format_id="instagram_portrait",
+                request=_req(),
+                db=db,
+                user=_admin_user(),
+            ))
+
+        mock_check.assert_not_called()
+
+
+# ── WCE-10  No-license user → redirect ───────────────────────────────────────
+
+class TestWCE10NoLicense:
+
+    def test_wce10_no_license_redirects(self):
+        """WCE-10: user without LFA_FOOTBALL_PLAYER license → redirect."""
+        from fastapi.responses import RedirectResponse
+        from app.api.web_routes.card_editor import welcome_card_editor
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = None  # no license
+
+        result = _run(welcome_card_editor(
+            format_id="instagram_portrait",
+            request=_req(),
+            db=db,
+            user=_user(),
+        ))
+
+        assert isinstance(result, RedirectResponse)
+        assert result.status_code == 303
+
+    def test_wce10_incomplete_onboarding_redirects(self):
+        """WCE-10b: license exists but onboarding_completed=False → redirect."""
+        from fastapi.responses import RedirectResponse
+        from app.api.web_routes.card_editor import welcome_card_editor
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = _license(
+            onboarding_completed=False
+        )
+
+        result = _run(welcome_card_editor(
+            format_id="instagram_portrait",
+            request=_req(),
+            db=db,
+            user=_user(),
+        ))
+
+        assert isinstance(result, RedirectResponse)
+        assert result.status_code == 303


### PR DESCRIPTION
## Summary

- New route `GET /card-editor/welcome/{format_id}` — 4-layer guard: auth → LFA license + onboarding → known format (404) → CDO ownership (redirect to shop if unowned; admin bypass skips CDO only)
- New template `card_editor_welcome.html`: breadcrumb, preview iframe, Download PNG CTA, back/shop nav links; reuses `mfg-ratio-*` and `mfg-preview-iframe` from `mc_format_grid.html`
- My Cards Welcome page CTA changed from direct download (`mfg-btn-download`) to editor link (`mfg-btn-edit` → `/card-editor/welcome/{design_id}`)
- `card_editor.py` wired into web routes `__init__` between `my_cards` and `shop`

## Scope guard (WCE-1 MVP only)
No CardDraft, no migration, no new model, no theme picker, no photo upload, no headline editor, no publish action, no unified Card Studio, no Player/Challenge Card editor changes.

## Files changed
- `app/api/web_routes/card_editor.py` — new file (route + guards)
- `app/templates/card_editor_welcome.html` — new template
- `app/templates/my_cards_welcome_card.html` — CTA change
- `app/api/web_routes/__init__.py` — router registration
- `tests/unit/api/web_routes/test_welcome_card_editor.py` — 24 new tests (WCE-01..WCE-10)
- `tests/unit/api/web_routes/test_my_cards_welcome_card.py` — MCW-11 updated (mfg-btn-edit)
- `tests/snapshots/openapi_snapshot.json` — refreshed (833 routes)

## Test plan
- [x] 24 WCE-01..WCE-10 unit tests pass
- [x] Full unit suite: 11582 passed, 0 failed
- [x] OpenAPI snapshot refreshed and matches
- [x] Playwright QA: My Cards WC CTA → editor → preview iframe live, Download PNG link, back/shop nav links, unknown format → 404, unowned redirect to shop

🤖 Generated with [Claude Code](https://claude.com/claude-code)