### PR TITLE
refactor(ref-p4): REF-P4 — design_panel.html + platform_panel.html extract (behavior-preserving)

### DIFF
--- a/app/templates/dashboard_card_editor.html
+++ b/app/templates/dashboard_card_editor.html
@@ -77,92 +77,13 @@
                 {# ── Panel: Card Design ─────────────────────────────────────────── #}
                 <div class="ce-tab-panel active" id="panel-design"
                      role="tabpanel" aria-labelledby="tab-design">
-
-                    {# Section 1: Card Layout — structural template family (card_variants) #}
-                    {% if show_variant_picker and card_variants is defined %}
-                    <div class="ce-section">
-                        <div class="ce-section-title">Card Layout</div>
-                        {% if card_variants %}
-                        <div class="ce-design-grid" id="variant-picker">
-                            {% for v in card_variants %}
-                            <button class="ce-design-tile ce-layout-tile
-                                           {% if v.id == active_card_variant %}active{% endif %}"
-                                    data-variant="{{ v.id }}"
-                                    title="{{ v.description }}"
-                                    onclick="setCardVariant('{{ v.id }}')">
-                                <div class="ce-design-tile-art"></div>
-                                <div class="ce-design-tile-footer">
-                                    <span class="ce-design-tile-name">{{ v.label }}</span>
-                                    <a href="/players/{{ user.id }}/card?preview={{ v.id }}" target="_blank"
-                                       onclick="event.stopPropagation();"
-                                       title="Preview {{ v.label }} in new tab"
-                                       style="font-size:0.58rem;opacity:0.55;text-decoration:none;color:inherit;flex-shrink:0;">↗</a>
-                                </div>
-                            </button>
-                            {% endfor %}
-                        </div>
-                        {% else %}
-                        <div class="ce-empty-state">
-                            No Player Card designs yet.
-                            <a href="/shop/cards/player">Browse Player Card designs →</a>
-                        </div>
-                        {% endif %}
-                    </div>
-                    {% endif %}
-
-                    {# Section 2: Color Theme — palette applied to the selected layout (card_themes) #}
-                    <div class="ce-section">
-                        <div class="ce-section-title">Color Theme</div>
-                        <div class="ce-design-grid" id="theme-picker">
-                            {% for t in card_themes %}
-                            <button class="ce-design-tile
-                                           {% if t.id == active_card_theme %}active{% endif %}"
-                                    style="--tile-accent: {{ t.dot_color }};"
-                                    onclick="setCardTheme('{{ t.id }}')"
-                                    title="{{ t.label }}">
-                                <div class="ce-design-tile-art"></div>
-                                <div class="ce-design-tile-footer">
-                                    <span class="ce-design-tile-name">{{ t.label }}</span>
-                                </div>
-                            </button>
-                            {% endfor %}
-                        </div>
-                    </div>
-
+                    {% include "includes/player_editor/design_panel.html" %}
                 </div>{# /panel-design #}
 
                 {# ── Panel: Format ──────────────────────────────────────────────── #}
                 <div class="ce-tab-panel" id="panel-format"
                      role="tabpanel" aria-labelledby="tab-format">
-
-                    <div class="ce-section">
-                        <div class="ce-section-title">Export Format</div>
-                        <div class="ce-platform-grid" id="platform-picker">
-                            {# Default tile — always first #}
-                            <button class="ce-platform-tile {% if not active_card_platform or active_card_platform == 'default' %}active{% endif %}"
-                                    data-platform="default"
-                                    onclick="setPlatform('default')"
-                                    title="Native card proportions">
-                                <div class="ce-platform-icon ce-platform-icon--portrait"></div>
-                                <div class="ce-platform-tile-name">Default</div>
-                                <div class="ce-platform-tile-dims">1080 × 1350</div>
-                            </button>
-                            {# Per-platform tiles #}
-                            {% for p in platforms %}
-                            <button class="ce-platform-tile {% if active_card_platform == p.id %}active{% endif %}"
-                                    data-platform="{{ p.id }}"
-                                    onclick="setPlatform('{{ p.id }}')"
-                                    title="{{ p.title }}">
-                                <div class="ce-platform-icon ce-platform-icon--{{ _orient_map.get(p.id, 'portrait') }}"></div>
-                                <div class="ce-platform-tile-name">{{ p.label }}</div>
-                                <div class="ce-platform-tile-dims">
-                                    {% if p.id in canvas_sizes %}{{ canvas_sizes[p.id].w }} × {{ canvas_sizes[p.id].h }}{% endif %}
-                                </div>
-                            </button>
-                            {% endfor %}
-                        </div>
-                    </div>
-
+                    {% include "includes/player_editor/platform_panel.html" %}
                 </div>{# /panel-format #}
 
                 {# ── Panel: Media ───────────────────────────────────────────────── #}

--- a/app/templates/includes/player_editor/design_panel.html
+++ b/app/templates/includes/player_editor/design_panel.html
@@ -1,0 +1,52 @@
+
+                    {# Section 1: Card Layout — structural template family (card_variants) #}
+                    {% if show_variant_picker and card_variants is defined %}
+                    <div class="ce-section">
+                        <div class="ce-section-title">Card Layout</div>
+                        {% if card_variants %}
+                        <div class="ce-design-grid" id="variant-picker">
+                            {% for v in card_variants %}
+                            <button class="ce-design-tile ce-layout-tile
+                                           {% if v.id == active_card_variant %}active{% endif %}"
+                                    data-variant="{{ v.id }}"
+                                    title="{{ v.description }}"
+                                    onclick="setCardVariant('{{ v.id }}')">
+                                <div class="ce-design-tile-art"></div>
+                                <div class="ce-design-tile-footer">
+                                    <span class="ce-design-tile-name">{{ v.label }}</span>
+                                    <a href="/players/{{ user.id }}/card?preview={{ v.id }}" target="_blank"
+                                       onclick="event.stopPropagation();"
+                                       title="Preview {{ v.label }} in new tab"
+                                       style="font-size:0.58rem;opacity:0.55;text-decoration:none;color:inherit;flex-shrink:0;">↗</a>
+                                </div>
+                            </button>
+                            {% endfor %}
+                        </div>
+                        {% else %}
+                        <div class="ce-empty-state">
+                            No Player Card designs yet.
+                            <a href="/shop/cards/player">Browse Player Card designs →</a>
+                        </div>
+                        {% endif %}
+                    </div>
+                    {% endif %}
+
+                    {# Section 2: Color Theme — palette applied to the selected layout (card_themes) #}
+                    <div class="ce-section">
+                        <div class="ce-section-title">Color Theme</div>
+                        <div class="ce-design-grid" id="theme-picker">
+                            {% for t in card_themes %}
+                            <button class="ce-design-tile
+                                           {% if t.id == active_card_theme %}active{% endif %}"
+                                    style="--tile-accent: {{ t.dot_color }};"
+                                    onclick="setCardTheme('{{ t.id }}')"
+                                    title="{{ t.label }}">
+                                <div class="ce-design-tile-art"></div>
+                                <div class="ce-design-tile-footer">
+                                    <span class="ce-design-tile-name">{{ t.label }}</span>
+                                </div>
+                            </button>
+                            {% endfor %}
+                        </div>
+                    </div>
+

--- a/app/templates/includes/player_editor/platform_panel.html
+++ b/app/templates/includes/player_editor/platform_panel.html
@@ -1,0 +1,29 @@
+
+                    <div class="ce-section">
+                        <div class="ce-section-title">Export Format</div>
+                        <div class="ce-platform-grid" id="platform-picker">
+                            {# Default tile — always first #}
+                            <button class="ce-platform-tile {% if not active_card_platform or active_card_platform == 'default' %}active{% endif %}"
+                                    data-platform="default"
+                                    onclick="setPlatform('default')"
+                                    title="Native card proportions">
+                                <div class="ce-platform-icon ce-platform-icon--portrait"></div>
+                                <div class="ce-platform-tile-name">Default</div>
+                                <div class="ce-platform-tile-dims">1080 × 1350</div>
+                            </button>
+                            {# Per-platform tiles #}
+                            {% for p in platforms %}
+                            <button class="ce-platform-tile {% if active_card_platform == p.id %}active{% endif %}"
+                                    data-platform="{{ p.id }}"
+                                    onclick="setPlatform('{{ p.id }}')"
+                                    title="{{ p.title }}">
+                                <div class="ce-platform-icon ce-platform-icon--{{ _orient_map.get(p.id, 'portrait') }}"></div>
+                                <div class="ce-platform-tile-name">{{ p.label }}</div>
+                                <div class="ce-platform-tile-dims">
+                                    {% if p.id in canvas_sizes %}{{ canvas_sizes[p.id].w }} × {{ canvas_sizes[p.id].h }}{% endif %}
+                                </div>
+                            </button>
+                            {% endfor %}
+                        </div>
+                    </div>
+

--- a/tests/unit/api/web_routes/test_card_editor_ce2.py
+++ b/tests/unit/api/web_routes/test_card_editor_ce2.py
@@ -159,8 +159,10 @@ def _html_from_template() -> str:
     """Effective editor source: main template + Jinja2 includes expanded."""
     parts = [
         (TEMPLATES_DIR / "dashboard_card_editor.html").read_text(encoding="utf-8"),
-        (TEMPLATES_DIR / "includes/player_editor/styles.html").read_text(encoding="utf-8"),   # REF-P1
-        (TEMPLATES_DIR / "includes/player_editor/preview_panel.html").read_text(encoding="utf-8"),  # REF-P3
+        (TEMPLATES_DIR / "includes/player_editor/styles.html").read_text(encoding="utf-8"),          # REF-P1
+        (TEMPLATES_DIR / "includes/player_editor/preview_panel.html").read_text(encoding="utf-8"),   # REF-P3
+        (TEMPLATES_DIR / "includes/player_editor/design_panel.html").read_text(encoding="utf-8"),    # REF-P4
+        (TEMPLATES_DIR / "includes/player_editor/platform_panel.html").read_text(encoding="utf-8"), # REF-P4
     ]
     return "\n".join(parts)
 

--- a/tests/unit/api/web_routes/test_card_editor_entitlement.py
+++ b/tests/unit/api/web_routes/test_card_editor_entitlement.py
@@ -192,13 +192,21 @@ class TestCardEditorLockedNote:
 # ── CE-10..CE-13: JS guard — template source checks ──────────────────────────
 
 def _editor_template_source() -> str:
+    """Effective editor source: main template + all Jinja2 includes expanded."""
     import os
-    tpl = os.path.normpath(os.path.join(
-        os.path.dirname(__file__),
-        "../../../../app/templates/dashboard_card_editor.html",
-    ))
-    with open(tpl, encoding="utf-8") as f:
-        return f.read()
+    tmpl_dir = os.path.normpath(os.path.join(os.path.dirname(__file__), "../../../../app/templates"))
+    includes = [
+        "dashboard_card_editor.html",
+        "includes/player_editor/styles.html",          # REF-P1
+        "includes/player_editor/preview_panel.html",   # REF-P3
+        "includes/player_editor/design_panel.html",    # REF-P4
+        "includes/player_editor/platform_panel.html",  # REF-P4
+    ]
+    parts = []
+    for rel in includes:
+        with open(os.path.join(tmpl_dir, rel), encoding="utf-8") as f:
+            parts.append(f.read())
+    return "\n".join(parts)
 
 
 class TestCardEditorJSGuards:

--- a/tests/unit/api/web_routes/test_player_card_gallery.py
+++ b/tests/unit/api/web_routes/test_player_card_gallery.py
@@ -397,9 +397,16 @@ class TestPlayerCardPublicTemplate:
 
 @pytest.fixture(scope="class")
 def editor_src():
-    """Effective editor source: main template + Jinja2 includes (REF-P1: CSS in styles.html)."""
-    _STYLES_INCLUDE = _REPO_ROOT / "app" / "templates" / "includes" / "player_editor" / "styles.html"
-    return _EDITOR_TPL.read_text(encoding="utf-8") + "\n" + _STYLES_INCLUDE.read_text(encoding="utf-8")
+    """Effective editor source: main template + all Jinja2 includes expanded."""
+    _inc = _REPO_ROOT / "app" / "templates" / "includes" / "player_editor"
+    parts = [
+        _EDITOR_TPL.read_text(encoding="utf-8"),
+        (_inc / "styles.html").read_text(encoding="utf-8"),          # REF-P1
+        (_inc / "preview_panel.html").read_text(encoding="utf-8"),   # REF-P3
+        (_inc / "design_panel.html").read_text(encoding="utf-8"),    # REF-P4
+        (_inc / "platform_panel.html").read_text(encoding="utf-8"),  # REF-P4
+    ]
+    return "\n".join(parts)
 
 
 class TestEditorDefaultPlatformFix:

--- a/tests/unit/services/test_fifa_default_card.py
+++ b/tests/unit/services/test_fifa_default_card.py
@@ -629,9 +629,14 @@ def test_tpl27_no_st_gk_orientation_labels_in_svg():
 
 def _editor_html():
     """Effective editor source: main template + Jinja2 includes expanded."""
-    _styles  = _ROOT / "app/templates/includes/player_editor/styles.html"        # REF-P1
-    _preview = _ROOT / "app/templates/includes/player_editor/preview_panel.html"  # REF-P3
-    return "\n".join([_read(_TPL_EDITOR), _read(_styles), _read(_preview)])
+    _inc_dir = _ROOT / "app/templates/includes/player_editor"
+    return "\n".join([
+        _read(_TPL_EDITOR),
+        _read(_inc_dir / "styles.html"),           # REF-P1
+        _read(_inc_dir / "preview_panel.html"),    # REF-P3
+        _read(_inc_dir / "design_panel.html"),     # REF-P4
+        _read(_inc_dir / "platform_panel.html"),   # REF-P4
+    ])
 
 
 def test_ed01_download_button_not_unconditionally_disabled():


### PR DESCRIPTION
## Summary
- **REF-P4**: Behavior-preserving Card Design and Format tab extract from `dashboard_card_editor.html` into two new includes.
- 52+29=81 lines extracted via exact copy — no DOM id, onclick, CSS class, or Jinja2 context changed.
- Template shrank from 868 → 789 lines (-79 lines; 1650 → 789 total from REF-P1 baseline).

## What moved
- `design_panel.html` (52 lines): variant picker (`#variant-picker`), color theme picker (`#theme-picker`), variant guard logic, `setCardVariant` / `setCardTheme` onclick refs
- `platform_panel.html` (29 lines): platform picker (`#platform-picker`), `setPlatform` onclick refs, `_orient_map` / `canvas_sizes` / `active_card_platform` context vars

## Notes
- `previewVariant()` is JS-only (scripts block) — correctly not in design panel HTML
- `_orient_map` defined in parent template (`{% set %}`) — inherited by include via Jinja2 context

## Invariants confirmed
- Route `GET /card-editor/player` unchanged (200)
- Handler unchanged
- All DOM ids, onclick refs, CSS classes, data-* attributes, context vars unchanged
- Route count: 844 (no new routes)

## What is NOT in this PR
Scripts, media/highlight panels — deferred to REF-P5a/b/P2.

## Test plan
- [x] 11 812 tests passed, 0 failures
- [x] Test fixtures updated in 4 files (ce2, entitlement, player_card_gallery, fifa_default_card) — all now include all 4 current includes

🤖 Generated with [Claude Code](https://claude.com/claude-code)