### PR TITLE
fix(vt-pv): guard score_normalized None in result template

### DIFF
--- a/app/templates/virtual_training_peripheral_vision_result.html
+++ b/app/templates/virtual_training_peripheral_vision_result.html
@@ -196,13 +196,13 @@
         {% else %}
 
         {# Status icon by score threshold #}
-        {% if attempt.score_normalized >= 85 %}
+        {% if attempt.score_normalized is not none and attempt.score_normalized >= 85 %}
         <div class="pvr-status-icon">🏆</div>
         <div class="pvr-status-title">Excellent awareness!</div>
-        {% elif attempt.score_normalized >= 65 %}
+        {% elif attempt.score_normalized is not none and attempt.score_normalized >= 65 %}
         <div class="pvr-status-icon">⚡</div>
         <div class="pvr-status-title">Strong peripheral detection!</div>
-        {% elif attempt.score_normalized >= 45 %}
+        {% elif attempt.score_normalized is not none and attempt.score_normalized >= 45 %}
         <div class="pvr-status-icon">💪</div>
         <div class="pvr-status-title">Keep training your periphery!</div>
         {% else %}
@@ -210,8 +210,13 @@
         <div class="pvr-status-title">Focus on the far targets!</div>
         {% endif %}
 
+        {% if attempt.score_normalized is not none %}
         <div class="pvr-score-big">{{ attempt.score_normalized | round(0) | int }}%</div>
         <div class="pvr-score-label">Eccentricity-weighted score</div>
+        {% else %}
+        <div class="pvr-score-big">—</div>
+        <div class="pvr-score-label">Score pending</div>
+        {% endif %}
 
         {% if attempt.xp_awarded > 0 %}
         <span class="pvr-xp-badge">+{{ attempt.xp_awarded }} XP earned</span>


### PR DESCRIPTION
## Problem

`/virtual-training/peripheral-vision/result/{id}` returned **HTTP 500** whenever `attempt.score_normalized` was `NULL`.

The PV scoring pipeline stores `score_normalized=NULL` (eccentricity-weighted raw score, not the legacy normalised 0–100 path). Jinja2 comparison `>= 85` on `None` raises `TypeError`.

## Fix

Added `{% if attempt.score_normalized is not none %}` guards to all score comparisons and the score display block. When `score_normalized` is `NULL` the score card shows `—` / `Score pending` instead of crashing.

## Changed files

| File | Change |
|---|---|
| `app/templates/virtual_training_peripheral_vision_result.html` | +8 lines, null-guards on score comparisons and display |

## Test results

```
tests/unit/api/web_routes/test_peripheral_vision.py  — 10 passed
tests/unit/services/test_pv_metrics.py               — 13 passed
Total: 23 passed, 0 failed
```

## Scope

Template-only. No DB, no routes, no other VT games touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)