### PR TITLE
feat(vt-training-day): Phase 1+2 timezone + Hand & Finger Stats UI

### DIFF
--- a/app/api/web_routes/virtual_training.py
+++ b/app/api/web_routes/virtual_training.py
@@ -1964,3 +1964,51 @@ async def virtual_training_number_color_conflict_result(
             "is_admin":      is_admin,
         },
     )
+
+
+# ── Hand/Finger Performance Stats ─────────────────────────────────────────────
+
+# Games that use the protocol assignment system (hand + finger tracking).
+# color_reaction and go_no_go were the original two; number_color_conflict
+# was added in Phase 2.5 and also uses assign_protocol().
+_VALID_GAME_CODES: frozenset[str] = frozenset({
+    "color_reaction",
+    "go_no_go",
+    "number_color_conflict",
+})
+
+
+@router.get("/virtual-training/hand-finger-stats", response_class=HTMLResponse)
+async def virtual_training_hand_finger_stats(
+    request: Request,
+    game: str = "all",
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user_web),
+):
+    """Hand/Finger performance aggregation — system-assigned v3 attempts only."""
+    guard = require_student_onboarding(user)
+    if guard:
+        return guard
+
+    # Resolve game query param → game_id (invalid param falls back to "all")
+    game_code = game if game in _VALID_GAME_CODES else "all"
+    game_id: int | None = None
+    if game_code != "all":
+        g = VirtualTrainingService.get_game(db, game_code)
+        if g:
+            game_id = g.id
+        else:
+            game_code = "all"
+
+    stats = VirtualTrainingService.get_hand_finger_stats(db, user.id, game_id)
+
+    return templates.TemplateResponse(
+        "virtual_training_hand_finger_stats.html",
+        {
+            "request":     request,
+            "user":        user,
+            **_spec_ctx(user, db),
+            "stats":       stats,
+            "game_filter": game_code,
+        },
+    )

--- a/app/api/web_routes/virtual_training.py
+++ b/app/api/web_routes/virtual_training.py
@@ -54,11 +54,19 @@ def _extract_training_ctx(body: dict) -> dict:
     All fields are safe to pass directly to VirtualTrainingService.record_attempt().
     """
     browser_tz = body.get("browser_timezone")
-    loc = body.get("location") or {}
-    _now = datetime.now(timezone.utc)
-    training_tz, _ = resolve_training_timezone(browser_tz)
-    training_date = compute_training_local_date(_now, training_tz)
+    loc    = body.get("location") or {}
+    _now   = datetime.now(timezone.utc)
     cap_at = _parse_location_captured_at(loc.get("captured_at"))
+    # Phase 2: lat/lng → timezonefinder takes priority over browser tz
+    training_tz, _ = resolve_training_timezone(
+        browser_tz,
+        lat=loc.get("lat"),
+        lng=loc.get("lng"),
+        accuracy_m=loc.get("accuracy_m"),
+        captured_at=cap_at,
+        now=_now,
+    )
+    training_date = compute_training_local_date(_now, training_tz)
     return {
         "training_local_date":   training_date,
         "training_tz":           training_tz,

--- a/app/services/training_day.py
+++ b/app/services/training_day.py
@@ -1,15 +1,19 @@
-"""training_day — Phase 1 training day resolution via browser timezone.
+"""training_day — Training day resolution via GPS coordinates or browser timezone.
 
-Phase 1 fallback chain:
+Phase 1 fallback chain (browser_timezone only):
   1. valid browser IANA timezone  → training_timezone_source = "browser_iana"
   2. UTC fallback                 → training_timezone_source = "utc_fallback"
 
-Phase 2 (separate approval):
-  lat/lng → timezonefinder → IANA timezone → training_timezone_source = "lat_lng_derived"
+Phase 2 fallback chain (lat/lng takes priority):
+  1. fresh GPS + accuracy ≤ 500m → timezonefinder → "lat_lng_derived"
+  2. valid browser IANA timezone  → "browser_iana"
+  3. UTC fallback                 → "utc_fallback"
 
-Design note: ?tz= query param on the Card Studio page is a Phase 1 interim
-solution only. Phase 2/3 will derive the training timezone from the stored
-attempt location or a user-session-level timezone profile.
+Design note: ?tz= query param on the Card Studio page remains Phase 1 (browser_iana)
+because the Card Studio does not collect GPS. Attempt submit routes use Phase 2.
+
+Phase 3 (separate approval):
+  Campus geofence, on-site challenge enforcement, location retention policy.
 """
 from __future__ import annotations
 
@@ -18,6 +22,29 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 _UTC = ZoneInfo("UTC")
 _LOCATION_FRESHNESS_SECONDS = 300   # 5 minutes
+_LOCATION_ACCURACY_MAX_M    = 500   # max accuracy_m for lat_lng_derived tz
+
+
+# ── timezonefinder singleton (lazy init — avoids startup cost) ────────────────
+
+_TZF = None  # type: ignore[assignment]
+
+
+def _get_tzf():
+    """Return module-level TimezoneFinder instance (lazy, thread-safe for reads)."""
+    global _TZF
+    if _TZF is None:
+        from timezonefinder import TimezoneFinder  # noqa: PLC0415
+        _TZF = TimezoneFinder()
+    return _TZF
+
+
+def _derive_tz_from_coords(lat: float, lng: float) -> str | None:
+    """Look up IANA timezone from GPS coordinates. Returns None on any error."""
+    try:
+        return _get_tzf().timezone_at(lat=lat, lng=lng)
+    except Exception:  # noqa: BLE001
+        return None
 
 
 # ── IANA timezone validation ───────────────────────────────────────────────────
