### PR TITLE
feat(ce3): CE-3.1 — Card Studio landing (GET /card-editor) + Player Card handler prep

### DIFF
--- a/app/api/web_routes/card_editor.py
+++ b/app/api/web_routes/card_editor.py
@@ -1,6 +1,7 @@
 """Card Editor routes — family-specific customizer/export pages.
 
-Phase WCE-1: Welcome Card Customizer (preview + export wrapper, no draft).
+Phase WCE-1:  Welcome Card Customizer (preview + export wrapper, no draft).
+Phase CE-3.1: Card Studio landing — /card-editor entry point.
 Future: /card-editor/player/{collection_id}, /card-editor/challenge/{id}
 """
 from pathlib import Path
@@ -15,7 +16,9 @@ from ...dependencies import get_current_user_web
 from ...models.user import User, UserRole
 from ...models.license import UserLicense
 from ...services.card_design_service import (
+    CHALLENGE_CARD_FORMATS,
     WELCOME_CARD_FORMATS,
+    get_owned_design_ids,
     is_design_accessible,
 )
 
@@ -37,6 +40,53 @@ _WC_RATIO: dict[str, str] = {
     "facebook_landscape":  "mfg-ratio-169",
     "banner_custom":       "mfg-ratio-169",
 }
+
+# Valid design-ID sets for WC / CC (used in landing ownership count)
+_WC_VALID_IDS: frozenset[str] = frozenset(f.design_id for f in WELCOME_CARD_FORMATS)
+_CC_VALID_IDS: frozenset[str] = frozenset(f.design_id for f in CHALLENGE_CARD_FORMATS)
+
+
+# ── Card Studio Landing ───────────────────────────────────────────────────────
+
+@router.get("/card-editor", response_class=HTMLResponse)
+async def card_studio_landing(
+    request: Request,
+    db: Session = Depends(get_db),
+    user: User  = Depends(get_current_user_web),
+):
+    """Card Studio landing — family picker entry point (CE-3.1).
+
+    Shows owned-design counts for all three card families and routes the user
+    to the appropriate editor or shop.  No family-specific license guard here;
+    each family editor enforces its own guard.
+    """
+    pc_owned_count = len(get_owned_design_ids(db, user.id, "player_card"))
+
+    wc_owned_count = len(
+        set(get_owned_design_ids(db, user.id, "welcome_card")) & _WC_VALID_IDS
+    )
+    cc_owned_count = len(
+        set(get_owned_design_ids(db, user.id, "challenge_card")) & _CC_VALID_IDS
+    )
+
+    any_owned = pc_owned_count > 0 or wc_owned_count > 0 or cc_owned_count > 0
+
+    return templates.TemplateResponse(
+        "card_studio_landing.html",
+        {
+            "request":         request,
+            "user":            user,
+            "pc_owned_count":  pc_owned_count,
+            "wc_owned_count":  wc_owned_count,
+            "cc_owned_count":  cc_owned_count,
+            "any_owned":       any_owned,
+            # Standard LFA spec nav context (used by spec_subpage_hdr.html)
+            "spec_dashboard_url":  "/dashboard/lfa-football-player",
+            "spec_dashboard_icon": "⚽",
+            "spec_profile_url":    "/profile/lfa-football-player",
+            "spec_profile_icon":   "🪪",
+        },
+    )
 
 
 # ── Welcome Card Customizer ───────────────────────────────────────────────────

--- a/app/api/web_routes/dashboard.py
+++ b/app/api/web_routes/dashboard.py
@@ -355,6 +355,7 @@ async def lfa_player_card_editor(
 ):
     """Player Card editor — canonical route (CE-1).  Old URL redirects here."""
     spec_enum = "LFA_FOOTBALL_PLAYER"
