### PR TITLE
refactor(ref-p5b): REF-P5b — highlight_video_panel.html extract (behavior-preserving)

### DIFF
--- a/app/templates/dashboard_card_editor.html
+++ b/app/templates/dashboard_card_editor.html
@@ -91,78 +91,7 @@
                      role="tabpanel" aria-labelledby="tab-media">
 
                     {% include "includes/player_editor/photo_panel.html" %}
-                    {# Highlight Video #}
-                    <div class="ce-section">
-                        <div class="ce-section-title">Highlight Video</div>
-
-                        {# State 1 — no draft video #}
-                        {% if not draft_highlight_video %}
-                        <div id="hv-no-video">
-                            <div class="hv-url-row">
-                                <input id="hv-url-input" class="hv-url-input" type="url"
-                                       placeholder="Paste YouTube or TikTok video link"
-                                       oninput="document.getElementById('hv-error').textContent=''">
-                                <button class="btn-hv-save" onclick="saveHighlightVideo()">Save Draft</button>
-                            </div>
-                            <p id="hv-error" class="hv-error"></p>
-                        </div>
-
-                        {# State 2 / 3 / 4 / 5 — draft video exists #}
-                        {% else %}
-                        <div id="hv-has-video">
-                            {% if draft_highlight_video.provider == "youtube" %}
-                            <div class="hv-preview-wrap">
-                                <iframe id="hv-iframe"
-                                        src="{{ draft_highlight_video.embed_url }}"
-                                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                                        allowfullscreen
-                                        loading="lazy"></iframe>
-                            </div>
-                            {% else %}
-                            {# TikTok — link-only preview (no iframe, no script) #}
-                            <div class="hv-tiktok-cta">
-                                <span class="hv-tiktok-badge">TikTok</span>
-                                <a href="{{ draft_highlight_video.source_url }}"
-                                   target="_blank" rel="noopener noreferrer"
-                                   class="hv-tiktok-link">Watch on TikTok ↗</a>
-                                <div class="hv-tiktok-id">ID: {{ draft_highlight_video.video_id }}</div>
-                            </div>
-                            {% endif %}
-
-                            {% if not published_highlight_video %}
-                                {# State 2: draft saved, never published #}
-                                <span class="hv-badge hv-badge-draft">Draft saved — not yet published</span>
-                            {% elif highlight_video_unpublished %}
-                                {# State 4: draft differs from published #}
-                                <span class="hv-badge hv-badge-pending">Unpublished change</span>
-                            {% else %}
-                                {# State 3: published and in sync #}
-                                <span class="hv-badge hv-badge-published">Published</span>
-                            {% endif %}
-
-                            <div class="hv-url-row" style="margin-top:10px;">
-                                <input id="hv-url-input" class="hv-url-input" type="url"
-                                       value="{{ draft_highlight_video.source_url }}"
-                                       placeholder="Paste YouTube or TikTok video link"
-                                       oninput="document.getElementById('hv-error').textContent=''">
-                                <button class="btn-hv-save" onclick="saveHighlightVideo()">Update</button>
-                            </div>
-                            <p id="hv-error" class="hv-error"></p>
-                            <button class="btn-hv-remove" onclick="removeHighlightVideo()">Remove</button>
-                        </div>
-                        {% endif %}
-
-                        {# State 5: removed from draft, but published video still live #}
-                        {% if not draft_highlight_video and published_highlight_video %}
-                        <div id="hv-will-remove-notice" style="margin-top:8px;">
-                            <span class="hv-badge hv-badge-will-remove">Will be removed on next publish</span>
-                        </div>
-                        {% endif %}
-
-                        {# JS state holders for dynamic UI updates #}
-                        <div id="hv-dynamic-section" style="display:none;"></div>
-                    </div>
-
+                    {% include "includes/player_editor/highlight_video_panel.html" %}
                 </div>{# /panel-media #}
 
             </div>{# /ce-tab-panels #}

--- a/app/templates/includes/player_editor/highlight_video_panel.html
+++ b/app/templates/includes/player_editor/highlight_video_panel.html
@@ -1,3 +1,6 @@
+                    {# Legacy external-link highlight video panel (YouTube/TikTok URL-based).
+                       Future: replaced/extended by player_video_panel.html (HV-1+) when
+                       uploaded short video feature lands. #}
                     {# Highlight Video #}
                     <div class="ce-section">
                         <div class="ce-section-title">Highlight Video</div>

--- a/app/templates/includes/player_editor/highlight_video_panel.html
+++ b/app/templates/includes/player_editor/highlight_video_panel.html
@@ -1,0 +1,72 @@
+                    {# Highlight Video #}
+                    <div class="ce-section">
+                        <div class="ce-section-title">Highlight Video</div>
+
+                        {# State 1 — no draft video #}
+                        {% if not draft_highlight_video %}
+                        <div id="hv-no-video">
+                            <div class="hv-url-row">
+                                <input id="hv-url-input" class="hv-url-input" type="url"
+                                       placeholder="Paste YouTube or TikTok video link"
+                                       oninput="document.getElementById('hv-error').textContent=''">
+                                <button class="btn-hv-save" onclick="saveHighlightVideo()">Save Draft</button>
+                            </div>
+                            <p id="hv-error" class="hv-error"></p>
+                        </div>
+
+                        {# State 2 / 3 / 4 / 5 — draft video exists #}
+                        {% else %}
+                        <div id="hv-has-video">
+                            {% if draft_highlight_video.provider == "youtube" %}
+                            <div class="hv-preview-wrap">
+                                <iframe id="hv-iframe"
+                                        src="{{ draft_highlight_video.embed_url }}"
+                                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                                        allowfullscreen
+                                        loading="lazy"></iframe>
+                            </div>
+                            {% else %}
+                            {# TikTok — link-only preview (no iframe, no script) #}
+                            <div class="hv-tiktok-cta">
+                                <span class="hv-tiktok-badge">TikTok</span>
+                                <a href="{{ draft_highlight_video.source_url }}"
+                                   target="_blank" rel="noopener noreferrer"
+                                   class="hv-tiktok-link">Watch on TikTok ↗</a>
+                                <div class="hv-tiktok-id">ID: {{ draft_highlight_video.video_id }}</div>
+                            </div>
+                            {% endif %}
+
+                            {% if not published_highlight_video %}
+                                {# State 2: draft saved, never published #}
+                                <span class="hv-badge hv-badge-draft">Draft saved — not yet published</span>
+                            {% elif highlight_video_unpublished %}
+                                {# State 4: draft differs from published #}
+                                <span class="hv-badge hv-badge-pending">Unpublished change</span>
+                            {% else %}
+                                {# State 3: published and in sync #}
+                                <span class="hv-badge hv-badge-published">Published</span>
+                            {% endif %}
+
+                            <div class="hv-url-row" style="margin-top:10px;">
+                                <input id="hv-url-input" class="hv-url-input" type="url"
+                                       value="{{ draft_highlight_video.source_url }}"
+                                       placeholder="Paste YouTube or TikTok video link"
+                                       oninput="document.getElementById('hv-error').textContent=''">
+                                <button class="btn-hv-save" onclick="saveHighlightVideo()">Update</button>
+                            </div>
+                            <p id="hv-error" class="hv-error"></p>
+                            <button class="btn-hv-remove" onclick="removeHighlightVideo()">Remove</button>
+                        </div>
+                        {% endif %}
+
+                        {# State 5: removed from draft, but published video still live #}
+                        {% if not draft_highlight_video and published_highlight_video %}
+                        <div id="hv-will-remove-notice" style="margin-top:8px;">
+                            <span class="hv-badge hv-badge-will-remove">Will be removed on next publish</span>
+                        </div>
+                        {% endif %}
+
+                        {# JS state holders for dynamic UI updates #}
+                        <div id="hv-dynamic-section" style="display:none;"></div>
+                    </div>
+

--- a/tests/unit/test_profile_grid_designer.py
+++ b/tests/unit/test_profile_grid_designer.py
@@ -87,7 +87,15 @@ _TEST_UID = 42
 _TMPL_DIR = Path(__file__).parent.parent.parent / "app" / "templates"
 _PLAYER_HTML = (_TMPL_DIR / "public" / "player_profile.html").read_text(encoding="utf-8")
 _EDITOR_HTML = (_TMPL_DIR / "dashboard" / "lfa_public_profile_editor.html").read_text(encoding="utf-8")
-_CARD_EDITOR_HTML = (_TMPL_DIR / "dashboard_card_editor.html").read_text(encoding="utf-8")
+_CARD_EDITOR_HTML = "\n".join([
+    (_TMPL_DIR / "dashboard_card_editor.html").read_text(encoding="utf-8"),
+    (_TMPL_DIR / "includes/player_editor/styles.html").read_text(encoding="utf-8"),           # REF-P1
+    (_TMPL_DIR / "includes/player_editor/preview_panel.html").read_text(encoding="utf-8"),    # REF-P3
+    (_TMPL_DIR / "includes/player_editor/design_panel.html").read_text(encoding="utf-8"),     # REF-P4
+    (_TMPL_DIR / "includes/player_editor/platform_panel.html").read_text(encoding="utf-8"),   # REF-P4
+    (_TMPL_DIR / "includes/player_editor/photo_panel.html").read_text(encoding="utf-8"),      # REF-P5a
+    (_TMPL_DIR / "includes/player_editor/highlight_video_panel.html").read_text(encoding="utf-8"),  # REF-P5b
+])
 
 
 # ── Draft builder helper ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- **REF-P5b**: Behavior-preserving Highlight Video section extract from `dashboard_card_editor.html` into `app/templates/includes/player_editor/highlight_video_panel.html`.
- 72 lines extracted via exact copy — no DOM id, onclick, JS state machine, or Jinja2 context changed.
- Template shrank from 696 → 625 lines (-71 lines; 1650 → 625 total from REF-P1 baseline).

## Stacking note
**Base:** `feat/ref-p5a-photo-panel-extract` (PR #221, pending merge). This PR must be merged after PR #221, OR after the base branch is updated to main. The GitHub PR diff shows only the REF-P5b changes (HV extract) on top of REF-P5a.

## What moved to highlight_video_panel.html
All `{# Highlight Video #}` section: `#hv-no-video`, `#hv-has-video`, `#hv-url-input`, `#hv-error`, `#hv-iframe`, `#hv-will-remove-notice`, `#hv-dynamic-section`, YouTube/TikTok states, draft/published/unpublished badges, URL input + save/remove buttons.

## What stays in scripts block (unchanged)
`saveHighlightVideo()`, `removeHighlightVideo()`, `_updateHvAfterSave()` — all JS functions remain in `{% block scripts %}`.

## Media tab final structure
```
<div id="panel-media">
  {% include "includes/player_editor/photo_panel.html" %}
  {% include "includes/player_editor/highlight_video_panel.html" %}
</div>
```

## Test changes
- `test_profile_grid_designer.py`: `_CARD_EDITOR_HTML` expanded to include all 6 includes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)