### PR TITLE
refactor(shop-3b1): SHOP-3B1 — Legacy shop listing test cleanup

### DIFF
--- a/tests/unit/api/web_routes/test_my_cards_feedback.py
+++ b/tests/unit/api/web_routes/test_my_cards_feedback.py
@@ -11,7 +11,7 @@ Rendering tests (Jinja2 direct render):
   MCF-03..04   CC formats render correct aspect-ratio class per design_id
   MCF-08       PC purchased flash renders human-readable label, not raw design_id
   MCF-12..17   WC My Cards formats render correct ratio class per preview_platform
-  MCF-18..19   Shop WC formats also render correct ratio classes
+  # MCF-18..19 removed (SHOP-3B1): shop_welcome_card.html legacy listing template tests
 """
 import pathlib
 from unittest.mock import MagicMock
@@ -24,7 +24,6 @@ _TMPL = pathlib.Path(_TMPL_DIR)
 _MCC  = (_TMPL / "my_cards_challenge_card.html").read_text()
 _MCP  = (_TMPL / "my_cards_player_card.html").read_text()
 _MCW  = (_TMPL / "my_cards_welcome_card.html").read_text()
-_SWC  = (_TMPL / "shop_welcome_card.html").read_text()
 _GRID = (_TMPL / "includes" / "mc_format_grid.html").read_text()
 
 
@@ -319,23 +318,6 @@ class TestMCWIframeRatio:
 
 
 # ── MCF-18..19: Shop WC also uses ratio classes (E bonus fix) ─────────────────
-
-class TestShopWCRatio:
-
-    def test_mcf18_shop_wc_story_renders_ratio_916(self):
-        """MCF-18: shop_welcome_card.html instagram_story renders mfg-ratio-916."""
-        html = _render("shop_welcome_card.html",
-                       _swc_ctx(rows=[_wc_row("instagram_story", state="get_card")]))
-        assert "mfg-ratio-916" in html
-
-    def test_mcf19_shop_wc_portrait_renders_ratio_45(self):
-        """MCF-19: shop_welcome_card.html instagram_portrait renders mfg-ratio-45."""
-        html = _render("shop_welcome_card.html",
-                       _swc_ctx(rows=[_wc_row("instagram_portrait", state="get_card")]))
-        assert "mfg-ratio-45" in html
-
-
-# ── MCF-20..21: new CSS ratio classes defined in mc_format_grid.html ─────────
 
 class TestGridCSSNewRatioClasses:
 

--- a/tests/unit/api/web_routes/test_shop.py
+++ b/tests/unit/api/web_routes/test_shop.py
@@ -280,54 +280,35 @@ class TestShopAuthDependencies:
 # ── SH-12: Template structure ─────────────────────────────────────────────────
 
 class TestShopTemplates:
+    """SH-12: Template structure tests.
 
