### PR TITLE
feat(ce3): CE-3.6-A — Card Studio landing CTA alignment (Welcome + Challenge → Studio)

### DIFF
--- a/app/templates/card_studio_landing.html
+++ b/app/templates/card_studio_landing.html
@@ -184,7 +184,7 @@
         {{ wc_owned_count }} format{{ 's' if wc_owned_count != 1 }} owned
       </span>
       {% if wc_owned_count > 0 %}
-        <a href="/my-cards/welcome" class="cs-btn-primary cs-welcome-cta">My Welcome Cards →</a>
+        <a href="/card-editor/welcome" class="cs-btn-primary cs-welcome-cta">Open Welcome Studio →</a>
       {% else %}
         <a href="/shop/cards/welcome" class="cs-btn-secondary">Browse Welcome Designs →</a>
       {% endif %}
@@ -203,7 +203,7 @@
         {{ cc_owned_count }} format{{ 's' if cc_owned_count != 1 }} owned
       </span>
       {% if cc_owned_count > 0 %}
-        <a href="/my-cards/challenge" class="cs-btn-primary cs-challenge-cta">My Challenge Cards →</a>
+        <a href="/card-editor/challenge" class="cs-btn-primary cs-challenge-cta">Open Challenge Studio →</a>
       {% else %}
         <a href="/shop/cards/challenge" class="cs-btn-secondary">Browse Challenge Designs →</a>
       {% endif %}

--- a/tests/unit/api/web_routes/test_card_studio_landing.py
+++ b/tests/unit/api/web_routes/test_card_studio_landing.py
@@ -263,16 +263,16 @@ class TestCEL091011CTALinks:
         assert "Open Editor" in src
 
     def test_cel_10_template_has_welcome_cta(self):
-        """CEL-10: template contains /my-cards/welcome CTA for owned welcome card."""
+        """CEL-10: template contains /card-editor/welcome CTA for owned welcome card (CE-3.6-A)."""
         src = (TEMPLATES_DIR / "card_studio_landing.html").read_text(encoding="utf-8")
-        assert 'href="/my-cards/welcome"' in src
-        assert "My Welcome Cards" in src
+        assert 'href="/card-editor/welcome"' in src
+        assert "Open Welcome Studio" in src
 
     def test_cel_11_template_has_challenge_cta(self):
-        """CEL-11: template contains /my-cards/challenge CTA for owned challenge card."""
+        """CEL-11: template contains /card-editor/challenge CTA for owned challenge card (CE-3.6-A)."""
         src = (TEMPLATES_DIR / "card_studio_landing.html").read_text(encoding="utf-8")
-        assert 'href="/my-cards/challenge"' in src
-        assert "My Challenge Cards" in src
+        assert 'href="/card-editor/challenge"' in src
+        assert "Open Challenge Studio" in src
 
     def test_cel_09b_cs_player_editor_cta_class_present(self):
         """CEL-09b: cs-player-editor-cta CSS class marks the player CTA for JS/test targeting."""


### PR DESCRIPTION
## Summary

- Aligns Card Studio landing owned CTAs with Player Card pattern: Welcome and Challenge tiles now link directly to their Studio entry pages
- Template-only change: 2 href + 2 text changes in `card_studio_landing.html`; 2 test assertion updates in `test_card_studio_landing.py`
- No route, handler, Python, CSS, or OpenAPI change

## Changes

| CTA | Before | After |
|---|---|---|
| Welcome owned | `/my-cards/welcome` "My Welcome Cards →" | `/card-editor/welcome` "Open Welcome Studio →" |
| Challenge owned | `/my-cards/challenge` "My Challenge Cards →" | `/card-editor/challenge` "Open Challenge Studio →" |

Unchanged: Player owned/no-owned, Welcome no-owned, Challenge no-owned, global empty state, all CSS classes.

## Scope guard

Unchanged: all routes, all handlers, all Python code, CSS, OpenAPI snapshot, route count (839). Untouched: `card_studio_welcome.html`, `card_studio_challenge.html`, `cs_studio_shared.html`, `card_editor_welcome.html`, `dashboard_card_editor.html`.

## Test plan

- [ ] 27/27 CEL tests PASS (verified locally)
- [ ] CEL-10: `/card-editor/welcome` + "Open Welcome Studio" ✓
- [ ] CEL-11: `/card-editor/challenge` + "Open Challenge Studio" ✓
- [ ] CEL-09/09b: Player CTA unchanged ✓
- [ ] Route count 839 unchanged ✓
- [ ] OpenAPI snapshot match true ✓
- [ ] CE-3.6-B/C not started

🤖 Generated with [Claude Code](https://claude.com/claude-code)