### PR TITLE
feat(vt-stroop): activate Stroop Challenge for QA testing

### DIFF
--- a/scripts/seed_virtual_training_games.py
+++ b/scripts/seed_virtual_training_games.py
@@ -66,7 +66,7 @@ _GAMES = [
         },
     },
 
-    # ── 2. stroop_challenge (QA-gated — is_active=False, show_in_hub=False) ────
+    # ── 2. stroop_challenge ───────────────────────────────────────────────────
     {
         "code": "stroop_challenge",
         "name": "Stroop Challenge",
@@ -76,7 +76,7 @@ _GAMES = [
             "respond to what you see."
         ),
         "game_type": "cognitive_inhibition",
-        "is_active": False,
+        "is_active": True,
         "base_xp": 12,
         "max_daily_attempts": 5,
         "skill_targets": {
@@ -117,7 +117,7 @@ _GAMES = [
                 "Sharpens selective attention and response inhibition under pressure — "
                 "trains you to ignore misleading cues and act on the right information."
             ),
-            "show_in_hub": False,
+            "show_in_hub": True,
             "validation_overrides": {
                 "min_duration_seconds": 20.0,
                 "min_stimuli_count":    20,

--- a/tests/unit/api/web_routes/test_vt_stroop_challenge.py
+++ b/tests/unit/api/web_routes/test_vt_stroop_challenge.py
@@ -1,17 +1,17 @@
 """Stroop Challenge — route, submit, scoring, and regression tests.
 
-SC-01   Seed: stroop_challenge is_active=False
+SC-01   Seed: stroop_challenge is_active=True (activated for QA testing)
 SC-02   Seed: 3 phases defined (3×8=24 stimuli)
 SC-03   Seed: protocol_assignment="free"
 SC-04   Seed: validation_overrides uses canonical keys (min_duration_seconds, min_stimuli_count)
 SC-04b  Seed: validation_overrides no legacy keys (min_dur, min_stim absent)
 SC-04c  Seed: 24 stimuli passes validation with Stroop overrides applied
 SC-05   Seed: skill_targets {decisions:0.50, concentration:0.30, composure:0.20}
-SC-06   Seed: show_in_hub=False
+SC-06   Seed: show_in_hub=True (hub-visible after activation)
 SC-07   Seed: colours is a dict (not a list)
 
 SC-R01  GET /virtual-training/stroop-challenge → 200 when is_active=True (QA direct URL)
-SC-R02  GET /virtual-training/stroop-challenge → hub+error when is_active=False (normal state)
+SC-R02  GET /virtual-training/stroop-challenge → hub+error when is_active=False
 SC-R03  GET /virtual-training/stroop-challenge → 303 redirect when not onboarded
 SC-R04  POST /virtual-training/stroop-challenge/submit → 200 + attempt_id on valid payload
 SC-R05  POST submit → 429 when daily cap exhausted (5/5 via training_local_date)
@@ -199,9 +199,9 @@ class TestStroopSeedConfig:
         from scripts.seed_virtual_training_games import _GAMES
         self._game = next(g for g in _GAMES if g["code"] == "stroop_challenge")
 
-    def test_sc01_stroop_is_inactive(self):
-        """SC-01: stroop_challenge is_active=False (QA-gated)."""
-        assert self._game["is_active"] is False
+    def test_sc01_stroop_is_active(self):
+        """SC-01: stroop_challenge is_active=True (activated for QA testing)."""
+        assert self._game["is_active"] is True
 
     def test_sc02_three_phases_24_stimuli(self):
         """SC-02: config has 3 phases summing to 24 stimuli."""
@@ -264,9 +264,9 @@ class TestStroopSeedConfig:
         assert st["concentration"] == 0.30
         assert st["composure"]     == 0.20
 
-    def test_sc06_show_in_hub_false(self):
-        """SC-06: show_in_hub=False — game hidden from the hub listing."""
-        assert self._game["config"]["show_in_hub"] is False
+    def test_sc06_show_in_hub_true(self):
+        """SC-06: show_in_hub=True — game visible in the Virtual Games hub after activation."""
+        assert self._game["config"]["show_in_hub"] is True
 
     def test_sc07_colours_is_dict(self):
         """SC-07: colours is a dict {name: hex} not a list."""

--- a/tests/unit/scripts/test_seed_virtual_training_games.py
+++ b/tests/unit/scripts/test_seed_virtual_training_games.py
@@ -5,7 +5,7 @@ SVT-02  All game codes are unique in _GAMES
 SVT-03  memory_sequence is defined with is_active=True
 SVT-04  target_tracking is defined with is_active=True
 SVT-05  color_reaction is defined with is_active=True
-SVT-06  stroop_challenge is defined with is_active=False
+SVT-06  stroop_challenge is defined with is_active=True (activated for QA testing)
 SVT-07  _UPDATE_FIELDS includes is_active (seed overrides admin toggles intentionally)
 SVT-08  _UPDATE_FIELDS includes config, name, skill_targets, base_xp, description
 SVT-09  All _CHALLENGE_COMPATIBLE codes exist in _GAMES and are active
@@ -51,10 +51,10 @@ class TestSeedGameDefinitions:
         game = next(g for g in self._games if g["code"] == "color_reaction")
         assert game["is_active"] is True
 
-    def test_svt06_stroop_inactive(self):
-        """SVT-06: stroop_challenge is_active=False."""
+    def test_svt06_stroop_active(self):
+        """SVT-06: stroop_challenge is_active=True (activated for QA testing)."""
         game = next(g for g in self._games if g["code"] == "stroop_challenge")
-        assert game["is_active"] is False
+        assert game["is_active"] is True
 
     def test_svt07_update_fields_includes_is_active(self):
         """SVT-07: _UPDATE_FIELDS includes is_active."""

--- a/tests/unit/services/test_virtual_training_service.py
+++ b/tests/unit/services/test_virtual_training_service.py
@@ -24,7 +24,7 @@ VT-25   attempt 4 below-neutral performance → negative skill delta (Phase 2.4)
 VT-26   attempt 6 → empty skill delta regardless of performance
 VT-14   calculate_skill_deltas() produces correct per-skill deltas
 VT-15   calculate_skill_deltas() returns empty dict when xp_awarded=0
-VT-16   seed data: 12 games present; color_reaction+go_no_go+number_color_conflict active; stroop_challenge hidden
+VT-16   seed data: 12 games present; 7 active (incl. stroop_challenge); rest planned
 VT-17   get_training_skill_deltas_for_user() merges VT attempt deltas with segment deltas
 """
 from __future__ import annotations
@@ -259,10 +259,10 @@ class TestSkillDeltas:
 class TestSeedData:
 
     def test_vt16_seed_presets_present_and_correct_active_state(self):
-        """VT-16: Seed contains 12 games; color_reaction+go_no_go+memory_sequence+target_tracking+direction_swipe+number_color_conflict active; stroop_challenge hidden; rest planned."""
+        """VT-16: Seed contains 12 games; 7 active (incl. stroop_challenge); rest planned."""
         from scripts.seed_virtual_training_games import _GAMES
 
-        # 6 active + 1 hidden + 5 planned = 12 total
+        # 7 active + 5 planned = 12 total
         assert len(_GAMES) == 12
 
         codes = {g["code"] for g in _GAMES}
@@ -283,15 +283,18 @@ class TestSeedData:
 
         game_map = {g["code"]: g for g in _GAMES}
 
-        # Active state — 6 active games
-        _active_games = {"color_reaction", "go_no_go", "memory_sequence", "target_tracking", "direction_swipe", "number_color_conflict"}
+        # Active state — 7 active games (stroop_challenge activated for QA testing)
+        _active_games = {
+            "color_reaction", "go_no_go", "memory_sequence", "target_tracking",
+            "direction_swipe", "number_color_conflict", "stroop_challenge",
+        }
         for code in _active_games:
             assert game_map[code]["is_active"] is True, f"{code} must be active"
         for code in codes - _active_games:
             assert game_map[code]["is_active"] is False, f"{code} must remain inactive until admin toggle"
 
-        # stroop_challenge hidden from hub
-        assert game_map["stroop_challenge"]["config"].get("show_in_hub") is False
+        # stroop_challenge visible in hub after activation
+        assert game_map["stroop_challenge"]["config"].get("show_in_hub") is True
 
         # number_color_conflict has full gameplay config
         ncc_cfg = game_map["number_color_conflict"]["config"]


### PR DESCRIPTION
## Summary

- Activates Stroop Challenge for mobile QA testing
- Sets `is_active=True` and `show_in_hub=True` in the seed script
- **Activation only** — no code logic changes, no DB migration, no template changes

## What changes

| Field | Before | After |
|---|---|---|
| `is_active` | `False` | `True` |
| `show_in_hub` | `False` | `True` |

All other seed config (phases, validation_overrides, skill_targets, score_weights) is unchanged.

## Prerequisites (already on main)

- PR #243 — Stroop Challenge game (routes, templates, 26 SC-* tests)
- PR #247 — Game loop freeze + Start button fix (SC-JS01..05)
- PR #248 — Validation override key fix (SC-04b/04c — all attempts were `too_few_stimuli` before this)

## What this enables

- Stroop visible on `/virtual-training` hub with Active badge
- `/virtual-training/stroop-challenge` returns game template (not "not available")
- Start Game → 24 trials → valid result → Score/Accuracy/Conflict Cost render
- Daily cap (5/5) enforced
- VTC eligibility after 5 valid standalone attempts
- Mobile QA testing

## DB reseed required after merge

```sql
UPDATE virtual_training_games
SET is_active = TRUE,
    config = config || '{"show_in_hub": true}'::jsonb
WHERE code = 'stroop_challenge';
```
Or re-run `scripts/seed_virtual_training_games.py`.

## Test plan

- [x] SC-01: `is_active=True` ✅
- [x] SC-06: `show_in_hub=True` ✅
- [x] SVT-06: `stroop_active` ✅
- [x] 46/46 Stroop+seed unit tests PASS
- [x] `/virtual-training` hub shows Stroop with Active badge
- [x] `GET /virtual-training/stroop-challenge` returns 200 + game template
- [x] Live QA smoke PASS (Score 90%, Accuracy 96%, Conflict Cost, per-phase table)

## Not included in this PR

- PV 500 fix (separate issue — pre-existing since fd573827)
- HFS, NCC, auth changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)