### PR TITLE
feat(ce3): CE-3.6-C — My Cards Studio CTA (Welcome + Challenge collection pages)

### DIFF
--- a/app/templates/my_cards_challenge_card.html
+++ b/app/templates/my_cards_challenge_card.html
@@ -88,6 +88,17 @@
     text-decoration: none;
   }
   .mcc-results-cta a:hover { opacity: 0.85; }
+  .mcc-studio-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.85rem;
+    font-weight: 700;
+    color: #FFD200;
+    text-decoration: none;
+    margin-bottom: 1.25rem;
+  }
+  .mcc-studio-link:hover { opacity: 0.88; text-decoration: none; }
 </style>
 {% endblock %}
 
@@ -137,6 +148,9 @@
     <h2>Owned Formats</h2>
     <span class="mfg-count-badge">{{ cc_owned_count }} owned</span>
   </div>
+
+  {# ── Studio entry link (CE-3.6-C) ── #}
+  <a href="/card-editor/challenge" class="mcc-studio-link">Open Challenge Studio →</a>
 
   {# ── Format grid (owned only) ── #}
   <div class="mfg-grid">

--- a/app/templates/my_cards_welcome_card.html
+++ b/app/templates/my_cards_welcome_card.html
@@ -76,6 +76,17 @@
     transition: opacity 0.15s;
   }
   .mcw-empty-cta:hover { opacity: 0.88; color: #0f172a; text-decoration: none; }
+  .mcw-studio-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.85rem;
+    font-weight: 700;
+    color: #FFD200;
+    text-decoration: none;
+    margin-bottom: 1.25rem;
+  }
+  .mcw-studio-link:hover { opacity: 0.88; text-decoration: none; }
 </style>
 {% endblock %}
 
@@ -125,6 +136,9 @@
     <h2>Owned Formats</h2>
     <span class="mfg-count-badge">{{ owned_count }} owned</span>
   </div>
+
+  {# ── Studio entry link (CE-3.6-C) ── #}
+  <a href="/card-editor/welcome" class="mcw-studio-link">Open Welcome Studio →</a>
 
   {# ── Format grid (owned only) ── #}
   <div class="mfg-grid">

--- a/tests/unit/api/web_routes/test_my_cards_challenge_card.py
+++ b/tests/unit/api/web_routes/test_my_cards_challenge_card.py
@@ -1,0 +1,86 @@
+"""
+MCC — My Cards Challenge Card template tests (CE-3.6-C).
+
+Template source: app/templates/my_cards_challenge_card.html
+Route: GET /my-cards/challenge
+
+MCC-01  template contains /card-editor/challenge Studio entry CTA
+MCC-02  Studio CTA text: "Open Challenge Studio"
+MCC-03  template contains /challenges/results (per-format + footer CTA)
+MCC-04  template contains /shop/cards/challenge (shop link + empty state)
+MCC-05  Studio CTA is inside the owned {% if cc_format_rows %} block
+MCC-06  template does not contain preview iframe or export link
+"""
+from pathlib import Path
+
+_TEMPLATE_PATH = (
+    Path(__file__).resolve().parents[4]
+    / "app" / "templates" / "my_cards_challenge_card.html"
+)
+
+
+def _src() -> str:
+    return _TEMPLATE_PATH.read_text(encoding="utf-8")
+
+
+# ── MCC-01: Studio entry CTA href ────────────────────────────────────────────
+
+class TestMCC01StudioCTA:
+
+    def test_mcc_01_template_has_studio_cta(self):
+        """MCC-01: template contains /card-editor/challenge Studio entry CTA."""
+        assert 'href="/card-editor/challenge"' in _src()
+
+    def test_mcc_02_studio_cta_text(self):
+        """MCC-02: Studio CTA label text is 'Open Challenge Studio'."""
+        assert "Open Challenge Studio" in _src()
+
+
+# ── MCC-03: /challenges/results links unchanged ───────────────────────────────
+
+class TestMCC03ChallengeResultsLinks:
+
+    def test_mcc_03_challenges_results_present(self):
+        """MCC-03: /challenges/results appears in template (per-format + footer CTA)."""
+        assert "/challenges/results" in _src()
+
+
+# ── MCC-04: shop link unchanged ──────────────────────────────────────────────
+
+class TestMCC04ShopLink:
+
+    def test_mcc_04_shop_link_present(self):
+        """MCC-04: /shop/cards/challenge appears in template (shop link + empty state)."""
+        assert "/shop/cards/challenge" in _src()
+
+
+# ── MCC-05: Studio CTA is inside owned block ─────────────────────────────────
+
+class TestMCC05OwnedBlockContainsCTA:
+
+    def test_mcc_05_studio_cta_inside_owned_block(self):
+        """MCC-05: Studio CTA appears after {% if cc_format_rows %} and before {% else %}."""
+        src = _src()
+        owned_block_start = src.find("{% if cc_format_rows %}")
+        else_marker       = src.find("{% else %}", owned_block_start)
+        studio_cta_pos    = src.find('href="/card-editor/challenge"', owned_block_start)
+
+        assert owned_block_start != -1, "{% if cc_format_rows %} block must exist"
+        assert studio_cta_pos   != -1, "/card-editor/challenge link must exist"
+        assert studio_cta_pos   <  else_marker, (
+            "Studio CTA must be inside the owned branch (before {% else %})"
+        )
+
+
+# ── MCC-06: no preview iframe, no export link ─────────────────────────────────
+
+class TestMCC06NoPreviewExport:
+
+    def test_mcc_06_no_preview_iframe(self):
+        """MCC-06: template must not contain a preview iframe."""
+        assert "<iframe" not in _src()
+
+    def test_mcc_06b_no_export_link(self):
+        """MCC-06b: template must not contain a /card/export link."""
+        assert "/card/export" not in _src()
+        assert "export_url" not in _src()

--- a/tests/unit/api/web_routes/test_my_cards_welcome_card.py
+++ b/tests/unit/api/web_routes/test_my_cards_welcome_card.py
@@ -165,6 +165,26 @@ class TestWelcomeCardShopRoute:
         src = _TEMPLATE_PATH.read_text()
         assert "/shop/cards/welcome" in src
 
+    def test_mcw13_template_has_studio_cta(self):
+        """MCW-13: template contains Studio entry CTA linking to /card-editor/welcome (CE-3.6-C)."""
+        src = _TEMPLATE_PATH.read_text()
+        assert 'href="/card-editor/welcome"' in src
+
+    def test_mcw13b_template_has_studio_cta_text(self):
+        """MCW-13b: Studio CTA has correct label text."""
+        src = _TEMPLATE_PATH.read_text()
+        assert "Open Welcome Studio" in src
+
+    def test_mcw13c_per_format_wce1_link_still_present(self):
+        """MCW-13c: legacy per-format /card-editor/welcome/{id} WCE-1 link unchanged."""
+        src = _TEMPLATE_PATH.read_text()
+        assert "/card-editor/welcome/" in src, "WCE-1 per-format link must remain"
+
+    def test_mcw13d_shop_link_still_present(self):
+        """MCW-13d: /shop/cards/welcome link unchanged after Studio CTA addition."""
+        src = _TEMPLATE_PATH.read_text()
+        assert "/shop/cards/welcome" in src
+
     def test_mcw_owned_count_correct(self):
         """MCW-owned: owned_count increments per owned format."""
         from app.services.card_design_service import WELCOME_CARD_FORMATS


### PR DESCRIPTION
## Summary

- Adds Studio entry CTAs to `/my-cards/welcome` and `/my-cards/challenge` collection pages so owned users navigate directly to the Card Studio
- Template-only additive change: 2 HTML insertions + 2 CSS class additions
- No handler, context, route, ownership, or OpenAPI change

## Changes

| Page | CTA Added | Location |
|---|---|---|
| `/my-cards/welcome` | `"Open Welcome Studio →"` → `/card-editor/welcome` | Owned block, after section header, before format grid |
| `/my-cards/challenge` | `"Open Challenge Studio →"` → `/card-editor/challenge` | Owned block, after section header, before format grid |

Unchanged: WCE-1 per-format links, shop links, empty state CTAs, challenge results links, all handlers, all context variables.

## Scope guard

No Python code, no route, no handler, no context change. Route count 839 unchanged. OpenAPI snapshot unchanged. Untouched: `card_studio_welcome.html`, `card_studio_challenge.html`, `card_studio_landing.html`, `dashboard_card_editor.html`, `card_editor_welcome.html`.

## Test plan

- [ ] 24/24 MCW + MCC tests PASS (verified locally)
- [ ] MCW-13: `/card-editor/welcome` href in Welcome template ✓
- [ ] MCW-13b: "Open Welcome Studio" text ✓
- [ ] MCW-13c: WCE-1 per-format link still present ✓
- [ ] MCW-13d: `/shop/cards/welcome` still present ✓
- [ ] MCC-01–06: Challenge Studio CTA + unchanged links verified ✓
- [ ] MCC-05: Studio CTA inside owned block ✓
- [ ] MCC-06: no iframe, no export link ✓
- [ ] Route count 839 unchanged ✓
- [ ] CE-3.6-B / CE-3.7 not started

🤖 Generated with [Claude Code](https://claude.com/claude-code)