### PR TITLE
feat(fc1a): PR-FC-1A — FClassic alias layer + public label + family metadata

### DIFF
--- a/alembic/versions/2026_05_30_1200_rename_fifa_label_to_fclassic_player.py
+++ b/alembic/versions/2026_05_30_1200_rename_fifa_label_to_fclassic_player.py
@@ -1,0 +1,27 @@
+"""Rename FIFA Classic display label to FClassic Player (PR-FC-1A).
+
+Updates the public-facing label for the legacy 'fifa' design from
+'FIFA Classic' to 'FClassic Player'.  The design_id PK ('fifa') is
+intentionally unchanged — that migration is deferred to PR-FC-1B.
+
+Revision ID: 2026_05_30_1200
+Revises:     2026_05_29_1200
+"""
+from alembic import op
+
+revision = "2026_05_30_1200"
+down_revision = "2026_05_29_1200"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "UPDATE card_designs SET label = 'FClassic Player' WHERE id = 'fifa'"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "UPDATE card_designs SET label = 'FIFA Classic' WHERE id = 'fifa'"
+    )

--- a/app/api/web_routes/admin/card_designs.py
+++ b/app/api/web_routes/admin/card_designs.py
@@ -197,7 +197,7 @@ async def admin_card_designs_toggle(
 
     if design_id == _PROTECTED_ID:
         return RedirectResponse(
-            "/admin/card-designs?error=The+FIFA+design+is+protected+and+cannot+be+deactivated.",
+            "/admin/card-designs?error=The+FClassic+Player+design+is+protected+and+cannot+be+deactivated.",
             status_code=303,
         )
 
@@ -225,7 +225,7 @@ async def admin_card_designs_toggle(
             if confirm != "1":
                 warn_msg = (
                     f"Design+'{design.label}'+is+used+by+{summary}.+"
-                    f"Deactivating+will+cause+visual+fallback+to+FIFA+for+affected+users.+"
+                    f"Deactivating+will+cause+visual+fallback+to+FClassic+Player+for+affected+users.+"
                     f"To+confirm%2C+click+Deactivate+again."
                 )
                 return RedirectResponse(

--- a/app/services/card_design_service.py
+++ b/app/services/card_design_service.py
@@ -40,6 +40,7 @@ class NonPlayerCardFormatDefinition:
     credit_cost:      int
     preview_platform: str
     sort_order:       int = 0
+    family_id:        str = "fclassic"  # PR-FC-1A: all current WC/CC formats belong to FClassic
 
 
 @dataclass(frozen=True)
@@ -113,7 +114,7 @@ _FIFA_COMPONENT_CONFIG: dict = {
 DESIGNS: dict[str, CardDesignDefinition] = {
     "fifa": CardDesignDefinition(
         id="fifa",
-        label="FIFA Classic",
+        label="FClassic Player",
         description="The original LFA player card with full skill breakdown and event history.",
         is_premium=True,
         credit_cost=300,
@@ -197,6 +198,69 @@ DESIGN_ORDER: list[str] = [
     "fifa", "compact", "compact_bg", "showcase", "showcase_bg", "atlas", "pulse",
 ]
 
+# ── FClassic family — PR-FC-1A ────────────────────────────────────────────────
+# "fclassic" is the canonical family / design identifier going forward.
+# "fifa" is a deprecated alias kept alive for backward compatibility until
+# PR-FC-1B completes the DB PK migration.
+
+FCLASSIC_FAMILY_ID: str = "fclassic"
+
+# Player Card design IDs that belong to the FClassic family.
+# Includes both the legacy "fifa" key (current DB PK) and the canonical "fclassic"
+# key (post-PR-FC-1B DB state).
+FCLASSIC_PLAYER_DESIGN_IDS: frozenset[str] = frozenset({"fifa", "fclassic"})
+
+# Deprecated design ID → canonical design ID.
+# Read path: resolve before lookup. Write path: new data must use canonical ID.
+_DESIGN_ID_ALIAS: dict[str, str] = {
+    "fifa": "fclassic",
+}
+
+# Design IDs that are deprecated and must not be used for new canonical writes.
+_DEPRECATED_DESIGN_IDS: frozenset[str] = frozenset(_DESIGN_ID_ALIAS.keys())
+
+
+def resolve_design_id(design_id: str) -> str:
+    """Resolve a deprecated design ID to its canonical form.
+
+    "fifa" → "fclassic".  All other IDs pass through unchanged.
+    Safe to call on any design_id without knowing whether it is current.
+    """
+    return _DESIGN_ID_ALIAS.get(design_id, design_id)
+
+
+def get_card_family(card_type_id: str, design_id: str | None = None) -> str | None:
+    """Return the family_id for a card_type + design combination, or None.
+
+    FClassic family covers:
+      - player_card with design_id in FCLASSIC_PLAYER_DESIGN_IDS (includes alias "fifa")
+      - all welcome_card formats
+      - all challenge_card formats
+    Other Player Card designs (compact, showcase, atlas, pulse …) return None.
+    """
+    if card_type_id == "player_card":
+        if design_id is not None and resolve_design_id(design_id) == FCLASSIC_FAMILY_ID:
+            return FCLASSIC_FAMILY_ID
+        return None
+    if card_type_id in ("welcome_card", "challenge_card"):
+        return FCLASSIC_FAMILY_ID
+    return None
+
+
+def assert_new_design_id_is_canonical(design_id: str, context: str = "") -> None:
+    """Raise ValueError if a deprecated design ID is used for a new canonical write.
+
+    PR-FC-1A no-new-fifa guard: new data must use 'fclassic', not legacy 'fifa'.
+    Call this before any DB write that creates or updates design_id associations.
+    """
+    if design_id in _DEPRECATED_DESIGN_IDS:
+        canonical = resolve_design_id(design_id)
+        suffix = f" Context: {context}" if context else ""
+        raise ValueError(
+            f"Deprecated design ID {design_id!r} must not be used for new writes. "
+            f"Use {canonical!r} instead.{suffix}"
+        )
+
 
 # ── Non-player-card format registries ────────────────────────────────────────
 # Format/variant definitions for Welcome Card and Challenge Card families.
@@ -270,12 +334,19 @@ def _maybe_reload(db=None) -> dict[str, CardDesignDefinition]:
 # ── Public API ────────────────────────────────────────────────────────────────
 
 def get_design(design_id: str, db=None) -> CardDesignDefinition:
-    """Return design by ID, falling back to 'fifa' for unknown IDs.
+    """Return design by ID. 'fifa' is a deprecated alias for 'fclassic'.
 
+    Resolution order: canonical ID → original ID → 'fifa' fallback → hardcoded.
     The available flag is NOT used here — render path must never be gated.
     """
+    canonical = resolve_design_id(design_id)
     cache = _maybe_reload(db)
-    return cache.get(design_id, cache.get("fifa", DESIGNS["fifa"]))
+    return (
+        cache.get(canonical)
+        or cache.get(design_id)
+        or cache.get("fifa")
+        or DESIGNS["fifa"]
+    )
 
 
 def get_all_designs(db=None) -> list[CardDesignDefinition]:

--- a/app/templates/shop_landing.html
+++ b/app/templates/shop_landing.html
@@ -120,7 +120,7 @@
         <span class="shop-cat-icon">🎴</span>
         <div class="shop-cat-meta">
           <div class="shop-cat-title">Player Card Designs</div>
-          <p class="shop-cat-desc">Choose your LFA player card design — FIFA Classic, Compact, Atlas, Pulse and more.</p>
+          <p class="shop-cat-desc">Choose your LFA player card design — FClassic Player, Compact, Atlas, Pulse and more.</p>
         </div>
       </div>
       <span class="shop-cat-cta">Browse Designs →</span>

--- a/tests/unit/api/web_routes/test_lfa_nav.py
+++ b/tests/unit/api/web_routes/test_lfa_nav.py
@@ -87,7 +87,7 @@ class TestMyCardsSpecContext:
 
         free_design = MagicMock()
         free_design.id = "fifa"
-        free_design.label = "FIFA Classic"
+        free_design.label = "FClassic Player"
         free_design.credit_cost = 0
         free_design.is_premium = False
 

--- a/tests/unit/api/web_routes/test_my_cards_hub.py
+++ b/tests/unit/api/web_routes/test_my_cards_hub.py
@@ -104,7 +104,7 @@ def _call_hub(
     db               = db   or _make_db()
     owned_ids_by_type = owned_ids_by_type or {}
     default_designs  = [
-        _design("fifa",    credit_cost=0,   is_premium=False, label="FIFA Classic"),
+        _design("fifa",    credit_cost=0,   is_premium=False, label="FClassic Player"),
         _design("compact", credit_cost=300, is_premium=True,  label="Compact"),
     ]
     captured = {}
@@ -176,7 +176,7 @@ class TestMyCardsDetailRoutes:
             captured["context"]  = ctx
             return MagicMock(status_code=200)
 
-        default_designs = [_design("fifa", credit_cost=0, is_premium=False, label="FIFA Classic")]
+        default_designs = [_design("fifa", credit_cost=0, is_premium=False, label="FClassic Player")]
 
         with patch(f"{_BASE}.get_all_designs", return_value=default_designs), \
              patch(f"{_BASE}.is_design_accessible", return_value=False), \

--- a/tests/unit/api/web_routes/test_publish_guard.py
+++ b/tests/unit/api/web_routes/test_publish_guard.py
@@ -91,15 +91,15 @@ class TestPublishGuard:
 class TestPricingGuard:
 
     def test_pg05_fifa_classic_not_free(self):
-        """PG-05: FIFA Classic credit_cost > 0 in DESIGNS fallback dict."""
+        """PG-05: FClassic Player credit_cost > 0 in DESIGNS fallback dict."""
         from app.services.card_design_service import DESIGNS
         fifa = DESIGNS.get("fifa")
-        assert fifa is not None, "DESIGNS must contain 'fifa'"
+        assert fifa is not None, "DESIGNS must contain 'fifa' (legacy alias key)"
         assert fifa.credit_cost > 0, (
-            f"FIFA Classic must not be free (credit_cost={fifa.credit_cost}); "
+            f"FClassic Player must not be free (credit_cost={fifa.credit_cost}); "
             "no 0-CR purchasable designs allowed"
         )
-        assert fifa.is_premium is True, "FIFA Classic must be is_premium=True"
+        assert fifa.is_premium is True, "FClassic Player must be is_premium=True"
 
     def test_pg06_zero_credit_cost_yields_not_available(self):
         """PG-06: shop route assigns 'not_available' to credit_cost=0 unowned designs."""

--- a/tests/unit/api/web_routes/test_shop_feedback.py
+++ b/tests/unit/api/web_routes/test_shop_feedback.py
@@ -68,7 +68,7 @@ def _call_pc(query_params=None, accessible_ids=None, designs=None, balance=500):
     accessible_ids = accessible_ids or set()
     default_designs = [
         _design("compact",    300, "Compact"),
-        _design("fifa",       0,   "FIFA Classic"),
+        _design("fifa",       0,   "FClassic Player"),
     ]
     captured = {}
 
@@ -145,7 +145,7 @@ def _pc_ctx(purchased=None, error=None, owned_ids=None, balance=500):
     owned_ids = owned_ids or []
     rows = [
         {"id": "compact",    "label": "Compact",      "credit_cost": 300, "state": "owned" if "compact" in owned_ids else "get_card", "description": None},
-        {"id": "fifa",       "label": "FIFA Classic",  "credit_cost": 0,   "state": "owned" if "fifa" in owned_ids else "not_available", "description": None},
+        {"id": "fifa",       "label": "FClassic Player",  "credit_cost": 0,   "state": "owned" if "fifa" in owned_ids else "not_available", "description": None},
     ]
     return {
         "request": MagicMock(query_params={}),

--- a/tests/unit/api/web_routes/test_shop_player_detail.py
+++ b/tests/unit/api/web_routes/test_shop_player_detail.py
@@ -59,7 +59,7 @@ def _db():
 def _fifa_design(available=True, credit_cost=300):
     d = MagicMock()
     d.id = "fifa"
-    d.label = "FIFA Classic"
+    d.label = "FClassic Player"
     d.description = "The original LFA player card."
     d.credit_cost = credit_cost
     d.is_premium = True
@@ -118,7 +118,7 @@ def _render_detail(state="get_card", owned=False):
     user.credit_balance = 500
 
     design = MagicMock()
-    design.label = "FIFA Classic"
+    design.label = "FClassic Player"
     design.description = "The original LFA player card."
     design.credit_cost = 300
     design.supported_export_buckets = _FIFA_BUCKETS
@@ -148,7 +148,7 @@ def _render_player_list():
     user.credit_balance = 500
 
     design_rows = [
-        {"id": "fifa", "label": "FIFA Classic", "description": "", "credit_cost": 300, "is_premium": True, "state": "get_card"},
+        {"id": "fifa", "label": "FClassic Player", "description": "", "credit_cost": 300, "is_premium": True, "state": "get_card"},
         {"id": "compact", "label": "Compact", "description": "", "credit_cost": 300, "is_premium": True, "state": "locked"},
     ]
 
@@ -203,12 +203,12 @@ class TestPCID03CollectionTitle:
     def test_pcid03_context_contains_design_with_correct_label(self):
         """PCID-03: context design.label == 'FIFA Classic'."""
         cap = _call_detail(collection_id="fifa")
-        assert cap["context"]["design"].label == "FIFA Classic"
+        assert cap["context"]["design"].label == "FClassic Player"
 
     def test_pcid03_rendered_html_contains_collection_title(self):
         """PCID-03b: rendered HTML contains 'FIFA Classic'."""
         html = _render_detail()
-        assert "FIFA Classic" in html
+        assert "FClassic Player" in html
 
 
 # ── PCID-04: 7 format rows ───────────────────────────────────────────────────

--- a/tests/unit/services/test_card_design_service.py
+++ b/tests/unit/services/test_card_design_service.py
@@ -50,7 +50,7 @@ def reset_cache():
 
 def _make_row(
     id="fifa",
-    label="FIFA Classic",
+    label="FClassic Player",
     description="Test description",
     is_premium=False,
     credit_cost=0,
@@ -95,7 +95,7 @@ def test_cd01_designs_has_7_expected_ids():
 def test_cd02_get_design_fifa_fields():
     d = get_design("fifa")
     assert d.id == "fifa"
-    assert d.label == "FIFA Classic"
+    assert d.label == "FClassic Player"
     assert d.is_premium is True
     assert d.credit_cost == 300
     assert d.template == "public/player_card_fifa.html"

--- a/tests/unit/services/test_fclassic_family.py
+++ b/tests/unit/services/test_fclassic_family.py
@@ -1,0 +1,180 @@
+"""
+FC-01..FC-20 — FClassic family alias layer + label + family mapping (PR-FC-1A).
+
+FC-01  FCLASSIC_FAMILY_ID == "fclassic"
+FC-02  FCLASSIC_PLAYER_DESIGN_IDS contains "fifa" (legacy) and "fclassic" (canonical)
+FC-03  resolve_design_id("fifa") == "fclassic"
+FC-04  resolve_design_id("fclassic") == "fclassic" (idempotent)
+FC-05  resolve_design_id("compact") == "compact" (pass-through)
+FC-06  resolve_design_id("pulse") == "pulse" (pass-through)
+FC-07  get_card_family("player_card", "fclassic") == "fclassic"
+FC-08  get_card_family("player_card", "fifa") == "fclassic" (alias)
+FC-09  get_card_family("player_card", "compact") is None
+FC-10  get_card_family("player_card", "pulse") is None
+FC-11  get_card_family("welcome_card", "instagram_portrait") == "fclassic"
+FC-12  get_card_family("welcome_card", None) == "fclassic"
+FC-13  get_card_family("challenge_card", "challenge_post_16_9") == "fclassic"
+FC-14  get_card_family("challenge_card", "challenge_story_9_16") == "fclassic"
+FC-15  get_card_family("unknown_type", None) is None
+FC-16  NonPlayerCardFormatDefinition.family_id default == "fclassic" for all WC formats
+FC-17  NonPlayerCardFormatDefinition.family_id default == "fclassic" for all CC formats
+FC-18  assert_new_design_id_is_canonical("fclassic") does NOT raise
+FC-19  assert_new_design_id_is_canonical("fifa") raises ValueError
+FC-20  DESIGNS["fifa"].label == "FClassic Player"
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.services.card_design_service import (
+    CHALLENGE_CARD_FORMATS,
+    DESIGNS,
+    FCLASSIC_FAMILY_ID,
+    FCLASSIC_PLAYER_DESIGN_IDS,
+    WELCOME_CARD_FORMATS,
+    assert_new_design_id_is_canonical,
+    get_card_family,
+    resolve_design_id,
+)
+
+
+# ── FC-01/02: constants ────────────────────────────────────────────────────────
+
+class TestFC0102Constants:
+
+    def test_fc_01_fclassic_family_id(self):
+        """FC-01: FCLASSIC_FAMILY_ID is the canonical family identifier."""
+        assert FCLASSIC_FAMILY_ID == "fclassic"
+
+    def test_fc_02_player_design_ids_contains_legacy_and_canonical(self):
+        """FC-02: FCLASSIC_PLAYER_DESIGN_IDS contains both 'fifa' and 'fclassic'."""
+        assert "fifa" in FCLASSIC_PLAYER_DESIGN_IDS, (
+            "'fifa' must remain in FCLASSIC_PLAYER_DESIGN_IDS as legacy alias"
+        )
+        assert "fclassic" in FCLASSIC_PLAYER_DESIGN_IDS, (
+            "'fclassic' must be in FCLASSIC_PLAYER_DESIGN_IDS as canonical ID"
+        )
+
+
+# ── FC-03..FC-06: resolve_design_id ───────────────────────────────────────────
+
+class TestFC0306ResolveDesignId:
+
+    def test_fc_03_resolve_fifa_to_fclassic(self):
+        """FC-03: resolve_design_id('fifa') returns the canonical 'fclassic'."""
+        assert resolve_design_id("fifa") == "fclassic"
+
+    def test_fc_04_resolve_fclassic_is_idempotent(self):
+        """FC-04: resolve_design_id('fclassic') returns 'fclassic' unchanged."""
+        assert resolve_design_id("fclassic") == "fclassic"
+
+    def test_fc_05_resolve_compact_passthrough(self):
+        """FC-05: resolve_design_id passes through non-aliased IDs unchanged."""
+        assert resolve_design_id("compact") == "compact"
+
+    def test_fc_06_resolve_pulse_passthrough(self):
+        """FC-06: resolve_design_id('pulse') passes through unchanged."""
+        assert resolve_design_id("pulse") == "pulse"
+
+
+# ── FC-07..FC-15: get_card_family ─────────────────────────────────────────────
+
+class TestFC0715GetCardFamily:
+
+    def test_fc_07_player_card_fclassic_canonical(self):
+        """FC-07: player_card + 'fclassic' (canonical) → 'fclassic' family."""
+        assert get_card_family("player_card", "fclassic") == "fclassic"
+
+    def test_fc_08_player_card_fifa_alias(self):
+        """FC-08: player_card + 'fifa' (deprecated alias) → 'fclassic' family."""
+        assert get_card_family("player_card", "fifa") == "fclassic"
+
+    def test_fc_09_player_card_compact_not_fclassic(self):
+        """FC-09: player_card + 'compact' is NOT in FClassic family."""
+        assert get_card_family("player_card", "compact") is None
+
+    def test_fc_10_player_card_pulse_not_fclassic(self):
+        """FC-10: player_card + 'pulse' is NOT in FClassic family."""
+        assert get_card_family("player_card", "pulse") is None
+
+    def test_fc_11_welcome_card_instagram_portrait(self):
+        """FC-11: welcome_card + 'instagram_portrait' → 'fclassic' family."""
+        assert get_card_family("welcome_card", "instagram_portrait") == "fclassic"
+
+    def test_fc_12_welcome_card_no_design_id(self):
+        """FC-12: welcome_card with no design_id → 'fclassic' family."""
+        assert get_card_family("welcome_card") == "fclassic"
+        assert get_card_family("welcome_card", None) == "fclassic"
+
+    def test_fc_13_challenge_card_post_16_9(self):
+        """FC-13: challenge_card + 'challenge_post_16_9' → 'fclassic' family."""
+        assert get_card_family("challenge_card", "challenge_post_16_9") == "fclassic"
+
+    def test_fc_14_challenge_card_story_9_16(self):
+        """FC-14: challenge_card + 'challenge_story_9_16' → 'fclassic' family."""
+        assert get_card_family("challenge_card", "challenge_story_9_16") == "fclassic"
+
+    def test_fc_15_unknown_type_returns_none(self):
+        """FC-15: unknown card_type_id returns None."""
+        assert get_card_family("unknown_type", None) is None
+        assert get_card_family("player_card", None) is None  # no design_id given
+
+
+# ── FC-16/17: NonPlayerCardFormatDefinition family_id ────────────────────────
+
+class TestFC1617FormatFamilyId:
+
+    def test_fc_16_all_welcome_formats_are_fclassic(self):
+        """FC-16: all 7 Welcome Card formats have family_id='fclassic'."""
+        for fmt in WELCOME_CARD_FORMATS:
+            assert fmt.family_id == "fclassic", (
+                f"Welcome Card format '{fmt.design_id}' must have family_id='fclassic', "
+                f"got {fmt.family_id!r}"
+            )
+        assert len(WELCOME_CARD_FORMATS) == 7
+
+    def test_fc_17_all_challenge_formats_are_fclassic(self):
+        """FC-17: both Challenge Card formats have family_id='fclassic'."""
+        for fmt in CHALLENGE_CARD_FORMATS:
+            assert fmt.family_id == "fclassic", (
+                f"Challenge Card format '{fmt.design_id}' must have family_id='fclassic', "
+                f"got {fmt.family_id!r}"
+            )
+        assert len(CHALLENGE_CARD_FORMATS) == 2
+
+
+# ── FC-18/19: assert_new_design_id_is_canonical ──────────────────────────────
+
+class TestFC1819WriteGuard:
+
+    def test_fc_18_canonical_id_does_not_raise(self):
+        """FC-18: assert_new_design_id_is_canonical('fclassic') must not raise."""
+        assert_new_design_id_is_canonical("fclassic")  # must not raise
+
+    def test_fc_18b_other_ids_do_not_raise(self):
+        """FC-18b: non-deprecated IDs pass through the write guard cleanly."""
+        for design_id in ("compact", "showcase", "atlas", "pulse"):
+            assert_new_design_id_is_canonical(design_id)  # must not raise
+
+    def test_fc_19_deprecated_fifa_raises_value_error(self):
+        """FC-19: assert_new_design_id_is_canonical('fifa') must raise ValueError."""
+        with pytest.raises(ValueError, match="fclassic"):
+            assert_new_design_id_is_canonical("fifa")
+
+    def test_fc_19b_error_message_names_canonical(self):
+        """FC-19b: ValueError message tells caller to use 'fclassic'."""
+        with pytest.raises(ValueError) as exc:
+            assert_new_design_id_is_canonical("fifa", context="test purchase")
+        assert "fclassic" in str(exc.value)
+        assert "fifa" in str(exc.value)
+
+
+# ── FC-20: label ──────────────────────────────────────────────────────────────
+
+class TestFC20Label:
+
+    def test_fc_20_fifa_design_label_is_fclassic_player(self):
+        """FC-20: DESIGNS['fifa'] fallback dict label == 'FClassic Player'."""
+        assert DESIGNS["fifa"].label == "FClassic Player", (
+            f"Expected 'FClassic Player', got {DESIGNS['fifa'].label!r}"
+        )

--- a/tests/unit/services/test_og_bucket_seed.py
+++ b/tests/unit/services/test_og_bucket_seed.py
@@ -53,7 +53,7 @@ def _make_db_row(buckets: list[str]):
     """Minimal mock CardDesign ORM row."""
     row = MagicMock()
     row.id = "fifa"
-    row.label = "FIFA Classic"
+    row.label = "FClassic Player"
     row.description = "Test"
     row.is_premium = True
     row.credit_cost = 300
@@ -170,7 +170,7 @@ class TestOG06DetailPageSevenFormats:
         user.id = 42
         user.credit_balance = 500
         design = MagicMock()
-        design.label = "FIFA Classic"
+        design.label = "FClassic Player"
         design.description = ""
         design.credit_cost = 300
         design.supported_export_buckets = tuple(_CANONICAL_7)
@@ -206,7 +206,7 @@ class TestOG06DetailPageSevenFormats:
         user.id = 42
         user.credit_balance = 500
         design = MagicMock()
-        design.label = "FIFA Classic"
+        design.label = "FClassic Player"
         design.description = ""
         design.credit_cost = 300
 

--- a/tests/unit/test_card_export_db_config_gate.py
+++ b/tests/unit/test_card_export_db_config_gate.py
@@ -42,7 +42,7 @@ def _make_cs5_portrait_def():
     from app.services.card_design_service import CardDesignDefinition
     return CardDesignDefinition(
         id="fifa",
-        label="FIFA Classic",
+        label="FClassic Player",
         description="",
         is_premium=False,
         credit_cost=0,
@@ -82,7 +82,7 @@ def _make_old_portrait_def():
     from app.services.card_design_service import CardDesignDefinition
     return CardDesignDefinition(
         id="fifa",
-        label="FIFA Classic",
+        label="FClassic Player",
         description="",
         is_premium=False,
         credit_cost=0,


### PR DESCRIPTION
## PR-FC-1A — FClassic Alias Layer + Label Update + Family Metadata

**Part of the full FIFA naming removal migration (PR-FC-1R).**
This is the safe preparatory step — no DB PK migration.

## What changed

### Service layer (`card_design_service.py`)
- `NonPlayerCardFormatDefinition`: `+family_id: str = "fclassic"` — all 7 WC + 2 CC formats carry FClassic family metadata
- `DESIGNS["fifa"].label`: `"FIFA Classic"` → `"FClassic Player"`
- New constants: `FCLASSIC_FAMILY_ID`, `FCLASSIC_PLAYER_DESIGN_IDS`, `_DESIGN_ID_ALIAS`
- New functions:
  - `resolve_design_id("fifa")` → `"fclassic"` (alias resolution)
  - `get_card_family(card_type_id, design_id)` → family membership
  - `assert_new_design_id_is_canonical()` → no-new-fifa write guard
- `get_design()`: pre/post-migration safe fallback chain

### Display label
- `shop_landing.html`: "FIFA Classic" → "FClassic Player" in public shop text
- `admin/card_designs.py`: admin warning messages updated to "FClassic Player"

### DB migration
- `2026_05_30_1200`: `UPDATE card_designs SET label='FClassic Player' WHERE id='fifa'`
- **`card_designs.id` PK unchanged** — DB PK migration deferred to PR-FC-1B

## Scope boundary
No DB PK migration · no CDO/UserLicense/CardDraft data migration · no template rename · no symbol rename · no test fixture mass cleanup · no route changes

## Test plan
- [ ] FC-01–FC-20 all PASS (new `test_fclassic_family.py`)
- [ ] 8 existing test files updated: label assertions → "FClassic Player"
- [ ] Route count: 842 (unchanged)
- [ ] Migration chain integrity PASS
- [ ] `resolve_design_id("fifa") == "fclassic"` ✓
- [ ] `get_card_family("player_card", "fifa") == "fclassic"` ✓
- [ ] `assert_new_design_id_is_canonical("fifa")` raises ValueError ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)