### PR TITLE
fix(vt-stroop): fix game loop freeze + start button visibility

### DIFF
--- a/app/templates/virtual_training_stroop_challenge.html
+++ b/app/templates/virtual_training_stroop_challenge.html
@@ -541,6 +541,7 @@
         startedAt = new Date().toISOString();
 
         elInstruction.style.display = "none";
+        elBtnStart.parentElement.style.display = "none";
         elArena.classList.add("active");
 
         elapsedInterval = setInterval(function() {
@@ -580,7 +581,7 @@
             windowExpiredAt = Date.now();
             setTimeout(function() {
                 if (!clickHandled && !lateHandled) {
-                    recordOutcome("missed", null);
+                    recordOutcome("missed", null, null);
                 }
                 lateHandled = true;
             }, LATE_GRACE_MS);
@@ -625,10 +626,10 @@
 
         var isCorrect = (value === currentColorName);
         var outcome   = isCorrect ? "correct" : "wrong";
-        recordOutcome(outcome, rt);
+        recordOutcome(outcome, rt, value);
     }
 
-    function recordOutcome(outcome, rt) {
+    function recordOutcome(outcome, rt, value) {
         var isCorrect = (outcome === "correct");
 
         if (isCorrect) {

--- a/tests/unit/api/web_routes/test_vt_stroop_challenge.py
+++ b/tests/unit/api/web_routes/test_vt_stroop_challenge.py
@@ -619,3 +619,82 @@ class TestStroopIntegration:
         assert eligible is True
         assert completed == 5
         assert required == 5
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# SC-JS01..05: Template JS game-loop regression (static source analysis)
+#
+# Guards against the ReferenceError bug where recordOutcome() referenced
+# `value` from handleAnswer()'s parameter scope — causing the game to freeze
+# after the first click because nextStimulus() never ran.
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _stroop_template_src() -> str:
+    from pathlib import Path
+    return (
+        Path(__file__).parents[4]
+        / "app" / "templates" / "virtual_training_stroop_challenge.html"
+    ).read_text(encoding="utf-8")
+
+
+class TestStroopJSGameLoop:
+
+    def setup_method(self):
+        self._src = _stroop_template_src()
+
+    def test_sc_js01_record_outcome_has_value_param(self):
+        """SC-JS01: recordOutcome signature must declare `value` as 3rd parameter.
+
+        Regression: without this, recordOutcome(outcome, rt) had no `value` param,
+        causing a ReferenceError on the first answer click and freezing the loop.
+        """
+        assert "function recordOutcome(outcome, rt, value)" in self._src, (
+            "recordOutcome must declare `value` as 3rd parameter — "
+            "otherwise accessing `value` inside the function raises ReferenceError."
+        )
+
+    def test_sc_js02_handle_answer_forwards_value(self):
+        """SC-JS02: handleAnswer must pass `value` to recordOutcome.
+
+        Regression: before fix, handleAnswer called recordOutcome(outcome, rt)
+        and `value` was never forwarded, so the log entry could never record
+        which colour the user tapped.
+        """
+        assert "recordOutcome(outcome, rt, value)" in self._src, (
+            "handleAnswer must forward `value` via recordOutcome(outcome, rt, value)."
+        )
+
+    def test_sc_js03_missed_timeout_passes_null_value(self):
+        """SC-JS03: timeout/missed path must pass null as the 3rd (value) argument.
+
+        Regression: before fix, the missed timeout called recordOutcome("missed", null)
+        with only 2 args — inconsistent with the corrected 3-param signature.
+        """
+        assert 'recordOutcome("missed", null, null)' in self._src, (
+            'Missed/timeout path must call recordOutcome("missed", null, null).'
+        )
+
+    def test_sc_js04_start_hides_btn_wrapper(self):
+        """SC-JS04: scStart() must hide the Start button's parent element.
+
+        Regression: before fix, scStart() only hid elInstruction, leaving the
+        Start Game button visible in the DOM throughout the entire game session.
+        """
+        assert "elBtnStart.parentElement.style.display" in self._src, (
+            "scStart() must set elBtnStart.parentElement.style.display so the "
+            "Start button disappears when the game arena activates."
+        )
+
+    def test_sc_js05_next_stimulus_in_record_outcome(self):
+        """SC-JS05: nextStimulus() must appear inside the recordOutcome function body.
+
+        Guards the core loop transition: every answered or missed stimulus must
+        call nextStimulus() to advance the sequence.
+        """
+        fn_start = self._src.find("function recordOutcome(outcome, rt, value)")
+        assert fn_start != -1, "recordOutcome(outcome, rt, value) not found in template"
+        body = self._src[fn_start: fn_start + 1400]
+        assert "nextStimulus()" in body, (
+            "nextStimulus() must be called inside recordOutcome() — "
+            "missing it halts the game loop after every stimulus."
+        )


### PR DESCRIPTION
## Summary

Fixes two bugs that made Stroop Challenge unplayable before activation.

### Bug 1 — Game loop freeze (ReferenceError) — Critical

`recordOutcome()` referenced `value` from `handleAnswer()`'s parameter scope. Since `value` is not accessible from `recordOutcome()`'s closure, the JS engine raised `ReferenceError` on every answer click, halting execution before `nextStimulus()` ran. The game froze after the first answer.

**Fix:** add `value` as explicit 3rd parameter to `recordOutcome()` and pass it from all call sites.

### Bug 2 — Start button stays visible

`scStart()` hid `elInstruction` but the Start Game button lives in a sibling `<div>` outside that element — so it stayed visible throughout the game session.

**Fix:** `elBtnStart.parentElement.style.display = "none"` in `scStart()`.

## Changes

- `app/templates/virtual_training_stroop_challenge.html` — 4 lines changed
- `tests/unit/api/web_routes/test_vt_stroop_challenge.py` — 5 JS game-loop regression tests added (SC-JS01..05, static source analysis)

## No scope changes

- `is_active=False` — unchanged
- `show_in_hub=False` — unchanged
- No backend, route, seed, or scoring changes

## Test plan

- [x] SC-JS01..05: JS regression tests PASS (static template analysis)
- [x] All 31 SC-* tests PASS
- [x] Full unit suite: **12 864 PASS, 0 FAIL**

🤖 Generated with [Claude Code](https://claude.com/claude-code)