### PR TITLE
feat(vt-pv-gaze): Phase 1 — consent flow, Web Worker skeleton, honor mode

### DIFF
--- a/app/static/js/vt/gaze-consent.js
+++ b/app/static/js/vt/gaze-consent.js
@@ -1,0 +1,100 @@
+'use strict';
+/*
+ * GazeConsent — camera permission and GDPR consent management for PV gaze validation.
+ *
+ * Phase 1 scope:
+ *   - Pre-game consent modal display
+ *   - getUserMedia wrapper with graceful denial handling
+ *   - Camera stream lifecycle (start, stop, visibility, unload)
+ *   - sessionStorage consent caching (per-session only)
+ *
+ * Nothing in this file sends any data to the server.
+ * The camera stream stays local; only the consent decision
+ * ('granted'|'denied'|'skip') is cached in sessionStorage.
+ */
+const GazeConsent = (() => {
+    const CONSENT_KEY = 'pv_gaze_consent';
+    let _stream      = null;
+    let _hideTimer   = null;
+
+    function _stop() {
+        if (_stream) {
+            _stream.getTracks().forEach(t => t.stop());
+            _stream = null;
+        }
+        const video = document.getElementById('pv-gaze-video');
+        if (video) { video.srcObject = null; }
+    }
+
+    async function request() {
+        return new Promise(resolve => {
+            const modal = document.getElementById('pv-gaze-consent-modal');
+            if (!modal) {
+                resolve('skip');
+                return;
+            }
+
+            modal.removeAttribute('hidden');
+
+            function onEnable() {
+                modal.setAttribute('hidden', '');
+                if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+                    sessionStorage.setItem(CONSENT_KEY, 'denied');
+                    resolve('denied');
+                    return;
+                }
+                navigator.mediaDevices.getUserMedia({
+                    video: {
+                        facingMode: 'user',
+                        width:  { ideal: 640 },
+                        height: { ideal: 480 },
+                    },
+                })
+                .then(stream => {
+                    _stream = stream;
+                    const video = document.getElementById('pv-gaze-video');
+                    if (video) {
+                        video.srcObject = stream;
+                        video.play().catch(() => {});
+                    }
+                    sessionStorage.setItem(CONSENT_KEY, 'granted');
+                    resolve('granted');
+                })
+                .catch(() => {
+                    sessionStorage.setItem(CONSENT_KEY, 'denied');
+                    resolve('denied');
+                });
+            }
+
+            function onSkip() {
+                modal.setAttribute('hidden', '');
+                sessionStorage.setItem(CONSENT_KEY, 'skip');
+                resolve('skip');
+            }
+
+            const enableBtn = document.getElementById('pv-gaze-enable-btn');
+            const skipBtn   = document.getElementById('pv-gaze-skip-btn');
+            if (enableBtn) enableBtn.addEventListener('click', onEnable, { once: true });
+            if (skipBtn)   skipBtn.addEventListener('click',   onSkip,   { once: true });
+        });
+    }
+
+    function stopCamera() { _stop(); }
+
+    function getStream() { return _stream; }
+
+    // Stop camera when page unloads
+    window.addEventListener('beforeunload', _stop);
+
+    // Pause/stop on tab hide to respect camera LED expectations
+    document.addEventListener('visibilitychange', () => {
+        if (document.hidden) {
+            _hideTimer = setTimeout(_stop, 30000);
+        } else {
+            clearTimeout(_hideTimer);
+            _hideTimer = null;
+        }
+    });
+
+    return { request, stopCamera, getStream };
+})();

--- a/app/static/js/vt/gaze-worker.js
+++ b/app/static/js/vt/gaze-worker.js
@@ -1,0 +1,53 @@
+'use strict';
+/*
+ * PV Gaze Worker — Phase 1 skeleton
+ *
+ * Phase 1: proves Worker infrastructure (creation, message passing, honor-mode
+ * fallback). MediaPipe model loading is intentionally deferred to Phase 2,
+ * which will also update connect-src CSP to allow https://cdn.jsdelivr.net for
+ * WASM model weight downloads.
+ *
+ * Phase 2 will replace the 'init' handler with:
+ *   import { FaceLandmarker, FilesetResolver } from
+ *     'https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.14/vision_bundle.min.js'
+ *
+ * Phase 3 will implement the 'frame' handler to extract iris landmarks and
+ * post them back to the main thread for the calibrated regression estimator.
+ *
+ * No video frames, iris coordinates, or biometric data ever leave this Worker
+ * toward the network. Only aggregated summary scalars are included in the
+ * submit payload (handled in gaze-session.js, Phase 3).
+ */
+
+self.onmessage = function (event) {
+    var msg = event.data;
+    if (!msg || !msg.type) return;
+
+    switch (msg.type) {
+
+        case 'init':
+            // Phase 1: Worker alive — model load deferred to Phase 2.
+            // Main thread receives this error → honor mode (gaze_validated=false).
+            self.postMessage({
+                type:    'error',
+                code:    'model_deferred',
+                message: 'Phase 1 — MediaPipe model load deferred to Phase 2',
+            });
+            break;
+
+        case 'frame':
+            // Phase 3 will extract iris landmarks from the ImageBitmap here.
+            // For now, just release the bitmap memory.
+            if (msg.bitmap) {
+                msg.bitmap.close();
+            }
+            break;
+
+        case 'stop':
+            // Clean shutdown — nothing to tear down in Phase 1.
+            break;
+
+        default:
+            break;
+    }
+};

