### PR TITLE
feat(fc1d): PR-FC-1D — CSS class rename .fifa-* → .fclassic-*

### DIFF
--- a/app/templates/admin/user_profile.html
+++ b/app/templates/admin/user_profile.html
@@ -22,7 +22,7 @@
     .breadcrumb-sep { color: #cbd5e0; }
 
     /* ── FIFA Split Header ───────────────────────────────────────────────── */
-    .fifa-header {
+    .fclassic-header {
         display: grid;
         grid-template-columns: 210px 1fr;
         margin-bottom: 1.25rem;
@@ -33,7 +33,7 @@
     }
 
     /* Left: dark panel — avatar + overall + tier + level */
-    .fifa-left {
+    .fclassic-left {
         background: linear-gradient(155deg, #1a2744 0%, #2a3a5c 60%, #1e3a4a 100%);
         padding: 1.75rem 1.25rem 1.5rem;
         display: flex;
@@ -42,7 +42,7 @@
         gap: 0.6rem;
         text-align: center;
     }
-    .fifa-avatar {
+    .fclassic-avatar {
         width: 76px; height: 76px; border-radius: 50%;
         display: flex; align-items: center; justify-content: center;
         font-size: 1.75rem; font-weight: 900; color: white;
@@ -64,15 +64,15 @@
         color:rgba(255,255,255,0.9); cursor:pointer; transition:background 0.15s;
     }
     .btn-photo-delete:hover { background:rgba(220,53,69,0.8); }
-    .fifa-overall-num {
+    .fclassic-overall-num {
         font-size: 3.2rem; font-weight: 900; line-height: 1;
         color: white; margin-top: 0.25rem;
     }
-    .fifa-tier-badge {
+    .fclassic-tier-badge {
         font-size: 0.62rem; font-weight: 800; text-transform: uppercase;
         letter-spacing: 0.12em; padding: 3px 11px; border-radius: 99px; color: white;
     }
-    .fifa-no-license { font-size: 0.75rem; color: rgba(255,255,255,0.4); font-style: italic; }
+    .fclassic-no-license { font-size: 0.75rem; color: rgba(255,255,255,0.4); font-style: italic; }
     .btn-back {
         display: inline-flex; align-items: center; gap: 0.35rem;
         padding: 5px 12px; border-radius: 6px; margin-top: auto;
@@ -93,7 +93,7 @@
     .btn-public-profile:hover { background: rgba(102,126,234,0.4); }
 
     /* Right: white panel — identity info */
-    .fifa-right {
+    .fclassic-right {
         background: white;
         padding: 1.5rem 1.75rem;
         display: flex;
@@ -101,49 +101,49 @@
         justify-content: center;
         gap: 0.85rem;
     }
-    .fifa-name {
+    .fclassic-name {
         font-size: 1.85rem; font-weight: 800; color: #1a202c;
         line-height: 1.1; margin: 0;
     }
-    .fifa-pos-badge {
+    .fclassic-pos-badge {
         display: inline-block;
         font-size: 0.7rem; font-weight: 800; text-transform: uppercase;
         letter-spacing: 0.1em; padding: 3px 13px; border-radius: 99px;
         background: #667eea; color: white;
     }
-    .fifa-identity-grid {
+    .fclassic-identity-grid {
         display: grid;
         grid-template-columns: repeat(3, 1fr);
         gap: 0.6rem 1.25rem;
     }
-    .fifa-field { display: flex; flex-direction: column; gap: 1px; }
-    .fifa-field-label {
+    .fclassic-field { display: flex; flex-direction: column; gap: 1px; }
+    .fclassic-field-label {
         font-size: 0.62rem; font-weight: 700; text-transform: uppercase;
         letter-spacing: 0.09em; color: #a0aec0;
     }
-    .fifa-field-value {
+    .fclassic-field-value {
         font-size: 0.875rem; font-weight: 600; color: #2d3748;
     }
-    .fifa-teams {
+    .fclassic-teams {
         display: flex; flex-wrap: wrap; gap: 0.4rem; margin-top: 0.1rem;
     }
-    .fifa-team-pill {
+    .fclassic-team-pill {
         display: inline-flex; align-items: center; gap: 0.3rem;
         background: #f0f4ff; border: 1px solid #c3d0f8; border-radius: 6px;
         padding: 3px 10px; font-size: 0.76rem; font-weight: 600; color: #4a5568;
     }
-    .fifa-email {
+    .fclassic-email {
         font-size: 0.8rem; color: #718096; word-break: break-all;
     }
 
     @media (max-width: 820px) {
-        .fifa-header { grid-template-columns: 1fr; }
-        .fifa-left { flex-direction: row; flex-wrap: wrap; padding: 1.25rem 1.5rem; gap: 1rem; justify-content: center; }
-        .fifa-overall-num { font-size: 2.4rem; }
-        .fifa-identity-grid { grid-template-columns: 1fr 1fr; }
+        .fclassic-header { grid-template-columns: 1fr; }
+        .fclassic-left { flex-direction: row; flex-wrap: wrap; padding: 1.25rem 1.5rem; gap: 1rem; justify-content: center; }
+        .fclassic-overall-num { font-size: 2.4rem; }
+        .fclassic-identity-grid { grid-template-columns: 1fr 1fr; }
     }
     @media (max-width: 480px) {
-        .fifa-identity-grid { grid-template-columns: 1fr; }
+        .fclassic-identity-grid { grid-template-columns: 1fr; }
     }
 
     /* ── Alert ───────────────────────────────────────────────────────────── */
@@ -261,15 +261,15 @@
 {% set _pos_bg = _pos_colors.get(target_position, '#667eea') %}
 
 <!-- ── FIFA Split Header ──────────────────────────────────────────────────── -->
-<div class="fifa-header">
+<div class="fclassic-header">
 
     <!-- Left: dark panel -->
-    <div class="fifa-left">
+    <div class="fclassic-left">
         {% if lfa_license and lfa_license.player_card_photo_url %}
-        <img class="fifa-avatar" src="{{ lfa_license.player_card_photo_url }}"
+        <img class="fclassic-avatar" src="{{ lfa_license.player_card_photo_url }}"
              alt="{{ _initials }}" style="background: {{ ns.avatar_bg }};">
         {% else %}
-        <div class="fifa-avatar" style="background: {{ ns.avatar_bg }};">{{ _initials }}</div>
+        <div class="fclassic-avatar" style="background: {{ ns.avatar_bg }};">{{ _initials }}</div>
         {% endif %}
 
         {% if lfa_license %}
@@ -286,10 +286,10 @@
         {% endif %}
 
         {% if lfa_license %}
-        <div class="fifa-overall-num">{{ _overall }}</div>
-        <span class="fifa-tier-badge" style="background: {{ ns.tier_color }};">{{ ns.tier_label }}</span>
+        <div class="fclassic-overall-num">{{ _overall }}</div>
+        <span class="fclassic-tier-badge" style="background: {{ ns.tier_color }};">{{ ns.tier_label }}</span>
         {% else %}
-        <div class="fifa-no-license">No active license</div>
+        <div class="fclassic-no-license">No active license</div>
         {% endif %}
 
         <!-- Back navigation -->
@@ -308,46 +308,46 @@
     </div>
 
     <!-- Right: identity info -->
-    <div class="fifa-right">
+    <div class="fclassic-right">
         <div>
-            <h2 class="fifa-name">{{ target.name or target.email }}</h2>
+            <h2 class="fclassic-name">{{ target.name or target.email }}</h2>
             {% if target_position %}
-            <span class="fifa-pos-badge" style="background: {{ _pos_bg }};">{{ target_position }}</span>
+            <span class="fclassic-pos-badge" style="background: {{ _pos_bg }};">{{ target_position }}</span>
             {% endif %}
         </div>
 
-        <div class="fifa-identity-grid">
-            <div class="fifa-field">
-                <span class="fifa-field-label">Nationality</span>
-                <span class="fifa-field-value">{{ target.nationality | nationalities_display(target.secondary_nationality) }}</span>
+        <div class="fclassic-identity-grid">
+            <div class="fclassic-field">
+                <span class="fclassic-field-label">Nationality</span>
+                <span class="fclassic-field-value">{{ target.nationality | nationalities_display(target.secondary_nationality) }}</span>
             </div>
-            <div class="fifa-field">
-                <span class="fifa-field-label">Gender</span>
-                <span class="fifa-field-value">{{ target.gender or "—" }}</span>
+            <div class="fclassic-field">
+                <span class="fclassic-field-label">Gender</span>
+                <span class="fclassic-field-value">{{ target.gender or "—" }}</span>
             </div>
-            <div class="fifa-field">
-                <span class="fifa-field-label">Date of Birth</span>
-                <span class="fifa-field-value">
+            <div class="fclassic-field">
+                <span class="fclassic-field-label">Date of Birth</span>
+                <span class="fclassic-field-value">
                     {{ target.date_of_birth.strftime('%Y-%m-%d') if target.date_of_birth else "—" }}
                     {% if target_age %}<span style="color:#a0aec0;font-weight:500;">({{ target_age }})</span>{% endif %}
                 </span>
             </div>
-            <div class="fifa-field">
-                <span class="fifa-field-label">Specialization</span>
-                <span class="fifa-field-value">{% if lfa_license %}{% set _spec_map = {'LFA_FOOTBALL_PLAYER': 'LFA Football Player', 'LFA_COACH': 'LFA Coach', 'INTERNSHIP': 'Internship', 'JUNIOR_INTERNSHIP': 'Junior Internship', 'SENIOR_INTERNSHIP': 'Senior Internship', 'GANCUJU_PLAYER': 'Gancuju Player'} %}{{ _spec_map.get(lfa_license.specialization_type, lfa_license.specialization_type) }}{% else %}—{% endif %}</span>
+            <div class="fclassic-field">
+                <span class="fclassic-field-label">Specialization</span>
+                <span class="fclassic-field-value">{% if lfa_license %}{% set _spec_map = {'LFA_FOOTBALL_PLAYER': 'LFA Football Player', 'LFA_COACH': 'LFA Coach', 'INTERNSHIP': 'Internship', 'JUNIOR_INTERNSHIP': 'Junior Internship', 'SENIOR_INTERNSHIP': 'Senior Internship', 'GANCUJU_PLAYER': 'Gancuju Player'} %}{{ _spec_map.get(lfa_license.specialization_type, lfa_license.specialization_type) }}{% else %}—{% endif %}</span>
             </div>
-            <div class="fifa-field">
-                <span class="fifa-field-label">Member since</span>
-                <span class="fifa-field-value">{{ target.created_at.strftime('%Y-%m-%d') if target.created_at else "—" }}</span>
+            <div class="fclassic-field">
+                <span class="fclassic-field-label">Member since</span>
+                <span class="fclassic-field-value">{{ target.created_at.strftime('%Y-%m-%d') if target.created_at else "—" }}</span>
             </div>
         </div>
 
-        <div class="fifa-email">📧 {{ target.email }}</div>
+        <div class="fclassic-email">📧 {{ target.email }}</div>
 
         {% if target_teams_info %}
-        <div class="fifa-teams">
+        <div class="fclassic-teams">
             {% for tinfo in target_teams_info %}
-            <span class="fifa-team-pill">
+            <span class="fclassic-team-pill">
                 🏟️ {{ tinfo.team.name }}{% if tinfo.club %} · {{ tinfo.club.name }}{% endif %}{% if tinfo.team.age_group_label %} · {{ tinfo.team.age_group_label }}{% endif %}
             </span>
             {% endfor %}

--- a/app/templates/macros/card_photo_fallback.html
+++ b/app/templates/macros/card_photo_fallback.html
@@ -9,7 +9,7 @@
    • landscape/fifa.html — <div class="ex-photo"> … <div class="ex-photo-fallback">
    • tiktok/fifa.html    — <div class="ex-hero-photo"> … <div class="ex-hero-photo-placeholder">
    • story/fifa.html     — <div class="ex-hero-photo"> … <div class="ex-hero-photo-placeholder">
-   • player_card_fifa.html — <div class="fifa-photo-area"> … JS-driven cropping logic
+   • player_card_fifa.html — <div class="fclassic-photo-area"> … JS-driven cropping logic
 
    URL-resolution pattern used across ALL export templates:
    ──────────────────────────────────────────────────────

--- a/app/templates/public/player_card.html
+++ b/app/templates/public/player_card.html
@@ -67,39 +67,39 @@ body.export-mode .skills-section { display: block !important; }
 body.export-mode .events-section { display: none !important; }
 
 /* ── Split header ─────────────────────────────────────────── */
-.fifa-header {
+.fclassic-header {
     display: grid;
     grid-template-columns: 170px 1fr;
 }
-.fifa-left {
+.fclassic-left {
     background: var(--card-panel-bg);
     padding: 1.5rem 1rem;
     display: flex; flex-direction: column;
     align-items: center; gap: 0.5rem; text-align: center;
 }
-.fifa-avatar {
+.fclassic-avatar {
     width: 68px; height: 68px; border-radius: 50%;
     display: flex; align-items: center; justify-content: center;
     font-size: 1.55rem; font-weight: 900; color: white;
     border: 3px solid rgba(255,255,255,0.18); flex-shrink: 0;
 }
-.fifa-overall { font-size: 2.8rem; font-weight: 900; color: white; line-height: 1; margin-top: 0.15rem; }
-.fifa-tier {
+.fclassic-overall { font-size: 2.8rem; font-weight: 900; color: white; line-height: 1; margin-top: 0.15rem; }
+.fclassic-tier {
     font-size: 0.58rem; font-weight: 800; text-transform: uppercase;
     letter-spacing: 0.12em; padding: 3px 10px; border-radius: 99px; color: white;
     white-space: nowrap;
 }
-.fifa-right {
+.fclassic-right {
     background: #ffffff;
     padding: 1.25rem 1.25rem 1rem;
     display: flex; flex-direction: column; gap: 0.7rem;
     min-width: 0; /* prevent grid blowout */
 }
-.fifa-name {
+.fclassic-name {
     font-size: 1.45rem; font-weight: 800; color: #1a202c; line-height: 1.1;
     overflow-wrap: break-word; word-break: break-word;
 }
-.fifa-pos-badge {
+.fclassic-pos-badge {
     display: inline-block; padding: 3px 11px; border-radius: 6px;
     font-size: 0.7rem; font-weight: 800; color: white;
     text-transform: uppercase; letter-spacing: 0.08em;
@@ -111,7 +111,7 @@ body.export-mode .events-section { display: none !important; }
 .id-field { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
 .id-label { font-size: 0.6rem; font-weight: 700; color: #a0aec0; text-transform: uppercase; letter-spacing: 0.07em; }
 .id-value { font-size: 0.84rem; font-weight: 700; color: #2d3748; overflow-wrap: break-word; }
-.fifa-club-pills { display: flex; flex-wrap: wrap; gap: 0.35rem; }
+.fclassic-club-pills { display: flex; flex-wrap: wrap; gap: 0.35rem; }
 .club-pill {
     font-size: 0.7rem; font-weight: 600; color: #4a5568;
     background: #f0f4ff; border: 1px solid #e2e8f0;
@@ -200,44 +200,44 @@ body.export-mode .events-section { display: none !important; }
 ───────────────────────────────────────────────────────────── */
 @media (max-width: 560px) {
     body { padding: 1rem 0.5rem 3rem; }
-    .fifa-header { grid-template-columns: 130px 1fr; }
-    .fifa-left { padding: 1.1rem 0.75rem; }
-    .fifa-avatar { width: 58px; height: 58px; font-size: 1.3rem; }
-    .fifa-overall { font-size: 2.3rem; }
-    .fifa-right { padding: 1rem; gap: 0.6rem; }
-    .fifa-name { font-size: 1.2rem; }
+    .fclassic-header { grid-template-columns: 130px 1fr; }
+    .fclassic-left { padding: 1.1rem 0.75rem; }
+    .fclassic-avatar { width: 58px; height: 58px; font-size: 1.3rem; }
+    .fclassic-overall { font-size: 2.3rem; }
+    .fclassic-right { padding: 1rem; gap: 0.6rem; }
+    .fclassic-name { font-size: 1.2rem; }
     .identity-grid { grid-template-columns: 1fr 1fr; }
     .skill-cats { grid-template-columns: 1fr 1fr; }
     .skills-section { padding: 0.9rem; }
 }
 @media (max-width: 440px) {
-    .fifa-header { grid-template-columns: 1fr; }
-    .fifa-left {
+    .fclassic-header { grid-template-columns: 1fr; }
+    .fclassic-left {
         flex-direction: row; justify-content: center;
         align-items: center; flex-wrap: wrap;
         gap: 0.6rem 1rem; padding: 1rem 1.25rem;
     }
-    .fifa-overall { font-size: 2.4rem; }
-    .fifa-right { padding: 1rem; }
+    .fclassic-overall { font-size: 2.4rem; }
+    .fclassic-right { padding: 1rem; }
     .identity-grid { grid-template-columns: repeat(3, 1fr); }
     .skill-cats { grid-template-columns: 1fr 1fr; }
 }
 @media (max-width: 340px) {
     .identity-grid { grid-template-columns: 1fr 1fr; }
     .skill-cats { grid-template-columns: 1fr; }
-    .fifa-name { font-size: 1.05rem; }
+    .fclassic-name { font-size: 1.05rem; }
 }
 
 /* ── Sprint C: Landscape layout ─────────────────────────────────────────── */
-body.export-mode.platform-facebook-landscape .fifa-header,
-body.export-mode.platform-og .fifa-header {
+body.export-mode.platform-facebook-landscape .fclassic-header,
+body.export-mode.platform-og .fclassic-header {
     flex: 0 0 300px; height: 100%; align-self: stretch;
     grid-template-columns: 150px 1fr;
 }
-body.export-mode.platform-facebook-landscape .fifa-left,
-body.export-mode.platform-og .fifa-left,
-body.export-mode.platform-facebook-landscape .fifa-right,
-body.export-mode.platform-og .fifa-right { min-height: 100%; }
+body.export-mode.platform-facebook-landscape .fclassic-left,
+body.export-mode.platform-og .fclassic-left,
+body.export-mode.platform-facebook-landscape .fclassic-right,
+body.export-mode.platform-og .fclassic-right { min-height: 100%; }
 body.export-mode.platform-facebook-landscape .skills-section,
 body.export-mode.platform-og .skills-section {
     flex: 1; height: 100%; overflow: hidden;
@@ -246,14 +246,14 @@ body.export-mode.platform-facebook-landscape .skill-cats,
 body.export-mode.platform-og .skill-cats { grid-template-columns: 1fr 1fr; }
 
 /* ── Sprint D: Banner layout ─────────────────────────────────────────────── */
-body.export-mode.platform-banner-custom .fifa-header {
+body.export-mode.platform-banner-custom .fclassic-header {
     flex: 1; height: 100%; align-self: stretch;
     grid-template-columns: var(--ex-photo-w) 1fr;
 }
-body.export-mode.platform-banner-custom .fifa-left  { min-height: 100%; justify-content: center; }
-body.export-mode.platform-banner-custom .fifa-right { min-height: 100%; justify-content: center; }
-body.export-mode.platform-banner-custom .fifa-overall { font-size: var(--ex-font-ovr); }
-body.export-mode.platform-banner-custom .fifa-name    { font-size: var(--ex-font-name); }
+body.export-mode.platform-banner-custom .fclassic-left  { min-height: 100%; justify-content: center; }
+body.export-mode.platform-banner-custom .fclassic-right { min-height: 100%; justify-content: center; }
+body.export-mode.platform-banner-custom .fclassic-overall { font-size: var(--ex-font-ovr); }
+body.export-mode.platform-banner-custom .fclassic-name    { font-size: var(--ex-font-name); }
 
 /* ── P0: Export scaling ──────────────────────────────────────────────────── */
 body.export-mode {
@@ -274,9 +274,9 @@ body.export-mode.platform-banner-custom {
     --ex-font-name: clamp(1.5rem, 3vw, 4rem);
     --ex-photo-w:   clamp(150px, 17vw, 300px);
 }
-body.export-mode .fifa-header   { grid-template-columns: var(--ex-photo-w) 1fr; }
-body.export-mode .fifa-overall  { font-size: var(--ex-font-ovr); }
-body.export-mode .fifa-name     { font-size: var(--ex-font-name); }
+body.export-mode .fclassic-header   { grid-template-columns: var(--ex-photo-w) 1fr; }
+body.export-mode .fclassic-overall  { font-size: var(--ex-font-ovr); }
+body.export-mode .fclassic-name     { font-size: var(--ex-font-name); }
 body.export-mode .skill-name,
 body.export-mode .skill-val     { font-size: var(--ex-font-skill); }
 body.export-mode .skill-bar-bg  { flex: 1 1 0 !important; max-width: none !important; }
@@ -289,22 +289,22 @@ body.export-mode .skill-bar-bg  { flex: 1 1 0 !important; max-width: none !impor
 <div class="card-wrap">
 
     <!-- Split header -->
-    <div class="fifa-header">
-        <div class="fifa-left">
+    <div class="fclassic-header">
+        <div class="fclassic-left">
             {% if photo_url %}
-            <img class="fifa-avatar" src="{{ photo_url }}" alt="{{ initials }}"
+            <img class="fclassic-avatar" src="{{ photo_url }}" alt="{{ initials }}"
                  style="background: {{ avatar_bg }}; object-fit: cover;">
             {% else %}
-            <div class="fifa-avatar" style="background: {{ avatar_bg }};">{{ initials }}</div>
+            <div class="fclassic-avatar" style="background: {{ avatar_bg }};">{{ initials }}</div>
             {% endif %}
-            <div class="fifa-overall">{{ overall }}</div>
-            <span class="fifa-tier" style="background: {{ tier_color }};">{{ tier_label }}</span>
+            <div class="fclassic-overall">{{ overall }}</div>
+            <span class="fclassic-tier" style="background: {{ tier_color }};">{{ tier_label }}</span>
         </div>
-        <div class="fifa-right">
+        <div class="fclassic-right">
             <div>
-                <h2 class="fifa-name">{{ player.name }}</h2>
+                <h2 class="fclassic-name">{{ player.name }}</h2>
                 {% if player.position and player.position != "Unknown" %}
-                <span class="fifa-pos-badge" style="background: {{ pos_color }};">{{ player.position }}</span>
+                <span class="fclassic-pos-badge" style="background: {{ pos_color }};">{{ player.position }}</span>
                 {% endif %}
             </div>
 
@@ -324,7 +324,7 @@ body.export-mode .skill-bar-bg  { flex: 1 1 0 !important; max-width: none !impor
             </div>
 
             {% if teams_info %}
-            <div class="fifa-club-pills">
+            <div class="fclassic-club-pills">
                 {% for t in teams_info %}
                 <span class="club-pill">🏟️ {{ t.team_name }}{% if t.club_name %} · {{ t.club_name }}{% endif %}{% if t.age_group_label %} · {{ t.age_group_label }}{% endif %}</span>
                 {% endfor %}

--- a/app/templates/public/player_card_fclassic.html
+++ b/app/templates/public/player_card_fclassic.html
@@ -27,7 +27,7 @@
     box-shadow: 0 12px 48px rgba(0,0,0,0.55);
     border: 1px solid rgba(255,255,255,0.06);
     /* Single source of truth for the photo column width.
-       Both .fifa-header and .card-body reference this token so they
+       Both .fclassic-header and .card-body reference this token so they
        always stay in sync regardless of viewport or render mode. */
     --photo-col-w: 170px;
 }
@@ -52,49 +52,49 @@ body.native-export-mode .events-section { display: none !important; }
 body.export-mode .card-body { display: grid !important; }
 
 /* ── Split header ─────────────────────────────────────────── */
-.fifa-header {
+.fclassic-header {
     display: grid;
     grid-template-columns: var(--photo-col-w) 1fr;
 }
-.fifa-left {
+.fclassic-left {
     position: relative; overflow: hidden;
     min-height: 200px;
 }
-.fifa-avatar { border-radius: 0; flex-shrink: 0; font-size: 2rem; font-weight: 900; color: white; }
-img.fifa-avatar {
+.fclassic-avatar { border-radius: 0; flex-shrink: 0; font-size: 2rem; font-weight: 900; color: white; }
+img.fclassic-avatar {
     position: absolute; inset: 0;
     width: 100%; height: 100%;
     object-fit: cover; object-position: top center;
 }
-div.fifa-avatar {
+div.fclassic-avatar {
     position: absolute; inset: 0; width: 100%; height: 100%;
     display: flex; align-items: center; justify-content: center;
 }
-.fifa-overall { font-size: 2.5rem; font-weight: 900; color: var(--card-accent); line-height: 1; flex-shrink: 0; }
-.fifa-name-row { display: flex; align-items: flex-start; gap: 0.65rem; }
-.fifa-right {
+.fclassic-overall { font-size: 2.5rem; font-weight: 900; color: var(--card-accent); line-height: 1; flex-shrink: 0; }
+.fclassic-name-row { display: flex; align-items: flex-start; gap: 0.65rem; }
+.fclassic-right {
     background: var(--card-right-bg);
     padding: 1.25rem 1.25rem 1rem;
     display: flex; flex-direction: column; gap: 0;
     min-width: 0;
     position: relative; overflow: hidden;
 }
-.fifa-right-body {
+.fclassic-right-body {
     position: relative; z-index: 1;
     display: flex; flex-direction: column; gap: 0.7rem;
     flex: 1; min-width: 0;
 }
-.fifa-name {
+.fclassic-name {
     font-size: 1.45rem; font-weight: 800; color: var(--card-right-text); line-height: 1.1;
     overflow-wrap: break-word; word-break: break-word;
 }
-.fifa-pos-badge {
+.fclassic-pos-badge {
     display: inline-block; padding: 3px 11px; border-radius: 6px;
     font-size: 0.7rem; font-weight: 800; color: white;
     text-transform: uppercase; letter-spacing: 0.08em;
 }
-.fifa-pos-secondary-badges { display: flex; flex-wrap: wrap; gap: 3px; margin-top: 4px; }
-.fifa-pos-secondary-badge {
+.fclassic-pos-secondary-badges { display: flex; flex-wrap: wrap; gap: 3px; margin-top: 4px; }
+.fclassic-pos-secondary-badge {
     display: inline-block; padding: 2px 8px; border-radius: 4px;
     font-size: 0.62rem; font-weight: 700; color: var(--card-right-subtext);
     background: var(--card-pill-bg); border: 1px solid var(--card-pill-border);
@@ -107,7 +107,7 @@ div.fifa-avatar {
 .id-field { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
 .id-label { font-size: 0.6rem; font-weight: 700; color: var(--card-right-subtext); text-transform: uppercase; letter-spacing: 0.07em; }
 .id-value { font-size: 0.84rem; font-weight: 700; color: var(--card-right-value); overflow-wrap: break-word; }
-.fifa-club-pills { display: flex; flex-wrap: wrap; gap: 0.35rem; }
+.fclassic-club-pills { display: flex; flex-wrap: wrap; gap: 0.35rem; }
 .club-pill {
     font-size: 0.7rem; font-weight: 600; color: var(--card-pill-text);
     background: var(--card-pill-bg); border: 1px solid var(--card-pill-border);
@@ -245,7 +245,7 @@ div.fifa-avatar {
 
 /* ── Export-mode: sync photo column width ────────────────────────────────
    In export-mode the base template sets --ex-photo-w (viewport-relative).
-   Overriding --photo-col-w here cascades to BOTH .fifa-header and .card-body
+   Overriding --photo-col-w here cascades to BOTH .fclassic-header and .card-body
    so the header photo column and the body spacer always stay in sync. */
 body.export-mode .card-wrap { --photo-col-w: var(--ex-photo-w); }
 
@@ -257,10 +257,10 @@ body.export-mode .card-wrap { --photo-col-w: var(--ex-photo-w); }
 ───────────────────────────────────────────────────────────── */
 @media (max-width: 560px) {
     body { padding: 1rem 0.5rem 3rem; }
-    .fifa-header { grid-template-columns: 130px 1fr; }
-    .fifa-overall { font-size: 2rem; }
-    .fifa-right { padding: 1rem; gap: 0.6rem; }
-    .fifa-name { font-size: 1.2rem; }
+    .fclassic-header { grid-template-columns: 130px 1fr; }
+    .fclassic-overall { font-size: 2rem; }
+    .fclassic-right { padding: 1rem; gap: 0.6rem; }
+    .fclassic-name { font-size: 1.2rem; }
     .identity-grid { grid-template-columns: 1fr 1fr; }
     .card-body { grid-template-columns: 1fr; }
     .card-body-photo-spacer { display: none; }
@@ -270,30 +270,30 @@ body.export-mode .card-wrap { --photo-col-w: var(--ex-photo-w); }
     .pitch-svg { max-height: 200px; width: auto; display: block; margin: 0 auto; }
 }
 @media (max-width: 440px) {
-    .fifa-header { grid-template-columns: 1fr; }
-    .fifa-left { min-height: 260px; }
-    .fifa-overall { font-size: 2.1rem; }
-    .fifa-right { padding: 1rem; }
+    .fclassic-header { grid-template-columns: 1fr; }
+    .fclassic-left { min-height: 260px; }
+    .fclassic-overall { font-size: 2.1rem; }
+    .fclassic-right { padding: 1rem; }
     .identity-grid { grid-template-columns: repeat(3, 1fr); }
 }
 @media (max-width: 340px) {
     .identity-grid { grid-template-columns: 1fr 1fr; }
     .skill-cats { flex-direction: column; }
-    .fifa-name { font-size: 1.05rem; }
+    .fclassic-name { font-size: 1.05rem; }
 }
 
 /* ── Sprint C: Landscape layout ─────────────────────────────────────────── */
-body.export-mode.platform-facebook-landscape .fifa-header,
-body.export-mode.platform-og .fifa-header {
+body.export-mode.platform-facebook-landscape .fclassic-header,
+body.export-mode.platform-og .fclassic-header {
     flex: 0 0 320px;
     height: 100%;
     align-self: stretch;
     grid-template-columns: 160px 1fr;
 }
-body.export-mode.platform-facebook-landscape .fifa-left,
-body.export-mode.platform-og .fifa-left,
-body.export-mode.platform-facebook-landscape .fifa-right,
-body.export-mode.platform-og .fifa-right { min-height: 100%; }
+body.export-mode.platform-facebook-landscape .fclassic-left,
+body.export-mode.platform-og .fclassic-left,
+body.export-mode.platform-facebook-landscape .fclassic-right,
+body.export-mode.platform-og .fclassic-right { min-height: 100%; }
 body.export-mode.platform-facebook-landscape .card-body,
 body.export-mode.platform-og .card-body {
     flex: 1; height: 100%; overflow: hidden;
@@ -302,27 +302,27 @@ body.export-mode.platform-facebook-landscape .skill-cats,
 body.export-mode.platform-og .skill-cats { grid-template-columns: 1fr 1fr; }
 
 /* ── Sprint D: Banner layout ─────────────────────────────────────────────── */
-body.export-mode.platform-banner-custom .fifa-header {
+body.export-mode.platform-banner-custom .fclassic-header {
     flex: 1;
     height: 100%;
     align-self: stretch;
     grid-template-columns: var(--ex-photo-w) 1fr;
 }
-body.export-mode.platform-banner-custom .fifa-left  { min-height: 100%; justify-content: center; }
-body.export-mode.platform-banner-custom .fifa-right { min-height: 100%; justify-content: center; }
-body.export-mode.platform-banner-custom .fifa-overall { font-size: var(--ex-font-ovr); }
-body.export-mode.platform-banner-custom .fifa-name    { font-size: var(--ex-font-name); }
+body.export-mode.platform-banner-custom .fclassic-left  { min-height: 100%; justify-content: center; }
+body.export-mode.platform-banner-custom .fclassic-right { min-height: 100%; justify-content: center; }
+body.export-mode.platform-banner-custom .fclassic-overall { font-size: var(--ex-font-ovr); }
+body.export-mode.platform-banner-custom .fclassic-name    { font-size: var(--ex-font-name); }
 
 /* ── P0: FIFA-specific export scaling ────────────────────────────────────── */
 /* Banner --ex-photo-w differs from base (150/17vw/300 vs 120/15vw/280) */
 body.export-mode.platform-banner-custom {
     --ex-photo-w: clamp(150px, 17vw, 300px);
 }
-/* grid-template-columns for .fifa-header is now driven by --photo-col-w
+/* grid-template-columns for .fclassic-header is now driven by --photo-col-w
    (set from --ex-photo-w via body.export-mode .card-wrap above) — no
    separate header rule needed. */
-body.export-mode .fifa-overall  { font-size: var(--ex-font-ovr); }
-body.export-mode .fifa-name     { font-size: var(--ex-font-name); }
+body.export-mode .fclassic-overall  { font-size: var(--ex-font-ovr); }
+body.export-mode .fclassic-name     { font-size: var(--ex-font-name); }
 body.export-mode .skill-name,
 body.export-mode .skill-val     { font-size: var(--ex-font-skill); }
 body.export-mode .skill-bar-bg  { flex: 1 1 0 !important; max-width: none !important; }
@@ -344,7 +344,7 @@ body.export-mode.platform-og .skills-panel { padding-left: 1rem; }
     from { opacity: 0; transform: scale(0.7); }
     to   { opacity: 1; transform: scale(1); }
 }
-.fifa-overall { animation: pc-ovr-in 0.5s cubic-bezier(.34,1.56,.64,1) forwards; }
+.fclassic-overall { animation: pc-ovr-in 0.5s cubic-bezier(.34,1.56,.64,1) forwards; }
 
 @keyframes pc-cat-in {
     from { opacity: 0; transform: translateY(10px); }
@@ -358,7 +358,7 @@ body.export-mode.platform-og .skills-panel { padding-left: 1rem; }
     0%, 100% { box-shadow: inset 0 0 0 0 rgba(102,126,234,0); }
     50%       { box-shadow: inset 0 0 48px 6px rgba(102,126,234,0.08); }
 }
-.fifa-left { animation: pc-hero-glow 3s ease-in-out infinite; }
+.fclassic-left { animation: pc-hero-glow 3s ease-in-out infinite; }
 {% endblock %}
 
 {% block extra_body_classes %}{% if native_export_mode %} native-export-mode{% endif %}{% endblock %}
@@ -377,27 +377,27 @@ body.export-mode.platform-og .skills-panel { padding-left: 1rem; }
 <div class="card-wrap">
 
     <!-- Split header -->
-    <div class="fifa-header">
-        <div class="fifa-left">
+    <div class="fclassic-header">
+        <div class="fclassic-left">
             {% if photo_url %}
-            <img class="fifa-avatar" src="{{ photo_url }}" alt="{{ initials }}">
+            <img class="fclassic-avatar" src="{{ photo_url }}" alt="{{ initials }}">
             {% else %}
-            <div class="fifa-avatar" style="background: {{ avatar_bg }};">{{ initials }}</div>
+            <div class="fclassic-avatar" style="background: {{ avatar_bg }};">{{ initials }}</div>
             {% endif %}
         </div>
-        <div class="fifa-right">
-            <div class="fifa-right-body">
-            <div class="fifa-name-row">
-                <div class="fifa-overall">{{ overall | round(0) | int }}</div>
+        <div class="fclassic-right">
+            <div class="fclassic-right-body">
+            <div class="fclassic-name-row">
+                <div class="fclassic-overall">{{ overall | round(0) | int }}</div>
                 <div>
-                    <h2 class="fifa-name">{{ player.name }}</h2>
+                    <h2 class="fclassic-name">{{ player.name }}</h2>
                     {% if primary_pos_label %}
-                    <span class="fifa-pos-badge" style="background: {{ pos_color }};">{{ primary_pos_label }}</span>
+                    <span class="fclassic-pos-badge" style="background: {{ pos_color }};">{{ primary_pos_label }}</span>
                     {% endif %}
                     {% if secondary_pos_labels %}
-                    <div class="fifa-pos-secondary-badges">
+                    <div class="fclassic-pos-secondary-badges">
                         {% for lbl in secondary_pos_labels %}
-                        <span class="fifa-pos-secondary-badge">{{ lbl }}</span>
+                        <span class="fclassic-pos-secondary-badge">{{ lbl }}</span>
                         {% endfor %}
                     </div>
                     {% endif %}
@@ -432,13 +432,13 @@ body.export-mode.platform-og .skills-panel { padding-left: 1rem; }
             </div>
 
             {% if teams_info %}
-            <div class="fifa-club-pills">
+            <div class="fclassic-club-pills">
                 {% for t in teams_info %}
                 <span class="club-pill">🏟️ {{ t.team_name }}{% if t.club_name %} · {{ t.club_name }}{% endif %}{% if t.age_group_label %} · {{ t.age_group_label }}{% endif %}</span>
                 {% endfor %}
             </div>
             {% endif %}
-            </div>{# /fifa-right-body #}
+            </div>{# /fclassic-right-body #}
         </div>
     </div>
 

--- a/tests/unit/api/web_routes/test_player_card_gallery.py
+++ b/tests/unit/api/web_routes/test_player_card_gallery.py
@@ -581,7 +581,7 @@ class TestFifaHeaderBodyAlignment:
     """CE-14..CE-21 — Photo column right edge must align with Outfield left edge.
 
     Design intent: --photo-col-w CSS custom property is set on .card-wrap (default 170px).
-    Both .fifa-header and .card-body reference var(--photo-col-w) so they are always
+    Both .fclassic-header and .card-body reference var(--photo-col-w) so they are always
     in sync. In export-mode, body.export-mode .card-wrap overrides --photo-col-w to
     var(--ex-photo-w) so the alignment is preserved at any viewport / render context.
     Spacer is hidden only for landscape/banner (side-by-side layouts) and on mobile
@@ -635,9 +635,9 @@ class TestFifaHeaderBodyAlignment:
         )
 
     def test_ce20_header_uses_photo_col_w_token(self):
-        """fifa-header grid must reference var(--photo-col-w), not a hardcoded width."""
+        """fclassic-header grid must reference var(--photo-col-w), not a hardcoded width."""
         assert "var(--photo-col-w) 1fr" in self._html, (
-            ".fifa-header must use grid-template-columns: var(--photo-col-w) 1fr "
+            ".fclassic-header must use grid-template-columns: var(--photo-col-w) 1fr "
             "so header and body spacer are always in sync"
         )
 

--- a/tests/unit/services/test_fifa_default_card.py
+++ b/tests/unit/services/test_fifa_default_card.py
@@ -51,8 +51,8 @@ Template (TPL-*)
   TPL-20 skill_categories[2:] slice used for right column (Mental + Physical)
   TPL-21 app_logo_url is None in public_player.py Default card context (Phase 4 regression guard)
   TPL-22 sponsor_logo_url is the card-logo-bar-img source (not app_logo_url, not card-watermark)
-  TPL-23 fifa-right-body wrapper present; z-index:1 ensures content above watermark
-  TPL-24 img.fifa-avatar has no background inline style (avatar_bg must not leak behind photo)
+  TPL-23 fclassic-right-body wrapper present; z-index:1 ensures content above watermark
+  TPL-24 img.fclassic-avatar has no background inline style (avatar_bg must not leak behind photo)
   TPL-25 primary pos badge uses primary_pos_label (display label), not player.position (canonical)
   TPL-26 secondary pos badge CSS + markup present; secondary_pos_labels referenced
   TPL-27 no ST/GK orientation text labels in SVG; node.label render still present
@@ -537,44 +537,44 @@ def test_tpl22_sponsor_logo_url_in_logo_bar():
 
 
 def test_tpl23_fifa_right_body_wrapper_present():
-    """fifa-right-body wrapper must be present to stack content above watermark (z-index:1)."""
+    """fclassic-right-body wrapper must be present to stack content above watermark (z-index:1)."""
     html = _fifa_html()
-    assert "fifa-right-body" in html, (
-        ".fifa-right-body wrapper div must be present — it carries z-index:1 "
+    assert "fclassic-right-body" in html, (
+        ".fclassic-right-body wrapper div must be present — it carries z-index:1 "
         "so the name/identity-grid/clubs render above the z-index:0 .card-watermark"
     )
     # CSS must define the class with position:relative and z-index
-    assert ".fifa-right-body" in html, (
-        ".fifa-right-body CSS class must be defined in the template"
+    assert ".fclassic-right-body" in html, (
+        ".fclassic-right-body CSS class must be defined in the template"
     )
 
 
 def test_tpl24_photo_img_has_no_background_style():
-    """img.fifa-avatar must carry no background inline style — avatar_bg must not leak behind photo."""
+    """img.fclassic-avatar must carry no background inline style — avatar_bg must not leak behind photo."""
     html = _fifa_html()
-    img_match = re.search(r'<img class="fifa-avatar"[^>]*>', html)
-    assert img_match, "img.fifa-avatar element must be present in the template"
+    img_match = re.search(r'<img class="fclassic-avatar"[^>]*>', html)
+    assert img_match, "img.fclassic-avatar element must be present in the template"
     img_tag = img_match.group(0)
     assert "background" not in img_tag, (
-        "img.fifa-avatar must NOT have a 'background' inline style. "
+        "img.fclassic-avatar must NOT have a 'background' inline style. "
         "The avatar_bg colour was showing as a gradient/solid behind the player photo. "
-        "background belongs only on the div.fifa-avatar fallback (no-photo state)."
+        "background belongs only on the div.fclassic-avatar fallback (no-photo state)."
     )
 
 
 def test_tpl25_primary_pos_badge_uses_display_label():
     """Primary pos badge must render primary_pos_label (display label), not player.position (canonical)."""
     html = _fifa_html()
-    badge_pos = html.find('class="fifa-pos-badge"')
-    assert badge_pos != -1, "fifa-pos-badge class must be present"
+    badge_pos = html.find('class="fclassic-pos-badge"')
+    assert badge_pos != -1, "fclassic-pos-badge class must be present"
     context = html[badge_pos: badge_pos + 150]
     assert "primary_pos_label" in context, (
-        "fifa-pos-badge must render {{ primary_pos_label }} — the human-readable display label "
+        "fclassic-pos-badge must render {{ primary_pos_label }} — the human-readable display label "
         "from position_label(). Rendering player.position directly produces CENTRE_MIDFIELD "
         "(with underscore), which is not acceptable."
     )
     assert "player.position" not in context, (
-        "fifa-pos-badge must NOT render {{ player.position }} directly — "
+        "fclassic-pos-badge must NOT render {{ player.position }} directly — "
         "it is the raw canonical key and contains underscores."
     )
 
@@ -593,18 +593,18 @@ def test_tpl25b_position_label_has_no_underscore():
 def test_tpl26_secondary_pos_badge_markup_present():
     """Secondary pos badge CSS and Jinja markup must be present; secondary_pos_labels must be referenced."""
     html = _fifa_html()
-    assert ".fifa-pos-secondary-badge" in html, (
-        ".fifa-pos-secondary-badge CSS class must be defined"
+    assert ".fclassic-pos-secondary-badge" in html, (
+        ".fclassic-pos-secondary-badge CSS class must be defined"
     )
-    assert "fifa-pos-secondary-badges" in html, (
-        ".fifa-pos-secondary-badges wrapper CSS must be defined"
+    assert "fclassic-pos-secondary-badges" in html, (
+        ".fclassic-pos-secondary-badges wrapper CSS must be defined"
     )
     assert "secondary_pos_labels" in html, (
         "secondary_pos_labels variable must be referenced in the template "
         "to render secondary position badges"
     )
-    assert 'class="fifa-pos-secondary-badge"' in html, (
-        "<span class='fifa-pos-secondary-badge'> HTML markup must be present"
+    assert 'class="fclassic-pos-secondary-badge"' in html, (
+        "<span class='fclassic-pos-secondary-badge'> HTML markup must be present"
     )
 
 

--- a/tests/unit/test_platform_export_layout.py
+++ b/tests/unit/test_platform_export_layout.py
@@ -406,13 +406,13 @@ class TestPlaywrightP0ComponentSizing:
     # Combined selectors — first match wins across all card variants and templates.
     # ex- prefixed classes are from dedicated export templates (export render layer).
     _OVR_SELECTOR = (
-        ".ex-ovr-badge > span:first-child, .ex-ovr-num, .cmp-overall, .atl-ovr-num, .sc-overall, .pls-ovr-text, .fifa-overall"
+        ".ex-ovr-badge > span:first-child, .ex-ovr-num, .cmp-overall, .atl-ovr-num, .sc-overall, .pls-ovr-text, .fclassic-overall"
     )
     # Photo column: only variants with a dedicated width column.
-    # Editor templates: .cmp-photo-col (compact) or .fifa-left (FIFA).
+    # Editor templates: .cmp-photo-col (compact) or .fclassic-left (FIFA).
     # Export templates (.ex-*) use a circular avatar, not a column — PL-08 skips for those.
     # Atlas/showcase/pulse use full-bleed hero backgrounds — also skip.
-    _PHOTO_COL_SELECTOR = ".cmp-photo-col, .fifa-left"
+    _PHOTO_COL_SELECTOR = ".cmp-photo-col, .fclassic-left"
 
     def _open_card(self, platform_id: str):
         """Return (page, browser, pw, w, h). Caller must call pw.stop()."""


### PR DESCRIPTION
## PR-FC-1D — CSS Class Rename: .fifa-* → .fclassic-*

**Part of the full FIFA naming removal migration (PR-FC-1R). Follows PR-FC-1C.**

Pure CSS selector rename — no logic, no structure, no property changes.

### Templates changed (4 files, 150 class occurrences)
| File | Occurrences |
|---|---|
| `public/player_card_fclassic.html` | 55 |
| `admin/user_profile.html` | 50 |
| `public/player_card.html` | 44 |
| `macros/card_photo_fallback.html` | 1 |

### 23 CSS classes renamed
`.fclassic-header`, `.fclassic-left`, `.fclassic-right`, `.fclassic-right-body`,
`.fclassic-avatar`, `.fclassic-overall`, `.fclassic-overall-num`,
`.fclassic-tier`, `.fclassic-tier-badge`, `.fclassic-name`, `.fclassic-name-row`,
`.fclassic-pos-badge`, `.fclassic-pos-secondary-badge/-badges`,
`.fclassic-identity-grid`, `.fclassic-field`, `.fclassic-field-label/-value`,
`.fclassic-teams`, `.fclassic-team-pill`, `.fclassic-club-pills`,
`.fclassic-email`, `.fclassic-no-license`

### Scope
No CSS property changes · no HTML structure changes · no logic changes
· no comments cleanup · no alias removal · no route rename · no CE-3.9

## Test plan
- [ ] 212 non-Playwright tests PASS
- [ ] Zero `.fifa-*` in production HTML templates
- [ ] Route count: 842 · OpenAPI snapshot: unchanged
- [ ] Card Export Gate PASS · Card Render Integration PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)