@@ -54,23 +81,47 @@ def resolve_location_source(
     return "browser_geolocation" if age <= _LOCATION_FRESHNESS_SECONDS else "stale_browser_geolocation"
 
 
-# ── Phase 1: timezone resolution ──────────────────────────────────────────────
+# ── Phase 2: timezone resolution ──────────────────────────────────────────────
 
 def resolve_training_timezone(
     browser_timezone: str | None,
+    lat: float | None = None,
+    lng: float | None = None,
+    accuracy_m: int | None = None,
+    captured_at: datetime | None = None,
+    now: datetime | None = None,
 ) -> tuple[str, str]:
     """Return (training_timezone, training_timezone_source).
 
-    Phase 1 fallback chain:
-      1. valid browser IANA tz → ("Europe/Budapest", "browser_iana")
-      2. UTC                   → ("UTC", "utc_fallback")
+    Phase 2 fallback chain:
+      1. Fresh GPS (≤5 min, accuracy ≤500m) → timezonefinder → "lat_lng_derived"
+      2. Valid browser IANA tz              → "browser_iana"
+      3. UTC                               → "utc_fallback"
 
-    Phase 2 will add lat/lng → timezone before step 1 without changing
-    this function's signature — a new param will be added with a default.
+    Backward-compatible: resolve_training_timezone("Europe/Budapest") still returns
+    ("Europe/Budapest", "browser_iana") unchanged — all Phase 1 callers unaffected.
     """
+    # ── Step 1: lat/lng → timezonefinder (Phase 2) ───────────────────────────
+    if lat is not None and lng is not None:
+        _now = now or datetime.now(_tz_module.utc)
+        _acc_ok    = (accuracy_m is None) or (accuracy_m <= _LOCATION_ACCURACY_MAX_M)
+        _fresh_ok  = (captured_at is None) or (
+            (_now - captured_at).total_seconds() <= _LOCATION_FRESHNESS_SECONDS
+        )
+        if _acc_ok and _fresh_ok:
+            try:
+                derived = _derive_tz_from_coords(lat, lng)
+            except Exception:  # noqa: BLE001
+                derived = None
+            if derived and _valid_iana_tz(derived):
+                return derived, "lat_lng_derived"
+
+    # ── Step 2: browser IANA timezone (Phase 1) ──────────────────────────────
     valid = _valid_iana_tz(browser_timezone)
     if valid:
         return valid, "browser_iana"
+
+    # ── Step 3: UTC fallback ─────────────────────────────────────────────────
     return "UTC", "utc_fallback"
 
 
@@ -86,7 +137,7 @@ def compute_training_local_date(
     """
     try:
         return completed_at.astimezone(ZoneInfo(training_timezone)).date()
-    except Exception:
+    except Exception:  # noqa: BLE001
         return completed_at.astimezone(_UTC).date()
 
 

--- a/app/services/virtual_training_service.py
+++ b/app/services/virtual_training_service.py
@@ -46,6 +46,16 @@ _FREE_PROTOCOL: dict = {
     "assignment_source": "system", "self_declared": True, "not_verified": True,
 }
 
+_MIN_SAMPLES: int = 3   # minimum eligible attempts per (hand, finger) cell to show data
+
+# Canonical finger display order for the stats page
+_FINGER_ORDER: list[tuple[str, str, str]] = [
+    ("right", "index", "Right Index"),
+    ("right", "thumb", "Right Thumb"),
+    ("left",  "index", "Left Index"),
+    ("left",  "thumb", "Left Thumb"),
+]
+
 
 class VirtualTrainingService:
 
@@ -543,3 +553,168 @@ class VirtualTrainingService:
             )
 
         return attempt
+
+    # ── Hand/Finger Performance Stats ─────────────────────────────────────────
+
+    @staticmethod
+    def get_hand_finger_stats(
+        db: Session,
+        user_id: int,
+        game_id: int | None = None,
+    ) -> dict:
+        """
+        Aggregate hand/finger performance from system-assigned v3 attempts.
+
+        Eligible filter: is_valid=TRUE, raw_metrics.v>=3, hand_profile present,
+        assignment_source="system".  v1/v2 and free-protocol attempts excluded.
+
+        game_id=None → all VT games combined.
+        This is a lifetime aggregation — training_local_date is not filtered here
+        because the purpose is all-time protocol performance, not a daily view.
+
+        Returns:
+          {
+            "min_samples":  3,
+            "finger_rows":  [...],   # 4 entries: ri/rt/li/lt in canonical order
+            "by_hand":      {"right": {...}, "left": {...}},
+            "skill_totals": {"right_index": {"reactions": 0.34, ...}, ...},
+          }
+        """
+        from collections import defaultdict
+
+        _base = """
+            a.user_id = :uid
+            AND a.is_valid = TRUE
+            AND a.raw_metrics IS NOT NULL
+            AND (a.raw_metrics->>'v')::int >= 3
+            AND a.raw_metrics ? 'hand_profile'
+            AND a.raw_metrics->'hand_profile'->>'assignment_source' = 'system'
+        """
+        params: dict = {"uid": user_id}
+        if game_id is not None:
+            _base += " AND a.game_id = :gid"
+            params["gid"] = game_id
+
+        # ── 1. Per-(hand, finger) aggregate metrics ───────────────────────────
+        finger_sql = text(f"""
+            SELECT
+                raw_metrics->'hand_profile'->>'hand'   AS hand,
+                raw_metrics->'hand_profile'->>'finger' AS finger,
+                raw_metrics->'hand_profile'->>'label'  AS label,
+                COUNT(*)                               AS attempt_count,
+                ROUND(AVG(a.score_normalized)::numeric, 1)  AS avg_score,
+                ROUND(AVG(a.avg_reaction_ms)::numeric, 0)   AS avg_rt_ms,
+                ROUND(MIN(a.avg_reaction_ms)::numeric, 0)   AS best_rt_ms,
+                ROUND(100.0 * AVG(
+                    a.correct_count::float / NULLIF(a.stimuli_count, 0)
+                )::numeric, 1) AS accuracy_pct,
+                ROUND(100.0 * AVG(
+                    a.error_count::float / NULLIF(a.stimuli_count, 0)
+                )::numeric, 1) AS miss_pct,
+                ROUND(100.0 * AVG(
+                    a.wrong_click_count::float / NULLIF(a.stimuli_count, 0)
+                )::numeric, 1) AS wrong_pct,
+                ROUND(100.0 * AVG(
+                    COALESCE(
+                        (a.raw_metrics->'late_summary'->>'late_click_count')::float, 0
+                    ) / NULLIF(a.stimuli_count, 0)
+                )::numeric, 1) AS late_pct
+            FROM virtual_training_attempts a
+            WHERE {_base}
+            GROUP BY hand, finger, label
+            ORDER BY hand, finger
+        """)
+
+        seen: dict[str, dict] = {}
+        for r in db.execute(finger_sql, params).fetchall():
+            cnt = int(r.attempt_count)
+            seen[f"{r.hand}_{r.finger}"] = {
+                "hand":          r.hand,
+                "finger":        r.finger,
+                "label":         r.label or f"{r.hand.capitalize()} {r.finger.capitalize()}",
+                "attempt_count": cnt,
+                "state":         "ready" if cnt >= _MIN_SAMPLES else "low_sample",
+                "avg_score":     float(r.avg_score)    if r.avg_score    is not None else None,
+                "avg_rt_ms":     int(r.avg_rt_ms)      if r.avg_rt_ms    is not None else None,
+                "best_rt_ms":    int(r.best_rt_ms)     if r.best_rt_ms   is not None else None,
+                "accuracy_pct":  float(r.accuracy_pct) if r.accuracy_pct is not None else None,
+                "miss_pct":      float(r.miss_pct)     if r.miss_pct     is not None else None,
+                "wrong_pct":     float(r.wrong_pct)    if r.wrong_pct    is not None else None,
+                "late_pct":      float(r.late_pct)     if r.late_pct     is not None else None,
+            }
+
+        finger_rows = []
+        for hand, finger, default_label in _FINGER_ORDER:
+            key = f"{hand}_{finger}"
+            if key in seen:
+                finger_rows.append(seen[key])
+            else:
+                finger_rows.append({
+                    "hand": hand, "finger": finger, "label": default_label,
+                    "attempt_count": 0, "state": "no_data",
+                })
+
+        # ── 2. Per-hand aggregate metrics ─────────────────────────────────────
+        hand_sql = text(f"""
+            SELECT
+                raw_metrics->'hand_profile'->>'hand' AS hand,
+                COUNT(*)                             AS attempt_count,
+                ROUND(AVG(a.score_normalized)::numeric, 1)  AS avg_score,
+                ROUND(AVG(a.avg_reaction_ms)::numeric, 0)   AS avg_rt_ms,
+                ROUND(100.0 * AVG(
+                    a.correct_count::float / NULLIF(a.stimuli_count, 0)
+                )::numeric, 1) AS accuracy_pct
+            FROM virtual_training_attempts a
+            WHERE {_base}
+            GROUP BY hand
+            ORDER BY hand
+        """)
+
+        by_hand: dict[str, dict] = {
+            "right": {"attempt_count": 0, "state": "no_data"},
+            "left":  {"attempt_count": 0, "state": "no_data"},
+        }
+        for r in db.execute(hand_sql, params).fetchall():
+            if r.hand in by_hand:
+                cnt = int(r.attempt_count)
+                by_hand[r.hand] = {
+                    "attempt_count": cnt,
+                    "state":         "ready" if cnt >= _MIN_SAMPLES else "low_sample",
+                    "avg_score":     float(r.avg_score)    if r.avg_score    is not None else None,
+                    "avg_rt_ms":     int(r.avg_rt_ms)      if r.avg_rt_ms    is not None else None,
+                    "accuracy_pct":  float(r.accuracy_pct) if r.accuracy_pct is not None else None,
+                }
+
+        # ── 3. Skill delta totals per (hand_finger) ───────────────────────────
+        delta_sql = text(f"""
+            SELECT
+                raw_metrics->'hand_profile'->>'hand'   AS hand,
+                raw_metrics->'hand_profile'->>'finger' AS finger,
+                a.skill_deltas
+            FROM virtual_training_attempts a
+            WHERE {_base}
+            ORDER BY a.completed_at
+        """)
+
+        skill_acc: dict[str, dict[str, float]] = defaultdict(lambda: defaultdict(float))
+        for r in db.execute(delta_sql, params).fetchall():
+            deltas = r.skill_deltas
+            if not isinstance(deltas, dict) or not deltas:
+                continue
+            combo = f"{r.hand}_{r.finger}"
+            for skill, delta in deltas.items():
+                try:
+                    skill_acc[combo][skill] = round(
+                        skill_acc[combo][skill] + float(delta), 4
+                    )
+                except (TypeError, ValueError):
+                    pass
+
+        skill_totals = {k: dict(v) for k, v in skill_acc.items()}
+
+        return {
+            "min_samples":  _MIN_SAMPLES,
+            "finger_rows":  finger_rows,
+            "by_hand":      by_hand,
+            "skill_totals": skill_totals,
+        }

--- a/app/services/virtual_training_service.py
+++ b/app/services/virtual_training_service.py
@@ -400,8 +400,15 @@ class VirtualTrainingService:
 
         now = datetime.now(timezone.utc)
 
-        # ── Phase 1: resolve training day from browser timezone ───────────────
-        training_tz, tz_src = resolve_training_timezone(browser_timezone)
+        # ── Phase 2: resolve training day — lat/lng takes priority over browser tz
+        training_tz, tz_src = resolve_training_timezone(
+            browser_timezone,
+            lat=location_lat,
+            lng=location_lng,
+            accuracy_m=location_accuracy_m,
+            captured_at=location_captured_at,
+            now=now,
+        )
         training_date = compute_training_local_date(now, training_tz)
         loc_src = resolve_location_source(location_lat, location_lng, location_captured_at, now)
 

--- a/app/templates/virtual_training_hand_finger_stats.html
+++ b/app/templates/virtual_training_hand_finger_stats.html
@@ -1,0 +1,579 @@
+{% extends "student_base.html" %}
+{% from "macros/vt_protocol_hand.html" import protocol_hand_diagram %}
+
+{% block title %}Hand & Finger Performance - LFA{% endblock %}
+{% block active_page %}lfa-player{% endblock %}
+
+{% block student_header %}
+{% set _page_icon = '🖐' %}
+{% set _page_name = 'Hand & Finger Performance' %}
+{% include "includes/spec_subpage_hdr.html" %}
+{% endblock %}
+
+{% block extra_styles %}
+<style>
+    /* ── Container — same 640px as game-start screens ───────────────────── */
+    .vt-hf-container {
+        max-width: 640px;
+        margin: 0 auto;
+        padding: 1.5rem 1rem 3rem;
+    }
+
+    /* ── Game filter tabs ────────────────────────────────────────────────── */
+    .vt-hf-tabs {
+        display: flex;
+        gap: 0.5rem;
+        margin-bottom: 1.25rem;
+        flex-wrap: wrap;
+    }
+
+    .vt-hf-tab {
+        font-size: 0.82rem;
+        font-weight: 700;
+        padding: 0.4rem 0.9rem;
+        border-radius: 20px;
+        border: 1.5px solid #c7d2fe;
+        color: #4f46e5;
+        background: var(--app-card);
+        text-decoration: none;
+        transition: background 0.13s, color 0.13s;
+    }
+    .vt-hf-tab:hover { background: #ede9fe; }
+    .vt-hf-tab.active { background: #4f46e5; color: #fff; border-color: #4f46e5; }
+
+    /* ── Disclaimer ──────────────────────────────────────────────────────── */
+    .vt-hf-disclaimer {
+        font-size: 0.75rem;
+        color: var(--app-text-muted);
+        background: #fef9ee;
+        border: 1px solid #fde68a;
+        border-radius: 8px;
+        padding: 0.5rem 0.9rem;
+        margin-bottom: 1.75rem;
+        line-height: 1.5;
+    }
+
+    /* ── Section titles ──────────────────────────────────────────────────── */
+    .vt-hf-section-title {
+        font-size: 0.78rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--app-text-muted);
+        margin: 0 0 0.85rem;
+    }
+
+    /* ── Hand diagram — calibrated for card column (50px vs 60px full-width) */
+    /* 50px × 73px in 2-col cards matches the ~19% proportion of game-start  */
+    .vt-hd-wrap {
+        display: flex;
+        justify-content: center;
+        align-items: flex-end;
+        gap: 4px;
+        margin: 0.4rem 0 0.75rem;
+        overflow: hidden;   /* hard stop — SVG never bleeds card edge */
+    }
+    .vt-hd-svg {
+        width: 50px;
+        height: 73px;
+        flex-shrink: 0;
+        max-width: 100%;    /* fallback for unexpected layout changes */
+    }
+
+    /* ── 2-column grid for both By Hand and By Finger sections ──────────── */
+    .vt-hf-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 0.875rem;
+        margin-bottom: 2rem;
+    }
+
+    /* ── Protocol card — mirrors game-start .cr-protocol-card ───────────── */
+    .vt-hf-proto-card {
+        background: var(--app-card);
+        border: 1px solid #c7d2fe;
+        border-radius: 14px;
+        padding: 1rem 1.2rem;
+        box-shadow: 0 2px 10px rgba(0,0,0,0.06);
+        overflow: hidden;   /* SVG cannot overflow card boundary */
+        min-width: 0;       /* grid item won't blow up min-content */
+    }
+
+    .vt-hf-proto-card.low-sample {
+        border-color: #fde68a;
+        box-shadow: 0 2px 10px rgba(217,119,6,0.08);
+    }
+
+    .vt-hf-proto-card.no-data {
+        border-color: #e2e8f0;
+        box-shadow: none;
+        opacity: 0.72;
+    }
+
+    /* ── Card header row (icon + PROTOCOL label) ─────────────────────────── */
+    .vt-hf-proto-header {
+        display: flex;
+        align-items: center;
+        gap: 0.4rem;
+        margin-bottom: 0.35rem;
+    }
+
+    .vt-hf-proto-title {
+        font-size: 0.72rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        color: var(--app-text-muted);
+    }
+
+    /* ── Combo name — mirrors .cr-protocol-card-combo ────────────────────── */
+    .vt-hf-proto-combo {
+        font-size: 1.0rem;
+        font-weight: 800;
+        color: #3730a3;
+        letter-spacing: 0.02em;
+        margin-bottom: 0.1rem;
+    }
+    .vt-hf-proto-combo.no-data { color: var(--app-text-muted); }
+
+    /* ── Attempt count line — mirrors .cr-protocol-card-mult ─────────────── */
+    .vt-hf-proto-attempts {
+        font-size: 0.8rem;
+        font-weight: 600;
+        color: #4f46e5;
+        margin-bottom: 0.5rem;
+    }
+    .vt-hf-proto-attempts.no-data { color: var(--app-text-muted); }
+
+    /* ── Stats list inside card ──────────────────────────────────────────── */
+    .vt-hf-stat-list {
+        border-top: 1px solid #e0e7ff;
+        padding-top: 0.45rem;
+        margin-top: 0.1rem;
+    }
+
+    .vt-hf-stat-row {
+        display: flex;
+        justify-content: space-between;
+        font-size: 0.79rem;
+        color: var(--app-text-muted);
+        margin-bottom: 0.18rem;
+    }
+    .vt-hf-stat-row b { color: var(--app-text); }
+
+    /* ── State badges ────────────────────────────────────────────────────── */
+    .vt-hf-badge {
+        display: inline-block;
+        font-size: 0.64rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        border-radius: 5px;
+        padding: 0.1rem 0.45rem;
+        margin-bottom: 0.35rem;
+    }
+    .vt-hf-badge.low { color: #92400e; background: #fef3c7; border: 1px solid #fde68a; }
+
+    .vt-hf-nudge {
+        font-size: 0.71rem;
+        color: var(--app-text-muted);
+        margin-top: 0.3rem;
+        line-height: 1.4;
+    }
+
+    .vt-hf-nodata-msg {
+        font-size: 0.78rem;
+        color: var(--app-text-muted);
+        line-height: 1.5;
+    }
+
+    /* ── Skill delta bars ────────────────────────────────────────────────── */
+    .vt-hf-delta-section { margin-bottom: 2rem; }
+    .vt-hf-delta-combo   { margin-bottom: 1.25rem; }
+
+    .vt-hf-delta-combo-title {
+        font-size: 0.78rem;
+        font-weight: 700;
+        color: #4f46e5;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        margin-bottom: 0.6rem;
+    }
+
+    .vt-hf-delta-row {
+        display: flex;
+        align-items: center;
+        gap: 0.6rem;
+        margin-bottom: 0.4rem;
+    }
+
+    .vt-hf-delta-skill {
+        width: 110px;
+        flex-shrink: 0;
+        font-size: 0.78rem;
+        color: var(--app-text-muted);
+        text-transform: capitalize;
+    }
+
+    .vt-hf-bar-track {
+        flex: 1;
+        height: 8px;
+        background: #f1f5f9;
+        border-radius: 4px;
+        overflow: hidden;
+    }
+    .vt-hf-bar-fill { height: 100%; border-radius: 4px; min-width: 2px; }
+    .vt-hf-bar-fill.pos { background: #10b981; }
+    .vt-hf-bar-fill.neg { background: #ef4444; }
+
+    .vt-hf-delta-val {
+        width: 52px;
+        text-align: right;
+        font-size: 0.78rem;
+        font-weight: 700;
+        flex-shrink: 0;
+    }
+    .vt-hf-delta-val.pos { color: #059669; }
+    .vt-hf-delta-val.neg { color: #dc2626; }
+
+    .vt-hf-low-badge {
+        display: inline-block;
+        font-size: 0.65rem;
+        font-weight: 700;
+        color: #92400e;
+        background: #fef3c7;
+        border: 1px solid #fde68a;
+        border-radius: 4px;
+        padding: 0.05rem 0.35rem;
+        margin-left: 0.3rem;
+        vertical-align: middle;
+    }
+
+    .vt-hf-nodata-delta {
+        font-size: 0.82rem;
+        color: var(--app-text-muted);
+        font-style: italic;
+    }
+
+    /* ── Footer ──────────────────────────────────────────────────────────── */
+    .vt-hf-footer {
+        text-align: center;
+        margin-top: 2rem;
+        padding-top: 1.5rem;
+        border-top: 1px solid #e2e8f0;
+    }
+    .vt-hf-footer a {
+        color: #667eea;
+        text-decoration: none;
+        margin: 0 0.75rem;
+        font-weight: 600;
+        font-size: 0.88rem;
+    }
+    .vt-hf-footer a:hover { text-decoration: underline; }
+
+    /* ── Hand Summary Card — single combined block for both hands ───────── */
+    .vt-hf-hand-summary-card {
+        background: var(--app-card);
+        border: 1px solid #c7d2fe;
+        border-radius: 14px;
+        padding: 1rem 1.2rem 1.1rem;
+        box-shadow: 0 2px 10px rgba(0,0,0,0.06);
+        margin-bottom: 2rem;
+        overflow: hidden;
+    }
+
+    .vt-hf-hand-summary-header {
+        display: flex;
+        align-items: center;
+        gap: 0.45rem;
+        margin-bottom: 0.85rem;
+        padding-bottom: 0.6rem;
+        border-bottom: 1px solid #e0e7ff;
+    }
+
+    .vt-hf-hand-summary-title {
+        font-size: 0.78rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        color: var(--app-text-muted);
+    }
+
+    /* Desktop: two columns side by side, separated by a hairline */
+    .vt-hf-hand-columns {
+        display: grid;
+        grid-template-columns: 1fr 1px 1fr;
+        gap: 0 0.85rem;
+        align-items: start;
+    }
+
+    .vt-hf-hand-divider {
+        background: #e0e7ff;
+        width: 1px;
+        align-self: stretch;
+        min-height: 1px;
+    }
+
+    .vt-hf-hand-panel {
+        min-width: 0;
+        overflow: hidden;
+    }
+
+    .vt-hf-hand-panel-label {
+        font-size: 0.72rem;
+        font-weight: 800;
+        text-transform: uppercase;
+        letter-spacing: 0.07em;
+        color: #4f46e5;
+        margin-bottom: 0.1rem;
+        text-align: center;
+    }
+
+    .vt-hf-hand-panel-attempts {
+        font-size: 0.78rem;
+        font-weight: 600;
+        color: #4f46e5;
+        text-align: center;
+        margin-bottom: 0.45rem;
+    }
+    .vt-hf-hand-panel-attempts.no-data { color: var(--app-text-muted); }
+
+    .vt-hf-hand-nodata {
+        font-size: 0.75rem;
+        color: var(--app-text-muted);
+        text-align: center;
+        padding: 0.3rem 0;
+        line-height: 1.45;
+    }
+
+    /* ── Mobile: collapse 2-col → 1-col below 580px ─────────────────────── */
+    @media (max-width: 580px) {
+        .vt-hf-grid {
+            grid-template-columns: 1fr;
+        }
+        /* On 1-col, cards are full-width → restore game-start SVG size */
+        .vt-hd-svg {
+            width: 58px;
+            height: 85px;
+        }
+        /* Stack hand panels vertically with horizontal divider */
+        .vt-hf-hand-columns {
+            grid-template-columns: 1fr;
+            grid-template-rows: auto 1px auto;
+            gap: 0.75rem 0;
+        }
+        .vt-hf-hand-divider {
+            width: auto;
+            height: 1px;
+        }
+    }
+</style>
+{% endblock %}
+
+{% block student_content %}
+<div class="vt-hf-container">
+
+    {# ── Game filter tabs ─────────────────────────────────────────────────── #}
+    <div class="vt-hf-tabs">
+        <a href="?game=all"
+           class="vt-hf-tab{% if game_filter == 'all' %} active{% endif %}">
+            🎮 All Games
+        </a>
+        <a href="?game=color_reaction"
+           class="vt-hf-tab{% if game_filter == 'color_reaction' %} active{% endif %}">
+            ⚡ Color Reaction
+        </a>
+        <a href="?game=go_no_go"
+           class="vt-hf-tab{% if game_filter == 'go_no_go' %} active{% endif %}">
+            🛑 Go / No-Go
+        </a>
+        <a href="?game=number_color_conflict"
+           class="vt-hf-tab{% if game_filter == 'number_color_conflict' %} active{% endif %}">
+            🔢 Number-Color
+        </a>
+    </div>
+
+    {# ── Disclaimer ───────────────────────────────────────────────────────── #}
+    <div class="vt-hf-disclaimer">
+        ⚠ Data reflects system-assigned protocols only.
+        Self-declared · Not automatically verified.
+        At least {{ stats.min_samples }} valid attempts per protocol are needed for reliable comparison.
+    </div>
+
+    {# ── By Hand — single combined summary card ──────────────────────────── #}
+    {# Active hand fully highlighted; _all = all fingers soft indigo, none dark #}
+    <h2 class="vt-hf-section-title">By Hand</h2>
+    <div class="vt-hf-hand-summary-card">
+
+        <div class="vt-hf-hand-summary-header">
+            <span>🖐</span>
+            <span class="vt-hf-hand-summary-title">Hand Performance</span>
+        </div>
+
+        <div class="vt-hf-hand-columns">
+
+            {% for side in ["right", "left"] %}
+            {% set hd = stats.by_hand[side] %}
+            {%- set _state = hd.state | default("no_data") -%}
+
+            {# Hairline divider between right and left panels #}
+            {% if loop.index == 2 %}<div class="vt-hf-hand-divider" aria-hidden="true"></div>{% endif %}
+
+            <div class="vt-hf-hand-panel">
+
+                <div class="vt-hf-hand-panel-label">{{ side | upper }} HAND</div>
+
+                {{ protocol_hand_diagram(side, "_all") }}
+
+                <div class="vt-hf-hand-panel-attempts{% if _state == 'no_data' %} no-data{% endif %}">
+                    {% if _state == 'no_data' %}No attempts yet
+                    {% else %}{{ hd.attempt_count }} attempt{{ 's' if hd.attempt_count != 1 else '' }}{% endif %}
+                </div>
+
+                {% if _state == 'no_data' %}
+                <div class="vt-hf-hand-nodata">Play a game with this hand.</div>
+
+                {% else %}
+                {% if _state == 'low_sample' %}
+                <span class="vt-hf-badge low">LOW confidence</span>
+                {%- set _rem = stats.min_samples - hd.attempt_count -%}
+                <div class="vt-hf-nudge">{{ _rem }} more attempt{{ 's' if _rem != 1 else '' }} needed.</div>
+                {% endif %}
+
+                <div class="vt-hf-stat-list">
+                    {% if hd.avg_score is not none %}
+                    <div class="vt-hf-stat-row"><span>Avg score</span><b>{{ hd.avg_score }}%</b></div>
+                    {% endif %}
+                    {% if hd.avg_rt_ms is not none %}
+                    <div class="vt-hf-stat-row"><span>Avg RT</span><b>{{ hd.avg_rt_ms }} ms</b></div>
+                    {% endif %}
+                    {% if hd.accuracy_pct is not none %}
+                    <div class="vt-hf-stat-row"><span>Accuracy</span><b>{{ hd.accuracy_pct }}%</b></div>
+                    {% endif %}
+                </div>
+                {% endif %}
+
+            </div>
+            {% endfor %}
+
+        </div>
+
+    </div>
+
+    {# ── By Finger (protocol cards — same visual as game-start) ──────────── #}
+    {# 2×2 grid: RI | RT  /  LI | LT — canonical FINGER_ORDER              #}
+    <h2 class="vt-hf-section-title">By Finger Protocol</h2>
+    <div class="vt-hf-grid">
+
+        {% for row in stats.finger_rows %}
+        {%- set _state = row.state | default("no_data") -%}
+        <div class="vt-hf-proto-card{% if _state == 'low_sample' %} low-sample{% elif _state == 'no_data' %} no-data{% endif %}">
+
+            <div class="vt-hf-proto-header">
+                <span>🎯</span>
+                <span class="vt-hf-proto-title">Protocol</span>
+            </div>
+
+            {# Exact hand + finger highlighted — identical to game-start diagram #}
+            {{ protocol_hand_diagram(row.hand, row.finger) }}
+
+            <div class="vt-hf-proto-combo{% if _state == 'no_data' %} no-data{% endif %}">
+                {{ row.label | upper }}
+            </div>
+            <div class="vt-hf-proto-attempts{% if _state == 'no_data' %} no-data{% endif %}">
+                {% if _state == 'no_data' %}No attempts yet
+                {% else %}{{ row.attempt_count }} attempt{{ 's' if row.attempt_count != 1 else '' }}{% endif %}
+            </div>
+
+            {% if _state == 'no_data' %}
+            <div class="vt-hf-nodata-msg">Play with this protocol to see stats here.</div>
+
+            {% else %}
+            {% if _state == 'low_sample' %}
+            <span class="vt-hf-badge low">LOW confidence</span>
+            {%- set _rem = stats.min_samples - row.attempt_count -%}
+            <div class="vt-hf-nudge">Complete {{ _rem }} more attempt{{ 's' if _rem != 1 else '' }} for reliable comparison.</div>
+            {% endif %}
+
+            <div class="vt-hf-stat-list">
+                {% if row.avg_score is not none %}
+                <div class="vt-hf-stat-row"><span>Avg score</span><b>{{ row.avg_score }}%</b></div>
+                {% endif %}
+                {% if row.avg_rt_ms is not none %}
+                <div class="vt-hf-stat-row"><span>Avg RT</span><b>{{ row.avg_rt_ms }} ms</b></div>
+                {% endif %}
+                {% if row.best_rt_ms is not none %}
+                <div class="vt-hf-stat-row"><span>Best RT</span><b>{{ row.best_rt_ms }} ms</b></div>
+                {% endif %}
+                {% if row.accuracy_pct is not none %}
+                <div class="vt-hf-stat-row"><span>Accuracy</span><b>{{ row.accuracy_pct }}%</b></div>
+                {% endif %}
+                {% if row.miss_pct is not none %}
+                <div class="vt-hf-stat-row"><span>Miss</span><b>{{ row.miss_pct }}%</b></div>
+                {% endif %}
+                {% if row.late_pct is not none %}
+                <div class="vt-hf-stat-row"><span>Late click</span><b>{{ row.late_pct }}%</b></div>
+                {% endif %}
+            </div>
+            {% endif %}
+
+        </div>
+        {% endfor %}
+
+    </div>
+
+    {# ── Skill Deltas by Protocol ─────────────────────────────────────────── #}
+    <h2 class="vt-hf-section-title">Skill Deltas by Protocol</h2>
+    <div class="vt-hf-delta-section">
+
+        {% set _has_any_delta = false %}
+        {% for row in stats.finger_rows %}
+        {% set _combo = row.hand ~ "_" ~ row.finger %}
+        {%- set _row_state = row.state | default("no_data") -%}
+        {% if _row_state != 'no_data' and stats.skill_totals.get(_combo) %}
+        {% set _has_any_delta = true %}
+        {% set _deltas = stats.skill_totals[_combo] %}
+
+        <div class="vt-hf-delta-combo">
+            <div class="vt-hf-delta-combo-title">
+                {{ row.label }}
+                {% if _row_state == 'low_sample' %}<span class="vt-hf-low-badge">LOW</span>{% endif %}
+            </div>
+            {% for skill, delta in _deltas.items() | sort %}
+            {%- set _abs = delta | abs -%}
+            {%- set _bar_w = [(_abs / 1.0 * 100) | int, 100] | min -%}
+            {%- set _pos = delta >= 0 -%}
+            <div class="vt-hf-delta-row">
+                <span class="vt-hf-delta-skill">{{ skill }}</span>
+                <div class="vt-hf-bar-track">
+                    <div class="vt-hf-bar-fill {% if _pos %}pos{% else %}neg{% endif %}"
+                         style="width: {{ _bar_w }}%;"></div>
+                </div>
+                <span class="vt-hf-delta-val {% if _pos %}pos{% else %}neg{% endif %}">
+                    {% if _pos %}+{% endif %}{{ "%.2f" | format(delta) }}
+                </span>
+            </div>
+            {% endfor %}
+        </div>
+
+        {% endif %}
+        {% endfor %}
+
+        {% if not _has_any_delta %}
+        <div class="vt-hf-nodata-delta">
+            No skill delta data yet.
+            Complete at least 1 valid system-assigned attempt to see skill impact.
+        </div>
+        {% endif %}
+
+    </div>
+
+    {# ── Footer ───────────────────────────────────────────────────────────── #}
+    <div class="vt-hf-footer">
+        <a href="/virtual-training">💻 All Games</a>
+        <a href="/virtual-training/history">📋 History</a>
+        <a href="/training">🎓 Training</a>
+    </div>
+
+</div>
+{% endblock %}

--- a/app/templates/virtual_training_history.html
+++ b/app/templates/virtual_training_history.html
@@ -174,7 +174,7 @@
                         {% else %}—{% endif %}
                     </td>
                     <td>
-                        {% if _hp and _hp.get("protocol_difficulty_multiplier", 1.0) | float > 1.0 %}
+                        {% if _hp and _hp.get("assignment_source") == "system" and _hp.get("hand") != "free" %}
                         <span class="vth-protocol-badge"
                               title="{{ _hp.get('label', '') }} · Self-declared · Not automatically verified">
                             🖐 {{ _hp.get("label", "—") }} ×{{ "%.2f"|format(_hp.get("protocol_difficulty_multiplier", 1.0) | float) }}
@@ -200,6 +200,7 @@
 
     <div class="vth-footer">
         <a href="/virtual-training">💻 All Games</a>
+        <a href="/virtual-training/hand-finger-stats">🖐 Hand Stats</a>
         <a href="/virtual-training/color-reaction">⚡ Play Color Reaction</a>
         <a href="/training">🎓 Training</a>
     </div>

--- a/app/templates/virtual_training_hub.html
+++ b/app/templates/virtual_training_hub.html
@@ -337,7 +337,10 @@
     </div>
     {% endif %}
 
-    <div style="margin-top: 1.25rem; text-align: right;">
+    <div style="margin-top: 1.25rem; display: flex; gap: 1.25rem; justify-content: flex-end; flex-wrap: wrap;">
+        <a href="/virtual-training/hand-finger-stats" style="color: #667eea; font-size: 0.88rem; font-weight: 600; text-decoration: none;">
+            🖐 Hand &amp; Finger Stats
+        </a>
         <a href="/virtual-training/history" style="color: #667eea; font-size: 0.88rem; font-weight: 600; text-decoration: none;">
             📋 View my history →
         </a>

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,6 @@ Pillow>=10.0.0
 # 1.26.0 — the tested+installed version compatible with rembg==2.0.75.
 rembg==2.0.75
 onnxruntime==1.26.0
+# Timezone derivation from GPS coordinates (Phase 2 — lat_lng_derived source)
+# Offline only — no network calls at runtime. numpy already required by onnxruntime.
+timezonefinder==6.5.9

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -67761,6 +67761,51 @@
         ]
       }
     },
+    "/virtual-training/hand-finger-stats": {
+      "get": {
+        "description": "Hand/Finger performance aggregation \u2014 system-assigned v3 attempts only.",
+        "operationId": "virtual_training_hand_finger_stats_virtual_training_hand_finger_stats_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "game",
+            "required": false,
+            "schema": {
+              "default": "all",
+              "title": "Game",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Virtual Training Hand Finger Stats",
+        "tags": [
+          "web",
+          "virtual-training"
+        ]
+      }
+    },
     "/virtual-training/history": {
       "get": {
         "description": "Attempt history \u2014 last 20 valid attempts across all VT games.",

--- a/tests/unit/api/web_routes/test_card_editor_ce2.py
+++ b/tests/unit/api/web_routes/test_card_editor_ce2.py
@@ -430,9 +430,9 @@ class TestCE216WelcomeEditorUnchanged:
 
 class TestCE217RouteCount:
     def test_openapi_snapshot_route_count_unchanged(self):
-        """feat/virtual-training-card adds 4 VT card routes — snapshot path count must equal 855."""
+        """feat/virtual-training-card adds 4 VT card routes — snapshot path count must equal 857."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 856, (
-            f"Expected 855 routes (851 prior baseline + 4 VT card routes), got {len(paths)}."
+        assert len(paths) == 857, (
+            f"Expected 857 routes (856 prior baseline + 1 hand-finger-stats route), got {len(paths)}."
         )

--- a/tests/unit/api/web_routes/test_card_editor_cs_s1.py
+++ b/tests/unit/api/web_routes/test_card_editor_cs_s1.py
@@ -294,7 +294,7 @@ class TestS109S110RouteAndSnapshot:
         """S1-09 (updated BG-REMOVAL-1): route count is 850 (+3 BG-REMOVAL-1 mood photo routes)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 856, (
+        assert len(paths) == 857, (
             f"Expected 850 routes (847 CS-S2A baseline + 3 BG-REMOVAL-1), got {len(paths)}"
         )
 

--- a/tests/unit/api/web_routes/test_card_editor_ref_p2.py
+++ b/tests/unit/api/web_routes/test_card_editor_ref_p2.py
@@ -287,7 +287,7 @@ class TestP227to29RouteAndOpenAPI:
         """P2-27: Route count = 846 (CS-S2A +1 /card-studio/player)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 856, f"Expected 846 routes, got {len(paths)}"
+        assert len(paths) == 857, f"Expected 846 routes, got {len(paths)}"
 
     def test_p2_28_openapi_snapshot_match(self):
         """P2-28: OpenAPI snapshot matches live API paths."""

--- a/tests/unit/api/web_routes/test_card_studio_challenge.py
+++ b/tests/unit/api/web_routes/test_card_studio_challenge.py
@@ -294,7 +294,7 @@ class TestCCS11RouteCount:
         """CCS-11: route count updated to 842 after CE-3.8 (+3 from-mood endpoints)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 856, (
+        assert len(paths) == 857, (
             f"Expected 845 routes (842 CE-3.7+CE-3.8 baseline + 2 CS-S0 card-studio routes), got {len(paths)}."
         )
 

--- a/tests/unit/api/web_routes/test_card_studio_landing.py
+++ b/tests/unit/api/web_routes/test_card_studio_landing.py
@@ -159,7 +159,7 @@ class TestCEL12RouteCount:
         """CEL-12: route count 844 (unchanged — redirect is handler change, not new route)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 856, (
+        assert len(paths) == 857, (
             f"Expected 845 routes (redirect handler change does not add routes), got {len(paths)}."
         )
 

--- a/tests/unit/api/web_routes/test_card_studio_shell.py
+++ b/tests/unit/api/web_routes/test_card_studio_shell.py
@@ -326,7 +326,7 @@ class TestCSS21to23RouteConfirmations:
         """CSS-21: adding 2 card-studio routes raises count from 842 to 844."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 856, (
+        assert len(paths) == 857, (
             f"Expected 845 routes (842 baseline + 2 new /card-studio routes), got {len(paths)}"
         )
 

--- a/tests/unit/api/web_routes/test_card_studio_welcome.py
+++ b/tests/unit/api/web_routes/test_card_studio_welcome.py
@@ -325,7 +325,7 @@ class TestCEW18RouteCount:
         """CEW-18: route count baseline check (updated by CE-3.8 to 842)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 856, (
+        assert len(paths) == 857, (
             f"Expected 842 routes (839 CE-3.7 baseline + 3 from-mood endpoints), got {len(paths)}."
         )
 
@@ -678,7 +678,7 @@ class TestCEW44to51TemplateMoodPicker:
         """CEW-47: CE-3.8 adds 3 from-mood routes → total 842."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 856, (
+        assert len(paths) == 857, (
             f"Expected 845 routes (842 baseline + 2 CS-S0 routes), got {len(paths)}"
         )
 

--- a/tests/unit/api/web_routes/test_cc_design_1.py
+++ b/tests/unit/api/web_routes/test_cc_design_1.py
@@ -780,7 +780,7 @@ class TestCCD22to23RouteSnapshot:
         """CCD-22: Route count is 851 (CC-DESIGN-1 SNAPSHOT adds POST /challenges/{id}/card/photo)."""
         from app.main import app
         count = len(app.openapi().get("paths", {}))
-        assert count == 856, f"Expected 851, got {count}"
+        assert count == 857, f"Expected 851, got {count}"
 
     def test_ccd_23_openapi_snapshot_match(self):
         """CCD-23: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_cs_color_1.py
+++ b/tests/unit/api/web_routes/test_cs_color_1.py
@@ -382,7 +382,7 @@ class TestCSCOL15to16RouteAndSnapshot:
         """CSCOL-15: route count = 845 (+1 POST /dashboard/wc-card-theme)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 856, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 857, f"Expected 845 routes, got {len(paths)}"
 
     def test_cscol_16_openapi_snapshot_includes_wc_card_theme(self):
         """CSCOL-16: OpenAPI snapshot includes /dashboard/wc-card-theme."""

--- a/tests/unit/api/web_routes/test_cs_s2a.py
+++ b/tests/unit/api/web_routes/test_cs_s2a.py
@@ -40,7 +40,7 @@ class TestS2A01to02RouteRegistration:
         """S2A-02 (updated CS-S4A): Total route count is 847 (CS-S2A+CS-S4A)."""
         from app.main import app
         count = len(app.openapi().get("paths", {}))
-        assert count == 856, f"Expected 847 routes, got {count}"
+        assert count == 857, f"Expected 847 routes, got {count}"
 
 
 # ── S2A-03..08: _resolve_player_context logic ────────────────────────────────

--- a/tests/unit/api/web_routes/test_cs_s4a.py
+++ b/tests/unit/api/web_routes/test_cs_s4a.py
@@ -152,7 +152,7 @@ class TestS4A12to13RouteAndSnapshot:
         """S4A-12: Route count == 851 (CC-DESIGN-1 SNAPSHOT adds +1 POST /challenges/{id}/card/photo)."""
         from app.main import app
         count = len(app.openapi().get("paths", {}))
-        assert count == 856, f"Expected 851 routes, got {count}"
+        assert count == 857, f"Expected 851 routes, got {count}"
 
     def test_s4a_13_openapi_snapshot_match(self):
         """S4A-13: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_family_color_shop.py
+++ b/tests/unit/api/web_routes/test_family_color_shop.py
@@ -223,7 +223,7 @@ class TestRouteRegistration:
     def test_ts_13_route_count_836(self):
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 856, (
+        assert len(paths) == 857, (
             f"Expected 845 routes (842 CE-3.7+CE-3.8 baseline + 2 CS-S0 card-studio routes), got {len(paths)}."
         )
 

--- a/tests/unit/api/web_routes/test_shop_3a.py
+++ b/tests/unit/api/web_routes/test_shop_3a.py
@@ -194,7 +194,7 @@ class TestS3A13to14RouteAndSnapshot:
         """S3A-13: Route count = 845 (template deletion does not affect routes)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 856, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 857, f"Expected 845 routes, got {len(paths)}"
 
     def test_s3a_14_openapi_snapshot_match(self):
         """S3A-14: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_shop_3b1.py
+++ b/tests/unit/api/web_routes/test_shop_3b1.py
@@ -158,7 +158,7 @@ class TestS3B112to13RouteAndSnapshot:
         """S3B1-12: Route count = 845 (test cleanup does not affect routes)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 856, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 857, f"Expected 845 routes, got {len(paths)}"
 
     def test_s3b1_13_openapi_snapshot_match(self):
         """S3B1-13: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_shop_3b2.py
+++ b/tests/unit/api/web_routes/test_shop_3b2.py
@@ -192,7 +192,7 @@ class TestS3B215to16RouteAndSnapshot:
         """S3B2-15: Route count = 845 (template deletion does not affect routes)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 856, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 857, f"Expected 845 routes, got {len(paths)}"
 
     def test_s3b2_16_openapi_snapshot_match(self):
         """S3B2-16: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_shop_unified.py
+++ b/tests/unit/api/web_routes/test_shop_unified.py
@@ -271,7 +271,7 @@ class TestSHOP14to15RouteAndSnapshot:
         """SHOP-14: route count = 845 (no new routes in SHOP-1)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 856, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 857, f"Expected 845 routes, got {len(paths)}"
 
     def test_shop_15_openapi_snapshot_match(self):
         """SHOP-15: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_virtual_training.py
+++ b/tests/unit/api/web_routes/test_virtual_training.py
@@ -1296,3 +1296,125 @@ class TestCompletionNotificationLink:
 
         for call in mock_svc.create_notification.call_args_list:
             assert call.kwargs["link"] == "/challenges"
+
+
+# ── Hand/Finger Stats route tests ─────────────────────────────────────────────
+
+class TestHandFingerStatsRoute:
+    """
+    HFS-R01  GET /virtual-training/hand-finger-stats → 200 for onboarded student
+    HFS-R02  GET /virtual-training/hand-finger-stats → 303 for non-onboarded student
+    HFS-R03  Response contains vt-hd-wrap (macro rendered) + single summary card
+    HFS-R04  ?game=color_reaction → 200 (valid game filter)
+    HFS-R05  ?game=bogus → 200 with game_filter='all' (soft fallback)
+    HFS-R06  By Hand: exactly one vt-hf-hand-summary-card block (not two separate cards)
+    HFS-R07  By Hand: both RIGHT HAND and LEFT HAND labels inside the single block
+    """
+
+    def _make_client(self, user_override=None, db_override=None):
+        from fastapi import FastAPI
+        from app.api.web_routes import virtual_training as vt_module
+        from app.dependencies import get_current_user_web
+        from app.database import get_db
+
+        _app = FastAPI()
+        _app.include_router(vt_module.router)
+        if user_override is not None:
+            _app.dependency_overrides[get_current_user_web] = lambda: user_override
+        if db_override is not None:
+            _app.dependency_overrides[get_db] = lambda: db_override
+        return TestClient(_app, raise_server_exceptions=False)
+
+    def _onboarded_user(self):
+        from app.models.user import UserRole
+        u = MagicMock()
+        u.id = 42
+        u.role = UserRole.STUDENT
+        u.onboarding_completed = True
+        u.specialization = MagicMock()
+        u.specialization.value = "LFA_FOOTBALL_PLAYER"
+        return u
+
+    def _db_no_attempts(self):
+        db = MagicMock()
+        result = MagicMock()
+        result.fetchall.return_value = []
+        db.execute.return_value = result
+        q = MagicMock()
+        q.filter.return_value = q
+        q.first.return_value = None
+        q.count.return_value = 0
+        q.order_by.return_value = q
+        q.all.return_value = []
+        db.query.return_value = q
+        return db
+
+    def test_hfs_r01_200_for_onboarded_student(self):
+        """HFS-R01: GET /virtual-training/hand-finger-stats → 200."""
+        resp = self._make_client(
+            user_override=self._onboarded_user(),
+            db_override=self._db_no_attempts(),
+        ).get("/virtual-training/hand-finger-stats", follow_redirects=False)
+        assert resp.status_code == 200
+
+    def test_hfs_r02_303_for_non_onboarded(self):
+        """HFS-R02: Non-onboarded student → 303 redirect."""
+        from app.models.user import UserRole
+        u = MagicMock()
+        u.id = 77; u.role = UserRole.STUDENT; u.onboarding_completed = False
+        u.specialization = MagicMock(); u.specialization.value = "LFA_FOOTBALL_PLAYER"
+        resp = self._make_client(
+            user_override=u,
+            db_override=self._db_no_attempts(),
+        ).get("/virtual-training/hand-finger-stats", follow_redirects=False)
+        assert resp.status_code == 303
+
+    def test_hfs_r03_hand_diagram_and_summary_card_rendered(self):
+        """HFS-R03: Response contains vt-hd-wrap (macro) + hand-summary-card wrapper."""
+        resp = self._make_client(
+            user_override=self._onboarded_user(),
+            db_override=self._db_no_attempts(),
+        ).get("/virtual-training/hand-finger-stats", follow_redirects=False)
+        assert resp.status_code == 200
+        assert "vt-hd-wrap" in resp.text, "Hand diagram macro not rendered"
+        assert "vt-hf-hand-summary-card" in resp.text, "Single hand summary card missing"
+
+    def test_hfs_r04_valid_game_filter(self):
+        """HFS-R04: ?game=color_reaction → 200."""
+        game = MagicMock(); game.id = 1; game.code = "color_reaction"
+        db = self._db_no_attempts()
+        db.query.return_value.filter.return_value.first.return_value = game
+        resp = self._make_client(
+            user_override=self._onboarded_user(),
+            db_override=db,
+        ).get("/virtual-training/hand-finger-stats?game=color_reaction", follow_redirects=False)
+        assert resp.status_code == 200
+
+    def test_hfs_r05_invalid_game_falls_back_to_all(self):
+        """HFS-R05: ?game=bogus → 200, game_filter='all' fallback."""
+        resp = self._make_client(
+            user_override=self._onboarded_user(),
+            db_override=self._db_no_attempts(),
+        ).get("/virtual-training/hand-finger-stats?game=bogus", follow_redirects=False)
+        assert resp.status_code == 200
+        assert "All Games" in resp.text
+
+    def test_hfs_r06_single_hand_summary_block(self):
+        """HFS-R06: Exactly one vt-hf-hand-summary-card in page (not two separate cards)."""
+        resp = self._make_client(
+            user_override=self._onboarded_user(),
+            db_override=self._db_no_attempts(),
+        ).get("/virtual-training/hand-finger-stats", follow_redirects=False)
+        assert resp.status_code == 200
+        assert "vt-hf-hand-summary-card" in resp.text
+        assert resp.text.count("vt-hf-hand-panel") >= 2, "Expected right + left hand panels"
+
+    def test_hfs_r07_both_hand_labels_in_summary(self):
+        """HFS-R07: RIGHT HAND and LEFT HAND both inside the summary card."""
+        resp = self._make_client(
+            user_override=self._onboarded_user(),
+            db_override=self._db_no_attempts(),
+        ).get("/virtual-training/hand-finger-stats", follow_redirects=False)
+        assert resp.status_code == 200
+        assert "RIGHT HAND" in resp.text
+        assert "LEFT HAND" in resp.text

--- a/tests/unit/services/test_training_day_phase2.py
+++ b/tests/unit/services/test_training_day_phase2.py
@@ -1,0 +1,207 @@
+"""Unit tests for training_day.py — Phase 2: lat/lng → lat_lng_derived timezone.
+
+TD2-01  Budapest coords (47.4979, 19.0402), fresh, 20m → ("Europe/Budapest", "lat_lng_derived")
+TD2-02  São Paulo coords (-23.5505, -46.6333), fresh, 30m → ("America/Sao_Paulo", "lat_lng_derived")
+TD2-03  London coords (51.5074, -0.1278), fresh, 15m → ("Europe/London", "lat_lng_derived")
+TD2-04  Fresh coords but accuracy=600m (> 500m) → fallback "browser_iana"
+TD2-05  Stale coords (7 min old), accuracy=20m → fallback "browser_iana"
+TD2-06  Invalid coords (lat=999, lng=999): TZF returns None → fallback "browser_iana"
+TD2-07  lat=None, lng=None → fallback "browser_iana"
+TD2-08  lat=None + browser_timezone=None → ("UTC", "utc_fallback")
+TD2-09  GPS (Budapest) wins over contradicting browser_timezone ("America/Sao_Paulo")
+TD2-10  Phase 1 regression: resolve_training_timezone("Europe/Budapest") with no lat/lng
+        → ("Europe/Budapest", "browser_iana") unchanged
+TD2-11  Exactly at freshness boundary (300s old) → still "lat_lng_derived" (≤ is fresh)
+TD2-12  accuracy_m=None (unknown) is treated as acceptable for lat_lng_derived
+TD2-13  timezonefinder ImportError → graceful fallback to browser_iana (mocked)
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.services.training_day import resolve_training_timezone
+
+_NOW = datetime(2026, 6, 5, 12, 0, 0, tzinfo=timezone.utc)
+
+_BUDAPEST  = (47.4979, 19.0402)
+_SAO_PAULO = (-23.5505, -46.6333)
+_LONDON    = (51.5074, -0.1278)
+
+
+def _fresh(minutes_ago: float = 1.0) -> datetime:
+    return _NOW - timedelta(minutes=minutes_ago)
+
+
+# ── TD2-01..03: valid GPS → lat_lng_derived ───────────────────────────────────
+
+class TestLatLngDerived:
+
+    def test_td2_01_budapest_coords(self):
+        """TD2-01: Budapest GPS → Europe/Budapest, lat_lng_derived."""
+        tz, src = resolve_training_timezone(
+            None,
+            lat=_BUDAPEST[0], lng=_BUDAPEST[1],
+            accuracy_m=20, captured_at=_fresh(), now=_NOW,
+        )
+        assert tz  == "Europe/Budapest"
+        assert src == "lat_lng_derived"
+
+    def test_td2_02_sao_paulo_coords(self):
+        """TD2-02: São Paulo GPS → America/Sao_Paulo, lat_lng_derived."""
+        tz, src = resolve_training_timezone(
+            None,
+            lat=_SAO_PAULO[0], lng=_SAO_PAULO[1],
+            accuracy_m=30, captured_at=_fresh(), now=_NOW,
+        )
+        assert tz  == "America/Sao_Paulo"
+        assert src == "lat_lng_derived"
+
+    def test_td2_03_london_coords(self):
+        """TD2-03: London GPS → Europe/London, lat_lng_derived."""
+        tz, src = resolve_training_timezone(
+            None,
+            lat=_LONDON[0], lng=_LONDON[1],
+            accuracy_m=15, captured_at=_fresh(), now=_NOW,
+        )
+        assert tz  == "Europe/London"
+        assert src == "lat_lng_derived"
+
+
+# ── TD2-04..05: quality gates → fallback ─────────────────────────────────────
+
+class TestLocationQualityFallback:
+
+    def test_td2_04_accuracy_too_low(self):
+        """TD2-04: accuracy=600m > 500m threshold → falls back to browser_iana."""
+        tz, src = resolve_training_timezone(
+            "Europe/Budapest",
+            lat=_BUDAPEST[0], lng=_BUDAPEST[1],
+            accuracy_m=600, captured_at=_fresh(), now=_NOW,
+        )
+        assert src == "browser_iana"
+        assert tz  == "Europe/Budapest"
+
+    def test_td2_05_stale_location(self):
+        """TD2-05: 7-minute-old GPS fix → stale, falls back to browser_iana."""
+        tz, src = resolve_training_timezone(
+            "America/Sao_Paulo",
+            lat=_BUDAPEST[0], lng=_BUDAPEST[1],
+            accuracy_m=20, captured_at=_fresh(minutes_ago=7), now=_NOW,
+        )
+        assert src == "browser_iana"
+        assert tz  == "America/Sao_Paulo"
+
+    def test_td2_11_exactly_at_boundary(self):
+        """TD2-11: captured_at exactly 300s ago → still fresh (≤ 300s = fresh)."""
+        captured = _NOW - timedelta(seconds=300)
+        tz, src = resolve_training_timezone(
+            None,
+            lat=_BUDAPEST[0], lng=_BUDAPEST[1],
+            accuracy_m=20, captured_at=captured, now=_NOW,
+        )
+        assert src == "lat_lng_derived"
+
+    def test_td2_12_accuracy_none_is_acceptable(self):
+        """TD2-12: accuracy_m=None (unknown) treated as acceptable, uses TZF."""
+        tz, src = resolve_training_timezone(
+            None,
+            lat=_BUDAPEST[0], lng=_BUDAPEST[1],
+            accuracy_m=None, captured_at=_fresh(), now=_NOW,
+        )
+        assert src == "lat_lng_derived"
+        assert tz  == "Europe/Budapest"
+
+
+# ── TD2-06..08: invalid / missing coords ─────────────────────────────────────
+
+class TestInvalidCoords:
+
+    def test_td2_06_invalid_coords(self):
+        """TD2-06: lat=999, lng=999 → TZF returns None → fallback browser_iana."""
+        tz, src = resolve_training_timezone(
+            "Europe/Budapest",
+            lat=999.0, lng=999.0,
+            accuracy_m=10, captured_at=_fresh(), now=_NOW,
+        )
+        # TZF returns None for ocean/invalid → fallback
+        assert src == "browser_iana"
+        assert tz  == "Europe/Budapest"
+
+    def test_td2_07_lat_lng_none_falls_back(self):
+        """TD2-07: lat=None, lng=None → skips TZF step → browser_iana."""
+        tz, src = resolve_training_timezone(
+            "Europe/Budapest",
+            lat=None, lng=None,
+            accuracy_m=10, captured_at=_fresh(), now=_NOW,
+        )
+        assert src == "browser_iana"
+        assert tz  == "Europe/Budapest"
+
+    def test_td2_08_no_lat_no_browser_tz(self):
+        """TD2-08: lat=None + browser_timezone=None → utc_fallback."""
+        tz, src = resolve_training_timezone(
+            None,
+            lat=None, lng=None,
+        )
+        assert tz  == "UTC"
+        assert src == "utc_fallback"
+
+
+# ── TD2-09: GPS priority over browser tz ─────────────────────────────────────
+
+class TestGpsPriority:
+
+    def test_td2_09_gps_wins_over_browser_tz(self):
+        """TD2-09: fresh Budapest GPS beats contradicting browser_timezone São Paulo."""
+        tz, src = resolve_training_timezone(
+            "America/Sao_Paulo",   # browser says São Paulo
+            lat=_BUDAPEST[0], lng=_BUDAPEST[1],  # GPS says Budapest
+            accuracy_m=20, captured_at=_fresh(), now=_NOW,
+        )
+        assert tz  == "Europe/Budapest"   # GPS wins
+        assert src == "lat_lng_derived"
+
+
+# ── TD2-10: Phase 1 regression ────────────────────────────────────────────────
+
+class TestPhase1Regression:
+
+    def test_td2_10_browser_only_still_browser_iana(self):
+        """TD2-10: Phase 1 call (browser tz only, no lat/lng) unchanged."""
+        tz, src = resolve_training_timezone("Europe/Budapest")
+        assert tz  == "Europe/Budapest"
+        assert src == "browser_iana"
+
+    def test_td2_10b_browser_only_sao_paulo(self):
+        tz, src = resolve_training_timezone("America/Sao_Paulo")
+        assert tz  == "America/Sao_Paulo"
+        assert src == "browser_iana"
+
+    def test_td2_10c_none_browser_utc_fallback(self):
+        tz, src = resolve_training_timezone(None)
+        assert tz  == "UTC"
+        assert src == "utc_fallback"
+
+
+# ── TD2-13: TZF failure → graceful fallback ───────────────────────────────────
+
+class TestTzfFailureFallback:
+
+    def test_td2_13_tzf_import_error_falls_back(self, monkeypatch):
+        """TD2-13: If timezonefinder raises any exception, fall back to browser_iana."""
+        import app.services.training_day as td_module
+
+        def _broken_derive(lat, lng):
+            raise RuntimeError("simulated TZF failure")
+
+        monkeypatch.setattr(td_module, "_derive_tz_from_coords", _broken_derive)
+
+        tz, src = resolve_training_timezone(
+            "Europe/Budapest",
+            lat=_BUDAPEST[0], lng=_BUDAPEST[1],
+            accuracy_m=20, captured_at=_fresh(), now=_NOW,
+        )
+        assert src == "browser_iana"
+        assert tz  == "Europe/Budapest"

--- a/tests/unit/services/test_vt_hand_finger_stats.py
+++ b/tests/unit/services/test_vt_hand_finger_stats.py
@@ -1,0 +1,423 @@
+"""Hand/Finger Stats service tests — Phase 2.4 (PR #158, UX fix).
+
+HFS-01  0 attempts → all 4 finger_rows state=no_data, attempt_count=0
+HFS-02  < _MIN_SAMPLES (2 attempts RI) → state=low_sample (not no_data)
+HFS-03  >= _MIN_SAMPLES (3 attempts RI) → state=ready
+HFS-04  all 4 combos ≥3 attempts → 4 rows all state=ready
+HFS-05  finger_rows canonical order: RI, RT, LI, LT
+HFS-06  return dict has all required keys
+HFS-07  min_samples == 3
+HFS-08  game_id=None → no gid param sent to SQL
+HFS-09  game_id=42 → gid=42 in SQL params
+HFS-10  SQL filters on is_valid + assignment_source (no v1/v2/free bleed)
+HFS-11  by_hand right state=ready when cnt >= 3
+HFS-12  by_hand left state=no_data when cnt == 0
+HFS-13  skill_totals accumulated correctly across two rows
+HFS-14  skill_totals empty when no valid skill_deltas rows
+HFS-15  game_id filter is forwarded to all 3 SQL execute calls
+HFS-16  attempt_count=0 → state="no_data"
+HFS-17  attempt_count=1 → state="low_sample", real metrics present
+HFS-18  attempt_count=2 → state="low_sample", real metrics present
+HFS-19  skill_totals returned regardless of state (no has_data gate in service)
+HFS-20  by_hand left state=low_sample when 1 ≤ cnt < 3
+"""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import MagicMock
+
+from app.services.virtual_training_service import VirtualTrainingService, _MIN_SAMPLES
+
+
+# ── row factories ─────────────────────────────────────────────────────────────
+
+def _fr(hand: str, finger: str, count: int, label: str | None = None, **kw) -> MagicMock:
+    """Build a finger-aggregate row mock."""
+    r = MagicMock()
+    r.hand = hand
+    r.finger = finger
+    r.label = label or f"{hand.capitalize()} {finger.capitalize()}"
+    r.attempt_count = count
+    r.avg_score     = kw.get("avg_score", 85.0)
+    r.avg_rt_ms     = kw.get("avg_rt_ms", 420)
+    r.best_rt_ms    = kw.get("best_rt_ms", 310)
+    r.accuracy_pct  = kw.get("accuracy_pct", 90.0)
+    r.miss_pct      = kw.get("miss_pct", 5.0)
+    r.wrong_pct     = kw.get("wrong_pct", 5.0)
+    r.late_pct      = kw.get("late_pct", 3.0)
+    return r
+
+
+def _hr(hand: str, count: int, **kw) -> MagicMock:
+    """Build a hand-aggregate row mock."""
+    r = MagicMock()
+    r.hand = hand
+    r.attempt_count = count
+    r.avg_score     = kw.get("avg_score", 85.0)
+    r.avg_rt_ms     = kw.get("avg_rt_ms", 420)
+    r.accuracy_pct  = kw.get("accuracy_pct", 90.0)
+    return r
+
+
+def _dr(hand: str, finger: str, skill_deltas: dict | None) -> MagicMock:
+    """Build a delta row mock."""
+    r = MagicMock()
+    r.hand = hand
+    r.finger = finger
+    r.skill_deltas = skill_deltas
+    return r
+
+
+def _make_db(finger_rows: list, hand_rows: list, delta_rows: list) -> MagicMock:
+    """Return a DB mock that cycles execute results: finger → hand → delta."""
+    db = MagicMock()
+    call_count = 0
+
+    def _execute(sql, params):
+        nonlocal call_count
+        call_count += 1
+        m = MagicMock()
+        if call_count == 1:
+            m.fetchall.return_value = finger_rows
+        elif call_count == 2:
+            m.fetchall.return_value = hand_rows
+        else:
+            m.fetchall.return_value = delta_rows
+        return m
+
+    db.execute.side_effect = _execute
+    return db
+
+
+def _call(finger_rows, hand_rows, delta_rows=None, game_id=None, user_id=202):
+    db = _make_db(finger_rows, hand_rows, delta_rows or [])
+    return VirtualTrainingService.get_hand_finger_stats(db, user_id=user_id, game_id=game_id)
+
+
+# ── HFS-01: 0 attempts ───────────────────────────────────────────────────────
+
+class TestZeroAttempts:
+
+    def test_hfs01_zero_attempts_all_rows_no_data_state(self):
+        """HFS-01: 0 attempts → all 4 finger_rows state=no_data, attempt_count=0."""
+        result = _call([], [], [])
+        rows = result["finger_rows"]
+        assert len(rows) == 4
+        for row in rows:
+            assert row["state"] == "no_data"
+            assert row["attempt_count"] == 0
+
+    def test_hfs01b_zero_attempts_by_hand_no_data_state(self):
+        """HFS-01b: 0 attempts → both hands state=no_data."""
+        result = _call([], [], [])
+        assert result["by_hand"]["right"]["state"] == "no_data"
+        assert result["by_hand"]["left"]["state"] == "no_data"
+
+    def test_hfs01c_zero_attempts_skill_totals_empty(self):
+        """HFS-01c: 0 attempts → skill_totals == {}."""
+        result = _call([], [], [])
+        assert result["skill_totals"] == {}
+
+
+# ── HFS-02/03: state thresholds ──────────────────────────────────────────────
+
+class TestStateThresholds:
+
+    def test_hfs02_below_threshold_is_low_sample(self):
+        """HFS-02: 2 RI attempts → state=low_sample (NOT no_data, NOT hidden)."""
+        result = _call(
+            [_fr("right", "index", 2)],
+            [_hr("right", 2)],
+        )
+        ri = next(r for r in result["finger_rows"] if r["hand"] == "right" and r["finger"] == "index")
+        assert ri["state"] == "low_sample"
+        assert ri["attempt_count"] == 2
+
+    def test_hfs02b_low_sample_metrics_are_present(self):
+        """HFS-02b: low_sample row contains real metric values (not hidden)."""
+        result = _call(
+            [_fr("right", "index", 2, avg_score=40.5, avg_rt_ms=1458)],
+            [_hr("right", 2)],
+        )
+        ri = next(r for r in result["finger_rows"] if r["hand"] == "right" and r["finger"] == "index")
+        assert ri["state"] == "low_sample"
+        assert ri["avg_score"] == 40.5
+        assert ri["avg_rt_ms"] == 1458
+
+    def test_hfs03_at_threshold_is_ready(self):
+        """HFS-03: 3 RI attempts → state=ready."""
+        result = _call(
+            [_fr("right", "index", 3)],
+            [_hr("right", 3)],
+        )
+        ri = next(r for r in result["finger_rows"] if r["hand"] == "right" and r["finger"] == "index")
+        assert ri["state"] == "ready"
+        assert ri["attempt_count"] == 3
+
+    def test_hfs03b_above_threshold_is_ready(self):
+        """HFS-03b: 10 LT attempts → state=ready."""
+        result = _call(
+            [_fr("left", "thumb", 10)],
+            [_hr("left", 10)],
+        )
+        lt = next(r for r in result["finger_rows"] if r["hand"] == "left" and r["finger"] == "thumb")
+        assert lt["state"] == "ready"
+
+
+# ── HFS-04: all 4 combos ─────────────────────────────────────────────────────
+
+class TestAllFourCombos:
+
+    def test_hfs04_all_combos_ready(self):
+        """HFS-04: all 4 combos ≥3 attempts → 4 rows all state=ready."""
+        finger_rows = [
+            _fr("right", "index", 5),
+            _fr("right", "thumb", 4),
+            _fr("left",  "index", 3),
+            _fr("left",  "thumb", 6),
+        ]
+        result = _call(
+            finger_rows,
+            [_hr("right", 9), _hr("left", 9)],
+        )
+        for row in result["finger_rows"]:
+            assert row["state"] == "ready", f"{row['label']} should be ready"
+
+
+# ── HFS-05: canonical order ───────────────────────────────────────────────────
+
+class TestCanonicalOrder:
+
+    def test_hfs05_finger_rows_canonical_order(self):
+        """HFS-05: finger_rows[0..3] = RI, RT, LI, LT regardless of DB return order."""
+        finger_rows = [
+            _fr("left",  "thumb",  4),
+            _fr("left",  "index",  3),
+            _fr("right", "thumb",  5),
+            _fr("right", "index",  6),
+        ]
+        result = _call(finger_rows, [])
+        rows = result["finger_rows"]
+        assert rows[0]["hand"] == "right" and rows[0]["finger"] == "index"
+        assert rows[1]["hand"] == "right" and rows[1]["finger"] == "thumb"
+        assert rows[2]["hand"] == "left"  and rows[2]["finger"] == "index"
+        assert rows[3]["hand"] == "left"  and rows[3]["finger"] == "thumb"
+
+
+# ── HFS-06/07: structure ─────────────────────────────────────────────────────
+
+class TestReturnStructure:
+
+    def test_hfs06_all_required_keys_present(self):
+        """HFS-06: return dict has all required keys."""
+        result = _call([], [], [])
+        for key in ("min_samples", "finger_rows", "by_hand", "skill_totals"):
+            assert key in result, f"Missing key: {key}"
+
+    def test_hfs07_min_samples_equals_3(self):
+        """HFS-07: min_samples == 3 (matches _MIN_SAMPLES constant)."""
+        result = _call([], [], [])
+        assert result["min_samples"] == 3
+        assert result["min_samples"] == _MIN_SAMPLES
+
+
+# ── HFS-08/09: game_id param ─────────────────────────────────────────────────
+
+class TestGameIdParam:
+
+    def _capture_params(self, game_id):
+        db = MagicMock()
+        captured = []
+
+        def _execute(sql, params):
+            captured.append(params.copy())
+            m = MagicMock()
+            m.fetchall.return_value = []
+            return m
+
+        db.execute.side_effect = _execute
+        VirtualTrainingService.get_hand_finger_stats(db, user_id=303, game_id=game_id)
+        return captured
+
+    def test_hfs08_no_game_id_no_gid_in_params(self):
+        """HFS-08: game_id=None → no gid key in SQL params."""
+        params_list = self._capture_params(game_id=None)
+        for params in params_list:
+            assert "gid" not in params
+
+    def test_hfs09_game_id_forwarded_to_sql(self):
+        """HFS-09: game_id=42 → gid=42 in all 3 SQL execute calls."""
+        params_list = self._capture_params(game_id=42)
+        assert len(params_list) == 3
+        for params in params_list:
+            assert params.get("gid") == 42
+
+
+# ── HFS-10: SQL filter content ───────────────────────────────────────────────
+
+class TestSQLFilterContent:
+
+    def test_hfs10_sql_contains_is_valid_and_assignment_source(self):
+        """HFS-10: SQL filters on is_valid and assignment_source = system."""
+        db = MagicMock()
+        sql_strings: list[str] = []
+
+        def _execute(sql, params):
+            sql_strings.append(str(sql))
+            m = MagicMock()
+            m.fetchall.return_value = []
+            return m
+
+        db.execute.side_effect = _execute
+        VirtualTrainingService.get_hand_finger_stats(db, user_id=404, game_id=None)
+
+        for sql_str in sql_strings:
+            assert "is_valid" in sql_str, "SQL must filter on is_valid"
+            assert "assignment_source" in sql_str, "SQL must filter on assignment_source"
+
+
+# ── HFS-11/12: by_hand state ─────────────────────────────────────────────────
+
+class TestByHandState:
+
+    def test_hfs11_right_hand_ready_at_threshold(self):
+        """HFS-11: right 3 attempts → by_hand[right] state=ready."""
+        result = _call(
+            [_fr("right", "index", 3)],
+            [_hr("right", 3)],
+        )
+        assert result["by_hand"]["right"]["state"] == "ready"
+        assert result["by_hand"]["right"]["attempt_count"] == 3
+
+    def test_hfs12_left_hand_no_data_when_zero(self):
+        """HFS-12: left 0 attempts → by_hand[left] state=no_data."""
+        result = _call(
+            [_fr("right", "index", 5)],
+            [_hr("right", 5)],
+        )
+        assert result["by_hand"]["left"]["state"] == "no_data"
+        assert result["by_hand"]["left"]["attempt_count"] == 0
+
+
+# ── HFS-13/14: skill_totals ───────────────────────────────────────────────────
+
+class TestSkillTotals:
+
+    def test_hfs13_skill_totals_accumulated(self):
+        """HFS-13: two RI delta rows → reactions sums to 0.3 (0.1 + 0.2)."""
+        delta_rows = [
+            _dr("right", "index", {"reactions": 0.1, "decisions": 0.05}),
+            _dr("right", "index", {"reactions": 0.2, "decisions": 0.10}),
+        ]
+        result = _call([], [], delta_rows)
+        ri_totals = result["skill_totals"].get("right_index", {})
+        assert abs(ri_totals.get("reactions", 0) - 0.3) < 1e-6
+        assert abs(ri_totals.get("decisions", 0) - 0.15) < 1e-6
+
+    def test_hfs13b_multiple_combos_independent_accumulation(self):
+        """HFS-13b: RI and LT accumulate independently."""
+        delta_rows = [
+            _dr("right", "index", {"reactions": 0.5}),
+            _dr("left",  "thumb", {"composure": 0.3}),
+        ]
+        result = _call([], [], delta_rows)
+        assert abs(result["skill_totals"]["right_index"]["reactions"] - 0.5) < 1e-6
+        assert abs(result["skill_totals"]["left_thumb"]["composure"] - 0.3) < 1e-6
+
+    def test_hfs14_no_skill_deltas_returns_empty(self):
+        """HFS-14: delta rows with None/empty skill_deltas → skill_totals == {}."""
+        delta_rows = [
+            _dr("right", "index", None),
+            _dr("right", "thumb", {}),
+        ]
+        result = _call([], [], delta_rows)
+        assert result["skill_totals"] == {}
+
+
+# ── HFS-15: game_id in all 3 queries ─────────────────────────────────────────
+
+class TestGameIdIsolation:
+
+    def test_hfs15_game_id_in_all_three_queries(self):
+        """HFS-15: game_id filter forwarded to all 3 SQL execute calls."""
+        db = MagicMock()
+        call_params: list[dict] = []
+
+        def _execute(sql, params):
+            call_params.append(dict(params))
+            m = MagicMock()
+            m.fetchall.return_value = []
+            return m
+
+        db.execute.side_effect = _execute
+        VirtualTrainingService.get_hand_finger_stats(db, user_id=505, game_id=7)
+
+        assert len(call_params) == 3, "Expected exactly 3 SQL execute calls"
+        for idx, params in enumerate(call_params):
+            assert params.get("gid") == 7, f"gid missing from query {idx + 1}"
+            assert params.get("uid") == 505
+
+
+# ── HFS-16..20: 3-state model correctness ────────────────────────────────────
+
+class TestThreeStateModel:
+
+    def test_hfs16_zero_attempts_state_no_data(self):
+        """HFS-16: attempt_count=0 (unseen combo) → state='no_data'."""
+        result = _call([], [], [])
+        for row in result["finger_rows"]:
+            assert row["state"] == "no_data"
+        for side in ("right", "left"):
+            assert result["by_hand"][side]["state"] == "no_data"
+
+    def test_hfs17_one_attempt_is_low_sample_with_metrics(self):
+        """HFS-17: attempt_count=1 → state=low_sample AND real metrics present."""
+        result = _call(
+            [_fr("right", "index", 1, avg_score=55.0, avg_rt_ms=900)],
+            [_hr("right", 1, avg_score=55.0, avg_rt_ms=900)],
+        )
+        ri = next(r for r in result["finger_rows"] if r["hand"] == "right" and r["finger"] == "index")
+        assert ri["state"] == "low_sample"
+        assert ri["avg_score"] == 55.0
+        assert ri["avg_rt_ms"] == 900
+
+        rh = result["by_hand"]["right"]
+        assert rh["state"] == "low_sample"
+        assert rh["avg_score"] == 55.0
+
+    def test_hfs18_two_attempts_is_low_sample_with_metrics(self):
+        """HFS-18: attempt_count=2 → state=low_sample AND real metrics present."""
+        result = _call(
+            [_fr("right", "index", 2, avg_score=40.5, avg_rt_ms=1458, accuracy_pct=41.0)],
+            [_hr("right", 2, avg_score=40.5, avg_rt_ms=1458)],
+        )
+        ri = next(r for r in result["finger_rows"] if r["hand"] == "right" and r["finger"] == "index")
+        assert ri["state"] == "low_sample"
+        assert ri["avg_score"] == 40.5
+        assert ri["avg_rt_ms"] == 1458
+        assert ri["accuracy_pct"] == 41.0
+
+    def test_hfs19_skill_totals_present_in_low_sample_state(self):
+        """HFS-19: skill_totals accumulate for low_sample combos (no state gate in service)."""
+        delta_rows = [
+            _dr("right", "index", {"reactions": 0.25}),
+        ]
+        # 2 attempts → low_sample; delta must still be in skill_totals
+        result = _call(
+            [_fr("right", "index", 2)],
+            [_hr("right", 2)],
+            delta_rows,
+        )
+        ri = next(r for r in result["finger_rows"] if r["hand"] == "right" and r["finger"] == "index")
+        assert ri["state"] == "low_sample"
+        assert "right_index" in result["skill_totals"]
+        assert abs(result["skill_totals"]["right_index"]["reactions"] - 0.25) < 1e-6
+
+    def test_hfs20_by_hand_low_sample_when_between_thresholds(self):
+        """HFS-20: by_hand left 1 ≤ cnt < 3 → state=low_sample."""
+        result = _call(
+            [_fr("left", "index", 2)],
+            [_hr("left", 2)],
+        )
+        assert result["by_hand"]["left"]["state"] == "low_sample"
+        assert result["by_hand"]["left"]["attempt_count"] == 2


### PR DESCRIPTION
## Summary

- **Phase 1** — Browser timezone daily reset: \`training_local_date\` replaces UTC \`completed_at\` window for VT daily attempt caps.
- **Phase 2** — GPS-derived timezone: \`resolve_training_timezone()\` extended with lat/lng → timezonefinder; fallback chain: \`lat_lng_derived\` → \`browser_iana\` → \`utc_fallback\`.
- **Hand & Finger Stats UI** — \`GET /virtual-training/hand-finger-stats\`: By Hand = single combined \`.vt-hf-hand-summary-card\` (RIGHT + LEFT panels, desktop 2-col / mobile stacked); By Finger = 2×2 protocol cards using \`protocol_hand_diagram\` macro (same SVG as game-start screen). Accessible from VT Hub + History footer.

## Changed files (27)

| Area | Files |
|---|---|
| Service | \`virtual_training_service.py\` (+186), \`training_day.py\` (+79) |
| Route | \`virtual_training.py\` (+64) |
| Templates | \`virtual_training_hand_finger_stats.html\` (NEW 579L), hub + history nav |
| Tests | \`test_vt_hand_finger_stats.py\` (NEW 25 HFS-* service), \`test_training_day_phase2.py\` (NEW), VT route tests (+7 HFS-R*) |
| Snapshot | 856 → 857 routes |

## Test plan

- [x] 25 HFS-* service tests (no_data/low_sample/ready, canonical order, game_id forwarding)
- [x] 7 HFS-R* route tests (200/303, hand diagram render, single summary card, game filter)
- [x] 12810 full unit suite — 0 FAIL
- [x] Clean fast-forward onto main (merge base = main HEAD \`d4468418\`)
- [x] OpenAPI snapshot updated (857 routes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)