### PR TITLE
feat(ce3): CE-3.2 — Card Studio nav refinement (quicknav + profile editor)

### DIFF
--- a/app/api/web_routes/dashboard.py
+++ b/app/api/web_routes/dashboard.py
@@ -1609,7 +1609,7 @@ async def lfa_public_profile_editor(
             "published_slots":  published_slots,
             "is_published":     is_pub,
             "profile_url":      f"/players/{user.id}",
-            "card_editor_url":  "/card-editor/player",
+            "card_editor_url":  "/card-editor",
         },
     )
 

--- a/app/templates/includes/spec_subpage_hdr.html
+++ b/app/templates/includes/spec_subpage_hdr.html
@@ -120,8 +120,8 @@
            class="spec-qn-item{% if _rp == '/profile/lfa-football-player' %} sqn-active{% endif %}">🪪 Profile</a>
         <a href="/my-cards"
            class="spec-qn-item{% if _rp.startswith('/my-cards') %} sqn-active{% endif %}">🃏 My Cards</a>
-        <a href="/card-editor/player"
-           class="spec-qn-item{% if 'card-editor' in _rp %} sqn-active{% endif %}">🎴 Card Editor</a>
+        <a href="/card-editor"
+           class="spec-qn-item{% if 'card-editor' in _rp %} sqn-active{% endif %}">🎨 Card Studio</a>
         <a href="/profile/my-mood-photos"
            class="spec-qn-item{% if _rp == '/profile/my-mood-photos' %} sqn-active{% endif %}">📸 Mood Photos</a>
         <a href="/events"

--- a/tests/unit/api/web_routes/test_card_editor_ce1.py
+++ b/tests/unit/api/web_routes/test_card_editor_ce1.py
@@ -292,63 +292,74 @@ class TestCE108LegacyAuth:
 # ── CE1-09 — internal links point to new URL ─────────────────────────────────
 
 class TestCE109InternalLinks:
-    """CE1-09: all navigation links to the card editor use /card-editor/player."""
+    """CE1-09: navigation links use correct card editor URLs.
 
-    OLD_URL = "/dashboard/lfa-football-player/card-editor"
-    NEW_URL = "/card-editor/player"
+    CE-3.2 refinement:
+    - Global quicknav (spec_subpage_hdr.html) → /card-editor (Card Studio landing)
+    - card_editor_url context (profile editor) → /card-editor (general entry)
+    - Player-specific CTAs (my-cards, shop, profile #media) → /card-editor/player (direct)
+    """
 
-    _TEMPLATE_CHECKS = [
-        "includes/spec_subpage_hdr.html",
-        "lfa_player_profile.html",
-        "my_cards_player_card.html",
-        "shop_player_card.html",
-        "shop_player_card_detail.html",
-    ]
+    OLD_URL    = "/dashboard/lfa-football-player/card-editor"
+    PLAYER_URL = "/card-editor/player"
+    STUDIO_URL = "/card-editor"
 
     def _html(self, rel_path: str) -> str:
         return (TEMPLATES_DIR / rel_path).read_text(encoding="utf-8")
 
     def test_ce1_09_spec_subpage_hdr_link(self):
+        """CE-3.2: quicknav links to Card Studio landing, not directly to player editor."""
         html = self._html("includes/spec_subpage_hdr.html")
-        assert f'href="{self.NEW_URL}"' in html
-        # The href must use the new URL (active-state href)
+        assert f'href="{self.STUDIO_URL}"' in html, (
+            "spec_subpage_hdr.html quicknav must link to /card-editor (Card Studio landing)"
+        )
+        assert f'href="{self.PLAYER_URL}"' not in html, (
+            "spec_subpage_hdr.html quicknav must NOT have a direct /card-editor/player link "
+            "(CE-3.2: global nav points to family picker)"
+        )
         assert f'href="{self.OLD_URL}"' not in html
 
     def test_ce1_09_lfa_player_profile_link(self):
+        """#media deep-link stays /card-editor/player — player-specific action."""
         html = self._html("lfa_player_profile.html")
-        assert f'href="{self.NEW_URL}#media"' in html
+        assert f'href="{self.PLAYER_URL}#media"' in html
         assert f'href="{self.OLD_URL}#media"' not in html
 
     def test_ce1_09_my_cards_player_card_link(self):
+        """my_cards_player_card.html Open Editor CTA stays /card-editor/player."""
         html = self._html("my_cards_player_card.html")
-        assert f'href="{self.NEW_URL}"' in html
+        assert f'href="{self.PLAYER_URL}"' in html
         assert f'href="{self.OLD_URL}"' not in html
 
     def test_ce1_09_shop_player_card_link(self):
+        """shop_player_card.html Edit/Download CTA stays /card-editor/player."""
         html = self._html("shop_player_card.html")
-        assert f'href="{self.NEW_URL}"' in html
+        assert f'href="{self.PLAYER_URL}"' in html
         assert f'href="{self.OLD_URL}"' not in html
 
     def test_ce1_09_shop_player_card_detail_link(self):
