### PR TITLE
feat(shop): TS-1 Family Color Shop MVP

### DIFF
--- a/alembic/versions/2026_05_29_1200_add_card_color_ownership.py
+++ b/alembic/versions/2026_05_29_1200_add_card_color_ownership.py
@@ -1,0 +1,112 @@
+"""Add card_color_ownership table.
+
+Family-aware color entitlement table for the Player Card Color Shop (TS-1).
+
+Schema: card_color_ownership
+  - id, user_id (FK→users), card_type_id, color_id, pack_id (nullable),
+    purchased_at, UNIQUE(user_id, card_type_id, color_id)
+
+Backfill: migrates every entry in user_licenses.unlocked_card_themes JSON
+array to a card_color_ownership row with card_type_id='player_card'.
+ON CONFLICT DO NOTHING ensures idempotency.
+
+The user_licenses.unlocked_card_themes JSON column is NOT removed — it
+remains as legacy / backward-compat storage for the old unlock-theme
+endpoint.
+
+Revision ID: 2026_05_29_1200
+Revises:     2026_05_29_1100
+Create Date: 2026-05-29 12:00:00.000000
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "2026_05_29_1200"
+down_revision = "2026_05_29_1100"
+branch_labels = None
+depends_on = None
+
+_KNOWN_COLOR_IDS = frozenset(
+    {"default", "midnight", "arctic", "gold", "emerald", "crimson"}
+)
+
+
+def upgrade() -> None:
+    op.create_table(
+        "card_color_ownership",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column(
+            "user_id",
+            sa.Integer,
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "card_type_id",
+            sa.String(64),
+            nullable=False,
+            comment="'player_card' | 'welcome_card' | 'challenge_card'",
+        ),
+        sa.Column(
+            "color_id",
+            sa.String(64),
+            nullable=False,
+            comment="e.g. 'gold', 'emerald', 'crimson'",
+        ),
+        sa.Column(
+            "pack_id",
+            sa.String(128),
+            nullable=True,
+            comment="NULL for individual purchase; bundle id for TS-3 bundle logic",
+        ),
+        sa.Column(
+            "purchased_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.UniqueConstraint(
+            "user_id", "card_type_id", "color_id",
+            name="uq_cco_user_type_color",
+        ),
+    )
+    op.create_index("ix_cco_user_id",      "card_color_ownership", ["user_id"])
+    op.create_index("ix_cco_family_color", "card_color_ownership", ["card_type_id", "color_id"])
+
+    # Backfill: migrate existing unlocked_card_themes JSON entries to the new table.
+    # Only player_card family is applicable — that was the only family in TS-1 scope.
+    # ON CONFLICT DO NOTHING makes this idempotent.
+    conn = op.get_bind()
+
+    rows = conn.execute(
+        sa.text(
+            "SELECT user_id, json_array_elements_text(unlocked_card_themes) AS color_id "
+            "FROM user_licenses "
+            "WHERE unlocked_card_themes IS NOT NULL "
+            "  AND unlocked_card_themes::text NOT IN ('null', '[]', '')"
+        )
+    ).fetchall()
+
+    for row in rows:
+        color_id = row[1]
+        if color_id not in _KNOWN_COLOR_IDS:
+            # Skip unknown color IDs (data anomaly guard)
+            continue
+        conn.execute(
+            sa.text(
+                "INSERT INTO card_color_ownership (user_id, card_type_id, color_id) "
+                "VALUES (:user_id, 'player_card', :color_id) "
+                "ON CONFLICT (user_id, card_type_id, color_id) DO NOTHING"
+            ),
+            {"user_id": row[0], "color_id": color_id},
+        )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_cco_family_color", table_name="card_color_ownership")
+    op.drop_index("ix_cco_user_id",      table_name="card_color_ownership")
+    op.drop_table("card_color_ownership")
+    # user_licenses.unlocked_card_themes is intentionally NOT touched —
+    # it remains as the legacy JSON field and source of truth for the old endpoint.

--- a/app/api/web_routes/dashboard.py
+++ b/app/api/web_routes/dashboard.py
@@ -385,20 +385,25 @@ async def lfa_player_card_editor(
     # Load (or create) the singleton card draft — single source of truth after 4D-2
     card_draft = _CardDraftService.get_player_card_draft(db, user.id)
 
-    # Card theme picker data — identical logic to spec_dashboard
-    from ...services.card_theme_service import get_all_themes as _get_all_themes, is_unlocked as _is_theme_unlocked
+    # Card color picker data — family-aware ownership (TS-1, card_color_service)
+    from ...services.card_color_service import (  # noqa: E402
+        get_colors_for_family as _get_colors_for_family,
+        get_owned_color_ids as _get_owned_color_ids,
+    )
+    _raw_colors   = _get_colors_for_family("player_card")
+    _owned_colors = _get_owned_color_ids(db, user.id, "player_card")
     card_themes = [
         {
-            "id": t.id,
-            "label": t.label,
-            "dot_color": t.dot_color,
-            "is_premium": t.is_premium,
-            "credit_cost": t.credit_cost,
-            "unlocked": _is_theme_unlocked(user_license, t.id, db=db),
+            "id":          c.id,
+            "label":       c.label,
+            "dot_color":   c.dot_color,
+            "is_premium":  c.is_premium,
+            "credit_cost": c.credit_cost,
+            "unlocked":    (not c.is_premium) or (c.id in _owned_colors),
         }
-        for t in _get_all_themes(db=db)
+        for c in _raw_colors
     ]
-    # CE-2: owned-only — free themes always pass (is_premium=False → always unlocked)
+    # CE-2: owned-only — free colors always pass; premium only if ownership row exists
     card_themes = [t for t in card_themes if t["unlocked"]]
     active_card_theme = card_draft.draft_theme
     # Render-time theme fallback — if draft theme was filtered out, fall back to "default"
@@ -1240,6 +1245,10 @@ from ...services.card_theme_service import apply_theme as _apply_theme, unlock_t
 from ...services.card_variant_service import unlock_variant as _unlock_variant  # noqa: E402
 from ...services.card_platform_service import PLATFORM_PRESETS as _PLATFORM_PRESETS  # noqa: E402
 from ...services.card_draft_service import CardDraftService as _CardDraftService  # noqa: E402
+from ...services.card_color_service import (  # noqa: E402
+    unlock_color as _unlock_color,
+    InsufficientCreditsError as _InsufficientCreditsError,
+)
 from pydantic import BaseModel as _BaseModel  # noqa: E402
 
 _VALID_PLATFORM_IDS: frozenset = frozenset(_PLATFORM_PRESETS.keys())
@@ -1251,6 +1260,11 @@ class _CardThemeRequest(_BaseModel):
 
 class _CardVariantRequest(_BaseModel):
     variant: str
+
+
+class _CardColorUnlockRequest(_BaseModel):
+    card_type_id: str
+    color_id: str
 
 
 class _CardPlatformRequest(_BaseModel):
@@ -1293,7 +1307,11 @@ async def student_unlock_theme(
     db: Session = Depends(get_db),
     user: User = Depends(get_current_user_web),
 ):
-    """Unlock a premium card theme by spending credits."""
+    """Unlock a premium card theme by spending credits.
+
+    LEGACY endpoint — writes to user_licenses.unlocked_card_themes JSON.
+    Kept for backward compatibility. New purchases use /dashboard/unlock-color.
+    """
     lfa_license = _get_lfa_license(db, user.id)
     if not lfa_license:
         return JSONResponse({"ok": False, "error": "No active LFA Football Player license"}, status_code=404)
@@ -1303,6 +1321,50 @@ async def student_unlock_theme(
                              "new_balance": user.credit_balance})
     except ValueError as e:
         return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
+
+
+@router.post("/dashboard/unlock-color")
+async def student_unlock_color(
+    payload: _CardColorUnlockRequest,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user_web),
+):
+    """Unlock a premium card color pack for a specific card family (TS-1).
+
+    Writes to card_color_ownership (family-aware, new ownership model).
+    Supports card_type_id='player_card' only in TS-1; other families return 422.
+    Idempotent: already-owned colors return ok=True with already_owned=True and
+    credits_charged=0 — no double deduction possible.
+    """
+    try:
+        result = _unlock_color(db, user, payload.card_type_id, payload.color_id)
+        return JSONResponse({
+            "ok":             True,
+            "already_owned":  result.already_owned,
+            "credits_charged": result.credits_charged,
+            "credit_balance": result.credit_balance,
+            "color_id":       result.color_id,
+            "card_type_id":   result.card_type_id,
+        })
+    except ValueError as e:
+        error_key = str(e)
+        if error_key == "unsupported_family":
+            return JSONResponse(
+                {"ok": False, "error": f"Unsupported card family: {payload.card_type_id!r}"},
+                status_code=422,
+            )
+        if error_key == "color_not_found":
+            return JSONResponse(
+                {"ok": False, "error": f"Unknown color: {payload.color_id!r}"},
+                status_code=422,
+            )
+        return JSONResponse({"ok": False, "error": error_key}, status_code=400)
+    except _InsufficientCreditsError as e:
+        return JSONResponse(
+            {"ok": False, "error": "insufficient_credits",
+             "required": e.required, "balance": e.available},
+            status_code=402,
+        )
 
 
 @router.post("/dashboard/card-variant")

--- a/app/api/web_routes/shop.py
+++ b/app/api/web_routes/shop.py
@@ -20,6 +20,10 @@ from ...services.card_design_service import (
 )
 from ...services.card_constants import PC_FORMAT_META
 from ...services.credit_service import InsufficientCreditsError
+from ...services.card_color_service import (
+    get_colors_for_family as _get_colors_for_family,
+    get_owned_color_ids as _get_owned_color_ids,
+)
 
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
 templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
@@ -111,6 +115,41 @@ async def shop_player_card(
             "flash_purchased": request.query_params.get("purchased"),
             "flash_error":     request.query_params.get("error"),
             "spec_dashboard_url": "/dashboard/lfa-football-player",
+        },
+    )
+
+
+# ── Player Card Color Shop ─────────────────────────────────────────────────────
+
+@router.get("/shop/cards/player/colors", response_class=HTMLResponse)
+async def shop_player_card_colors(
+    request: Request,
+    db: Session = Depends(get_db),
+    user: User  = Depends(get_current_user_web),
+):
+    """Player Card Color Shop — browse and unlock premium color packs (TS-1)."""
+    raw_colors = _get_colors_for_family("player_card")
+    owned_ids  = _get_owned_color_ids(db, user.id, "player_card")
+
+    player_colors = [
+        {
+            "id":          c.id,
+            "label":       c.label,
+            "dot_color":   c.dot_color,
+            "is_premium":  c.is_premium,
+            "credit_cost": c.credit_cost,
+            "is_owned":    (not c.is_premium) or (c.id in owned_ids),
+        }
+        for c in raw_colors
+    ]
+
+    return templates.TemplateResponse(
+        "shop_card_player_colors.html",
+        {
+            "request":       request,
+            "user":          user,
+            "player_colors": player_colors,
+            "credit_balance": user.credit_balance,
         },
     )
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -59,6 +59,7 @@ from .card_draft import CardDraft
 from .card_theme import CardTheme
 from .card_design import CardDesign
 from .card_design_ownership import CardDesignOwnership
+from .card_color_ownership import CardColorOwnership
 from .virtual_training import VirtualTrainingGame, VirtualTrainingAttempt
 from .friendship import Friendship, FriendshipStatus, is_friends, get_friendship
 from .vt_challenge import (

--- a/app/models/card_color_ownership.py
+++ b/app/models/card_color_ownership.py
@@ -1,0 +1,67 @@
+"""CardColorOwnership — per-user, per-family color entitlement record.
+
+One row per (user_id, card_type_id, color_id) triplet.
+
+Ownership key:
+  user_id + card_type_id + color_id
+
+The same color_id in different families is a distinct product — e.g.
+"gold" for "player_card" is independent of "gold" for "welcome_card".
+
+pack_id: nullable, reserved for TS-3 bundle logic. When a color is
+purchased individually, pack_id is NULL. When purchased as part of a
+named bundle, pack_id carries the bundle identifier (e.g.
+"player_color_bundle_v1") for audit purposes.
+"""
+from datetime import datetime, timezone
+
+from sqlalchemy import Column, DateTime, ForeignKey, Index, Integer, String, UniqueConstraint
+
+from ..database import Base
+
+
+class CardColorOwnership(Base):
+    __tablename__ = "card_color_ownership"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(
+        Integer,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    card_type_id = Column(
+        String(64),
+        nullable=False,
+        comment="'player_card' | 'welcome_card' | 'challenge_card'",
+    )
+    color_id = Column(
+        String(64),
+        nullable=False,
+        comment="e.g. 'gold', 'emerald', 'crimson'",
+    )
+    pack_id = Column(
+        String(128),
+        nullable=True,
+        comment="NULL for individual purchase; bundle id for TS-3 bundle logic",
+    )
+    purchased_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "user_id", "card_type_id", "color_id",
+            name="uq_cco_user_type_color",
+        ),
+        Index("ix_cco_user_id", "user_id"),
+        Index("ix_cco_family_color", "card_type_id", "color_id"),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<CardColorOwnership user_id={self.user_id} "
+            f"card_type_id={self.card_type_id!r} "
+            f"color_id={self.color_id!r}>"
+        )

--- a/app/services/card_color_service.py
+++ b/app/services/card_color_service.py
@@ -1,0 +1,240 @@
+"""
+Card Color Service — Family-Specific Color Ownership (TS-1)
+===========================================================
+Manages color ownership for card families.
+
+Key concepts:
+  - Each card family (player_card, welcome_card, …) has its own color palette.
+  - The same color_id in different families is a distinct product.
+  - Ownership key: (user_id, card_type_id, color_id) in card_color_ownership.
+  - Free colors (is_premium=False) are always unlocked — no DB row required.
+  - Premium colors require an ownership row; purchased via unlock_color().
+
+TS-1 scope: player_card family only. Additional families added in TS-2.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from .credit_service import CreditService, InsufficientCreditsError  # noqa: F401 — re-exported
+from ..models.card_color_ownership import CardColorOwnership
+from ..models.user import User
+
+
+# ── Color definition ──────────────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class ColorDefinition:
+    id: str
+    label: str
+    is_premium: bool
+    credit_cost: int
+    dot_color: str
+    sort_order: int = 0
+    available: bool = True
+
+
+# ── Family color catalog ──────────────────────────────────────────────────────
+# Source of truth for TS-1. Only player_card family populated.
+# welcome_card and challenge_card are added in TS-2 once palettes are defined.
+
+FAMILY_COLORS: dict[str, dict[str, ColorDefinition]] = {
+    "player_card": {
+        "default": ColorDefinition(
+            id="default", label="Slate", is_premium=False, credit_cost=0,
+            dot_color="#667eea", sort_order=0,
+        ),
+        "midnight": ColorDefinition(
+            id="midnight", label="Midnight", is_premium=False, credit_cost=0,
+            dot_color="#00d4ff", sort_order=1,
+        ),
+        "arctic": ColorDefinition(
+            id="arctic", label="Arctic", is_premium=False, credit_cost=0,
+            dot_color="#4299e1", sort_order=2,
+        ),
+        "gold": ColorDefinition(
+            id="gold", label="Gold", is_premium=True, credit_cost=500,
+            dot_color="#f6ad3c", sort_order=3,
+        ),
+        "emerald": ColorDefinition(
+            id="emerald", label="Emerald", is_premium=True, credit_cost=500,
+            dot_color="#4cde82", sort_order=4,
+        ),
+        "crimson": ColorDefinition(
+            id="crimson", label="Crimson", is_premium=True, credit_cost=500,
+            dot_color="#ff6b6b", sort_order=5,
+        ),
+    },
+    # TS-2: "welcome_card": {...},
+    # TS-2: "challenge_card": {...},
+}
+
+# Supported families in TS-1 — used for route validation.
+_SUPPORTED_FAMILIES: frozenset[str] = frozenset(FAMILY_COLORS.keys())
+
+
+# ── Public API ────────────────────────────────────────────────────────────────
+
+def get_colors_for_family(card_type_id: str) -> list[ColorDefinition]:
+    """Return all available colors for a family, ordered by sort_order.
+
+    Returns an empty list for unknown or not-yet-supported families
+    (never raises KeyError).
+    """
+    palette = FAMILY_COLORS.get(card_type_id, {})
+    return sorted(
+        (c for c in palette.values() if c.available),
+        key=lambda c: c.sort_order,
+    )
+
+
+def get_owned_color_ids(db: Session, user_id: int, card_type_id: str) -> set[str]:
+    """Return the set of color_ids the user owns for the given family.
+
+    Does NOT include free colors (those are always implicitly owned).
+    A single DB query — use this for batch checks (e.g. editor filter loop).
+    """
+    rows = (
+        db.query(CardColorOwnership.color_id)
+        .filter(
+            CardColorOwnership.user_id == user_id,
+            CardColorOwnership.card_type_id == card_type_id,
+        )
+        .all()
+    )
+    return {r[0] for r in rows}
+
+
+def is_color_unlocked(db: Session, user_id: int, card_type_id: str, color_id: str) -> bool:
+    """Return True if the user may use this color.
+
+    Free colors always return True (no DB query).
+    Premium colors require a card_color_ownership row.
+    Unknown color_ids return False.
+    """
+    palette = FAMILY_COLORS.get(card_type_id, {})
+    color = palette.get(color_id)
+    if color is None:
+        return False
+    if not color.is_premium:
+        return True
+    return (
+        db.query(CardColorOwnership.id)
+        .filter(
+            CardColorOwnership.user_id == user_id,
+            CardColorOwnership.card_type_id == card_type_id,
+            CardColorOwnership.color_id == color_id,
+        )
+        .first()
+    ) is not None
+
+
+@dataclass
+class UnlockColorResult:
+    ok: bool
+    already_owned: bool
+    credits_charged: int
+    credit_balance: int
+    color_id: str
+    card_type_id: str
+
+
+def unlock_color(
+    db: Session,
+    user: User,
+    card_type_id: str,
+    color_id: str,
+    pack_id: Optional[str] = None,
+) -> UnlockColorResult:
+    """Unlock a premium color for the user.
+
+    Idempotency contract:
+      1. Free color → already_owned=True, 0 CR, no DB write.
+      2. Already owned premium → already_owned=True, 0 CR, no DB write.
+      3. Insufficient credits → raises InsufficientCreditsError, no DB write.
+      4. Valid purchase → credit deduction + ownership INSERT in one SAVEPOINT.
+         If INSERT conflicts (race condition), credit deduction is rolled back.
+
+    Raises:
+      ValueError("unsupported_family")   — family not in FAMILY_COLORS
+      ValueError("color_not_found")      — color_id not in family palette
+      InsufficientCreditsError           — user balance < credit_cost
+    """
+    # Step 1: validate family
+    if card_type_id not in _SUPPORTED_FAMILIES:
+        raise ValueError("unsupported_family")
+
+    palette = FAMILY_COLORS[card_type_id]
+
+    # Step 2: validate color
+    color = palette.get(color_id)
+    if color is None:
+        raise ValueError("color_not_found")
+
+    # Step 3: free color — always owned, no charge
+    if not color.is_premium:
+        return UnlockColorResult(
+            ok=True,
+            already_owned=True,
+            credits_charged=0,
+            credit_balance=user.credit_balance,
+            color_id=color_id,
+            card_type_id=card_type_id,
+        )
+
+    # Step 4: already owned premium — idempotent return
+    existing = (
+        db.query(CardColorOwnership.id)
+        .filter(
+            CardColorOwnership.user_id == user.id,
+            CardColorOwnership.card_type_id == card_type_id,
+            CardColorOwnership.color_id == color_id,
+        )
+        .first()
+    )
+    if existing:
+        return UnlockColorResult(
+            ok=True,
+            already_owned=True,
+            credits_charged=0,
+            credit_balance=user.credit_balance,
+            color_id=color_id,
+            card_type_id=card_type_id,
+        )
+
+    # Step 5 + 6: credit deduction + ownership INSERT — atomic SAVEPOINT.
+    # If INSERT conflicts (concurrent purchase), the SAVEPOINT rolls back both.
+    with db.begin_nested():
+        # InsufficientCreditsError propagates; SAVEPOINT rolls back automatically.
+        CreditService(db).deduct(
+            user=user,
+            amount=color.credit_cost,
+            transaction_type="COLOR_UNLOCK",
+            description=f"Card color unlock: {color.label} ({card_type_id})",
+            idempotency_key=f"color_unlock_{user.id}_{card_type_id}_{color_id}",
+        )
+
+        ownership = CardColorOwnership(
+            user_id=user.id,
+            card_type_id=card_type_id,
+            color_id=color_id,
+            pack_id=pack_id,
+            purchased_at=datetime.now(timezone.utc),
+        )
+        db.add(ownership)
+        db.flush()
+
+    db.commit()
+
+    return UnlockColorResult(
+        ok=True,
+        already_owned=False,
+        credits_charged=color.credit_cost,
+        credit_balance=user.credit_balance,
+        color_id=color_id,
+        card_type_id=card_type_id,
+    )

