### PR TITLE
feat(ce3): CE-3.3 — Welcome Card Studio (GET /card-editor/welcome, draft-free)

### DIFF
--- a/app/api/web_routes/card_editor.py
+++ b/app/api/web_routes/card_editor.py
@@ -2,11 +2,12 @@
 
 Phase WCE-1:  Welcome Card Customizer (preview + export wrapper, no draft).
 Phase CE-3.1: Card Studio landing — /card-editor entry point.
+Phase CE-3.3: Welcome Card Studio — /card-editor/welcome (draft-free, query-param format).
 Future: /card-editor/player/{collection_id}, /card-editor/challenge/{id}
 """
 from pathlib import Path
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from sqlalchemy.orm import Session
@@ -89,7 +90,95 @@ async def card_studio_landing(
     )
 
 
-# ── Welcome Card Customizer ───────────────────────────────────────────────────
+# ── Welcome Card Studio ──────────────────────────────────────────────────────
+
+@router.get("/card-editor/welcome", response_class=HTMLResponse)
+async def card_studio_welcome(
+    request: Request,
+    format_id: str | None = Query(default=None, alias="format"),
+    db: Session = Depends(get_db),
+    user: User  = Depends(get_current_user_web),
+):
+    """Welcome Card Studio — draft-free entry point (CE-3.3).
+
+    Owned-only format selector with preview and export.  Active format is
+    driven by the ?format= query param; absent or invalid values redirect to
+    the canonical URL for the first owned format.
+
+    Guards (same pattern as welcome_card_editor / WCE-1):
+      1. Authenticated (get_current_user_web)
+      2. LFA_FOOTBALL_PLAYER license + onboarding complete
+      3. No owned formats → redirect shop
+      4. No/invalid ?format → 303 canonical first owned format URL
+    """
+    # ── Guard 2: license + onboarding (identical to WCE-1) ───────────────────
+    license = db.query(UserLicense).filter(
+        UserLicense.user_id == user.id,
+        UserLicense.specialization_type == "LFA_FOOTBALL_PLAYER",
+    ).first()
+    if not license:
+        return RedirectResponse(
+            url="/dashboard?info=complete_lfa_onboarding_first", status_code=303
+        )
+    if not license.onboarding_completed:
+        return RedirectResponse(
+            url="/specialization/lfa-player/onboarding", status_code=303
+        )
+
+    # ── Guard 3: owned formats — WELCOME_CARD_FORMATS order preserved ─────────
+    owned_set = set(get_owned_design_ids(db, user.id, "welcome_card")) & _WC_VALID_IDS
+    owned_formats_ordered = [
+        f for f in WELCOME_CARD_FORMATS if f.design_id in owned_set
+    ]
+    if not owned_formats_ordered:
+        return RedirectResponse(url="/shop/cards/welcome", status_code=303)
+
+    first_owned_id = owned_formats_ordered[0].design_id
+
+    # ── Guard 4: canonical redirect for absent/invalid/unowned format ─────────
+    if format_id is None or format_id not in owned_set:
+        return RedirectResponse(
+            url=f"/card-editor/welcome?format={first_owned_id}", status_code=303
+        )
+
+    # ── 200 path — format_id is valid and owned ───────────────────────────────
+    fmt         = _WC_FORMAT_BY_ID[format_id]
+    ratio_class = _WC_RATIO.get(fmt.preview_platform, "mfg-ratio-11")
+    preview_url = f"/profile/onboarding-card?platform={fmt.preview_platform}"
+    export_url  = f"/profile/onboarding-card/export?platform={fmt.preview_platform}"
+
+    owned_format_rows = [
+        {
+            "design_id":   f.design_id,
+            "label":       f.label,
+            "style_tag":   f.style_tag,
+            "dims":        f.dims,
+            "preview_url": f"/profile/onboarding-card?platform={f.preview_platform}",
+            "active":      f.design_id == format_id,
+        }
+        for f in owned_formats_ordered
+    ]
+
+    return templates.TemplateResponse(
+        "card_studio_welcome.html",
+        {
+            "request":            request,
+            "user":               user,
+            "active_format":      format_id,
+            "fmt":                fmt,
+            "ratio_class":        ratio_class,
+            "preview_url":        preview_url,
+            "export_url":         export_url,
+            "owned_format_rows":  owned_format_rows,
+            "spec_dashboard_url":  "/dashboard/lfa-football-player",
+            "spec_dashboard_icon": "⚽",
+            "spec_profile_url":    "/profile/lfa-football-player",
+            "spec_profile_icon":   "🪪",
+        },
+    )
+
+
+# ── Welcome Card Customizer (WCE-1 — per-format, unchanged) ──────────────────
 
 @router.get("/card-editor/welcome/{format_id}", response_class=HTMLResponse)
 async def welcome_card_editor(

--- a/app/templates/card_studio_welcome.html
+++ b/app/templates/card_studio_welcome.html
@@ -1,0 +1,237 @@
+{% extends "student_base.html" %}
+
+{% block title %}Welcome Card Studio — LFA Education Center{% endblock %}
+{% block active_page %}lfa-player{% endblock %}
+
+{% block student_header %}
+{% set _page_icon = '👋' %}
+{% set _page_name = 'Welcome Card Studio' %}
+{% include "includes/spec_subpage_hdr.html" %}
+{% endblock %}
+
+{% block extra_styles %}
+{% include "includes/mc_format_grid.html" %}
+<style>
+  .wcs-wrap {
+    max-width: 860px;
+    margin: 0 auto;
+    padding: 1.5rem 1rem 4rem;
+  }
+
+  /* ── Header ── */
+  .wcs-breadcrumb {
+    font-size: 0.8rem;
+    color: #64748b;
+    margin-bottom: 1.25rem;
+  }
+  .wcs-breadcrumb a { color: #94a3b8; text-decoration: none; }
+  .wcs-breadcrumb a:hover { color: #f1f5f9; }
+  .wcs-breadcrumb span { margin: 0 0.35rem; }
+
+  .wcs-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 1.25rem;
+  }
+  .wcs-header h1 { font-size: 1.4rem; font-weight: 700; color: #f8fafc; margin: 0; }
+
+  /* ── Format selector ── */
+  .wcs-format-selector {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 1.5rem;
+  }
+  .wcs-format-btn {
+    display: inline-flex;
+    flex-direction: column;
+    align-items: flex-start;
+    padding: 0.5rem 0.85rem;
+    border-radius: 8px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    text-decoration: none;
+    border: 1px solid #334155;
+    color: #94a3b8;
+    background: transparent;
+    transition: border-color 0.15s, color 0.15s;
+    line-height: 1.3;
+  }
+  .wcs-format-btn:hover { border-color: #64748b; color: #f1f5f9; text-decoration: none; }
+  .wcs-format-btn.wcs-active {
+    border-color: #FFD200;
+    color: #FFD200;
+    background: rgba(255, 210, 0, 0.06);
+  }
+  .wcs-format-dims { font-size: 0.68rem; font-weight: 400; color: #475569; margin-top: 0.1rem; }
+  .wcs-format-btn.wcs-active .wcs-format-dims { color: #b89c00; }
+
+  /* ── Active format meta ── */
+  .wcs-meta {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    margin-bottom: 1.25rem;
+  }
+  .wcs-style-tag {
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #64748b;
+  }
+  .wcs-dims { font-size: 0.8rem; color: #475569; }
+  .wcs-owned-badge {
+    font-size: 0.75rem;
+    font-weight: 700;
+    color: #86efac;
+    background: rgba(134,239,172,.12);
+    border: 1px solid rgba(134,239,172,.25);
+    border-radius: 20px;
+    padding: 0.2rem 0.65rem;
+  }
+
+  /* ── Preview ── */
+  .wcs-preview-panel {
+    background: #0f172a;
+    border: 1px solid #1e293b;
+    border-radius: 14px;
+    padding: 1.25rem;
+    margin-bottom: 1.5rem;
+  }
+  .wcs-preview-label {
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+    color: #475569;
+    margin-bottom: 0.75rem;
+  }
+  .wcs-preview-container { display: flex; justify-content: center; }
+  .wcs-preview-wrap {
+    width: 100%;
+    max-width: 320px;
+    position: relative;
+    border-radius: 8px;
+    overflow: hidden;
+    background: #0b1120;
+  }
+
+  /* ── Export ── */
+  .wcs-export-panel {
+    background: #0f172a;
+    border: 1px solid #1e293b;
+    border-radius: 14px;
+    padding: 1.25rem 1.5rem;
+    margin-bottom: 1.5rem;
+  }
+  .wcs-export-title { font-size: 1rem; font-weight: 700; color: #f1f5f9; margin: 0 0 0.3rem; }
+  .wcs-export-sub   { font-size: 0.8rem; color: #475569; margin: 0 0 1rem; }
+  .wcs-btn-download {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.6rem 1.4rem;
+    background: #FFD200;
+    color: #0f172a;
+    font-size: 0.875rem;
+    font-weight: 700;
+    border-radius: 8px;
+    text-decoration: none;
+    transition: opacity 0.15s;
+  }
+  .wcs-btn-download:hover { opacity: 0.88; color: #0f172a; text-decoration: none; }
+
+  /* ── Nav ── */
+  .wcs-nav {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+    margin-top: 2rem;
+  }
+  .wcs-nav-back {
+    font-size: 0.82rem;
+    font-weight: 600;
+    color: #93c5fd;
+    text-decoration: none;
+  }
+  .wcs-nav-back:hover { color: #bfdbfe; text-decoration: none; }
+  .wcs-nav-shop {
+    font-size: 0.82rem;
+    font-weight: 600;
+    color: #FFD200;
+    text-decoration: none;
+  }
+  .wcs-nav-shop:hover { opacity: 0.85; text-decoration: none; }
+</style>
+{% endblock %}
+
+{% block student_content %}
+<div class="wcs-wrap">
+
+  <nav class="wcs-breadcrumb" aria-label="Breadcrumb">
+    <a href="/card-editor">Card Studio</a>
+    <span>›</span>
+    <a href="/my-cards/welcome">Welcome Card</a>
+    <span>›</span>
+    <span>{{ fmt.label }}</span>
+  </nav>
+
+  <div class="wcs-header">
+    <h1>Welcome Card Studio</h1>
+  </div>
+
+  {# ── Format selector ── #}
+  <div class="wcs-format-selector">
+    {% for f in owned_format_rows %}
+      <a href="/card-editor/welcome?format={{ f.design_id }}"
+         class="wcs-format-btn{% if f.active %} wcs-active{% endif %}">
+        {{ f.label }}
+        <span class="wcs-format-dims">{{ f.dims }}</span>
+      </a>
+    {% endfor %}
+  </div>
+
+  <div class="wcs-meta">
+    <span class="wcs-style-tag">{{ fmt.style_tag }}</span>
+    <span class="wcs-dims">{{ fmt.dims }}</span>
+    <span class="wcs-owned-badge">Owned ✓</span>
+  </div>
+
+  {# ── Preview panel ── #}
+  <div class="wcs-preview-panel">
+    <p class="wcs-preview-label">Preview</p>
+    <div class="wcs-preview-container">
+      <div class="wcs-preview-wrap mfg-preview-wrap {{ ratio_class }}">
+        <iframe
+          class="mfg-preview-iframe"
+          src="{{ preview_url }}"
+          loading="lazy"
+          scrolling="no"
+          title="{{ fmt.label }} Welcome Card preview"
+        ></iframe>
+      </div>
+    </div>
+  </div>
+
+  {# ── Export panel ── #}
+  <div class="wcs-export-panel">
+    <p class="wcs-export-title">Download your Welcome Card</p>
+    <p class="wcs-export-sub">Exports a full-resolution PNG at {{ fmt.dims }} using your current player data.</p>
+    <a href="{{ export_url }}" class="wcs-btn-download" download>
+      ↓ Download PNG ({{ fmt.dims }})
+    </a>
+  </div>
+
+  {# ── Navigation ── #}
+  <div class="wcs-nav">
+    <a href="/my-cards/welcome" class="wcs-nav-back">← My Welcome Cards</a>
+    <a href="/shop/cards/welcome" class="wcs-nav-shop">Browse Welcome Formats →</a>
+  </div>
+
+</div>
+{% endblock %}

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -59896,6 +59896,57 @@
         ]
       }
     },
+    "/card-editor/welcome": {
+      "get": {
+        "description": "Welcome Card Studio \u2014 draft-free entry point (CE-3.3).\n\nOwned-only format selector with preview and export.  Active format is\ndriven by the ?format= query param; absent or invalid values redirect to\nthe canonical URL for the first owned format.\n\nGuards (same pattern as welcome_card_editor / WCE-1):\n  1. Authenticated (get_current_user_web)\n  2. LFA_FOOTBALL_PLAYER license + onboarding complete\n  3. No owned formats \u2192 redirect shop\n  4. No/invalid ?format \u2192 303 canonical first owned format URL",
+        "operationId": "card_studio_welcome_card_editor_welcome_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Format"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Card Studio Welcome",
+        "tags": [
+          "web",
+          "card-editor"
+        ]
+      }
+    },
     "/card-editor/welcome/{format_id}": {
       "get": {
         "description": "Welcome Card Customizer \u2014 preview + export wrapper for an owned format.\n\nGuards (in order):\n  1. Authenticated (get_current_user_web)\n  2. LFA_FOOTBALL_PLAYER license + onboarding complete\n  3. format_id in WELCOME_CARD_FORMATS \u2192 404 otherwise\n  4. CDO ownership (is_design_accessible) \u2192 redirect shop if not owned\n     Admin bypass: skipped for UserRole.ADMIN",

--- a/tests/unit/api/web_routes/test_card_editor_ce2.py
+++ b/tests/unit/api/web_routes/test_card_editor_ce2.py
@@ -418,9 +418,9 @@ class TestCE216WelcomeEditorUnchanged:
 
 class TestCE217RouteCount:
     def test_openapi_snapshot_route_count_unchanged(self):
-        """CE-3.1 adds GET /card-editor — snapshot path count must equal 837."""
+        """CE-3.3 adds GET /card-editor/welcome — snapshot path count must equal 838."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 837, (
-            f"Expected 837 routes (834 CE-2 + 2 TS-1 + 1 CE-3.1), got {len(paths)}."
+        assert len(paths) == 838, (
+            f"Expected 838 routes (834 CE-2 + 2 TS-1 + 1 CE-3.1 + 1 CE-3.3), got {len(paths)}."
         )