--- a/app/templates/includes/vt/pv_gaze_consent_modal.html
+++ b/app/templates/includes/vt/pv_gaze_consent_modal.html
@@ -1,0 +1,60 @@
+{# Peripheral Vision — Gaze Validation Consent Modal
+   Phase 1: consent + privacy notice.
+   All processing is client-side only; no video or biometric data is sent to the server.
+#}
+<div id="pv-gaze-consent-modal"
+     hidden
+     role="dialog"
+     aria-modal="true"
+     aria-labelledby="pvGazeModalTitle"
+     style="position:fixed;inset:0;z-index:1000;
+            background:rgba(15,14,38,0.55);
+            display:flex;align-items:center;justify-content:center;padding:1rem;">
+  <div style="background:#fff;border-radius:16px;
+              padding:1.75rem 1.5rem 1.5rem;
+              max-width:420px;width:100%;
+              box-shadow:0 8px 32px rgba(0,0,0,0.22);">
+
+    <h2 id="pvGazeModalTitle"
+        style="font-size:1.05rem;font-weight:700;color:#1e1b4b;margin:0 0 0.7rem;">
+      👁 Optional: Gaze Validation
+    </h2>
+
+    <p style="font-size:0.875rem;color:#4b5563;line-height:1.6;margin:0 0 0.5rem;">
+      This game can optionally use your front camera to verify that you keep
+      your eyes on the central fixation cross during play.
+      All analysis runs <strong>entirely on your device</strong>.
+    </p>
+
+    <ul style="font-size:0.82rem;color:#6b7280;line-height:1.75;
+               padding-left:1.15rem;margin:0 0 0.9rem;">
+      <li>No video frames or images are sent to the server</li>
+      <li>No iris coordinates or face data leave your browser</li>
+      <li>Only a summary (e.g. "kept gaze 87% of the time") is saved</li>
+    </ul>
+
+    <p style="font-size:0.78rem;color:#9ca3af;margin:0 0 1.25rem;">
+      Skipping the camera is fine — your attempt will still be counted normally.
+    </p>
+
+    <div style="display:flex;gap:0.65rem;flex-wrap:wrap;">
+      <button id="pv-gaze-enable-btn"
+              style="flex:1;min-width:130px;
+                     padding:0.65rem 1rem;
+                     background:#4f46e5;color:#fff;
+                     border:none;border-radius:8px;
+                     font-size:0.88rem;font-weight:600;cursor:pointer;">
+        Enable camera
+      </button>
+      <button id="pv-gaze-skip-btn"
+              style="flex:1;min-width:130px;
+                     padding:0.65rem 1rem;
+                     background:#f3f4f6;color:#374151;
+                     border:none;border-radius:8px;
+                     font-size:0.88rem;font-weight:600;cursor:pointer;">
+        Play without camera
+      </button>
+    </div>
+
+  </div>
+</div>

--- a/app/templates/virtual_training_peripheral_vision.html
+++ b/app/templates/virtual_training_peripheral_vision.html
@@ -620,10 +620,15 @@ function endGame() {
                 protocol_difficulty_multiplier: 1.0,
                 assignment_source: "system", self_declared: true, not_verified: true,
             },
+            gaze_validation: PvGaze.summary(),
         },
         browser_timezone: Intl.DateTimeFormat().resolvedOptions().timeZone || null,
         location:         VtLocation.get(),
     };
+
+    // Stop camera and worker after game ends — before network request
+    PvGaze.stop();
+    GazeConsent.stopCamera();
 
     fetch("/virtual-training/peripheral-vision/submit", {
         method:  "POST",
@@ -647,6 +652,76 @@ function endGame() {
     });
 }
 