-    @pytest.fixture(scope="class")
-    def player_src(self):
-        return (_TEMPLATE_BASE / "shop_player_card.html").read_text()
-
-    @pytest.fixture(scope="class")
-    def welcome_src(self):
-        return (_TEMPLATE_BASE / "shop_welcome_card.html").read_text()
-
-    @pytest.fixture(scope="class")
-    def challenge_src(self):
-        return (_TEMPLATE_BASE / "shop_challenge_card.html").read_text()
-
-    def test_sh12a_player_template_extends_student_base(self, player_src):
-        """SH-12a: shop_player_card.html extends student_base."""
-        assert "student_base.html" in player_src
-
-    def test_sh12b_player_template_includes_spec_hdr(self, player_src):
-        """SH-12b: shop_player_card.html includes spec_subpage_hdr."""
-        assert "spec_subpage_hdr.html" in player_src
-
-    def test_sh12c_player_template_has_breadcrumb_to_shop(self, player_src):
-        """SH-12c: shop_player_card.html breadcrumb links to /shop."""
-        assert 'href="/shop"' in player_src
-
-    def test_sh12d_player_template_has_purchase_form(self, player_src):
-        """SH-12d: shop_player_card.html has POST form to /shop/cards/player_card/buy/."""
-        assert "/shop/cards/player_card/buy/" in player_src
-        assert 'method="POST"' in player_src
-
-    def test_sh12e_welcome_template_has_my_collection_link(self, welcome_src):
-        """SH-12e: shop_welcome_card.html has back link to /my-cards/welcome-card."""
-        assert "/my-cards/welcome" in welcome_src
-
-    def test_sh12f_challenge_template_has_results_cta(self, challenge_src):
-        """SH-12f: shop_challenge_card.html has link to /challenges/results."""
-        assert "/challenges/results" in challenge_src
+    SHOP-3B1: player_src, welcome_src, challenge_src fixtures removed.
+    SH-12a..12f (legacy listing template tests) removed — templates now unused.
+    SH-12g ported to shop_unified.html (SHOP-3A).
+    SH-12e/SH-12h ported to shop_unified.html buy form + studio CTA.
+    """
 
     def test_sh12g_unified_has_filter_links(self):
-        """SH-12g (SHOP-3A): shop_unified.html has filter links for all three card types.
-        Replaces: shop_landing.html links check (shop_landing.html deleted in SHOP-3A).
-        """
+        """SH-12g (SHOP-3A): shop_unified.html has filter links for all three card types."""
         src = (_TEMPLATE_BASE / "shop_unified.html").read_text()
         assert 'href="/shop?type=player_card"'    in src
         assert 'href="/shop?type=welcome_card"'   in src
         assert 'href="/shop?type=challenge_card"' in src
 
-    def test_sh12h_welcome_template_purchase_form(self, welcome_src):
-        """SH-12h: shop_welcome_card.html has POST form to /shop/cards/welcome_card/buy/."""
-        assert "/shop/cards/welcome_card/buy/" in welcome_src
-        assert 'method="POST"' in welcome_src
+    def test_sh12e_unified_has_buy_forms(self):
+        """SH-12e (SHOP-3B1): shop_unified.html has POST buy forms via item.buy_url."""
+        src = (_TEMPLATE_BASE / "shop_unified.html").read_text()
+        assert 'method="POST"' in src, "shop_unified.html must have POST buy forms"
+        assert 'action="{{ item.buy_url }}"' in src, "shop_unified.html must use item.buy_url"
+
+    def test_sh12f_unified_has_studio_cta(self):
+        """SH-12f (SHOP-3B1): shop_unified.html has studio CTA for owned items."""
+        src = (_TEMPLATE_BASE / "shop_unified.html").read_text()
+        assert "su-btn-studio" in src, "shop_unified.html must have su-btn-studio for owned items"
+
+    def test_sh12h_unified_has_welcome_buy_url(self):
+        """SH-12h (SHOP-3B1): shop_unified.html buy URL covers welcome_card type."""
+        src = (_TEMPLATE_BASE / "shop_unified.html").read_text()
+        # shop_catalog_service builds buy_url as /shop/cards/{card_type_id}/buy/{id}
+        # The template renders: action="{{ item.buy_url }}"
+        assert "item.buy_url" in src, "shop_unified.html must use item.buy_url for buy form"

--- a/tests/unit/api/web_routes/test_shop_3b1.py
+++ b/tests/unit/api/web_routes/test_shop_3b1.py
@@ -1,0 +1,168 @@
+"""
+SHOP-3B1 — Legacy shop listing test cleanup verification.
+
+shop_player_card.html, shop_welcome_card.html, shop_challenge_card.html
+still exist as files (deletion in SHOP-3B2), but no active test read/render
+references remain after SHOP-3B1 cleanup.
+
+S3B1-01  No active test reference to shop_player_card.html
+S3B1-02  No active test reference to shop_welcome_card.html
+S3B1-03  No active test reference to shop_challenge_card.html
+S3B1-04  shop_unified.html handles purchased flash state
+S3B1-05  shop_unified.html handles error=credits flash
+S3B1-06  shop_unified.html handles error=owned flash
+S3B1-07  shop_unified.html has POST buy form (item.buy_url)
+S3B1-08  GET /shop → 200
+S3B1-09  GET /shop?type=player_card → Player items
+S3B1-10  GET /shop?type=welcome_card → Welcome items
+S3B1-11  GET /shop?type=challenge_card → Challenge items
+S3B1-12  Route count == 845
+S3B1-13  OpenAPI snapshot match true
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+TEMPLATES_DIR = Path(__file__).resolve().parents[4] / "app" / "templates"
+SNAP_DIR      = Path(__file__).resolve().parents[4] / "tests" / "snapshots"
+APP_DIR       = Path(__file__).resolve().parents[4] / "app"
+TESTS_DIR     = Path(__file__).resolve().parents[3]
+
+_ACTIVE_PATTERNS = [
+    'TemplateResponse("{tmpl}"', "TemplateResponse('{tmpl}'",
+    'get_template("{tmpl}")', "get_template('{tmpl}')",
+    '"{tmpl}").read_text', "'{tmpl}').read_text",
+    '/ "{tmpl}")', "/ '{tmpl}')",
+    '_render("{tmpl}"', "_render('{tmpl}'",
+]
+
+
+# ── S3B1-01..03: No active test read/render references ──────────────────────
+
+class TestS3B101to03NoActiveReferences:
+
+    def _scan(self, filename: str) -> list[str]:
+        found = []
+        this_file = Path(__file__)
+        patterns = [p.replace("{tmpl}", filename) for p in _ACTIVE_PATTERNS]
+        for glob_pat in ["*.py"]:
+            for base in [APP_DIR, TESTS_DIR]:
+                for fpath in base.rglob(glob_pat):
+                    if "__pycache__" in str(fpath) or fpath == this_file: continue
+                    try:
+                        content = fpath.read_text(encoding="utf-8")
+                        for p in patterns:
+                            if p in content:
+                                found.append(f"{fpath.name}: {p!r}")
+                                break
+                    except (UnicodeDecodeError, PermissionError):
+                        pass
+        return found
+
+    def test_s3b1_01_no_reference_to_shop_player_card(self):
+        """S3B1-01: No active test read/render reference to shop_player_card.html."""
+        refs = self._scan("shop_player_card.html")
+        assert len(refs) == 0, \
+            "shop_player_card.html still referenced:\n" + "\n".join(refs)
+
+    def test_s3b1_02_no_reference_to_shop_welcome_card(self):
+        """S3B1-02: No active test read/render reference to shop_welcome_card.html."""
+        refs = self._scan("shop_welcome_card.html")
+        assert len(refs) == 0, \
+            "shop_welcome_card.html still referenced:\n" + "\n".join(refs)
+
+    def test_s3b1_03_no_reference_to_shop_challenge_card(self):
+        """S3B1-03: No active test read/render reference to shop_challenge_card.html."""
+        refs = self._scan("shop_challenge_card.html")
+        assert len(refs) == 0, \
+            "shop_challenge_card.html still referenced:\n" + "\n".join(refs)
+
+
+# ── S3B1-04..07: shop_unified.html flash + buy form behavior ─────────────────
+
+class TestS3B104to07UnifiedBehavior:
+
+    @classmethod
+    def _unified_src(cls) -> str:
+        return (TEMPLATES_DIR / "shop_unified.html").read_text(encoding="utf-8")
+
+    def test_s3b1_04_unified_handles_purchased_flash(self):
+        """S3B1-04: shop_unified.html renders purchased flash state."""
+        src = self._unified_src()
+        assert "purchased" in src, "shop_unified.html must handle ?purchased= flash"
+        assert "su-flash--ok" in src, "shop_unified.html must have su-flash--ok class for success"
+
+    def test_s3b1_05_unified_handles_credits_error(self):
+        """S3B1-05: shop_unified.html handles error=credits flash."""
+        src = self._unified_src()
+        assert "credits" in src.lower(), "shop_unified.html must mention credits in error flash"
+        assert "su-flash--error" in src, "shop_unified.html must have su-flash--error class"
+
+    def test_s3b1_06_unified_handles_owned_error(self):
+        """S3B1-06: shop_unified.html handles error=owned flash."""
+        src = self._unified_src()
+        assert "'owned'" in src or '"owned"' in src, \
+            "shop_unified.html must check for error=owned param"
+
+    def test_s3b1_07_unified_has_buy_form(self):
+        """S3B1-07: shop_unified.html has POST buy form via item.buy_url."""
+        src = self._unified_src()
+        assert 'method="POST"' in src, "shop_unified.html must have POST buy form"
+        assert 'action="{{ item.buy_url }}"' in src, "shop_unified.html must use item.buy_url"
+
+
+# ── S3B1-08..11: Route behavior unchanged ────────────────────────────────────
+
+class TestS3B108to11RouteBehavior:
+
+    def test_s3b1_08_shop_returns_200(self):
+        """S3B1-08: GET /shop registered."""
+        from app.main import app
+        paths = [getattr(r, "path", "") for r in app.routes]
+        assert "/shop" in paths
+
+    def test_s3b1_09_player_type_filter(self):
+        """S3B1-09: ?type=player_card → Player items only."""
+        from app.services.shop_catalog_service import build_shop_catalog
+        db = MagicMock()
+        with patch("app.services.shop_catalog_service.get_owned_design_ids", return_value=set()):
+            items = build_shop_catalog(db, 1, 500, "player_card")
+        assert all(i.card_type_id == "player_card" for i in items) and len(items) > 0
+
+    def test_s3b1_10_welcome_type_filter(self):
+        """S3B1-10: ?type=welcome_card → Welcome items only."""
+        from app.services.shop_catalog_service import build_shop_catalog
+        db = MagicMock()
+        with patch("app.services.shop_catalog_service.get_owned_design_ids", return_value=set()):
+            items = build_shop_catalog(db, 1, 500, "welcome_card")
+        assert all(i.card_type_id == "welcome_card" for i in items) and len(items) == 7
+
+    def test_s3b1_11_challenge_type_filter(self):
+        """S3B1-11: ?type=challenge_card → Challenge items only."""
+        from app.services.shop_catalog_service import build_shop_catalog
+        db = MagicMock()
+        with patch("app.services.shop_catalog_service.get_owned_design_ids", return_value=set()):
+            items = build_shop_catalog(db, 1, 500, "challenge_card")
+        assert all(i.card_type_id == "challenge_card" for i in items) and len(items) == 2
+
+
+# ── S3B1-12/13: Route count + OpenAPI ────────────────────────────────────────
+
+class TestS3B112to13RouteAndSnapshot:
+
+    def test_s3b1_12_route_count_845(self):
+        """S3B1-12: Route count = 845 (test cleanup does not affect routes)."""
+        from app.main import app
+        paths = app.openapi().get("paths", {})
+        assert len(paths) == 845, f"Expected 845 routes, got {len(paths)}"
+
+    def test_s3b1_13_openapi_snapshot_match(self):
+        """S3B1-13: OpenAPI snapshot matches live API."""
+        snap = json.loads((SNAP_DIR / "openapi_snapshot.json").read_text())
+        snap_paths = set(snap.get("paths", {}).keys())
+        from app.main import app
+        live_paths = set(app.openapi().get("paths", {}).keys())
+        assert snap_paths == live_paths