--- a/tests/unit/api/web_routes/test_card_studio_landing.py
+++ b/tests/unit/api/web_routes/test_card_studio_landing.py
@@ -295,11 +295,11 @@ class TestCEL091011CTALinks:
 class TestCEL12RouteCount:
 
     def test_cel_12_route_count_837(self):
-        """CEL-12: adding GET /card-editor raises route count from 836 to 837."""
+        """CE-3.3 adds GET /card-editor/welcome — total route count is 838."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 837, (
-            f"Expected 837 routes (836 CE-3.0 baseline + GET /card-editor), got {len(paths)}."
+        assert len(paths) == 838, (
+            f"Expected 838 routes (836 CE-3.0 + 1 CE-3.1 + 1 CE-3.3), got {len(paths)}."
         )
 
     def test_cel_12b_card_editor_route_registered(self):

--- a/tests/unit/api/web_routes/test_card_studio_welcome.py
+++ b/tests/unit/api/web_routes/test_card_studio_welcome.py
@@ -1,0 +1,494 @@
+"""
+CEW — Welcome Card Studio tests (CE-3.3).
+
+GET /card-editor/welcome — draft-free WC Studio with ?format= query param.
+
+CEW-01  authenticated valid owned ?format → 200
+CEW-02  unauthenticated → auth guard (get_current_user_web)
+CEW-03  no LFA license → 303 /dashboard
+CEW-04  onboarding incomplete → 303 /specialization
+CEW-05  no owned formats → 303 /shop/cards/welcome
+CEW-06  no ?format param → 303 canonical first owned URL
+CEW-07  invalid ?format param (unknown format) → 303 canonical first owned URL
+CEW-08  unowned ?format param → 303 canonical first owned URL
+CEW-09  valid owned ?format → active_format in context matches param
+CEW-10  owned_format_rows contains only owned format IDs
+CEW-11  owned_format_rows respects WELCOME_CARD_FORMATS order
+CEW-12  preview_url = /profile/onboarding-card?platform={active_format}
+CEW-13  export_url = /profile/onboarding-card/export?platform={active_format}
+CEW-14  template contains format selector (owned_format_rows present)
+CEW-15  legacy "default" CDO bulk-grant: all 7 valid formats visible
+CEW-16  CardDraftService is never called
+CEW-17  /card-editor/welcome/{format_id} WCE-1 route unchanged
+CEW-18  route count = 838 (837 + GET /card-editor/welcome)
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.card_design_service import WELCOME_CARD_FORMATS
+
+_CE_BASE = "app.api.web_routes.card_editor"
+
+TEMPLATES_DIR = Path(__file__).resolve().parents[4] / "app" / "templates"
+
+# All valid WC format IDs in canonical WELCOME_CARD_FORMATS order
+_ALL_WC_IDS: list[str] = [f.design_id for f in WELCOME_CARD_FORMATS]
+# One known-valid owned ID used for most tests
+_FIRST_ID = _ALL_WC_IDS[0]   # "instagram_portrait"
+_SECOND_ID = _ALL_WC_IDS[1]  # "instagram_story"
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _user(uid: int = 42) -> MagicMock:
+    u = MagicMock()
+    u.id = uid
+    u.credit_balance = 500
+    u.role = MagicMock()
+    return u
+
+
+def _license(onboarding_completed: bool = True) -> MagicMock:
+    lic = MagicMock()
+    lic.onboarding_completed = onboarding_completed
+    return lic
+
+
+def _db_with_license(license_obj) -> MagicMock:
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = license_obj
+    return db
+
+
+def _invoke_welcome(
+    format_param: str | None,
+    owned_ids: list[str],
+    license_obj=None,
+    user_obj=None,
+) -> tuple[MagicMock, dict, MagicMock]:
+    """
+    Call card_studio_welcome and return (response, context, mock_cds).
+    context is empty dict if a redirect was returned.
+    """
+    from app.api.web_routes.card_editor import card_studio_welcome
+
+    user = user_obj or _user()
+    lic  = license_obj if license_obj is not None else _license(onboarding_completed=True)
+    db   = _db_with_license(lic)
+    captured: dict = {}
+
+    def _fake_tmpl(tmpl, ctx, **kw):
+        captured["context"] = ctx
+        return MagicMock(status_code=200)
+
+    with patch(f"{_CE_BASE}.get_owned_design_ids", return_value=owned_ids), \
+         patch(f"{_CE_BASE}.templates") as mock_tpl:
+        mock_tpl.TemplateResponse.side_effect = _fake_tmpl
+
+        request = MagicMock()
+        resp = _run(card_studio_welcome(
+            request=request,
+            format_id=format_param,
+            db=db,
+            user=user,
+        ))
+
+    return resp, captured.get("context", {}), None
+
+
+# ── CEW-01: authenticated valid owned format → 200 ───────────────────────────
+
+class TestCEW01Authenticated:
+
+    def test_cew_01_valid_owned_format_returns_200(self):
+        """CEW-01: valid owned ?format → handler callable, context captured."""
+        _, ctx, _ = _invoke_welcome(_FIRST_ID, owned_ids=[_FIRST_ID])
+        assert ctx, "context must be captured (200 path)"
+
+    def test_cew_01_template_is_welcome_studio(self):
+        """CEW-01: handler renders card_studio_welcome.html."""
+        from app.api.web_routes.card_editor import card_studio_welcome
+
+        user = _user()
+        lic  = _license(onboarding_completed=True)
+        db   = _db_with_license(lic)
+        captured: dict = {}
+
+        def _fake(tmpl, ctx, **kw):
+            captured["template"] = tmpl
+            return MagicMock(status_code=200)
+
+        with patch(f"{_CE_BASE}.get_owned_design_ids", return_value=[_FIRST_ID]), \
+             patch(f"{_CE_BASE}.templates") as mock_tpl:
+            mock_tpl.TemplateResponse.side_effect = _fake
+            _run(card_studio_welcome(
+                request=MagicMock(), format_id=_FIRST_ID, db=db, user=user,
+            ))
+
+        assert captured.get("template") == "card_studio_welcome.html"
+
+
+# ── CEW-02: auth dependency on route ─────────────────────────────────────────
+
+class TestCEW02AuthGuard:
+
+    def test_cew_02_route_has_get_current_user_web_dependency(self):
+        """CEW-02: /card-editor/welcome has get_current_user_web in dependant tree."""
+        from app.main import app
+        route = next(
+            (r for r in app.routes if getattr(r, "path", None) == "/card-editor/welcome"),
+            None,
+        )
+        assert route is not None, "/card-editor/welcome route must be registered"
+        dep_names = [
+            getattr(d.call, "__name__", "")
+            for d in getattr(route.dependant, "dependencies", [])
+        ]
+        assert "get_current_user_web" in dep_names, (
+            f"/card-editor/welcome must depend on get_current_user_web; found: {dep_names}"
+        )
+
+
+# ── CEW-03: no LFA license → 303 /dashboard ──────────────────────────────────
+
+class TestCEW03NoLicense:
+
+    def test_cew_03_no_license_redirects_to_dashboard(self):
+        """CEW-03: missing LFA license → 303 to /dashboard."""
+        from fastapi.responses import RedirectResponse
+        from app.api.web_routes.card_editor import card_studio_welcome
+
+        user = _user()
+        db   = _db_with_license(None)   # no license row
+
+        with patch(f"{_CE_BASE}.get_owned_design_ids", return_value=[_FIRST_ID]):
+            resp = _run(card_studio_welcome(
+                request=MagicMock(), format_id=_FIRST_ID, db=db, user=user,
+            ))
+
+        assert isinstance(resp, RedirectResponse)
+        assert resp.status_code == 303
+        assert "/dashboard" in resp.headers["location"]
+
+
+# ── CEW-04: onboarding incomplete → 303 /specialization ──────────────────────
+
+class TestCEW04OnboardingIncomplete:
+
+    def test_cew_04_onboarding_incomplete_redirects_to_onboarding(self):
+        """CEW-04: onboarding not complete → 303 to /specialization."""
+        from fastapi.responses import RedirectResponse
+        from app.api.web_routes.card_editor import card_studio_welcome
+
+        user = _user()
+        db   = _db_with_license(_license(onboarding_completed=False))
+
+        with patch(f"{_CE_BASE}.get_owned_design_ids", return_value=[_FIRST_ID]):
+            resp = _run(card_studio_welcome(
+                request=MagicMock(), format_id=_FIRST_ID, db=db, user=user,
+            ))
+
+        assert isinstance(resp, RedirectResponse)
+        assert resp.status_code == 303
+        assert "onboarding" in resp.headers["location"]
+
+
+# ── CEW-05: no owned formats → 303 /shop/cards/welcome ───────────────────────
+
+class TestCEW05NoOwnedFormats:
+
+    def test_cew_05_no_owned_redirects_to_shop(self):
+        """CEW-05: no owned WC formats → 303 /shop/cards/welcome."""
+        from fastapi.responses import RedirectResponse
+        from app.api.web_routes.card_editor import card_studio_welcome
+
+        user = _user()
+        db   = _db_with_license(_license())
+
+        with patch(f"{_CE_BASE}.get_owned_design_ids", return_value=[]):
+            resp = _run(card_studio_welcome(
+                request=MagicMock(), format_id=None, db=db, user=user,
+            ))
+
+        assert isinstance(resp, RedirectResponse)
+        assert resp.status_code == 303
+        assert resp.headers["location"] == "/shop/cards/welcome"
+
+
+# ── CEW-06: no ?format → 303 canonical first owned ───────────────────────────
+
+class TestCEW06NoFormatParam:
+
+    def test_cew_06_no_format_param_redirects_canonical(self):
+        """CEW-06: absent ?format → 303 /card-editor/welcome?format={first_owned}."""
+        from fastapi.responses import RedirectResponse
+        from app.api.web_routes.card_editor import card_studio_welcome
+
+        user = _user()
+        db   = _db_with_license(_license())
+
+        with patch(f"{_CE_BASE}.get_owned_design_ids", return_value=[_FIRST_ID, _SECOND_ID]):
+            resp = _run(card_studio_welcome(
+                request=MagicMock(), format_id=None, db=db, user=user,
+            ))
+
+        assert isinstance(resp, RedirectResponse)
+        assert resp.status_code == 303
+        assert resp.headers["location"] == f"/card-editor/welcome?format={_FIRST_ID}"
+
+    def test_cew_06b_canonical_uses_first_in_welcome_card_formats_order(self):
+        """CEW-06b: first_owned = first in WELCOME_CARD_FORMATS order, not alphabetical."""
+        from fastapi.responses import RedirectResponse
+        from app.api.web_routes.card_editor import card_studio_welcome
+
+        # Own only the second and third format — first_owned should be second by WCF order
+        owned = [_ALL_WC_IDS[1], _ALL_WC_IDS[2]]
+
+        user = _user()
+        db   = _db_with_license(_license())
+
+        with patch(f"{_CE_BASE}.get_owned_design_ids", return_value=owned):
+            resp = _run(card_studio_welcome(
+                request=MagicMock(), format_id=None, db=db, user=user,
+            ))
+
+        assert isinstance(resp, RedirectResponse)
+        assert f"format={_ALL_WC_IDS[1]}" in resp.headers["location"]
+
+
+# ── CEW-07: invalid ?format → 303 canonical ──────────────────────────────────
+
+class TestCEW07InvalidFormat:
+
+    def test_cew_07_unknown_format_id_redirects_canonical(self):
+        """CEW-07: unknown ?format value → 303 canonical first owned."""
+        from fastapi.responses import RedirectResponse
+        from app.api.web_routes.card_editor import card_studio_welcome
+
+        user = _user()
+        db   = _db_with_license(_license())
+
+        with patch(f"{_CE_BASE}.get_owned_design_ids", return_value=[_FIRST_ID]):
+            resp = _run(card_studio_welcome(
+                request=MagicMock(), format_id="totally_fake_format", db=db, user=user,
+            ))
+
+        assert isinstance(resp, RedirectResponse)
+        assert f"format={_FIRST_ID}" in resp.headers["location"]
+
+
+# ── CEW-08: unowned ?format → 303 canonical ──────────────────────────────────
+
+class TestCEW08UnownedFormat:
+
+    def test_cew_08_unowned_valid_format_id_redirects_canonical(self):
+        """CEW-08: valid format_id but not owned → 303 canonical first owned."""
+        from fastapi.responses import RedirectResponse
+        from app.api.web_routes.card_editor import card_studio_welcome
+
+        user = _user()
+        db   = _db_with_license(_license())
+
+        # User only owns _FIRST_ID, requests _SECOND_ID
+        with patch(f"{_CE_BASE}.get_owned_design_ids", return_value=[_FIRST_ID]):
+            resp = _run(card_studio_welcome(
+                request=MagicMock(), format_id=_SECOND_ID, db=db, user=user,
+            ))
+
+        assert isinstance(resp, RedirectResponse)
+        assert f"format={_FIRST_ID}" in resp.headers["location"]
+
+
+# ── CEW-09: active_format context ────────────────────────────────────────────
+
+class TestCEW09ActiveFormatContext:
+
+    def test_cew_09_active_format_matches_param(self):
+        """CEW-09: context active_format equals the ?format param."""
+        _, ctx, _ = _invoke_welcome(_FIRST_ID, owned_ids=[_FIRST_ID, _SECOND_ID])
+        assert ctx.get("active_format") == _FIRST_ID
+
+    def test_cew_09b_fmt_object_matches_active_format(self):
+        """CEW-09b: context fmt.design_id matches active_format."""
+        _, ctx, _ = _invoke_welcome(_SECOND_ID, owned_ids=[_FIRST_ID, _SECOND_ID])
+        assert ctx.get("active_format") == _SECOND_ID
+        fmt = ctx.get("fmt")
+        assert fmt is not None
+        assert fmt.design_id == _SECOND_ID
+
+
+# ── CEW-10/11: owned_format_rows correctness and order ───────────────────────
+
+class TestCEW1011OwnedFormatRows:
+
+    def test_cew_10_owned_format_rows_contains_only_owned(self):
+        """CEW-10: owned_format_rows contains only IDs from the owned set."""
+        # User owns first and third, not second
+        owned = [_ALL_WC_IDS[0], _ALL_WC_IDS[2]]
+        _, ctx, _ = _invoke_welcome(_ALL_WC_IDS[0], owned_ids=owned)
+
+        rows = ctx.get("owned_format_rows", [])
+        row_ids = [r["design_id"] for r in rows]
+        assert _ALL_WC_IDS[0] in row_ids
+        assert _ALL_WC_IDS[2] in row_ids
+        assert _ALL_WC_IDS[1] not in row_ids, "Unowned format must not appear in rows"
+
+    def test_cew_11_owned_format_rows_follow_welcome_card_formats_order(self):
+        """CEW-11: owned_format_rows are ordered by WELCOME_CARD_FORMATS, not by input list."""
+        # Pass owned in reversed order — output must still be WCF order
+        owned_reversed = list(reversed(_ALL_WC_IDS[:3]))
+        _, ctx, _ = _invoke_welcome(_ALL_WC_IDS[0], owned_ids=owned_reversed)
+
+        rows = ctx.get("owned_format_rows", [])
+        row_ids = [r["design_id"] for r in rows]
+        # Expected: [_ALL_WC_IDS[0], _ALL_WC_IDS[1], _ALL_WC_IDS[2]] in WCF order
+        assert row_ids == _ALL_WC_IDS[:3], (
+            f"Rows must follow WELCOME_CARD_FORMATS order. Got: {row_ids}"
+        )
+
+    def test_cew_11b_active_row_is_marked(self):
+        """CEW-11b: owned_format_rows marks exactly the active format as active=True."""
+        _, ctx, _ = _invoke_welcome(_SECOND_ID, owned_ids=[_FIRST_ID, _SECOND_ID])
+        rows = ctx.get("owned_format_rows", [])
+        active_ids = [r["design_id"] for r in rows if r.get("active")]
+        assert active_ids == [_SECOND_ID], (
+            f"Exactly one row must be active={_SECOND_ID!r}; active rows: {active_ids}"
+        )
+
+
+# ── CEW-12/13: preview_url and export_url ────────────────────────────────────
+
+class TestCEW1213URLs:
+
+    def test_cew_12_preview_url_uses_active_format(self):
+        """CEW-12: preview_url = /profile/onboarding-card?platform={active_format}."""
+        _, ctx, _ = _invoke_welcome(_FIRST_ID, owned_ids=[_FIRST_ID])
+        assert ctx.get("preview_url") == f"/profile/onboarding-card?platform={_FIRST_ID}"
+
+    def test_cew_13_export_url_uses_active_format(self):
+        """CEW-13: export_url = /profile/onboarding-card/export?platform={active_format}."""
+        _, ctx, _ = _invoke_welcome(_FIRST_ID, owned_ids=[_FIRST_ID])
+        assert ctx.get("export_url") == f"/profile/onboarding-card/export?platform={_FIRST_ID}"
+
+    def test_cew_12b_preview_and_export_change_with_format(self):
+        """CEW-12b: preview_url and export_url reflect the selected format."""
+        _, ctx, _ = _invoke_welcome(_SECOND_ID, owned_ids=[_FIRST_ID, _SECOND_ID])
+        assert ctx.get("preview_url") == f"/profile/onboarding-card?platform={_SECOND_ID}"
+        assert ctx.get("export_url") == f"/profile/onboarding-card/export?platform={_SECOND_ID}"
+
+
+# ── CEW-14: template has format selector ─────────────────────────────────────
+
+class TestCEW14Template:
+
+    def test_cew_14_template_has_format_selector(self):
+        """CEW-14: card_studio_welcome.html contains format selector block."""
+        src = (TEMPLATES_DIR / "card_studio_welcome.html").read_text(encoding="utf-8")
+        assert "wcs-format-selector" in src
+        assert "owned_format_rows" in src
+
+    def test_cew_14b_template_has_preview_and_export(self):
+        """CEW-14b: template has preview iframe and export link."""
+        src = (TEMPLATES_DIR / "card_studio_welcome.html").read_text(encoding="utf-8")
+        assert "preview_url" in src
+        assert "export_url" in src
+        assert "mfg-preview-iframe" in src
+        assert "wcs-btn-download" in src
+
+    def test_cew_14c_template_has_nav_links(self):
+        """CEW-14c: template links back to /my-cards/welcome and /shop/cards/welcome."""
+        src = (TEMPLATES_DIR / "card_studio_welcome.html").read_text(encoding="utf-8")
+        assert 'href="/my-cards/welcome"' in src
+        assert 'href="/shop/cards/welcome"' in src
+
+
+# ── CEW-15: legacy "default" CDO bulk-grant ──────────────────────────────────
+
+class TestCEW15LegacyDefaultGrant:
+
+    def test_cew_15_default_cdo_grants_all_7_formats(self):
+        """CEW-15: if 'default' is owned, all 7 WC formats appear in owned_format_rows."""
+        # get_owned_design_ids already handles the shim; simulate by returning all IDs
+        _, ctx, _ = _invoke_welcome(_FIRST_ID, owned_ids=list(_ALL_WC_IDS))
+        rows = ctx.get("owned_format_rows", [])
+        assert len(rows) == 7, (
+            f"Legacy 'default' grant must expose all 7 formats; got {len(rows)}"
+        )
+
+
+# ── CEW-16: CardDraftService never called ────────────────────────────────────
+
+class TestCEW16NoDraftService:
+
+    def test_cew_16_card_draft_service_not_called(self):
+        """CEW-16: handler never calls CardDraftService — fully draft-free."""
+        from app.api.web_routes.card_editor import card_studio_welcome
+
+        user = _user()
+        db   = _db_with_license(_license())
+
+        with patch(f"{_CE_BASE}.get_owned_design_ids", return_value=[_FIRST_ID]), \
+             patch(f"{_CE_BASE}.templates") as mock_tpl, \
+             patch("app.services.card_draft_service.CardDraftService") as MockCDS:
+            mock_tpl.TemplateResponse.side_effect = lambda t, c, **kw: MagicMock(status_code=200)
+            _run(card_studio_welcome(
+                request=MagicMock(), format_id=_FIRST_ID, db=db, user=user,
+            ))
+
+        MockCDS.get_draft.assert_not_called()
+        MockCDS.get_player_card_draft.assert_not_called()
+        MockCDS.get_or_create_singleton.assert_not_called()
+
+
+# ── CEW-17: WCE-1 route unchanged ────────────────────────────────────────────
+
+class TestCEW17WCE1Unchanged:
+
+    def test_cew_17_wce1_route_still_registered(self):
+        """CEW-17: /card-editor/welcome/{format_id} WCE-1 route is still registered."""
+        from app.main import app
+        paths = [r.path for r in app.routes]
+        assert "/card-editor/welcome/{format_id}" in paths, (
+            "WCE-1 route /card-editor/welcome/{format_id} must remain registered"
+        )
+
+    def test_cew_17b_wce1_handler_is_welcome_card_editor(self):
+        """CEW-17b: /card-editor/welcome/{format_id} maps to welcome_card_editor function."""
+        from app.main import app
+        from app.api.web_routes.card_editor import welcome_card_editor
+        route = next(
+            (r for r in app.routes if getattr(r, "path", None) == "/card-editor/welcome/{format_id}"),
+            None,
+        )
+        assert route is not None
+        assert route.endpoint is welcome_card_editor
+
+
+# ── CEW-18: route count = 838 ────────────────────────────────────────────────
+
+class TestCEW18RouteCount:
+
+    def test_cew_18_route_count_838(self):
+        """CEW-18: adding GET /card-editor/welcome raises route count from 837 to 838."""
+        from app.main import app
+        paths = app.openapi().get("paths", {})
+        assert len(paths) == 838, (
+            f"Expected 838 routes (837 CE-3.2 baseline + GET /card-editor/welcome), got {len(paths)}."
+        )
+
+    def test_cew_18b_card_editor_welcome_route_registered(self):
+        """CEW-18b: GET /card-editor/welcome is in the registered routes."""
+        from app.main import app
+        route_paths = [r.path for r in app.routes]
+        assert "/card-editor/welcome" in route_paths, (
+            "/card-editor/welcome must be a registered route"
+        )