+    _FAMILY   = "player_card"           # CE-3.1: consolidated for family-aware prep
 
     # Same license guard as spec_dashboard
     user_license = db.query(UserLicense).filter(
@@ -383,15 +384,15 @@ async def lfa_player_card_editor(
     credit_balance = user.credit_balance if hasattr(user, "credit_balance") else 0
 
     # Load (or create) the singleton card draft — single source of truth after 4D-2
-    card_draft = _CardDraftService.get_player_card_draft(db, user.id)
+    card_draft = _CardDraftService.get_draft(db, user.id, _FAMILY)
 
     # Card color picker data — family-aware ownership (TS-1, card_color_service)
     from ...services.card_color_service import (  # noqa: E402
         get_colors_for_family as _get_colors_for_family,
         get_owned_color_ids as _get_owned_color_ids,
     )
-    _raw_colors   = _get_colors_for_family("player_card")
-    _owned_colors = _get_owned_color_ids(db, user.id, "player_card")
+    _raw_colors   = _get_colors_for_family(_FAMILY)
+    _owned_colors = _get_owned_color_ids(db, user.id, _FAMILY)
     card_themes = [
         {
             "id":          c.id,
@@ -426,14 +427,14 @@ async def lfa_player_card_editor(
             "is_premium": v.is_premium,
             "credit_cost": v.credit_cost,
             "available": v.available,
-            "unlocked": _is_design_accessible(db, user.id, "player_card", v.id),
+            "unlocked": _is_design_accessible(db, user.id, _FAMILY, v.id),
         }
         for v in _get_all_variants()
     ]
     # CE-2: owned-only — no purchase affordance in editor (CE-2 policy)
     card_variants = [v for v in card_variants if v["unlocked"]]
     active_card_variant  = card_draft.draft_variant
-    active_variant_owned = _is_design_accessible(db, user.id, "player_card", active_card_variant)
+    active_variant_owned = _is_design_accessible(db, user.id, _FAMILY, active_card_variant)
     # CE-2: render-time fallback — if draft points to unowned design, use first owned
     # Does NOT write to DB; user explicit tile-click will persist the change.
     if not active_variant_owned and card_variants:

--- a/app/templates/card_studio_landing.html
+++ b/app/templates/card_studio_landing.html
@@ -1,0 +1,225 @@
+{% extends "student_base.html" %}
+
+{% block title %}Card Studio — LFA Education Center{% endblock %}
+{% block active_page %}lfa-player{% endblock %}
+
+{% block student_header %}
+{% set _page_icon = '🎨' %}
+{% set _page_name = 'Card Studio' %}
+{% include "includes/spec_subpage_hdr.html" %}
+{% endblock %}
+
+{% block extra_styles %}
+<style>
+  .cs-landing {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 1.5rem 1rem 3rem;
+  }
+
+  /* ── Page header ── */
+  .cs-page-header { margin-bottom: 1.5rem; }
+  .cs-page-header h1 {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--app-text, #f1f5f9);
+    margin: 0 0 0.25rem;
+  }
+  .cs-page-header p {
+    font-size: 0.9rem;
+    color: #94a3b8;
+    margin: 0;
+  }
+
+  /* ── Tile grid ── */
+  .cs-tiles {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    gap: 1.25rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .cs-tile {
+    background: var(--app-card, #1a1f2e);
+    border: 1px solid var(--app-border, #252d42);
+    border-radius: 14px;
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    transition: border-color 0.15s;
+  }
+  .cs-tile:hover { border-color: #334155; }
+
+  .cs-tile-top {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.85rem;
+  }
+  .cs-tile-icon { font-size: 2rem; line-height: 1; flex-shrink: 0; }
+  .cs-tile-meta { flex: 1; min-width: 0; }
+  .cs-tile-title {
+    font-size: 1rem;
+    font-weight: 700;
+    color: var(--app-text, #f1f5f9);
+    margin-bottom: 0.2rem;
+  }
+  .cs-tile-desc {
+    font-size: 0.82rem;
+    color: #64748b;
+    line-height: 1.4;
+  }
+
+  /* ── Count badge ── */
+  .cs-count-badge {
+    display: inline-flex;
+    align-items: center;
+    background: #0f172a;
+    border: 1px solid #1e293b;
+    border-radius: 20px;
+    padding: 0.25rem 0.75rem;
+    font-size: 0.78rem;
+    color: #64748b;
+    width: fit-content;
+  }
+  .cs-count-nonzero { color: #94a3b8; border-color: #334155; }
+
+  /* ── CTAs ── */
+  .cs-btn-primary {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.55rem 1rem;
+    border-radius: 8px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    text-decoration: none;
+    background: #FFD200;
+    color: #0a0a0a;
+    transition: opacity 0.15s;
+  }
+  .cs-btn-primary:hover { opacity: 0.88; color: #0a0a0a; }
+
+  .cs-btn-secondary {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.45rem 1rem;
+    border-radius: 8px;
+    font-size: 0.82rem;
+    font-weight: 600;
+    text-decoration: none;
+    border: 1px solid #334155;
+    color: #94a3b8;
+    transition: border-color 0.15s, color 0.15s;
+  }
+  .cs-btn-secondary:hover { border-color: #FFD200; color: #FFD200; }
+
+  /* ── Global empty state ── */
+  .cs-empty-state {
+    background: var(--app-card, #1a1f2e);
+    border: 1px solid var(--app-border, #252d42);
+    border-radius: 14px;
+    padding: 2.5rem 1.5rem;
+    text-align: center;
+  }
+  .cs-empty-icon { font-size: 2.5rem; margin-bottom: 0.75rem; }
+  .cs-empty-state h2 {
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--app-text, #f1f5f9);
+    margin: 0 0 0.5rem;
+  }
+  .cs-empty-state p {
+    font-size: 0.88rem;
+    color: #64748b;
+    margin: 0 0 1.25rem;
+  }
+  .cs-empty-state .cs-btn-primary {
+    max-width: 200px;
+    margin: 0 auto;
+  }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="cs-landing">
+
+  <div class="cs-page-header">
+    <h1>Card Studio</h1>
+    <p>Edit and export your cards</p>
+  </div>
+
+  <div class="cs-tiles">
+
+    {# ── Player Card ──────────────────────────────────────────────── #}
+    <div class="cs-tile">
+      <div class="cs-tile-top">
+        <span class="cs-tile-icon">🎴</span>
+        <div class="cs-tile-meta">
+          <div class="cs-tile-title">Player Card</div>
+          <p class="cs-tile-desc">Your LFA player identity card. Customise design and export.</p>
+        </div>
+      </div>
+      <span class="cs-count-badge{% if pc_owned_count > 0 %} cs-count-nonzero{% endif %}">
+        {{ pc_owned_count }} design{{ 's' if pc_owned_count != 1 }} owned
+      </span>
+      {% if pc_owned_count > 0 %}
+        <a href="/card-editor/player" class="cs-btn-primary cs-player-editor-cta">Open Editor →</a>
+      {% else %}
+        <a href="/shop/cards/player" class="cs-btn-secondary">Browse Player Designs →</a>
+      {% endif %}
+    </div>
+
+    {# ── Welcome Card ─────────────────────────────────────────────── #}
+    <div class="cs-tile">
+      <div class="cs-tile-top">
+        <span class="cs-tile-icon">👋</span>
+        <div class="cs-tile-meta">
+          <div class="cs-tile-title">Welcome Card</div>
+          <p class="cs-tile-desc">Your onboarding milestone card in multiple platform formats.</p>
+        </div>
+      </div>
+      <span class="cs-count-badge{% if wc_owned_count > 0 %} cs-count-nonzero{% endif %}">
+        {{ wc_owned_count }} format{{ 's' if wc_owned_count != 1 }} owned
+      </span>
+      {% if wc_owned_count > 0 %}
+        <a href="/my-cards/welcome" class="cs-btn-primary cs-welcome-cta">My Welcome Cards →</a>
+      {% else %}
+        <a href="/shop/cards/welcome" class="cs-btn-secondary">Browse Welcome Designs →</a>
+      {% endif %}
+    </div>
+
+    {# ── Challenge Card ───────────────────────────────────────────── #}
+    <div class="cs-tile">
+      <div class="cs-tile-top">
+        <span class="cs-tile-icon">⚡</span>
+        <div class="cs-tile-meta">
+          <div class="cs-tile-title">Challenge Card</div>
+          <p class="cs-tile-desc">Social card for VT challenge results.</p>
+        </div>
+      </div>
+      <span class="cs-count-badge{% if cc_owned_count > 0 %} cs-count-nonzero{% endif %}">
+        {{ cc_owned_count }} format{{ 's' if cc_owned_count != 1 }} owned
+      </span>
+      {% if cc_owned_count > 0 %}
+        <a href="/my-cards/challenge" class="cs-btn-primary cs-challenge-cta">My Challenge Cards →</a>
+      {% else %}
+        <a href="/shop/cards/challenge" class="cs-btn-secondary">Browse Challenge Designs →</a>
+      {% endif %}
+    </div>
+
+  </div>{# /cs-tiles #}
+
+  {# ── Global empty state — shown only when no family has owned designs ── #}
+  {% if not any_owned %}
+  <div class="cs-empty-state">
+    <div class="cs-empty-icon">🃏</div>
+    <h2>You don't own any card designs yet.</h2>
+    <p>Browse the card shop to get your first design.</p>
+    <a href="/shop/cards" class="cs-btn-primary">Browse Card Shop →</a>
+  </div>
+  {% endif %}
+
+</div>{# /cs-landing #}
+{% endblock %}

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -59851,6 +59851,29 @@
         ]
       }
     },
+    "/card-editor": {
+      "get": {
+        "description": "Card Studio landing \u2014 family picker entry point (CE-3.1).\n\nShows owned-design counts for all three card families and routes the user\nto the appropriate editor or shop.  No family-specific license guard here;\neach family editor enforces its own guard.",
+        "operationId": "card_studio_landing_card_editor_get",
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Card Studio Landing",
+        "tags": [
+          "web",
+          "card-editor"
+        ]
+      }
+    },
     "/card-editor/player": {
       "get": {
         "description": "Player Card editor \u2014 canonical route (CE-1).  Old URL redirects here.",

--- a/tests/unit/api/web_routes/test_card_draft_routes.py
+++ b/tests/unit/api/web_routes/test_card_draft_routes.py
@@ -101,7 +101,7 @@ class TestCardEditorGetContext:
              patch("app.services.card_constants.CANVAS_SIZES", {}), \
              patch("app.services.card_constants.CARD_EDITOR_PLATFORM_IDS", []), \
              patch("app.services.highlight_video_service.build_youtube_embed_url", return_value=None):
-            MockCDS.get_player_card_draft.return_value = draft
+            MockCDS.get_draft.return_value = draft
             mock_tpl.TemplateResponse.side_effect = fake_template_response
 
             # Patch the DB query chain so license lookup works

--- a/tests/unit/api/web_routes/test_card_editor_ce2.py
+++ b/tests/unit/api/web_routes/test_card_editor_ce2.py
@@ -418,10 +418,9 @@ class TestCE216WelcomeEditorUnchanged:
 
 class TestCE217RouteCount:
     def test_openapi_snapshot_route_count_unchanged(self):
-        """CE-2 adds no new routes — snapshot path count must equal 836 (834 CE-2 + 2 TS-1)."""
+        """CE-3.1 adds GET /card-editor — snapshot path count must equal 837."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 836, (
-            f"Expected 836 routes (834 CE-2 baseline + 2 TS-1), got {len(paths)}. "
-            "CE-2 must not add or remove routes."
+        assert len(paths) == 837, (
+            f"Expected 837 routes (834 CE-2 + 2 TS-1 + 1 CE-3.1), got {len(paths)}."
         )

--- a/tests/unit/api/web_routes/test_card_studio_landing.py
+++ b/tests/unit/api/web_routes/test_card_studio_landing.py
@@ -1,0 +1,429 @@
+"""
+CEL — Card Studio Landing tests (CE-3.1).
+
+GET /card-editor — authenticated entry point showing owned counts per card family.
+
+CEL-01  authenticated user → handler callable, 200
+CEL-02  unauthenticated → 401/redirect (get_current_user_web guard)
+CEL-03  player_card owned_count reflects CDO rows
+CEL-04  player_card owned=0 → CTA links to /shop/cards/player
+CEL-05  welcome_card owned_count is filtered to valid format IDs only
+CEL-06  challenge_card owned_count is filtered to valid format IDs only
+CEL-07  any_owned=True when at least one family has owned designs
+CEL-08  any_owned=False when all owned counts are zero
+CEL-09  Player Card owned → CTA links to /card-editor/player
+CEL-10  Welcome Card owned → CTA links to /my-cards/welcome
+CEL-11  Challenge Card owned → CTA links to /my-cards/challenge
+CEL-12  route count = 837 (836 baseline + GET /card-editor)
+CEL-13  OpenAPI snapshot is up to date (837 routes)
+CEL-14  /card-editor/player regression — lfa_player_card_editor still callable
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import jinja2
+import pytest
+
+from app.services.card_design_service import CHALLENGE_CARD_FORMATS, WELCOME_CARD_FORMATS
+
+_CE_BASE = "app.api.web_routes.card_editor"
+
+# Valid format-ID sets (same logic as the handler uses at module level)
+_VALID_WC_IDS: frozenset[str] = frozenset(f.design_id for f in WELCOME_CARD_FORMATS)
+_VALID_CC_IDS: frozenset[str] = frozenset(f.design_id for f in CHALLENGE_CARD_FORMATS)
+
+# One known-valid ID from each family for owned tests
+_WC_VALID_ID: str = sorted(_VALID_WC_IDS)[0]
+_CC_VALID_ID: str = sorted(_VALID_CC_IDS)[0]
+
+SNAPSHOTS_DIR = Path(__file__).resolve().parents[4] / "tests" / "snapshots"
+TEMPLATES_DIR = Path(__file__).resolve().parents[4] / "app" / "templates"
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _user(uid: int = 42) -> MagicMock:
+    u = MagicMock()
+    u.id = uid
+    return u
+
+
+def _invoke_landing(
+    pc_design_ids: list[str] | None = None,
+    wc_design_ids: list[str] | None = None,
+    cc_design_ids: list[str] | None = None,
+) -> dict:
+    """Call card_studio_landing with mocked deps; return captured template context."""
+    pc_design_ids = pc_design_ids or []
+    wc_design_ids = wc_design_ids or []
+    cc_design_ids = cc_design_ids or []
+
+    from app.api.web_routes.card_editor import card_studio_landing
+
+    user = _user()
+    db   = MagicMock()
+    captured: dict = {}
+
+    def _fake_tmpl(tmpl, ctx, **kw):
+        captured["template"] = tmpl
+        captured["context"]  = ctx
+        return MagicMock(status_code=200)
+
+    def _mock_get_owned(db_, uid, card_type_id):
+        if card_type_id == "player_card":   return pc_design_ids
+        if card_type_id == "welcome_card":  return wc_design_ids
+        if card_type_id == "challenge_card": return cc_design_ids
+        return []
+
+    with patch(f"{_CE_BASE}.get_owned_design_ids", side_effect=_mock_get_owned), \
+         patch(f"{_CE_BASE}.templates") as mock_tpl:
+        mock_tpl.TemplateResponse.side_effect = _fake_tmpl
+        try:
+            _run(card_studio_landing(request=MagicMock(), db=db, user=user))
+        except Exception:
+            pass
+
+    return captured.get("context", {})
+
+
+def _render_landing(ctx: dict) -> str:
+    """Render card_studio_landing.html with Jinja2 for CTA link assertions."""
+    src = (TEMPLATES_DIR / "card_studio_landing.html").read_text(encoding="utf-8")
+    # Strip extends / include directives so standalone render works
+    src = "\n".join(
+        line for line in src.splitlines()
+        if not line.strip().startswith("{%") or
+        any(k in line for k in ("if ", "else", "endif", "for ", "endfor", "set "))
+    )
+    env = jinja2.Environment()
+    return env.from_string(src).render(**ctx)
+
+
+# ── CEL-01: authenticated call succeeds ───────────────────────────────────────
+
+class TestCEL01Authenticated:
+
+    def test_cel_01_handler_callable_returns_context(self):
+        """CEL-01: card_studio_landing is callable and populates template context."""
+        ctx = _invoke_landing()
+        assert ctx, "context must be captured — handler likely raised"
+
+    def test_cel_01_template_is_landing(self):
+        """CEL-01: handler renders card_studio_landing.html."""
+        from app.api.web_routes.card_editor import card_studio_landing
+
+        user = _user()
+        captured = {}
+
+        def _fake(tmpl, ctx, **kw):
+            captured["template"] = tmpl
+            return MagicMock(status_code=200)
+
+        with patch(f"{_CE_BASE}.get_owned_design_ids", return_value=[]), \
+             patch(f"{_CE_BASE}.templates") as mock_tpl:
+            mock_tpl.TemplateResponse.side_effect = _fake
+            try:
+                _run(card_studio_landing(request=MagicMock(), db=MagicMock(), user=user))
+            except Exception:
+                pass
+
+        assert captured.get("template") == "card_studio_landing.html"
+
+
+# ── CEL-02: unauthenticated guard ─────────────────────────────────────────────
+
+class TestCEL02Unauthenticated:
+
+    def test_cel_02_route_has_current_user_dependency(self):
+        """CEL-02: /card-editor route has get_current_user_web in its dependant tree."""
+        from app.main import app
+        route = next(
+            (r for r in app.routes if getattr(r, "path", None) == "/card-editor"),
+            None,
+        )
+        assert route is not None, "/card-editor route must be registered"
+        # FastAPI stores parameter-level Depends in route.dependant.dependencies
+        dep_names = [
+            getattr(d.call, "__name__", "") for d in getattr(route.dependant, "dependencies", [])
+        ]
+        assert "get_current_user_web" in dep_names, (
+            f"/card-editor must depend on get_current_user_web for auth guard; found: {dep_names}"
+        )
+
+
+# ── CEL-03/04: player_card owned count ────────────────────────────────────────
+
+class TestCEL03PlayerCardOwnership:
+
+    def test_cel_03_pc_owned_count_reflects_cdo_rows(self):
+        """CEL-03: pc_owned_count equals the number of owned player_card design IDs."""
+        ctx = _invoke_landing(pc_design_ids=["fifa", "compact", "showcase"])
+        assert ctx.get("pc_owned_count") == 3
+
+    def test_cel_03b_pc_owned_count_zero_when_no_designs(self):
+        """CEL-03b: pc_owned_count=0 when get_owned_design_ids returns empty list."""
+        ctx = _invoke_landing(pc_design_ids=[])
+        assert ctx.get("pc_owned_count") == 0
+
+    def test_cel_04_pc_no_owned_cta_points_to_shop(self):
+        """CEL-04: template source has Browse Player Designs CTA for no-owned state."""
+        src = (TEMPLATES_DIR / "card_studio_landing.html").read_text(encoding="utf-8")
+        assert 'href="/shop/cards/player"' in src, (
+            "Template must contain shop CTA for no-owned player_card state"
+        )
+        assert "Browse Player Designs" in src
+
+
+# ── CEL-05: welcome_card count filtered to valid IDs ─────────────────────────
+
+class TestCEL05WelcomeCardCount:
+
+    def test_cel_05_only_valid_wc_formats_counted(self):
+        """CEL-05: wc_owned_count ignores non-existent format IDs."""
+        # Pass one valid + one invented ID → count must be 1
+        ctx = _invoke_landing(wc_design_ids=[_WC_VALID_ID, "invented_format_xyz"])
+        assert ctx.get("wc_owned_count") == 1, (
+            f"Only the valid format '{_WC_VALID_ID}' should count, not 'invented_format_xyz'"
+        )
+
+    def test_cel_05b_all_valid_wc_formats_counted(self):
+        """CEL-05b: all valid WC format IDs are counted correctly."""
+        ctx = _invoke_landing(wc_design_ids=list(_VALID_WC_IDS))
+        assert ctx.get("wc_owned_count") == len(_VALID_WC_IDS)
+
+    def test_cel_05c_empty_wc_list_gives_zero(self):
+        """CEL-05c: wc_owned_count=0 when no WC designs owned."""
+        ctx = _invoke_landing(wc_design_ids=[])
+        assert ctx.get("wc_owned_count") == 0
+
+
+# ── CEL-06: challenge_card count filtered to valid IDs ───────────────────────
+
+class TestCEL06ChallengeCardCount:
+
+    def test_cel_06_only_valid_cc_formats_counted(self):
+        """CEL-06: cc_owned_count ignores non-existent format IDs."""
+        ctx = _invoke_landing(cc_design_ids=[_CC_VALID_ID, "fake_challenge_format"])
+        assert ctx.get("cc_owned_count") == 1
+
+    def test_cel_06b_empty_cc_list_gives_zero(self):
+        """CEL-06b: cc_owned_count=0 when no CC designs owned."""
+        ctx = _invoke_landing(cc_design_ids=[])
+        assert ctx.get("cc_owned_count") == 0
+
+
+# ── CEL-07/08: any_owned boolean ─────────────────────────────────────────────
+
+class TestCEL0708AnyOwned:
+
+    def test_cel_07_any_owned_true_when_pc_owned(self):
+        """CEL-07: any_owned=True when player_card has owned designs."""
+        ctx = _invoke_landing(pc_design_ids=["fifa"])
+        assert ctx.get("any_owned") is True
+
+    def test_cel_07b_any_owned_true_when_wc_owned(self):
+        """CEL-07b: any_owned=True when welcome_card has owned designs."""
+        ctx = _invoke_landing(wc_design_ids=[_WC_VALID_ID])
+        assert ctx.get("any_owned") is True
+
+    def test_cel_07c_any_owned_true_when_cc_owned(self):
+        """CEL-07c: any_owned=True when challenge_card has owned designs."""
+        ctx = _invoke_landing(cc_design_ids=[_CC_VALID_ID])
+        assert ctx.get("any_owned") is True
+
+    def test_cel_08_any_owned_false_when_all_zero(self):
+        """CEL-08: any_owned=False when no family has owned designs."""
+        ctx = _invoke_landing(pc_design_ids=[], wc_design_ids=[], cc_design_ids=[])
+        assert ctx.get("any_owned") is False
+
+    def test_cel_08b_template_has_empty_state_block(self):
+        """CEL-08b: template source contains cs-empty-state block."""
+        src = (TEMPLATES_DIR / "card_studio_landing.html").read_text(encoding="utf-8")
+        assert "cs-empty-state" in src
+        assert "You don't own any card designs yet." in src
+        assert 'href="/shop/cards"' in src
+
+
+# ── CEL-09/10/11: CTA links ───────────────────────────────────────────────────
+
+class TestCEL091011CTALinks:
+
+    def test_cel_09_template_has_player_editor_cta(self):
+        """CEL-09: template contains /card-editor/player CTA for owned player card."""
+        src = (TEMPLATES_DIR / "card_studio_landing.html").read_text(encoding="utf-8")
+        assert 'href="/card-editor/player"' in src
+        assert "Open Editor" in src
+
+    def test_cel_10_template_has_welcome_cta(self):
+        """CEL-10: template contains /my-cards/welcome CTA for owned welcome card."""
+        src = (TEMPLATES_DIR / "card_studio_landing.html").read_text(encoding="utf-8")
+        assert 'href="/my-cards/welcome"' in src
+        assert "My Welcome Cards" in src
+
+    def test_cel_11_template_has_challenge_cta(self):
+        """CEL-11: template contains /my-cards/challenge CTA for owned challenge card."""
+        src = (TEMPLATES_DIR / "card_studio_landing.html").read_text(encoding="utf-8")
+        assert 'href="/my-cards/challenge"' in src
+        assert "My Challenge Cards" in src
+
+    def test_cel_09b_cs_player_editor_cta_class_present(self):
+        """CEL-09b: cs-player-editor-cta CSS class marks the player CTA for JS/test targeting."""
+        src = (TEMPLATES_DIR / "card_studio_landing.html").read_text(encoding="utf-8")
+        assert "cs-player-editor-cta" in src
+
+    def test_cel_10b_cs_welcome_cta_class_present(self):
+        """CEL-10b: cs-welcome-cta class marks the welcome CTA."""
+        src = (TEMPLATES_DIR / "card_studio_landing.html").read_text(encoding="utf-8")
+        assert "cs-welcome-cta" in src
+
+    def test_cel_11b_cs_challenge_cta_class_present(self):
+        """CEL-11b: cs-challenge-cta class marks the challenge CTA."""
+        src = (TEMPLATES_DIR / "card_studio_landing.html").read_text(encoding="utf-8")
+        assert "cs-challenge-cta" in src
+
+
+# ── CEL-12: route count = 837 ────────────────────────────────────────────────
+
+class TestCEL12RouteCount:
+
+    def test_cel_12_route_count_837(self):
+        """CEL-12: adding GET /card-editor raises route count from 836 to 837."""
+        from app.main import app
+        paths = app.openapi().get("paths", {})
+        assert len(paths) == 837, (
+            f"Expected 837 routes (836 CE-3.0 baseline + GET /card-editor), got {len(paths)}."
+        )
+
+    def test_cel_12b_card_editor_route_registered(self):
+        """CEL-12b: GET /card-editor is in the registered routes."""
+        from app.main import app
+        route_paths = [r.path for r in app.routes]
+        assert "/card-editor" in route_paths, "/card-editor must be a registered route"
+
+
+# ── CEL-13: OpenAPI snapshot updated ─────────────────────────────────────────
+
+class TestCEL13OpenAPISnapshot:
+
+    def test_cel_13_snapshot_matches_live_openapi(self):
+        """CEL-13: committed openapi_snapshot.json reflects the live 837-route API."""
+        snapshot_path = SNAPSHOTS_DIR / "openapi_snapshot.json"
+        assert snapshot_path.exists(), f"Snapshot not found: {snapshot_path}"
+
+        snapshot = json.loads(snapshot_path.read_text(encoding="utf-8"))
+        snap_paths = set(snapshot.get("paths", {}).keys())
+
+        from app.main import app
+        live_paths = set(app.openapi().get("paths", {}).keys())
+
+        assert "/card-editor" in snap_paths, (
+            "Snapshot must include /card-editor (regenerate with update_openapi_snapshot.py)"
+        )
+        assert snap_paths == live_paths, (
+            f"Snapshot paths differ from live API.\n"
+            f"In snapshot only: {snap_paths - live_paths}\n"
+            f"In live only: {live_paths - snap_paths}"
+        )
+
+
+# ── CEL-14: /card-editor/player regression ───────────────────────────────────
+
+class TestCEL14PlayerCardRegression:
+
+    def test_cel_14_player_card_editor_still_callable(self):
+        """CEL-14: lfa_player_card_editor handler still works after _FAMILY refactor."""
+        from app.api.web_routes.dashboard import lfa_player_card_editor
+        from app.models.card_draft import CardDraft
+
+        user        = MagicMock(); user.id = 42; user.credit_balance = 0
+        mock_license = MagicMock(); mock_license.onboarding_completed = True
+        db           = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = mock_license
+
+        _DASH_BASE = "app.api.web_routes.dashboard"
+        captured: dict = {}
+
+        def _fake_tmpl(tmpl, ctx, **kw):
+            captured["context"] = ctx
+            return MagicMock(status_code=200)
+
+        with patch(f"{_DASH_BASE}._CardDraftService") as MockCDS, \
+             patch(f"{_DASH_BASE}.templates") as mock_tpl, \
+             patch(f"{_DASH_BASE}.SemesterEnrollment"), \
+             patch("app.services.card_design_service.is_design_accessible", return_value=True), \
+             patch("app.services.card_variant_service.get_all_variants", return_value=[]), \
+             patch("app.services.card_color_service.get_colors_for_family", return_value=[]), \
+             patch("app.services.card_color_service.get_owned_color_ids",  return_value=set()), \
+             patch("app.services.card_platform_service.build_platform_list", return_value=[]), \
+             patch("app.services.card_constants.ANIMATED_EXPORT_CAPABLE", []), \
+             patch("app.services.card_constants.CANVAS_SIZES", {}), \
+             patch("app.services.card_constants.CARD_EDITOR_PLATFORM_IDS", []), \
+             patch("app.services.highlight_video_service.build_youtube_embed_url", return_value=None):
+            draft = MagicMock()
+            draft.draft_theme    = "default"
+            draft.draft_variant  = "fifa"
+            draft.draft_platform = None
+            draft.draft_data     = None
+            draft.published_theme    = "default"
+            draft.published_variant  = "fifa"
+            draft.published_platform = None
+            draft.published_data     = None
+            MockCDS.get_draft.return_value = draft
+            mock_tpl.TemplateResponse.side_effect = _fake_tmpl
+            try:
+                asyncio.run(lfa_player_card_editor(
+                    request=MagicMock(), db=db, user=user,
+                ))
+            except Exception:
+                pass
+
+        assert captured.get("context"), "lfa_player_card_editor must still populate context"
+        assert captured["context"].get("active_card_variant") is not None
+
+    def test_cel_14b_player_card_editor_uses_get_draft_api(self):
+        """CEL-14b: lfa_player_card_editor calls CardDraftService.get_draft (CE-3.0 API)."""
+        from app.api.web_routes.dashboard import lfa_player_card_editor
+
+        user        = MagicMock(); user.id = 42; user.credit_balance = 0
+        mock_license = MagicMock(); mock_license.onboarding_completed = True
+        db           = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = mock_license
+
+        _DASH_BASE = "app.api.web_routes.dashboard"
+
+        with patch(f"{_DASH_BASE}._CardDraftService") as MockCDS, \
+             patch(f"{_DASH_BASE}.templates") as mock_tpl, \
+             patch(f"{_DASH_BASE}.SemesterEnrollment"), \
+             patch("app.services.card_design_service.is_design_accessible", return_value=True), \
+             patch("app.services.card_variant_service.get_all_variants", return_value=[]), \
+             patch("app.services.card_color_service.get_colors_for_family", return_value=[]), \
+             patch("app.services.card_color_service.get_owned_color_ids",  return_value=set()), \
+             patch("app.services.card_platform_service.build_platform_list", return_value=[]), \
+             patch("app.services.card_constants.ANIMATED_EXPORT_CAPABLE", []), \
+             patch("app.services.card_constants.CANVAS_SIZES", {}), \
+             patch("app.services.card_constants.CARD_EDITOR_PLATFORM_IDS", []), \
+             patch("app.services.highlight_video_service.build_youtube_embed_url", return_value=None):
+            draft = MagicMock()
+            draft.draft_theme = draft.draft_variant = "default"
+            draft.draft_platform = draft.draft_data = None
+            draft.published_theme = draft.published_variant = None
+            draft.published_platform = draft.published_data = None
+            MockCDS.get_draft.return_value = draft
+            mock_tpl.TemplateResponse.side_effect = lambda t, c, **kw: MagicMock()
+            try:
+                asyncio.run(lfa_player_card_editor(
+                    request=MagicMock(), db=db, user=user,
+                ))
+            except Exception:
+                pass
+
+        MockCDS.get_draft.assert_called_once_with(db, user.id, "player_card")
+        MockCDS.get_player_card_draft.assert_not_called()

--- a/tests/unit/api/web_routes/test_family_color_shop.py
+++ b/tests/unit/api/web_routes/test_family_color_shop.py
@@ -223,8 +223,8 @@ class TestRouteRegistration:
     def test_ts_13_route_count_836(self):
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 836, (
-            f"Expected 836 routes (834 CE-2 baseline + 2 TS-1), got {len(paths)}."
+        assert len(paths) == 837, (
+            f"Expected 837 routes (834 CE-2 + 2 TS-1 + 1 CE-3.1), got {len(paths)}."
         )
 
     def test_ts_14_unlock_theme_still_registered(self):


### PR DESCRIPTION
## Summary

- **New route**: `GET /card-editor` — Card Studio landing page, authenticated entry point
- **3 family tiles**: Player Card / Welcome Card / Challenge Card with owned-count display
- **CTA logic**: owned → editor/my-cards link; not owned → shop link; all zero → global empty state
- **Player Card handler prep**: `_FAMILY = "player_card"` variable + `get_draft()` API (CE-3.0) — no behavior change
- **Route count**: 836 → 837
- **27 CEL tests** (CEL-01..CEL-14) + updated CD-RT / CE2-17 / TS-13

## Scope (CE-3.1 only)

No Welcome Card Studio, No Challenge Card Studio, No Mood Photo picker, No photo upload refactor, No highlight video route refactor, No legacy cleanup, No migration, No model changes.

## Test plan

- [ ] `pytest tests/unit/api/web_routes/test_card_studio_landing.py` — 27/27 PASS
- [ ] Full unit suite: 11739 PASS, 0 FAIL
- [ ] Manual QA: /card-editor 200 auth, 401 unauth, 3 tiles, empty state, player editor compat, legacy redirect 303

🤖 Generated with [Claude Code](https://claude.com/claude-code)