### PR TITLE
refactor(ce3): CE-3.5 — Card Studio shared CSS include (wrap, breadcrumb, nav)

### DIFF
--- a/app/templates/card_studio_challenge.html
+++ b/app/templates/card_studio_challenge.html
@@ -10,23 +10,8 @@
 {% endblock %}
 
 {% block extra_styles %}
+{% include "includes/cs_studio_shared.html" %}
 <style>
-  .ccs-wrap {
-    max-width: 860px;
-    margin: 0 auto;
-    padding: 1.5rem 1rem 4rem;
-  }
-
-  /* ── Breadcrumb ── */
-  .ccs-breadcrumb {
-    font-size: 0.8rem;
-    color: #64748b;
-    margin-bottom: 1.25rem;
-  }
-  .ccs-breadcrumb a { color: #94a3b8; text-decoration: none; }
-  .ccs-breadcrumb a:hover { color: #f1f5f9; }
-  .ccs-breadcrumb span { margin: 0 0.35rem; }
-
   /* ── Header ── */
   .ccs-header {
     margin-bottom: 0.5rem;
@@ -147,29 +132,11 @@
   }
   .ccs-btn-secondary:hover { border-color: #FFD200; color: #FFD200; text-decoration: none; }
 
-  /* ── Nav ── */
+  /* ── Nav (CCS extension — base is shared) ── */
   .ccs-nav {
-    display: flex;
-    gap: 1rem;
-    flex-wrap: wrap;
-    margin-top: 2rem;
     padding-top: 1.25rem;
     border-top: 1px solid #1e293b;
   }
-  .ccs-nav-back {
-    font-size: 0.82rem;
-    font-weight: 600;
-    color: #93c5fd;
-    text-decoration: none;
-  }
-  .ccs-nav-back:hover { color: #bfdbfe; text-decoration: none; }
-  .ccs-nav-shop {
-    font-size: 0.82rem;
-    font-weight: 600;
-    color: #FFD200;
-    text-decoration: none;
-  }
-  .ccs-nav-shop:hover { opacity: 0.85; text-decoration: none; }
 </style>
 {% endblock %}
 

--- a/app/templates/card_studio_welcome.html
+++ b/app/templates/card_studio_welcome.html
@@ -10,24 +10,10 @@
 {% endblock %}
 
 {% block extra_styles %}
+{% include "includes/cs_studio_shared.html" %}
 {% include "includes/mc_format_grid.html" %}
 <style>
-  .wcs-wrap {
-    max-width: 860px;
-    margin: 0 auto;
-    padding: 1.5rem 1rem 4rem;
-  }
-
   /* ── Header ── */
-  .wcs-breadcrumb {
-    font-size: 0.8rem;
-    color: #64748b;
-    margin-bottom: 1.25rem;
-  }
-  .wcs-breadcrumb a { color: #94a3b8; text-decoration: none; }
-  .wcs-breadcrumb a:hover { color: #f1f5f9; }
-  .wcs-breadcrumb span { margin: 0 0.35rem; }
-
   .wcs-header {
     display: flex;
     align-items: center;
@@ -146,27 +132,6 @@
   }
   .wcs-btn-download:hover { opacity: 0.88; color: #0f172a; text-decoration: none; }
 
-  /* ── Nav ── */
-  .wcs-nav {
-    display: flex;
-    gap: 1rem;
-    flex-wrap: wrap;
-    margin-top: 2rem;
-  }
-  .wcs-nav-back {
-    font-size: 0.82rem;
-    font-weight: 600;
-    color: #93c5fd;
-    text-decoration: none;
-  }
-  .wcs-nav-back:hover { color: #bfdbfe; text-decoration: none; }
-  .wcs-nav-shop {
-    font-size: 0.82rem;
-    font-weight: 600;
-    color: #FFD200;
-    text-decoration: none;
-  }
-  .wcs-nav-shop:hover { opacity: 0.85; text-decoration: none; }
 </style>
 {% endblock %}
 

--- a/app/templates/includes/cs_studio_shared.html
+++ b/app/templates/includes/cs_studio_shared.html
@@ -1,0 +1,58 @@
+{# ─────────────────────────────────────────────────────────────────────────────
+   includes/cs_studio_shared.html
+   Shared CSS tokens for Card Studio family pages (CE-3.5).
+
+   Include at the top of {% block extra_styles %} in each Studio template:
+       {% include "includes/cs_studio_shared.html" %}
+
+   Covers: page wrap, breadcrumb, nav footer base, nav back/shop links.
+   These rules are identical across card_studio_welcome.html and
+   card_studio_challenge.html — centralised here to eliminate duplication.
+
+   File-specific CSS (format selector, preview/export panels, info box, CTA
+   buttons, owned badge) must remain in each template's own <style> block.
+   ───────────────────────────────────────────────────────────────────────────── #}
+<style>
+  /* ── Page wrap ── */
+  .wcs-wrap, .ccs-wrap {
+    max-width: 860px;
+    margin: 0 auto;
+    padding: 1.5rem 1rem 4rem;
+  }
+
+  /* ── Breadcrumb ── */
+  .wcs-breadcrumb, .ccs-breadcrumb {
+    font-size: 0.8rem;
+    color: #64748b;
+    margin-bottom: 1.25rem;
+  }
+  .wcs-breadcrumb a, .ccs-breadcrumb a { color: #94a3b8; text-decoration: none; }
+  .wcs-breadcrumb a:hover, .ccs-breadcrumb a:hover { color: #f1f5f9; }
+  .wcs-breadcrumb span, .ccs-breadcrumb span { margin: 0 0.35rem; }
+
+  /* ── Nav footer (base) — CCS extends with padding-top + border-top ── */
+  .wcs-nav, .ccs-nav {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+    margin-top: 2rem;
+  }
+
+  /* ── Nav back link ── */
+  .wcs-nav-back, .ccs-nav-back {
+    font-size: 0.82rem;
+    font-weight: 600;
+    color: #93c5fd;
+    text-decoration: none;
+  }
+  .wcs-nav-back:hover, .ccs-nav-back:hover { color: #bfdbfe; text-decoration: none; }
+
+  /* ── Nav shop link ── */
+  .wcs-nav-shop, .ccs-nav-shop {
+    font-size: 0.82rem;
+    font-weight: 600;
+    color: #FFD200;
+    text-decoration: none;
+  }
+  .wcs-nav-shop:hover, .ccs-nav-shop:hover { opacity: 0.85; text-decoration: none; }
+</style>


### PR DESCRIPTION
## Summary

- Extracts identical CSS from `card_studio_welcome.html` and `card_studio_challenge.html` into a shared Jinja2 include (`includes/cs_studio_shared.html`)
- CSS-only change: no HTML structure, no routes, no handlers, no behaviour affected
- Shared: page wrap, breadcrumb, nav footer base, nav back/shop links (10 rule groups, eliminating ~37 lines of duplication)
- `card_studio_challenge.html` retains its CCS-specific nav extension (padding-top + border-top) as a cascade override

## Scope guard

Unchanged: all HTML, all hrefs, all routes, all handlers, all Jinja context, all format selectors, all preview/export URLs, all CTAs, all auth/guard logic, all ownership logic. Untouched: `dashboard_card_editor.html`, `card_editor_welcome.html`, `card_studio_landing.html`, `student_base.html`, `spec_subpage_hdr.html`, export templates.

## Test plan

- [ ] 47/47 CEW + CCS tests PASS (verified locally)
- [ ] Route count 839 unchanged (no new routes)
- [ ] OpenAPI snapshot unchanged
- [ ] `wcs-format-selector`, `mfg-preview-iframe`, `ccs-section-label` still present in respective templates
- [ ] All CTA links still present in templates
- [ ] Challenge Studio: no iframe, no export link
- [ ] No `card_studio_base` / template inheritance / UserLicense / migration / model / route change

🤖 Generated with [Claude Code](https://claude.com/claude-code)