--- a/tests/unit/api/web_routes/test_shop_feedback.py
+++ b/tests/unit/api/web_routes/test_shop_feedback.py
@@ -1,15 +1,14 @@
-"""Shop Flash / Feedback UX tests — SCF-01..23.
+"""Shop Feedback UX tests — SCF-12..14, SCF-18..19.
 
-Structural tests (template text assertions):
-  SCF-01..04   purchased flash uses label resolution (selectattr + _pl or fallback)
-  SCF-05..11   error messages contain correct CTA links per template
-  SCF-15..19   count badge + CSS classes present in templates
+SHOP-3B1: Legacy template-specific tests (SCF-01..11, SCF-15..17, SCF-20..24) removed.
+These tested shop_player_card.html, shop_welcome_card.html, shop_challenge_card.html
+which are now unused listing templates (SHOP-1/2 redirects).
 
-Route context tests (direct handler calls):
-  SCF-12..14   shop.py routes expose owned_count and total_count in context
+Route context tests (shop_catalog_service):
+  SCF-12..14   owned_count via catalog service
 
-Rendering tests (Jinja2 direct render):
-  SCF-20..23   mfg-card-just-purchased applied to correct item; badge conditional
+Format grid CSS:
+  SCF-18..19   mc_format_grid.html CSS classes
 """
 import asyncio
 import pathlib
@@ -20,9 +19,6 @@ from jinja2 import Environment, FileSystemLoader, Undefined
 _TMPL_DIR = str(pathlib.Path(__file__).resolve().parents[4] / "app" / "templates")
 _TMPL = pathlib.Path(_TMPL_DIR)
 
-_SPC  = (_TMPL / "shop_player_card.html").read_text()
-_SWC  = (_TMPL / "shop_welcome_card.html").read_text()
-_SCC  = (_TMPL / "shop_challenge_card.html").read_text()
 _GRID = (_TMPL / "includes" / "mc_format_grid.html").read_text()
 
 _BASE = "app.api.web_routes.shop"
@@ -197,93 +193,6 @@ def _cc_ctx(purchased=None, error=None, owned_ids=None):
 
 # ── SCF-01..04: purchased flash label resolution — template structure ─────────
 
-class TestPurchasedFlashLabelStructure:
-
-    def test_scf01_pc_template_has_label_resolution(self):
-        """SCF-01: PC template resolves flash label via selectattr + label attribute."""
-        assert "selectattr('id', 'equalto', flash_purchased)" in _SPC
-        assert "map(attribute='label')" in _SPC
-        assert "_pl or flash_purchased" in _SPC
-
-    def test_scf02_wc_template_has_label_resolution(self):
-        """SCF-02: WC template resolves flash label via selectattr on design_id."""
-        assert "selectattr('design_id', 'equalto', flash_purchased)" in _SWC
-        assert "map(attribute='label')" in _SWC
-        assert "_pl or flash_purchased" in _SWC
-
-    def test_scf03_cc_template_has_label_resolution(self):
-        """SCF-03: CC template resolves flash label via selectattr on design_id."""
-        assert "selectattr('design_id', 'equalto', flash_purchased)" in _SCC
-        assert "map(attribute='label')" in _SCC
-        assert "_pl or flash_purchased" in _SCC
-
-    def test_scf04_pc_flash_renders_label_not_raw_id(self):
-        """SCF-04: PC flash renders 'Compact', not raw 'compact', when purchased."""
-        html = _render("shop_player_card.html", _pc_ctx(purchased="compact", owned_ids=["compact"]))
-        assert "Compact" in html
-        assert "Design unlocked" in html
-        # The raw lower-case ID should not appear in the flash banner sentence
-        flash_section = html.split("Design unlocked")[1].split("</div>")[0] if "Design unlocked" in html else ""
-        assert "compact" not in flash_section.lower() or "Compact" in flash_section
-
-
-# ── SCF-05..11: error feedback + CTA links — template structure ───────────────
-
-class TestErrorFeedbackCTA:
-
-    def test_scf05_pc_credits_error_has_credits_link(self):
-        """SCF-05: PC template credits error block contains /credits."""
-        assert "/credits" in _SPC
-        assert "Get more credits" in _SPC
-
-    def test_scf06_pc_owned_error_has_my_cards_player(self):
-        """SCF-06: PC template owned error links to /my-cards/player."""
-        assert "/my-cards/player" in _SPC
-        assert "View in My Cards" in _SPC
-
-    def test_scf07_wc_owned_error_has_my_cards_welcome(self):
-        """SCF-07: WC template owned error links to /my-cards/welcome."""
-        assert "/my-cards/welcome" in _SWC
-        assert "View in My Cards" in _SWC
-
-    def test_scf08_cc_owned_error_has_my_cards_challenge(self):
-        """SCF-08: CC template owned error links to /my-cards/challenge."""
-        assert "/my-cards/challenge" in _SCC
-        assert "View in My Cards" in _SCC
-
-    def test_scf09_pc_invalid_error_has_back_to_shop(self):
-        """SCF-09: PC template invalid error links back to /shop/cards."""
-        assert "Back to shop" in _SPC
-
-    def test_scf10_wc_invalid_error_has_back_to_shop(self):
-        """SCF-10: WC template invalid error links back to /shop/cards."""
-        assert "Back to shop" in _SWC
-
-    def test_scf11_cc_invalid_error_has_back_to_shop(self):
-        """SCF-11: CC template invalid error links back to /shop/cards."""
-        assert "Back to shop" in _SCC
-
-    def test_scf05b_pc_credits_renders_cta_link(self):
-        """SCF-05b: PC flash credits error renders /credits link in HTML output."""
-        html = _render("shop_player_card.html", _pc_ctx(error="credits"))
-        assert "/credits" in html
-        assert "Get more credits" in html
-
-    def test_scf06b_pc_owned_renders_my_cards_link(self):
-        """SCF-06b: PC owned error renders /my-cards/player link."""
-        html = _render("shop_player_card.html", _pc_ctx(error="owned"))
-        assert "/my-cards/player" in html
-
-    def test_scf08b_cc_owned_renders_my_cards_challenge_link(self):
-        """SCF-08b: CC owned error renders /my-cards/challenge link."""
-        html = _render("shop_challenge_card.html", _cc_ctx(error="owned"))
-        assert "/my-cards/challenge" in html
-
-
-# ── SCF-12..14: owned/total counts via shop_catalog_service (SHOP-2) ──────────
-# The listing route handlers are now 302 redirects. Owned/total logic lives in
-# shop_catalog_service.build_shop_catalog().
-
 class TestRouteContextCounts:
 
     def test_scf12_pc_owned_count_in_catalog(self):
@@ -335,33 +244,6 @@ class TestRouteContextCounts:
 
 # ── SCF-15..17: count badge in section header ─────────────────────────────────
 
-class TestCountBadgeTemplate:
-
-    def test_scf15_pc_template_has_count_badge(self):
-        """SCF-15: PC template section header contains mfg-count-badge."""
-        assert "mfg-count-badge" in _SPC
-
-    def test_scf16_wc_template_has_count_badge(self):
-        """SCF-16: WC template section header contains mfg-count-badge."""
-        assert "mfg-count-badge" in _SWC
-
-    def test_scf17_cc_template_has_count_badge(self):
-        """SCF-17: CC template section header contains mfg-count-badge."""
-        assert "mfg-count-badge" in _SCC
-
-    def test_scf15b_pc_badge_renders_when_owned(self):
-        """SCF-15b: PC renders 'X / Y owned' badge when owned_count > 0."""
-        html = _render("shop_player_card.html", _pc_ctx(owned_ids=["compact"]))
-        assert "1 / 2 owned" in html
-
-    def test_scf15c_pc_badge_absent_when_zero_owned(self):
-        """SCF-15c: PC badge does not render when owned_count == 0."""
-        html = _render("shop_player_card.html", _pc_ctx(owned_ids=[]))
-        assert "0 / 2 owned" not in html
-
-
-# ── SCF-18..19: CSS additions in mc_format_grid.html ─────────────────────────
-
 class TestFormatGridCSSAdditions:
 
     def test_scf18_mfg_card_just_purchased_css_defined(self):
@@ -375,31 +257,3 @@ class TestFormatGridCSSAdditions:
 
 # ── SCF-20..23: purchased highlight class wiring ─────────────────────────────
 
-class TestPurchasedHighlight:
-
-    def test_scf20_pc_template_wires_highlight_on_d_id(self):
-        """SCF-20: PC template wires mfg-card-just-purchased on d.id == flash_purchased."""
-        assert "mfg-card-just-purchased" in _SPC
-        assert "d.id == flash_purchased" in _SPC
-
-    def test_scf21_wc_template_wires_highlight_on_design_id(self):
-        """SCF-21: WC template wires mfg-card-just-purchased on r.design_id == flash_purchased."""
-        assert "mfg-card-just-purchased" in _SWC
-        assert "r.design_id == flash_purchased" in _SWC
-
-    def test_scf22_cc_template_wires_highlight_on_design_id(self):
-        """SCF-22: CC template wires mfg-card-just-purchased on r.design_id == flash_purchased."""
-        assert "mfg-card-just-purchased" in _SCC
-        assert "r.design_id == flash_purchased" in _SCC
-
-    def test_scf23_pc_highlight_renders_on_purchased_item(self):
-        """SCF-23: PC renders mfg-card-just-purchased on the compact card when purchased=compact."""
-        html = _render("shop_player_card.html", _pc_ctx(purchased="compact", owned_ids=["compact"]))
-        assert "mfg-card-just-purchased" in html
-
-    def test_scf24_pc_highlight_absent_without_param(self):
-        """SCF-24: PC does not apply mfg-card-just-purchased to any card when no ?purchased param."""
-        html = _render("shop_player_card.html", _pc_ctx())
-        # The CSS definition is always present in the included <style> block.
-        # Check that no <div class="mfg-card mfg-card-just-purchased"> is emitted.
-        assert 'mfg-card mfg-card-just-purchased' not in html

--- a/tests/unit/api/web_routes/test_shop_player_detail.py
+++ b/tests/unit/api/web_routes/test_shop_player_detail.py
@@ -12,7 +12,7 @@ PCID-09  Unowned state → preview wrappers carry mfg-locked class
 PCID-10  Owned state → preview wrappers do NOT carry mfg-locked class
 PCID-11  Unowned state → collection buy form targets /shop/cards/player_card/buy/fclassic
 PCID-12  No per-format buy form present in rendered HTML
-PCID-BF  Browse formats → link present on /shop/cards/player list page
+# PCID-BF removed (SHOP-3B1): tested shop_player_card.html listing (now redirect)
 """
 import asyncio
 import pathlib
