### PR TITLE
feat(mood-photos): Phase 2 background removal — rembg processor + full pipeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,7 +44,9 @@ CELERY_RESULT_BACKEND=redis://localhost:6379/1
 #   Subsequent tasks use the cached model (2–5 s per image on CPU).
 #   Timeout: PROCESSING_TIMEOUT_SECONDS=300 — if worker is not running, the UI
 #   shows a Reset button after 5 minutes so the user is not stuck.
-BG_REMOVAL_PROCESSOR=rembg
+BG_REMOVAL_PROCESSOR=null
+# Set to "rembg" only when Redis + Celery worker + rembg/onnxruntime dependencies
+# are fully deployed (see startup instructions above).
 
 # ── E2E Testing ─────────────────────────────────────────────────────────────
 # Base URLs for Playwright/Selenium tests

--- a/.env.example
+++ b/.env.example
@@ -23,16 +23,22 @@ CELERY_RESULT_BACKEND=redis://localhost:6379/1
 # "rembg" → RembgProcessor: real u2net background removal; requires two separate processes:
 #
 #   App process (terminal 1):
-#     BG_REMOVAL_PROCESSOR=rembg uvicorn app.main:app --reload --port 8000
+#     BG_REMOVAL_PROCESSOR=rembg uvicorn app.main:app \
+#       --host 0.0.0.0 --port 8000 --reload --reload-dir app
+#
+#     --reload-dir app is important: without it, uvicorn's watchfiles reloader watches
+#     the entire project directory. The rembg/ONNX inference loads heavy ML libraries
+#     (~500 MB RSS peak); on low-memory dev machines this can kill the HTTP worker
+#     subprocess during a reload cycle. --reload-dir app avoids spurious reloads.
 #
 #   Worker process (terminal 2):
 #     BG_REMOVAL_PROCESSOR=rembg celery -A app.celery_app worker \
 #       -Q mood_photos -c 1 -l info --pool=solo
 #
-#   --pool=solo is required on Python 3.13 + macOS arm64: the default prefork pool
-#   crashes with SIGSEGV (signal 11) on this platform. solo runs the worker in a
-#   single process with no fork, which is safe for development.
-#   Production (Linux): prefork works; omit --pool=solo.
+#     --pool=solo is required on Python 3.13 + macOS arm64: the default prefork pool
+#     crashes with SIGSEGV (signal 11) on this platform. solo runs everything in the
+#     main process with no fork, which is safe for development.
+#     Production (Linux): prefork works; omit --pool=solo.
 #
 #   u2net model: ~176 MB, auto-downloaded on first task to ~/.u2net/u2net.onnx.
 #   Subsequent tasks use the cached model (2–5 s per image on CPU).

--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,14 @@ REDIS_URL=redis://localhost:6379/0
 CELERY_BROKER_URL=redis://localhost:6379/0
 CELERY_RESULT_BACKEND=redis://localhost:6379/1
 
+# ── Background Removal (Mood Photos Phase 2) ────────────────────────────────
+# "null"  → NullProcessor: Remove Background button hidden (safe default for Phase 1)
+# "rembg" → RembgProcessor: real u2net background removal (requires Celery worker +
+#            rembg==2.0.75 + onnxruntime>=1.19.0; u2net.onnx ~176 MB downloaded on first use)
+# App:    BG_REMOVAL_PROCESSOR=rembg uvicorn app.main:app --reload --port 8000
+# Worker: BG_REMOVAL_PROCESSOR=rembg celery -A app.celery_app worker -Q mood_photos -c 1 -l info
+BG_REMOVAL_PROCESSOR=rembg
+
 # ── E2E Testing ─────────────────────────────────────────────────────────────
 # Base URLs for Playwright/Selenium tests
 BASE_URL=http://localhost:8501     # Streamlit app

--- a/.env.example
+++ b/.env.example
@@ -20,10 +20,24 @@ CELERY_RESULT_BACKEND=redis://localhost:6379/1
 
 # ── Background Removal (Mood Photos Phase 2) ────────────────────────────────
 # "null"  → NullProcessor: Remove Background button hidden (safe default for Phase 1)
-# "rembg" → RembgProcessor: real u2net background removal (requires Celery worker +
-#            rembg==2.0.75 + onnxruntime>=1.19.0; u2net.onnx ~176 MB downloaded on first use)
-# App:    BG_REMOVAL_PROCESSOR=rembg uvicorn app.main:app --reload --port 8000
-# Worker: BG_REMOVAL_PROCESSOR=rembg celery -A app.celery_app worker -Q mood_photos -c 1 -l info
+# "rembg" → RembgProcessor: real u2net background removal; requires two separate processes:
+#
+#   App process (terminal 1):
+#     BG_REMOVAL_PROCESSOR=rembg uvicorn app.main:app --reload --port 8000
+#
+#   Worker process (terminal 2):
+#     BG_REMOVAL_PROCESSOR=rembg celery -A app.celery_app worker \
+#       -Q mood_photos -c 1 -l info --pool=solo
+#
+#   --pool=solo is required on Python 3.13 + macOS arm64: the default prefork pool
+#   crashes with SIGSEGV (signal 11) on this platform. solo runs the worker in a
+#   single process with no fork, which is safe for development.
+#   Production (Linux): prefork works; omit --pool=solo.
+#
+#   u2net model: ~176 MB, auto-downloaded on first task to ~/.u2net/u2net.onnx.
+#   Subsequent tasks use the cached model (2–5 s per image on CPU).
+#   Timeout: PROCESSING_TIMEOUT_SECONDS=300 — if worker is not running, the UI
+#   shows a Reset button after 5 minutes so the user is not stuck.
 BG_REMOVAL_PROCESSOR=rembg
 
 # ── E2E Testing ─────────────────────────────────────────────────────────────