+        """shop_player_card_detail.html Open Editor CTA stays /card-editor/player."""
         html = self._html("shop_player_card_detail.html")
-        assert f'href="{self.NEW_URL}"' in html
+        assert f'href="{self.PLAYER_URL}"' in html
         assert f'href="{self.OLD_URL}"' not in html
 
     def test_ce1_09_dashboard_card_editor_no_nav_old_url(self):
         """dashboard_card_editor.html must not contain the old URL as a nav href
         (the highlight-video API endpoint is a fetch call, not a nav link — allowed)."""
         html = self._html("dashboard_card_editor.html")
-        # Only API fetch calls are allowed to reference the old path
         nav_old = f'href="{self.OLD_URL}"'
         assert nav_old not in html, (
             f"Found navigation link to old URL in dashboard_card_editor.html: {nav_old}"
         )
 
     def test_ce1_09_api_context_var_updated(self):
-        """The card_editor_url context variable in dashboard.py uses new URL."""
+        """CE-3.2: card_editor_url context variable points to Card Studio landing."""
         src = (
             Path(__file__).resolve().parents[4]
             / "app" / "api" / "web_routes" / "dashboard.py"
         ).read_text()
-        assert f'"card_editor_url":  "{self.NEW_URL}"' in src
+        assert f'"card_editor_url":  "{self.STUDIO_URL}"' in src, (
+            "card_editor_url must be /card-editor (Card Studio landing)"
+        )
+        assert f'"card_editor_url":  "{self.PLAYER_URL}"' not in src
         assert f'"card_editor_url":  "{self.OLD_URL}"' not in src

--- a/tests/unit/api/web_routes/test_mood_photos.py
+++ b/tests/unit/api/web_routes/test_mood_photos.py
@@ -309,8 +309,8 @@ def test_mp_r12_dashboard_has_card_media_section():
     assert "/profile/my-mood-photos" in quicknav, (
         "quicknav should still link to /profile/my-mood-photos"
     )
-    assert "/card-editor/player" in quicknav, (
-        "quicknav should still link to card-editor"
+    assert "/card-editor" in quicknav, (
+        "quicknav should still link to Card Studio (/card-editor)"
     )
 
 
@@ -453,7 +453,7 @@ def test_mp_r17_spec_subpage_hdr_has_lfa_quicknav():
     required_links = {
         "/profile/lfa-football-player": "Profile",
         "/my-cards":                    "My Cards",
-        "/card-editor/player": "Card Editor",
+        "/card-editor":       "Card Studio",   # CE-3.2: landing → /card-editor
         "/profile/my-mood-photos":      "Mood Photos",
         "/events":                      "Events",
         "/training":                    "Training",
@@ -485,10 +485,10 @@ def test_mp_r18_dashboard_modnav_has_profile_editor_moodphotos():
     for url in ("/calendar", "/achievements", "/sessions", "/progress"):
         assert url in modnav_block, f"dashboard mod-nav missing Quick Access tile: {url!r}"
 
-    # Mood Photos, Card Editor, Profile accessible via quicknav (not mod-nav)
-    assert "/profile/my-mood-photos"                    in quicknav
-    assert "/card-editor/player" in quicknav
-    assert "/profile/lfa-football-player"               in quicknav
+    # Mood Photos, Card Studio, Profile accessible via quicknav (not mod-nav)
+    assert "/profile/my-mood-photos"       in quicknav
+    assert "/card-editor" in quicknav      # CE-3.2: general Card Studio entry
+    assert "/profile/lfa-football-player"  in quicknav
 
 
 # ── MP-R19 ── mood_photos_page route passes explicit LFA spec context ─────────


### PR DESCRIPTION
## Summary

CE-3.2: Small navigation refinement — global quicknav and profile editor link updated to point to Card Studio landing (`/card-editor`) instead of directly to the Player Card editor.

**Changed:**
- `spec_subpage_hdr.html`: quicknav href `/card-editor/player` → `/card-editor`; label "🎴 Card Editor" → "🎨 Card Studio"
- `dashboard.py`: `card_editor_url` context `/card-editor/player` → `/card-editor` (feeds profile editor "Card Editor" button)

**Unchanged (player-specific CTAs):**
- `my_cards_player_card.html` "Open Editor →" → `/card-editor/player`
- `shop_player_card.html` "Edit / Download" → `/card-editor/player`
- `shop_card_player_colors.html` "Open Card Editor →" → `/card-editor/player`
- `shop_player_card_detail.html` "Open Editor →" → `/card-editor/player`
- `lfa_player_profile.html` `#media` deep-link → `/card-editor/player#media`
- `card_studio_landing.html` Player tile CTA → `/card-editor/player`

**No new routes. Route count 837 unchanged. OpenAPI snapshot unchanged.**

## Test plan

- [ ] `test_card_editor_ce1.py` — 26 CE1-* tests including updated CE1-09
- [ ] `test_mood_photos.py` — 40 MP-* tests including updated MP-R12/17/18
- [ ] Full unit suite: 11758 PASS, 0 FAIL

🤖 Generated with [Claude Code](https://claude.com/claude-code)