--- a/app/templates/shop_card_player_colors.html
+++ b/app/templates/shop_card_player_colors.html
@@ -1,0 +1,238 @@
+{% extends "student_base.html" %}
+
+{% block title %}Player Card Colors — LFA Card Shop{% endblock %}
+{% block active_page %}lfa-player{% endblock %}
+
+{% block student_header %}
+{% set _page_icon = '🎨' %}
+{% set _page_name = 'Player Card Colors' %}
+{% include "includes/spec_subpage_hdr.html" %}
+{% endblock %}
+
+{% block extra_styles %}
+<style>
+  .scc-wrap {
+    max-width: 860px;
+    margin: 0 auto;
+    padding: 1.5rem 1rem 4rem;
+  }
+  .scc-breadcrumb {
+    font-size: 0.8rem;
+    color: #64748b;
+    margin-bottom: 1.25rem;
+  }
+  .scc-breadcrumb a { color: #94a3b8; text-decoration: none; }
+  .scc-breadcrumb a:hover { color: #f1f5f9; }
+  .scc-breadcrumb span { margin: 0 0.35rem; }
+  .scc-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 1.75rem;
+  }
+  .scc-header h1 { font-size: 1.4rem; font-weight: 700; color: #f8fafc; margin: 0; }
+  .scc-credits-badge {
+    background: #1e293b;
+    border: 1px solid #334155;
+    border-radius: 20px;
+    padding: 0.35rem 0.9rem;
+    font-size: 0.85rem;
+    color: #94a3b8;
+  }
+  .scc-credits-badge strong { color: #FFD200; }
+  .scc-credits-display { font-size: 0.85rem; color: #94a3b8; }
+  .scc-credits-display strong { color: #FFD200; }
+
+  /* Color grid */
+  .scc-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: 1rem;
+    margin-bottom: 2rem;
+  }
+  .scc-tile {
+    background: #1e293b;
+    border: 1px solid #334155;
+    border-radius: 12px;
+    padding: 1.25rem 1rem 1rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.6rem;
+    transition: border-color 0.15s;
+  }
+  .scc-tile:hover { border-color: #475569; }
+  .scc-tile.scc-owned { border-color: #22543d; background: #1a2e22; }
+  .scc-swatch {
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    border: 3px solid rgba(255,255,255,0.15);
+    flex-shrink: 0;
+  }
+  .scc-label {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: #f1f5f9;
+    text-align: center;
+  }
+  .scc-badge {
+    font-size: 0.75rem;
+    font-weight: 600;
+    border-radius: 20px;
+    padding: 0.2rem 0.65rem;
+  }
+  .scc-badge-free    { background: #1e3a5f; color: #7dd3fc; border: 1px solid #1d4ed8; }
+  .scc-badge-owned   { background: #14532d; color: #86efac; border: 1px solid #15803d; }
+  .scc-badge-price   { background: #292524; color: #fbbf24; border: 1px solid #78350f; }
+  .scc-cta { margin-top: 0.25rem; width: 100%; }
+  .scc-btn-unlock {
+    width: 100%;
+    background: linear-gradient(135deg, #d97706 0%, #b45309 100%);
+    color: #fff;
+    border: none;
+    border-radius: 8px;
+    padding: 0.55rem 0.75rem;
+    font-size: 0.85rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: opacity 0.15s;
+  }
+  .scc-btn-unlock:hover:not(:disabled) { opacity: 0.88; }
+  .scc-btn-unlock:disabled { opacity: 0.4; cursor: default; }
+  .scc-error {
+    font-size: 0.75rem;
+    color: #f87171;
+    text-align: center;
+    min-height: 1.1em;
+    margin-top: 0.1rem;
+  }
+
+  /* Nav links */
+  .scc-nav-links {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+    margin-top: 0.5rem;
+  }
+  .scc-nav-link {
+    font-size: 0.82rem;
+    color: #94a3b8;
+    text-decoration: none;
+  }
+  .scc-nav-link:hover { color: #f1f5f9; }
+</style>
+{% endblock %}
+
+{% block student_content %}
+<div class="scc-wrap">
+
+  <nav class="scc-breadcrumb" aria-label="Breadcrumb">
+    <a href="/shop">Shop</a>
+    <span>›</span>
+    <a href="/shop/cards">Cards</a>
+    <span>›</span>
+    <a href="/shop/cards/player">Player Card</a>
+    <span>›</span>
+    <span>Colors</span>
+  </nav>
+
+  <div class="scc-header">
+    <h1>Player Card Colors</h1>
+    <span class="scc-credits-badge" id="scc-balance-badge">
+      Balance: <strong id="scc-balance-val">{{ credit_balance }} CR</strong>
+    </span>
+  </div>
+
+  <div class="scc-grid">
+    {% for c in player_colors %}
+    <div class="scc-tile{% if c.is_owned %} scc-owned{% endif %}" id="scc-tile-{{ c.id }}">
+      <div class="scc-swatch" style="background:{{ c.dot_color }};"></div>
+      <span class="scc-label">{{ c.label }}</span>
+
+      {% if not c.is_premium %}
+        <span class="scc-badge scc-badge-free">Free</span>
+      {% elif c.is_owned %}
+        <span class="scc-badge scc-badge-owned" id="scc-badge-{{ c.id }}">Owned ✓</span>
+      {% else %}
+        <span class="scc-badge scc-badge-price" id="scc-badge-{{ c.id }}">{{ c.credit_cost }} CR</span>
+      {% endif %}
+
+      <div class="scc-cta">
+        {% if c.is_premium and not c.is_owned %}
+        <button
+          class="scc-btn-unlock"
+          id="scc-btn-{{ c.id }}"
+          onclick="unlockColor('player_card', '{{ c.id }}', {{ c.credit_cost }}, this)">
+          Unlock for {{ c.credit_cost }} CR
+        </button>
+        {% endif %}
+        <div class="scc-error" id="scc-err-{{ c.id }}"></div>
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+
+  <div class="scc-nav-links">
+    <a href="/shop/cards/player" class="scc-nav-link">← Player Card Designs</a>
+    <a href="/card-editor/player" class="scc-nav-link">Open Card Editor →</a>
+  </div>
+
+</div>
+{% endblock %}
+
+{% block extra_scripts %}
+<script>
+function _csrf() {
+    return (document.cookie.split('; ').find(r => r.startsWith('csrf_token=')) || '').split('=')[1];
+}
+
+async function unlockColor(cardTypeId, colorId, creditCost, btn) {
+    btn.disabled = true;
+    btn.textContent = 'Unlocking…';
+    const errEl  = document.getElementById('scc-err-' + colorId);
+    const tile   = document.getElementById('scc-tile-' + colorId);
+    const badge  = document.getElementById('scc-badge-' + colorId);
+    if (errEl) errEl.textContent = '';
+
+    try {
+        const resp = await fetch('/dashboard/unlock-color', {
+            method:  'POST',
+            headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': _csrf() },
+            body:    JSON.stringify({ card_type_id: cardTypeId, color_id: colorId }),
+        });
+        const data = await resp.json();
+
+        if (data.ok) {
+            // Update tile to owned state
+            tile.classList.add('scc-owned');
+            btn.closest('.scc-cta').innerHTML =
+                '<div class="scc-error"></div>';
+            if (badge) {
+                badge.className = 'scc-badge scc-badge-owned';
+                badge.textContent = 'Owned ✓';
+            }
+            // Update credit balance display
+            const balEl = document.getElementById('scc-balance-val');
+            if (balEl) balEl.textContent = data.credit_balance + ' CR';
+        } else {
+            btn.disabled  = false;
+            btn.textContent = 'Unlock for ' + creditCost + ' CR';
+            if (errEl) {
+                if (resp.status === 402) {
+                    errEl.textContent = 'Not enough credits';
+                } else {
+                    errEl.textContent = data.error || 'Something went wrong';
+                }
+            }
+        }
+    } catch (_) {
+        btn.disabled  = false;
+        btn.textContent = 'Unlock for ' + creditCost + ' CR';
+        if (errEl) errEl.textContent = 'Request failed — try again';
+    }
+}
+</script>
+{% endblock %}

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -22014,6 +22014,24 @@
         "title": "XPResponse",
         "type": "object"
       },
+      "_CardColorUnlockRequest": {
+        "properties": {
+          "card_type_id": {
+            "title": "Card Type Id",
+            "type": "string"
+          },
+          "color_id": {
+            "title": "Color Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "card_type_id",
+          "color_id"
+        ],
+        "title": "_CardColorUnlockRequest",
+        "type": "object"
+      },
       "_CardPlatformRequest": {
         "properties": {
           "platform": {
@@ -61489,9 +61507,49 @@
         ]
       }
     },
+    "/dashboard/unlock-color": {
+      "post": {
+        "description": "Unlock a premium card color pack for a specific card family (TS-1).\n\nWrites to card_color_ownership (family-aware, new ownership model).\nSupports card_type_id='player_card' only in TS-1; other families return 422.\nIdempotent: already-owned colors return ok=True with already_owned=True and\ncredits_charged=0 \u2014 no double deduction possible.",
+        "operationId": "student_unlock_color_dashboard_unlock_color_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/_CardColorUnlockRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Student Unlock Color",
+        "tags": [
+          "web"
+        ]
+      }
+    },
     "/dashboard/unlock-theme": {
       "post": {
-        "description": "Unlock a premium card theme by spending credits.",
+        "description": "Unlock a premium card theme by spending credits.\n\nLEGACY endpoint \u2014 writes to user_licenses.unlocked_card_themes JSON.\nKept for backward compatibility. New purchases use /dashboard/unlock-color.",
         "operationId": "student_unlock_theme_dashboard_unlock_theme_post",
         "requestBody": {
           "content": {
@@ -64890,6 +64948,29 @@
           }
         },
         "summary": "Shop Player Card",
+        "tags": [
+          "web",
+          "shop"
+        ]
+      }
+    },
+    "/shop/cards/player/colors": {
+      "get": {
+        "description": "Player Card Color Shop \u2014 browse and unlock premium color packs (TS-1).",
+        "operationId": "shop_player_card_colors_shop_cards_player_colors_get",
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Shop Player Card Colors",
         "tags": [
           "web",
           "shop"

--- a/tests/unit/api/web_routes/test_card_draft_routes.py
+++ b/tests/unit/api/web_routes/test_card_draft_routes.py
@@ -93,8 +93,14 @@ class TestCardEditorGetContext:
 
         with patch(_CDS_PATH) as MockCDS, \
              patch("app.api.web_routes.dashboard.templates") as mock_tpl, \
-             patch("app.api.web_routes.dashboard.db") if False else \
-             patch("app.api.web_routes.dashboard.SemesterEnrollment"):
+             patch("app.api.web_routes.dashboard.SemesterEnrollment"), \
+             patch("app.services.card_variant_service.get_all_variants", return_value=[]), \
+             patch("app.services.card_color_service.get_owned_color_ids", return_value=set()), \
+             patch("app.services.card_platform_service.build_platform_list", return_value=[]), \
+             patch("app.services.card_constants.ANIMATED_EXPORT_CAPABLE", []), \
+             patch("app.services.card_constants.CANVAS_SIZES", {}), \
+             patch("app.services.card_constants.CARD_EDITOR_PLATFORM_IDS", []), \
+             patch("app.services.highlight_video_service.build_youtube_embed_url", return_value=None):
             MockCDS.get_player_card_draft.return_value = draft
             mock_tpl.TemplateResponse.side_effect = fake_template_response
 

--- a/tests/unit/api/web_routes/test_card_editor_ce2.py
+++ b/tests/unit/api/web_routes/test_card_editor_ce2.py
@@ -98,13 +98,13 @@ def _theme_def(tid: str, is_premium: bool = False, credit_cost: int = 0, dot_col
 def _invoke_editor(
     draft: MagicMock,
     owned_variant_ids: list[str],
-    unlocked_theme_ids: list[str] | None = None,
+    owned_color_ids: set[str] | None = None,
     all_variants: list[MagicMock] | None = None,
     all_themes: list[MagicMock] | None = None,
 ) -> dict:
     """Invoke lfa_player_card_editor and return the captured template context."""
-    if unlocked_theme_ids is None:
-        unlocked_theme_ids = []
+    if owned_color_ids is None:
+        owned_color_ids = set()
 
     from app.api.web_routes.dashboard import lfa_player_card_editor
 
@@ -132,18 +132,13 @@ def _invoke_editor(
     def _is_da_side_effect(db_, user_id, card_type_id, design_id):
         return design_id in owned_variant_ids
 
-    def _is_theme_unlocked_side_effect(lic, theme_id, db=None):
-        if not _theme_by_id(theme_id, all_themes).is_premium:
-            return True
-        return theme_id in unlocked_theme_ids
-
     with patch(f"{_DASH_BASE}._CardDraftService") as MockCDS, \
          patch(f"{_DASH_BASE}.templates") as mock_tpl, \
          patch(f"{_DASH_BASE}.SemesterEnrollment"), \
          patch(_IS_DA_PATH, side_effect=_is_da_side_effect), \
          patch("app.services.card_variant_service.get_all_variants", return_value=all_variants), \
-         patch("app.services.card_theme_service.get_all_themes", return_value=all_themes), \
-         patch("app.services.card_theme_service.is_unlocked", side_effect=_is_theme_unlocked_side_effect), \
+         patch("app.services.card_color_service.get_colors_for_family", return_value=all_themes), \
+         patch("app.services.card_color_service.get_owned_color_ids", return_value=owned_color_ids), \
          patch("app.services.card_platform_service.build_platform_list", return_value=[]), \
          patch("app.services.card_constants.ANIMATED_EXPORT_CAPABLE", []), \
          patch("app.services.card_constants.CANVAS_SIZES", {}), \
@@ -158,14 +153,6 @@ def _invoke_editor(
 
     return captured.get("context", {})
 
-
-def _theme_by_id(tid: str, themes: list[MagicMock]) -> MagicMock:
-    for t in themes:
-        if t.id == tid:
-            return t
-    m = MagicMock()
-    m.is_premium = False
-    return m
 
 
 def _html_from_template() -> str:
@@ -223,7 +210,7 @@ class TestCE203OwnedThemes:
         ctx = _invoke_editor(
             draft=_draft("fifa"),
             owned_variant_ids=["fifa"],
-            unlocked_theme_ids=[],
+            owned_color_ids=set(),
         )
         theme_ids = [t["id"] for t in ctx.get("card_themes", [])]
         assert "default"  in theme_ids, "free theme 'default' must always appear"
@@ -233,7 +220,7 @@ class TestCE203OwnedThemes:
         ctx = _invoke_editor(
             draft=_draft("fifa"),
             owned_variant_ids=["fifa"],
-            unlocked_theme_ids=[],
+            owned_color_ids=set(),
         )
         theme_ids = [t["id"] for t in ctx.get("card_themes", [])]
         assert "gold" not in theme_ids, "locked premium theme 'gold' must not appear"
@@ -242,7 +229,7 @@ class TestCE203OwnedThemes:
         ctx = _invoke_editor(
             draft=_draft("fifa"),
             owned_variant_ids=["fifa"],
-            unlocked_theme_ids=["gold"],
+            owned_color_ids={"gold"},
         )
         theme_ids = [t["id"] for t in ctx.get("card_themes", [])]
         assert "gold" in theme_ids, "owned premium theme 'gold' must appear"
@@ -255,7 +242,7 @@ class TestCE204LockedThemeAbsent:
         ctx = _invoke_editor(
             draft=_draft("fifa"),
             owned_variant_ids=["fifa"],
-            unlocked_theme_ids=[],
+            owned_color_ids=set(),
         )
         assert all(t["unlocked"] for t in ctx.get("card_themes", [])), \
             "card_themes must contain only unlocked themes"
@@ -431,10 +418,10 @@ class TestCE216WelcomeEditorUnchanged:
 
 class TestCE217RouteCount:
     def test_openapi_snapshot_route_count_unchanged(self):
-        """CE-2 adds no new routes — snapshot path count must equal 834."""
+        """CE-2 adds no new routes — snapshot path count must equal 836 (834 CE-2 + 2 TS-1)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 834, (
-            f"Expected 834 routes (CE-1 baseline), got {len(paths)}. "
+        assert len(paths) == 836, (
+            f"Expected 836 routes (834 CE-2 baseline + 2 TS-1), got {len(paths)}. "
             "CE-2 must not add or remove routes."
         )

--- a/tests/unit/api/web_routes/test_card_editor_entitlement.py
+++ b/tests/unit/api/web_routes/test_card_editor_entitlement.py
@@ -64,8 +64,8 @@ def _invoke_editor(draft: MagicMock, is_owned: bool) -> dict:
          patch(f"{_DASH_BASE}.SemesterEnrollment"), \
          patch(_IS_DA_PATH, return_value=is_owned), \
          patch("app.services.card_variant_service.get_all_variants", return_value=[]), \
-         patch("app.services.card_theme_service.get_all_themes",     return_value=[]), \
-         patch("app.services.card_theme_service.is_unlocked",        return_value=False), \
+         patch("app.services.card_color_service.get_colors_for_family", return_value=[]), \
+         patch("app.services.card_color_service.get_owned_color_ids",  return_value=set()), \
          patch("app.services.card_platform_service.build_platform_list", return_value=[]), \
          patch("app.services.card_constants.ANIMATED_EXPORT_CAPABLE", []), \
          patch("app.services.card_constants.CANVAS_SIZES", {}), \

--- a/tests/unit/api/web_routes/test_family_color_shop.py
+++ b/tests/unit/api/web_routes/test_family_color_shop.py
@@ -1,0 +1,284 @@
+"""
+TS — Family Color Shop route tests (TS-1).
+
+TS-01: GET /shop/cards/player/colors → 200 for authenticated user
+TS-02: context player_colors list has 6 items
+TS-03: free colors have is_owned=True in context
+TS-04: premium color is_owned=True when ownership row exists
+TS-05: premium color is_owned=False when no ownership row
+TS-06: GET /shop/cards/player/colors redirects unauthenticated user
+TS-07: POST /dashboard/unlock-color creates ownership and returns ok=True
+TS-08: POST /dashboard/unlock-color deducts credit_balance 500
+TS-09: POST /dashboard/unlock-color idempotent — second call already_owned=True, credits_charged=0
+TS-10: POST /dashboard/unlock-color insufficient credits → 402
+TS-11: POST /dashboard/unlock-color unknown color_id → 422
+TS-12: POST /dashboard/unlock-color unsupported card_type_id → 422
+TS-13: route count = 836
+TS-14: /dashboard/unlock-theme still registered (backward compat)
+TS-15: template source contains unlockColor JS function
+TS-16: template source contains Unlock CTA button pattern
+TS-17: template source contains credit balance display
+TS-18: template source contains link to /shop/cards/player
+TS-19: template source contains link to /card-editor/player
+TS-20: editor template has no Unlock / Buy / price purchase affordance (CE-2 regression)
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.card_color_service import (
+    UnlockColorResult,
+    get_colors_for_family,
+)
+from app.services.credit_service import InsufficientCreditsError
+
+_SHOP_BASE  = "app.api.web_routes.shop"
+_DASH_BASE  = "app.api.web_routes.dashboard"
+_CCS_PATH   = "app.services.card_color_service"
+# Module-level imports in shop.py — patch at the usage site
+_SHOP_GET_OWNED = "app.api.web_routes.shop._get_owned_color_ids"
+
+TEMPLATES_DIR = Path(__file__).resolve().parents[4] / "app" / "templates"
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _user(uid: int = 42, credit_balance: int = 1000) -> MagicMock:
+    u = MagicMock()
+    u.id = uid
+    u.credit_balance = credit_balance
+    return u
+
+
+def _invoke_color_shop(owned_color_ids: set | None = None) -> dict:
+    """Call shop_player_card_colors and return captured template context."""
+    if owned_color_ids is None:
+        owned_color_ids = set()
+
+    from app.api.web_routes.shop import shop_player_card_colors
+
+    user = _user()
+    db   = MagicMock()
+    captured: dict = {}
+
+    def _fake_tmpl(tmpl, ctx, **kw):
+        captured["template"] = tmpl
+        captured["context"]  = ctx
+        return MagicMock(status_code=200)
+
+    with patch(f"{_SHOP_BASE}.templates") as mock_tpl, \
+         patch(_SHOP_GET_OWNED, return_value=owned_color_ids):
+        mock_tpl.TemplateResponse.side_effect = _fake_tmpl
+        try:
+            _run(shop_player_card_colors(request=MagicMock(), db=db, user=user))
+        except Exception:
+            pass
+
+    return captured.get("context", {})
+
+
+def _call_unlock_color(
+    card_type_id: str,
+    color_id: str,
+    unlock_result=None,
+    side_effect=None,
+):
+    """Call student_unlock_color and return the JSONResponse."""
+    from app.api.web_routes.dashboard import student_unlock_color, _CardColorUnlockRequest
+
+    user = _user()
+    db   = MagicMock()
+    payload = MagicMock()
+    payload.card_type_id = card_type_id
+    payload.color_id     = color_id
+
+    with patch(f"{_DASH_BASE}._unlock_color") as mock_unlock:
+        if side_effect is not None:
+            mock_unlock.side_effect = side_effect
+        elif unlock_result is not None:
+            mock_unlock.return_value = unlock_result
+        else:
+            mock_unlock.return_value = UnlockColorResult(
+                ok=True, already_owned=False, credits_charged=500,
+                credit_balance=500, color_id=color_id, card_type_id=card_type_id,
+            )
+
+        resp = _run(student_unlock_color(payload=payload, db=db, user=user))
+
+    return resp
+
+
+# ── TS-01..TS-05: GET /shop/cards/player/colors context ───────────────────────
+
+class TestColorShopGet:
+
+    def test_ts_01_returns_200(self):
+        ctx = _invoke_color_shop()
+        assert ctx, "context not captured — handler likely raised"
+
+    def test_ts_02_context_has_six_colors(self):
+        ctx = _invoke_color_shop()
+        colors = ctx.get("player_colors", [])
+        assert len(colors) == 6
+
+    def test_ts_03_free_colors_always_owned(self):
+        ctx = _invoke_color_shop(owned_color_ids=set())
+        colors = {c["id"]: c for c in ctx.get("player_colors", [])}
+        assert colors["default"]["is_owned"] is True
+        assert colors["midnight"]["is_owned"] is True
+        assert colors["arctic"]["is_owned"] is True
+
+    def test_ts_04_premium_color_owned_when_row_exists(self):
+        ctx = _invoke_color_shop(owned_color_ids={"gold"})
+        colors = {c["id"]: c for c in ctx.get("player_colors", [])}
+        assert colors["gold"]["is_owned"] is True
+
+    def test_ts_05_premium_color_not_owned_when_no_row(self):
+        ctx = _invoke_color_shop(owned_color_ids=set())
+        colors = {c["id"]: c for c in ctx.get("player_colors", [])}
+        assert colors["gold"]["is_owned"] is False
+        assert colors["emerald"]["is_owned"] is False
+        assert colors["crimson"]["is_owned"] is False
+
+
+# ── TS-07..TS-12: POST /dashboard/unlock-color ────────────────────────────────
+
+class TestUnlockColorRoute:
+
+    def test_ts_07_valid_purchase_returns_ok(self):
+        resp = _call_unlock_color("player_card", "gold")
+        body = json.loads(resp.body)
+        assert body["ok"] is True
+        assert resp.status_code == 200
+
+    def test_ts_08_credit_balance_in_response(self):
+        result = UnlockColorResult(
+            ok=True, already_owned=False, credits_charged=500,
+            credit_balance=500, color_id="gold", card_type_id="player_card",
+        )
+        resp = _call_unlock_color("player_card", "gold", unlock_result=result)
+        body = json.loads(resp.body)
+        assert body["credits_charged"] == 500
+        assert body["credit_balance"] == 500
+
+    def test_ts_09_idempotent_already_owned(self):
+        result = UnlockColorResult(
+            ok=True, already_owned=True, credits_charged=0,
+            credit_balance=1000, color_id="gold", card_type_id="player_card",
+        )
+        resp = _call_unlock_color("player_card", "gold", unlock_result=result)
+        body = json.loads(resp.body)
+        assert body["ok"] is True
+        assert body["already_owned"] is True
+        assert body["credits_charged"] == 0
+
+    def test_ts_10_insufficient_credits_returns_402(self):
+        resp = _call_unlock_color(
+            "player_card", "gold",
+            side_effect=InsufficientCreditsError(required=500, available=100),
+        )
+        assert resp.status_code == 402
+        body = json.loads(resp.body)
+        assert body["ok"] is False
+        assert body["error"] == "insufficient_credits"
+        assert body["required"] == 500
+        assert body["balance"] == 100
+
+    def test_ts_11_unknown_color_id_returns_422(self):
+        resp = _call_unlock_color(
+            "player_card", "nonexistent",
+            side_effect=ValueError("color_not_found"),
+        )
+        assert resp.status_code == 422
+        body = json.loads(resp.body)
+        assert body["ok"] is False
+
+    def test_ts_12_unsupported_family_returns_422(self):
+        resp = _call_unlock_color(
+            "welcome_card", "gold",
+            side_effect=ValueError("unsupported_family"),
+        )
+        assert resp.status_code == 422
+        body = json.loads(resp.body)
+        assert body["ok"] is False
+
+
+# ── TS-13..TS-14: Route registration ──────────────────────────────────────────
+
+class TestRouteRegistration:
+
+    def _route_paths(self) -> list[str]:
+        from app.main import app
+        return [r.path for r in app.routes]
+
+    def test_ts_13_route_count_836(self):
+        from app.main import app
+        paths = app.openapi().get("paths", {})
+        assert len(paths) == 836, (
+            f"Expected 836 routes (834 CE-2 baseline + 2 TS-1), got {len(paths)}."
+        )
+
+    def test_ts_14_unlock_theme_still_registered(self):
+        assert "/dashboard/unlock-theme" in self._route_paths()
+
+    def test_ts_14b_unlock_color_registered(self):
+        assert "/dashboard/unlock-color" in self._route_paths()
+
+    def test_ts_14c_player_colors_shop_registered(self):
+        assert "/shop/cards/player/colors" in self._route_paths()
+
+
+# ── TS-15..TS-19: Template source checks ──────────────────────────────────────
+
+class TestColorShopTemplate:
+
+    def _src(self) -> str:
+        return (TEMPLATES_DIR / "shop_card_player_colors.html").read_text(encoding="utf-8")
+
+    def test_ts_15_js_unlock_function_present(self):
+        assert "unlockColor" in self._src()
+
+    def test_ts_16_unlock_cta_button_present(self):
+        assert "scc-btn-unlock" in self._src()
+        assert "Unlock for" in self._src()
+
+    def test_ts_17_credit_balance_display_present(self):
+        assert "scc-balance" in self._src() or "credit_balance" in self._src()
+
+    def test_ts_18_back_link_to_player_shop(self):
+        assert 'href="/shop/cards/player"' in self._src()
+
+    def test_ts_19_link_to_card_editor(self):
+        assert 'href="/card-editor/player"' in self._src()
+
+
+# ── TS-20: Editor has no purchase affordance (CE-2 regression) ────────────────
+
+class TestEditorNoPurchaseAffordance:
+
+    def _editor_src(self) -> str:
+        return (TEMPLATES_DIR / "dashboard_card_editor.html").read_text(encoding="utf-8")
+
+    def test_ts_20a_no_unlock_cta_in_editor(self):
+        src = self._editor_src()
+        assert "unlockTheme" not in src
+        assert "unlockVariant" not in src
+
+    def test_ts_20b_no_price_in_theme_picker(self):
+        src = self._editor_src()
+        assert "credit_cost" not in src
+        assert "var-cost" not in src
+
+    def test_ts_20c_no_buy_or_get_cta_in_editor(self):
+        src = self._editor_src()
+        assert "Get Card" not in src
+        assert "Unlock for" not in src

--- a/tests/unit/migration/test_card_color_ownership_migration.py
+++ b/tests/unit/migration/test_card_color_ownership_migration.py
@@ -1,0 +1,138 @@
+"""
+MG — card_color_ownership migration tests (TS-1).
+
+Static code-analysis tests: verify ORM model structure, migration metadata,
+SQL patterns, and backfill contract without hitting a real database.
+
+MG-01: card_color_ownership table name in migration source
+MG-02: UNIQUE constraint present in migration source
+MG-03: ix_cco_user_id index in migration source
+MG-04: ix_cco_family_color index in migration source
+MG-05: backfill INSERT statement present in migration source
+MG-06: backfill uses ON CONFLICT DO NOTHING
+MG-07: backfill guarded by known color ID set
+MG-08: backfill skips empty/null JSON (filter in WHERE clause)
+MG-09: backfill is idempotent (ON CONFLICT DO NOTHING)
+MG-10: downgrade drops the table
+MG-11: downgrade does NOT touch unlocked_card_themes
+MG-12: ORM model has all required columns
+MG-13: ORM model unique constraint defined
+MG-14: ORM model indexes defined
+"""
+import pathlib
+import pytest
+
+_MIGRATION_PATH = (
+    pathlib.Path(__file__).resolve().parents[3]
+    / "alembic" / "versions" / "2026_05_29_1200_add_card_color_ownership.py"
+)
+
+_MODEL_PATH = (
+    pathlib.Path(__file__).resolve().parents[3]
+    / "app" / "models" / "card_color_ownership.py"
+)
+
+
+def _migration_src() -> str:
+    return _MIGRATION_PATH.read_text()
+
+
+def _model_src() -> str:
+    return _MODEL_PATH.read_text()
+
+
+@pytest.fixture(scope="module")
+def migration_src():
+    return _migration_src()
+
+
+@pytest.fixture(scope="module")
+def model_src():
+    return _model_src()
+
+
+@pytest.fixture(scope="module")
+def cco_cls():
+    from app.models.card_color_ownership import CardColorOwnership
+    return CardColorOwnership
+
+
+# ── MG-01..MG-11: Migration source analysis ────────────────────────────────────
+
+class TestCardColorOwnershipMigrationSource:
+
+    def test_mg_01_table_name_in_migration(self, migration_src):
+        assert "card_color_ownership" in migration_src
+
+    def test_mg_02_unique_constraint_present(self, migration_src):
+        assert "uq_cco_user_type_color" in migration_src
+
+    def test_mg_03_user_id_index_present(self, migration_src):
+        assert "ix_cco_user_id" in migration_src
+
+    def test_mg_04_family_color_index_present(self, migration_src):
+        assert "ix_cco_family_color" in migration_src
+
+    def test_mg_05_backfill_insert_present(self, migration_src):
+        assert "INSERT INTO card_color_ownership" in migration_src
+
+    def test_mg_06_backfill_on_conflict_do_nothing(self, migration_src):
+        assert "ON CONFLICT" in migration_src
+        assert "DO NOTHING" in migration_src
+
+    def test_mg_07_backfill_guarded_by_known_color_ids(self, migration_src):
+        assert "_KNOWN_COLOR_IDS" in migration_src
+        assert "gold" in migration_src
+        assert "emerald" in migration_src
+        assert "crimson" in migration_src
+
+    def test_mg_08_backfill_skips_empty_json(self, migration_src):
+        assert "'[]'" in migration_src or "NOT IN" in migration_src
+
+    def test_mg_09_backfill_idempotent_via_on_conflict(self, migration_src):
+        assert "ON CONFLICT (user_id, card_type_id, color_id) DO NOTHING" in migration_src
+
+    def test_mg_10_downgrade_drops_table(self, migration_src):
+        assert "drop_table" in migration_src
+        assert "card_color_ownership" in migration_src.split("def downgrade")[1]
+
+    def test_mg_11_downgrade_does_not_touch_unlocked_card_themes(self, migration_src):
+        downgrade_section = migration_src.split("def downgrade")[1]
+        # No ALTER TABLE or DROP COLUMN touching unlocked_card_themes in downgrade
+        assert "alter_column" not in downgrade_section
+        assert "drop_column" not in downgrade_section
+        # Only drop_index + drop_table operations present
+        assert "drop_table(\"card_color_ownership\")" in downgrade_section or \
+               "drop_table('card_color_ownership')" in downgrade_section
+
+
+# ── MG-12..MG-14: ORM model structure ─────────────────────────────────────────
+
+class TestCardColorOwnershipOrmModel:
+
+    def test_mg_12_all_required_columns_present(self, cco_cls):
+        cols = {c.key for c in cco_cls.__table__.columns}
+        assert "id"           in cols
+        assert "user_id"      in cols
+        assert "card_type_id" in cols
+        assert "color_id"     in cols
+        assert "pack_id"      in cols
+        assert "purchased_at" in cols
+
+    def test_mg_13_unique_constraint_defined(self, cco_cls):
+        constraint_names = {
+            c.name for c in cco_cls.__table__.constraints
+        }
+        assert "uq_cco_user_type_color" in constraint_names
+
+    def test_mg_14_indexes_defined(self, cco_cls):
+        index_names = {i.name for i in cco_cls.__table__.indexes}
+        assert "ix_cco_user_id" in index_names
+        assert "ix_cco_family_color" in index_names
+
+    def test_mg_15_pack_id_is_nullable(self, cco_cls):
+        col = cco_cls.__table__.columns["pack_id"]
+        assert col.nullable is True
+
+    def test_mg_16_tablename_correct(self, cco_cls):
+        assert cco_cls.__tablename__ == "card_color_ownership"

--- a/tests/unit/services/test_card_color_service.py
+++ b/tests/unit/services/test_card_color_service.py
@@ -1,0 +1,230 @@
+"""
+CS — card_color_service unit tests (TS-1).
+
+CS-01: get_colors_for_family("player_card") → 6 colors
+CS-02: player_card palette contains all expected color IDs
+CS-03: get_colors_for_family("unknown_family") → empty list (no KeyError)
+CS-04: get_colors_for_family("welcome_card") → empty list (TS-2 scope)
+CS-05: free color is_color_unlocked → True without DB query
+CS-06: premium color is_color_unlocked → True when ownership row exists
+CS-07: premium color is_color_unlocked → False when no ownership row
+CS-08: welcome_card gold is_color_unlocked → False even if player_card gold owned
+CS-09: get_owned_color_ids returns set of owned premium color ids for user
+CS-10: get_owned_color_ids returns empty set when user has no owned colors
+CS-11: unlock_color valid purchase → ownership row + credit deduction
+CS-12: unlock_color already owned → already_owned=True, 0 CR
+CS-13: unlock_color free color → already_owned=True, 0 CR, no DB write
+CS-14: unlock_color unknown color → ValueError("color_not_found")
+CS-15: unlock_color unsupported family → ValueError("unsupported_family")
+CS-16: unlock_color insufficient credits → InsufficientCreditsError, no DB write
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+from app.services.card_color_service import (
+    FAMILY_COLORS,
+    ColorDefinition,
+    get_colors_for_family,
+    get_owned_color_ids,
+    is_color_unlocked,
+    unlock_color,
+    UnlockColorResult,
+)
+from app.services.credit_service import InsufficientCreditsError
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _db_with_no_ownership():
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = None
+    db.query.return_value.filter.return_value.all.return_value = []
+    return db
+
+
+def _db_with_ownership(user_id: int, card_type_id: str, color_id: str):
+    """Return a mock DB that returns an ownership row for the given triplet."""
+    db = MagicMock()
+    row = MagicMock()
+    row.__getitem__ = lambda s, i: color_id if i == 0 else None
+
+    def _filter_side(*args, **kwargs):
+        m = MagicMock()
+        m.first.return_value = row
+        m.all.return_value = [row]
+        return m
+
+    db.query.return_value.filter.side_effect = _filter_side
+    return db
+
+
+def _user(credit_balance: int = 1000) -> MagicMock:
+    u = MagicMock()
+    u.id = 42
+    u.credit_balance = credit_balance
+    return u
+
+
+# ── CS-01..CS-04: get_colors_for_family ───────────────────────────────────────
+
+class TestGetColorsForFamily:
+
+    def test_cs_01_player_card_returns_six_colors(self):
+        colors = get_colors_for_family("player_card")
+        assert len(colors) == 6
+
+    def test_cs_02_player_card_contains_all_ids(self):
+        ids = {c.id for c in get_colors_for_family("player_card")}
+        assert ids == {"default", "midnight", "arctic", "gold", "emerald", "crimson"}
+
+    def test_cs_02b_player_card_ordered_by_sort_order(self):
+        colors = get_colors_for_family("player_card")
+        orders = [c.sort_order for c in colors]
+        assert orders == sorted(orders)
+
+    def test_cs_03_unknown_family_returns_empty_list(self):
+        result = get_colors_for_family("unknown_family_xyz")
+        assert result == []
+
+    def test_cs_04_welcome_card_returns_empty_list(self):
+        result = get_colors_for_family("welcome_card")
+        assert result == []
+
+
+# ── CS-05..CS-08: is_color_unlocked ───────────────────────────────────────────
+
+class TestIsColorUnlocked:
+
+    def test_cs_05_free_color_always_unlocked(self):
+        db = MagicMock()
+        assert is_color_unlocked(db, 42, "player_card", "default") is True
+        assert is_color_unlocked(db, 42, "player_card", "midnight") is True
+        assert is_color_unlocked(db, 42, "player_card", "arctic") is True
+        # DB was never queried for free colors
+        db.query.assert_not_called()
+
+    def test_cs_06_premium_color_owned_returns_true(self):
+        db = MagicMock()
+        ownership_row = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = ownership_row
+        assert is_color_unlocked(db, 42, "player_card", "gold") is True
+
+    def test_cs_07_premium_color_not_owned_returns_false(self):
+        db = _db_with_no_ownership()
+        assert is_color_unlocked(db, 42, "player_card", "gold") is False
+
+    def test_cs_08_different_family_not_owned(self):
+        # welcome_card family has no colors defined in TS-1 → always False for premium
+        db = MagicMock()
+        assert is_color_unlocked(db, 42, "welcome_card", "gold") is False
+        db.query.assert_not_called()  # unknown family exits early
+
+    def test_cs_08b_unknown_color_returns_false(self):
+        db = MagicMock()
+        assert is_color_unlocked(db, 42, "player_card", "nonexistent") is False
+
+
+# ── CS-09..CS-10: get_owned_color_ids ─────────────────────────────────────────
+
+class TestGetOwnedColorIds:
+
+    def test_cs_09_returns_set_of_owned_ids(self):
+        db = MagicMock()
+        db.query.return_value.filter.return_value.all.return_value = [
+            ("gold",), ("emerald",)
+        ]
+        result = get_owned_color_ids(db, 42, "player_card")
+        assert result == {"gold", "emerald"}
+
+    def test_cs_10_returns_empty_set_when_no_owned(self):
+        db = MagicMock()
+        db.query.return_value.filter.return_value.all.return_value = []
+        result = get_owned_color_ids(db, 42, "player_card")
+        assert result == set()
+
+
+# ── CS-11..CS-16: unlock_color ────────────────────────────────────────────────
+
+class TestUnlockColor:
+
+    def _no_ownership_db(self):
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = None
+        return db
+
+    def test_cs_11_valid_purchase_creates_ownership_row(self):
+        db = self._no_ownership_db()
+        user = _user(credit_balance=1000)
+
+        with patch("app.services.card_color_service.CreditService") as MockCS:
+            MockCS.return_value.deduct.return_value = MagicMock()
+            result = unlock_color(db, user, "player_card", "gold")
+
+        assert result.ok is True
+        assert result.already_owned is False
+        assert result.credits_charged == 500
+        assert result.color_id == "gold"
+        assert result.card_type_id == "player_card"
+        db.add.assert_called_once()
+        db.commit.assert_called_once()
+
+    def test_cs_12_already_owned_returns_idempotent_result(self):
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = MagicMock()
+        user = _user()
+
+        with patch("app.services.card_color_service.CreditService") as MockCS:
+            result = unlock_color(db, user, "player_card", "gold")
+
+        assert result.ok is True
+        assert result.already_owned is True
+        assert result.credits_charged == 0
+        MockCS.return_value.deduct.assert_not_called()
+        db.add.assert_not_called()
+        db.commit.assert_not_called()
+
+    def test_cs_13_free_color_returns_already_owned_no_db_write(self):
+        db = MagicMock()
+        user = _user()
+
+        with patch("app.services.card_color_service.CreditService") as MockCS:
+            result = unlock_color(db, user, "player_card", "default")
+
+        assert result.ok is True
+        assert result.already_owned is True
+        assert result.credits_charged == 0
+        MockCS.return_value.deduct.assert_not_called()
+        # No ownership lookup for free colors
+        db.add.assert_not_called()
+        db.commit.assert_not_called()
+
+    def test_cs_14_unknown_color_raises_value_error(self):
+        db = self._no_ownership_db()
+        user = _user()
+        with pytest.raises(ValueError, match="color_not_found"):
+            unlock_color(db, user, "player_card", "nonexistent_color")
+
+    def test_cs_15_unsupported_family_raises_value_error(self):
+        db = self._no_ownership_db()
+        user = _user()
+        with pytest.raises(ValueError, match="unsupported_family"):
+            unlock_color(db, user, "welcome_card", "gold")
+
+    def test_cs_16_insufficient_credits_raises_error_no_db_write(self):
+        db = self._no_ownership_db()
+        user = _user(credit_balance=100)  # less than 500 CR
+
+        with patch("app.services.card_color_service.CreditService") as MockCS:
+            MockCS.return_value.deduct.side_effect = InsufficientCreditsError(
+                required=500, available=100
+            )
+            with pytest.raises(InsufficientCreditsError):
+                unlock_color(db, user, "player_card", "gold")
+
+        db.add.assert_not_called()
+        db.commit.assert_not_called()


### PR DESCRIPTION
## Summary

Implements the TS-1 Family Color Shop MVP for the `player_card` family. Introduces a dedicated ownership model, purchase flow, and shop UI — replacing the legacy `unlocked_card_themes` JSON approach with a proper relational ownership table.

## Migration Summary

- **File:** `alembic/versions/2026_05_29_1200_add_card_color_ownership.py`
- **down_revision:** `2026_05_29_1100` (CE-2 baseline)
- **Table:** `card_color_ownership` — columns: `id`, `user_id` (FK→CASCADE), `card_type_id`, `color_id`, `pack_id` (nullable, reserved for TS-3 bundles), `purchased_at`
- **Constraints:** `uq_cco_user_type_color` (user_id, card_type_id, color_id UNIQUE), `ix_cco_user_id`, `ix_cco_family_color`
- **Backfill:** `json_array_elements_text(unlocked_card_themes)` → `player_card` family, filtered to `_KNOWN_COLOR_IDS`, `ON CONFLICT DO NOTHING` (0 rows on dev — all themes were `[]`)
- **Downgrade:** drops indexes + table; does NOT touch `unlocked_card_themes` column

## Service Summary (`card_color_service.py`)

- `ColorDefinition` frozen dataclass (id, label, is_premium, credit_cost, dot_color, sort_order)
- `FAMILY_COLORS["player_card"]`: Slate/Midnight/Arctic (free); Gold/Emerald/Crimson (500 CR each)
- `get_colors_for_family(family)` — pure, no DB
- `get_owned_color_ids(db, user_id, family)` — returns `set[str]` of owned premium ids
- `is_color_unlocked(db, user_id, family, color_id)` — free=True always; premium=DB query
- `unlock_color(db, user, family, color_id)` — SAVEPOINT atomicity + idempotency key

## Route Summary

| Method | Path | Notes |
|--------|------|-------|
| GET | `/shop/cards/player/colors` | NEW — family color picker page |
| POST | `/dashboard/unlock-color` | NEW — 200/402/422 |
| POST | `/dashboard/unlock-theme` | KEPT — legacy backward compat unchanged |

**OpenAPI route count: 836** (834 CE-2 baseline + 2 new)

Editor: `lfa_player_card_editor` theme filter switched from `card_theme_service` to `card_color_service`. CE-2 owned-only policy preserved — no purchase affordance in editor.

## Idempotency / Atomicity

- **Double-click protection:** JS `btn.disabled = true` immediately on click; `CreditService.deduct()` idempotency key = `color_unlock_{user_id}_{card_type_id}_{color_id}` prevents double charge under concurrent requests
- **SAVEPOINT:** `with db.begin_nested():` couples credit deduction + ownership INSERT atomically; `InsufficientCreditsError` inside the block rolls back both — no orphaned ownership rows
- **Already-owned:** second `unlock_color()` call returns `already_owned=True, credits_charged=0` without any DB write (fast path before SAVEPOINT)
- **Free colors:** return `already_owned=True, credits_charged=0` without any DB query

## Test Results

| Suite | Tests | Result |
|-------|-------|--------|
| Migration (MG-01..16) | 16 | ✅ 16/16 PASS |
| Service (CS-01..16+) | 20 | ✅ 20/20 PASS |
| Route/UI (TS-01..20) | 23 | ✅ 23/23 PASS |
| CE2-* (mock paths updated, CE2-17: 834→836) | 29 | ✅ 29/29 PASS |
| Entitlement (mock paths updated) | 13 | ✅ 13/13 PASS |
| Draft routes (mock paths updated) | 8 | ✅ 8/8 PASS |
| **Total targeted** | **109** | ✅ **109/109 PASS** |
| Full suite (excl. e2e + 4 pre-existing) | 2341 | ✅ **0 new failures** |

## Manual QA

All 17 checks passed against live dev server (`seed.player.2@promo-seed.test`, 1005 CR balance):

- ✅ `GET /shop/cards/player/colors` → 200, correct title, 6 tiles
- ✅ 3 free tiles "Free" badge + `scc-owned` state; 3 premium tiles "500 CR" price badge + Unlock button
- ✅ Unlock Gold → `ok=true, credits_charged=500, credit_balance=505`
- ✅ Second unlock Gold → `already_owned=true, credits_charged=0` (idempotency)
- ✅ Page reload: Gold tile shows `scc-owned` + "Owned ✓" badge, balance 505 CR
- ✅ Unlock Emerald (5 CR remaining) → Crimson fails with 402 `insufficient_credits`
- ✅ Unknown color_id → 422; unsupported family → 422
- ✅ Unauthenticated access → 401
- ✅ `/dashboard/unlock-theme` still responds (backward compat, not 404)
- ✅ `/card-editor/player` → 0 purchase CTAs, Gold in color picker after ownership

## Scope Guard

**In scope (TS-1 only):**
`CardColorOwnership` model, migration `2026_05_29_1200`, `card_color_service`, `GET /shop/cards/player/colors`, `POST /dashboard/unlock-color`, `shop_card_player_colors.html`, editor color filter switch, 57 new tests + 3 updated test files

**Explicitly NOT included (gated for later):**
Welcome/Challenge color shop, color bundles, full family bundle, C2 format purchase, editor purchase affordance, mood photo picker, family selector, BG removal changes, physical shop, refund flow, `unlocked_card_themes` column deletion

## Pre-existing Failures (unrelated to TS-1)

These 4 integration tests fail on `main` before this branch and are confirmed pre-existing via `git stash` verification:

| Test | Root Cause |
|------|-----------|
| `test_00_genesis_clean_db_full_flow` | Tries `CREATE DATABASE lfa_intern_system` — DB already exists in dev |
| `test_downgrade_to_base_removes_index` | `user_mood_photos` check constraint violation in migration rollback |
| `TestDryRun::test_dry_run_writes_nothing` | Promotion seed scenario failure, unrelated to card system |
| `test_submit_answer_negative_time_spent_accepted_as_float` | Adaptive learning smoke, pre-existing flaky test |

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)