+// ── Gaze infrastructure (Phase 1) ────────────────────────────────────────────
+//
+// PvGaze: thin wrapper that tracks the consent decision and exposes summary().
+// Phase 2 will extend this with calibration; Phase 3 with live estimation.
+// summary() always returns a valid object — backend handles all cases gracefully.
+//
+var PvGaze = (function () {
+    var _cameraDenied = true;   // conservative default: assume no camera
+    var _worker       = null;
+    var _workerAlive  = false;
+
+    function init(consentResult) {
+        _cameraDenied = consentResult !== "granted";
+
+        if (!_cameraDenied && window.Worker) {
+            try {
+                _worker = new Worker("/static/js/vt/gaze-worker.js");
+                _worker.onmessage = function (e) {
+                    if (e.data && e.data.type === "ready") {
+                        _workerAlive = true;
+                        var badge = document.getElementById("pv-gaze-badge");
+                        if (badge) badge.removeAttribute("hidden");
+                    }
+                    // error (model_deferred in Phase 1) → stay in honor mode
+                };
+                _worker.onerror = function () { _worker = null; };
+                _worker.postMessage({ type: "init" });
+            } catch (_) {
+                _worker = null;
+            }
+        }
+    }
+
+    function stop() {
+        if (_worker) { _worker.postMessage({ type: "stop" }); _worker = null; }
+    }
+
+    function summary() {
+        // Phase 1: model not loaded yet → gaze_validated always false.
+        // Aggregated fields only — no iris/camera data.
+        return {
+            enabled:               !_cameraDenied,
+            gaze_validated:        false,   // Phase 3 will set true when model works
+            fixation_rate:         null,
+            drift_count:           null,
+            camera_denied:         _cameraDenied,
+            validation_confidence: "none",
+            calibration_quality:   null,
+            calibration_error_deg: null,
+            frames_tracked:        0,
+            model_used:            "none",  // Phase 2: mediapipe_face_landmarker_v1
+            near_zone_validated:   false,
+        };
+    }
+
+    return { init: init, stop: stop, summary: summary };
+}());
+
+// ── Consent-gated start wrapper ───────────────────────────────────────────────
+window.pvStartWithConsent = async function () {
+    var btn = document.getElementById("btnStart");
+    if (btn) btn.disabled = true;
+
+    var consentResult = await GazeConsent.request();
+    PvGaze.init(consentResult);
+
+    pvStart();
+};
+
 }());
 </script>
+<script src="/static/js/vt/gaze-consent.js"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary

Phase 1 of the Gaze Estimation MVP for Peripheral Vision.
Establishes the client-side infrastructure only — no MediaPipe model load, no calibration, no scoring changes.

## What this adds

| Component | File | Role |
|---|---|---|
| Consent module | `app/static/js/vt/gaze-consent.js` | getUserMedia, GDPR modal driver, stream lifecycle |
| Worker skeleton | `app/static/js/vt/gaze-worker.js` | Web Worker protocol (model load deferred to Phase 2) |
| Consent modal | `app/templates/includes/vt/pv_gaze_consent_modal.html` | GDPR-compliant privacy notice + two-button choice |
| Template wiring | `app/templates/virtual_training_peripheral_vision.html` | Modal include, video element, PvGaze IIFE, consent-gated start |

## How it works

1. Player clicks **▶ Start Game** → `pvStartWithConsent()` async wrapper runs
2. Consent modal appears with full privacy disclosure
3. Player chooses:
   - **Enable camera** → `getUserMedia` → stream starts → `PvGaze.init("granted")` → Worker created → `pvStart()`
   - **Play without camera** → `PvGaze.init("skip")` → honor mode → `pvStart()`
4. Worker posts `{ type: "error", code: "model_deferred" }` (Phase 1 always → honor mode)
5. On game end: `PvGaze.stop()` + `GazeConsent.stopCamera()` before submit
6. Submit payload includes `raw_metrics.gaze_validation = PvGaze.summary()`:

```json
{
  "enabled": false,
  "gaze_validated": false,
  "camera_denied": true,
  "validation_confidence": "none",
  "frames_tracked": 0,
  "model_used": "none"
}
```

## Privacy guarantees

- No video frames, iris coordinates, or biometric data sent to server
- Only aggregated honor-mode scalars in `gaze_validation` block
- Camera stream stops on: game end, page unload, tab hidden 30 s
- sessionStorage consent: session-scoped only, no persistence

## Scope boundaries

- **NOT included:** MediaPipe model loading (Phase 2), calibration (Phase 2), regression (Phase 3), backend invalidation (Phase 4)
- **NOT changed:** scoring, `virtual_training.py`, `virtual_training_metrics.py`, DB schema, any other VT game

## Backward compatibility

Backend already handles `gaze_validation` block gracefully (all conditions short-circuit when `gaze_validated=false`).

## Test results

```
tests/unit/api/web_routes/test_peripheral_vision.py  10 passed
tests/unit/services/test_pv_metrics.py               13 passed
Total: 23 passed, 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)