### PR TITLE
feat(cs-s0): CS-S0 — Unified Card Studio shell MVP (Welcome mode)

### DIFF
--- a/app/api/web_routes/__init__.py
+++ b/app/api/web_routes/__init__.py
@@ -29,6 +29,7 @@ from . import (
     sport_director,
     my_cards,
     card_editor,
+    card_studio,
     shop,
     friends,
     vt_challenges,
@@ -68,6 +69,7 @@ router.include_router(public_tournament.router)  # 🌐 Public event detail page
 router.include_router(sport_director.router)     # 🏅 Sport Director team enrollment
 router.include_router(my_cards.router)           # 🃏 My Cards hub (/my-cards)
 router.include_router(card_editor.router)        # ✏️  Card Editor (/card-editor)
+router.include_router(card_studio.router)        # 🎴  Card Studio shell (/card-studio)
 router.include_router(shop.router)               # 🛒 Card Shop (/shop)
 router.include_router(friends.router)            # 👥 Friendship system (/friends)
 router.include_router(vt_challenges.router)      # 🎮 VT Challenges (/challenges)

--- a/app/api/web_routes/card_studio.py
+++ b/app/api/web_routes/card_studio.py
@@ -1,0 +1,165 @@
+"""Card Studio unified shell routes (CS-S0).
+
+Single unified studio shell with card-type switcher.
+CS-S0 MVP: Welcome Card mode fully functional.
+Player and Challenge modes shown as Coming Soon.
+
+Canonical routes:
+  GET /card-studio              → shell (Welcome default for CS-S0)
+  GET /card-studio/welcome      → shell, Welcome mode
+  GET /card-studio/welcome?format=X → shell, Welcome mode, specific format
+
+Backward-compat routes remain in card_editor.py unchanged.
+"""
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, Query, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+from sqlalchemy.orm import Session
+
+from ...database import get_db
+from ...dependencies import get_current_user_web
+from ...models.license import UserLicense
+from ...models.user import User
+from ...services.card_design_service import get_owned_design_ids
+from ...services.card_design_service import (
+    WELCOME_CARD_FORMATS,
+    get_card_family,
+)
+from ...services.mood_photo_service import get_mood_photos_for_user
+from .card_editor import (
+    _WC_FORMAT_BY_ID,
+    _WC_RATIO,
+    _WC_VALID_IDS,
+    _MOOD_SLOT_META,
+)
+
+BASE_DIR = Path(__file__).resolve().parent.parent.parent
+templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
+
+router = APIRouter(tags=["card-studio"])
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+_STUDIO_NAV_CTX = {
+    "spec_dashboard_url":  "/dashboard/lfa-football-player",
+    "spec_dashboard_icon": "⚽",
+    "spec_profile_url":    "/profile/lfa-football-player",
+    "spec_profile_icon":   "🪪",
+}
+
+_WELCOME_FORMATS_ORDERED = WELCOME_CARD_FORMATS  # 7 formats, canonical order
+
+
+def _license_guard(db: Session, user_id: int):
+    """Return active LFA license or None."""
+    return db.query(UserLicense).filter(
+        UserLicense.user_id == user_id,
+        UserLicense.specialization_type == "LFA_FOOTBALL_PLAYER",
+    ).first()
+
+
+def _resolve_welcome_context(db: Session, user, format_id: str | None):
+    """
+    Resolve all context needed for Welcome mode in the unified shell.
+    Returns (context_dict, redirect_url_or_None).
+    redirect_url: caller must issue 303 redirect if set.
+    """
+    lic = _license_guard(db, user.id)
+    if not lic:
+        return None, "/dashboard?info=complete_lfa_onboarding_first"
+    if not lic.onboarding_completed:
+        return None, "/specialization/lfa-player/onboarding"
+
+    owned_set = set(get_owned_design_ids(db, user.id, "welcome_card")) & _WC_VALID_IDS
+    owned_formats_ordered = [f for f in _WELCOME_FORMATS_ORDERED if f.design_id in owned_set]
+    if not owned_formats_ordered:
+        return None, "/shop/cards/welcome"
+
+    first_owned_id = owned_formats_ordered[0].design_id
+
+    if format_id is None or format_id not in owned_set:
+        return None, f"/card-studio/welcome?format={first_owned_id}"
+
+    fmt = _WC_FORMAT_BY_ID[format_id]
+    ratio_class = _WC_RATIO.get(fmt.preview_platform, "mfg-ratio-11")
+    preview_url = f"/profile/onboarding-card?platform={fmt.preview_platform}"
+    export_url  = f"/profile/onboarding-card/export?platform={fmt.preview_platform}"
+
+    owned_format_rows = [
+        {
+            "design_id":   f.design_id,
+            "label":       f.label,
+            "style_tag":   f.style_tag,
+            "dims":        f.dims,
+            "preview_url": f"/profile/onboarding-card?platform={f.preview_platform}",
+            "active":      f.design_id == format_id,
+        }
+        for f in owned_formats_ordered
+    ]
+
+    mood_photos = get_mood_photos_for_user(user.id, db)
+
+    ctx = {
+        "active_type":        "welcome",
+        "active_format":      format_id,
+        "fmt":                fmt,
+        "ratio_class":        ratio_class,
+        "preview_url":        preview_url,
+        "export_url":         export_url,
+        "owned_format_rows":  owned_format_rows,
+        "wc_photo_url":           lic.wc_photo_url,
+        "wc_photo_portrait_url":  lic.wc_photo_portrait_url,
+        "wc_photo_landscape_url": lic.wc_photo_landscape_url,
+        "mood_photos":            mood_photos,
+        "mood_slot_meta":         _MOOD_SLOT_META,
+        **_STUDIO_NAV_CTX,
+    }
+    return ctx, None
+
+
+# ── Routes ────────────────────────────────────────────────────────────────────
+
+@router.get("/card-studio", response_class=HTMLResponse)
+async def card_studio_default(
+    request: Request,
+    db:   Session = Depends(get_db),
+    user: User    = Depends(get_current_user_web),
+):
+    """Card Studio landing — defaults to Welcome mode for CS-S0.
+
+    Renders the unified shell with Welcome Card active.
+    Player and Challenge shown as Coming Soon.
+    """
+    # CS-S0: default to Welcome — redirect to canonical with first owned format
+    lic = _license_guard(db, user.id)
+    if not lic or not lic.onboarding_completed:
+        target = "/dashboard?info=complete_lfa_onboarding_first" if not lic else "/specialization/lfa-player/onboarding"
+        return RedirectResponse(url=target, status_code=303)
+
+    owned_set = set(get_owned_design_ids(db, user.id, "welcome_card")) & _WC_VALID_IDS
+    if owned_set:
+        first = next((f.design_id for f in _WELCOME_FORMATS_ORDERED if f.design_id in owned_set), None)
+        if first:
+            return RedirectResponse(url=f"/card-studio/welcome?format={first}", status_code=303)
+
+    return RedirectResponse(url="/shop/cards/welcome", status_code=303)
+
+
+@router.get("/card-studio/welcome", response_class=HTMLResponse)
+async def card_studio_welcome(
+    request:   Request,
+    format_id: str | None = Query(default=None, alias="format"),
+    db:        Session    = Depends(get_db),
+    user:      User       = Depends(get_current_user_web),
+):
+    """Unified Studio shell — Welcome Card mode (CS-S0 fully functional)."""
+    ctx, redirect = _resolve_welcome_context(db, user, format_id)
+    if redirect:
+        return RedirectResponse(url=redirect, status_code=303)
+
+    return templates.TemplateResponse(
+        "card_studio_shell.html",
+        {"request": request, "user": user, **ctx},
+    )

--- a/app/templates/card_studio_shell.html
+++ b/app/templates/card_studio_shell.html
@@ -1,0 +1,531 @@
+{% extends "student_base.html" %}
+
+{% block title %}Card Studio — LFA Education Center{% endblock %}
+{% block active_page %}card-studio{% endblock %}
+
+{% block student_header %}
+{% set _page_icon = '🎴' %}
+{% set _page_name = 'Card Studio' %}
+{% include "includes/spec_subpage_hdr.html" %}
+{% endblock %}
+
+{% block extra_styles %}
+{% include "includes/cs_studio_shared.html" %}
+{% include "includes/mc_format_grid.html" %}
+<style>
+
+/* ── Shell Layout ── */
+.cs-shell-wrap { max-width: 1200px; margin: 0 auto; padding: 0 0 2rem; }
+
+/* ── Type Switcher ── */
+.cs-type-switcher {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+.cs-type-btn {
+  display: inline-flex; align-items: center; gap: 0.4rem;
+  padding: 0.5rem 1rem;
+  border-radius: 8px; border: 1.5px solid #334155;
+  background: transparent; color: #94a3b8;
+  font-size: 0.82rem; font-weight: 600;
+  cursor: pointer; transition: border-color 0.15s, color 0.15s;
+}
+.cs-type-btn:hover:not(:disabled) { border-color: #64748b; color: #f1f5f9; }
+.cs-type-btn.cs-type-active {
+  border-color: #FFD200; color: #FFD200;
+  background: rgba(255,210,0,0.06);
+}
+.cs-type-btn.cs-type-soon {
+  opacity: 0.45; cursor: not-allowed;
+}
+.cs-type-icon { font-size: 1rem; }
+.cs-type-badge {
+  font-size: 0.62rem; font-weight: 700;
+  background: #1e293b; color: #64748b;
+  border-radius: 4px; padding: 0.1rem 0.35rem;
+  text-transform: uppercase; letter-spacing: 0.05em;
+}
+
+/* ── Format Bar ── */
+.cs-format-bar {
+  display: flex; flex-wrap: wrap; gap: 0.4rem;
+  margin-bottom: 1rem;
+}
+.cs-format-pill {
+  display: inline-flex; flex-direction: column; align-items: flex-start;
+  padding: 0.4rem 0.75rem; border-radius: 7px;
+  border: 1px solid #334155; color: #94a3b8;
+  background: transparent; text-decoration: none;
+  font-size: 0.78rem; font-weight: 600;
+  transition: border-color 0.15s, color 0.15s; line-height: 1.3;
+}
+.cs-format-pill:hover { border-color: #64748b; color: #f1f5f9; text-decoration: none; }
+.cs-format-pill.cs-format-active {
+  border-color: #FFD200; color: #FFD200;
+  background: rgba(255,210,0,0.06);
+}
+.cs-format-dims { font-size: 0.64rem; font-weight: 400; color: #475569; }
+.cs-format-pill.cs-format-active .cs-format-dims { color: #b89c00; }
+
+/* ── Body Layout: desktop two-col, mobile single-col ── */
+.cs-shell-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+@media (min-width: 900px) {
+  .cs-shell-body {
+    flex-direction: row;
+    align-items: flex-start;
+    gap: 1.5rem;
+  }
+  .cs-control-panel {
+    flex: 0 0 320px;
+    position: sticky;
+    top: 1rem;
+    max-height: calc(100vh - 5rem);
+    overflow-y: auto;
+  }
+  .cs-preview-col {
+    flex: 1;
+    min-width: 0;
+  }
+}
+
+/* ── Control Panel ── */
+.cs-control-panel {
+  background: #0f172a;
+  border: 1px solid #1e293b;
+  border-radius: 14px;
+  padding: 1.25rem 1.25rem;
+}
+.cs-section-label {
+  font-size: 0.7rem; font-weight: 700;
+  letter-spacing: 0.08em; text-transform: uppercase;
+  color: #475569; margin: 0 0 0.6rem;
+}
+.cs-section-divider { border: none; border-top: 1px solid #1e293b; margin: 1rem 0; }
+
+/* ── Mood Photos Quick Row ── */
+.cs-mood-section { margin-bottom: 0; }
+.cs-mood-title {
+  font-size: 0.7rem; font-weight: 700;
+  letter-spacing: 0.08em; text-transform: uppercase;
+  color: #475569; margin: 0 0 0.5rem;
+}
+.cs-mood-grid { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-bottom: 0.4rem; }
+.cs-mood-chip {
+  position: relative;
+  background: #0b1120; border: 1.5px solid #334155; border-radius: 8px;
+  cursor: pointer; padding: 0.35rem 0.25rem;
+  display: flex; flex-direction: column; align-items: center; gap: 0.12rem;
+  transition: border-color 0.15s, background 0.15s;
+  width: 58px; min-height: 52px;
+}
+.cs-mood-chip:not([disabled]):hover { border-color: #FFD200; }
+.cs-mood-chip--empty { opacity: 0.35; cursor: not-allowed; }
+.cs-mood-chip--selected {
+  border-color: #FFD200;
+  background: rgba(255,210,0,0.08);
+}
+.cs-mood-emoji { font-size: 1.3rem; line-height: 1; }
+.cs-mood-label {
+  font-size: 0.56rem; color: #64748b; text-align: center;
+  line-height: 1.2; max-width: 54px;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.cs-mood-chip--selected .cs-mood-label { color: #b89c00; }
+.cs-mood-check {
+  position: absolute; top: 2px; right: 3px;
+  font-size: 0.58rem; color: #FFD200; font-weight: 700;
+}
+.cs-mood-manage { margin: 0.35rem 0 0; }
+.cs-mood-manage-link { font-size: 0.73rem; color: #64748b; text-decoration: none; transition: color 0.15s; }
+.cs-mood-manage-link:hover { color: #FFD200; text-decoration: none; }
+
+/* ── Upload / Photo actions ── */
+.cs-photo-panel { }
+.cs-photo-preview {
+  width: 64px; height: 64px; object-fit: cover;
+  border-radius: 7px; border: 1px solid #334155; display: block; margin-bottom: 0.5rem;
+}
+.cs-photo-empty {
+  width: 64px; height: 64px; border-radius: 7px;
+  border: 1px dashed #334155; background: #0b1120;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 1.3rem; color: #334155; margin-bottom: 0.5rem;
+}
+.cs-photo-actions { display: flex; gap: 0.4rem; flex-wrap: wrap; align-items: center; }
+.cs-btn-upload {
+  display: inline-flex; align-items: center; gap: 0.25rem;
+  padding: 0.4rem 0.85rem; background: #FFD200; color: #0f172a;
+  font-size: 0.78rem; font-weight: 700; border-radius: 6px;
+  cursor: pointer; border: none; transition: opacity 0.15s;
+}
+.cs-btn-upload:hover { opacity: 0.88; }
+.cs-btn-delete {
+  display: inline-flex; align-items: center; gap: 0.25rem;
+  padding: 0.4rem 0.75rem; background: transparent; color: #94a3b8;
+  font-size: 0.78rem; font-weight: 600;
+  border: 1px solid #334155; border-radius: 6px; cursor: pointer;
+  transition: border-color 0.15s, color 0.15s;
+}
+.cs-btn-delete:hover { border-color: #ef4444; color: #ef4444; }
+.cs-photo-error { font-size: 0.78rem; color: #f87171; margin-top: 0.4rem; display: none; }
+.cs-slot-hint { font-size: 0.72rem; color: #475569; margin: 0 0 0.6rem; }
+
+/* ── Preview column ── */
+.cs-preview-col { }
+.cs-preview-panel {
+  background: #0f172a; border: 1px solid #1e293b;
+  border-radius: 14px; padding: 1.25rem;
+  margin-bottom: 1rem;
+}
+.cs-preview-label {
+  font-size: 0.7rem; font-weight: 700;
+  letter-spacing: 0.07em; text-transform: uppercase;
+  color: #475569; margin: 0 0 0.75rem;
+}
+.cs-preview-container { display: flex; justify-content: center; }
+.cs-preview-wrap {
+  width: 100%; max-width: 320px; position: relative;
+  border-radius: 8px; overflow: hidden; background: #0b1120;
+}
+
+/* ── Export panel ── */
+.cs-export-panel {
+  background: #0f172a; border: 1px solid #1e293b;
+  border-radius: 14px; padding: 1.25rem 1.5rem;
+}
+.cs-export-title { font-size: 1rem; font-weight: 700; color: #f1f5f9; margin: 0 0 0.25rem; }
+.cs-export-dims { font-size: 0.8rem; color: #475569; margin: 0 0 0.75rem; }
+.cs-btn-download {
+  display: inline-flex; align-items: center; gap: 0.35rem;
+  padding: 0.55rem 1.25rem; background: #FFD200; color: #0f172a;
+  font-size: 0.875rem; font-weight: 700; border-radius: 8px;
+  text-decoration: none; transition: opacity 0.15s;
+}
+.cs-btn-download:hover { opacity: 0.88; color: #0f172a; text-decoration: none; }
+
+/* ── Format meta strip ── */
+.cs-format-meta { display: flex; align-items: center; gap: 0.65rem; flex-wrap: wrap; margin-bottom: 1rem; }
+.cs-style-tag { font-size: 0.68rem; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: #64748b; }
+.cs-dims-text { font-size: 0.78rem; color: #475569; }
+.cs-owned-badge { font-size: 0.73rem; font-weight: 700; color: #86efac; background: rgba(134,239,172,.12); border: 1px solid rgba(134,239,172,.25); border-radius: 20px; padding: 0.18rem 0.6rem; }
+
+</style>
+{% endblock %}
+
+{% block student_content %}
+<div class="cs-shell-wrap">
+
+  <nav class="wcs-breadcrumb" aria-label="Breadcrumb">
+    <a href="/card-studio">Card Studio</a>
+    {% if active_type == "welcome" and fmt %}
+    <span>›</span>
+    <span>Welcome Card</span>
+    <span>›</span>
+    <span>{{ fmt.label }}</span>
+    {% endif %}
+  </nav>
+
+  {# ── Type Switcher ── #}
+  {% include "includes/cs_type_switcher.html" %}
+
+  {# ── Format Bar ── #}
+  {% include "includes/cs_format_bar.html" %}
+
+  {# ── Format meta strip (Welcome mode) ── #}
+  {% if active_type == "welcome" and fmt %}
+  <div class="cs-format-meta">
+    <span class="cs-style-tag">{{ fmt.style_tag }}</span>
+    <span class="cs-dims-text">{{ fmt.dims }}</span>
+    <span class="cs-owned-badge">Owned ✓</span>
+  </div>
+  {% endif %}
+
+  {# ── Main body: control panel + preview ── #}
+  <div class="cs-shell-body">
+
+    {# ── LEFT: Control Panel ── #}
+    <div class="cs-control-panel">
+
+      {# Determine format-aware photo slot and endpoints #}
+      {% if active_type == "welcome" and active_format %}
+        {% if active_format in ('instagram_portrait', 'instagram_story', 'tiktok') %}
+          {% set _cs_photo_current = wc_photo_portrait_url %}
+          {% set _cs_upload_url    = '/dashboard/wc-photo-portrait' %}
+          {% set _cs_delete_url    = '/dashboard/wc-photo-portrait/delete' %}
+          {% set _cs_assign_url    = '/dashboard/wc-photo-portrait/from-mood' %}
+          {% set _cs_slot_label    = 'Portrait Photo' %}
+          {% set _cs_slot_hint     = 'Used for portrait and Story formats (1080 × 1920, 1080 × 1350).' %}
+        {% elif active_format in ('facebook_landscape', 'banner_custom') %}
+          {% set _cs_photo_current = wc_photo_landscape_url %}
+          {% set _cs_upload_url    = '/dashboard/wc-photo-landscape' %}
+          {% set _cs_delete_url    = '/dashboard/wc-photo-landscape/delete' %}
+          {% set _cs_assign_url    = '/dashboard/wc-photo-landscape/from-mood' %}
+          {% set _cs_slot_label    = 'Landscape Photo' %}
+          {% set _cs_slot_hint     = 'Used for landscape and banner formats (1200 × 630, 1500 × 500).' %}
+        {% else %}
+          {% set _cs_photo_current = wc_photo_url %}
+          {% set _cs_upload_url    = '/dashboard/wc-photo' %}
+          {% set _cs_delete_url    = '/dashboard/wc-photo/delete' %}
+          {% set _cs_assign_url    = '/dashboard/wc-photo/from-mood' %}
+          {% set _cs_slot_label    = 'Welcome Photo' %}
+          {% set _cs_slot_hint     = 'Used for square and default formats (1080 × 1080).' %}
+        {% endif %}
+      {% else %}
+        {% set _cs_photo_current = none %}
+        {% set _cs_assign_url = '/dashboard/wc-photo/from-mood' %}
+        {% set _cs_slot_hint = '' %}
+        {% set _cs_slot_label = 'Photo' %}
+        {% set _cs_upload_url = '/dashboard/wc-photo' %}
+        {% set _cs_delete_url = '/dashboard/wc-photo/delete' %}
+      {% endif %}
+
+      {# ── SECTION 1: Mood Photos Quick Row (ALWAYS VISIBLE) ── #}
+      <p class="cs-section-label">Mood Photos</p>
+      {# Render mood quick row with assign URL and selected detection #}
+      {% set mood_photos    = mood_photos    if mood_photos    is defined else {} %}
+      {% set mood_slot_meta = mood_slot_meta if mood_slot_meta is defined else [] %}
+      <div class="cs-mood-section"
+           data-assign-url="{{ _cs_assign_url }}">
+        <div class="cs-mood-grid" id="cs-mood-grid">
+          {% for meta in mood_slot_meta %}
+            {% set _mp  = mood_photos.get(meta.slot) %}
+            {% set _has = _mp and _mp.original_url %}
+            {% set _sel = _has and _mp.original_url == _cs_photo_current %}
+            <button class="cs-mood-chip{% if _sel %} cs-mood-chip--selected{% endif %}{% if not _has %} cs-mood-chip--empty{% endif %}"
+                    type="button"
+                    data-mood-slot="{{ meta.slot }}"
+                    {% if not _has %}disabled aria-disabled="true"{% endif %}
+                    title="{{ meta.label }}">
+              <span class="cs-mood-emoji">{{ meta.emoji }}</span>
+              <span class="cs-mood-label">{{ meta.label }}</span>
+              {% if _sel %}<span class="cs-mood-check" aria-hidden="true">✓</span>{% endif %}
+            </button>
+          {% endfor %}
+        </div>
+        <p class="cs-mood-manage">
+          <a href="/profile/my-mood-photos" class="cs-mood-manage-link">Manage Mood Photos →</a>
+        </p>
+      </div>
+
+      <hr class="cs-section-divider">
+
+      {# ── SECTION 2: Upload Fallback ── #}
+      <p class="cs-section-label">{{ _cs_slot_label }}</p>
+      {% if _cs_slot_hint %}
+      <p class="cs-slot-hint">{{ _cs_slot_hint }}</p>
+      {% endif %}
+
+      <div class="cs-photo-panel"
+           data-upload-url="{{ _cs_upload_url }}"
+           data-delete-url="{{ _cs_delete_url }}">
+        {% if _cs_photo_current %}
+        <img id="cs-current-photo" class="cs-photo-preview"
+             src="{{ _cs_photo_current }}" alt="{{ _cs_slot_label }}">
+        <div id="cs-photo-empty" class="cs-photo-empty" style="display:none;">📷</div>
+        {% else %}
+        <img id="cs-current-photo" class="cs-photo-preview"
+             src="" alt="{{ _cs_slot_label }}" style="display:none;">
+        <div id="cs-photo-empty" class="cs-photo-empty">📷</div>
+        {% endif %}
+
+        <div class="cs-photo-actions">
+          <label class="cs-btn-upload">
+            ↑ Upload Photo
+            <input id="cs-photo-input" type="file" accept="image/*" style="display:none;">
+          </label>
+          <button id="cs-photo-delete-btn" class="cs-btn-delete"
+                  {% if not _cs_photo_current %}style="display:none;"{% endif %}>
+            ✕ Remove
+          </button>
+        </div>
+        <p id="cs-photo-error" class="cs-photo-error"></p>
+      </div>
+
+      <hr class="cs-section-divider">
+
+      {# ── SECTION 3: Color / Theme placeholder (CS-S3) ── #}
+      <p class="cs-section-label">Color / Theme</p>
+      <p style="font-size:0.75rem;color:#475569;margin:0;">Color picker coming in next update.</p>
+
+    </div>{# END .cs-control-panel #}
+
+    {# ── RIGHT: Preview + Export ── #}
+    <div class="cs-preview-col">
+
+      {# Preview panel #}
+      <div class="cs-preview-panel">
+        <p class="cs-preview-label">Preview</p>
+        <div class="cs-preview-container">
+          <div class="cs-preview-wrap mfg-preview-wrap {{ ratio_class }}">
+            <iframe
+              id="cs-preview-iframe"
+              class="mfg-preview-iframe"
+              src="{{ preview_url }}"
+              loading="lazy"
+              scrolling="no"
+              title="{{ fmt.label if fmt else 'Card' }} Preview"
+            ></iframe>
+          </div>
+        </div>
+      </div>
+
+      {# Export panel #}
+      <div class="cs-export-panel">
+        <p class="cs-export-title">Download your card</p>
+        {% if fmt %}
+        <p class="cs-export-dims">{{ fmt.dims }} — {{ fmt.label }}</p>
+        {% endif %}
+        <a href="{{ export_url }}" class="cs-btn-download" download>
+          ↓ Download PNG{% if fmt %} ({{ fmt.dims }}){% endif %}
+        </a>
+      </div>
+
+    </div>{# END .cs-preview-col #}
+
+  </div>{# END .cs-shell-body #}
+
+  {# ── Bottom nav ── #}
+  <div class="wcs-nav">
+    <a href="/my-cards/welcome" class="wcs-nav-back">← My Welcome Cards</a>
+    <a href="/shop/cards/welcome" class="wcs-nav-shop">Browse Formats →</a>
+  </div>
+
+</div>{# END .cs-shell-wrap #}
+
+<script>
+(function () {
+  'use strict';
+
+  // ── Common helpers ────────────────────────────────────────────────────────
+  var iframe     = document.getElementById('cs-preview-iframe');
+  var currentImg = document.getElementById('cs-current-photo');
+  var emptyBox   = document.getElementById('cs-photo-empty');
+  var deleteBtn  = document.getElementById('cs-photo-delete-btn');
+  var photoInput = document.getElementById('cs-photo-input');
+  var errorEl    = document.getElementById('cs-photo-error');
+
+  var uploadPanel = document.querySelector('.cs-photo-panel');
+  var moodSection = document.querySelector('.cs-mood-section');
+
+  var uploadUrl = uploadPanel ? uploadPanel.dataset.uploadUrl : '';
+  var deleteUrl = uploadPanel ? uploadPanel.dataset.deleteUrl : '';
+  var assignUrl = moodSection ? moodSection.dataset.assignUrl : '';
+
+  function _csrf() {
+    return (document.cookie.split('; ').find(function (r) { return r.startsWith('csrf_token='); }) || '').split('=')[1] || '';
+  }
+  function _reloadPreview() { if (iframe) { iframe.src = iframe.src; } }
+  function _showError(msg) { if (errorEl) { errorEl.textContent = msg; errorEl.style.display = 'block'; } }
+  function _clearError()   { if (errorEl) { errorEl.style.display = 'none'; errorEl.textContent = ''; } }
+
+  function _showPhoto(url) {
+    if (currentImg) { currentImg.src = url; currentImg.style.display = 'block'; }
+    if (emptyBox)   { emptyBox.style.display = 'none'; }
+    if (deleteBtn)  { deleteBtn.style.display = 'inline-flex'; }
+  }
+  function _clearPhoto() {
+    if (currentImg) { currentImg.src = ''; currentImg.style.display = 'none'; }
+    if (emptyBox)   { emptyBox.style.display = 'flex'; }
+    if (deleteBtn)  { deleteBtn.style.display = 'none'; }
+  }
+
+  // ── Upload fallback ───────────────────────────────────────────────────────
+  if (photoInput) {
+    photoInput.addEventListener('change', function (e) {
+      var file = e.target.files[0];
+      if (!file) return;
+      _clearError();
+      var csrf = _csrf();
+      if (!csrf) { _showError('Session expired — please reload the page.'); photoInput.value = ''; return; }
+      var fd = new FormData();
+      fd.append('file', file);
+      fetch(uploadUrl, { method: 'POST', body: fd, headers: { 'X-CSRF-Token': csrf } })
+        .then(function (r) {
+          if (r.status === 403) { return Promise.reject(new Error('csrf')); }
+          return r.json();
+        })
+        .then(function (data) {
+          if (data.ok) { _showPhoto(data.photo_url); _reloadPreview(); }
+          else { _showError(data.error || 'Upload failed. Please try again.'); }
+        })
+        .catch(function (err) {
+          if (err && err.message === 'csrf') { _showError('Session expired — please reload the page.'); }
+          else { _showError('Upload failed. Please check the file and try again.'); }
+        });
+      photoInput.value = '';
+    });
+  }
+
+  // ── Delete fallback ───────────────────────────────────────────────────────
+  if (deleteBtn) {
+    deleteBtn.addEventListener('click', function () {
+      _clearError();
+      var csrf = _csrf();
+      if (!csrf) { _showError('Session expired — please reload the page.'); return; }
+      fetch(deleteUrl, { method: 'POST', headers: { 'X-CSRF-Token': csrf } })
+        .then(function (r) {
+          if (r.status === 403) { return Promise.reject(new Error('csrf')); }
+          return r.json();
+        })
+        .then(function (data) {
+          if (data.ok) { _clearPhoto(); _reloadPreview(); }
+          else { _showError(data.error || 'Delete failed. Please try again.'); }
+        })
+        .catch(function (err) {
+          if (err && err.message === 'csrf') { _showError('Session expired — please reload the page.'); }
+          else { _showError('Delete failed. Please try again.'); }
+        });
+    });
+  }
+
+  // ── Mood Photos assign ────────────────────────────────────────────────────
+  document.querySelectorAll('.cs-mood-chip:not([disabled])').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      var moodSlot = btn.dataset.moodSlot;
+      var csrf = _csrf();
+      if (!csrf) { _showError('Session expired — please reload the page.'); return; }
+      _clearError();
+      fetch(assignUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrf },
+        body: JSON.stringify({ mood_slot: moodSlot }),
+      })
+        .then(function (r) {
+          if (r.status === 403) { return Promise.reject(new Error('csrf')); }
+          return r.json();
+        })
+        .then(function (data) {
+          if (data.ok) {
+            _showPhoto(data.photo_url);
+            _reloadPreview();
+            document.querySelectorAll('.cs-mood-chip').forEach(function (c) {
+              c.classList.remove('cs-mood-chip--selected');
+              var chk = c.querySelector('.cs-mood-check');
+              if (chk) { chk.parentNode.removeChild(chk); }
+            });
+            btn.classList.add('cs-mood-chip--selected');
+            var chkEl = document.createElement('span');
+            chkEl.className = 'cs-mood-check';
+            chkEl.setAttribute('aria-hidden', 'true');
+            chkEl.textContent = '✓';
+            btn.appendChild(chkEl);
+          } else {
+            _showError(data.error || 'Could not assign mood photo. Please try again.');
+          }
+        })
+        .catch(function (err) {
+          if (err && err.message === 'csrf') { _showError('Session expired — please reload the page.'); }
+          else { _showError('Could not assign mood photo. Please try again.'); }
+        });
+    });
+  });
+
+})();
+</script>
+{% endblock %}

--- a/app/templates/includes/cs_export_panel.html
+++ b/app/templates/includes/cs_export_panel.html
@@ -1,0 +1,12 @@
+{# CS-S0: Export / Publish panel
+   export_url: PNG export URL
+   fmt:        NonPlayerCardFormatDefinition #}
+<div class="cs-export-panel">
+  <p class="cs-export-title">Export</p>
+  {% if fmt %}
+  <p class="cs-export-dims">{{ fmt.dims }}</p>
+  <a href="{{ export_url }}" class="cs-btn-download" download>
+    ↓ Download PNG
+  </a>
+  {% endif %}
+</div>

--- a/app/templates/includes/cs_format_bar.html
+++ b/app/templates/includes/cs_format_bar.html
@@ -1,0 +1,15 @@
+{# CS-S0: Format/Design bar — Welcome Card mode
+   owned_format_rows: list of {design_id, label, style_tag, dims, active}
+   active_type: "welcome" | "player" | "challenge" #}
+{% if active_type == "welcome" %}
+<div class="cs-format-bar" aria-label="Format selector">
+  {% for f in owned_format_rows %}
+  <a href="/card-studio/welcome?format={{ f.design_id }}"
+     class="cs-format-pill{% if f.active %} cs-format-active{% endif %}"
+     aria-current="{{ 'true' if f.active else 'false' }}">
+    <span class="cs-format-label">{{ f.label }}</span>
+    <span class="cs-format-dims">{{ f.dims }}</span>
+  </a>
+  {% endfor %}
+</div>
+{% endif %}

--- a/app/templates/includes/cs_mood_quick_row.html
+++ b/app/templates/includes/cs_mood_quick_row.html
@@ -1,0 +1,32 @@
+{# CS-S0: Mood Photos Quick Row — always visible, never collapsed.
+   Receives context vars from parent template:
+     mood_photos:    dict[str, UserMoodPhoto|None]
+     mood_slot_meta: list[{slot, emoji, label}]
+     _cs_assign_url: the format-aware assign endpoint URL
+     _cs_photo_current: current WC slot photo URL (for selected detection)
+   Guards: mood_photos/mood_slot_meta are defined else {} / [] #}
+{% set mood_photos    = mood_photos    if mood_photos    is defined else {} %}
+{% set mood_slot_meta = mood_slot_meta if mood_slot_meta is defined else [] %}
+
+<div class="cs-mood-section" id="cs-mood-section">
+  <p class="cs-mood-title">Mood Photos</p>
+  <div class="cs-mood-grid" id="cs-mood-grid">
+    {% for meta in mood_slot_meta %}
+      {% set _mp  = mood_photos.get(meta.slot) %}
+      {% set _has = _mp and _mp.original_url %}
+      {% set _sel = _has and _mp.original_url == _cs_photo_current %}
+      <button class="cs-mood-chip{% if _sel %} cs-mood-chip--selected{% endif %}{% if not _has %} cs-mood-chip--empty{% endif %}"
+              type="button"
+              data-mood-slot="{{ meta.slot }}"
+              {% if not _has %}disabled aria-disabled="true"{% endif %}
+              title="{{ meta.label }}">
+        <span class="cs-mood-emoji">{{ meta.emoji }}</span>
+        <span class="cs-mood-label">{{ meta.label }}</span>
+        {% if _sel %}<span class="cs-mood-check" aria-hidden="true">✓</span>{% endif %}
+      </button>
+    {% endfor %}
+  </div>
+  <p class="cs-mood-manage">
+    <a href="/profile/my-mood-photos" class="cs-mood-manage-link">Manage Mood Photos →</a>
+  </p>
+</div>

--- a/app/templates/includes/cs_preview_panel.html
+++ b/app/templates/includes/cs_preview_panel.html
@@ -1,0 +1,20 @@
+{# CS-S0: Preview iframe panel
+   preview_url:  the iframe src URL
+   ratio_class:  mfg-ratio-* CSS class for aspect ratio
+   fmt:          NonPlayerCardFormatDefinition (has .label)
+   active_type:  "welcome" | "player" | "challenge" #}
+<div class="cs-preview-panel">
+  <p class="cs-preview-label">Preview</p>
+  <div class="cs-preview-container">
+    <div class="cs-preview-wrap mfg-preview-wrap {{ ratio_class }}">
+      <iframe
+        id="cs-preview-iframe"
+        class="mfg-preview-iframe"
+        src="{{ preview_url }}"
+        loading="lazy"
+        scrolling="no"
+        title="{{ fmt.label if fmt else 'Card Preview' }} Preview"
+      ></iframe>
+    </div>
+  </div>
+</div>

--- a/app/templates/includes/cs_type_switcher.html
+++ b/app/templates/includes/cs_type_switcher.html
@@ -1,0 +1,40 @@
+{# CS-S0: Card Studio Type Switcher (Player/Welcome/Challenge)
+   active_type: "welcome" | "player" | "challenge"
+   CS-S0: Welcome fully functional; Player/Challenge shown as Coming Soon. #}
+<div class="cs-type-switcher" role="tablist" aria-label="Card type">
+
+  {# ── Player Card — Coming Soon in CS-S0 ── #}
+  <button class="cs-type-btn cs-type-soon"
+          role="tab"
+          aria-selected="false"
+          disabled
+          aria-disabled="true"
+          title="Player Card Studio — coming soon">
+    <span class="cs-type-icon">👤</span>
+    <span class="cs-type-label">Player Card</span>
+    <span class="cs-type-badge">Soon</span>
+  </button>
+
+  {# ── Welcome Card — active in CS-S0 ── #}
+  <button class="cs-type-btn{% if active_type == 'welcome' %} cs-type-active{% endif %}"
+          role="tab"
+          aria-selected="{{ 'true' if active_type == 'welcome' else 'false' }}"
+          onclick="{% if active_type != 'welcome' %}window.location='/card-studio/welcome'{% endif %}"
+          {% if active_type == 'welcome' %}aria-current="page"{% endif %}>
+    <span class="cs-type-icon">👋</span>
+    <span class="cs-type-label">Welcome Card</span>
+  </button>
+
+  {# ── Challenge Card — Coming Soon in CS-S0 ── #}
+  <button class="cs-type-btn cs-type-soon"
+          role="tab"
+          aria-selected="false"
+          disabled
+          aria-disabled="true"
+          title="Challenge Card Studio — coming soon">
+    <span class="cs-type-icon">⚔️</span>
+    <span class="cs-type-label">Challenge Card</span>
+    <span class="cs-type-badge">Soon</span>
+  </button>
+
+</div>

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -60027,6 +60027,80 @@
         ]
       }
     },
+    "/card-studio": {
+      "get": {
+        "description": "Card Studio landing \u2014 defaults to Welcome mode for CS-S0.\n\nRenders the unified shell with Welcome Card active.\nPlayer and Challenge shown as Coming Soon.",
+        "operationId": "card_studio_default_card_studio_get",
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Card Studio Default",
+        "tags": [
+          "web",
+          "card-studio"
+        ]
+      }
+    },
+    "/card-studio/welcome": {
+      "get": {
+        "description": "Unified Studio shell \u2014 Welcome Card mode (CS-S0 fully functional).",
+        "operationId": "card_studio_welcome_card_studio_welcome_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Format"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Card Studio Welcome",
+        "tags": [
+          "web",
+          "card-studio"
+        ]
+      }
+    },
     "/challenges": {
       "get": {
         "operationId": "challenge_inbox_challenges_get",

--- a/tests/unit/api/web_routes/test_card_editor_ce2.py
+++ b/tests/unit/api/web_routes/test_card_editor_ce2.py
@@ -421,6 +421,6 @@ class TestCE217RouteCount:
         """CE-3.8 adds 3 from-mood endpoints — snapshot path count must equal 842."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 842, (
-            f"Expected 842 routes (839 CE-3.7 baseline + 3 CE-3.8 from-mood endpoints), got {len(paths)}."
+        assert len(paths) == 844, (
+            f"Expected 844 routes (842 CE-3.7+CE-3.8 baseline + 2 CS-S0 card-studio routes), got {len(paths)}."
         )

--- a/tests/unit/api/web_routes/test_card_studio_challenge.py
+++ b/tests/unit/api/web_routes/test_card_studio_challenge.py
@@ -294,8 +294,8 @@ class TestCCS11RouteCount:
         """CCS-11: route count updated to 842 after CE-3.8 (+3 from-mood endpoints)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 842, (
-            f"Expected 842 routes (839 CE-3.7 baseline + 3 CE-3.8 from-mood endpoints), got {len(paths)}."
+        assert len(paths) == 844, (
+            f"Expected 844 routes (842 CE-3.7+CE-3.8 baseline + 2 CS-S0 card-studio routes), got {len(paths)}."
         )
 
     def test_ccs_11b_card_editor_challenge_route_registered(self):

--- a/tests/unit/api/web_routes/test_card_studio_landing.py
+++ b/tests/unit/api/web_routes/test_card_studio_landing.py
@@ -298,8 +298,8 @@ class TestCEL12RouteCount:
         """CE-3.4 adds GET /card-editor/challenge — total route count is 839."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 842, (
-            f"Expected 842 routes (839 CE-3.7 baseline + 3 CE-3.8 from-mood endpoints), got {len(paths)}."
+        assert len(paths) == 844, (
+            f"Expected 844 routes (842 CE-3.7+CE-3.8 baseline + 2 CS-S0 card-studio routes), got {len(paths)}."
         )
 
     def test_cel_12b_card_editor_route_registered(self):

--- a/tests/unit/api/web_routes/test_card_studio_shell.py
+++ b/tests/unit/api/web_routes/test_card_studio_shell.py
@@ -1,0 +1,338 @@
+"""
+CSS-S0 — Unified Card Studio Shell (Welcome mode MVP) tests.
+
+CSS-01  GET /card-studio → 303 to /card-studio/welcome?format=X (first owned)
+CSS-02  GET /card-studio/welcome → 200 with unified shell template
+CSS-03  unauthenticated → auth guard
+CSS-04  no LFA license → 303 /dashboard
+CSS-05  onboarding incomplete → 303 /specialization
+CSS-06  no owned Welcome formats → 303 /shop/cards/welcome
+CSS-07  no ?format → 303 canonical first owned URL
+CSS-08  invalid ?format → 303 canonical first owned URL
+CSS-09  valid ?format → active_format in context
+CSS-10  active_type == "welcome" in context
+CSS-11  mood_photos in context
+CSS-12  mood_slot_meta 6 entries in context
+CSS-13  template contains cs-type-switcher element
+CSS-14  template contains Player, Welcome, Challenge in type switcher
+CSS-15  template contains cs-mood-section (Mood Photos quick row)
+CSS-16  Mood Photos section NOT in accordion (always open)
+CSS-17  mobile markup: cs-mood-section before cs-preview-panel
+CSS-18  template contains cs-preview-iframe
+CSS-19  template contains X-CSRF-Token in assign JS
+CSS-20  template contains !csrf guard
+CSS-21  route count == 844 (842 + 2 new card-studio routes)
+CSS-22  GET /card-studio route registered
+CSS-23  GET /card-studio/welcome route registered
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.card_design_service import WELCOME_CARD_FORMATS
+
+_CS_BASE = "app.api.web_routes.card_studio"
+
+TEMPLATES_DIR = Path(__file__).resolve().parents[4] / "app" / "templates"
+_ALL_WC_IDS: list[str] = [f.design_id for f in WELCOME_CARD_FORMATS]
+_FIRST_ID = _ALL_WC_IDS[0]
+_SECOND_ID = _ALL_WC_IDS[1]
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _user(uid: int = 42) -> MagicMock:
+    u = MagicMock()
+    u.id = uid
+    u.credit_balance = 500
+    u.role = MagicMock()
+    return u
+
+
+def _license(onboarding_completed: bool = True) -> MagicMock:
+    lic = MagicMock()
+    lic.onboarding_completed = onboarding_completed
+    lic.wc_photo_url = None
+    lic.wc_photo_portrait_url = None
+    lic.wc_photo_landscape_url = None
+    return lic
+
+
+def _db_with_license(license_obj) -> MagicMock:
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = license_obj
+    return db
+
+
+def _invoke_welcome(format_param, owned_ids, license_obj=None, user_obj=None):
+    from app.api.web_routes.card_studio import card_studio_welcome
+
+    user = user_obj or _user()
+    lic  = license_obj if license_obj is not None else _license(onboarding_completed=True)
+    db   = _db_with_license(lic)
+    captured: dict = {}
+
+    def _fake_tmpl(tmpl, ctx, **kw):
+        captured["context"] = ctx
+        captured["template"] = tmpl
+        return MagicMock(status_code=200)
+
+    from app.models.user_mood_photos import MOOD_PHOTO_SLOTS
+    empty_mood = {slot: None for slot in MOOD_PHOTO_SLOTS}
+
+    with patch(f"{_CS_BASE}.get_owned_design_ids", return_value=owned_ids), \
+         patch(f"{_CS_BASE}.get_mood_photos_for_user", return_value=empty_mood), \
+         patch(f"{_CS_BASE}.templates") as mock_tpl:
+        mock_tpl.TemplateResponse.side_effect = _fake_tmpl
+        resp = _run(card_studio_welcome(
+            request=MagicMock(), format_id=format_param, db=db, user=user
+        ))
+
+    return resp, captured.get("context", {}), captured.get("template", "")
+
+
+# ── CSS-01: /card-studio default redirect ─────────────────────────────────────
+
+class TestCSS01DefaultRedirect:
+
+    def test_css_01_card_studio_redirects_to_welcome(self):
+        """CSS-01: GET /card-studio → 303 to /card-studio/welcome?format=X."""
+        from fastapi.responses import RedirectResponse
+        from app.api.web_routes.card_studio import card_studio_default
+        from app.models.user_mood_photos import MOOD_PHOTO_SLOTS
+
+        user = _user()
+        lic  = _license(onboarding_completed=True)
+        db   = _db_with_license(lic)
+
+        with patch(f"{_CS_BASE}.get_owned_design_ids", return_value=[_FIRST_ID]):
+            resp = _run(card_studio_default(request=MagicMock(), db=db, user=user))
+
+        assert isinstance(resp, RedirectResponse)
+        assert resp.status_code == 303
+        assert f"/card-studio/welcome?format={_FIRST_ID}" in resp.headers["location"]
+
+    def test_css_01b_no_owned_redirects_to_shop(self):
+        """CSS-01b: no owned formats → 303 /shop/cards/welcome."""
+        from fastapi.responses import RedirectResponse
+        from app.api.web_routes.card_studio import card_studio_default
+
+        user = _user()
+        lic  = _license(onboarding_completed=True)
+        db   = _db_with_license(lic)
+
+        with patch(f"{_CS_BASE}.get_owned_design_ids", return_value=[]):
+            resp = _run(card_studio_default(request=MagicMock(), db=db, user=user))
+
+        assert isinstance(resp, RedirectResponse)
+        assert "/shop/cards/welcome" in resp.headers["location"]
+
+
+# ── CSS-02..CSS-09: /card-studio/welcome handler ──────────────────────────────
+
+class TestCSS02to09WelcomeHandler:
+
+    def test_css_02_welcome_200(self):
+        """CSS-02: GET /card-studio/welcome → 200 with unified shell."""
+        resp, ctx, tmpl = _invoke_welcome(_FIRST_ID, owned_ids=[_FIRST_ID])
+        assert ctx, "context must be captured"
+        assert tmpl == "card_studio_shell.html"
+
+    def test_css_03_no_license_redirects(self):
+        """CSS-04: missing license → 303 /dashboard."""
+        from fastapi.responses import RedirectResponse
+        from app.api.web_routes.card_studio import card_studio_welcome
+
+        user = _user()
+        db   = _db_with_license(None)
+        with patch(f"{_CS_BASE}.get_owned_design_ids", return_value=[_FIRST_ID]):
+            resp = _run(card_studio_welcome(
+                request=MagicMock(), format_id=_FIRST_ID, db=db, user=user
+            ))
+        assert isinstance(resp, RedirectResponse)
+        assert "/dashboard" in resp.headers["location"]
+
+    def test_css_05_onboarding_incomplete_redirects(self):
+        """CSS-05: onboarding not complete → 303."""
+        from fastapi.responses import RedirectResponse
+        from app.api.web_routes.card_studio import card_studio_welcome
+
+        user = _user()
+        db   = _db_with_license(_license(onboarding_completed=False))
+        with patch(f"{_CS_BASE}.get_owned_design_ids", return_value=[_FIRST_ID]):
+            resp = _run(card_studio_welcome(
+                request=MagicMock(), format_id=_FIRST_ID, db=db, user=user
+            ))
+        assert isinstance(resp, RedirectResponse)
+        assert "onboarding" in resp.headers["location"]
+
+    def test_css_06_no_owned_redirects_shop(self):
+        """CSS-06: no owned Welcome formats → 303 /shop/cards/welcome."""
+        from fastapi.responses import RedirectResponse
+        from app.api.web_routes.card_studio import card_studio_welcome
+
+        user = _user()
+        db   = _db_with_license(_license())
+        with patch(f"{_CS_BASE}.get_owned_design_ids", return_value=[]):
+            resp = _run(card_studio_welcome(
+                request=MagicMock(), format_id=None, db=db, user=user
+            ))
+        assert isinstance(resp, RedirectResponse)
+        assert resp.headers["location"] == "/shop/cards/welcome"
+
+    def test_css_07_no_format_redirects_canonical(self):
+        """CSS-07: absent ?format → 303 canonical first owned."""
+        from fastapi.responses import RedirectResponse
+        from app.api.web_routes.card_studio import card_studio_welcome
+
+        user = _user()
+        db   = _db_with_license(_license())
+        with patch(f"{_CS_BASE}.get_owned_design_ids", return_value=[_FIRST_ID]):
+            resp = _run(card_studio_welcome(
+                request=MagicMock(), format_id=None, db=db, user=user
+            ))
+        assert isinstance(resp, RedirectResponse)
+        assert f"format={_FIRST_ID}" in resp.headers["location"]
+
+    def test_css_09_active_format_in_context(self):
+        """CSS-09: context active_format matches ?format param."""
+        _, ctx, _ = _invoke_welcome(_FIRST_ID, owned_ids=[_FIRST_ID])
+        assert ctx.get("active_format") == _FIRST_ID
+
+    def test_css_10_active_type_welcome(self):
+        """CSS-10: context active_type == 'welcome'."""
+        _, ctx, _ = _invoke_welcome(_FIRST_ID, owned_ids=[_FIRST_ID])
+        assert ctx.get("active_type") == "welcome"
+
+    def test_css_11_mood_photos_in_context(self):
+        """CSS-11: context contains mood_photos key."""
+        _, ctx, _ = _invoke_welcome(_FIRST_ID, owned_ids=[_FIRST_ID])
+        assert "mood_photos" in ctx
+
+    def test_css_12_mood_slot_meta_6_entries(self):
+        """CSS-12: mood_slot_meta has 6 entries with slot/emoji/label."""
+        _, ctx, _ = _invoke_welcome(_FIRST_ID, owned_ids=[_FIRST_ID])
+        meta = ctx.get("mood_slot_meta", [])
+        assert len(meta) == 6
+        for entry in meta:
+            assert "slot" in entry and "emoji" in entry and "label" in entry
+
+
+# ── CSS-13..CSS-20: Template confirmations ────────────────────────────────────
+
+class TestCSS13to20TemplateConfirmations:
+
+    @classmethod
+    def _src(cls) -> str:
+        return (TEMPLATES_DIR / "card_studio_shell.html").read_text(encoding="utf-8")
+
+    def test_css_13_template_has_type_switcher(self):
+        """CSS-13: template contains cs-type-switcher element."""
+        assert "cs-type-switcher" in self._src()
+
+    def test_css_14_template_has_all_three_types(self):
+        """CSS-14: type switcher (include) contains Player, Welcome, Challenge."""
+        # Type switcher is an include — check include file and shell include directive
+        src = self._src()
+        assert "cs_type_switcher.html" in src, "shell must include cs_type_switcher"
+        # Check include file for type labels
+        switcher_src = (TEMPLATES_DIR / "includes/cs_type_switcher.html").read_text()
+        assert "Player Card" in switcher_src
+        assert "Welcome Card" in switcher_src
+        assert "Challenge Card" in switcher_src
+
+    def test_css_14b_player_challenge_disabled_in_cs_s0(self):
+        """CSS-14b: Player and Challenge buttons are disabled (CS-S0 Coming Soon)."""
+        src = self._src()
+        # cs-type-soon class marks them as disabled
+        assert "cs-type-soon" in src
+
+    def test_css_15_template_has_mood_section(self):
+        """CSS-15: template contains cs-mood-section (Mood Photos quick row)."""
+        assert "cs-mood-section" in self._src()
+        assert "cs-mood-grid" in self._src()
+
+    def test_css_16_mood_not_in_accordion(self):
+        """CSS-16: Mood section is NOT inside a collapsed accordion — always open."""
+        src = self._src()
+        # Find position of cs-mood-section vs any accordion/collapsed markup
+        mood_pos = src.find('cs-mood-section')
+        # Should not be inside an accordion-type wrapper
+        # cs-mood-section has no 'hidden' or 'collapsed' class by default
+        # The section itself should not have display:none or aria-hidden
+        assert 'cs-mood-section' in src
+        assert 'id="cs-mood-section"' not in src or 'display:none' not in src
+
+    def test_css_17_mobile_markup_mood_before_preview(self):
+        """CSS-17: in DOM order, cs-mood-section appears before cs-preview-panel."""
+        src = self._src()
+        mood_pos    = src.find('cs-mood-section')
+        preview_pos = src.find('cs-preview-panel')
+        assert mood_pos != -1, "cs-mood-section must be present"
+        assert preview_pos != -1, "cs-preview-panel must be present"
+        assert mood_pos < preview_pos, (
+            "cs-mood-section must appear before cs-preview-panel in DOM order "
+            "(ensures correct mobile stacking)"
+        )
+
+    def test_css_18_template_has_preview_iframe(self):
+        """CSS-18: template contains cs-preview-iframe."""
+        assert "cs-preview-iframe" in self._src()
+
+    def test_css_19_assign_js_has_csrf_header(self):
+        """CSS-19: assign JS fetch carries X-CSRF-Token header."""
+        src = self._src()
+        assert "'X-CSRF-Token'" in src
+
+    def test_css_20_assign_js_has_csrf_guard(self):
+        """CSS-20: assign JS checks for missing CSRF token."""
+        assert "!csrf" in self._src()
+
+    def test_css_20b_upload_fallback_present(self):
+        """CSS-20b: upload fallback input and button present."""
+        src = self._src()
+        assert "cs-btn-upload" in src
+        assert "cs-btn-delete" in src
+
+    def test_css_20c_export_cta_present(self):
+        """CSS-20c: Download PNG export CTA present."""
+        assert "cs-btn-download" in src
+        assert "export_url" in src
+    def test_css_20c_export_cta_present(self):
+        """CSS-20c: Download PNG export CTA present."""
+        src = self._src()
+        assert "cs-btn-download" in src
+        assert "export_url" in src
+
+
+# ── CSS-21..CSS-23: Route confirmations ──────────────────────────────────────
+
+class TestCSS21to23RouteConfirmations:
+
+    def test_css_21_route_count_844(self):
+        """CSS-21: adding 2 card-studio routes raises count from 842 to 844."""
+        from app.main import app
+        paths = app.openapi().get("paths", {})
+        assert len(paths) == 844, (
+            f"Expected 844 routes (842 baseline + 2 new /card-studio routes), got {len(paths)}"
+        )
+
+    def test_css_22_card_studio_route_registered(self):
+        """CSS-22: GET /card-studio is registered."""
+        from app.main import app
+        paths = app.openapi().get("paths", {})
+        assert "/card-studio" in paths
+
+    def test_css_23_card_studio_welcome_route_registered(self):
+        """CSS-23: GET /card-studio/welcome is registered."""
+        from app.main import app
+        paths = app.openapi().get("paths", {})
+        assert "/card-studio/welcome" in paths

--- a/tests/unit/api/web_routes/test_card_studio_welcome.py
+++ b/tests/unit/api/web_routes/test_card_studio_welcome.py
@@ -527,7 +527,7 @@ class TestCEW18RouteCount:
         """CEW-18: route count baseline check (updated by CE-3.8 to 842)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 842, (
+        assert len(paths) == 844, (
             f"Expected 842 routes (839 CE-3.7 baseline + 3 from-mood endpoints), got {len(paths)}."
         )
 
@@ -926,8 +926,8 @@ class TestCEW44to51TemplateMoodPicker:
         """CEW-47: CE-3.8 adds 3 from-mood routes → total 842."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 842, (
-            f"Expected 842 routes (839 + 3 from-mood), got {len(paths)}"
+        assert len(paths) == 844, (
+            f"Expected 844 routes (842 baseline + 2 CS-S0 routes), got {len(paths)}"
         )
 
     def test_cew_48_assign_js_has_csrf_header(self):

--- a/tests/unit/api/web_routes/test_family_color_shop.py
+++ b/tests/unit/api/web_routes/test_family_color_shop.py
@@ -223,8 +223,8 @@ class TestRouteRegistration:
     def test_ts_13_route_count_836(self):
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 842, (
-            f"Expected 842 routes (839 CE-3.7 baseline + 3 CE-3.8 from-mood endpoints), got {len(paths)}."
+        assert len(paths) == 844, (
+            f"Expected 844 routes (842 CE-3.7+CE-3.8 baseline + 2 CS-S0 card-studio routes), got {len(paths)}."
         )
 
     def test_ts_14_unlock_theme_still_registered(self):


### PR DESCRIPTION
## CS-S0 — Unified Card Studio Shell MVP

**First PR in the Card Studio unification series.**

Single unified shell with card-type switcher. CS-S0 delivers Welcome Card mode fully functional. Player and Challenge shown as Coming Soon.

### New routes
- `GET /card-studio` → 303 to `/card-studio/welcome?format=X`
- `GET /card-studio/welcome` → unified shell, Welcome mode

### Panel-first UX
- Type switcher: `[Player (Soon)] [Welcome ✓] [Challenge (Soon)]`
- Format pill bar (7 WC formats)
- **Mood Photos quick-row** — always visible, DOM-before-preview (mobile-correct)
- Upload fallback (secondary)
- Live preview iframe
- Export panel

### Backward compatibility
All `/card-editor/*` routes unchanged. No existing routes broken.

### Tests: 25/25 PASS · Route count: 844

🤖 Generated with [Claude Code](https://claude.com/claude-code)