### PR TITLE
feat(card-editor): CE-2 — owned-only filter; no purchase affordance in editor

### DIFF
--- a/app/api/web_routes/dashboard.py
+++ b/app/api/web_routes/dashboard.py
@@ -398,7 +398,12 @@ async def lfa_player_card_editor(
         }
         for t in _get_all_themes(db=db)
     ]
+    # CE-2: owned-only — free themes always pass (is_premium=False → always unlocked)
+    card_themes = [t for t in card_themes if t["unlocked"]]
     active_card_theme = card_draft.draft_theme
+    # Render-time theme fallback — if draft theme was filtered out, fall back to "default"
+    if not any(t["id"] == active_card_theme for t in card_themes):
+        active_card_theme = "default"
 
     # Published public card state (read-only in the editor — shown as indicator)
     published_card_theme    = card_draft.published_theme    or "default"
@@ -420,8 +425,15 @@ async def lfa_player_card_editor(
         }
         for v in _get_all_variants()
     ]
+    # CE-2: owned-only — no purchase affordance in editor (CE-2 policy)
+    card_variants = [v for v in card_variants if v["unlocked"]]
     active_card_variant  = card_draft.draft_variant
     active_variant_owned = _is_design_accessible(db, user.id, "player_card", active_card_variant)
+    # CE-2: render-time fallback — if draft points to unowned design, use first owned
+    # Does NOT write to DB; user explicit tile-click will persist the change.
+    if not active_variant_owned and card_variants:
+        active_card_variant = card_variants[0]["id"]
+        active_variant_owned = True
 
     # Animated video export capability: list of platforms supported for the
     # current variant. Used by the card editor to show/hide the video button.

--- a/app/templates/dashboard_card_editor.html
+++ b/app/templates/dashboard_card_editor.html
@@ -187,8 +187,6 @@
     border-color: var(--tile-accent, var(--ce-accent));
     box-shadow: 0 0 0 2px color-mix(in srgb, var(--tile-accent, var(--ce-accent)) 22%, transparent);
 }
-.ce-design-tile.locked { opacity: 0.62; }
-.ce-design-tile.locked:hover { opacity: 0.85; }
 
 /* Mini card art — two pseudo-elements, no images, works everywhere */
 .ce-design-tile-art {
@@ -234,13 +232,6 @@
     text-overflow: ellipsis;
     line-height: 1;
 }
-.ce-design-tile-lock {
-    font-size: 0.58rem;
-    color: rgba(255,255,255,0.38);
-    white-space: nowrap;
-    flex-shrink: 0;
-}
-
 /* ── Layout tiles (Card Layout section) ─────────────────────────────────────── */
 /* Unavailable / previewing states not in base ce-design-tile — added here */
 .ce-layout-tile.unavailable { opacity: 0.55; cursor: pointer; }
@@ -613,18 +604,17 @@
     gap: 0.35rem;
     flex-shrink: 0;
 }
