### PR TITLE
refactor(ref-p3): REF-P3 — preview_panel.html extract (behavior-preserving)

### DIFF
--- a/app/templates/dashboard_card_editor.html
+++ b/app/templates/dashboard_card_editor.html
@@ -341,48 +341,7 @@
         </aside>{# /ce-sidebar #}
 
         {# ══════════════════ RIGHT: PREVIEW AREA ══════════════════ #}
-        <div class="ce-preview-area">
-
-            <div class="ce-preview-stage">
-                <div class="ce-preview-wrap">
-                    <iframe id="player-card-iframe"
-                            width="1080" height="1350"
-                            src="{% if active_card_platform and active_card_platform != 'default' %}/players/{{ user.id }}/card?preview={{ active_card_variant }}&theme={{ active_card_theme }}&platform={{ active_card_platform }}&export=1{% if active_card_platform in animated_capable_platforms %}&animated=1{% endif %}{% else %}/players/{{ user.id }}/card?preview={{ active_card_variant }}&theme={{ active_card_theme }}&native_export=1{% endif %}"
-                            scrolling="no" title="Card Editor — Player Card"></iframe>
-                </div>
-            </div>
-
-            {# ── Action bar: publish status + export CTA ─────────────────────── #}
-            <div class="ce-action-bar">
-                <div class="ce-publish-zone">
-                    <span class="publish-status-dot" id="publish-status-dot"></span>
-                    <span class="publish-status-text" id="publish-status-text"></span>
-                    <a href="/players/{{ user.id }}/card" target="_blank"
-                       class="publish-view-link">View ↗</a>
-                    <button class="btn-publish-card" id="btn-publish-card"
-                            onclick="publishCard()"
-                            {% if not active_variant_owned %}disabled{% endif %}>Publish Card</button>
-                </div>
-                <div class="ce-export-zone">
-                    <button id="btn-export-card" class="btn-export-card" onclick="exportCard()"
-                            {% if not active_variant_owned %}disabled{% endif %}
-                            title="Download PNG — Default exports at native card proportions">⬇ PNG</button>
-                    <button id="btn-export-video" class="btn-export-card btn-export-video"
-                            style="display:none;" onclick="exportCardVideo()"
-                            title="Download animated MP4 (5s, H.264)">▶ MP4</button>
-                    <button id="btn-export-webm-debug" class="btn-export-card btn-export-video"
-                            style="display:none;" onclick="exportCardWebmDebug()"
-                            title="[DEBUG] Raw WebM">⬇ WebM</button>
-                </div>
-            </div>
-            {% if not active_variant_owned %}
-            <div class="ce-empty-state">
-                No Player Card designs yet.
-                <a href="/shop/cards/player">Browse Player Card designs →</a>
-            </div>
-            {% endif %}
-
-        </div>{# /ce-preview-area #}
+        {% include "includes/player_editor/preview_panel.html" %}
 
     </div>{# /ce-layout #}
 </div>{# /ce-shell #}

--- a/app/templates/includes/player_editor/preview_panel.html
+++ b/app/templates/includes/player_editor/preview_panel.html
@@ -1,0 +1,42 @@
+        <div class="ce-preview-area">
+
+            <div class="ce-preview-stage">
+                <div class="ce-preview-wrap">
+                    <iframe id="player-card-iframe"
+                            width="1080" height="1350"
+                            src="{% if active_card_platform and active_card_platform != 'default' %}/players/{{ user.id }}/card?preview={{ active_card_variant }}&theme={{ active_card_theme }}&platform={{ active_card_platform }}&export=1{% if active_card_platform in animated_capable_platforms %}&animated=1{% endif %}{% else %}/players/{{ user.id }}/card?preview={{ active_card_variant }}&theme={{ active_card_theme }}&native_export=1{% endif %}"
+                            scrolling="no" title="Card Editor — Player Card"></iframe>
+                </div>
+            </div>
+
+            {# ── Action bar: publish status + export CTA ─────────────────────── #}
+            <div class="ce-action-bar">
+                <div class="ce-publish-zone">
+                    <span class="publish-status-dot" id="publish-status-dot"></span>
+                    <span class="publish-status-text" id="publish-status-text"></span>
+                    <a href="/players/{{ user.id }}/card" target="_blank"
+                       class="publish-view-link">View ↗</a>
+                    <button class="btn-publish-card" id="btn-publish-card"
+                            onclick="publishCard()"
+                            {% if not active_variant_owned %}disabled{% endif %}>Publish Card</button>
+                </div>
+                <div class="ce-export-zone">
+                    <button id="btn-export-card" class="btn-export-card" onclick="exportCard()"
+                            {% if not active_variant_owned %}disabled{% endif %}
+                            title="Download PNG — Default exports at native card proportions">⬇ PNG</button>
+                    <button id="btn-export-video" class="btn-export-card btn-export-video"
+                            style="display:none;" onclick="exportCardVideo()"
+                            title="Download animated MP4 (5s, H.264)">▶ MP4</button>
+                    <button id="btn-export-webm-debug" class="btn-export-card btn-export-video"
+                            style="display:none;" onclick="exportCardWebmDebug()"
+                            title="[DEBUG] Raw WebM">⬇ WebM</button>
+                </div>
+            </div>
+            {% if not active_variant_owned %}
+            <div class="ce-empty-state">
+                No Player Card designs yet.
+                <a href="/shop/cards/player">Browse Player Card designs →</a>
+            </div>
+            {% endif %}
+
+        </div>{# /ce-preview-area #}

--- a/tests/unit/api/web_routes/test_card_editor_ce2.py
+++ b/tests/unit/api/web_routes/test_card_editor_ce2.py
@@ -156,7 +156,13 @@ def _invoke_editor(
 
 
 def _html_from_template() -> str:
-    return (TEMPLATES_DIR / "dashboard_card_editor.html").read_text(encoding="utf-8")
+    """Effective editor source: main template + Jinja2 includes expanded."""
+    parts = [
+        (TEMPLATES_DIR / "dashboard_card_editor.html").read_text(encoding="utf-8"),
+        (TEMPLATES_DIR / "includes/player_editor/styles.html").read_text(encoding="utf-8"),   # REF-P1
+        (TEMPLATES_DIR / "includes/player_editor/preview_panel.html").read_text(encoding="utf-8"),  # REF-P3
+    ]
+    return "\n".join(parts)
 
 
 # ── CE2-01 — card_variants context contains only owned variants ───────────────

--- a/tests/unit/services/test_fifa_default_card.py
+++ b/tests/unit/services/test_fifa_default_card.py
@@ -628,7 +628,10 @@ def test_tpl27_no_st_gk_orientation_labels_in_svg():
 # ── ED-*: Editor template ──────────────────────────────────────────────────────
 
 def _editor_html():
-    return _read(_TPL_EDITOR)
+    """Effective editor source: main template + Jinja2 includes expanded."""
+    _styles  = _ROOT / "app/templates/includes/player_editor/styles.html"        # REF-P1
+    _preview = _ROOT / "app/templates/includes/player_editor/preview_panel.html"  # REF-P3
+    return "\n".join([_read(_TPL_EDITOR), _read(_styles), _read(_preview)])
 
 
 def test_ed01_download_button_not_unconditionally_disabled():


### PR DESCRIPTION
## Summary
- **REF-P3**: Behavior-preserving preview area extract from `dashboard_card_editor.html` into `app/templates/includes/player_editor/preview_panel.html`.
- 42 lines extracted via exact copy — no DOM id, CSS class, JS function, or Jinja2 context changed.
- Template shrank from 909 → 868 lines (-41 lines net reduction from 1650 baseline → -782 total).

## What moved to preview_panel.html
Preview iframe (`#player-card-iframe`), preview stage/wrap, action bar, publish zone (`#btn-publish-card`, `#publish-status-dot`, `#publish-status-text`), export buttons (`#btn-export-card`, `#btn-export-video`, `#btn-export-webm-debug`), empty state for no-owned design.

## Invariants confirmed
- Route `GET /card-editor/player` unchanged (200)
- Handler `lfa_player_card_editor` unchanged
- All DOM ids, CSS classes, JS functions, context vars, endpoints unchanged
- Route count: 844 (no new routes)
- OpenAPI snapshot: unchanged

## What is NOT in this PR
Scripts, design/platform panels, media/highlight panels — deferred to REF-P4/P5/P2. No `/card-studio/player`. No `/card-editor/player` redirect.

## Test plan
- [x] 11 812 tests passed, 0 failures
- [x] `test_card_editor_ce2.py` (publish/export guard): `_html_from_template()` expanded with preview_panel.html
- [x] `test_fifa_default_card.py` (ED-01 download button): `_editor_html()` expanded with preview_panel.html
- [x] `test_no_fifa_strings.py`, `test_published_card_state.py`, `test_player_card_gallery.py` — all PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)