### PR TITLE
feat(vt): activate Stroop Challenge — is_active=True, show_in_hub=True

### DIFF
--- a/scripts/seed_virtual_training_games.py
+++ b/scripts/seed_virtual_training_games.py
@@ -5,7 +5,7 @@ config/skill_targets/base_xp/description/name/is_active updated in-place (idempo
 
 Active after seed: color_reaction, go_no_go, direction_swipe, number_color_conflict,
 memory_sequence, target_tracking.
-Inactive after seed: stroop_challenge, peripheral_vision, dual_task, fake_target,
+Inactive after seed: peripheral_vision, dual_task, fake_target,
 audio_visual_reaction, pattern_break.
 
 memory_sequence and target_tracking are challenge-compatible (CHALLENGE_COMPATIBLE_GAMES).
@@ -66,7 +66,7 @@ _GAMES = [
         },
     },
 
-    # ── 2. stroop_challenge (QA-gated — is_active=False, show_in_hub=False) ────
+    # ── 2. stroop_challenge (ACTIVE) ─────────────────────────────────────────
     {
         "code": "stroop_challenge",
         "name": "Stroop Challenge",
@@ -76,7 +76,7 @@ _GAMES = [
             "respond to what you see."
         ),
         "game_type": "cognitive_inhibition",
-        "is_active": False,
+        "is_active": True,
         "base_xp": 12,
         "max_daily_attempts": 5,
         "skill_targets": {
@@ -117,7 +117,7 @@ _GAMES = [
                 "Sharpens selective attention and response inhibition under pressure — "
                 "trains you to ignore misleading cues and act on the right information."
             ),
-            "show_in_hub": False,
+            "show_in_hub": True,
             "validation_overrides": {
                 "min_dur":  20.0,
                 "min_stim": 20,

--- a/tests/unit/api/web_routes/test_vt_stroop_challenge.py
+++ b/tests/unit/api/web_routes/test_vt_stroop_challenge.py
@@ -1,11 +1,11 @@
 """Stroop Challenge — route, submit, scoring, and regression tests.
 
-SC-01   Seed: stroop_challenge is_active=False
+SC-01   Seed: stroop_challenge is_active=True (activated after QA sign-off)
 SC-02   Seed: 3 phases defined (3×8=24 stimuli)
 SC-03   Seed: protocol_assignment="free"
 SC-04   Seed: validation_overrides present (min_dur=20.0, min_stim=20)
 SC-05   Seed: skill_targets {decisions:0.50, concentration:0.30, composure:0.20}
-SC-06   Seed: show_in_hub=False
+SC-06   Seed: show_in_hub=True (visible in hub after activation)
 SC-07   Seed: colours is a dict (not a list)
 
 SC-R01  GET /virtual-training/stroop-challenge → 200 when is_active=True (QA direct URL)
@@ -62,7 +62,7 @@ _SC_CONFIG = {
     "late_grace_ms": 300,
     "icon": "🎨",
     "football_benefit": "Sharpens selective attention.",
-    "show_in_hub": False,
+    "show_in_hub": True,
     "validation_overrides": {"min_dur": 20.0, "min_stim": 20},
 }
 
@@ -196,9 +196,9 @@ class TestStroopSeedConfig:
         from scripts.seed_virtual_training_games import _GAMES
         self._game = next(g for g in _GAMES if g["code"] == "stroop_challenge")
 
-    def test_sc01_stroop_is_inactive(self):
-        """SC-01: stroop_challenge is_active=False (QA-gated)."""
-        assert self._game["is_active"] is False
+    def test_sc01_stroop_is_active(self):
+        """SC-01: stroop_challenge is_active=True (activated after QA sign-off)."""
+        assert self._game["is_active"] is True
 
     def test_sc02_three_phases_24_stimuli(self):
         """SC-02: config has 3 phases summing to 24 stimuli."""
@@ -223,9 +223,9 @@ class TestStroopSeedConfig:
         assert st["concentration"] == 0.30
         assert st["composure"]     == 0.20
 
-    def test_sc06_show_in_hub_false(self):
-        """SC-06: show_in_hub=False — game hidden from the hub listing."""
-        assert self._game["config"]["show_in_hub"] is False
+    def test_sc06_show_in_hub_true(self):
+        """SC-06: show_in_hub=True — game visible in hub after activation."""
+        assert self._game["config"]["show_in_hub"] is True
 
     def test_sc07_colours_is_dict(self):
         """SC-07: colours is a dict {name: hex} not a list."""

--- a/tests/unit/scripts/test_seed_virtual_training_games.py
+++ b/tests/unit/scripts/test_seed_virtual_training_games.py
@@ -5,7 +5,7 @@ SVT-02  All game codes are unique in _GAMES
 SVT-03  memory_sequence is defined with is_active=True
 SVT-04  target_tracking is defined with is_active=True
 SVT-05  color_reaction is defined with is_active=True
-SVT-06  stroop_challenge is defined with is_active=False
+SVT-06  stroop_challenge is defined with is_active=True (activated)
 SVT-07  _UPDATE_FIELDS includes is_active (seed overrides admin toggles intentionally)
 SVT-08  _UPDATE_FIELDS includes config, name, skill_targets, base_xp, description
 SVT-09  All _CHALLENGE_COMPATIBLE codes exist in _GAMES and are active
@@ -51,10 +51,10 @@ class TestSeedGameDefinitions:
         game = next(g for g in self._games if g["code"] == "color_reaction")
         assert game["is_active"] is True
 
-    def test_svt06_stroop_inactive(self):
-        """SVT-06: stroop_challenge is_active=False."""
+    def test_svt06_stroop_active(self):
+        """SVT-06: stroop_challenge is_active=True (activated after QA sign-off)."""
         game = next(g for g in self._games if g["code"] == "stroop_challenge")
-        assert game["is_active"] is False
+        assert game["is_active"] is True
 
     def test_svt07_update_fields_includes_is_active(self):
         """SVT-07: _UPDATE_FIELDS includes is_active."""


### PR DESCRIPTION
## Summary

Activates Stroop Challenge in the Virtual Training hub after QA sign-off.

- `is_active: False → True`
- `show_in_hub: False → True`

Requires DB reseed to take effect:
```bash
python scripts/seed_virtual_training_games.py
```

## Scope

- `scripts/seed_virtual_training_games.py` — Stroop activation only
- `tests/unit/scripts/test_seed_virtual_training_games.py` — SVT-06 updated
- `tests/unit/api/web_routes/test_vt_stroop_challenge.py` — SC-01, SC-06 updated

No DB migration. No route changes. No template changes.
Does not affect HFS, Peripheral Vision, Number-Color Conflict.

## Test plan

- [x] SVT-06: asserts is_active=True
- [x] SC-01: asserts is_active=True
- [x] SC-06: asserts show_in_hub=True
- [x] 38 Stroop + seed tests PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)