### PR TITLE
feat(cs-color-1a): CS-COLOR-1A — Welcome Studio Free/Basic Theme Selector MVP

### DIFF
--- a/app/api/web_routes/card_studio.py
+++ b/app/api/web_routes/card_studio.py
@@ -28,6 +28,8 @@ from ...services.card_design_service import (
     get_card_family,
 )
 from ...services.mood_photo_service import get_mood_photos_for_user
+from ...services.card_theme_service import get_all_themes as _get_all_themes
+from ...services.card_draft_service import CardDraftService as _CardDraftService
 from .card_editor import (
     _WC_FORMAT_BY_ID,
     _WC_RATIO,
@@ -84,8 +86,16 @@ def _resolve_welcome_context(db: Session, user, format_id: str | None):
 
     fmt = _WC_FORMAT_BY_ID[format_id]
     ratio_class = _WC_RATIO.get(fmt.preview_platform, "mfg-ratio-11")
-    preview_url = f"/profile/onboarding-card?platform={fmt.preview_platform}"
-    export_url  = f"/profile/onboarding-card/export?platform={fmt.preview_platform}"
+
+    # CS-COLOR-1: read active theme from Welcome Card draft, default to "default"
+    welcome_draft = _CardDraftService.get_draft(db, user.id, "welcome_card")
+    active_theme  = welcome_draft.draft_theme or "default"
+
+    # CS-COLOR-1: free themes only (no shop/unlock scope in COLOR-1)
+    card_themes = [t for t in _get_all_themes(db) if not t.is_premium]
+
+    preview_url = f"/profile/onboarding-card?platform={fmt.preview_platform}&theme={active_theme}"
+    export_url  = f"/profile/onboarding-card/export?platform={fmt.preview_platform}&theme={active_theme}"
 
     owned_format_rows = [
         {
@@ -93,7 +103,7 @@ def _resolve_welcome_context(db: Session, user, format_id: str | None):
             "label":       f.label,
             "style_tag":   f.style_tag,
             "dims":        f.dims,
-            "preview_url": f"/profile/onboarding-card?platform={f.preview_platform}",
+            "preview_url": f"/profile/onboarding-card?platform={f.preview_platform}&theme={active_theme}",
             "active":      f.design_id == format_id,
         }
         for f in owned_formats_ordered
@@ -104,6 +114,8 @@ def _resolve_welcome_context(db: Session, user, format_id: str | None):
     ctx = {
         "active_type":        "welcome",
         "active_format":      format_id,
+        "active_theme":       active_theme,
+        "card_themes":        card_themes,
         "fmt":                fmt,
         "ratio_class":        ratio_class,
         "preview_url":        preview_url,

--- a/app/api/web_routes/card_studio.py
+++ b/app/api/web_routes/card_studio.py
@@ -87,11 +87,11 @@ def _resolve_welcome_context(db: Session, user, format_id: str | None):
     fmt = _WC_FORMAT_BY_ID[format_id]
     ratio_class = _WC_RATIO.get(fmt.preview_platform, "mfg-ratio-11")
 
-    # CS-COLOR-1: read active theme from Welcome Card draft, default to "default"
+    # CS-COLOR-1A: read active theme from Welcome Card draft, default to "default"
     welcome_draft = _CardDraftService.get_draft(db, user.id, "welcome_card")
     active_theme  = welcome_draft.draft_theme or "default"
 
-    # CS-COLOR-1: free themes only (no shop/unlock scope in COLOR-1)
+    # CS-COLOR-1A: free themes only (no shop/unlock scope in COLOR-1)
     card_themes = [t for t in _get_all_themes(db) if not t.is_premium]
 
     preview_url = f"/profile/onboarding-card?platform={fmt.preview_platform}&theme={active_theme}"

--- a/app/api/web_routes/dashboard.py
+++ b/app/api/web_routes/dashboard.py
@@ -1369,6 +1369,40 @@ async def student_set_card_theme(
         return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
 
 
+@router.post("/dashboard/wc-card-theme")
+async def student_set_wc_card_theme(
+    payload: _CardThemeRequest,
+    db: Session = Depends(get_db),
+    user: User  = Depends(get_current_user_web),
+):
+    """CS-COLOR-1: Set the active colour theme for the Welcome Card Studio.
+
+    Writes to CardDraft(card_type_id='welcome_card').draft_theme.
+    Only free themes are valid in CS-COLOR-1 (no premium unlock scope).
+    Requires active LFA Football Player license + onboarding completed.
+    """
+    from ...services.card_theme_service import get_all_themes as _get_wc_themes
+    from ...services.card_draft_service import CardDraftService as _WCDraftService
+
+    lfa_license = _get_lfa_license(db, user.id)
+    if not lfa_license:
+        return JSONResponse({"ok": False, "error": "No active LFA Football Player license"}, status_code=404)
+    if not lfa_license.onboarding_completed:
+        return JSONResponse({"ok": False, "error": "Onboarding not completed"}, status_code=403)
+
+    # Validate: theme must exist and be free (CS-COLOR-1: no premium unlock)
+    free_theme_ids = {t.id for t in _get_wc_themes(db) if not t.is_premium}
+    if payload.theme not in free_theme_ids:
+        return JSONResponse(
+            {"ok": False, "error": f"Unknown or locked theme: {payload.theme!r}"},
+            status_code=400,
+        )
+
+    draft = _WCDraftService.get_draft(db, user.id, "welcome_card")
+    _WCDraftService.update_draft_theme(db, draft, payload.theme)
+    return JSONResponse({"ok": True, "theme": payload.theme})
+
+
 @router.post("/dashboard/unlock-theme")
 async def student_unlock_theme(
     payload: _CardThemeRequest,

--- a/app/api/web_routes/dashboard.py
+++ b/app/api/web_routes/dashboard.py
@@ -1378,7 +1378,7 @@ async def student_set_wc_card_theme(
     """CS-COLOR-1: Set the active colour theme for the Welcome Card Studio.
 
     Writes to CardDraft(card_type_id='welcome_card').draft_theme.
-    Only free themes are valid in CS-COLOR-1 (no premium unlock scope).
+    Only free themes are valid in CS-COLOR-1AA (no premium unlock scope).
     Requires active LFA Football Player license + onboarding completed.
     """
     from ...services.card_theme_service import get_all_themes as _get_wc_themes

--- a/app/api/web_routes/profile.py
+++ b/app/api/web_routes/profile.py
@@ -720,6 +720,7 @@ def _build_welcome_card_context(
     platform: str | None,
     export: bool,
     use_nickname: bool = False,
+    theme_id: str = "default",
 ) -> dict:
     """
     Build the FClassic template context for the Welcome Card.
@@ -829,7 +830,8 @@ def _build_welcome_card_context(
     )
 
     platform_preset = _get_platform_preset(platform)
-    theme           = _get_theme("midnight")  # dark FClassic Player default
+    # CS-COLOR-1: use caller-supplied theme_id; falls back to "default" for unknown ids
+    theme           = _get_theme(theme_id or "default")
 
     return {
         "request":               request,
@@ -956,6 +958,7 @@ async def onboarding_welcome_card(
     platform: str | None     = Query(default=None),
     export: bool             = Query(default=False),
     use_nickname: bool       = Query(default=False),
+    theme: str               = Query(default="default"),  # CS-COLOR-1
     render_token: str | None = None,
     db: Session              = Depends(get_db),
     user: "User | None"      = Depends(get_current_user_optional),
@@ -1017,7 +1020,7 @@ async def onboarding_welcome_card(
         )
 
     logger.info("welcome_card_rendered", extra={"user": user.email, "platform": platform, "export": export})
-    ctx  = _build_welcome_card_context(request, user, license, platform, export, use_nickname)
+    ctx  = _build_welcome_card_context(request, user, license, platform, export, use_nickname, theme_id=theme)
     tmpl = _select_welcome_card_template(platform, export)
     return templates.TemplateResponse(tmpl, ctx)
 
@@ -1025,10 +1028,11 @@ async def onboarding_welcome_card(
 @router.get("/profile/onboarding-card/export")
 async def export_onboarding_welcome_card(
     request: Request,
-    platform: str    = Query(default="instagram_square"),
+    platform: str      = Query(default="instagram_square"),
     use_nickname: bool = Query(default=False),
-    db: Session      = Depends(get_db),
-    user: User       = Depends(get_current_user_web),
+    theme: str         = Query(default="default"),  # CS-COLOR-1
+    db: Session        = Depends(get_db),
+    user: User         = Depends(get_current_user_web),
 ):
     """
     Export the Welcome Card as a PNG at a social-media canvas size.
@@ -1072,11 +1076,12 @@ async def export_onboarding_welcome_card(
             detail="Export rate limit exceeded (5 per minute). Please wait before exporting again.",
         )
 
-    _nick_param = "&use_nickname=1" if use_nickname else ""
+    _nick_param   = "&use_nickname=1" if use_nickname else ""
+    _theme_param  = f"&theme={theme}" if theme and theme != "default" else ""
     render_url = (
         f"http://127.0.0.1:{settings.APP_INTERNAL_PORT}"
         f"/profile/onboarding-card?platform={platform}&export=1"
-        f"{_nick_param}&render_token={_create_render_token(user.id)}"
+        f"{_theme_param}{_nick_param}&render_token={_create_render_token(user.id)}"
     )
 
     logger.info("welcome_card_export", extra={"user": user.email, "platform": platform})

--- a/app/templates/card_studio_shell.html
+++ b/app/templates/card_studio_shell.html
@@ -215,6 +215,29 @@
 .cs-dims-text { font-size: 0.78rem; color: #475569; }
 .cs-owned-badge { font-size: 0.73rem; font-weight: 700; color: #86efac; background: rgba(134,239,172,.12); border: 1px solid rgba(134,239,172,.25); border-radius: 20px; padding: 0.18rem 0.6rem; }
 
+/* ── CS-COLOR-1: Color/Theme picker ── */
+.cs-color-panel { margin-bottom: 1.25rem; }
+.cs-color-chips  { display: flex; gap: 0.5rem; flex-wrap: wrap; margin-bottom: 0.4rem; }
+.cs-color-chip {
+  display: flex; align-items: center; gap: 0.35rem;
+  padding: 0.28rem 0.7rem 0.28rem 0.4rem;
+  background: rgba(255,255,255,0.05); border: 1.5px solid rgba(255,255,255,0.1);
+  border-radius: 20px; cursor: pointer; font-size: 0.72rem; font-weight: 600;
+  color: rgba(255,255,255,0.65); transition: border-color 0.15s, background 0.15s;
+}
+.cs-color-chip:hover { border-color: rgba(255,255,255,0.25); background: rgba(255,255,255,0.09); }
+.cs-color-chip--active {
+  border-color: var(--chip-dot, #FFD200);
+  background: color-mix(in srgb, var(--chip-dot, #FFD200) 14%, transparent);
+  color: rgba(255,255,255,0.9);
+}
+.cs-color-dot {
+  width: 10px; height: 10px; border-radius: 50%; flex-shrink: 0;
+  border: 1px solid rgba(255,255,255,0.18);
+}
+.cs-color-label { line-height: 1; }
+.cs-color-error { font-size: 0.72rem; color: #f87171; margin: 0.25rem 0 0; display: none; }
+
 </style>
 {% endblock %}
 
@@ -349,9 +372,10 @@
 
       <hr class="cs-section-divider">
 
-      {# ── SECTION 3: Color / Theme placeholder (CS-S3) ── #}
-      <p class="cs-section-label">Color / Theme</p>
-      <p style="font-size:0.75rem;color:#475569;margin:0;">Color picker coming in next update.</p>
+      {# ── SECTION 3: Color / Theme (CS-COLOR-1) ── #}
+      {% if card_themes is defined and card_themes %}
+        {% include "includes/cs_color_panel.html" %}
+      {% endif %}
 
     </div>{# END .cs-control-panel #}
 
@@ -527,5 +551,75 @@
   });
 
 })();
+
+// ── CS-COLOR-1: Welcome Studio Theme Picker ───────────────────────────────
+(function () {
+  'use strict';
+
+  function _wcsThemeCsrf() {
+    return (document.cookie.split('; ').find(function (r) { return r.startsWith('csrf_token='); }) || '').split('=')[1] || '';
+  }
+
+  function _wcsUpdatePreviewTheme(themeId) {
+    var iframe = document.getElementById('cs-preview-iframe');
+    if (!iframe) return;
+    var src = iframe.src;
+    // Replace or insert theme param
+    src = src.replace(/[?&]theme=[^&]*/g, '');
+    src += (src.indexOf('?') === -1 ? '?' : '&') + 'theme=' + encodeURIComponent(themeId);
+    iframe.src = src;
+  }
+
+  function _wcsUpdateExportTheme(themeId) {
+    var link = document.querySelector('.cs-btn-download');
+    if (!link) return;
+    var href = link.getAttribute('href') || '';
+    href = href.replace(/[?&]theme=[^&]*/g, '');
+    href += (href.indexOf('?') === -1 ? '?' : '&') + 'theme=' + encodeURIComponent(themeId);
+    link.setAttribute('href', href);
+  }
+
+  function _wcsUpdateChips(themeId) {
+    document.querySelectorAll('.cs-color-chip').forEach(function (btn) {
+      var t = btn.getAttribute('data-theme');
+      btn.classList.toggle('cs-color-chip--active', t === themeId);
+    });
+  }
+
+  window.setWelcomeTheme = function (themeId) {
+    var errEl  = document.getElementById('cs-color-error');
+    var csrf   = _wcsThemeCsrf();
+    if (!csrf) {
+      if (errEl) { errEl.textContent = 'Session expired — reload page.'; errEl.style.display = 'block'; }
+      return;
+    }
+    fetch('/dashboard/wc-card-theme', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrf },
+      body: JSON.stringify({ theme: themeId }),
+    })
+      .then(function (r) {
+        if (r.status === 403) { return Promise.reject(new Error('csrf')); }
+        return r.json();
+      })
+      .then(function (data) {
+        if (data.ok) {
+          if (errEl) { errEl.style.display = 'none'; errEl.textContent = ''; }
+          _wcsUpdateChips(themeId);
+          _wcsUpdatePreviewTheme(themeId);
+          _wcsUpdateExportTheme(themeId);
+        } else {
+          if (errEl) { errEl.textContent = data.error || 'Could not apply theme.'; errEl.style.display = 'block'; }
+        }
+      })
+      .catch(function (err) {
+        if (errEl) {
+          errEl.textContent = (err && err.message === 'csrf') ? 'Session expired — reload page.' : 'Network error — please try again.';
+          errEl.style.display = 'block';
+        }
+      });
+  };
+
+}());
 </script>
 {% endblock %}

--- a/app/templates/card_studio_shell.html
+++ b/app/templates/card_studio_shell.html
@@ -215,27 +215,32 @@
 .cs-dims-text { font-size: 0.78rem; color: #475569; }
 .cs-owned-badge { font-size: 0.73rem; font-weight: 700; color: #86efac; background: rgba(134,239,172,.12); border: 1px solid rgba(134,239,172,.25); border-radius: 20px; padding: 0.18rem 0.6rem; }
 
-/* ── CS-COLOR-1: Color/Theme picker ── */
+/* ── CS-COLOR-1A: Welcome Studio Free/Basic Theme Selector ── */
+/* Swatch circles are the primary visual — label is secondary (active-name) */
 .cs-color-panel { margin-bottom: 1.25rem; }
-.cs-color-chips  { display: flex; gap: 0.5rem; flex-wrap: wrap; margin-bottom: 0.4rem; }
+.cs-color-chips  { display: flex; gap: 0.55rem; flex-wrap: wrap; margin-bottom: 0.35rem; }
 .cs-color-chip {
-  display: flex; align-items: center; gap: 0.35rem;
-  padding: 0.28rem 0.7rem 0.28rem 0.4rem;
-  background: rgba(255,255,255,0.05); border: 1.5px solid rgba(255,255,255,0.1);
-  border-radius: 20px; cursor: pointer; font-size: 0.72rem; font-weight: 600;
-  color: rgba(255,255,255,0.65); transition: border-color 0.15s, background 0.15s;
+  display: flex; align-items: center; justify-content: center;
+  width: 32px; height: 32px;
+  background: transparent; border: 2px solid transparent;
+  border-radius: 50%; cursor: pointer;
+  transition: border-color 0.15s, transform 0.12s;
+  padding: 0;
 }
-.cs-color-chip:hover { border-color: rgba(255,255,255,0.25); background: rgba(255,255,255,0.09); }
+.cs-color-chip:hover { transform: scale(1.12); }
 .cs-color-chip--active {
   border-color: var(--chip-dot, #FFD200);
-  background: color-mix(in srgb, var(--chip-dot, #FFD200) 14%, transparent);
-  color: rgba(255,255,255,0.9);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--chip-dot, #FFD200) 28%, transparent);
 }
-.cs-color-dot {
-  width: 10px; height: 10px; border-radius: 50%; flex-shrink: 0;
-  border: 1px solid rgba(255,255,255,0.18);
+.cs-color-swatch {
+  width: 22px; height: 22px; border-radius: 50%; flex-shrink: 0;
+  border: 1.5px solid rgba(255,255,255,0.22);
+  display: block;
 }
-.cs-color-label { line-height: 1; }
+.cs-color-active-name {
+  font-size: 0.7rem; font-weight: 600; color: rgba(255,255,255,0.55);
+  margin: 0.1rem 0 0; min-height: 1rem;
+}
 .cs-color-error { font-size: 0.72rem; color: #f87171; margin: 0.25rem 0 0; display: none; }
 
 </style>
@@ -552,7 +557,7 @@
 
 })();
 
-// ── CS-COLOR-1: Welcome Studio Theme Picker ───────────────────────────────
+// ── CS-COLOR-1A: Welcome Studio Free/Basic Theme Selector MVP ───────────────
 (function () {
   'use strict';
 
@@ -579,11 +584,23 @@
     link.setAttribute('href', href);
   }
 
+  // Theme labels map built from server-rendered chips
+  var _themeLabels = {};
+  document.querySelectorAll('.cs-color-chip[data-theme]').forEach(function (btn) {
+    _themeLabels[btn.getAttribute('data-theme')] = btn.getAttribute('aria-label') || btn.getAttribute('title') || '';
+  });
+
   function _wcsUpdateChips(themeId) {
     document.querySelectorAll('.cs-color-chip').forEach(function (btn) {
       var t = btn.getAttribute('data-theme');
       btn.classList.toggle('cs-color-chip--active', t === themeId);
     });
+    // Update active name label (CS-COLOR-1A: secondary text label)
+    var nameEl = document.getElementById('cs-color-active-name');
+    if (nameEl && _themeLabels[themeId]) {
+      var label = _themeLabels[themeId].replace(' (active)', '');
+      nameEl.textContent = label;
+    }
   }
 
   window.setWelcomeTheme = function (themeId) {

--- a/app/templates/includes/cs_color_panel.html
+++ b/app/templates/includes/cs_color_panel.html
@@ -1,0 +1,21 @@
+{# CS-COLOR-1: Color/Theme picker for Welcome Studio.
+   Context vars required:
+     card_themes   — list of ThemeDefinition (free themes only, CS-COLOR-1)
+     active_theme  — currently active theme id (str)
+#}
+<div class="cs-color-panel">
+  <p class="cs-section-label">Color Theme</p>
+  <div class="cs-color-chips" id="cs-color-chips">
+    {% for t in card_themes %}
+    <button class="cs-color-chip{% if t.id == active_theme %} cs-color-chip--active{% endif %}"
+            data-theme="{{ t.id }}"
+            title="{{ t.label }}"
+            onclick="setWelcomeTheme('{{ t.id }}')"
+            style="--chip-dot: {{ t.dot_color }};">
+      <span class="cs-color-dot" style="background:{{ t.dot_color }};"></span>
+      <span class="cs-color-label">{{ t.label }}</span>
+    </button>
+    {% endfor %}
+  </div>
+  <p class="cs-color-error" id="cs-color-error" style="display:none;"></p>
+</div>

--- a/app/templates/includes/cs_color_panel.html
+++ b/app/templates/includes/cs_color_panel.html
@@ -1,7 +1,9 @@
-{# CS-COLOR-1: Color/Theme picker for Welcome Studio.
+{# CS-COLOR-1A: Welcome Studio Free/Basic Theme Selector MVP.
+   Free/basic themes only (default/midnight/arctic).
+   No premium purchase, no shop unlock, no family/format ownership (COLOR-OWNERSHIP series).
    Context vars required:
-     card_themes   — list of ThemeDefinition (free themes only, CS-COLOR-1)
-     active_theme  — currently active theme id (str)
+     card_themes  — list of ThemeDefinition (free themes only)
+     active_theme — currently active theme id (str)
 #}
 <div class="cs-color-panel">
   <p class="cs-section-label">Color Theme</p>
@@ -10,12 +12,15 @@
     <button class="cs-color-chip{% if t.id == active_theme %} cs-color-chip--active{% endif %}"
             data-theme="{{ t.id }}"
             title="{{ t.label }}"
+            aria-label="{{ t.label }}{% if t.id == active_theme %} (active){% endif %}"
             onclick="setWelcomeTheme('{{ t.id }}')"
             style="--chip-dot: {{ t.dot_color }};">
-      <span class="cs-color-dot" style="background:{{ t.dot_color }};"></span>
-      <span class="cs-color-label">{{ t.label }}</span>
+      <span class="cs-color-swatch" style="background:{{ t.dot_color }};"></span>
     </button>
     {% endfor %}
   </div>
+  <p class="cs-color-active-name" id="cs-color-active-name">
+    {% for t in card_themes %}{% if t.id == active_theme %}{{ t.label }}{% endif %}{% endfor %}
+  </p>
   <p class="cs-color-error" id="cs-color-error" style="display:none;"></p>
 </div>

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -61811,6 +61811,46 @@
         ]
       }
     },
+    "/dashboard/wc-card-theme": {
+      "post": {
+        "description": "CS-COLOR-1: Set the active colour theme for the Welcome Card Studio.\n\nWrites to CardDraft(card_type_id='welcome_card').draft_theme.\nOnly free themes are valid in CS-COLOR-1 (no premium unlock scope).\nRequires active LFA Football Player license + onboarding completed.",
+        "operationId": "student_set_wc_card_theme_dashboard_wc_card_theme_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/_CardThemeRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Student Set Wc Card Theme",
+        "tags": [
+          "web"
+        ]
+      }
+    },
     "/dashboard/wc-photo": {
       "post": {
         "operationId": "student_upload_wc_photo_dashboard_wc_photo_post",
@@ -64348,6 +64388,16 @@
           },
           {
             "in": "query",
+            "name": "theme",
+            "required": false,
+            "schema": {
+              "default": "default",
+              "title": "Theme",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "render_token",
             "required": false,
             "schema": {
@@ -64414,6 +64464,16 @@
               "default": false,
               "title": "Use Nickname",
               "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "theme",
+            "required": false,
+            "schema": {
+              "default": "default",
+              "title": "Theme",
+              "type": "string"
             }
           }
         ],

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -61813,7 +61813,7 @@
     },
     "/dashboard/wc-card-theme": {
       "post": {
-        "description": "CS-COLOR-1: Set the active colour theme for the Welcome Card Studio.\n\nWrites to CardDraft(card_type_id='welcome_card').draft_theme.\nOnly free themes are valid in CS-COLOR-1 (no premium unlock scope).\nRequires active LFA Football Player license + onboarding completed.",
+        "description": "CS-COLOR-1: Set the active colour theme for the Welcome Card Studio.\n\nWrites to CardDraft(card_type_id='welcome_card').draft_theme.\nOnly free themes are valid in CS-COLOR-1AA (no premium unlock scope).\nRequires active LFA Football Player license + onboarding completed.",
         "operationId": "student_set_wc_card_theme_dashboard_wc_card_theme_post",
         "requestBody": {
           "content": {

--- a/tests/unit/api/web_routes/test_card_editor_ce2.py
+++ b/tests/unit/api/web_routes/test_card_editor_ce2.py
@@ -432,6 +432,6 @@ class TestCE217RouteCount:
         """CE-3.8 adds 3 from-mood endpoints — snapshot path count must equal 842."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 844, (
-            f"Expected 844 routes (842 CE-3.7+CE-3.8 baseline + 2 CS-S0 card-studio routes), got {len(paths)}."
+        assert len(paths) == 845, (
+            f"Expected 845 routes (842 CE-3.7+CE-3.8 baseline + 2 CS-S0 card-studio routes), got {len(paths)}."
         )

--- a/tests/unit/api/web_routes/test_card_editor_cs_s1.py
+++ b/tests/unit/api/web_routes/test_card_editor_cs_s1.py
@@ -292,8 +292,8 @@ class TestS109S110RouteAndSnapshot:
         """S1-09: route count is still 844 — redirect is handler change, not new route."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 844, (
-            f"Expected 844 routes (CS-S1 does not add routes), got {len(paths)}"
+        assert len(paths) == 845, (
+            f"Expected 845 routes (CS-S1 does not add routes), got {len(paths)}"
         )
 
     def test_s1_10_openapi_snapshot_still_matches(self):

--- a/tests/unit/api/web_routes/test_card_editor_ref_p2.py
+++ b/tests/unit/api/web_routes/test_card_editor_ref_p2.py
@@ -31,7 +31,7 @@ P2-23  #btn-export-video present in expanded source
 P2-24  all 11 Jinja2-rendered values present in scripts.html
 P2-25  no unexpected Jinja2 {{ }} patterns in scripts.html
 P2-26  scripts.html starts with <script>, ends with </script>
-P2-27  route count = 844 (no new routes)
+P2-27  route count = 845 (no new routes)
 P2-28  OpenAPI snapshot match
 P2-29  /card-editor/player route still registered
 """
@@ -287,7 +287,7 @@ class TestP227to29RouteAndOpenAPI:
         """P2-27: Route count = 844 — REF-P2 adds no new routes."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 844, f"Expected 844 routes, got {len(paths)}"
+        assert len(paths) == 845, f"Expected 844 routes, got {len(paths)}"
 
     def test_p2_28_openapi_snapshot_match(self):
         """P2-28: OpenAPI snapshot matches live API paths."""

--- a/tests/unit/api/web_routes/test_card_studio_challenge.py
+++ b/tests/unit/api/web_routes/test_card_studio_challenge.py
@@ -294,8 +294,8 @@ class TestCCS11RouteCount:
         """CCS-11: route count updated to 842 after CE-3.8 (+3 from-mood endpoints)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 844, (
-            f"Expected 844 routes (842 CE-3.7+CE-3.8 baseline + 2 CS-S0 card-studio routes), got {len(paths)}."
+        assert len(paths) == 845, (
+            f"Expected 845 routes (842 CE-3.7+CE-3.8 baseline + 2 CS-S0 card-studio routes), got {len(paths)}."
         )
 
     def test_ccs_11b_card_editor_challenge_route_registered(self):

--- a/tests/unit/api/web_routes/test_card_studio_landing.py
+++ b/tests/unit/api/web_routes/test_card_studio_landing.py
@@ -159,8 +159,8 @@ class TestCEL12RouteCount:
         """CEL-12: route count 844 (unchanged — redirect is handler change, not new route)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 844, (
-            f"Expected 844 routes (redirect handler change does not add routes), got {len(paths)}."
+        assert len(paths) == 845, (
+            f"Expected 845 routes (redirect handler change does not add routes), got {len(paths)}."
         )
 
     def test_cel_12b_card_editor_route_registered(self):

--- a/tests/unit/api/web_routes/test_card_studio_shell.py
+++ b/tests/unit/api/web_routes/test_card_studio_shell.py
@@ -21,7 +21,7 @@ CSS-17  mobile markup: cs-mood-section before cs-preview-panel
 CSS-18  template contains cs-preview-iframe
 CSS-19  template contains X-CSRF-Token in assign JS
 CSS-20  template contains !csrf guard
-CSS-21  route count == 844 (842 + 2 new card-studio routes)
+CSS-21  route count == 845 (842 + 2 new card-studio routes)
 CSS-22  GET /card-studio route registered
 CSS-23  GET /card-studio/welcome route registered
 """
@@ -321,8 +321,8 @@ class TestCSS21to23RouteConfirmations:
         """CSS-21: adding 2 card-studio routes raises count from 842 to 844."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 844, (
-            f"Expected 844 routes (842 baseline + 2 new /card-studio routes), got {len(paths)}"
+        assert len(paths) == 845, (
+            f"Expected 845 routes (842 baseline + 2 new /card-studio routes), got {len(paths)}"
         )
 
     def test_css_22_card_studio_route_registered(self):

--- a/tests/unit/api/web_routes/test_card_studio_welcome.py
+++ b/tests/unit/api/web_routes/test_card_studio_welcome.py
@@ -325,7 +325,7 @@ class TestCEW18RouteCount:
         """CEW-18: route count baseline check (updated by CE-3.8 to 842)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 844, (
+        assert len(paths) == 845, (
             f"Expected 842 routes (839 CE-3.7 baseline + 3 from-mood endpoints), got {len(paths)}."
         )
 
@@ -677,8 +677,8 @@ class TestCEW44to51TemplateMoodPicker:
         """CEW-47: CE-3.8 adds 3 from-mood routes → total 842."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 844, (
-            f"Expected 844 routes (842 baseline + 2 CS-S0 routes), got {len(paths)}"
+        assert len(paths) == 845, (
+            f"Expected 845 routes (842 baseline + 2 CS-S0 routes), got {len(paths)}"
         )
 
     def test_cew_48_assign_js_has_csrf_header(self):

--- a/tests/unit/api/web_routes/test_cs_color_1.py
+++ b/tests/unit/api/web_routes/test_cs_color_1.py
@@ -1,0 +1,375 @@
+"""
+CS-COLOR-1 — Welcome Studio Color/Theme selector tests.
+
+CSCOL-01  GET /profile/onboarding-card?platform=instagram_square&theme=midnight → 200
+CSCOL-02  context card_theme_id == active theme
+CSCOL-03  GET /profile/onboarding-card?platform=X no theme → fallback "default"
+CSCOL-04  GET /card-studio/welcome?format=X → context has card_themes + active_theme
+CSCOL-05  card_themes list non-empty, free themes only
+CSCOL-06  active_theme == CardDraft(welcome_card).draft_theme or "default"
+CSCOL-07  POST /dashboard/wc-card-theme {"theme":"midnight"} → 200 {"ok":true}
+CSCOL-08  POST /dashboard/wc-card-theme unknown theme → 400
+CSCOL-09  Welcome CardDraft.draft_theme updated after POST
+CSCOL-10  preview_url contains theme={active_theme}
+CSCOL-11  export_url contains theme={active_theme}
+CSCOL-12  card_studio_shell.html contains cs-color-chip UI
+CSCOL-13  setWelcomeTheme JS present, POST /dashboard/wc-card-theme with X-CSRF-Token
+CSCOL-14  format change URL preserves theme via CardDraft (server-side persistence)
+CSCOL-15  route count == 845
+CSCOL-16  OpenAPI snapshot includes /dashboard/wc-card-theme
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.card_design_service import WELCOME_CARD_FORMATS
+from app.services.card_theme_service import THEMES
+
+TEMPLATES_DIR = Path(__file__).resolve().parents[4] / "app" / "templates"
+SNAP_DIR      = Path(__file__).resolve().parents[4] / "tests" / "snapshots"
+
+_ALL_WC_IDS = [f.design_id for f in WELCOME_CARD_FORMATS]
+_FIRST_ID   = _ALL_WC_IDS[0]
+_FREE_THEME_IDS = {tid for tid, t in THEMES.items() if not t.is_premium}
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _user(uid: int = 42) -> MagicMock:
+    u = MagicMock()
+    u.id = uid
+    u.credit_balance = 500
+    u.role = MagicMock()
+    return u
+
+
+def _license(onboarding_completed: bool = True) -> MagicMock:
+    lic = MagicMock()
+    lic.onboarding_completed = onboarding_completed
+    lic.wc_photo_url = None
+    lic.wc_photo_portrait_url = None
+    lic.wc_photo_landscape_url = None
+    return lic
+
+
+def _db_with_license(lic) -> MagicMock:
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = lic
+    return db
+
+
+def _make_welcome_draft(draft_theme: str = "default") -> MagicMock:
+    d = MagicMock()
+    d.draft_theme = draft_theme
+    return d
+
+
+# ── CSCOL-01/02/03: /profile/onboarding-card theme param ─────────────────────
+
+class TestCSCOL01to03ProfileThemeParam:
+
+    def test_cscol_01_theme_param_accepted(self):
+        """CSCOL-01: GET /profile/onboarding-card?platform=X&theme=midnight → 200."""
+        from app.main import app
+        routes = [getattr(r, 'path', '') for r in app.routes]
+        assert '/profile/onboarding-card' in routes, "Route must be registered"
+
+    def test_cscol_01b_handler_signature_has_theme(self):
+        """CSCOL-01b: onboarding_welcome_card handler accepts theme param."""
+        from app.api.web_routes.profile import onboarding_welcome_card
+        import inspect
+        sig = inspect.signature(onboarding_welcome_card)
+        assert 'theme' in sig.parameters, "Handler must accept ?theme= Query param"
+
+    def test_cscol_02_build_context_uses_theme_id(self):
+        """CSCOL-02: _build_welcome_card_context with theme_id='midnight' uses midnight theme."""
+        from app.api.web_routes.profile import _build_welcome_card_context
+        import inspect
+        sig = inspect.signature(_build_welcome_card_context)
+        assert 'theme_id' in sig.parameters, "_build_welcome_card_context must accept theme_id"
+
+    def test_cscol_02b_default_theme_is_not_hardcoded_midnight(self):
+        """CSCOL-02b: default theme param is 'default', not hardcoded 'midnight'."""
+        from app.api.web_routes.profile import onboarding_welcome_card
+        import inspect
+        sig = inspect.signature(onboarding_welcome_card)
+        theme_param = sig.parameters.get('theme')
+        assert theme_param is not None
+        assert theme_param.default is not None
+        assert 'midnight' not in str(theme_param.default), \
+            "Default theme must not be hardcoded to 'midnight'"
+
+    def test_cscol_03_export_handler_accepts_theme(self):
+        """CSCOL-03: export_onboarding_welcome_card accepts ?theme= param."""
+        from app.api.web_routes.profile import export_onboarding_welcome_card
+        import inspect
+        sig = inspect.signature(export_onboarding_welcome_card)
+        assert 'theme' in sig.parameters, "Export handler must accept ?theme= param"
+
+
+# ── CSCOL-04/05/06: /card-studio/welcome context has card_themes ─────────────
+
+_CS_BASE = "app.api.web_routes.card_studio"
+
+
+def _invoke_welcome_studio(format_param, owned_ids, draft_theme="default"):
+    from app.api.web_routes.card_studio import card_studio_welcome
+    from app.models.user_mood_photos import MOOD_PHOTO_SLOTS
+
+    user = _user()
+    lic  = _license(onboarding_completed=True)
+    db   = _db_with_license(lic)
+    captured: dict = {}
+
+    def _fake_tmpl(tmpl, ctx, **kw):
+        captured["context"] = ctx
+        captured["template"] = tmpl
+        return MagicMock(status_code=200)
+
+    empty_mood = {slot: None for slot in MOOD_PHOTO_SLOTS}
+    mock_draft = _make_welcome_draft(draft_theme)
+
+    with patch(f"{_CS_BASE}.get_owned_design_ids", return_value=owned_ids), \
+         patch(f"{_CS_BASE}.get_mood_photos_for_user", return_value=empty_mood), \
+         patch(f"{_CS_BASE}._CardDraftService") as MockCDS, \
+         patch(f"{_CS_BASE}.templates") as mock_tpl:
+        MockCDS.get_draft.return_value = mock_draft
+        mock_tpl.TemplateResponse.side_effect = _fake_tmpl
+        _run(card_studio_welcome(
+            request=MagicMock(), format_id=format_param, db=db, user=user,
+        ))
+
+    return captured.get("context", {})
+
+
+class TestCSCOL04to06WelcomeContext:
+
+    def test_cscol_04_context_has_card_themes(self):
+        """CSCOL-04: /card-studio/welcome context contains card_themes key."""
+        ctx = _invoke_welcome_studio(_FIRST_ID, owned_ids=[_FIRST_ID])
+        assert "card_themes" in ctx, "context must contain card_themes"
+
+    def test_cscol_04b_context_has_active_theme(self):
+        """CSCOL-04b: /card-studio/welcome context contains active_theme key."""
+        ctx = _invoke_welcome_studio(_FIRST_ID, owned_ids=[_FIRST_ID])
+        assert "active_theme" in ctx, "context must contain active_theme"
+
+    def test_cscol_05_card_themes_non_empty_and_free_only(self):
+        """CSCOL-05: card_themes non-empty, all themes are free (is_premium=False)."""
+        ctx = _invoke_welcome_studio(_FIRST_ID, owned_ids=[_FIRST_ID])
+        themes = ctx.get("card_themes", [])
+        assert len(themes) > 0, "card_themes must not be empty"
+        for t in themes:
+            assert not t.is_premium, f"CS-COLOR-1: only free themes, got premium {t.id!r}"
+
+    def test_cscol_06_active_theme_from_draft(self):
+        """CSCOL-06: active_theme == CardDraft(welcome_card).draft_theme."""
+        ctx = _invoke_welcome_studio(_FIRST_ID, owned_ids=[_FIRST_ID], draft_theme="midnight")
+        assert ctx.get("active_theme") == "midnight"
+
+    def test_cscol_06b_active_theme_defaults_to_default(self):
+        """CSCOL-06b: active_theme falls back to 'default' when draft_theme is empty."""
+        ctx = _invoke_welcome_studio(_FIRST_ID, owned_ids=[_FIRST_ID], draft_theme="")
+        assert ctx.get("active_theme") in ("default", ""), \
+            "active_theme must default to 'default' when draft is empty"
+
+
+# ── CSCOL-10/11: preview_url + export_url contain theme param ────────────────
+
+class TestCSCOL10to11ThemeInUrls:
+
+    def test_cscol_10_preview_url_contains_theme(self):
+        """CSCOL-10: preview_url contains theme={active_theme}."""
+        ctx = _invoke_welcome_studio(_FIRST_ID, owned_ids=[_FIRST_ID], draft_theme="arctic")
+        preview_url = ctx.get("preview_url", "")
+        assert "theme=arctic" in preview_url, \
+            f"preview_url must contain theme=arctic; got {preview_url!r}"
+
+    def test_cscol_11_export_url_contains_theme(self):
+        """CSCOL-11: export_url contains theme={active_theme}."""
+        ctx = _invoke_welcome_studio(_FIRST_ID, owned_ids=[_FIRST_ID], draft_theme="arctic")
+        export_url = ctx.get("export_url", "")
+        assert "theme=arctic" in export_url, \
+            f"export_url must contain theme=arctic; got {export_url!r}"
+
+    def test_cscol_10b_format_row_preview_urls_contain_theme(self):
+        """CSCOL-10b: owned_format_rows preview URLs include theme param."""
+        ctx = _invoke_welcome_studio(_FIRST_ID, owned_ids=[_FIRST_ID], draft_theme="midnight")
+        rows = ctx.get("owned_format_rows", [])
+        for row in rows:
+            assert "theme=midnight" in row["preview_url"], \
+                f"format row preview_url must contain theme param; got {row['preview_url']!r}"
+
+
+# ── CSCOL-07/08/09: POST /dashboard/wc-card-theme ────────────────────────────
+
+_DASH_BASE = "app.api.web_routes.dashboard"
+
+
+class TestCSCOL07to09WcCardThemeEndpoint:
+
+    def test_cscol_07_valid_free_theme_returns_ok(self):
+        """CSCOL-07: POST /dashboard/wc-card-theme {"theme":"midnight"} → {"ok":true}."""
+        from app.api.web_routes.dashboard import student_set_wc_card_theme, _CardThemeRequest
+        from app.models.user_mood_photos import MOOD_PHOTO_SLOTS
+
+        user    = _user()
+        lic     = _license(onboarding_completed=True)
+        db      = _db_with_license(lic)
+        payload = _CardThemeRequest(theme="midnight")
+        draft   = _make_welcome_draft("default")
+
+        with patch(f"{_DASH_BASE}._CardDraftService") as MockCDS, \
+             patch(f"{_DASH_BASE}._get_lfa_license", return_value=lic):
+            MockCDS.get_draft.return_value = draft
+            MockCDS.update_draft_theme.return_value = draft
+            resp = _run(student_set_wc_card_theme(payload=payload, db=db, user=user))
+
+        assert resp.status_code == 200
+        body = json.loads(resp.body)
+        assert body["ok"] is True
+        assert body["theme"] == "midnight"
+
+    def test_cscol_08_unknown_theme_returns_400(self):
+        """CSCOL-08: POST /dashboard/wc-card-theme with unknown theme → 400."""
+        from app.api.web_routes.dashboard import student_set_wc_card_theme, _CardThemeRequest
+
+        user    = _user()
+        lic     = _license(onboarding_completed=True)
+        db      = _db_with_license(lic)
+        payload = _CardThemeRequest(theme="nonexistent_theme_xyz")
+
+        with patch(f"{_DASH_BASE}._get_lfa_license", return_value=lic):
+            resp = _run(student_set_wc_card_theme(payload=payload, db=db, user=user))
+
+        assert resp.status_code == 400
+        body = json.loads(resp.body)
+        assert body["ok"] is False
+
+    def test_cscol_08b_premium_theme_rejected(self):
+        """CSCOL-08b: POST /dashboard/wc-card-theme premium theme → 400 (no unlock scope)."""
+        from app.api.web_routes.dashboard import student_set_wc_card_theme, _CardThemeRequest
+
+        user    = _user()
+        lic     = _license(onboarding_completed=True)
+        db      = _db_with_license(lic)
+        payload = _CardThemeRequest(theme="gold")  # premium — must be rejected in CS-COLOR-1
+
+        with patch(f"{_DASH_BASE}._get_lfa_license", return_value=lic):
+            resp = _run(student_set_wc_card_theme(payload=payload, db=db, user=user))
+
+        assert resp.status_code == 400
+        body = json.loads(resp.body)
+        assert body["ok"] is False
+
+    def test_cscol_09_draft_theme_updated(self):
+        """CSCOL-09: CardDraftService.update_draft_theme called with correct theme."""
+        from app.api.web_routes.dashboard import student_set_wc_card_theme, _CardThemeRequest
+
+        user    = _user()
+        lic     = _license(onboarding_completed=True)
+        db      = _db_with_license(lic)
+        payload = _CardThemeRequest(theme="arctic")
+        draft   = _make_welcome_draft("default")
+
+        # Endpoint uses a local import — patch the service directly
+        with patch("app.services.card_draft_service.CardDraftService.get_draft", return_value=draft), \
+             patch("app.services.card_draft_service.CardDraftService.update_draft_theme", return_value=draft) as mock_update, \
+             patch(f"{_DASH_BASE}._get_lfa_license", return_value=lic):
+            _run(student_set_wc_card_theme(payload=payload, db=db, user=user))
+
+        mock_update.assert_called_once_with(db, draft, "arctic")
+
+    def test_cscol_09b_no_license_returns_404(self):
+        """CSCOL-09b: missing license → 404."""
+        from app.api.web_routes.dashboard import student_set_wc_card_theme, _CardThemeRequest
+
+        user    = _user()
+        db      = MagicMock()
+        payload = _CardThemeRequest(theme="midnight")
+
+        with patch(f"{_DASH_BASE}._get_lfa_license", return_value=None):
+            resp = _run(student_set_wc_card_theme(payload=payload, db=db, user=user))
+
+        assert resp.status_code == 404
+
+
+# ── CSCOL-12/13: template source checks ──────────────────────────────────────
+
+class TestCSCOL12to13TemplateSource:
+
+    def test_cscol_12_shell_has_cs_color_chip(self):
+        """CSCOL-12: card_studio_shell.html contains cs-color-chip class."""
+        src = (TEMPLATES_DIR / "card_studio_shell.html").read_text()
+        assert "cs-color-chip" in src, "shell must contain cs-color-chip CSS class"
+        assert "cs_color_panel.html" in src, "shell must include cs_color_panel.html"
+
+    def test_cscol_12b_color_panel_include_exists(self):
+        """CSCOL-12b: cs_color_panel.html include file exists."""
+        assert (TEMPLATES_DIR / "includes/cs_color_panel.html").exists()
+
+    def test_cscol_12c_color_panel_has_data_theme_attr(self):
+        """CSCOL-12c: cs_color_panel.html uses data-theme attribute."""
+        src = (TEMPLATES_DIR / "includes/cs_color_panel.html").read_text()
+        assert "data-theme" in src
+
+    def test_cscol_13_shell_has_set_welcome_theme_js(self):
+        """CSCOL-13: card_studio_shell.html contains setWelcomeTheme JS function."""
+        src = (TEMPLATES_DIR / "card_studio_shell.html").read_text()
+        assert "setWelcomeTheme" in src, "shell must define setWelcomeTheme JS function"
+
+    def test_cscol_13b_set_welcome_theme_calls_wc_card_theme(self):
+        """CSCOL-13b: setWelcomeTheme posts to /dashboard/wc-card-theme."""
+        src = (TEMPLATES_DIR / "card_studio_shell.html").read_text()
+        assert "/dashboard/wc-card-theme" in src
+
+    def test_cscol_13c_set_welcome_theme_has_csrf_header(self):
+        """CSCOL-13c: setWelcomeTheme includes X-CSRF-Token header."""
+        src = (TEMPLATES_DIR / "card_studio_shell.html").read_text()
+        # Find the setWelcomeTheme function context
+        start = src.find("setWelcomeTheme")
+        snippet = src[start:start + 800]
+        assert "X-CSRF-Token" in snippet, "setWelcomeTheme must send X-CSRF-Token header"
+
+
+# ── CSCOL-14: format change preserves theme via CardDraft ────────────────────
+
+class TestCSCOL14FormatThemePersistence:
+
+    def test_cscol_14_format_change_reads_draft_theme(self):
+        """CSCOL-14: format change re-reads active_theme from CardDraft (server-side persist)."""
+        # When user navigates to /card-studio/welcome?format=X (new format),
+        # _resolve_welcome_context reads CardDraft.draft_theme → active_theme preserved
+        ctx1 = _invoke_welcome_studio(_FIRST_ID, owned_ids=[_FIRST_ID], draft_theme="arctic")
+        ctx2 = _invoke_welcome_studio(_FIRST_ID, owned_ids=[_FIRST_ID], draft_theme="arctic")
+        assert ctx1.get("active_theme") == ctx2.get("active_theme") == "arctic"
+
+
+# ── CSCOL-15/16: route count + OpenAPI snapshot ──────────────────────────────
+
+class TestCSCOL15to16RouteAndSnapshot:
+
+    def test_cscol_15_route_count_845(self):
+        """CSCOL-15: route count = 845 (+1 POST /dashboard/wc-card-theme)."""
+        from app.main import app
+        paths = app.openapi().get("paths", {})
+        assert len(paths) == 845, f"Expected 845 routes, got {len(paths)}"
+
+    def test_cscol_16_openapi_snapshot_includes_wc_card_theme(self):
+        """CSCOL-16: OpenAPI snapshot includes /dashboard/wc-card-theme."""
+        snap = json.loads((SNAP_DIR / "openapi_snapshot.json").read_text())
+        snap_paths = set(snap.get("paths", {}).keys())
+        assert "/dashboard/wc-card-theme" in snap_paths, \
+            "Snapshot must include /dashboard/wc-card-theme"
+        from app.main import app
+        live_paths = set(app.openapi().get("paths", {}).keys())
+        assert snap_paths == live_paths, "Snapshot must match live API"

--- a/tests/unit/api/web_routes/test_cs_color_1.py
+++ b/tests/unit/api/web_routes/test_cs_color_1.py
@@ -1,18 +1,22 @@
 """
-CS-COLOR-1 — Welcome Studio Color/Theme selector tests.
+CS-COLOR-1A — Welcome Studio Free/Basic Theme Selector MVP tests.
+
+MVP scope: free/basic theme selection only (default/midnight/arctic).
+No premium purchase, no family/format ownership, no shop unlock.
+Full ownership system: COLOR-OWNERSHIP series (future).
 
 CSCOL-01  GET /profile/onboarding-card?platform=instagram_square&theme=midnight → 200
 CSCOL-02  context card_theme_id == active theme
 CSCOL-03  GET /profile/onboarding-card?platform=X no theme → fallback "default"
 CSCOL-04  GET /card-studio/welcome?format=X → context has card_themes + active_theme
-CSCOL-05  card_themes list non-empty, free themes only
+CSCOL-05  card_themes list non-empty, FREE themes only (no premium in CS-COLOR-1A)
 CSCOL-06  active_theme == CardDraft(welcome_card).draft_theme or "default"
 CSCOL-07  POST /dashboard/wc-card-theme {"theme":"midnight"} → 200 {"ok":true}
 CSCOL-08  POST /dashboard/wc-card-theme unknown theme → 400
 CSCOL-09  Welcome CardDraft.draft_theme updated after POST
 CSCOL-10  preview_url contains theme={active_theme}
 CSCOL-11  export_url contains theme={active_theme}
-CSCOL-12  card_studio_shell.html contains cs-color-chip UI
+CSCOL-12  card_studio_shell.html contains cs-color-chip swatch UI
 CSCOL-13  setWelcomeTheme JS present, POST /dashboard/wc-card-theme with X-CSRF-Token
 CSCOL-14  format change URL preserves theme via CardDraft (server-side persistence)
 CSCOL-15  route count == 845
@@ -308,10 +312,26 @@ class TestCSCOL07to09WcCardThemeEndpoint:
 class TestCSCOL12to13TemplateSource:
 
     def test_cscol_12_shell_has_cs_color_chip(self):
-        """CSCOL-12: card_studio_shell.html contains cs-color-chip class."""
+        """CSCOL-12: card_studio_shell.html contains cs-color-chip swatch UI."""
         src = (TEMPLATES_DIR / "card_studio_shell.html").read_text()
         assert "cs-color-chip" in src, "shell must contain cs-color-chip CSS class"
         assert "cs_color_panel.html" in src, "shell must include cs_color_panel.html"
+
+    def test_cscol_12d_color_panel_uses_swatch_circle(self):
+        """CSCOL-12d (CS-COLOR-1A): color chip uses swatch circle (.cs-color-swatch), not text list."""
+        src = (TEMPLATES_DIR / "includes/cs_color_panel.html").read_text()
+        assert "cs-color-swatch" in src, "panel must use .cs-color-swatch circle element"
+        # Label text should NOT be inside the chip button (it's secondary via active-name)
+        assert "cs-color-label" not in src, \
+            "CS-COLOR-1A: label must not be inside chip — circle is primary visual"
+
+    def test_cscol_12e_no_premium_themes_in_context(self):
+        """CSCOL-12e (CS-COLOR-1A): card_themes context never contains premium themes."""
+        ctx = _invoke_welcome_studio(_FIRST_ID, owned_ids=[_FIRST_ID])
+        themes = ctx.get("card_themes", [])
+        premium = [t for t in themes if t.is_premium]
+        assert len(premium) == 0, \
+            f"CS-COLOR-1A must show free themes only; found premium: {[t.id for t in premium]}"
 
     def test_cscol_12b_color_panel_include_exists(self):
         """CSCOL-12b: cs_color_panel.html include file exists."""

--- a/tests/unit/api/web_routes/test_family_color_shop.py
+++ b/tests/unit/api/web_routes/test_family_color_shop.py
@@ -223,8 +223,8 @@ class TestRouteRegistration:
     def test_ts_13_route_count_836(self):
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 844, (
-            f"Expected 844 routes (842 CE-3.7+CE-3.8 baseline + 2 CS-S0 card-studio routes), got {len(paths)}."
+        assert len(paths) == 845, (
+            f"Expected 845 routes (842 CE-3.7+CE-3.8 baseline + 2 CS-S0 card-studio routes), got {len(paths)}."
         )
 
     def test_ts_14_unlock_theme_still_registered(self):


### PR DESCRIPTION
## Summary — CS-COLOR-1A: Welcome Studio Free/Basic Theme Selector MVP

**This is a free/basic theme selector MVP only.** Not the final color ownership system.
Full family/format/premium color ownership → **COLOR-OWNERSHIP series** (separate PRs, future).

## What CS-COLOR-1A does
- Welcome Studio gets circle swatch chips for color/theme selection
- Free themes only: **Slate** / **Midnight** / **Arctic** (no premium purchase)
- Active theme stored in `CardDraft(welcome_card).draft_theme` — no migration needed
- `POST /dashboard/wc-card-theme` — validates free themes, CSRF-required
- Preview iframe and export URL include `&theme={active_theme}`
- Swatch circle is the primary visual; label shown below as active name

## What CS-COLOR-1A does NOT do
- No premium color purchase
- No `CardColorOwnership` welcome/challenge (TS-2)
- No family/format-level ownership (COLOR-OWNERSHIP-1+)
- No shop color listing
- No locked chip with buy CTA
- No TS-2, no Player integration, no Challenge integration

## UI: Swatch circles (not text list)
- `.cs-color-chip`: 32px circle button, border on active
- `.cs-color-swatch`: 22px filled circle (primary visual)
- Active theme name shown separately below the chip row

## Route count: 845 (+1 `POST /dashboard/wc-card-theme`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)