@@ -137,33 +137,6 @@ def _render_detail(state="get_card", owned=False):
     return tmpl.render(**ctx)
 
 
-def _render_player_list():
-    """Render shop_player_card.html and return HTML."""
-    from jinja2 import Environment, FileSystemLoader
-
-    env = Environment(loader=FileSystemLoader(str(_TEMPLATE_BASE)), autoescape=True)
-
-    user = MagicMock()
-    user.id = 42
-    user.credit_balance = 500
-
-    design_rows = [
-        {"id": "fclassic", "label": "FClassic Player", "description": "", "credit_cost": 300, "is_premium": True, "state": "get_card"},
-        {"id": "compact", "label": "Compact", "description": "", "credit_cost": 300, "is_premium": True, "state": "locked"},
-    ]
-
-    ctx = {
-        "request": MagicMock(),
-        "user": user,
-        "design_rows": design_rows,
-        "owned_count": 0,
-        "total_count": 2,
-        "flash_purchased": None,
-        "flash_error": None,
-        "spec_dashboard_url": "/dashboard/lfa-football-player",
-    }
-    tmpl = env.get_template("shop_player_card.html")
-    return tmpl.render(**ctx)
 
 
 # ── PCID-01: route → 200 ─────────────────────────────────────────────────────
@@ -352,23 +325,6 @@ class TestPCID12NoPerFormatBuy:
 
 
 # ── PCID-BF: Browse formats → on list page ───────────────────────────────────