--- a/app/api/web_routes/mood_photos.py
+++ b/app/api/web_routes/mood_photos.py
@@ -31,6 +31,7 @@ from ...models.user_mood_photos import MOOD_PHOTO_SLOTS, MoodPhotoStatus, UserMo
 from ...services.mood_photo_service import (
     MOOD_PHOTO_DIR,
     apply_removal_failure,
+    check_bg_removal_rate_limit,
     delete_mood_photo,
     get_mood_photos_for_user,
     reset_processing,
@@ -239,6 +240,11 @@ async def mood_photo_remove_bg(
         MoodPhotoStatus.ready.value,
     ):
         return RedirectResponse(url="/profile/my-mood-photos", status_code=303)
+
+    # Rate limit: 3 triggers / 60 s per user — prevents duplicate clicks and
+    # rapid uploaded→failed→retry loops from flooding the task queue.
+    if not check_bg_removal_rate_limit(user.id):
+        raise HTTPException(status_code=429, detail="Too many background removal requests")
 
     # Fast-fail: original file missing from disk
     orig_path = MOOD_PHOTO_DIR / Path(record.original_url).name

--- a/app/api/web_routes/mood_photos.py
+++ b/app/api/web_routes/mood_photos.py
@@ -3,14 +3,18 @@ mood_photos — web routes for the mood photo feature.
 
 Routes
 ------
-GET  /profile/my-mood-photos            — management page
-POST /profile/my-mood-photos/{slot}/upload  — upload / replace a slot
-POST /profile/my-mood-photos/{slot}/delete  — HTML-form delete fallback
-DELETE /profile/my-mood-photos/{slot}       — JS-fetch delete endpoint
+GET    /profile/my-mood-photos                        — management page
+POST   /profile/my-mood-photos/{slot}/upload          — upload / replace a slot
+POST   /profile/my-mood-photos/{slot}/delete          — HTML-form delete fallback
+DELETE /profile/my-mood-photos/{slot}                 — JS-fetch delete endpoint
+POST   /profile/my-mood-photos/{slot}/remove-bg       — trigger background removal
+GET    /profile/my-mood-photos/{slot}/status          — JSON status + timeout flag
+POST   /profile/my-mood-photos/{slot}/reset-processing — reset stuck processing
 """
 from __future__ import annotations
 
 import logging
+from datetime import datetime, timezone
 from pathlib import Path
 
 from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile
@@ -18,16 +22,22 @@ from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from sqlalchemy.orm import Session
 
+from ...config import settings
 from ...database import get_db
 from ...dependencies import get_current_user_web
 from ...models.user import User
 from ...models.license import UserLicense
-from ...models.user_mood_photos import MOOD_PHOTO_SLOTS
+from ...models.user_mood_photos import MOOD_PHOTO_SLOTS, MoodPhotoStatus, UserMoodPhoto
 from ...services.mood_photo_service import (
+    MOOD_PHOTO_DIR,
+    apply_removal_failure,
     delete_mood_photo,
     get_mood_photos_for_user,
+    reset_processing,
     save_mood_photo,
+    set_status_processing,
 )
+from ...tasks.mood_photo_tasks import remove_background_task
 
 logger = logging.getLogger(__name__)
 
@@ -90,10 +100,14 @@ async def mood_photos_page(
     return templates.TemplateResponse(
         "lfa_player_mood_photos.html",
         {
-            "request":     request,
-            "user":        user,
-            "mood_photos": mood_photos,
-            "slots_meta":  _SLOT_META,
+            "request":            request,
+            "user":               user,
+            "mood_photos":        mood_photos,
+            "slots_meta":         _SLOT_META,
+            # Drives processor-aware UI:
+            #   "null"  → Remove Background button hidden; no removal claims shown
+            #   "rembg" → Remove Background / Retry / Background Removed enabled (Phase 2)
+            "bg_processor_mode":  settings.BG_REMOVAL_PROCESSOR,
             # Explicit LFA spec context — mood photos is an LFA Football Player
             # feature; do not rely on user.specialization which can be any active
             # spec (e.g. GANCUJU_PLAYER) on multi-spec accounts.
@@ -186,3 +200,141 @@ async def mood_photo_delete_api(
     delete_mood_photo(user.id, slot, db)
     db.commit()
     logger.info("mood_photo_deleted_api", extra={"user": user.email, "slot": slot})
+
+
+# ── POST /profile/my-mood-photos/{slot}/remove-bg ────────────────────────────
+
+@router.post("/profile/my-mood-photos/{slot}/remove-bg")
+async def mood_photo_remove_bg(
+    slot: str,
+    user: User    = Depends(get_current_user_web),
+    db:   Session = Depends(get_db),
+):
+    """
+    Trigger background removal for a slot.
+
+    State machine:
+      uploaded | failed → set processing → enqueue task → 303
+      processing | ready → 303 no-op (no double enqueue / no re-trigger)
+
+    Fast-fail: if the original file is missing from disk, status is set to
+    'failed' immediately without enqueueing the task.
+
+    Auth: get_current_user_web; filter_by(user_id=user.id) enforces own record only.
+    CSRF: caller must supply X-CSRF-Token header (JS fetch, same as delete).
+    """
+    if slot not in MOOD_PHOTO_SLOTS:
+        raise HTTPException(status_code=422, detail=f"Invalid slot: {slot!r}")
+
+    record = (
+        db.query(UserMoodPhoto)
+        .filter_by(user_id=user.id, slot=slot)
+        .first()
+    )
+    if record is None:
+        raise HTTPException(status_code=404, detail="No uploaded photo for this slot")
+
+    if record.status in (
+        MoodPhotoStatus.processing.value,
+        MoodPhotoStatus.ready.value,
+    ):
+        return RedirectResponse(url="/profile/my-mood-photos", status_code=303)
+
+    # Fast-fail: original file missing from disk
+    orig_path = MOOD_PHOTO_DIR / Path(record.original_url).name
+    if not orig_path.exists():
+        apply_removal_failure(user.id, slot, db)
+        logger.warning(
+            "bg_removal_missing_original",
+            extra={"user": user.email, "slot": slot},
+        )
+        return RedirectResponse(url="/profile/my-mood-photos", status_code=303)
+
+    set_status_processing(user.id, slot, db)
+    db.commit()
+    remove_background_task.delay(user.id, slot, record.original_url)
+    logger.info("bg_removal_triggered", extra={"user": user.email, "slot": slot})
+    return RedirectResponse(url="/profile/my-mood-photos", status_code=303)
+
+
+# ── GET /profile/my-mood-photos/{slot}/status ────────────────────────────────
+
+@router.get("/profile/my-mood-photos/{slot}/status")
+async def mood_photo_status(
+    slot: str,
+    user: User    = Depends(get_current_user_web),
+    db:   Session = Depends(get_db),
+):
+    """
+    Return JSON status for a slot.  Used by the template JS polling loop when
+    status='processing'.
+
+    Response shape:
+      {status, processed_png_url, updated_at, processing_timed_out}
+
+    processing_timed_out=True when status='processing' and updated_at is older
+    than settings.PROCESSING_TIMEOUT_SECONDS — signals a stuck worker to the UI.
+
+    Auth: filter_by(user_id=user.id) — own record only; no cross-user leakage.
+    """
+    if slot not in MOOD_PHOTO_SLOTS:
+        raise HTTPException(status_code=422, detail=f"Invalid slot: {slot!r}")
+
+    record = (
+        db.query(UserMoodPhoto)
+        .filter_by(user_id=user.id, slot=slot)
+        .first()
+    )
+    if record is None:
+        return JSONResponse({
+            "status":               "not_uploaded",
+            "processed_png_url":    None,
+            "updated_at":           None,
+            "processing_timed_out": False,
+        })
+
+    timed_out = (
+        record.status == MoodPhotoStatus.processing.value
+        and record.updated_at is not None
+        and (
+            datetime.now(timezone.utc) - record.updated_at
+        ).total_seconds() > settings.PROCESSING_TIMEOUT_SECONDS
+    )
+    return JSONResponse({
+        "status":               record.status,
+        "processed_png_url":    record.processed_png_url,
+        "updated_at":           record.updated_at.isoformat() if record.updated_at else None,
+        "processing_timed_out": timed_out,
+    })
+
+
+# ── POST /profile/my-mood-photos/{slot}/reset-processing ─────────────────────
+
+@router.post("/profile/my-mood-photos/{slot}/reset-processing")
+async def mood_photo_reset_processing(
+    slot: str,
+    user: User    = Depends(get_current_user_web),
+    db:   Session = Depends(get_db),
+):
+    """
+    Reset a stuck 'processing' record back to 'uploaded'.
+
+    Idempotent: no-op if status != 'processing' or no record exists.
+    Auth: filter_by(user_id=user.id) in reset_processing — own record only.
+    CSRF: caller must supply X-CSRF-Token header (JS fetch).
+    """
+    if slot not in MOOD_PHOTO_SLOTS:
+        raise HTTPException(status_code=422, detail=f"Invalid slot: {slot!r}")
+
+    record = (
+        db.query(UserMoodPhoto)
+        .filter_by(user_id=user.id, slot=slot)
+        .first()
+    )
+    if record is None:
+        raise HTTPException(status_code=404, detail="No mood photo record for this slot")
+
+    reset_processing(user.id, slot, db)
+    db.commit()
+    logger.info("bg_processing_reset", extra={"user": user.email, "slot": slot})
+    return RedirectResponse(url="/profile/my-mood-photos", status_code=303)

--- a/app/celery_app.py
+++ b/app/celery_app.py
@@ -29,6 +29,7 @@ def create_celery() -> Celery:
         backend=settings.CELERY_RESULT_BACKEND,
         include=[
             "app.tasks.tournament_tasks",
+            "app.tasks.mood_photo_tasks",
         ],
     )
 
@@ -59,15 +60,17 @@ def create_celery() -> Celery:
             "socket_connect_timeout": 10,   # seconds to establish Redis connection
             "retry_on_timeout": True,       # re-issue timed-out Redis commands
         },
-        # Routing: large tournament generation goes to dedicated queue
+        # Routing
         task_routes={
             "app.tasks.tournament_tasks.generate_sessions_task": {"queue": "tournaments"},
+            "app.tasks.mood_photo_tasks.remove_background_task": {"queue": "mood_photos"},
         },
         # Queues
         task_default_queue="default",
         task_queues={
-            "default": {},
+            "default":     {},
             "tournaments": {},
+            "mood_photos": {},
         },
         # Rate limiting (protect DB under heavy load)
         task_annotations={

--- a/app/config.py
+++ b/app/config.py
@@ -275,6 +275,14 @@ class Settings(BaseSettings):
     # giving up.  0 = unlimited (not recommended for long broker outages).
     CELERY_BROKER_CONNECTION_MAX_RETRIES: int = 10
 
+    # ── Background removal ─────────────────────────────────────────────────────
+    # "null"  → NullProcessor (Phase 1 skeleton; no real removal; button hidden)
+    # "rembg" → RembgProcessor (Phase 2; requires rembg + onnxruntime-cpu)
+    BG_REMOVAL_PROCESSOR: str = "null"
+    # Seconds after which a stuck 'processing' record is flagged timed-out in
+    # the status endpoint so the user can reset it back to 'uploaded'.
+    PROCESSING_TIMEOUT_SECONDS: int = 300
+
     # ── Slow-query monitoring ──────────────────────────────────────────────────
     # Queries slower than SLOW_QUERY_THRESHOLD_MS are logged to app.slow_query
     # and counted in the slow_queries_total metric.  Raise this value if normal

--- a/app/services/background_removal/__init__.py
+++ b/app/services/background_removal/__init__.py
@@ -1,0 +1,26 @@
+"""
+background_removal package — processor factory + public interface.
+
+get_processor() returns the active BackgroundProcessor based on
+settings.BG_REMOVAL_PROCESSOR:
+  "null"  → NullProcessor  (Phase 1 default; no real removal)
+  "rembg" → RembgProcessor (Phase 2; requires rembg + onnxruntime-cpu)
+
+The RembgProcessor import is deferred so that Phase 1 code never imports
+rembg or onnxruntime, even if those packages happen to be installed.
+"""
+from __future__ import annotations
+
+from app.config import settings
+
+from .processor import BackgroundProcessor, NullProcessor
+
+__all__ = ["BackgroundProcessor", "NullProcessor", "get_processor"]
+
+
+def get_processor() -> BackgroundProcessor:
+    """Return the processor configured by BG_REMOVAL_PROCESSOR."""
+    if settings.BG_REMOVAL_PROCESSOR == "rembg":
+        from .rembg_processor import RembgProcessor  # Phase 2 — deferred import
+        return RembgProcessor()
+    return NullProcessor()

--- a/app/services/background_removal/processor.py
+++ b/app/services/background_removal/processor.py
@@ -1,0 +1,38 @@
+"""
+Background removal processor interface.
+
+Phase 1: NullProcessor — returns the input image unchanged.
+         The Remove Background button is hidden from users when this processor
+         is active (BG_REMOVAL_PROCESSOR="null").
+
+Phase 2: RembgProcessor (rembg_processor.py) — real U2Net background removal.
+         Only used when BG_REMOVAL_PROCESSOR="rembg" and rembg + onnxruntime
+         are installed.
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class BackgroundProcessor(ABC):
+    @abstractmethod
+    def remove(self, input_png_bytes: bytes) -> bytes:
+        """
+        Accept PNG bytes, return PNG bytes with background removed (or unchanged).
+        Input is already a valid PNG (converted and resized by save_mood_photo).
+        """
+        ...
+
+
+class NullProcessor(BackgroundProcessor):
+    """
+    Phase 1 passthrough processor.  Returns the input image without any
+    modification.  Used when BG_REMOVAL_PROCESSOR="null" (default).
+
+    The user-facing "Remove Background" button is hidden when this processor
+    is active — the pipeline is wired end-to-end for testing but no removal
+    claim is shown to users.
+    """
+
+    def remove(self, input_png_bytes: bytes) -> bytes:
+        return input_png_bytes

--- a/app/services/background_removal/rembg_processor.py
+++ b/app/services/background_removal/rembg_processor.py
@@ -5,7 +5,7 @@ from .processor import BackgroundProcessor
 
 class RembgProcessor(BackgroundProcessor):
     """
-    Phase 2 processor.  Uses rembg + u2netp ONNX model to remove the
+    Phase 2 processor.  Uses rembg (default u2net ONNX model) to remove the
     background from a PNG image.  Returns RGBA PNG bytes with the
     background replaced by transparency.
 
@@ -20,4 +20,4 @@ class RembgProcessor(BackgroundProcessor):
 
     def remove(self, input_png_bytes: bytes) -> bytes:
         import rembg
-        return rembg.remove(input_png_bytes, model="u2netp")
+        return rembg.remove(input_png_bytes)

--- a/app/services/background_removal/rembg_processor.py
+++ b/app/services/background_removal/rembg_processor.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from .processor import BackgroundProcessor
+
+
+class RembgProcessor(BackgroundProcessor):
+    """
+    Phase 2 processor.  Uses rembg + u2netp ONNX model to remove the
+    background from a PNG image.  Returns RGBA PNG bytes with the
+    background replaced by transparency.
+
+    rembg is imported inside remove() so the web process can import this
+    class without requiring rembg to be installed; the package is only
+    needed in the Celery worker that calls remove().
+
+    Any exception from rembg.remove() propagates to the caller
+    (remove_background_task), which catches it and calls
+    apply_removal_failure() to mark the record as 'failed'.
+    """
+
+    def remove(self, input_png_bytes: bytes) -> bytes:
+        import rembg
+        return rembg.remove(input_png_bytes, model="u2netp")

--- a/app/services/mood_photo_service.py
+++ b/app/services/mood_photo_service.py
@@ -15,8 +15,10 @@ from __future__ import annotations
 
 import io
 import time
+from collections import deque
 from datetime import datetime, timezone
 from pathlib import Path
+from threading import Lock
 
 from PIL import Image
 from sqlalchemy.orm import Session
@@ -29,6 +31,37 @@ _ALLOWED_MIME: frozenset[str] = frozenset(
     {"image/jpeg", "image/png", "image/webp"}
 )
 _MAX_DIMENSION: int = 2048   # pixels; larger images are resized down
+
+# ── Background removal rate limiter — 3 triggers / 60 s per user ─────────────
+# Mirrors the pattern from card_export_service.check_export_rate_limit.
+# Guards against duplicate clicks and rapid uploaded→failed→retry loops.
+# Keyed by user_id (int); reset_bg_removal_rate_counters() is a test helper.
+_BG_RATE_LIMIT:    int                    = 3
+_BG_RATE_WINDOW:   int                    = 60  # seconds
+_bg_rate_counters: dict[int, deque]       = {}
+_bg_rate_lock:     Lock                   = Lock()
+
+
+def check_bg_removal_rate_limit(user_id: int) -> bool:
+    """Return True if within 3 remove-bg triggers/60s for this user, False if exceeded."""
+    now = time.monotonic()
+    with _bg_rate_lock:
+        if user_id not in _bg_rate_counters:
+            _bg_rate_counters[user_id] = deque()
+        dq     = _bg_rate_counters[user_id]
+        cutoff = now - _BG_RATE_WINDOW
+        while dq and dq[0] < cutoff:
+            dq.popleft()
+        if len(dq) >= _BG_RATE_LIMIT:
+            return False
+        dq.append(now)
+        return True
+
+
+def reset_bg_removal_rate_counters() -> None:
+    """Test helper — clears all in-memory remove-bg rate counters."""
+    with _bg_rate_lock:
+        _bg_rate_counters.clear()
 
 
 # ── Public API ────────────────────────────────────────────────────────────────

--- a/app/services/mood_photo_service.py
+++ b/app/services/mood_photo_service.py
@@ -5,13 +5,17 @@ Completely independent from player_photo_service.  Never reads or writes
 player_card_photo_url, wc_photo_url, or any other UserLicense photo field.
 No fallback in either direction.
 
-Background removal (processed_png_url) is NOT implemented in this module —
-that is a future phase requiring separate approval.
+Background removal pipeline (Phase 1):
+  set_status_processing / apply_removal_result / apply_removal_failure /
+  reset_processing handle DB state transitions.  The actual image processing
+  is done by app.services.background_removal (NullProcessor in Phase 1).
+  Real background removal remains Phase 2.
 """
 from __future__ import annotations
 
 import io
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 
 from PIL import Image
@@ -102,9 +106,9 @@ def get_mood_photos_for_user(
     user_id: int, db: Session
 ) -> dict[str, UserMoodPhoto | None]:
     """
-    Return {slot: record_or_None} for all 4 MOOD_PHOTO_SLOTS.
+    Return {slot: record_or_None} for all 6 MOOD_PHOTO_SLOTS.
 
-    Always returns all 4 keys so callers can iterate predictably.
+    Always returns all 6 keys so callers can iterate predictably.
     """
     rows = (
         db.query(UserMoodPhoto)
@@ -167,3 +171,75 @@ def _delete_files_for_slot(user_id: int, slot: str) -> None:
             f.unlink(missing_ok=True)
         except OSError:
             pass
+
+
+# ── Background removal pipeline — Phase 1 ────────────────────────────────────
+# These functions manage DB state transitions only.  Actual image processing
+# is handled by the Celery task in app.tasks.mood_photo_tasks.
+# Real background removal remains Phase 2 (rembg + onnxruntime-cpu).
+
+def set_status_processing(user_id: int, slot: str, db: Session) -> UserMoodPhoto:
+    """Set status='processing' before the Celery task is enqueued."""
+    record = (
+        db.query(UserMoodPhoto)
+        .filter_by(user_id=user_id, slot=slot)
+        .first()
+    )
+    if record is None:
+        raise ValueError(
+            f"No mood photo record for user_id={user_id} slot={slot!r}"
+        )
+    record.status = MoodPhotoStatus.processing.value
+    db.flush()
+    return record
+
+
+def apply_removal_result(
+    user_id: int, slot: str, processed_url: str, db: Session
+) -> None:
+    """Called by the Celery task on success. Commits the DB session."""
+    record = (
+        db.query(UserMoodPhoto)
+        .filter_by(user_id=user_id, slot=slot)
+        .first()
+    )
+    if record is None:
+        return
+    record.processed_png_url = processed_url
+    record.status            = MoodPhotoStatus.ready.value
+    record.processed_at      = datetime.now(timezone.utc)
+    db.commit()
+
+
+def apply_removal_failure(user_id: int, slot: str, db: Session) -> None:
+    """Called by the Celery task on failure (including max retries). Commits."""
+    record = (
+        db.query(UserMoodPhoto)
+        .filter_by(user_id=user_id, slot=slot)
+        .first()
+    )
+    if record is None:
+        return
+    record.status       = MoodPhotoStatus.failed.value
+    record.processed_at = datetime.now(timezone.utc)
+    db.commit()
+
+
+def reset_processing(user_id: int, slot: str, db: Session) -> None:
+    """
+    Reset a stuck 'processing' record back to 'uploaded'.
+
+    Idempotent: no-op if the record does not exist or status != 'processing'.
+    Only operates on the record belonging to user_id (own record guard).
+    """
+    record = (
+        db.query(UserMoodPhoto)
+        .filter_by(user_id=user_id, slot=slot)
+        .first()
+    )
+    if record is None or record.status != MoodPhotoStatus.processing.value:
+        return
+    record.status            = MoodPhotoStatus.uploaded.value
+    record.processed_png_url = None
+    record.processed_at      = None
+    db.flush()

--- a/app/tasks/mood_photo_tasks.py
+++ b/app/tasks/mood_photo_tasks.py
@@ -1,0 +1,99 @@
+"""
+Mood photo background removal Celery task.
+
+State flow (managed by mood_photo_service helpers):
+  uploaded → processing  (set by the /remove-bg route before enqueue)
+           → ready       (set by this task on success)
+           → failed      (set by this task on max-retries exceeded or missing file)
+
+Phase 1: NullProcessor is used — no real background removal occurs.
+         The "Remove Background" button is hidden from users when
+         BG_REMOVAL_PROCESSOR="null", so this task is not reachable from
+         the UI in Phase 1.  It is fully exercised by the test suite.
+
+Real background removal remains Phase 2 (rembg + onnxruntime-cpu).
+"""
+from __future__ import annotations
+
+import logging
+import time
+from pathlib import Path
+
+from app.celery_app import celery_app
+from app.database import SessionLocal
+from app.services.background_removal import get_processor
+from app.services.mood_photo_service import (
+    MOOD_PHOTO_DIR,
+    apply_removal_failure,
+    apply_removal_result,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@celery_app.task(
+    bind=True,
+    max_retries=2,
+    default_retry_delay=10,
+    queue="mood_photos",
+    name="app.tasks.mood_photo_tasks.remove_background_task",
+)
+def remove_background_task(
+    self,
+    user_id: int,
+    slot: str,
+    original_url: str,
+) -> dict:
+    """
+    Load the original PNG, run the background processor, save the result,
+    update the DB record.
+
+    original_url is passed from the route so the task can locate the file
+    without an extra DB read.  The task opens its own SessionLocal for the
+    write-back; it does not share the web worker's DB session.
+    """
+    db = SessionLocal()
+    try:
+        filename  = Path(original_url).name
+        orig_path = MOOD_PHOTO_DIR / filename
+
+        if not orig_path.exists():
+            apply_removal_failure(user_id, slot, db)
+            logger.warning(
+                "bg_removal_missing_file",
+                extra={"user_id": user_id, "slot": slot, "path": str(orig_path)},
+            )
+            return {"status": "failed", "reason": "missing_file"}
+
+        input_bytes  = orig_path.read_bytes()
+        processor    = get_processor()
+        output_bytes = processor.remove(input_bytes)
+
+        # Remove any previous processed file for this slot before writing
+        for old in MOOD_PHOTO_DIR.glob(f"{user_id}_mood_{slot}_proc_*.png"):
+            old.unlink(missing_ok=True)
+
+        ts            = int(time.time())
+        proc_filename = f"{user_id}_mood_{slot}_proc_{ts}.png"
+        (MOOD_PHOTO_DIR / proc_filename).write_bytes(output_bytes)
+
+        processed_url = f"/static/uploads/mood_photos/{proc_filename}"
+        apply_removal_result(user_id, slot, processed_url, db)
+        logger.info(
+            "bg_removal_done",
+            extra={"user_id": user_id, "slot": slot, "processor": type(processor).__name__},
+        )
+        return {"status": "ready", "processed_url": processed_url}
+
+    except Exception as exc:
+        logger.warning(
+            "bg_removal_error",
+            extra={"user_id": user_id, "slot": slot, "error": str(exc)},
+        )
+        try:
+            raise self.retry(exc=exc)
+        except self.MaxRetriesExceededError:
+            apply_removal_failure(user_id, slot, db)
+            return {"status": "failed", "reason": str(exc)}
+    finally:
+        db.close()

--- a/app/templates/lfa_player_mood_photos.html
+++ b/app/templates/lfa_player_mood_photos.html
@@ -39,7 +39,7 @@
         margin: 0;
     }
 
-    /* ── Back link as secondary button ── */
+    /* ── Buttons ── */
     .btn {
         padding: 0.75rem 1.4rem;
         border: none;
@@ -65,6 +65,11 @@
         color: var(--hub-btn-text, #fff);
         border: none;
     }
+    .btn-accent {
+        background: var(--hub-accent-bg, #d97706);
+        color: #fff;
+        border: none;
+    }
     .btn-danger {
         background: transparent;
         color: #f87171;
@@ -73,7 +78,7 @@
     .btn-danger:hover { background: rgba(248,113,113,0.1); }
     .btn-sm { padding: 0.45rem 0.9rem; font-size: 0.85rem; }
 
-    /* ── 2×2 mood grid ── */
+    /* ── 2-column mood grid ── */
     .mp-grid {
         display: grid;
         grid-template-columns: repeat(2, 1fr);
@@ -108,7 +113,7 @@
         flex: 1;
     }
 
-    /* ── Status badge ── */
+    /* ── Status badges ── */
     .mp-badge {
         display: inline-block;
         font-size: 0.72rem;
@@ -123,6 +128,23 @@
     .mp-badge-uploaded {
         background: rgba(134,239,172,0.15);
         color: #86efac;
+    }
+    .mp-badge-processing {
+        background: rgba(251,191,36,0.15);
+        color: #fbbf24;
+        animation: mp-pulse 1.5s ease-in-out infinite;
+    }
+    .mp-badge-ready {
+        background: rgba(96,165,250,0.15);
+        color: #60a5fa;
+    }
+    .mp-badge-failed {
+        background: rgba(248,113,113,0.15);
+        color: #f87171;
+    }
+    @keyframes mp-pulse {
+        0%, 100% { opacity: 1; }
+        50%       { opacity: 0.55; }
     }
 
     /* ── Instruction text ── */
@@ -151,6 +173,7 @@
         object-fit: contain;
         border-radius: 8px;
     }
+    .mp-preview img.mp-img-dimmed { opacity: 0.5; }
     .mp-preview-placeholder {
         text-align: center;
         color: var(--hub-text-muted, #94a3b8);
@@ -166,62 +189,119 @@
         align-items: center;
     }
 
-    /* ── Timestamp hint ── */
+    /* ── Timestamp / hint text ── */
     .mp-hint {
         font-size: 0.75rem;
         color: var(--hub-text-muted, #94a3b8);
         margin: 0;
+    }
+    .mp-hint-warn {
+        color: #fbbf24;
     }
 </style>
 {% endblock %}
 
 {% block extra_scripts %}
 <script>
-/* Mood photo upload: must use fetch() + X-CSRF-Token header.
-   form.submit() skips the submit event so base.html CSRF interceptor never fires.
-   Using FormData (not URLSearchParams) preserves the file as multipart/form-data. */
+/* ── CSRF helper ── */
 function _mpCsrfToken() {
     var m = document.cookie.match(/(?:^|;\s*)csrf_token=([^;]+)/);
     return m ? decodeURIComponent(m[1]) : null;
 }
 
-/* Upload: form.submit() bypasses submit event so base.html CSRF interceptor
-   never fires. Sending FormData directly preserves the file as multipart. */
+/* ── Upload / Replace ──
+   Must use fetch() + X-CSRF-Token; form.submit() skips the submit event so
+   the base.html CSRF interceptor never fires.  FormData preserves the file
+   as multipart/form-data. */
 function _mpUpload(input) {
     var form = input.closest('form');
     var tok  = _mpCsrfToken();
     if (!tok || !input.files || !input.files[0]) return;
-
     fetch(form.action, {
         method:      'POST',
         headers:     { 'X-CSRF-Token': tok },
         body:        new FormData(form),
         credentials: 'include',
         redirect:    'follow',
-    }).then(function (r) {
+    }).then(function(r) {
         window.location.href = r.redirected ? r.url : '/profile/my-mood-photos';
-    }).catch(function () {
-        window.location.reload();
-    });
+    }).catch(function() { window.location.reload(); });
 }
 
-/* Delete: type="button" avoids submit event entirely; confirm() runs first so
-   the user can cancel before the request is sent. */
+/* ── Delete ── */
 function _mpDelete(url) {
     if (!confirm('Delete this mood photo?')) return;
     var tok = _mpCsrfToken();
     if (!tok) { window.location.reload(); return; }
-
     fetch(url, {
         method:      'POST',
         headers:     { 'X-CSRF-Token': tok, 'Content-Type': 'application/x-www-form-urlencoded' },
         credentials: 'include',
         redirect:    'follow',
-    }).then(function (r) {
+    }).then(function(r) {
         window.location.href = r.redirected ? r.url : '/profile/my-mood-photos';
-    }).catch(function () {
-        window.location.reload();
+    }).catch(function() { window.location.reload(); });
+}
+
+/* ── Remove Background / Retry ──
+   Only wired when bg_processor_mode == "rembg" (Phase 2).
+   In Phase 1 (null processor) the button is not rendered. */
+function _mpRemoveBg(slot) {
+    var tok = _mpCsrfToken();
+    if (!tok) { window.location.reload(); return; }
+    fetch('/profile/my-mood-photos/' + slot + '/remove-bg', {
+        method:      'POST',
+        headers:     { 'X-CSRF-Token': tok },
+        credentials: 'include',
+        redirect:    'follow',
+    }).then(function(r) {
+        window.location.href = r.redirected ? r.url : '/profile/my-mood-photos';
+    }).catch(function() { window.location.reload(); });
+}
+
+/* ── Reset stuck processing ── */
+function _mpResetProcessing(slot) {
+    var tok = _mpCsrfToken();
+    if (!tok) { window.location.reload(); return; }
+    fetch('/profile/my-mood-photos/' + slot + '/reset-processing', {
+        method:      'POST',
+        headers:     { 'X-CSRF-Token': tok },
+        credentials: 'include',
+        redirect:    'follow',
+    }).then(function(r) {
+        window.location.href = r.redirected ? r.url : '/profile/my-mood-photos';
+    }).catch(function() { window.location.reload(); });
+}
+
+/* ── Status polling ──
+   Started for every slot whose badge carries data-poll-slot.
+   Polls GET /{slot}/status every 3 s.
+   Stops when status != 'processing', then reloads the page.
+   On processing_timed_out=true: reveals the Reset button and warning text. */
+document.addEventListener('DOMContentLoaded', function() {
+    document.querySelectorAll('[data-poll-slot]').forEach(function(el) {
+        _mpStartPolling(el.dataset.pollSlot);
     });
+});
+
+function _mpStartPolling(slot) {
+    var interval = setInterval(function() {
+        fetch('/profile/my-mood-photos/' + slot + '/status', { credentials: 'include' })
+            .then(function(r) { return r.json(); })
+            .then(function(data) {
+                if (data.processing_timed_out) {
+                    clearInterval(interval);
+                    var btn = document.getElementById('btn-reset-' + slot);
+                    var msg = document.getElementById('timeout-msg-' + slot);
+                    if (btn) btn.style.display = '';
+                    if (msg) msg.style.display = '';
+                } else if (data.status !== 'processing') {
+                    clearInterval(interval);
+                    window.location.reload();
+                }
+            })
+            .catch(function() { clearInterval(interval); });
+    }, 3000);
 }
 </script>
 {% endblock %}
@@ -249,10 +329,23 @@ function _mpDelete(url) {
             <div class="mp-card-header">
                 <span class="mp-card-emoji">{{ meta.emoji }}</span>
                 <span class="mp-card-title">{{ meta.label }}</span>
-                {% if record %}
-                <span class="mp-badge mp-badge-uploaded">✓ Uploaded</span>
-                {% else %}
-                <span class="mp-badge">Not uploaded</span>
+
+                {% if not record %}
+                    <span class="mp-badge">Not uploaded</span>
+                {% elif record.status == 'uploaded' %}
+                    <span class="mp-badge mp-badge-uploaded">✓ Uploaded</span>
+                {% elif record.status == 'processing' %}
+                    {# data-poll-slot triggers JS polling loop #}
+                    <span class="mp-badge mp-badge-processing"
+                          data-poll-slot="{{ meta.slot }}">⏳ Processing...</span>
+                {% elif record.status == 'ready' %}
+                    {% if bg_processor_mode == 'rembg' %}
+                        <span class="mp-badge mp-badge-ready">✨ Background Removed</span>
+                    {% else %}
+                        <span class="mp-badge mp-badge-ready">✓ Processed</span>
+                    {% endif %}
+                {% elif record.status == 'failed' %}
+                    <span class="mp-badge mp-badge-failed">⚠ Processing Failed</span>
                 {% endif %}
             </div>
 
@@ -262,28 +355,35 @@ function _mpDelete(url) {
             <!-- Photo preview -->
             <div class="mp-preview">
                 {% if record %}
-                {% if record.status == 'ready' and record.processed_png_url %}
-                <img src="{{ record.processed_png_url }}"
-                     alt="Mood photo — {{ meta.label }}"
-                     onerror="this.src='{{ record.original_url }}'; this.onerror=null;">
+                    {# Show processed PNG if ready; fall back to original on img error #}
+                    {% if record.status == 'ready' and record.processed_png_url %}
+                        <img src="{{ record.processed_png_url }}"
+                             alt="Processed mood photo — {{ meta.label }}"
+                             onerror="this.src='{{ record.original_url }}'; this.onerror=null;">
+                    {% else %}
+                        <img src="{{ record.original_url }}"
+                             alt="Mood photo — {{ meta.label }}"
+                             {% if record.status == 'processing' %}class="mp-img-dimmed"{% endif %}>
+                    {% endif %}
                 {% else %}
-                <img src="{{ record.original_url }}" alt="Mood photo — {{ meta.label }}">
-                {% endif %}
-                {% else %}
-                <div class="mp-preview-placeholder">
-                    No photo uploaded yet<br>
-                    <small>JPEG · PNG · WebP · max 5 MB</small>
-                </div>
+                    <div class="mp-preview-placeholder">
+                        No photo uploaded yet<br>
+                        <small>JPEG · PNG · WebP · max 5 MB</small>
+                    </div>
                 {% endif %}
             </div>
 
-            <!-- Actions: Upload/Replace + Delete -->
+            <!-- Actions -->
             <div class="mp-actions">
+
+                <!-- Upload / Replace: always available -->
                 <form method="post"
                       action="/profile/my-mood-photos/{{ meta.slot }}/upload"
                       enctype="multipart/form-data"
                       style="display:contents;">
-                    <label class="btn btn-primary btn-sm" for="file-{{ meta.slot }}" style="cursor:pointer;">
+                    <label class="btn btn-primary btn-sm"
+                           for="file-{{ meta.slot }}"
+                           style="cursor:pointer;">
                         {% if record %}🔄 Replace{% else %}📷 Upload{% endif %}
                     </label>
                     <input id="file-{{ meta.slot }}"
@@ -294,6 +394,7 @@ function _mpDelete(url) {
                            onchange="_mpUpload(this)">
                 </form>
 
+                <!-- Delete: if record exists -->
                 {% if record %}
                 <button type="button"
                         class="btn btn-danger btn-sm"
@@ -301,9 +402,51 @@ function _mpDelete(url) {
                     🗑 Delete
                 </button>
                 {% endif %}
+
+                <!-- Remove Background: ONLY when rembg processor is active AND status=uploaded.
+                     Phase 1 (null processor): this button is never rendered.
+                     No background removal claim is shown to users with NullProcessor. -->
+                {% if bg_processor_mode == 'rembg' and record and record.status == 'uploaded' %}
+                <button type="button"
+                        class="btn btn-accent btn-sm"
+                        onclick="_mpRemoveBg('{{ meta.slot }}')">
+                    ✂ Remove Background
+                </button>
+                {% endif %}
+
+                <!-- Retry Remove Background: ONLY rembg + status=failed -->
+                {% if bg_processor_mode == 'rembg' and record and record.status == 'failed' %}
+                <button type="button"
+                        class="btn btn-accent btn-sm"
+                        onclick="_mpRemoveBg('{{ meta.slot }}')">
+                    ↺ Retry Remove Background
+                </button>
+                {% endif %}
+
+                <!-- Reset processing: shown when status=processing; initially hidden.
+                     JS polling reveals it when processing_timed_out=True. -->
+                {% if record and record.status == 'processing' %}
+                <button type="button"
+                        id="btn-reset-{{ meta.slot }}"
+                        class="btn btn-secondary btn-sm"
+                        style="display:none;"
+                        onclick="_mpResetProcessing('{{ meta.slot }}')">
+                    ↺ Reset
+                </button>
+                {% endif %}
+
             </div>
 
-            <!-- Timestamp hint if photo exists -->
+            <!-- Timeout warning: hidden until JS polling detects processing_timed_out -->
+            {% if record and record.status == 'processing' %}
+            <p id="timeout-msg-{{ meta.slot }}"
+               class="mp-hint mp-hint-warn"
+               style="display:none;">
+                Processing is taking longer than expected. You can reset and re-upload.
+            </p>
+            {% endif %}
+
+            <!-- Timestamp hint -->
             {% if record %}
             <p class="mp-hint">
                 Uploaded {{ record.created_at.strftime('%Y-%m-%d %H:%M') if record.created_at else '—' }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,5 +25,8 @@ apscheduler==3.10.4
 # Image processing (LFA player card photo upload)
 Pillow>=10.0.0
 # Background removal (mood photos Phase 2)
+# rembg/onnxruntime only needed in Celery worker; web process uses deferred import.
+# onnxruntime 1.19.x does not exist (versions jump 1.18.x → 1.20.0); pinned to
+# 1.26.0 — the tested+installed version compatible with rembg==2.0.75.
 rembg==2.0.75
-onnxruntime>=1.19.0
+onnxruntime==1.26.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,6 @@ redis==5.0.1
 apscheduler==3.10.4
 # Image processing (LFA player card photo upload)
 Pillow>=10.0.0
+# Background removal (mood photos Phase 2)
+rembg==2.0.75
+onnxruntime>=1.19.0

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -63875,6 +63875,129 @@
         ]
       }
     },
+    "/profile/my-mood-photos/{slot}/remove-bg": {
+      "post": {
+        "description": "Trigger background removal for a slot.\n\nState machine:\n  uploaded | failed \u2192 set processing \u2192 enqueue task \u2192 303\n  processing | ready \u2192 303 no-op (no double enqueue / no re-trigger)\n\nFast-fail: if the original file is missing from disk, status is set to\n'failed' immediately without enqueueing the task.\n\nAuth: get_current_user_web; filter_by(user_id=user.id) enforces own record only.\nCSRF: caller must supply X-CSRF-Token header (JS fetch, same as delete).",
+        "operationId": "mood_photo_remove_bg_profile_my_mood_photos__slot__remove_bg_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slot",
+            "required": true,
+            "schema": {
+              "title": "Slot",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Mood Photo Remove Bg",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/profile/my-mood-photos/{slot}/reset-processing": {
+      "post": {
+        "description": "Reset a stuck 'processing' record back to 'uploaded'.\n\nIdempotent: no-op if status != 'processing' or no record exists.\nAuth: filter_by(user_id=user.id) in reset_processing \u2014 own record only.\nCSRF: caller must supply X-CSRF-Token header (JS fetch).",
+        "operationId": "mood_photo_reset_processing_profile_my_mood_photos__slot__reset_processing_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slot",
+            "required": true,
+            "schema": {
+              "title": "Slot",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Mood Photo Reset Processing",
+        "tags": [
+          "web"
+        ]
+      }
+    },
+    "/profile/my-mood-photos/{slot}/status": {
+      "get": {
+        "description": "Return JSON status for a slot.  Used by the template JS polling loop when\nstatus='processing'.\n\nResponse shape:\n  {status, processed_png_url, updated_at, processing_timed_out}\n\nprocessing_timed_out=True when status='processing' and updated_at is older\nthan settings.PROCESSING_TIMEOUT_SECONDS \u2014 signals a stuck worker to the UI.\n\nAuth: filter_by(user_id=user.id) \u2014 own record only; no cross-user leakage.",
+        "operationId": "mood_photo_status_profile_my_mood_photos__slot__status_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slot",
+            "required": true,
+            "schema": {
+              "title": "Slot",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Mood Photo Status",
+        "tags": [
+          "web"
+        ]
+      }
+    },
     "/profile/my-mood-photos/{slot}/upload": {
       "post": {
         "operationId": "mood_photo_upload_profile_my_mood_photos__slot__upload_post",

--- a/tests/unit/api/web_routes/test_mood_photos.py
+++ b/tests/unit/api/web_routes/test_mood_photos.py
@@ -728,10 +728,11 @@ def _render_mood_page(record_for_slot: MagicMock | None, slot: str = "mood_happy
         autoescape=False,
     )
     return env.get_template("lfa_player_mood_photos.html").render(
-        request           = MagicMock(),
-        user              = user,
-        mood_photos       = mood_photos,
-        slots_meta        = _SLOT_META,
+        request             = MagicMock(),
+        user                = user,
+        mood_photos         = mood_photos,
+        slots_meta          = _SLOT_META,
+        bg_processor_mode   = "null",   # explicit null mode — button must be hidden
         spec_dashboard_url  = "/dashboard/lfa-football-player",
         spec_dashboard_icon = "⚽",
         spec_profile_url    = "/profile/lfa-football-player",
@@ -815,29 +816,38 @@ class TestMPD04OnerrorFallback:
         assert "this.onerror=null" in html
 
 
-# ── MP-D05 ── Remove Background button absent in display-only fix ─────────────
+# ── MP-D05 ── Remove Background button absent in null processor mode ──────────
+#
+# _render_mood_page passes bg_processor_mode="null" explicitly.
+# The template gates the Remove Background button behind
+# {% if bg_processor_mode == 'rembg' ... %}.
+#
+# The JS block always contains the _mpRemoveBg() function definition and a
+# comment mentioning "Remove Background" — these are not the button element.
+# We check for the ✂-emoji button text which uniquely identifies the rendered
+# HTML button element (not the JS comment).
 
 class TestMPD05NoRemoveBackgroundButton:
 
     def test_mp_d05_no_remove_bg_when_uploaded(self):
-        """MP-D05a: Remove Background button must not appear for uploaded status."""
+        """MP-D05a: Remove Bg button (✂) must not render in null mode / uploaded."""
         record = _mood_record(status="uploaded", processed_png_url=None)
         html = _render_mood_page(record)
-        assert "Remove Background" not in html
-        assert "_mpRemoveBg" not in html
+        assert "✂ Remove Background" not in html
+        assert 'onclick="_mpRemoveBg(' not in html
 
     def test_mp_d05_no_remove_bg_when_ready(self):
-        """MP-D05b: Remove Background button must not appear for ready status."""
+        """MP-D05b: Remove Bg button (✂) must not render in null mode / ready."""
         record = _mood_record(status="ready", processed_png_url=_PROC_URL)
         html = _render_mood_page(record)
-        assert "Remove Background" not in html
+        assert "✂ Remove Background" not in html
 
     def test_mp_d05_no_retry_remove_bg_when_failed(self):
-        """MP-D05c: Retry Remove Background button must not appear for failed status."""
+        """MP-D05c: Retry Remove Bg button must not render in null mode / failed."""
         record = _mood_record(status="failed", processed_png_url=None)
         html = _render_mood_page(record)
-        assert "Retry Remove Background" not in html
-        assert "Remove Background" not in html
+        assert "↺ Retry Remove Background" not in html
+        assert "✂ Remove Background" not in html
 
 
 # ── MP-D06 ── Regression: no-record placeholder unchanged ─────────────────────
@@ -1424,3 +1434,42 @@ def test_mp_r51_rembg_uploaded_button_onclick_null_hidden():
     assert "_mpRemoveBg('mood_happy_smile')" not in html_null, (
         "Slot-specific onclick must NOT appear when bg_processor_mode='null'"
     )
+
+
+# ── MP-R52 ── /remove-bg rate limit: 4th call in 60 s → 429 ──────────────────
+
+def test_mp_r52_remove_bg_rate_limit_exceeded(tmp_path, monkeypatch):
+    """MP-R52: 4th remove-bg call within the 60 s window raises HTTP 429."""
+    from app.api.web_routes.mood_photos import mood_photo_remove_bg
+    from app.services.mood_photo_service import reset_bg_removal_rate_counters
+
+    reset_bg_removal_rate_counters()
+
+    orig_file = tmp_path / "42_mood_happy_smile_orig_1.png"
+    orig_file.write_bytes(b"PNG")
+    monkeypatch.setattr("app.api.web_routes.mood_photos.MOOD_PHOTO_DIR", tmp_path)
+
+    rec = _record(
+        status="uploaded",
+        original_url=f"/static/uploads/mood_photos/{orig_file.name}",
+    )
+
+    # First 3 calls: allowed (pass through state-machine guard after mock)
+    for _ in range(3):
+        db = _db_with(_record(status="uploaded", original_url=f"/static/uploads/mood_photos/{orig_file.name}"))
+        with patch(f"{_BASE}.set_status_processing"), \
+             patch(f"{_TASK}.delay"):
+            resp = _run(mood_photo_remove_bg(slot="mood_happy_smile", user=_user(42), db=db))
+        assert resp.status_code == 303
+
+    # 4th call: must be rate-limited
+    db = _db_with(_record(status="uploaded", original_url=f"/static/uploads/mood_photos/{orig_file.name}"))
+    with patch(f"{_BASE}.set_status_processing"), \
+         patch(f"{_TASK}.delay") as mock_delay, \
+         pytest.raises(HTTPException) as exc:
+        _run(mood_photo_remove_bg(slot="mood_happy_smile", user=_user(42), db=db))
+
+    assert exc.value.status_code == 429
+    mock_delay.assert_not_called()
+
+    reset_bg_removal_rate_counters()

--- a/tests/unit/api/web_routes/test_mood_photos.py
+++ b/tests/unit/api/web_routes/test_mood_photos.py
@@ -1217,3 +1217,96 @@ def test_mp_r46_reset_button_and_timeout_message_present():
     assert "style=\"display:none;\"" in content or "style='display:none;'" in content, (
         "Reset button and timeout message must be initially hidden (display:none)"
     )
+
+
+# ── MP-R47 ── rembg mode + uploaded → Remove Background button rendered ───────
+
+def test_mp_r47_rembg_mode_uploaded_shows_remove_bg_button():
+    """
+    When bg_processor_mode == 'rembg' and a slot has status='uploaded',
+    the rendered HTML must contain the Remove Background button text.
+    Rendered via Jinja2 directly — no web server required.
+    """
+    from datetime import datetime, timezone
+    from pathlib import Path
+
+    from jinja2 import Environment, FileSystemLoader
+
+    tpl_dir = (
+        Path(__file__).resolve().parent.parent.parent.parent.parent / "app" / "templates"
+    )
+    env = Environment(loader=FileSystemLoader(str(tpl_dir)), autoescape=True)
+    tpl = env.get_template("lfa_player_mood_photos.html")
+
+    record = MagicMock()
+    record.status           = "uploaded"
+    record.original_url     = "/static/uploads/mood_photos/1_mood_happy_smile_orig_1.png"
+    record.processed_png_url = None
+    record.created_at       = datetime.now(timezone.utc)
+    record.updated_at       = None
+
+    from app.api.web_routes.mood_photos import _SLOT_META
+    slots_meta  = _SLOT_META
+    mood_photos = {m["slot"]: (record if m["slot"] == "mood_happy_smile" else None)
+                   for m in slots_meta}
+
+    html = tpl.render(
+        slots_meta       = slots_meta,
+        mood_photos      = mood_photos,
+        bg_processor_mode = "rembg",
+        request          = MagicMock(),
+    )
+
+    assert "Remove Background" in html, (
+        "Remove Background button must appear in rendered HTML when bg_processor_mode='rembg' "
+        "and slot status='uploaded'"
+    )
+    assert "Background Removed" not in html or "uploaded" not in html.split("Remove Background")[0], (
+        "Background Removed badge must NOT appear for uploaded status"
+    )
+
+
+# ── MP-R48 ── rembg mode + ready → Background Removed badge rendered ──────────
+
+def test_mp_r48_rembg_mode_ready_shows_background_removed_badge():
+    """
+    When bg_processor_mode == 'rembg' and a slot has status='ready',
+    the rendered HTML must contain the Background Removed badge text.
+    """
+    from datetime import datetime, timezone
+    from pathlib import Path
+
+    from jinja2 import Environment, FileSystemLoader
+
+    tpl_dir = (
+        Path(__file__).resolve().parent.parent.parent.parent.parent / "app" / "templates"
+    )
+    env = Environment(loader=FileSystemLoader(str(tpl_dir)), autoescape=True)
+    tpl = env.get_template("lfa_player_mood_photos.html")
+
+    record = MagicMock()
+    record.status            = "ready"
+    record.original_url      = "/static/uploads/mood_photos/1_mood_happy_smile_orig_1.png"
+    record.processed_png_url = "/static/uploads/mood_photos/1_mood_mood_happy_smile_proc_1.png"
+    record.created_at        = datetime.now(timezone.utc)
+    record.updated_at        = datetime.now(timezone.utc)
+
+    from app.api.web_routes.mood_photos import _SLOT_META
+    slots_meta  = _SLOT_META
+    mood_photos = {m["slot"]: (record if m["slot"] == "mood_happy_smile" else None)
+                   for m in slots_meta}
+
+    html = tpl.render(
+        slots_meta        = slots_meta,
+        mood_photos       = mood_photos,
+        bg_processor_mode = "rembg",
+        request           = MagicMock(),
+    )
+
+    assert "Background Removed" in html, (
+        "Background Removed badge must appear in rendered HTML when bg_processor_mode='rembg' "
+        "and slot status='ready'"
+    )
+    assert "✓ Processed" not in html, (
+        "'✓ Processed' must NOT appear when bg_processor_mode='rembg'"
+    )

--- a/tests/unit/api/web_routes/test_mood_photos.py
+++ b/tests/unit/api/web_routes/test_mood_photos.py
@@ -1,5 +1,5 @@
 """
-MP-R01..MP-R26 — unit tests for mood_photos web routes.
+MP-R01..MP-R46 — unit tests for mood_photos web routes.
 MP-D01..MP-D06 — display fallback tests (processed_png_url rendering).
 
 Tests call route functions directly (asyncio.run) with patched
@@ -854,3 +854,366 @@ class TestMPD06Regression:
         html = _render_mood_page(record_for_slot=None)
         preview_section = html.split("mp-preview")[1].split("mp-actions")[0]
         assert "<img" not in preview_section
+
+
+# ── MP-R27..R46 — background removal pipeline routes ─────────────────────────
+
+_TASK = "app.tasks.mood_photo_tasks.remove_background_task"
+
+
+def _record(status: str = "uploaded", original_url: str = "/static/uploads/mood_photos/42_mood_happy_smile_orig_1.png"):
+    r = MagicMock()
+    r.status       = status
+    r.original_url = original_url
+    return r
+
+
+def _db_with(record):
+    db = MagicMock()
+    db.query.return_value.filter_by.return_value.first.return_value = record
+    return db
+
+
+# ── MP-R27 ── POST /remove-bg uploaded + file exists → 303, task enqueued ────
+
+def test_mp_r27_remove_bg_uploaded_enqueues_task(tmp_path, monkeypatch):
+    from app.api.web_routes.mood_photos import mood_photo_remove_bg
+
+    orig_file = tmp_path / "42_mood_happy_smile_orig_1.png"
+    orig_file.write_bytes(b"PNG")
+    monkeypatch.setattr("app.api.web_routes.mood_photos.MOOD_PHOTO_DIR", tmp_path)
+
+    rec = _record(status="uploaded", original_url=f"/static/uploads/mood_photos/{orig_file.name}")
+    db  = _db_with(rec)
+
+    with patch(f"{_BASE}.set_status_processing") as mock_set, \
+         patch(f"{_BASE}.apply_removal_failure") as mock_fail, \
+         patch(f"{_TASK}.delay") as mock_delay:
+        resp = _run(mood_photo_remove_bg(slot="mood_happy_smile", user=_user(42), db=db))
+
+    assert resp.status_code == 303
+    mock_set.assert_called_once()
+    mock_delay.assert_called_once()
+    mock_fail.assert_not_called()
+
+
+# ── MP-R28 ── POST /remove-bg failed (Retry) + file exists → 303, task ───────
+
+def test_mp_r28_remove_bg_failed_retry_enqueues_task(tmp_path, monkeypatch):
+    from app.api.web_routes.mood_photos import mood_photo_remove_bg
+
+    orig_file = tmp_path / "42_mood_happy_smile_orig_1.png"
+    orig_file.write_bytes(b"PNG")
+    monkeypatch.setattr("app.api.web_routes.mood_photos.MOOD_PHOTO_DIR", tmp_path)
+
+    rec = _record(status="failed", original_url=f"/static/uploads/mood_photos/{orig_file.name}")
+    db  = _db_with(rec)
+
+    with patch(f"{_BASE}.set_status_processing"), \
+         patch(f"{_TASK}.delay") as mock_delay:
+        resp = _run(mood_photo_remove_bg(slot="mood_happy_smile", user=_user(42), db=db))
+
+    assert resp.status_code == 303
+    mock_delay.assert_called_once()
+
+
+# ── MP-R29 ── POST /remove-bg status=processing → 303 no-op, no enqueue ──────
+
+def test_mp_r29_remove_bg_processing_no_double_enqueue(tmp_path, monkeypatch):
+    from app.api.web_routes.mood_photos import mood_photo_remove_bg
+
+    monkeypatch.setattr("app.api.web_routes.mood_photos.MOOD_PHOTO_DIR", tmp_path)
+    rec = _record(status="processing")
+    db  = _db_with(rec)
+
+    with patch(f"{_TASK}.delay") as mock_delay:
+        resp = _run(mood_photo_remove_bg(slot="mood_happy_smile", user=_user(42), db=db))
+
+    assert resp.status_code == 303
+    mock_delay.assert_not_called()
+
+
+# ── MP-R30 ── POST /remove-bg status=ready → 303 no-op, no re-trigger ────────
+
+def test_mp_r30_remove_bg_ready_no_retrigger(tmp_path, monkeypatch):
+    from app.api.web_routes.mood_photos import mood_photo_remove_bg
+
+    monkeypatch.setattr("app.api.web_routes.mood_photos.MOOD_PHOTO_DIR", tmp_path)
+    rec = _record(status="ready")
+    db  = _db_with(rec)
+
+    with patch(f"{_TASK}.delay") as mock_delay:
+        resp = _run(mood_photo_remove_bg(slot="mood_happy_smile", user=_user(42), db=db))
+
+    assert resp.status_code == 303
+    mock_delay.assert_not_called()
+
+
+# ── MP-R31 ── POST /remove-bg invalid slot → 422 ─────────────────────────────
+
+def test_mp_r31_remove_bg_invalid_slot_raises_422():
+    from app.api.web_routes.mood_photos import mood_photo_remove_bg
+
+    with pytest.raises(HTTPException) as exc:
+        _run(mood_photo_remove_bg(slot="not_a_slot", user=_user(42), db=_db()))
+
+    assert exc.value.status_code == 422
+
+
+# ── MP-R32 ── POST /remove-bg no record → 404 ────────────────────────────────
+
+def test_mp_r32_remove_bg_no_record_raises_404():
+    from app.api.web_routes.mood_photos import mood_photo_remove_bg
+
+    db = _db_with(None)
+    with pytest.raises(HTTPException) as exc:
+        _run(mood_photo_remove_bg(slot="mood_happy_smile", user=_user(42), db=db))
+
+    assert exc.value.status_code == 404
+
+
+# ── MP-R33 ── POST /remove-bg missing file → 303, status=failed, no enqueue ──
+
+def test_mp_r33_remove_bg_missing_file_fast_fail(tmp_path, monkeypatch):
+    from app.api.web_routes.mood_photos import mood_photo_remove_bg
+
+    monkeypatch.setattr("app.api.web_routes.mood_photos.MOOD_PHOTO_DIR", tmp_path)
+    # original_url points to a file that does NOT exist
+    rec = _record(status="uploaded", original_url="/static/uploads/mood_photos/missing.png")
+    db  = _db_with(rec)
+
+    with patch(f"{_BASE}.apply_removal_failure") as mock_fail, \
+         patch(f"{_TASK}.delay") as mock_delay:
+        resp = _run(mood_photo_remove_bg(slot="mood_happy_smile", user=_user(42), db=db))
+
+    assert resp.status_code == 303
+    mock_fail.assert_called_once()
+    mock_delay.assert_not_called()
+
+
+# ── MP-R34 ── GET /status uploaded → JSON, processing_timed_out=False ─────────
+
+def test_mp_r34_status_uploaded():
+    from app.api.web_routes.mood_photos import mood_photo_status
+
+    rec = _record(status="uploaded")
+    rec.updated_at        = None
+    rec.processed_png_url = None
+    db  = _db_with(rec)
+
+    resp    = _run(mood_photo_status(slot="mood_happy_smile", user=_user(42), db=db))
+    payload = resp.body if hasattr(resp, "body") else resp.body
+
+    import json
+    data = json.loads(resp.body)
+    assert data["status"] == "uploaded"
+    assert data["processing_timed_out"] is False
+
+
+# ── MP-R35 ── GET /status processing, fresh → processing_timed_out=False ──────
+
+def test_mp_r35_status_processing_fresh():
+    from datetime import datetime, timezone
+
+    from app.api.web_routes.mood_photos import mood_photo_status
+
+    rec = _record(status="processing")
+    rec.updated_at        = datetime.now(timezone.utc)
+    rec.processed_png_url = None
+    db  = _db_with(rec)
+
+    import json
+    resp = _run(mood_photo_status(slot="mood_happy_smile", user=_user(42), db=db))
+    data = json.loads(resp.body)
+    assert data["status"] == "processing"
+    assert data["processing_timed_out"] is False
+
+
+# ── MP-R36 ── GET /status processing, stale → processing_timed_out=True ───────
+
+def test_mp_r36_status_processing_timed_out():
+    from datetime import datetime, timedelta, timezone
+
+    from app.api.web_routes.mood_photos import mood_photo_status
+
+    rec = _record(status="processing")
+    rec.updated_at        = datetime.now(timezone.utc) - timedelta(seconds=400)
+    rec.processed_png_url = None
+    db  = _db_with(rec)
+
+    import json
+    with patch("app.api.web_routes.mood_photos.settings") as mock_settings:
+        mock_settings.MOOD_PHOTO_SLOTS   = None   # not used in this route
+        mock_settings.PROCESSING_TIMEOUT_SECONDS = 300
+        resp = _run(mood_photo_status(slot="mood_happy_smile", user=_user(42), db=db))
+
+    data = json.loads(resp.body)
+    assert data["status"] == "processing"
+    assert data["processing_timed_out"] is True
+
+
+# ── MP-R37 ── GET /status ready → processed_png_url in response ───────────────
+
+def test_mp_r37_status_ready():
+    from datetime import datetime, timezone
+
+    from app.api.web_routes.mood_photos import mood_photo_status
+
+    import json
+    rec = _record(status="ready")
+    rec.updated_at        = datetime.now(timezone.utc)
+    rec.processed_png_url = "/static/uploads/mood_photos/42_mood_happy_smile_proc_1.png"
+    db  = _db_with(rec)
+
+    resp = _run(mood_photo_status(slot="mood_happy_smile", user=_user(42), db=db))
+    data = json.loads(resp.body)
+    assert data["status"] == "ready"
+    assert data["processed_png_url"] is not None
+
+
+# ── MP-R38 ── GET /status no record → not_uploaded ────────────────────────────
+
+def test_mp_r38_status_no_record():
+    import json
+    from app.api.web_routes.mood_photos import mood_photo_status
+
+    db = _db_with(None)
+    resp = _run(mood_photo_status(slot="mood_happy_smile", user=_user(42), db=db))
+    data = json.loads(resp.body)
+    assert data["status"] == "not_uploaded"
+    assert data["processing_timed_out"] is False
+
+
+# ── MP-R39 ── POST /reset-processing: processing → uploaded ───────────────────
+
+def test_mp_r39_reset_processing_resets_to_uploaded():
+    from app.api.web_routes.mood_photos import mood_photo_reset_processing
+
+    rec = _record(status="processing")
+    db  = _db_with(rec)
+
+    with patch(f"{_BASE}.reset_processing") as mock_reset:
+        resp = _run(mood_photo_reset_processing(
+            slot="mood_happy_smile", user=_user(42), db=db
+        ))
+
+    assert resp.status_code == 303
+    mock_reset.assert_called_once_with(42, "mood_happy_smile", db)
+
+
+# ── MP-R40 ── POST /reset-processing: status=uploaded → no-op (idempotent) ────
+
+def test_mp_r40_reset_processing_noop_when_not_processing():
+    from app.api.web_routes.mood_photos import mood_photo_reset_processing
+
+    rec = _record(status="uploaded")
+    db  = _db_with(rec)
+
+    with patch(f"{_BASE}.reset_processing") as mock_reset:
+        resp = _run(mood_photo_reset_processing(
+            slot="mood_happy_smile", user=_user(42), db=db
+        ))
+
+    assert resp.status_code == 303
+    mock_reset.assert_called_once()   # called; service handles no-op internally
+
+
+# ── MP-R41 ── POST /reset-processing: invalid slot → 422 ─────────────────────
+
+def test_mp_r41_reset_processing_invalid_slot():
+    from app.api.web_routes.mood_photos import mood_photo_reset_processing
+
+    with pytest.raises(HTTPException) as exc:
+        _run(mood_photo_reset_processing(slot="bad_slot", user=_user(42), db=_db()))
+
+    assert exc.value.status_code == 422
+
+
+# ── MP-R42 ── POST /reset-processing: no record → 404 ────────────────────────
+
+def test_mp_r42_reset_processing_no_record_raises_404():
+    from app.api.web_routes.mood_photos import mood_photo_reset_processing
+
+    db = _db_with(None)
+    with pytest.raises(HTTPException) as exc:
+        _run(mood_photo_reset_processing(
+            slot="mood_happy_smile", user=_user(42), db=db
+        ))
+
+    assert exc.value.status_code == 404
+
+
+# ── MP-R43..R46 ── Template processor-aware assertions ───────────────────────
+
+def _tpl():
+    from pathlib import Path
+    return (
+        Path(__file__).resolve()
+        .parent.parent.parent.parent.parent
+        / "app" / "templates" / "lfa_player_mood_photos.html"
+    ).read_text(encoding="utf-8")
+
+
+# ── MP-R43 ── null mode: "Remove Background" not in template source ───────────
+
+def test_mp_r43_null_mode_remove_bg_button_gated():
+    """
+    The Remove Background button must be inside a
+    {% if bg_processor_mode == 'rembg' ... %} guard so it is
+    never rendered when BG_REMOVAL_PROCESSOR="null".
+    """
+    content = _tpl()
+    assert "bg_processor_mode == 'rembg'" in content, (
+        "Template must gate Remove Background on bg_processor_mode == 'rembg'"
+    )
+    # Verify the button text exists but is inside the guard
+    assert "Remove Background" in content
+    # "Background Removed" label must also be inside the rembg guard
+    assert "Background Removed" in content
+
+
+# ── MP-R44 ── null mode ready badge says "Processed", not "Background Removed" ─
+
+def test_mp_r44_null_mode_ready_badge_no_removal_claim():
+    """
+    When bg_processor_mode != 'rembg' and status == 'ready', the template
+    must show "Processed" not "Background Removed".
+    The check: template has both labels but gates "Background Removed"
+    behind bg_processor_mode == 'rembg'.
+    """
+    content = _tpl()
+    # "Processed" badge must exist for null processor path
+    assert "✓ Processed" in content, (
+        "Template must show '✓ Processed' badge when bg_processor_mode != 'rembg'"
+    )
+    # "Background Removed" must be inside rembg guard
+    rembg_block_start = content.find("bg_processor_mode == 'rembg'")
+    bg_removed_pos    = content.find("Background Removed")
+    assert rembg_block_start < bg_removed_pos, (
+        "'Background Removed' text must appear after the rembg processor mode guard"
+    )
+
+
+# ── MP-R45 ── processing badge has data-poll-slot for JS polling ──────────────
+
+def test_mp_r45_processing_badge_has_poll_slot():
+    content = _tpl()
+    assert "data-poll-slot" in content, (
+        "Template must attach data-poll-slot to the processing badge "
+        "so the JS polling loop can target the correct slot"
+    )
+
+
+# ── MP-R46 ── reset button initially hidden, timeout message present ──────────
+
+def test_mp_r46_reset_button_and_timeout_message_present():
+    content = _tpl()
+    assert "btn-reset-" in content, (
+        "Template must render a reset button (id=btn-reset-{slot}) for stuck processing"
+    )
+    assert "Processing is taking longer than expected" in content, (
+        "Template must contain the timeout warning message"
+    )
+    assert "style=\"display:none;\"" in content or "style='display:none;'" in content, (
+        "Reset button and timeout message must be initially hidden (display:none)"
+    )

--- a/tests/unit/api/web_routes/test_mood_photos.py
+++ b/tests/unit/api/web_routes/test_mood_photos.py
@@ -1310,3 +1310,117 @@ def test_mp_r48_rembg_mode_ready_shows_background_removed_badge():
     assert "✓ Processed" not in html, (
         "'✓ Processed' must NOT appear when bg_processor_mode='rembg'"
     )
+
+
+# ── MP-R49..R51 ── Route-level bg_processor_mode wiring + button visibility ──
+
+# ── MP-R49 ── route passes bg_processor_mode="rembg" from settings to context ─
+
+def test_mp_r49_route_passes_rembg_mode_to_template_context():
+    """
+    mood_photos_page must pass bg_processor_mode = settings.BG_REMOVAL_PROCESSOR
+    to the template context.  Patching settings to "rembg" must produce
+    bg_processor_mode="rembg" in the context dict.
+    """
+    from app.api.web_routes.mood_photos import mood_photos_page
+
+    six_slots = {s: None for s in _ALL_SLOTS}
+
+    with patch(f"{_BASE}.get_mood_photos_for_user", return_value=six_slots), \
+         patch(f"{_BASE}.settings") as mock_settings, \
+         patch(f"{_BASE}.templates") as mock_tpl:
+        mock_settings.BG_REMOVAL_PROCESSOR = "rembg"
+        mock_tpl.TemplateResponse.return_value = MagicMock()
+
+        _run(mood_photos_page(request=_request(), user=_user(), db=_db()))
+
+        ctx = mock_tpl.TemplateResponse.call_args[0][1]
+        assert ctx.get("bg_processor_mode") == "rembg", (
+            "Route must pass bg_processor_mode='rembg' when BG_REMOVAL_PROCESSOR='rembg'"
+        )
+
+
+# ── MP-R50 ── route passes bg_processor_mode="null" from settings to context ──
+
+def test_mp_r50_route_passes_null_mode_to_template_context():
+    """
+    When BG_REMOVAL_PROCESSOR="null" (default), bg_processor_mode must be "null"
+    in the template context — the Remove Background button will not be rendered.
+    """
+    from app.api.web_routes.mood_photos import mood_photos_page
+
+    six_slots = {s: None for s in _ALL_SLOTS}
+
+    with patch(f"{_BASE}.get_mood_photos_for_user", return_value=six_slots), \
+         patch(f"{_BASE}.settings") as mock_settings, \
+         patch(f"{_BASE}.templates") as mock_tpl:
+        mock_settings.BG_REMOVAL_PROCESSOR = "null"
+        mock_tpl.TemplateResponse.return_value = MagicMock()
+
+        _run(mood_photos_page(request=_request(), user=_user(), db=_db()))
+
+        ctx = mock_tpl.TemplateResponse.call_args[0][1]
+        assert ctx.get("bg_processor_mode") == "null", (
+            "Route must pass bg_processor_mode='null' when BG_REMOVAL_PROCESSOR='null'"
+        )
+
+
+# ── MP-R51 ── rendered HTML: rembg+uploaded → button+onclick; null → no button ─
+
+def test_mp_r51_rembg_uploaded_button_onclick_null_hidden():
+    """
+    Full Jinja2 render using a context built to match what the route passes:
+      - rembg mode + status='uploaded' → Remove Background button present,
+        onclick calls _mpRemoveBg with the correct slot
+      - null mode + status='uploaded'  → button absent
+    """
+    from datetime import datetime, timezone
+    from pathlib import Path
+
+    from jinja2 import Environment, FileSystemLoader
+
+    from app.api.web_routes.mood_photos import _SLOT_META
+
+    tpl_dir = (
+        Path(__file__).resolve().parent.parent.parent.parent.parent / "app" / "templates"
+    )
+    env = Environment(loader=FileSystemLoader(str(tpl_dir)), autoescape=True)
+    tpl = env.get_template("lfa_player_mood_photos.html")
+
+    record = MagicMock()
+    record.status            = "uploaded"
+    record.original_url      = "/static/uploads/mood_photos/1_mood_happy_smile_orig_1.png"
+    record.processed_png_url = None
+    record.created_at        = datetime.now(timezone.utc)
+    record.updated_at        = None
+
+    mood_photos = {m["slot"]: (record if m["slot"] == "mood_happy_smile" else None)
+                   for m in _SLOT_META}
+
+    base_ctx = dict(slots_meta=_SLOT_META, mood_photos=mood_photos, request=MagicMock())
+
+    # rembg mode: button must appear with correct onclick target.
+    # Check "✂ Remove Background" (button label) and the slot-specific onclick call.
+    # The JS section defines _mpRemoveBg(slot) unconditionally, so we check
+    # the rendered button label (with scissors) and slot-specific onclick instead
+    # of the bare string "Remove Background" which appears in JS comments too.
+    html_rembg = tpl.render(**base_ctx, bg_processor_mode="rembg")
+    assert "✂ Remove Background" in html_rembg, (
+        "Remove Background button (✂ label) must appear when bg_processor_mode='rembg' and status='uploaded'"
+    )
+    assert "_mpRemoveBg('mood_happy_smile')" in html_rembg, (
+        "Button onclick must call _mpRemoveBg('mood_happy_smile') — "
+        "which POSTs to /profile/my-mood-photos/mood_happy_smile/remove-bg"
+    )
+
+    # null mode: button element must be absent.
+    # The JS comment block contains "Remove Background" unconditionally, so we
+    # check for the rendered button label (scissors prefix) which only appears
+    # when the {% if bg_processor_mode == 'rembg' %} guard is true.
+    html_null = tpl.render(**base_ctx, bg_processor_mode="null")
+    assert "✂ Remove Background" not in html_null, (
+        "Remove Background button (✂ label) must NOT appear when bg_processor_mode='null'"
+    )
+    assert "_mpRemoveBg('mood_happy_smile')" not in html_null, (
+        "Slot-specific onclick must NOT appear when bg_processor_mode='null'"
+    )

--- a/tests/unit/services/test_mood_photo_service.py
+++ b/tests/unit/services/test_mood_photo_service.py
@@ -1,5 +1,5 @@
 """
-MP-S01..MP-S08 — unit tests for mood_photo_service.
+MP-S01..MP-S13 — unit tests for mood_photo_service.
 
 Uses MagicMock for the SQLAlchemy Session; no real DB required.
 Disk I/O is patched via tmp_path / monkeypatch so tests stay hermetic.
@@ -186,3 +186,88 @@ def test_mp_s08_get_returns_all_six_slots():
     assert result["mood_sad_disappointed"]  is None
     assert result["mood_angry_competitive"] is None
     assert result["mood_surprised_shocked"] is None
+
+
+# ── MP-S09 ── set_status_processing sets status and calls flush ───────────────
+
+def test_mp_s09_set_status_processing():
+    record = MagicMock()
+    record.status = "uploaded"
+    db = _make_db(existing_row=record)
+
+    from app.services.mood_photo_service import set_status_processing
+
+    result = set_status_processing(user_id=42, slot="mood_happy_smile", db=db)
+
+    assert record.status == "processing"
+    db.flush.assert_called()
+    assert result is record
+
+
+# ── MP-S10 ── apply_removal_result sets ready + url + timestamp ───────────────
+
+def test_mp_s10_apply_removal_result():
+    from datetime import datetime, timezone
+
+    record = MagicMock()
+    db = _make_db(existing_row=record)
+
+    from app.services.mood_photo_service import apply_removal_result
+
+    apply_removal_result(
+        user_id=42,
+        slot="mood_happy_smile",
+        processed_url="/static/uploads/mood_photos/42_mood_happy_smile_proc_999.png",
+        db=db,
+    )
+
+    assert record.status == "ready"
+    assert record.processed_png_url == "/static/uploads/mood_photos/42_mood_happy_smile_proc_999.png"
+    assert record.processed_at is not None
+    db.commit.assert_called()
+
+
+# ── MP-S11 ── apply_removal_failure sets failed, clears processed_at ─────────
+
+def test_mp_s11_apply_removal_failure():
+    record = MagicMock()
+    db = _make_db(existing_row=record)
+
+    from app.services.mood_photo_service import apply_removal_failure
+
+    apply_removal_failure(user_id=42, slot="mood_happy_smile", db=db)
+
+    assert record.status == "failed"
+    assert record.processed_at is not None
+    db.commit.assert_called()
+
+
+# ── MP-S12 ── reset_processing: status=processing → uploaded, cleared ────────
+
+def test_mp_s12_reset_processing_from_processing():
+    record = MagicMock()
+    record.status = "processing"
+    db = _make_db(existing_row=record)
+
+    from app.services.mood_photo_service import reset_processing
+
+    reset_processing(user_id=42, slot="mood_happy_smile", db=db)
+
+    assert record.status == "uploaded"
+    assert record.processed_png_url is None
+    assert record.processed_at is None
+    db.flush.assert_called()
+
+
+# ── MP-S13 ── reset_processing: status != processing → no-op ─────────────────
+
+def test_mp_s13_reset_processing_noop_when_not_processing():
+    record = MagicMock()
+    record.status = "uploaded"
+    db = _make_db(existing_row=record)
+
+    from app.services.mood_photo_service import reset_processing
+
+    reset_processing(user_id=42, slot="mood_happy_smile", db=db)
+
+    db.flush.assert_not_called()

--- a/tests/unit/tasks/test_mood_photo_tasks.py
+++ b/tests/unit/tasks/test_mood_photo_tasks.py
@@ -186,7 +186,7 @@ def test_mp_t08_rembg_processor_calls_rembg_remove():
         result = RembgProcessor().remove(b"INPUT_PNG")
 
     assert result == b"TRANSPARENT_PNG"
-    mock_rembg.remove.assert_called_once_with(b"INPUT_PNG", model="u2netp")
+    mock_rembg.remove.assert_called_once_with(b"INPUT_PNG")
 
 
 # ── MP-T09 ── rembg.remove() exception → task calls apply_removal_failure ─────

--- a/tests/unit/tasks/test_mood_photo_tasks.py
+++ b/tests/unit/tasks/test_mood_photo_tasks.py
@@ -1,19 +1,25 @@
 """
-MP-T01..MP-T06 — unit tests for mood_photo_tasks (background removal Celery task).
+MP-T01..MP-T09 — unit tests for mood_photo_tasks (background removal Celery task).
 
 All tests use MagicMock / patch — no real Celery worker, no real DB,
-no rembg/onnxruntime required.
+no rembg/onnxruntime model download required.
 
-Phase 1 invariants tested:
+Phase 1 invariants tested (MP-T01..T06):
   - NullProcessor returns bytes unchanged
   - get_processor() returns NullProcessor when BG_REMOVAL_PROCESSOR="null"
   - Task writes processed file and calls apply_removal_result on success
   - Task calls apply_removal_failure when original file is missing (no retry)
   - Task calls apply_removal_failure when max retries are exhausted
   - apply_removal_failure is NOT called on a successful run
+
+Phase 2 invariants tested (MP-T07..T09):
+  - get_processor() returns RembgProcessor when BG_REMOVAL_PROCESSOR="rembg"
+  - RembgProcessor.remove() calls rembg.remove(..., model="u2netp")
+  - rembg.remove() exception causes the Celery task to call apply_removal_failure
 """
 from __future__ import annotations
 
+import sys
 from unittest.mock import MagicMock, patch
 
 _TASK_MOD = "app.tasks.mood_photo_tasks"
@@ -153,3 +159,70 @@ def test_mp_t06_no_failure_call_on_success(tmp_path):
         )
 
     mock_fail.assert_not_called()
+
+
+# ── MP-T07 ── get_processor() with rembg config → RembgProcessor ─────────────
+
+def test_mp_t07_get_processor_rembg_mode():
+    from app.services.background_removal.rembg_processor import RembgProcessor
+
+    with patch("app.services.background_removal.settings") as mock_cfg:
+        mock_cfg.BG_REMOVAL_PROCESSOR = "rembg"
+        from app.services.background_removal import get_processor
+        proc = get_processor()
+
+    assert isinstance(proc, RembgProcessor)
+
+
+# ── MP-T08 ── RembgProcessor.remove() calls rembg.remove(model="u2netp") ─────
+# rembg is imported inside remove() (deferred), so we patch via sys.modules.
+
+def test_mp_t08_rembg_processor_calls_rembg_remove():
+    mock_rembg = MagicMock()
+    mock_rembg.remove.return_value = b"TRANSPARENT_PNG"
+
+    with patch.dict(sys.modules, {"rembg": mock_rembg}):
+        from app.services.background_removal.rembg_processor import RembgProcessor
+        result = RembgProcessor().remove(b"INPUT_PNG")
+
+    assert result == b"TRANSPARENT_PNG"
+    mock_rembg.remove.assert_called_once_with(b"INPUT_PNG", model="u2netp")
+
+
+# ── MP-T09 ── rembg.remove() exception → task calls apply_removal_failure ─────
+
+def test_mp_t09_rembg_exception_causes_task_failure(tmp_path):
+    orig_file = tmp_path / "42_mood_happy_smile_orig_1.png"
+    orig_file.write_bytes(b"FAKEDATA")
+    original_url = f"/static/uploads/mood_photos/{orig_file.name}"
+
+    mock_rembg = MagicMock()
+    mock_rembg.remove.side_effect = RuntimeError("ONNX session failed")
+
+    with patch.dict(sys.modules, {"rembg": mock_rembg}):
+        from app.services.background_removal.rembg_processor import RembgProcessor
+        rembg_proc = RembgProcessor()
+
+    with patch(f"{_TASK_MOD}.MOOD_PHOTO_DIR", new=tmp_path), \
+         patch(f"{_TASK_MOD}.get_processor", return_value=rembg_proc), \
+         patch(f"{_TASK_MOD}.apply_removal_result") as mock_ok, \
+         patch(f"{_TASK_MOD}.apply_removal_failure") as mock_fail, \
+         patch(f"{_TASK_MOD}.SessionLocal", return_value=MagicMock()):
+
+        from app.tasks.mood_photo_tasks import remove_background_task
+
+        mock_self = MagicMock()
+        mock_self.MaxRetriesExceededError = RuntimeError
+        mock_self.retry.side_effect = RuntimeError("max retries exceeded")
+
+        with patch.dict(sys.modules, {"rembg": mock_rembg}):
+            result = remove_background_task.run.__func__(
+                mock_self,
+                user_id=42,
+                slot="mood_happy_smile",
+                original_url=original_url,
+            )
+
+    assert result["status"] == "failed"
+    mock_fail.assert_called_once()
+    mock_ok.assert_not_called()

--- a/tests/unit/tasks/test_mood_photo_tasks.py
+++ b/tests/unit/tasks/test_mood_photo_tasks.py
@@ -1,0 +1,155 @@
+"""
+MP-T01..MP-T06 — unit tests for mood_photo_tasks (background removal Celery task).
+
+All tests use MagicMock / patch — no real Celery worker, no real DB,
+no rembg/onnxruntime required.
+
+Phase 1 invariants tested:
+  - NullProcessor returns bytes unchanged
+  - get_processor() returns NullProcessor when BG_REMOVAL_PROCESSOR="null"
+  - Task writes processed file and calls apply_removal_result on success
+  - Task calls apply_removal_failure when original file is missing (no retry)
+  - Task calls apply_removal_failure when max retries are exhausted
+  - apply_removal_failure is NOT called on a successful run
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+_TASK_MOD = "app.tasks.mood_photo_tasks"
+
+
+# ── MP-T01 ── NullProcessor.remove() returns input unchanged ─────────────────
+
+def test_mp_t01_null_processor_passthrough():
+    from app.services.background_removal.processor import NullProcessor
+
+    data = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+    assert NullProcessor().remove(data) == data
+
+
+# ── MP-T02 ── get_processor() with null config → NullProcessor ────────────────
+
+def test_mp_t02_get_processor_null_mode():
+    from app.services.background_removal.processor import NullProcessor
+
+    with patch("app.services.background_removal.settings") as mock_cfg:
+        mock_cfg.BG_REMOVAL_PROCESSOR = "null"
+        from app.services.background_removal import get_processor
+        proc = get_processor()
+
+    assert isinstance(proc, NullProcessor)
+
+
+# ── MP-T03 ── Task success: proc file written, apply_removal_result called ────
+
+def test_mp_t03_task_success_writes_proc_file(tmp_path):
+    orig_file = tmp_path / "42_mood_happy_smile_orig_1.png"
+    orig_file.write_bytes(b"FAKEDATA")
+    original_url = f"/static/uploads/mood_photos/{orig_file.name}"
+
+    fake_proc = MagicMock()
+    fake_proc.remove.return_value = b"PROCESSED"
+
+    with patch(f"{_TASK_MOD}.MOOD_PHOTO_DIR", new=tmp_path), \
+         patch(f"{_TASK_MOD}.get_processor", return_value=fake_proc), \
+         patch(f"{_TASK_MOD}.apply_removal_result") as mock_ok, \
+         patch(f"{_TASK_MOD}.apply_removal_failure") as mock_fail, \
+         patch(f"{_TASK_MOD}.SessionLocal", return_value=MagicMock()):
+
+        from app.tasks.mood_photo_tasks import remove_background_task
+        result = remove_background_task.run(
+            user_id=42, slot="mood_happy_smile", original_url=original_url
+        )
+
+    assert result["status"] == "ready"
+    mock_ok.assert_called_once()
+    mock_fail.assert_not_called()
+
+    # Slot names start with "mood_" and the filename template adds "_mood_" prefix,
+    # so the actual pattern is: 42_mood_{slot}_proc_*.png = 42_mood_mood_happy_smile_proc_*.png
+    proc_files = list(tmp_path.glob(f"42_mood_mood_happy_smile_proc_*.png"))
+    assert len(proc_files) == 1
+    assert proc_files[0].read_bytes() == b"PROCESSED"
+
+
+# ── MP-T04 ── Task: max retries exhausted → apply_removal_failure called ──────
+
+def test_mp_t04_task_max_retries_calls_failure(tmp_path):
+    orig_file = tmp_path / "42_mood_happy_smile_orig_1.png"
+    orig_file.write_bytes(b"FAKEDATA")
+    original_url = f"/static/uploads/mood_photos/{orig_file.name}"
+
+    failing_proc = MagicMock()
+    failing_proc.remove.side_effect = RuntimeError("boom")
+
+    with patch(f"{_TASK_MOD}.MOOD_PHOTO_DIR", new=tmp_path), \
+         patch(f"{_TASK_MOD}.get_processor", return_value=failing_proc), \
+         patch(f"{_TASK_MOD}.apply_removal_result") as mock_ok, \
+         patch(f"{_TASK_MOD}.apply_removal_failure") as mock_fail, \
+         patch(f"{_TASK_MOD}.SessionLocal", return_value=MagicMock()):
+
+        from app.tasks.mood_photo_tasks import remove_background_task
+
+        # Simulate max retries exhausted: task.retry raises MaxRetriesExceededError
+        mock_self = MagicMock()
+        mock_self.MaxRetriesExceededError = RuntimeError
+        mock_self.retry.side_effect = RuntimeError("max retries exceeded")
+
+        # Invoke the underlying function directly with a mock self
+        result = remove_background_task.run.__func__(
+            mock_self,
+            user_id=42,
+            slot="mood_happy_smile",
+            original_url=original_url,
+        )
+
+    assert result["status"] == "failed"
+    mock_fail.assert_called_once()
+    mock_ok.assert_not_called()
+
+
+# ── MP-T05 ── Task: missing original file → failed immediately, no retry ───────
+
+def test_mp_t05_task_missing_file_immediate_failure(tmp_path):
+    # original_url points to a file that does NOT exist
+    original_url = "/static/uploads/mood_photos/nonexistent.png"
+
+    with patch(f"{_TASK_MOD}.MOOD_PHOTO_DIR", new=tmp_path), \
+         patch(f"{_TASK_MOD}.apply_removal_failure") as mock_fail, \
+         patch(f"{_TASK_MOD}.apply_removal_result") as mock_ok, \
+         patch(f"{_TASK_MOD}.SessionLocal", return_value=MagicMock()):
+
+        from app.tasks.mood_photo_tasks import remove_background_task
+        result = remove_background_task.run(
+            user_id=42, slot="mood_happy_smile", original_url=original_url
+        )
+
+    assert result["status"] == "failed"
+    assert result.get("reason") == "missing_file"
+    mock_fail.assert_called_once()
+    mock_ok.assert_not_called()
+
+
+# ── MP-T06 ── apply_removal_failure NOT called on success ────────────────────
+
+def test_mp_t06_no_failure_call_on_success(tmp_path):
+    orig_file = tmp_path / "99_mood_celebration_orig_1.png"
+    orig_file.write_bytes(b"DATA")
+    original_url = f"/static/uploads/mood_photos/{orig_file.name}"
+
+    fake_proc = MagicMock()
+    fake_proc.remove.return_value = b"OUTPUT"
+
+    with patch(f"{_TASK_MOD}.MOOD_PHOTO_DIR", new=tmp_path), \
+         patch(f"{_TASK_MOD}.get_processor", return_value=fake_proc), \
+         patch(f"{_TASK_MOD}.apply_removal_result"), \
+         patch(f"{_TASK_MOD}.apply_removal_failure") as mock_fail, \
+         patch(f"{_TASK_MOD}.SessionLocal", return_value=MagicMock()):
+
+        from app.tasks.mood_photo_tasks import remove_background_task
+        remove_background_task.run(
+            user_id=99, slot="mood_celebration", original_url=original_url
+        )
+
+    mock_fail.assert_not_called()


### PR DESCRIPTION
## Summary

- **Phase 2A (safety hardening)**: Rebase onto main (`2ad0faa5`), conflict resolution (template + test docstring), `.env.example` null default, `onnxruntime==1.26.0` pin, rate limit (3 calls/60s), Celery queue registration, `config.py` `BG_REMOVAL_PROCESSOR` + `PROCESSING_TIMEOUT_SECONDS`
- **Phase 2 pipeline**: `NullProcessor` (Phase 1 skeleton) + `RembgProcessor` (deferred `import rembg`); `get_processor()` factory; Celery `remove_background_task` (queue=`mood_photos`, max_retries=2)
- **State machine**: uploaded → processing → ready | failed; `set_status_processing` / `apply_removal_result` / `apply_removal_failure` / `reset_processing`
- **New routes**: `POST /remove-bg`, `GET /status` (polling), `POST /reset-processing`
- **Template**: status badges, Remove Bg button (rembg-mode gated), Retry button, Reset button, JS polling every 3s; processed PNG shown when ready (with `onerror` fallback from PR #195)
- **Safety**: `BG_REMOVAL_PROCESSOR=null` default in `.env.example`; all Remove Bg UI gated behind `{% if bg_processor_mode == 'rembg' %}`; rate limit 429 guard; fast-fail on missing disk file

## Scope (Phase 2A only — no model/migration/schema change)

No new Alembic migration. No `UserMoodPhoto` model change. No production activation (`.env.example` defaults to `null`). No Player/Welcome/Challenge card changes.

## Test plan

- [ ] `pytest tests/unit/api/web_routes/test_mood_photos.py` — 88 tests (MP-R* + MP-D*)
- [ ] `pytest tests/unit/services/test_mood_photo_service.py` — service + rate limit tests
- [ ] `pytest tests/unit/tasks/test_mood_photo_tasks.py` — Celery task tests
- [ ] Full unit suite: 11636/11636 PASS (verified locally)
- [ ] Manual QA null mode: Remove Bg button absent, processed fallback display works ✓
- [ ] Manual QA rembg mode: 17/17 Playwright checks PASS (uploaded → processing → ready → proc image shown; Retry on failed; Reset on stuck) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)