--- a/tests/unit/api/web_routes/test_family_color_shop.py
+++ b/tests/unit/api/web_routes/test_family_color_shop.py
@@ -223,8 +223,8 @@ class TestRouteRegistration:
     def test_ts_13_route_count_836(self):
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 837, (
-            f"Expected 837 routes (834 CE-2 + 2 TS-1 + 1 CE-3.1), got {len(paths)}."
+        assert len(paths) == 838, (
+            f"Expected 838 routes (834 CE-2 + 2 TS-1 + 1 CE-3.1 + 1 CE-3.3), got {len(paths)}."
         )
 
     def test_ts_14_unlock_theme_still_registered(self):


### PR DESCRIPTION
## Summary

CE-3.3: Adds `GET /card-editor/welcome` — draft-free Welcome Card Studio entry point.

**Active format** driven by `?format={format_id}` query param. Absent/invalid/unowned values canonically redirect to `?format={first_owned}`. No owned formats → redirect to shop.

**Owned format order** follows `WELCOME_CARD_FORMATS` definition order (deterministic, not sorted/random).

**No CardDraftService calls** — fully draft-free. Guard pattern identical to WCE-1 (`/card-editor/welcome/{format_id}`).

**Unchanged:** `/card-editor/welcome/{format_id}`, `/my-cards/welcome`, `/shop/cards/welcome`, `/profile/onboarding-card`, all wc-photo routes, CE-3.1 landing WC CTA.

Route count: **837 → 838**. OpenAPI snapshot updated.

## Test plan

- [ ] 27 CEW tests: `pytest tests/unit/api/web_routes/test_card_studio_welcome.py`
- [ ] Full unit suite: 11785 PASS, 0 FAIL
- [ ] Manual smoke: 401 unauth, 303 no-owned → shop, 303 no-param → canonical, WCE-1 intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)