### PR TITLE
fix(mobile): fix horizontal overflow on student dashboard

### DIFF
--- a/app/static/css/student.css
+++ b/app/static/css/student.css
@@ -6,10 +6,12 @@
 
 /* ── Reset (same as admin.css baseline) ──────────────────────────────────── */
 * { margin: 0; padding: 0; box-sizing: border-box; }
+html { overflow-x: hidden; }   /* prevent horizontal scroll at document level */
 body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
     background: #f5f7fa;
     min-height: 100vh;
+    overflow-x: hidden;
 }
 
 /* ── Design Tokens ────────────────────────────────────────────────────────── */
@@ -843,11 +845,16 @@ body {
     text-decoration: none;
 }
 .mod-nav-icon  { font-size: 1.75rem; line-height: 1; }
-.mod-nav-title { font-size: 0.82rem; font-weight: 600; color: #4a5568; white-space: nowrap; }
+.mod-nav-title {
+    font-size: 0.82rem; font-weight: 600; color: #4a5568;
+    white-space: normal; word-break: break-word;
+    text-align: center; max-width: 100%;
+}
 
 @media (max-width: 768px) {
     .mod-nav-grid    { grid-template-columns: repeat(2, 1fr); gap: 0.6rem; }
     .mod-nav-section { padding: 1rem 1rem 0.25rem; }
+    .mod-nav-card    { min-width: 0; }
 }
 @media (max-width: 480px) {
     .mod-nav-grid  { gap: 0.5rem; }

--- a/app/templates/dashboard_student_new.html
+++ b/app/templates/dashboard_student_new.html
@@ -136,9 +136,11 @@
             grid-template-columns: 1fr;
             grid-auto-rows: unset;
         }
-        .dc-hero { height: auto; overflow: visible; }
-        .s-kpi-row { grid-template-columns: repeat(2, 1fr); }
-        .container { padding: 1rem; }
+        .dc-hero      { height: auto; overflow: hidden; }
+        .s-kpi-row    { grid-template-columns: repeat(2, 1fr); }
+        .s-kpi-card   { min-width: 0; }
+        .section-block { min-width: 0; }
+        .container    { padding: 1rem; }
         .mod-nav-section { padding: 1rem 1rem 0.25rem; }
     }
 

--- a/app/templates/includes/spec_subpage_hdr.html
+++ b/app/templates/includes/spec_subpage_hdr.html
@@ -70,6 +70,11 @@
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
     scrollbar-width: none;
+    /* width:100% is required: without it the flex container expands to fit
+       all nowrap items instead of creating a scroll context */
+    width: 100%;
+    box-sizing: border-box;
+    max-width: 100%;
 }
 .spec-quicknav::-webkit-scrollbar { display: none; }
 @media (max-width: 640px) {


### PR DESCRIPTION
## Problem

Student dashboard mobilon vízszintesen görgethetővé vált — bizonyos blokkok (Social, KPI, Quick Access) a képernyő bal ~60%-ára szűkültek, jobbra fehér tér maradt.

## Root cause

`.spec-quicknav` (6 `flex-shrink:0; white-space:nowrap` pill) nem kapott `width:100%`-t. Enélkül a flex container nem hoz létre scroll contextet, hanem kitágul ~500px-re — ezzel az egész dokumentumot szélesebbé téve a mobile viewportnál.

## Fixes

**`spec_subpage_hdr.html`** — fő ok javítása:
- `.spec-quicknav`: `width:100%; max-width:100%; box-sizing:border-box` hozzáadva — most az `overflow-x:auto` valóban scroll contextet hoz létre

**`student.css`**:
- `html, body { overflow-x: hidden }` — safety net, semmi sem tud kiszaladni
- `.mod-nav-title`: `white-space:nowrap` → `normal; word-break:break-word` — "Achievements" törhet ha kell
- `.mod-nav-card` mobilon: `min-width:0` — grid item overflow guard

**`dashboard_student_new.html`** (mobile `@media`):
- `.dc-hero`: `overflow:visible` → `overflow:hidden` — iframe transform nem szivárog ki
- `.s-kpi-card`, `.section-block`: `min-width:0` hozzáadva

🤖 Generated with [Claude Code](https://claude.com/claude-code)