-
-class TestPCIDBrowseFormats:
-
-    def test_pcid_bf_browse_formats_link_present_in_list(self):
-        """PCID-BF: /shop/cards/player list — each card has 'Browse formats →' link."""
-        html = _render_player_list()
-        assert "Browse formats →" in html
-        assert "/shop/cards/player/fclassic" in html
-        assert "/shop/cards/player/compact" in html
-
-    def test_pcid_bf_browse_formats_link_count_matches_design_count(self):
-        """PCID-BF-2: number of 'Browse formats →' links equals number of designs."""
-        html = _render_player_list()
-        assert html.count("Browse formats →") == 2
-
-
-# ── SPD-L: Layout — fixed-height grid, aspect-ratio previews ─────────────────
 
 class TestSPDLayout:
 

--- a/tests/unit/api/web_routes/test_shop_preview.py
+++ b/tests/unit/api/web_routes/test_shop_preview.py
@@ -1,17 +1,10 @@
-"""Shop preview / watermark 3A+3B structural tests — SUX-01..12.
+"""Shop preview structural tests — SUX-01..04, SUX-12.
 
-SUX-01  mc_format_grid.html defines .mfg-unavailable
-SUX-02  mc_format_grid.html defines .mfg-cc-mock
-SUX-03  mc_format_grid.html defines .mfg-ratio-916
-SUX-04  mc_format_grid.html defines .mfg-ratio-169
-SUX-05  shop_player_card.html not_available state uses mfg-unavailable (not mfg-locked)
-SUX-06  shop_player_card.html get_card/locked branch uses mfg-preview-iframe
-SUX-07  shop_player_card.html does not contain mfg-preview-placeholder anywhere
-SUX-08  shop_challenge_card.html mfg-locked is conditional (state != 'owned')
-SUX-09  shop_challenge_card.html mfg-cc-mock present, mfg-preview-placeholder absent
-SUX-10  shop_challenge_card.html owned CTA uses mfg-btn-edit, not mfg-btn-download
-SUX-11  shop_challenge_card.html mfg-ratio-916 present (9:16 format mock)
-SUX-12  my_cards_challenge_card.html does not contain mfg-locked (owned-only collection)
+SHOP-3B1: SUX-05..11 removed (tested shop_player_card.html + shop_challenge_card.html,
+now unused listing templates after SHOP-1/2 redirects).
+
+SUX-01..04: mc_format_grid.html CSS class definitions (still active)
+SUX-12:     my_cards_challenge_card.html no mfg-locked (still active)
 """
 import pathlib
 
@@ -20,8 +13,6 @@ _TMPL = (
     / "app" / "templates"
 )
 _GRID  = (_TMPL / "includes" / "mc_format_grid.html").read_text()
-_SPC   = (_TMPL / "shop_player_card.html").read_text()
-_SCC   = (_TMPL / "shop_challenge_card.html").read_text()
 _MCC   = (_TMPL / "my_cards_challenge_card.html").read_text()
 
 
@@ -55,78 +46,6 @@ class TestFormatGridCSS:
 
 
 # ── SUX-05..07: shop_player_card.html preview logic ───────────────────────────
-
-class TestPlayerCardShopPreview:
-
-    def test_sux05_not_available_uses_mfg_unavailable(self):
-        """SUX-05: shop_player_card.html not_available state uses mfg-unavailable, not mfg-locked."""
-        assert "mfg-unavailable" in _SPC, (
-            "shop_player_card.html must use mfg-unavailable class for not_available state"
-        )
-        # not_available branch must reference mfg-unavailable — verified by its presence
-        # additionally confirm mfg-na-label is used (inner content)
-        assert "mfg-na-label" in _SPC
-
-    def test_sux06_get_card_locked_uses_iframe(self):
-        """SUX-06: shop_player_card.html get_card/locked branch uses mfg-preview-iframe."""
-        assert "mfg-preview-iframe" in _SPC, (
-            "shop_player_card.html must render iframe for get_card/locked states (not placeholder)"
-        )
-        # The else branch (get_card + locked) must have mfg-locked + iframe
-        assert "mfg-locked" in _SPC, (
-            "shop_player_card.html must still apply mfg-locked overlay for locked/get_card states"
-        )
-
-    def test_sux07_no_placeholder_in_player_shop(self):
-        """SUX-07: shop_player_card.html does not use mfg-preview-placeholder anywhere."""
-        assert "mfg-preview-placeholder" not in _SPC, (
-            "shop_player_card.html must not use 2-letter placeholder — "
-            "locked/get_card now use iframe; not_available uses mfg-unavailable"
-        )
-
-
-# ── SUX-08..11: shop_challenge_card.html preview + CTA ────────────────────────
-
-class TestChallengeCardShopPreview:
-
-    def test_sux08_mfg_locked_is_conditional(self):
-        """SUX-08: shop_challenge_card.html mfg-locked only when state != 'owned'."""
-        assert "state != 'owned'" in _SCC, (
-            "shop_challenge_card.html must conditionally apply mfg-locked "
-            "only when state != 'owned' — owned CC must not show locked overlay"
-        )
-
-    def test_sux09_cc_mock_present_placeholder_absent(self):
-        """SUX-09: shop_challenge_card.html has mfg-cc-mock, no mfg-preview-placeholder."""
-        assert "mfg-cc-mock" in _SCC, (
-            "shop_challenge_card.html must use mfg-cc-mock for CC preview (aspect-ratio mock)"
-        )
-        assert "mfg-preview-placeholder" not in _SCC, (
-            "shop_challenge_card.html must not use 2-letter placeholder — "
-            "CC mock replaces it for all states"
-        )
-
-    def test_sux10_owned_cta_is_edit_not_download(self):
-        """SUX-10: shop_challenge_card.html owned CTA uses mfg-btn-edit, not mfg-btn-download."""
-        assert "mfg-btn-edit" in _SCC, (
-            "shop_challenge_card.html owned CTA must use mfg-btn-edit (navigate style)"
-        )
-        assert "View Challenges" in _SCC, (
-            "shop_challenge_card.html owned CTA text must be 'View Challenges →'"
-        )
-        assert "mfg-btn-download" not in _SCC, (
-            "shop_challenge_card.html must not use mfg-btn-download — "
-            "CC owned CTA navigates to results, does not download"
-        )
-
-    def test_sux11_ratio_916_present(self):
-        """SUX-11: shop_challenge_card.html uses mfg-ratio-916 for 9:16 story format."""
-        assert "mfg-ratio-916" in _SCC, (
-            "shop_challenge_card.html must apply mfg-ratio-916 for challenge_story_9_16 format"
-        )
-
-
-# ── SUX-12: my_cards_challenge_card.html — no mfg-locked on owned ─────────────
 
 class TestMyCardsChallengeCardNoBug:
 


### PR DESCRIPTION
## Summary
SHOP-3B1: Removes all active test references to legacy shop listing templates. Templates themselves NOT deleted yet (SHOP-3B2).

## Removed tests
- `test_shop_feedback.py`: SCF-01..11, 15..17, 20..24 (legacy `_SPC`/`_SWC`/`_SCC` source + render)
- `test_shop_preview.py`: SUX-05..11 (legacy `mfg-*` CSS class tests)
- `test_my_cards_feedback.py`: MCF-18/19 (legacy WC listing ratio CSS)
- `test_shop_player_detail.py`: PCID-BF + `_render_player_list` (legacy listing render)

## Ported to `shop_unified.html`
- `test_shop.py` SH-12e/12f/12g/12h: buy form, Studio CTA, filter links

## New tests
- `test_shop_3b1.py`: 13 S3B1-* tests (reference audit, unified behavior, routes)

## Kept (still active)
SCF-12..14 (catalog service), SUX-01..04/12 (mc_format_grid/my_cards), PCID-01..12 (detail route)

## Templates NOT deleted: shop_player_card.html, shop_welcome_card.html, shop_challenge_card.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)