-.ce-locked-note {
+.ce-empty-state {
     margin-top: 0.6rem;
     font-size: 0.78rem;
     color: rgba(255,255,255,0.45);
 }
-.ce-locked-note a {
+.ce-empty-state a {
     color: var(--app-accent, #667eea);
     text-decoration: none;
     font-weight: 600;
     margin-left: 0.25rem;
 }
-.ce-locked-note a:hover { opacity: 0.8; }
 
 /* Publish status elements */
 .publish-status-dot {
@@ -721,7 +711,6 @@
     .ce-design-tile        { background: rgba(0,0,0,0.04); border-color: rgba(0,0,0,0.1); }
     .ce-design-tile:hover  { background: rgba(0,0,0,0.07); border-color: rgba(0,0,0,0.18); }
     .ce-design-tile-name   { color: rgba(0,0,0,0.75); }
-    .ce-design-tile-lock   { color: rgba(0,0,0,0.38); }
     .ce-design-tile-art    { background: #dde2ec; }
     .ce-platform-tile      { background: rgba(0,0,0,0.04); border-color: rgba(0,0,0,0.1); }
     .ce-platform-tile:hover { background: rgba(0,0,0,0.07); }
@@ -834,26 +823,17 @@
                     {% if show_variant_picker and card_variants is defined %}
                     <div class="ce-section">
                         <div class="ce-section-title">Card Layout</div>
+                        {% if card_variants %}
                         <div class="ce-design-grid" id="variant-picker">
                             {% for v in card_variants %}
                             <button class="ce-design-tile ce-layout-tile
-                                           {% if v.id == active_card_variant %}active{% endif %}
-                                           {% if not v.unlocked %}locked{% endif %}
-                                           {% if not v.available %}unavailable{% endif %}"
+                                           {% if v.id == active_card_variant %}active{% endif %}"
                                     data-variant="{{ v.id }}"
-                                    title="{{ v.description }}{% if not v.available %} · Preview only{% elif v.is_premium and not v.unlocked %} · Unlock for {{ v.credit_cost }} CR{% endif %}"
-                                    onclick="{% if v.available %}setCardVariant('{{ v.id }}', {{ 'true' if v.unlocked else 'false' }}, '{{ v.label }}', {{ v.credit_cost }}){% else %}previewVariant('{{ v.id }}'){% endif %}">
+                                    title="{{ v.description }}"
+                                    onclick="setCardVariant('{{ v.id }}')">
                                 <div class="ce-design-tile-art"></div>
                                 <div class="ce-design-tile-footer">
-                                    <span class="ce-design-tile-name">
-                                        {%- if not v.available -%}⏳&thinsp;
-                                        {%- elif v.is_premium and not v.unlocked -%}🔒&thinsp;
-                                        {%- endif -%}
-                                        {{ v.label }}
-                                        {%- if v.is_premium and not v.unlocked and v.available -%}
-                                        <span class="var-cost">&thinsp;{{ v.credit_cost }}&thinsp;CR</span>
-                                        {%- endif -%}
-                                    </span>
+                                    <span class="ce-design-tile-name">{{ v.label }}</span>
                                     <a href="/players/{{ user.id }}/card?preview={{ v.id }}" target="_blank"
                                        onclick="event.stopPropagation();"
                                        title="Preview {{ v.label }} in new tab"
@@ -862,6 +842,12 @@
                             </button>
                             {% endfor %}
                         </div>
+                        {% else %}
+                        <div class="ce-empty-state">
+                            No Player Card designs yet.
+                            <a href="/shop/cards/player">Browse Player Card designs →</a>
+                        </div>
+                        {% endif %}
                     </div>
                     {% endif %}
 
@@ -871,17 +857,13 @@
                         <div class="ce-design-grid" id="theme-picker">
                             {% for t in card_themes %}
                             <button class="ce-design-tile
-                                           {% if t.id == active_card_theme %}active{% endif %}
-                                           {% if not t.unlocked %}locked{% endif %}"
+                                           {% if t.id == active_card_theme %}active{% endif %}"
                                     style="--tile-accent: {{ t.dot_color }};"
-                                    onclick="setCardTheme('{{ t.id }}', {{ 'true' if t.unlocked else 'false' }}, '{{ t.label }}', {{ t.credit_cost }})"
-                                    title="{{ t.label }}{% if t.is_premium and not t.unlocked %} · Unlock for {{ t.credit_cost }} CR{% endif %}">
+                                    onclick="setCardTheme('{{ t.id }}')"
+                                    title="{{ t.label }}">
                                 <div class="ce-design-tile-art"></div>
                                 <div class="ce-design-tile-footer">
                                     <span class="ce-design-tile-name">{{ t.label }}</span>
-                                    {% if t.is_premium and not t.unlocked %}
-                                    <span class="ce-design-tile-lock">🔒 {{ t.credit_cost }}&thinsp;CR</span>
-                                    {% endif %}
                                 </div>
                             </button>
                             {% endfor %}
@@ -1135,9 +1117,9 @@
                 </div>
             </div>
             {% if not active_variant_owned %}
-            <div class="ce-locked-note">
-                This design requires a Player Card.
-                <a href="/my-cards/player-card">Get Player Card →</a>
+            <div class="ce-empty-state">
+                No Player Card designs yet.
+                <a href="/shop/cards/player">Browse Player Card designs →</a>
             </div>
             {% endif %}
 
@@ -1228,23 +1210,7 @@ function _updateFullscreenLink() {
     link.href = `/players/${_cardUserId}/card`;
 }
 
-async function unlockTheme(themeId, label, cost) {
-    if (!confirm(`Unlock "${label}" for ${cost} CR from your credit balance?`)) return;
-    try {
-        const r = await fetch('/dashboard/unlock-theme', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': _csrf() },
-            body: JSON.stringify({ theme: themeId }),
-        });
-        if (r.status === 403) { alert('Session expired — reloading page.'); location.reload(); return; }
-        const data = await r.json();
-        if (data.ok) { location.reload(); }
-        else { alert('❌ ' + (data.error || 'Could not unlock theme.')); }
-    } catch(e) { alert('Network error. Please try again.'); }
-}
-
-async function setCardTheme(themeId, unlocked, label, cost) {
-    if (!unlocked) { await unlockTheme(themeId, label, cost); return; }
+async function setCardTheme(themeId) {
     try {
         const r = await fetch('/dashboard/card-theme', {
             method: 'POST',
@@ -1262,21 +1228,6 @@ async function setCardTheme(themeId, unlocked, label, cost) {
             if (iframe) { iframe.src = _cardIframeSrc(); }
             _updatePublishIndicator();
         } else { alert(data.error || 'Could not apply theme.'); }
-    } catch(e) { alert('Network error. Please try again.'); }
-}
-
-async function unlockVariant(variantId, label, cost) {
-    if (!confirm(`Unlock "${label}" layout for ${cost} CR from your credit balance?`)) return;
-    try {
-        const r = await fetch('/dashboard/unlock-variant', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': _csrf() },
-            body: JSON.stringify({ variant: variantId }),
-        });
-        if (r.status === 403) { alert('Session expired — reloading page.'); location.reload(); return; }
-        const data = await r.json();
-        if (data.ok) { location.reload(); }
-        else { alert('❌ ' + (data.error || 'Could not unlock variant.')); }
     } catch(e) { alert('Network error. Please try again.'); }
 }
 
@@ -1526,8 +1477,7 @@ function previewVariant(variantId) {
     if (btn) btn.classList.add('previewing');
 }
 
-async function setCardVariant(variantId, unlocked, label, cost) {
-    if (!unlocked) { await unlockVariant(variantId, label, cost); return; }
+async function setCardVariant(variantId) {
     try {
         const r = await fetch('/dashboard/card-variant', {
             method: 'POST',

--- a/tests/unit/api/web_routes/test_card_draft_routes.py
+++ b/tests/unit/api/web_routes/test_card_draft_routes.py
@@ -114,11 +114,15 @@ class TestCardEditorGetContext:
         return captured.get("context", {})
 
     def test_cd_rt_01_active_theme_from_draft(self):
-        """CD-RT-01: active_card_theme comes from card_draft.draft_theme."""
-        draft = _draft(draft_theme="gold")
+        """CD-RT-01: active_card_theme comes from card_draft.draft_theme.
+
+        Uses a free theme ('midnight') so the CE-2 owned-only filter never
+        discards it — the test goal is draft-persistence, not premium unlock.
+        """
+        draft = _draft(draft_theme="midnight")
         ctx = self._invoke_editor_get(draft)
-        assert ctx.get("active_card_theme") == "gold", (
-            f"active_card_theme must equal draft.draft_theme='gold', got {ctx.get('active_card_theme')!r}"
+        assert ctx.get("active_card_theme") == "midnight", (
+            f"active_card_theme must equal draft.draft_theme='midnight', got {ctx.get('active_card_theme')!r}"
         )
 
     def test_cd_rt_02_active_variant_from_draft(self):

--- a/tests/unit/api/web_routes/test_card_editor_ce2.py
+++ b/tests/unit/api/web_routes/test_card_editor_ce2.py
@@ -1,0 +1,440 @@
+"""
+CE-2 tests — Card Editor owned-only filtering + no purchase affordance.
+
+CE2-01  card_variants context contains only owned variants (unlocked=True)
+CE2-02  locked (not-owned) variant never appears in card_variants context
+CE2-03  card_themes context contains only free + owned premium themes
+CE2-04  locked premium theme never appears in card_themes context
+CE2-05  response body does NOT contain "Unlock for"
+CE2-06  response body does NOT contain "Get Card" or "Get Player Card"
+CE2-07  response body does NOT contain credit-price locked string
+CE2-08  response body does NOT contain unlockVariant JS function
+CE2-09  response body does NOT contain unlockTheme JS function
+CE2-10  stale draft_variant (unowned) → render-time fallback to first owned variant
+CE2-11  zero owned variants → card_variants is empty list in context
+CE2-12  empty state block contains Browse Player Card designs shop link
+CE2-13  /dashboard/unlock-variant endpoint still registered (backward compat)
+CE2-14  /dashboard/unlock-theme endpoint still registered (backward compat)
+CE2-15  publish/export CDO guard unchanged — active_variant_owned=False disables buttons
+CE2-16  Welcome editor unowned → 303 redirect unchanged
+CE2-17  route count unchanged — no new routes added
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_DASH_BASE  = "app.api.web_routes.dashboard"
+_IS_DA_PATH = "app.services.card_design_service.is_design_accessible"
+
+TEMPLATES_DIR = Path(__file__).resolve().parents[4] / "app" / "templates"
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _req():
+    return MagicMock()
+
+
+def _student(uid: int = 42):
+    u = MagicMock()
+    u.id = uid
+    u.credit_balance = 100
+    return u
+
+
+def _license(uid: int = 42):
+    lic = MagicMock()
+    lic.user_id = uid
+    lic.specialization_type = "LFA_FOOTBALL_PLAYER"
+    lic.onboarding_completed = True
+    lic.football_skills = {"passing": 60}
+    lic.unlocked_card_variants = []
+    lic.unlocked_card_themes   = []
+    return lic
+
+
+def _draft(variant: str = "fifa", theme: str = "default") -> MagicMock:
+    d = MagicMock()
+    d.draft_theme    = theme
+    d.draft_variant  = variant
+    d.draft_platform = None
+    d.draft_data     = {}
+    d.published_theme    = theme
+    d.published_variant  = variant
+    d.published_platform = None
+    d.published_data     = {}
+    return d
+
+
+def _variant(vid: str, label: str = "", is_premium: bool = True, credit_cost: int = 300) -> MagicMock:
+    v = MagicMock()
+    v.id          = vid
+    v.label       = label or vid
+    v.description = f"{vid} description"
+    v.is_premium  = is_premium
+    v.credit_cost = credit_cost
+    v.available   = True
+    return v
+
+
+def _theme_def(tid: str, is_premium: bool = False, credit_cost: int = 0, dot_color: str = "#667eea") -> MagicMock:
+    t = MagicMock()
+    t.id          = tid
+    t.label       = tid
+    t.dot_color   = dot_color
+    t.is_premium  = is_premium
+    t.credit_cost = credit_cost
+    return t
+
+
+def _invoke_editor(
+    draft: MagicMock,
+    owned_variant_ids: list[str],
+    unlocked_theme_ids: list[str] | None = None,
+    all_variants: list[MagicMock] | None = None,
+    all_themes: list[MagicMock] | None = None,
+) -> dict:
+    """Invoke lfa_player_card_editor and return the captured template context."""
+    if unlocked_theme_ids is None:
+        unlocked_theme_ids = []
+
+    from app.api.web_routes.dashboard import lfa_player_card_editor
+
+    user    = _student()
+    license = _license(uid=user.id)
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.side_effect = [license, None]
+
+    if all_variants is None:
+        all_variants = [_variant("fifa"), _variant("compact"), _variant("showcase")]
+    if all_themes is None:
+        all_themes = [
+            _theme_def("default", is_premium=False),
+            _theme_def("midnight", is_premium=False),
+            _theme_def("gold", is_premium=True, credit_cost=500),
+        ]
+
+    captured: dict = {}
+
+    def _fake_tmpl(tmpl, ctx, **kw):
+        captured["template"] = tmpl
+        captured["context"]  = ctx
+        return MagicMock(status_code=200)
+
+    def _is_da_side_effect(db_, user_id, card_type_id, design_id):
+        return design_id in owned_variant_ids
+
+    def _is_theme_unlocked_side_effect(lic, theme_id, db=None):
+        if not _theme_by_id(theme_id, all_themes).is_premium:
+            return True
+        return theme_id in unlocked_theme_ids
+
+    with patch(f"{_DASH_BASE}._CardDraftService") as MockCDS, \
+         patch(f"{_DASH_BASE}.templates") as mock_tpl, \
+         patch(f"{_DASH_BASE}.SemesterEnrollment"), \
+         patch(_IS_DA_PATH, side_effect=_is_da_side_effect), \
+         patch("app.services.card_variant_service.get_all_variants", return_value=all_variants), \
+         patch("app.services.card_theme_service.get_all_themes", return_value=all_themes), \
+         patch("app.services.card_theme_service.is_unlocked", side_effect=_is_theme_unlocked_side_effect), \
+         patch("app.services.card_platform_service.build_platform_list", return_value=[]), \
+         patch("app.services.card_constants.ANIMATED_EXPORT_CAPABLE", []), \
+         patch("app.services.card_constants.CANVAS_SIZES", {}), \
+         patch("app.services.card_constants.CARD_EDITOR_PLATFORM_IDS", []), \
+         patch("app.services.highlight_video_service.build_youtube_embed_url", return_value=None):
+        MockCDS.get_player_card_draft.return_value = draft
+        mock_tpl.TemplateResponse.side_effect = _fake_tmpl
+        try:
+            _run(lfa_player_card_editor(_req(), db=db, user=user))
+        except Exception:
+            pass
+
+    return captured.get("context", {})
+
+
+def _theme_by_id(tid: str, themes: list[MagicMock]) -> MagicMock:
+    for t in themes:
+        if t.id == tid:
+            return t
+    m = MagicMock()
+    m.is_premium = False
+    return m
+
+
+def _html_from_template() -> str:
+    return (TEMPLATES_DIR / "dashboard_card_editor.html").read_text(encoding="utf-8")
+
+
+# ── CE2-01 — card_variants context contains only owned variants ───────────────
+
+class TestCE201OwnedOnlyVariants:
+    def test_owned_variants_in_context(self):
+        ctx = _invoke_editor(
+            draft=_draft("fifa"),
+            owned_variant_ids=["fifa"],
+        )
+        assert ctx, "context not captured"
+        variants = ctx.get("card_variants", [])
+        assert all(v["unlocked"] for v in variants), \
+            "card_variants must contain only unlocked (owned) items"
+
+    def test_all_returned_variants_are_owned(self):
+        ctx = _invoke_editor(
+            draft=_draft("fifa"),
+            owned_variant_ids=["fifa"],
+        )
+        ids = [v["id"] for v in ctx.get("card_variants", [])]
+        assert "fifa" in ids
+        assert "compact" not in ids
+        assert "showcase" not in ids
+
+
+# ── CE2-02 — locked variant not in card_variants context ─────────────────────
+
+class TestCE202LockedVariantAbsent:
+    def test_unowned_variant_not_in_context(self):
+        ctx = _invoke_editor(
+            draft=_draft("fifa"),
+            owned_variant_ids=["fifa"],
+        )
+        unowned_ids = [v["id"] for v in ctx.get("card_variants", []) if not v["unlocked"]]
+        assert unowned_ids == [], \
+            f"Unowned variants leaked into context: {unowned_ids}"
+
+    def test_zero_owned_gives_empty_list(self):
+        ctx = _invoke_editor(
+            draft=_draft("fifa"),
+            owned_variant_ids=[],
+        )
+        assert ctx.get("card_variants") == []
+
+
+# ── CE2-03 — card_themes context contains only free + owned premium themes ────
+
+class TestCE203OwnedThemes:
+    def test_free_themes_always_in_context(self):
+        ctx = _invoke_editor(
+            draft=_draft("fifa"),
+            owned_variant_ids=["fifa"],
+            unlocked_theme_ids=[],
+        )
+        theme_ids = [t["id"] for t in ctx.get("card_themes", [])]
+        assert "default"  in theme_ids, "free theme 'default' must always appear"
+        assert "midnight" in theme_ids, "free theme 'midnight' must always appear"
+
+    def test_unowned_premium_theme_absent(self):
+        ctx = _invoke_editor(
+            draft=_draft("fifa"),
+            owned_variant_ids=["fifa"],
+            unlocked_theme_ids=[],
+        )
+        theme_ids = [t["id"] for t in ctx.get("card_themes", [])]
+        assert "gold" not in theme_ids, "locked premium theme 'gold' must not appear"
+
+    def test_owned_premium_theme_present(self):
+        ctx = _invoke_editor(
+            draft=_draft("fifa"),
+            owned_variant_ids=["fifa"],
+            unlocked_theme_ids=["gold"],
+        )
+        theme_ids = [t["id"] for t in ctx.get("card_themes", [])]
+        assert "gold" in theme_ids, "owned premium theme 'gold' must appear"
+
+
+# ── CE2-04 — locked premium theme not in card_themes context ─────────────────
+
+class TestCE204LockedThemeAbsent:
+    def test_unlocked_only_in_themes(self):
+        ctx = _invoke_editor(
+            draft=_draft("fifa"),
+            owned_variant_ids=["fifa"],
+            unlocked_theme_ids=[],
+        )
+        assert all(t["unlocked"] for t in ctx.get("card_themes", [])), \
+            "card_themes must contain only unlocked themes"
+
+
+# ── CE2-05..CE2-09 — template source has no purchase affordance ───────────────
+
+class TestCE205to209NoPurchaseInTemplate:
+    def _src(self) -> str:
+        return _html_from_template()
+
+    def test_ce2_05_no_unlock_for_text(self):
+        assert "Unlock for" not in self._src()
+
+    def test_ce2_06_no_get_card_cta(self):
+        src = self._src()
+        assert "Get Card" not in src
+        assert "Get Player Card" not in src
+
+    def test_ce2_07_no_credit_price_locked_text(self):
+        src = self._src()
+        assert "var-cost" not in src
+        assert "ce-design-tile-lock" not in src
+        assert "credit_cost" not in src
+
+    def test_ce2_08_no_unlock_variant_js(self):
+        assert "unlockVariant" not in self._src()
+
+    def test_ce2_09_no_unlock_theme_js(self):
+        assert "unlockTheme" not in self._src()
+
+
+# ── CE2-10 — stale draft → render-time fallback to first owned ────────────────
+
+class TestCE210DraftFallback:
+    def test_stale_draft_variant_replaced_by_first_owned(self):
+        """draft_variant='showcase' but only 'fifa' owned → active_card_variant='fifa'."""
+        ctx = _invoke_editor(
+            draft=_draft("showcase"),   # stale — not owned
+            owned_variant_ids=["fifa"],
+        )
+        assert ctx.get("active_card_variant") == "fifa", \
+            "render-time fallback must set active_card_variant to first owned design"
+
+    def test_stale_draft_fallback_sets_owned_true(self):
+        ctx = _invoke_editor(
+            draft=_draft("showcase"),
+            owned_variant_ids=["fifa"],
+        )
+        assert ctx.get("active_variant_owned") is True
+
+    def test_owned_draft_variant_unchanged(self):
+        ctx = _invoke_editor(
+            draft=_draft("fifa"),
+            owned_variant_ids=["fifa"],
+        )
+        assert ctx.get("active_card_variant") == "fifa"
+
+
+# ── CE2-11 — zero owned → empty list ─────────────────────────────────────────
+
+class TestCE211ZeroOwned:
+    def test_zero_owned_card_variants_empty(self):
+        ctx = _invoke_editor(
+            draft=_draft("fifa"),
+            owned_variant_ids=[],
+        )
+        assert ctx.get("card_variants") == []
+
+    def test_zero_owned_active_variant_owned_false(self):
+        ctx = _invoke_editor(
+            draft=_draft("fifa"),
+            owned_variant_ids=[],
+        )
+        assert ctx.get("active_variant_owned") is False
+
+
+# ── CE2-12 — empty state block in template ───────────────────────────────────
+
+class TestCE212EmptyState:
+    def _src(self) -> str:
+        return _html_from_template()
+
+    def test_empty_state_div_present(self):
+        assert "ce-empty-state" in self._src()
+
+    def test_empty_state_links_to_shop(self):
+        assert 'href="/shop/cards/player"' in self._src()
+
+    def test_empty_state_uses_neutral_language(self):
+        src = self._src()
+        assert "Browse Player Card designs" in src
+
+    def test_empty_state_no_buy_or_unlock_language(self):
+        # The empty state must not say "Buy", "Unlock", or "Get"
+        import re
+        # Find the ce-empty-state block
+        m = re.search(r'ce-empty-state.*?</div>', src := self._src(), re.DOTALL)
+        if m:
+            block = m.group(0)
+            assert "Buy" not in block
+            assert "Unlock" not in block
+
+
+# ── CE2-13 / CE2-14 — backend endpoints still registered ─────────────────────
+
+class TestCE213_14EndpointsRegistered:
+    def _route_paths(self) -> list[str]:
+        from app.main import app
+        return [r.path for r in app.routes]
+
+    def test_ce2_13_unlock_variant_endpoint_exists(self):
+        assert "/dashboard/unlock-variant" in self._route_paths(), \
+            "/dashboard/unlock-variant must remain registered for backward compat"
+
+    def test_ce2_14_unlock_theme_endpoint_exists(self):
+        assert "/dashboard/unlock-theme" in self._route_paths(), \
+            "/dashboard/unlock-theme must remain registered for backward compat"
+
+
+# ── CE2-15 — publish/export CDO guard unchanged ───────────────────────────────
+
+class TestCE215PublishExportGuard:
+    def _src(self) -> str:
+        return _html_from_template()
+
+    def test_publish_button_disabled_when_not_owned(self):
+        src = self._src()
+        assert '{% if not active_variant_owned %}disabled{% endif %}' in src or \
+               'not active_variant_owned' in src, \
+               "publish button must remain guarded by active_variant_owned"
+
+    def test_export_button_disabled_when_not_owned(self):
+        src = self._src()
+        assert 'not active_variant_owned' in src
+
+    def test_active_variant_owned_js_var_present(self):
+        src = self._src()
+        assert "_activeVariantOwned" in src
+
+
+# ── CE2-16 — Welcome editor unowned → 303 unchanged ──────────────────────────
+
+class TestCE216WelcomeEditorUnchanged:
+    def test_welcome_editor_redirect_unowned(self):
+        from fastapi.responses import RedirectResponse
+        from app.api.web_routes.card_editor import welcome_card_editor
+
+        user = MagicMock()
+        user.id = 42
+        from app.models.user import UserRole
+        user.role = UserRole.STUDENT
+
+        license = MagicMock()
+        license.onboarding_completed = True
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = license
+
+        with patch("app.api.web_routes.card_editor.is_design_accessible", return_value=False):
+            result = _run(welcome_card_editor(
+                format_id="instagram_portrait",
+                request=MagicMock(),
+                db=db,
+                user=user,
+            ))
+
+        assert isinstance(result, RedirectResponse)
+        assert result.status_code == 303
+
+
+# ── CE2-17 — route count unchanged ────────────────────────────────────────────
+
+class TestCE217RouteCount:
+    def test_openapi_snapshot_route_count_unchanged(self):
+        """CE-2 adds no new routes — snapshot path count must equal 834."""
+        from app.main import app
+        paths = app.openapi().get("paths", {})
+        assert len(paths) == 834, (
+            f"Expected 834 routes (CE-1 baseline), got {len(paths)}. "
+            "CE-2 must not add or remove routes."
+        )

--- a/tests/unit/api/web_routes/test_card_editor_entitlement.py
+++ b/tests/unit/api/web_routes/test_card_editor_entitlement.py
@@ -7,8 +7,8 @@ CE-04  btn-publish-card rendered without disabled when active_variant_owned=True
 CE-05  btn-publish-card rendered with disabled when active_variant_owned=False
 CE-06  btn-export-card rendered without disabled when active_variant_owned=True
 CE-07  btn-export-card rendered with disabled when active_variant_owned=False
-CE-08  Get Player Card CTA present when active_variant_owned=False
-CE-09  Get Player Card CTA absent when active_variant_owned=True
+CE-08  ce-empty-state block present in template source (locked note removed in CE-2)
+CE-09  ce-locked-note absent from template source (purchase CTA removed in CE-2)
 CE-10  _activeVariantOwned JS variable present in rendered template
 CE-11  _updatePublishIndicator disables Publish when _activeVariantOwned=false
 CE-12  exportCard finally block keeps PNG disabled when _activeVariantOwned=false
@@ -98,12 +98,6 @@ _ACTION_BAR_FRAGMENT = """\
                 title="Download PNG">⬇ PNG</button>
     </div>
 </div>
-{% if not active_variant_owned %}
-<div class="ce-locked-note">
-    This design requires a Player Card.
-    <a href="/my-cards/player-card">Get Player Card &rarr;</a>
-</div>
-{% endif %}
 """
 
 
@@ -174,21 +168,25 @@ class TestCardEditorButtonState:
         assert "disabled" in btn_match.group(0)
 
 
-# ── CE-08..CE-09: Template fragment — locked note CTA ────────────────────────
+# ── CE-08..CE-09: Template source — CE-2 purchase CTA removal ────────────────
 
 class TestCardEditorLockedNote:
 
-    def test_ce08_locked_note_present_when_not_owned(self):
-        """CE-08: ce-locked-note with Get Player Card CTA visible when active_variant_owned=False."""
-        html = _render_fragment(active_variant_owned=False)
-        assert "ce-locked-note" in html
-        assert "/my-cards/player-card" in html
+    def test_ce08_empty_state_present_in_template(self):
+        """CE-08: ce-empty-state block replaced ce-locked-note in CE-2 (no purchase CTA)."""
+        src = _editor_template_source()
+        assert "ce-empty-state" in src, \
+            "ce-empty-state block must be present in template"
+        assert 'href="/shop/cards/player"' in src, \
+            "empty state must link to the player card shop"
 
-    def test_ce09_locked_note_absent_when_owned(self):
-        """CE-09: ce-locked-note not rendered when active_variant_owned=True."""
-        html = _render_fragment(active_variant_owned=True)
-        assert "ce-locked-note" not in html
-        assert "/my-cards/player-card" not in html
+    def test_ce09_locked_note_absent_from_template(self):
+        """CE-09: ce-locked-note class completely removed from template in CE-2."""
+        src = _editor_template_source()
+        assert "ce-locked-note" not in src, \
+            "ce-locked-note must not appear in template after CE-2 removal"
+        assert "Get Player Card" not in src, \
+            "Get Player Card purchase CTA must not appear in template after CE-2"
 
 
 # ── CE-10..CE-13: JS guard — template source checks ──────────────────────────


### PR DESCRIPTION
## Summary

- **Owned-only filter**: `card_variants` and `card_themes` are filtered server-side to owned items only before reaching the template. No locked tiles ever render.
- **Render-time fallback**: if `draft_variant` points to an unowned design, the editor silently renders the first owned design without writing to DB. Same for themes → falls back to `"default"`.
- **Zero owned**: `card_variants == []` triggers a neutral empty state with a link to `/shop/cards/player`. No "Buy", "Unlock", or "Get Card" language.
- **Template cleanup**: removed `ce-design-tile.locked` CSS, `ce-locked-note` block, `unlockVariant()` / `unlockTheme()` JS, and all `credit_cost` / locked-tile branches from `setCardVariant` / `setCardTheme`.
- **Backward compat**: `/dashboard/unlock-variant` and `/dashboard/unlock-theme` endpoints kept; Welcome/Challenge editors untouched; route count stays at 834.

## Files changed

| File | Change |
|---|---|
| `app/api/web_routes/dashboard.py` | owned-only filter + render-time fallback logic |
| `app/templates/dashboard_card_editor.html` | purchase affordance removal, empty state |
| `tests/unit/api/web_routes/test_card_editor_ce2.py` | 29 new CE2-* tests (new file) |
| `tests/unit/api/web_routes/test_card_editor_entitlement.py` | CE-08/CE-09 updated to new behavior |
| `tests/unit/api/web_routes/test_card_draft_routes.py` | CD-RT-01 switched to free theme (CE-2 filter compat) |

## Test results

- CE2-* suite: **29/29 PASS**
- Full unit suite: **11651 passed, 0 failed**

## Test plan

- [ ] Log in as a player with ≥1 owned Player Card design → verify only owned designs appear in variant picker
- [ ] Log in as a player with 0 owned designs → verify empty state shown with Browse link, no design tiles
- [ ] With owned free theme + no premium themes unlocked → verify only free themes in picker
- [ ] Click Browse link from empty state → lands on `/shop/cards/player`
- [ ] Publish/Export buttons: disabled when 0 owned designs, enabled when ≥1 owned
- [ ] `/dashboard/unlock-variant` and `/dashboard/unlock-theme` routes: still respond (not 404)
- [ ] Route count: `len(app.openapi()["paths"]) == 834`

🤖 Generated with [Claude Code](https://claude.com/claude-code)