### PR TITLE
feat(ios): add LFA player unlock and onboarding flow

### DIFF
--- a/app/tests/test_academy_id.py
+++ b/app/tests/test_academy_id.py
@@ -239,6 +239,67 @@ def test_aid16_qr_data_uses_verify_base_url(client, student_token):
 
 
 # ---------------------------------------------------------------------------
+# AID-17 — Registration smoke: new user INSERT succeeds with Phase 2A columns
+#
+# Regression for: "RegisterView Join the Academy → 500" caused by
+# lfa_academy_id / public_token columns missing from DB (migration not run).
+# This test catches that class of breakage at the integration level.
+# ---------------------------------------------------------------------------
+
+def test_aid17_new_user_register_does_not_500(client, db_session):
+    """
+    AID-17: POST /api/v1/auth/register-with-invitation succeeds (200) for a
+    fresh user — verifying lfa_academy_id (nullable) and public_token
+    (DB default gen_random_uuid()) don't break the INSERT.
+
+    If migration 2026_06_09_1000 is not applied, this raises UndefinedColumn
+    and the endpoint returns 500 — the bug this regression guards against.
+    """
+    from ..models.invitation_code import InvitationCode
+    from datetime import datetime, timezone
+
+    # Create a fresh, unrestricted invite code for this test
+    invite = InvitationCode(
+        code="AID17-TEST-CODE",
+        invited_name="AID17 Test Invitee",
+        is_used=False,
+        bonus_credits=50,
+        invited_email=None,
+        created_at=datetime.now(timezone.utc),
+    )
+    db_session.add(invite)
+    db_session.flush()
+
+    r = client.post(
+        "/api/v1/auth/register-with-invitation",
+        json={
+            "email":          "aid17.regression@test.lfa",
+            "password":       "TestPass123!",
+            "name":           "AID17 Regression",
+            "first_name":     "AID17",
+            "last_name":      "Regression",
+            "nickname":       "aid17reg",
+            "phone":          "+36301234500",
+            "date_of_birth":  "2000-06-01T00:00:00",
+            "nationality":    "HU",
+            "gender":         "Male",
+            "street_address": "Teszt u. 17",
+            "city":           "Budapest",
+            "postal_code":    "1000",
+            "country":        "Hungary",
+            "invitation_code": "AID17-TEST-CODE",
+        },
+    )
+    assert r.status_code == 200, (
+        f"Registration returned {r.status_code} — "
+        f"likely missing migration 2026_06_09_1000 (lfa_academy_id/public_token).\n"
+        f"Response: {r.text[:300]}"
+    )
+    body = r.json()
+    assert "access_token" in body, "No access_token in registration response"
+
+
+# ---------------------------------------------------------------------------
 # Unit: specialization display labels
 # ---------------------------------------------------------------------------
 

--- a/ios/LFAEducationCenter.xcodeproj/project.pbxproj
+++ b/ios/LFAEducationCenter.xcodeproj/project.pbxproj
@@ -46,6 +46,10 @@
 		BB000004000000000000037 /* AcademyIDResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000039 /* AcademyIDResponse.swift */; };
 		BB000004000000000000038 /* AcademyIDViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000040 /* AcademyIDViewModel.swift */; };
 		BB000004000000000000039 /* AcademyIDFullScreenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000041 /* AcademyIDFullScreenView.swift */; };
+		BB000004000000000000040 /* CreditTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000042 /* CreditTransaction.swift */; };
+		BB000004000000000000041 /* CreditsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000043 /* CreditsViewModel.swift */; };
+		BB000004000000000000042 /* CreditsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000044 /* CreditsView.swift */; };
+		BB000004000000000000043 /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000045 /* ProfileView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -90,6 +94,10 @@
 		BB000003000000000000039 /* AcademyIDResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcademyIDResponse.swift; sourceTree = "<group>"; };
 		BB000003000000000000040 /* AcademyIDViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcademyIDViewModel.swift; sourceTree = "<group>"; };
 		BB000003000000000000041 /* AcademyIDFullScreenView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcademyIDFullScreenView.swift; sourceTree = "<group>"; };
+		BB000003000000000000042 /* CreditTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreditTransaction.swift; sourceTree = "<group>"; };
+		BB000003000000000000043 /* CreditsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreditsViewModel.swift; sourceTree = "<group>"; };
+		BB000003000000000000044 /* CreditsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreditsView.swift; sourceTree = "<group>"; };
+		BB000003000000000000045 /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -132,6 +140,8 @@
 				BB000002000000000000011 /* Education */,
 				BB000002000000000000012 /* Training */,
 				BB000002000000000000013 /* Networking */,
+				BB000002000000000000014 /* Credits */,
+				BB000002000000000000015 /* Profile */,
 				BB000003000000000000004 /* Assets.xcassets */,
 			);
 			path = LFAEducationCenter;
@@ -193,6 +203,7 @@
 				BB000003000000000000027 /* SpecializationProgress.swift */,
 				BB000003000000000000028 /* SkillProfile.swift */,
 				BB000003000000000000039 /* AcademyIDResponse.swift */,
+				BB000003000000000000042 /* CreditTransaction.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -244,6 +255,23 @@
 				BB000003000000000000017 /* APIClient.swift */,
 			);
 			path = Networking;
+			sourceTree = "<group>";
+		};
+		BB000002000000000000014 /* Credits */ = {
+			isa = PBXGroup;
+			children = (
+				BB000003000000000000043 /* CreditsViewModel.swift */,
+				BB000003000000000000044 /* CreditsView.swift */,
+			);
+			path = Credits;
+			sourceTree = "<group>";
+		};
+		BB000002000000000000015 /* Profile */ = {
+			isa = PBXGroup;
+			children = (
+				BB000003000000000000045 /* ProfileView.swift */,
+			);
+			path = Profile;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -353,6 +381,10 @@
 				BB000004000000000000037 /* AcademyIDResponse.swift in Sources */,
 				BB000004000000000000038 /* AcademyIDViewModel.swift in Sources */,
 				BB000004000000000000039 /* AcademyIDFullScreenView.swift in Sources */,
+				BB000004000000000000040 /* CreditTransaction.swift in Sources */,
+				BB000004000000000000041 /* CreditsViewModel.swift in Sources */,
+				BB000004000000000000042 /* CreditsView.swift in Sources */,
+				BB000004000000000000043 /* ProfileView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/LFAEducationCenter.xcodeproj/project.pbxproj
+++ b/ios/LFAEducationCenter.xcodeproj/project.pbxproj
@@ -42,6 +42,10 @@
 		BB000004000000000000033 /* RegisterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000035 /* RegisterView.swift */; };
 		BB000004000000000000034 /* WelcomeSuccessView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000036 /* WelcomeSuccessView.swift */; };
 		BB000004000000000000035 /* AcademyIDCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000037 /* AcademyIDCardView.swift */; };
+		BB000004000000000000036 /* QRCodeGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000038 /* QRCodeGenerator.swift */; };
+		BB000004000000000000037 /* AcademyIDResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000039 /* AcademyIDResponse.swift */; };
+		BB000004000000000000038 /* AcademyIDViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000040 /* AcademyIDViewModel.swift */; };
+		BB000004000000000000039 /* AcademyIDFullScreenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000041 /* AcademyIDFullScreenView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -82,6 +86,10 @@
 		BB000003000000000000035 /* RegisterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterView.swift; sourceTree = "<group>"; };
 		BB000003000000000000036 /* WelcomeSuccessView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeSuccessView.swift; sourceTree = "<group>"; };
 		BB000003000000000000037 /* AcademyIDCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcademyIDCardView.swift; sourceTree = "<group>"; };
+		BB000003000000000000038 /* QRCodeGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeGenerator.swift; sourceTree = "<group>"; };
+		BB000003000000000000039 /* AcademyIDResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcademyIDResponse.swift; sourceTree = "<group>"; };
+		BB000003000000000000040 /* AcademyIDViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcademyIDViewModel.swift; sourceTree = "<group>"; };
+		BB000003000000000000041 /* AcademyIDFullScreenView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcademyIDFullScreenView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -148,6 +156,7 @@
 			children = (
 				BB000003000000000000006 /* Theme.swift */,
 				BB000003000000000000033 /* BrandLogoView.swift */,
+				BB000003000000000000038 /* QRCodeGenerator.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -183,6 +192,7 @@
 				BB000003000000000000026 /* SpecializationStatus.swift */,
 				BB000003000000000000027 /* SpecializationProgress.swift */,
 				BB000003000000000000028 /* SkillProfile.swift */,
+				BB000003000000000000039 /* AcademyIDResponse.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -196,6 +206,8 @@
 				BB000003000000000000016 /* LoginView.swift */,
 				BB000003000000000000035 /* RegisterView.swift */,
 				BB000003000000000000037 /* AcademyIDCardView.swift */,
+				BB000003000000000000040 /* AcademyIDViewModel.swift */,
+				BB000003000000000000041 /* AcademyIDFullScreenView.swift */,
 			);
 			path = Auth;
 			sourceTree = "<group>";
@@ -337,6 +349,10 @@
 				BB000004000000000000033 /* RegisterView.swift in Sources */,
 				BB000004000000000000034 /* WelcomeSuccessView.swift in Sources */,
 				BB000004000000000000035 /* AcademyIDCardView.swift in Sources */,
+				BB000004000000000000036 /* QRCodeGenerator.swift in Sources */,
+				BB000004000000000000037 /* AcademyIDResponse.swift in Sources */,
+				BB000004000000000000038 /* AcademyIDViewModel.swift in Sources */,
+				BB000004000000000000039 /* AcademyIDFullScreenView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/LFAEducationCenter.xcodeproj/project.pbxproj
+++ b/ios/LFAEducationCenter.xcodeproj/project.pbxproj
@@ -50,6 +50,8 @@
 		BB000004000000000000041 /* CreditsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000043 /* CreditsViewModel.swift */; };
 		BB000004000000000000042 /* CreditsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000044 /* CreditsView.swift */; };
 		BB000004000000000000043 /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000045 /* ProfileView.swift */; };
+		BB000004000000000000044 /* UnlockViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000046 /* UnlockViewModel.swift */; };
+		BB000004000000000000045 /* UnlockConfirmView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000047 /* UnlockConfirmView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -98,6 +100,8 @@
 		BB000003000000000000043 /* CreditsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreditsViewModel.swift; sourceTree = "<group>"; };
 		BB000003000000000000044 /* CreditsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreditsView.swift; sourceTree = "<group>"; };
 		BB000003000000000000045 /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
+		BB000003000000000000046 /* UnlockViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnlockViewModel.swift; sourceTree = "<group>"; };
+		BB000003000000000000047 /* UnlockConfirmView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnlockConfirmView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -142,6 +146,7 @@
 				BB000002000000000000013 /* Networking */,
 				BB000002000000000000014 /* Credits */,
 				BB000002000000000000015 /* Profile */,
+				BB000002000000000000016 /* Unlock */,
 				BB000003000000000000004 /* Assets.xcassets */,
 			);
 			path = LFAEducationCenter;
@@ -274,6 +279,15 @@
 			path = Profile;
 			sourceTree = "<group>";
 		};
+		BB000002000000000000016 /* Unlock */ = {
+			isa = PBXGroup;
+			children = (
+				BB000003000000000000046 /* UnlockViewModel.swift */,
+				BB000003000000000000047 /* UnlockConfirmView.swift */,
+			);
+			path = Unlock;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -385,6 +399,8 @@
 				BB000004000000000000041 /* CreditsViewModel.swift in Sources */,
 				BB000004000000000000042 /* CreditsView.swift in Sources */,
 				BB000004000000000000043 /* ProfileView.swift in Sources */,
+				BB000004000000000000044 /* UnlockViewModel.swift in Sources */,
+				BB000004000000000000045 /* UnlockConfirmView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/LFAEducationCenter.xcodeproj/project.pbxproj
+++ b/ios/LFAEducationCenter.xcodeproj/project.pbxproj
@@ -52,6 +52,10 @@
 		BB000004000000000000043 /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000045 /* ProfileView.swift */; };
 		BB000004000000000000044 /* UnlockViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000046 /* UnlockViewModel.swift */; };
 		BB000004000000000000045 /* UnlockConfirmView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000047 /* UnlockConfirmView.swift */; };
+		BB000004000000000000046 /* FootballPosition.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000048 /* FootballPosition.swift */; };
+		BB000004000000000000047 /* PitchSelectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000049 /* PitchSelectorView.swift */; };
+		BB000004000000000000048 /* LFAOnboardingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000050 /* LFAOnboardingViewModel.swift */; };
+		BB000004000000000000049 /* LFAOnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000051 /* LFAOnboardingView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -102,6 +106,10 @@
 		BB000003000000000000045 /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
 		BB000003000000000000046 /* UnlockViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnlockViewModel.swift; sourceTree = "<group>"; };
 		BB000003000000000000047 /* UnlockConfirmView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnlockConfirmView.swift; sourceTree = "<group>"; };
+		BB000003000000000000048 /* FootballPosition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FootballPosition.swift; sourceTree = "<group>"; };
+		BB000003000000000000049 /* PitchSelectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PitchSelectorView.swift; sourceTree = "<group>"; };
+		BB000003000000000000050 /* LFAOnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LFAOnboardingViewModel.swift; sourceTree = "<group>"; };
+		BB000003000000000000051 /* LFAOnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LFAOnboardingView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -147,6 +155,7 @@
 				BB000002000000000000014 /* Credits */,
 				BB000002000000000000015 /* Profile */,
 				BB000002000000000000016 /* Unlock */,
+				BB000002000000000000017 /* Onboarding */,
 				BB000003000000000000004 /* Assets.xcassets */,
 			);
 			path = LFAEducationCenter;
@@ -288,6 +297,17 @@
 			path = Unlock;
 			sourceTree = "<group>";
 		};
+		BB000002000000000000017 /* Onboarding */ = {
+			isa = PBXGroup;
+			children = (
+				BB000003000000000000048 /* FootballPosition.swift */,
+				BB000003000000000000049 /* PitchSelectorView.swift */,
+				BB000003000000000000050 /* LFAOnboardingViewModel.swift */,
+				BB000003000000000000051 /* LFAOnboardingView.swift */,
+			);
+			path = Onboarding;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -401,6 +421,10 @@
 				BB000004000000000000043 /* ProfileView.swift in Sources */,
 				BB000004000000000000044 /* UnlockViewModel.swift in Sources */,
 				BB000004000000000000045 /* UnlockConfirmView.swift in Sources */,
+				BB000004000000000000046 /* FootballPosition.swift in Sources */,
+				BB000004000000000000047 /* PitchSelectorView.swift in Sources */,
+				BB000004000000000000048 /* LFAOnboardingViewModel.swift in Sources */,
+				BB000004000000000000049 /* LFAOnboardingView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/LFAEducationCenter/App/LFASpecTabView.swift
+++ b/ios/LFAEducationCenter/App/LFASpecTabView.swift
@@ -37,15 +37,23 @@ private struct LFAProfileTab: View {
     @EnvironmentObject var dashboardVM: DashboardViewModel
     let onReturnToHub: () -> Void
 
+    @State private var isShowingAcademyID = false
+
     var body: some View {
         NavigationView {
             VStack(spacing: Theme.Spacing.md) {
                 profileHeader
                 Spacer()
+                academyIDRow
                 returnToHubButton
                 signOutButton
             }
             .navigationTitle("Profile")
+            .fullScreenCover(isPresented: $isShowingAcademyID) {
+                AcademyIDFullScreenView()
+                    .environmentObject(authManager)
+                    .environmentObject(dashboardVM)
+            }
         }
         .navigationViewStyle(.stack)
     }
@@ -89,6 +97,27 @@ private struct LFAProfileTab: View {
                     ProgressView().padding(.top, Theme.Spacing.sm)
                 }
             }
+        }
+    }
+
+    // My Academy ID — universally accessible from Profile tab
+    private var academyIDRow: some View {
+        Button { isShowingAcademyID = true } label: {
+            HStack {
+                Image(systemName: "creditcard.fill")
+                    .font(.system(size: 15))
+                    .foregroundColor(Theme.Color.secondary)
+                    .frame(width: 28)
+                Text("My Academy ID")
+                    .font(.body.weight(.semibold))
+                    .foregroundColor(Theme.Color.onSurface)
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(Theme.Color.muted)
+            }
+            .padding(.horizontal, Theme.Spacing.xl)
+            .frame(height: 48)
         }
     }
 

--- a/ios/LFAEducationCenter/App/LFASpecTabView.swift
+++ b/ios/LFAEducationCenter/App/LFASpecTabView.swift
@@ -38,6 +38,8 @@ private struct LFAProfileTab: View {
     let onReturnToHub: () -> Void
 
     @State private var isShowingAcademyID = false
+    @State private var isShowingCredits   = false
+    @State private var isShowingProfile   = false
 
     var body: some View {
         NavigationView {
@@ -45,12 +47,24 @@ private struct LFAProfileTab: View {
                 profileHeader
                 Spacer()
                 academyIDRow
+                creditsRow
+                profileRow
                 returnToHubButton
                 signOutButton
             }
             .navigationTitle("Profile")
             .fullScreenCover(isPresented: $isShowingAcademyID) {
                 AcademyIDFullScreenView()
+                    .environmentObject(authManager)
+                    .environmentObject(dashboardVM)
+            }
+            .fullScreenCover(isPresented: $isShowingCredits) {
+                CreditsView()
+                    .environmentObject(authManager)
+                    .environmentObject(dashboardVM)
+            }
+            .fullScreenCover(isPresented: $isShowingProfile) {
+                ProfileView()
                     .environmentObject(authManager)
                     .environmentObject(dashboardVM)
             }
@@ -100,18 +114,26 @@ private struct LFAProfileTab: View {
         }
     }
 
-    // My Academy ID — universally accessible from Profile tab
-    private var academyIDRow: some View {
-        Button { isShowingAcademyID = true } label: {
+    private func tabRow(icon: String, label: String, badge: String? = nil, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
             HStack {
-                Image(systemName: "creditcard.fill")
+                Image(systemName: icon)
                     .font(.system(size: 15))
                     .foregroundColor(Theme.Color.secondary)
                     .frame(width: 28)
-                Text("My Academy ID")
+                Text(label)
                     .font(.body.weight(.semibold))
                     .foregroundColor(Theme.Color.onSurface)
                 Spacer()
+                if let badge = badge {
+                    Text(badge)
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundColor(Theme.Color.secondary)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 3)
+                        .background(Theme.Color.secondary.opacity(0.12))
+                        .cornerRadius(Theme.Radius.sm)
+                }
                 Image(systemName: "chevron.right")
                     .font(.system(size: 12, weight: .semibold))
                     .foregroundColor(Theme.Color.muted)
@@ -119,6 +141,19 @@ private struct LFAProfileTab: View {
             .padding(.horizontal, Theme.Spacing.xl)
             .frame(height: 48)
         }
+    }
+
+    private var academyIDRow: some View {
+        tabRow(icon: "creditcard.fill", label: "My Academy ID") { isShowingAcademyID = true }
+    }
+
+    private var creditsRow: some View {
+        let cr = dashboardVM.profile?.creditBalance ?? 0
+        return tabRow(icon: "banknote", label: "Credits", badge: "\(cr) CR") { isShowingCredits = true }
+    }
+
+    private var profileRow: some View {
+        tabRow(icon: "person.fill", label: "Profile") { isShowingProfile = true }
     }
 
     private var returnToHubButton: some View {

--- a/ios/LFAEducationCenter/App/MainHubView.swift
+++ b/ios/LFAEducationCenter/App/MainHubView.swift
@@ -12,6 +12,8 @@ struct MainHubView: View {
     @EnvironmentObject var dashboardVM: DashboardViewModel
     @State private var isShowingLFASpec   = false
     @State private var isShowingAcademyID = false
+    @State private var isShowingCredits   = false
+    @State private var isShowingProfile   = false
 
     private let gridColumns = [GridItem(.adaptive(minimum: 150), spacing: Theme.Spacing.sm)]
 
@@ -34,7 +36,9 @@ struct MainHubView: View {
                             subtitle: lfaSubtitle(for: lfaState),
                             ageLabel: "5+",
                             status:   lfaSpecStatus(for: lfaState),
-                            action:   lfaState == .active ? { isShowingLFASpec = true } : nil
+                            // .active → open LFASpecTabView
+                            // .insufficientCredits → open CreditsView (R3A)
+                            action:   lfaCardAction(for: lfaState)
                         )
                         SpecCard(
                             icon:     "🏮",
@@ -66,6 +70,8 @@ struct MainHubView: View {
 
                     Divider().padding(.vertical, Theme.Spacing.xs)
                     academyIDButton
+                    creditsButton
+                    profileButton
                     Divider().padding(.vertical, Theme.Spacing.xs)
                     signOutButton
                 }
@@ -85,9 +91,31 @@ struct MainHubView: View {
                 .environmentObject(authManager)
                 .environmentObject(dashboardVM)
         }
+        .fullScreenCover(isPresented: $isShowingCredits) {
+            CreditsView()
+                .environmentObject(authManager)
+                .environmentObject(dashboardVM)
+        }
+        .fullScreenCover(isPresented: $isShowingProfile) {
+            ProfileView()
+                .environmentObject(authManager)
+                .environmentObject(dashboardVM)
+        }
     }
 
     // MARK: — LFA card helpers
+
+    // Returns the tap action for the LFA Football Player SpecCard.
+    // .active            → open LFASpecTabView (specialization dashboard)
+    // .insufficientCredits → open CreditsView (R3A: no more zsákutca)
+    // all other states   → nil (tap disabled)
+    private func lfaCardAction(for state: LFACardState) -> (() -> Void)? {
+        switch state {
+        case .active:              return { isShowingLFASpec = true }
+        case .insufficientCredits: return { isShowingCredits = true }
+        default:                   return nil
+        }
+    }
 
     private func lfaSpecStatus(for state: LFACardState) -> SpecStatus {
         switch state {
@@ -104,7 +132,9 @@ struct MainHubView: View {
         switch state {
         case .loading:             return "Loading..."
         case .ageLocked:           return "Min. age: 5 years"
-        case .insufficientCredits: return "100 CR to unlock"
+        case .insufficientCredits:
+            let cr = dashboardVM.profile?.creditBalance ?? 0
+            return "\(cr)/100 CR · Tap for credits"
         case .unlockAvailable:
             let cr = dashboardVM.profile?.creditBalance ?? 0
             return "\(cr) CR · Ready"
@@ -145,15 +175,57 @@ struct MainHubView: View {
 
     // My Academy ID — universal entry (not gated by LFA card state)
     private var academyIDButton: some View {
-        Button { isShowingAcademyID = true } label: {
+        hubEntryButton(
+            icon: "creditcard.fill",
+            label: "My Academy ID",
+            action: { isShowingAcademyID = true }
+        )
+    }
+
+    // Credits — balance overview + history + how to get info
+    private var creditsButton: some View {
+        hubEntryButton(
+            icon: "banknote",
+            label: "Credits",
+            badge: "\(dashboardVM.profile?.creditBalance ?? 0) CR",
+            action: { isShowingCredits = true }
+        )
+    }
+
+    // Profile — read-only name / email / role / Academy ID link
+    private var profileButton: some View {
+        hubEntryButton(
+            icon: "person.fill",
+            label: "Profile",
+            action: { isShowingProfile = true }
+        )
+    }
+
+    private func hubEntryButton(
+        icon: String,
+        label: String,
+        badge: String? = nil,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
             HStack {
-                Image(systemName: "creditcard.fill")
+                Image(systemName: icon)
                     .font(.system(size: 15))
                     .foregroundColor(Theme.Color.secondary)
-                Text("My Academy ID")
+                    .frame(width: 24)
+                Text(label)
                     .font(.body.weight(.semibold))
                     .foregroundColor(Theme.Color.onSurface)
                 Spacer()
+                if let badge = badge {
+                    Text(badge)
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundColor(Theme.Color.secondary)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 3)
+                        .background(Theme.Color.secondary.opacity(0.12))
+                        .cornerRadius(Theme.Radius.sm)
+                }
                 Image(systemName: "chevron.right")
                     .font(.system(size: 12, weight: .semibold))
                     .foregroundColor(Theme.Color.muted)
@@ -193,8 +265,8 @@ private enum SpecStatus {
     // Full opacity + primary title colour for actionable/prominent states.
     var isProminent: Bool {
         switch self {
-        case .active, .unlockAvailable: return true
-        default:                        return false
+        case .active, .unlockAvailable, .insufficientCredits: return true
+        default:                                              return false
         }
     }
 }

--- a/ios/LFAEducationCenter/App/MainHubView.swift
+++ b/ios/LFAEducationCenter/App/MainHubView.swift
@@ -10,7 +10,8 @@ import SwiftUI
 struct MainHubView: View {
     @EnvironmentObject var authManager: AuthManager
     @EnvironmentObject var dashboardVM: DashboardViewModel
-    @State private var isShowingLFASpec = false
+    @State private var isShowingLFASpec   = false
+    @State private var isShowingAcademyID = false
 
     private let gridColumns = [GridItem(.adaptive(minimum: 150), spacing: Theme.Spacing.sm)]
 
@@ -64,6 +65,8 @@ struct MainHubView: View {
                     }
 
                     Divider().padding(.vertical, Theme.Spacing.xs)
+                    academyIDButton
+                    Divider().padding(.vertical, Theme.Spacing.xs)
                     signOutButton
                 }
                 .padding(Theme.Spacing.md)
@@ -76,6 +79,11 @@ struct MainHubView: View {
         }
         .fullScreenCover(isPresented: $isShowingLFASpec) {
             LFASpecTabView()
+        }
+        .fullScreenCover(isPresented: $isShowingAcademyID) {
+            AcademyIDFullScreenView()
+                .environmentObject(authManager)
+                .environmentObject(dashboardVM)
         }
     }
 
@@ -132,6 +140,28 @@ struct MainHubView: View {
                     .background(Theme.Color.secondary.opacity(0.12))
                     .cornerRadius(Theme.Radius.sm)
             }
+        }
+    }
+
+    // My Academy ID — universal entry (not gated by LFA card state)
+    private var academyIDButton: some View {
+        Button { isShowingAcademyID = true } label: {
+            HStack {
+                Image(systemName: "creditcard.fill")
+                    .font(.system(size: 15))
+                    .foregroundColor(Theme.Color.secondary)
+                Text("My Academy ID")
+                    .font(.body.weight(.semibold))
+                    .foregroundColor(Theme.Color.onSurface)
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(Theme.Color.muted)
+            }
+            .padding(.horizontal, Theme.Spacing.md)
+            .frame(height: 48)
+            .background(Theme.Color.surface)
+            .cornerRadius(Theme.Radius.sm)
         }
     }
 

--- a/ios/LFAEducationCenter/App/MainHubView.swift
+++ b/ios/LFAEducationCenter/App/MainHubView.swift
@@ -10,11 +10,12 @@ import SwiftUI
 struct MainHubView: View {
     @EnvironmentObject var authManager: AuthManager
     @EnvironmentObject var dashboardVM: DashboardViewModel
-    @State private var isShowingLFASpec      = false
-    @State private var isShowingAcademyID   = false
-    @State private var isShowingCredits     = false
-    @State private var isShowingProfile     = false
+    @State private var isShowingLFASpec       = false
+    @State private var isShowingAcademyID    = false
+    @State private var isShowingCredits      = false
+    @State private var isShowingProfile      = false
     @State private var isShowingUnlockConfirm = false
+    @State private var isShowingOnboarding   = false
 
     private let gridColumns = [GridItem(.adaptive(minimum: 150), spacing: Theme.Spacing.sm)]
 
@@ -107,6 +108,11 @@ struct MainHubView: View {
                 .environmentObject(authManager)
                 .environmentObject(dashboardVM)
         }
+        .fullScreenCover(isPresented: $isShowingOnboarding) {
+            LFAOnboardingView()
+                .environmentObject(authManager)
+                .environmentObject(dashboardVM)
+        }
     }
 
     // MARK: — LFA card helpers
@@ -114,12 +120,14 @@ struct MainHubView: View {
     // Returns the tap action for the LFA Football Player SpecCard.
     // .active              → open LFASpecTabView (specialization dashboard)
     // .unlockAvailable     → open UnlockConfirmView (R3B: confirm + pay 100 CR)
+    // .setupPending        → open LFAOnboardingView (R3C: minimum onboarding)
     // .insufficientCredits → open CreditsView (R3A: no more zsákutca)
     // all other states     → nil (tap disabled)
     private func lfaCardAction(for state: LFACardState) -> (() -> Void)? {
         switch state {
         case .active:              return { isShowingLFASpec = true }
         case .unlockAvailable:     return { isShowingUnlockConfirm = true }
+        case .setupPending:        return { isShowingOnboarding = true }
         case .insufficientCredits: return { isShowingCredits = true }
         default:                   return nil
         }
@@ -146,7 +154,7 @@ struct MainHubView: View {
         case .unlockAvailable:
             let cr = dashboardVM.profile?.creditBalance ?? 0
             return "\(cr) CR · Ready"
-        case .setupPending:        return "Onboarding pending"
+        case .setupPending:        return "Tap to complete setup"
         case .active:              return "Skills · Cards"
         }
     }
@@ -270,11 +278,11 @@ private enum SpecStatus {
     case setupPending
     case comingSoon
 
-    // Full opacity + primary title colour for actionable/prominent states.
+    // Full opacity for actionable/prominent states.
     var isProminent: Bool {
         switch self {
-        case .active, .unlockAvailable, .insufficientCredits: return true
-        default:                                              return false
+        case .active, .unlockAvailable, .insufficientCredits, .setupPending: return true
+        default:                                                               return false
         }
     }
 }

--- a/ios/LFAEducationCenter/App/MainHubView.swift
+++ b/ios/LFAEducationCenter/App/MainHubView.swift
@@ -10,10 +10,11 @@ import SwiftUI
 struct MainHubView: View {
     @EnvironmentObject var authManager: AuthManager
     @EnvironmentObject var dashboardVM: DashboardViewModel
-    @State private var isShowingLFASpec   = false
-    @State private var isShowingAcademyID = false
-    @State private var isShowingCredits   = false
-    @State private var isShowingProfile   = false
+    @State private var isShowingLFASpec      = false
+    @State private var isShowingAcademyID   = false
+    @State private var isShowingCredits     = false
+    @State private var isShowingProfile     = false
+    @State private var isShowingUnlockConfirm = false
 
     private let gridColumns = [GridItem(.adaptive(minimum: 150), spacing: Theme.Spacing.sm)]
 
@@ -101,17 +102,24 @@ struct MainHubView: View {
                 .environmentObject(authManager)
                 .environmentObject(dashboardVM)
         }
+        .fullScreenCover(isPresented: $isShowingUnlockConfirm) {
+            UnlockConfirmView()
+                .environmentObject(authManager)
+                .environmentObject(dashboardVM)
+        }
     }
 
     // MARK: — LFA card helpers
 
     // Returns the tap action for the LFA Football Player SpecCard.
-    // .active            → open LFASpecTabView (specialization dashboard)
+    // .active              → open LFASpecTabView (specialization dashboard)
+    // .unlockAvailable     → open UnlockConfirmView (R3B: confirm + pay 100 CR)
     // .insufficientCredits → open CreditsView (R3A: no more zsákutca)
-    // all other states   → nil (tap disabled)
+    // all other states     → nil (tap disabled)
     private func lfaCardAction(for state: LFACardState) -> (() -> Void)? {
         switch state {
         case .active:              return { isShowingLFASpec = true }
+        case .unlockAvailable:     return { isShowingUnlockConfirm = true }
         case .insufficientCredits: return { isShowingCredits = true }
         default:                   return nil
         }

--- a/ios/LFAEducationCenter/Auth/AcademyIDFullScreenView.swift
+++ b/ios/LFAEducationCenter/Auth/AcademyIDFullScreenView.swift
@@ -1,0 +1,350 @@
+import SwiftUI
+import UIKit
+
+// Full-screen My Academy ID view — suitable for on-site verification.
+//
+// Layout (scrollable):
+//   Profile photo (96pt circle, processed → original → placeholder)
+//   Full name + lfa_academy_id (amber monospaced)
+//   Verified LFA Member badge
+//   Chip row: Member since YYYY | Specialization
+//   QR code (200×200pt, white background) — tap to toggle brightness boost
+//   Hint + verify URL
+//
+// Brightness boost:
+//   tap QR → UIScreen.main.brightness = 1.0
+//   tap again or dismiss → restore original brightness
+//
+// Privacy: email / phone / user_id / credits are never rendered.
+// Offline: fast path uses cached publicToken — QR visible without network.
+struct AcademyIDFullScreenView: View {
+
+    @EnvironmentObject private var authManager: AuthManager
+    @EnvironmentObject private var dashboardVM: DashboardViewModel
+    @StateObject         private var viewModel  = AcademyIDViewModel()
+
+    @Environment(\.presentationMode) private var presentationMode
+
+    @State private var brightnessBoostActive = false
+    @State private var originalBrightness: CGFloat = UIScreen.main.brightness
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                VStack(spacing: 0) {
+                    photoSection
+                    nameSection
+                    verifiedBadge
+                    chipRow
+                    qrSection
+                    Spacer(minLength: Theme.Spacing.xl)
+                }
+                .padding(.horizontal, Theme.Spacing.md)
+                .padding(.top, Theme.Spacing.lg)
+            }
+            .background(Color(UIColor.systemBackground).ignoresSafeArea())
+            .navigationTitle("My Academy ID")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button {
+                        restoreBrightness()
+                        presentationMode.wrappedValue.dismiss()
+                    } label: {
+                        Image(systemName: "xmark")
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundColor(Theme.Color.onSurface)
+                    }
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button {
+                        Task { await viewModel.reload(using: authManager, profile: dashboardVM.profile) }
+                    } label: {
+                        Image(systemName: "arrow.clockwise")
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundColor(Theme.Color.primary)
+                    }
+                    .disabled(isReloading)
+                }
+            }
+        }
+        .navigationViewStyle(.stack)
+        .onAppear { Task { await viewModel.load(using: authManager, profile: dashboardVM.profile) } }
+        .onDisappear { restoreBrightness() }
+    }
+
+    // MARK: — Profile photo
+
+    private var photoSection: some View {
+        let photoUrl = dashboardVM.profile?.profilePhotoProcessedUrl
+                    ?? dashboardVM.profile?.profilePhotoUrl
+
+        return Group {
+            if let url = photoUrl {
+                URLPhotoView(urlPath: url)
+                    .frame(width: 96, height: 96)
+                    .clipShape(Circle())
+                    .overlay(Circle().stroke(Theme.Color.secondary.opacity(0.4), lineWidth: 2))
+            } else {
+                Circle()
+                    .fill(Theme.Color.muted.opacity(0.08))
+                    .frame(width: 96, height: 96)
+                    .overlay(
+                        Image(systemName: "person.fill")
+                            .font(.system(size: 40))
+                            .foregroundColor(Theme.Color.muted.opacity(0.3))
+                    )
+            }
+        }
+        .padding(.bottom, Theme.Spacing.md)
+    }
+
+    // MARK: — Name + Academy ID
+
+    private var nameSection: some View {
+        VStack(spacing: 6) {
+            if let name = dashboardVM.profile?.displayName, !name.isEmpty {
+                Text(name)
+                    .font(.title2.weight(.semibold))
+                    .foregroundColor(Theme.Color.onSurface)
+                    .multilineTextAlignment(.center)
+            }
+
+            if let aid = viewModel.loadState.response?.lfaAcademyId
+                      ?? dashboardVM.profile?.lfaAcademyId {
+                Text(aid)
+                    .font(.system(size: 15, weight: .bold, design: .monospaced))
+                    .foregroundColor(Color(red: 0.91, green: 0.72, blue: 0.29)) // amber
+                    .kerning(1.2)
+            }
+        }
+        .padding(.bottom, Theme.Spacing.md)
+    }
+
+    // MARK: — Verified badge
+
+    private var verifiedBadge: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "checkmark.seal.fill")
+                .font(.system(size: 16))
+            Text("Verified LFA Member")
+                .font(.subheadline.weight(.semibold))
+        }
+        .foregroundColor(Color(red: 0.18, green: 0.80, blue: 0.44)) // green
+        .padding(.horizontal, Theme.Spacing.md)
+        .padding(.vertical, 10)
+        .background(Color(red: 0.18, green: 0.80, blue: 0.44).opacity(0.12))
+        .cornerRadius(Theme.Radius.md)
+        .padding(.bottom, Theme.Spacing.sm)
+    }
+
+    // MARK: — Chip row: Member since + Specialization
+
+    private var chipRow: some View {
+        HStack(spacing: Theme.Spacing.sm) {
+            if let year = memberSinceYear {
+                chip(label: "Member since", value: "\(year)")
+            }
+            chip(label: "Specialization", value: specializationLabel)
+        }
+        .padding(.bottom, Theme.Spacing.lg)
+    }
+
+    private func chip(label: String, value: String) -> some View {
+        VStack(spacing: 3) {
+            Text(label.uppercased())
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundColor(Theme.Color.muted)
+                .kerning(0.5)
+            Text(value)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundColor(Theme.Color.onSurface)
+                .multilineTextAlignment(.center)
+        }
+        .padding(.horizontal, Theme.Spacing.sm)
+        .padding(.vertical, 8)
+        .frame(maxWidth: .infinity)
+        .background(Theme.Color.surface)
+        .cornerRadius(Theme.Radius.sm)
+        .overlay(
+            RoundedRectangle(cornerRadius: Theme.Radius.sm)
+                .stroke(Theme.Color.secondary.opacity(0.15), lineWidth: 1)
+        )
+    }
+
+    // MARK: — QR section
+
+    @ViewBuilder
+    private var qrSection: some View {
+        switch viewModel.loadState {
+        case .loading:
+            ProgressView()
+                .frame(width: 200, height: 200)
+                .padding(.bottom, Theme.Spacing.md)
+
+        case .loaded(let response):
+            loadedQR(qrData: response.qrData)
+
+        case .error(let msg):
+            errorState(message: msg)
+
+        case .idle:
+            ProgressView()
+                .frame(width: 200, height: 200)
+                .padding(.bottom, Theme.Spacing.md)
+        }
+    }
+
+    private func loadedQR(qrData: String) -> some View {
+        VStack(spacing: Theme.Spacing.sm) {
+            if let qrImage = QRCodeGenerator.image(from: qrData, scale: 20) {
+                Image(uiImage: qrImage)
+                    .interpolation(.none)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 200, height: 200)
+                    .padding(12)
+                    .background(Color.white)
+                    .cornerRadius(Theme.Radius.md)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: Theme.Radius.md)
+                            .stroke(Theme.Color.secondary.opacity(0.2), lineWidth: 1)
+                    )
+                    .contentShape(Rectangle())
+                    .onTapGesture { toggleBrightness() }
+            }
+
+            // Brightness hint
+            HStack(spacing: 5) {
+                Image(systemName: brightnessBoostActive ? "sun.max.fill" : "sun.min")
+                    .font(.system(size: 11))
+                Text(brightnessBoostActive
+                     ? "Brightness boosted — tap to restore"
+                     : "Tap QR to boost brightness for scanning")
+                    .font(.system(size: 11))
+            }
+            .foregroundColor(brightnessBoostActive ? Theme.Color.secondary : Theme.Color.muted)
+            .animation(.easeInOut(duration: 0.2), value: brightnessBoostActive)
+
+            // Verify URL (tiny, muted — for transparency)
+            Text(qrData)
+                .font(.system(size: 8))
+                .foregroundColor(Theme.Color.muted.opacity(0.5))
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .padding(.top, 2)
+        }
+    }
+
+    private func errorState(message: String) -> some View {
+        VStack(spacing: Theme.Spacing.md) {
+            Image(systemName: "qrcode")
+                .font(.system(size: 56))
+                .foregroundColor(Theme.Color.muted.opacity(0.25))
+                .frame(width: 200, height: 200)
+
+            Text(message)
+                .font(.subheadline)
+                .foregroundColor(Theme.Color.muted)
+                .multilineTextAlignment(.center)
+
+            Button {
+                Task { await viewModel.reload(using: authManager, profile: dashboardVM.profile) }
+            } label: {
+                Text("Try Again")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundColor(Theme.Color.primary)
+                    .padding(.horizontal, Theme.Spacing.lg)
+                    .padding(.vertical, 10)
+                    .background(Theme.Color.primary.opacity(0.12))
+                    .cornerRadius(Theme.Radius.sm)
+            }
+        }
+        .padding(.vertical, Theme.Spacing.lg)
+    }
+
+    // MARK: — Brightness
+
+    private func toggleBrightness() {
+        brightnessBoostActive.toggle()
+        UIScreen.main.brightness = brightnessBoostActive ? 1.0 : originalBrightness
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+    }
+
+    private func restoreBrightness() {
+        if brightnessBoostActive {
+            UIScreen.main.brightness = originalBrightness
+            brightnessBoostActive = false
+        }
+    }
+
+    // MARK: — Computed helpers
+
+    private var isReloading: Bool {
+        if case .loading = viewModel.loadState { return true }
+        return false
+    }
+
+    private var memberSinceYear: Int? {
+        // Could come from profile if it had created_at — use lfaAcademyId year as proxy
+        guard let aid = viewModel.loadState.response?.lfaAcademyId
+                     ?? dashboardVM.profile?.lfaAcademyId,
+              aid.count >= 8 else { return nil }
+        // Format: LFA-YYYY-NNNNN — year is characters 4..7
+        let start = aid.index(aid.startIndex, offsetBy: 4)
+        let end   = aid.index(start, offsetBy: 4)
+        return Int(String(aid[start..<end]))
+    }
+
+    private var specializationLabel: String {
+        // Primary: lfaLicense from DashboardViewModel
+        if let spec = dashboardVM.lfaLicense?.specializationType {
+            return specLabel(spec) ?? spec
+        }
+        // Fallback: first active license from profile
+        if let active = dashboardVM.profile?.licenses?.first(where: { $0.isActive }) {
+            return specLabel(active.specializationType) ?? active.specializationType
+        }
+        return "No active specialization"
+    }
+
+    private func specLabel(_ raw: String) -> String? {
+        let map: [String: String] = [
+            "lfa_football_player": "LFA Football Player",
+            "lfa_coach":           "LFA Coach",
+            "gancuju_player":      "GānCuju Player",
+            "internship":          "Internship",
+        ]
+        return map[raw.lowercased()]
+    }
+}
+
+
+// MARK: — URL photo loader (reused from AcademyIDCardView, scoped privately)
+
+private struct URLPhotoView: View {
+    let urlPath: String
+    @State private var image: UIImage?
+
+    var body: some View {
+        Group {
+            if let img = image {
+                Image(uiImage: img).resizable().scaledToFill()
+            } else {
+                Rectangle()
+                    .fill(Theme.Color.muted.opacity(0.08))
+                    .overlay(ProgressView().scaleEffect(0.7))
+            }
+        }
+        .onAppear { loadImage() }
+    }
+
+    private func loadImage() {
+        guard image == nil,
+              let url = URL(string: APIConfig.baseURL + urlPath) else { return }
+        URLSession.shared.dataTask(with: url) { data, _, _ in
+            guard let data = data, let img = UIImage(data: data) else { return }
+            DispatchQueue.main.async { self.image = img }
+        }.resume()
+    }
+}

--- a/ios/LFAEducationCenter/Auth/AcademyIDViewModel.swift
+++ b/ios/LFAEducationCenter/Auth/AcademyIDViewModel.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+// ViewModel for My Academy ID full-screen view.
+//
+// Load strategy (two paths):
+//   Fast path — publicToken already in UserProfile (from /users/me cache):
+//     qr_data is assembled locally from APIConfig.verifyBaseURL.
+//     Works offline once the token is cached.
+//   Slow path — publicToken == nil (first-ever access or fresh install):
+//     Calls GET /api/v1/users/me/academy-id which lazy-assigns the ID on the
+//     backend and returns the complete response including qr_data.
+//
+// Reload forces the slow path and re-fetches from backend.
+@MainActor
+final class AcademyIDViewModel: ObservableObject {
+
+    enum LoadState {
+        case idle
+        case loading
+        case loaded(AcademyIDResponse)
+        case error(String)
+
+        var isLoaded: Bool {
+            if case .loaded = self { return true }
+            return false
+        }
+        var response: AcademyIDResponse? {
+            if case .loaded(let r) = self { return r }
+            return nil
+        }
+    }
+
+    @Published private(set) var loadState: LoadState = .idle
+
+    // MARK: — Load (guarded — no-op if already loaded)
+
+    func load(using authManager: AuthManager, profile: UserProfile?) async {
+        guard case .idle = loadState else { return }
+        await fetch(using: authManager, profile: profile, forceRemote: false)
+    }
+
+    // MARK: — Reload (forced — always hits backend)
+
+    func reload(using authManager: AuthManager, profile: UserProfile?) async {
+        loadState = .idle
+        await fetch(using: authManager, profile: profile, forceRemote: true)
+    }
+
+    // MARK: — Private
+
+    private func fetch(
+        using authManager: AuthManager,
+        profile: UserProfile?,
+        forceRemote: Bool
+    ) async {
+        loadState = .loading
+
+        // Fast path: token already known → assemble qr_data locally, no network needed.
+        if !forceRemote,
+           let token = profile?.publicToken,
+           let aid   = profile?.lfaAcademyId {
+            let qrData = APIConfig.verifyBaseURL + "/verify/" + token
+            loadState = .loaded(AcademyIDResponse(
+                lfaAcademyId: aid,
+                publicToken:  token,
+                qrUrl:        "/verify/" + token,
+                qrData:       qrData
+            ))
+            return
+        }
+
+        // Slow path: call backend.
+        do {
+            let response: AcademyIDResponse = try await authManager.authenticatedGet(
+                path: "/api/v1/users/me/academy-id"
+            )
+            loadState = .loaded(response)
+        } catch {
+            loadState = .error("Could not load Academy ID. Check your connection.")
+        }
+    }
+}

--- a/ios/LFAEducationCenter/Auth/AuthManager.swift
+++ b/ios/LFAEducationCenter/Auth/AuthManager.swift
@@ -209,6 +209,20 @@ final class AuthManager: ObservableObject {
         }
     }
 
+    // Form-encoded POST with automatic Bearer inject, single 401 refresh + retry.
+    // Used for FastAPI endpoints that declare Form(...) parameters.
+    func authenticatedFormPost<T: Decodable>(path: String, fields: [String: String]) async throws -> T {
+        guard let token = accessToken else { logout(); throw APIError.unauthorized }
+
+        do {
+            return try await APIClient.formPost(path: path, fields: fields, token: token)
+        } catch APIError.httpError(401, _) {
+            let refreshed = await performRefresh()
+            guard refreshed, let newToken = accessToken else { throw APIError.unauthorized }
+            return try await APIClient.formPost(path: path, fields: fields, token: newToken)
+        }
+    }
+
     // MARK: — Token accessors
 
     var accessToken: String? {

--- a/ios/LFAEducationCenter/Credits/CreditsView.swift
+++ b/ios/LFAEducationCenter/Credits/CreditsView.swift
@@ -1,0 +1,211 @@
+import SwiftUI
+
+// Credits overview — balance hero, how to get credits info, transaction history.
+//
+// Balance:        read from DashboardViewModel.profile.creditBalance (already loaded)
+// Transactions:   CreditsViewModel loads from GET /api/v1/lfa-player/credits/transactions
+//                 Returns 404 if no license yet → empty list, no error shown
+//
+// NOTE: There is no in-app credit purchase gateway.
+// Credits are admin-verified (offline payment / registration bonus / academic milestone).
+struct CreditsView: View {
+
+    @EnvironmentObject private var authManager:  AuthManager
+    @EnvironmentObject private var dashboardVM:  DashboardViewModel
+    @StateObject         private var viewModel   = CreditsViewModel()
+
+    @Environment(\.presentationMode) private var presentationMode
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                VStack(spacing: 0) {
+                    balanceHero
+                    howToGetSection
+                    transactionSection
+                    Spacer(minLength: Theme.Spacing.xl)
+                }
+            }
+            .background(Color(UIColor.systemBackground).ignoresSafeArea())
+            .navigationTitle("Credits")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button {
+                        presentationMode.wrappedValue.dismiss()
+                    } label: {
+                        Image(systemName: "xmark")
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundColor(Theme.Color.onSurface)
+                    }
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button {
+                        Task { await viewModel.reload(using: authManager) }
+                    } label: {
+                        Image(systemName: "arrow.clockwise")
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundColor(Theme.Color.primary)
+                    }
+                    .disabled(isLoading)
+                }
+            }
+        }
+        .navigationViewStyle(.stack)
+        .onAppear { Task { await viewModel.load(using: authManager) } }
+    }
+
+    // MARK: — Balance hero
+
+    private var balanceHero: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "creditcard.fill")
+                .font(.system(size: 36))
+                .foregroundColor(Theme.Color.secondary)
+
+            Text("\(dashboardVM.profile?.creditBalance ?? 0)")
+                .font(.system(size: 48, weight: .bold, design: .rounded))
+                .foregroundColor(Theme.Color.onSurface)
+
+            Text("CR Balance")
+                .font(.subheadline)
+                .foregroundColor(Theme.Color.muted)
+
+            // Unlock cost context when insufficient
+            if (dashboardVM.profile?.creditBalance ?? 0) < 100 {
+                let needed = 100 - (dashboardVM.profile?.creditBalance ?? 0)
+                Text("You need \(needed) more CR to unlock LFA Football Player")
+                    .font(.caption)
+                    .foregroundColor(Theme.Color.error)
+                    .multilineTextAlignment(.center)
+                    .padding(.top, 4)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, Theme.Spacing.xl)
+        .padding(.horizontal, Theme.Spacing.md)
+        .background(Theme.Color.surface)
+        .padding(.horizontal, Theme.Spacing.md)
+        .padding(.top, Theme.Spacing.md)
+        .cornerRadius(Theme.Radius.md)
+    }
+
+    // MARK: — How to get credits
+
+    private var howToGetSection: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            Text("HOW TO GET CREDITS")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(Theme.Color.muted)
+                .kerning(0.8)
+                .padding(.horizontal, Theme.Spacing.md)
+                .padding(.top, Theme.Spacing.lg)
+
+            VStack(spacing: 1) {
+                infoRow(icon: "gift.fill",          title: "Registration Bonus",        detail: "Granted automatically when you join")
+                infoRow(icon: "person.badge.plus",   title: "Academy Milestones",        detail: "Awarded by your LFA instructor")
+                infoRow(icon: "building.columns",    title: "Admin Grant",               detail: "Contact your Academy administrator")
+            }
+            .background(Theme.Color.surface)
+            .cornerRadius(Theme.Radius.md)
+            .padding(.horizontal, Theme.Spacing.md)
+        }
+    }
+
+    private func infoRow(icon: String, title: String, detail: String) -> some View {
+        HStack(spacing: Theme.Spacing.sm) {
+            Image(systemName: icon)
+                .font(.system(size: 15))
+                .foregroundColor(Theme.Color.secondary)
+                .frame(width: 28)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundColor(Theme.Color.onSurface)
+                Text(detail)
+                    .font(.caption)
+                    .foregroundColor(Theme.Color.muted)
+            }
+            Spacer()
+        }
+        .padding(.horizontal, Theme.Spacing.md)
+        .padding(.vertical, 10)
+    }
+
+    // MARK: — Transaction history
+
+    @ViewBuilder
+    private var transactionSection: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            Text("TRANSACTION HISTORY")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(Theme.Color.muted)
+                .kerning(0.8)
+                .padding(.horizontal, Theme.Spacing.md)
+                .padding(.top, Theme.Spacing.lg)
+
+            switch viewModel.loadState {
+            case .loading:
+                ProgressView()
+                    .frame(maxWidth: .infinity)
+                    .padding(Theme.Spacing.lg)
+
+            case .loaded(let txs) where txs.isEmpty:
+                Text("No transactions yet.")
+                    .font(.subheadline)
+                    .foregroundColor(Theme.Color.muted)
+                    .frame(maxWidth: .infinity)
+                    .padding(Theme.Spacing.lg)
+
+            case .loaded(let txs):
+                VStack(spacing: 1) {
+                    ForEach(txs) { tx in
+                        transactionRow(tx)
+                    }
+                }
+                .background(Theme.Color.surface)
+                .cornerRadius(Theme.Radius.md)
+                .padding(.horizontal, Theme.Spacing.md)
+
+            case .error(let msg):
+                Text(msg)
+                    .font(.caption)
+                    .foregroundColor(Theme.Color.muted)
+                    .frame(maxWidth: .infinity)
+                    .padding(Theme.Spacing.lg)
+
+            case .idle:
+                EmptyView()
+            }
+        }
+    }
+
+    private func transactionRow(_ tx: CreditTransaction) -> some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(tx.typeLabel)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundColor(Theme.Color.onSurface)
+                if let desc = tx.description, !desc.isEmpty {
+                    Text(desc)
+                        .font(.caption)
+                        .foregroundColor(Theme.Color.muted)
+                        .lineLimit(1)
+                }
+            }
+            Spacer()
+            Text(tx.amountDisplay)
+                .font(.subheadline.weight(.bold))
+                .foregroundColor(tx.isCredit ? Color(red: 0.18, green: 0.80, blue: 0.44) : Theme.Color.error)
+        }
+        .padding(.horizontal, Theme.Spacing.md)
+        .padding(.vertical, 10)
+    }
+
+    // MARK: — Helpers
+
+    private var isLoading: Bool {
+        if case .loading = viewModel.loadState { return true }
+        return false
+    }
+}

--- a/ios/LFAEducationCenter/Credits/CreditsViewModel.swift
+++ b/ios/LFAEducationCenter/Credits/CreditsViewModel.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+// ViewModel for CreditsView.
+//
+// Credit balance comes from DashboardViewModel.profile.creditBalance (already loaded —
+// no extra network call needed for the balance display).
+//
+// Transaction history: GET /api/v1/lfa-player/credits/transactions
+//   Returns 404 if the user has no LFA Player license — handled gracefully
+//   (empty list, no error shown to user).
+@MainActor
+final class CreditsViewModel: ObservableObject {
+
+    enum LoadState {
+        case idle
+        case loading
+        case loaded([CreditTransaction])
+        case error(String)
+    }
+
+    @Published private(set) var loadState: LoadState = .idle
+
+    var transactions: [CreditTransaction] {
+        if case .loaded(let txs) = loadState { return txs }
+        return []
+    }
+
+    // MARK: — Load (guarded)
+
+    func load(using authManager: AuthManager) async {
+        guard case .idle = loadState else { return }
+        await fetch(using: authManager)
+    }
+
+    func reload(using authManager: AuthManager) async {
+        loadState = .idle
+        await fetch(using: authManager)
+    }
+
+    // MARK: — Private
+
+    private func fetch(using authManager: AuthManager) async {
+        loadState = .loading
+        do {
+            let txs: [CreditTransaction] = try await authManager.authenticatedGet(
+                path: "/api/v1/lfa-player/credits/transactions?limit=50"
+            )
+            loadState = .loaded(txs)
+        } catch APIError.httpError(let code, _) where code == 404 {
+            // No LFA Player license → empty history is fine (not an error)
+            loadState = .loaded([])
+        } catch {
+            loadState = .error("Could not load transaction history.")
+        }
+    }
+}

--- a/ios/LFAEducationCenter/Dashboard/DashboardView.swift
+++ b/ios/LFAEducationCenter/Dashboard/DashboardView.swift
@@ -8,7 +8,7 @@ struct DashboardView: View {
         NavigationView {
             Group {
                 switch dashboardVM.loadState {
-                case .idle, .loading:
+                case .idle, .loading, .unlocking:
                     loadingView
                 case .loaded:
                     if let profile = dashboardVM.profile {

--- a/ios/LFAEducationCenter/Dashboard/DashboardViewModel.swift
+++ b/ios/LFAEducationCenter/Dashboard/DashboardViewModel.swift
@@ -22,14 +22,15 @@ enum LFACardState {
 enum DashboardLoadState: Equatable {
     case idle
     case loading
+    case unlocking  // post-unlock reload — prevents card from flashing unlockAvailable again
     case loaded
     case error(String)
 
     static func == (lhs: DashboardLoadState, rhs: DashboardLoadState) -> Bool {
         switch (lhs, rhs) {
-        case (.idle, .idle), (.loading, .loading), (.loaded, .loaded): return true
-        case (.error(let a), .error(let b)):                           return a == b
-        default:                                                        return false
+        case (.idle, .idle), (.loading, .loading), (.unlocking, .unlocking), (.loaded, .loaded): return true
+        case (.error(let a), .error(let b)):                                                      return a == b
+        default:                                                                                   return false
         }
     }
 }
@@ -77,6 +78,19 @@ final class DashboardViewModel: ObservableObject {
 
     func reload(using authManager: AuthManager) async {
         loadState  = .idle
+        profile    = nil
+        lfaLicense = nil
+        dashboard  = nil
+        licenses   = []
+        await fetchData(using: authManager)
+    }
+
+    // MARK: — Reload after unlock
+    // Called by UnlockViewModel on success. Sets .unlocking so the card does not
+    // flash back to .unlockAvailable during the post-unlock dashboard refresh.
+
+    func reloadAfterUnlock(using authManager: AuthManager) async {
+        loadState  = .unlocking
         profile    = nil
         lfaLicense = nil
         dashboard  = nil

--- a/ios/LFAEducationCenter/Models/AcademyIDResponse.swift
+++ b/ios/LFAEducationCenter/Models/AcademyIDResponse.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+// Decoded from GET /api/v1/users/me/academy-id.
+//
+// Backend lazy-assigns lfa_academy_id + public_token on first call.
+// qr_data is the absolute URL to encode in the QR code:
+//   {VERIFY_BASE_URL}/verify/{public_token}
+struct AcademyIDResponse: Decodable {
+    let lfaAcademyId: String
+    let publicToken:  String
+    let qrUrl:        String  // relative: /verify/{token}
+    let qrData:       String  // absolute: https://lfa.hu/verify/{token}
+
+    enum CodingKeys: String, CodingKey {
+        case lfaAcademyId = "lfa_academy_id"
+        case publicToken  = "public_token"
+        case qrUrl        = "qr_url"
+        case qrData       = "qr_data"
+    }
+}

--- a/ios/LFAEducationCenter/Models/CreditTransaction.swift
+++ b/ios/LFAEducationCenter/Models/CreditTransaction.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+// Decoded from GET /api/v1/lfa-player/credits/transactions
+// Returns 404 if no LFA Player license exists — callers handle gracefully.
+struct CreditTransaction: Decodable, Identifiable {
+    let id:                   Int
+    let transactionType:      String   // e.g. "SPECIALIZATION_UNLOCK", "INVITATION_BONUS"
+    let amount:               Int      // positive = credit in, negative = credit out
+    let description:          String?
+    let createdAt:            String?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case transactionType      = "transaction_type"
+        case amount
+        case description
+        case createdAt            = "created_at"
+    }
+
+    // Signed display: "+150 CR" or "-100 CR"
+    var amountDisplay: String {
+        amount >= 0 ? "+\(amount) CR" : "\(amount) CR"
+    }
+
+    var isCredit: Bool { amount >= 0 }
+
+    // Human-readable type label
+    var typeLabel: String {
+        switch transactionType.lowercased() {
+        case "invitation_bonus":        return "Registration Bonus"
+        case "specialization_unlock":   return "Specialization Unlock"
+        case "enrollment":              return "Enrollment"
+        case "refund":                  return "Refund"
+        case "admin_grant":             return "Admin Grant"
+        default:
+            return transactionType
+                .replacingOccurrences(of: "_", with: " ")
+                .capitalized
+        }
+    }
+}

--- a/ios/LFAEducationCenter/Networking/APIClient.swift
+++ b/ios/LFAEducationCenter/Networking/APIClient.swift
@@ -6,7 +6,7 @@ import Foundation
 // Base URL sourced from APIConfig — one place to change for all environments.
 enum APIClient {
 
-    // MARK: — POST
+    // MARK: — POST (JSON)
 
     static func post<B: Encodable, T: Decodable>(
         path:  String,
@@ -15,6 +15,22 @@ enum APIClient {
     ) async throws -> T {
         var request = try buildRequest(path: path, method: "POST", token: token)
         request.httpBody = try JSONEncoder().encode(body)
+        return try await execute(request)
+    }
+
+    // MARK: — POST (Form-encoded)
+    // Used by endpoints that declare FastAPI Form(...) parameters (e.g. /specialization/unlock).
+
+    static func formPost<T: Decodable>(
+        path:   String,
+        fields: [String: String],
+        token:  String? = nil
+    ) async throws -> T {
+        var request = try buildFormRequest(path: path, token: token)
+        request.httpBody = fields
+            .map { "\($0.key)=\($0.value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? $0.value)" }
+            .joined(separator: "&")
+            .data(using: .utf8)
         return try await execute(request)
     }
 
@@ -37,6 +53,20 @@ enum APIClient {
         var request = URLRequest(url: url)
         request.httpMethod = method
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        if let token = token {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        return request
+    }
+
+    private static func buildFormRequest(path: String, token: String?) throws -> URLRequest {
+        guard let url = URL(string: APIConfig.baseURL + path) else {
+            throw APIError.invalidURL
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         if let token = token {
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")

--- a/ios/LFAEducationCenter/Onboarding/FootballPosition.swift
+++ b/ios/LFAEducationCenter/Onboarding/FootballPosition.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+// 21-position taxonomy (v2).
+// Canonical values are snake_case strings stored in the DB.
+// Mirrors app/utils/football_positions.py — keep in sync.
+struct FootballPosition: Identifiable, Equatable, Hashable {
+    let id: String        // canonical DB value e.g. "striker"
+    let label: String     // "Striker"
+    let short: String     // "ST"
+    let group: Group
+
+    enum Group: String {
+        case forward, midfielder, defender, goalkeeper
+        var label: String {
+            switch self {
+            case .forward:    return "Forwards"
+            case .midfielder: return "Midfielders"
+            case .defender:   return "Defenders"
+            case .goalkeeper: return "Goalkeepers"
+            }
+        }
+    }
+
+    static func == (lhs: FootballPosition, rhs: FootballPosition) -> Bool { lhs.id == rhs.id }
+    func hash(into hasher: inout Hasher) { hasher.combine(id) }
+}
+
+// MARK: — Static position registry (21 positions)
+
+extension FootballPosition {
+
+    static let all: [FootballPosition] = [
+        // Forwards (5)
+        .init(id: "striker",               label: "Striker",               short: "ST",  group: .forward),
+        .init(id: "centre_forward",        label: "Centre Forward",        short: "CF",  group: .forward),
+        .init(id: "left_wing",             label: "Left Wing",             short: "LW",  group: .forward),
+        .init(id: "right_wing",            label: "Right Wing",            short: "RW",  group: .forward),
+        .init(id: "second_striker",        label: "Second Striker",        short: "SS",  group: .forward),
+        // Midfielders (7)
+        .init(id: "attacking_midfield",    label: "Attacking Midfielder",  short: "AM",  group: .midfielder),
+        .init(id: "centre_midfield",       label: "Central Midfielder",    short: "CM",  group: .midfielder),
+        .init(id: "defensive_midfield",    label: "Defensive Midfielder",  short: "DM",  group: .midfielder),
+        .init(id: "left_midfield",         label: "Left Midfielder",       short: "LM",  group: .midfielder),
+        .init(id: "right_midfield",        label: "Right Midfielder",      short: "RM",  group: .midfielder),
+        .init(id: "left_centre_midfield",  label: "Left Centre Mid",       short: "LCM", group: .midfielder),
+        .init(id: "right_centre_midfield", label: "Right Centre Mid",      short: "RCM", group: .midfielder),
+        // Defenders (7)
+        .init(id: "centre_back",           label: "Centre Back",           short: "CB",  group: .defender),
+        .init(id: "left_back",             label: "Left Back",             short: "LB",  group: .defender),
+        .init(id: "right_back",            label: "Right Back",            short: "RB",  group: .defender),
+        .init(id: "left_wing_back",        label: "Left Wing Back",        short: "LWB", group: .defender),
+        .init(id: "right_wing_back",       label: "Right Wing Back",       short: "RWB", group: .defender),
+        .init(id: "left_centre_back",      label: "Left Centre-Back",      short: "LCB", group: .defender),
+        .init(id: "right_centre_back",     label: "Right Centre-Back",     short: "RCB", group: .defender),
+        // Goalkeepers (2)
+        .init(id: "goalkeeper",            label: "Goalkeeper",            short: "GK",  group: .goalkeeper),
+        .init(id: "sweeper_keeper",        label: "Sweeper Keeper",        short: "SK",  group: .goalkeeper),
+    ]
+
+    static func byId(_ id: String) -> FootballPosition? {
+        all.first { $0.id == id }
+    }
+
+    // Positions with no pitch node — shown as chip buttons below the pitch.
+    // Mirrors pitch-selector.js which omits second_striker and centre_back from node list.
+    static let noPitchPositions: [FootballPosition] = [
+        byId("second_striker")!,
+        byId("centre_back")!,
+    ]
+}
+
+// MARK: — Pitch node (visual layout)
+
+// A tappable node on the SwiftUI pitch map.
+// ST has two visual nodes (ST1, ST2) both mapping to canonical "striker".
+// x/y are fractions of the pitch interior (0-1), matching pitch-selector.js PITCH_NODES.
+struct PitchNode: Identifiable {
+    let id: String          // unique node key: "GK", "ST1", "ST2", etc.
+    let positionId: String  // canonical FootballPosition.id this node represents
+    let short: String       // display abbreviation on the button
+    let x: Double           // horizontal fraction: 0 = GK end, 1 = ST end
+    let y: Double           // vertical fraction:   0 = top,    1 = bottom
+}
+
+extension FootballPosition {
+
+    static let pitchNodes: [PitchNode] = [
+        PitchNode(id: "GK",  positionId: "goalkeeper",            short: "GK",  x: 0.02, y: 0.50),
+        PitchNode(id: "SK",  positionId: "sweeper_keeper",        short: "SK",  x: 0.10, y: 0.50),
+        PitchNode(id: "LB",  positionId: "left_back",             short: "LB",  x: 0.19, y: 0.15),
+        PitchNode(id: "LCB", positionId: "left_centre_back",      short: "LCB", x: 0.19, y: 0.37),
+        PitchNode(id: "RCB", positionId: "right_centre_back",     short: "RCB", x: 0.19, y: 0.63),
+        PitchNode(id: "RB",  positionId: "right_back",            short: "RB",  x: 0.19, y: 0.85),
+        PitchNode(id: "LWB", positionId: "left_wing_back",        short: "LWB", x: 0.28, y: 0.10),
+        PitchNode(id: "RWB", positionId: "right_wing_back",       short: "RWB", x: 0.28, y: 0.90),
+        PitchNode(id: "DM",  positionId: "defensive_midfield",    short: "DM",  x: 0.37, y: 0.50),
+        PitchNode(id: "LCM", positionId: "left_centre_midfield",  short: "LCM", x: 0.47, y: 0.33),
+        PitchNode(id: "CM",  positionId: "centre_midfield",       short: "CM",  x: 0.50, y: 0.50),
+        PitchNode(id: "RCM", positionId: "right_centre_midfield", short: "RCM", x: 0.47, y: 0.67),
+        PitchNode(id: "LM",  positionId: "left_midfield",         short: "LM",  x: 0.55, y: 0.17),
+        PitchNode(id: "RM",  positionId: "right_midfield",        short: "RM",  x: 0.55, y: 0.83),
+        PitchNode(id: "AM",  positionId: "attacking_midfield",    short: "AM",  x: 0.68, y: 0.50),
+        PitchNode(id: "LW",  positionId: "left_wing",             short: "LW",  x: 0.73, y: 0.07),
+        PitchNode(id: "RW",  positionId: "right_wing",            short: "RW",  x: 0.73, y: 0.93),
+        PitchNode(id: "CF",  positionId: "centre_forward",        short: "CF",  x: 0.83, y: 0.50),
+        PitchNode(id: "ST1", positionId: "striker",               short: "ST",  x: 0.88, y: 0.34),
+        PitchNode(id: "ST2", positionId: "striker",               short: "ST",  x: 0.88, y: 0.66),
+    ]
+}

--- a/ios/LFAEducationCenter/Onboarding/LFAOnboardingView.swift
+++ b/ios/LFAEducationCenter/Onboarding/LFAOnboardingView.swift
@@ -1,0 +1,287 @@
+import SwiftUI
+
+// Minimum onboarding for LFA Football Player (R3C).
+// Presented as fullScreenCover when lfaCardState == .setupPending.
+//
+// Collects:
+//   - Primary + secondary positions (pitch map)
+//   - Height (cm), weight (kg), preferred foot, foot dominance
+//
+// Skill payload: 44 keys × 50 (neutral / not self-assessed — R3E adds sliders).
+//
+// On success: dashboardVM.reload() → lfaLicense.onboardingCompleted = true
+//             → lfaCardState → .active → LFASpecTabView becomes accessible.
+struct LFAOnboardingView: View {
+
+    @EnvironmentObject private var authManager: AuthManager
+    @EnvironmentObject private var dashboardVM: DashboardViewModel
+    @StateObject         private var viewModel  = LFAOnboardingViewModel()
+    @Environment(\.presentationMode) private var presentationMode
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                VStack(spacing: 0) {
+                    positionSection
+                    sectionDivider
+                    physiqueSection
+                    sectionDivider
+                    submitSection
+                    Spacer(minLength: Theme.Spacing.xl)
+                }
+                .padding(.horizontal, Theme.Spacing.md)
+                .padding(.top, Theme.Spacing.md)
+            }
+            .background(Color(UIColor.systemBackground).ignoresSafeArea())
+            .navigationTitle("LFA Player Setup")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    if !isSubmitting {
+                        Button {
+                            presentationMode.wrappedValue.dismiss()
+                        } label: {
+                            Image(systemName: "xmark")
+                                .font(.system(size: 14, weight: .semibold))
+                                .foregroundColor(Theme.Color.onSurface)
+                        }
+                    }
+                }
+            }
+        }
+        .navigationViewStyle(.stack)
+    }
+
+    // MARK: — Position section
+
+    private var positionSection: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            sectionHeader("⚽", title: "YOUR POSITION")
+
+            Text("Tap to set primary. Tap again to add secondary (max 3).")
+                .font(.caption)
+                .foregroundColor(Theme.Color.muted)
+                .padding(.bottom, 2)
+
+            PitchSelectorView(
+                primaryPosition: $viewModel.primaryPosition,
+                secondaryPositions: $viewModel.secondaryPositions
+            )
+
+            if let primary = viewModel.primaryPosition {
+                positionSummary(primary: primary)
+            } else {
+                Text("No position selected yet.")
+                    .font(.caption)
+                    .foregroundColor(Theme.Color.error.opacity(0.8))
+                    .padding(.top, 2)
+            }
+        }
+    }
+
+    private func positionSummary(primary: FootballPosition) -> some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                positionBadge(primary, isPrimary: true)
+                ForEach(viewModel.secondaryPositions) { pos in
+                    positionBadge(pos, isPrimary: false)
+                }
+            }
+            .padding(.vertical, 2)
+        }
+    }
+
+    private func positionBadge(_ position: FootballPosition, isPrimary: Bool) -> some View {
+        VStack(spacing: 2) {
+            Text(position.short)
+                .font(.system(size: 11, weight: .bold))
+                .foregroundColor(.white)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(isPrimary ? Theme.Color.primary : Theme.Color.secondary)
+                .cornerRadius(4)
+            Text(isPrimary ? "Primary" : "Secondary")
+                .font(.system(size: 9))
+                .foregroundColor(Theme.Color.muted)
+        }
+    }
+
+    // MARK: — Physique section
+
+    private var physiqueSection: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.md) {
+            sectionHeader("📐", title: "PHYSICAL PROFILE")
+
+            // Height
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Text("Height")
+                        .font(.subheadline)
+                        .foregroundColor(Theme.Color.onSurface)
+                    Spacer()
+                    Text("\(Int(viewModel.heightCm.rounded())) cm")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundColor(Theme.Color.primary)
+                }
+                Slider(value: $viewModel.heightCm, in: 120...230, step: 1)
+                    .accentColor(Theme.Color.primary)
+                HStack {
+                    Text("120 cm").font(.caption2).foregroundColor(Theme.Color.muted)
+                    Spacer()
+                    Text("230 cm").font(.caption2).foregroundColor(Theme.Color.muted)
+                }
+            }
+
+            // Weight
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Text("Weight")
+                        .font(.subheadline)
+                        .foregroundColor(Theme.Color.onSurface)
+                    Spacer()
+                    Text("\(Int(viewModel.weightKg.rounded())) kg")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundColor(Theme.Color.primary)
+                }
+                Slider(value: $viewModel.weightKg, in: 35...160, step: 1)
+                    .accentColor(Theme.Color.primary)
+                HStack {
+                    Text("35 kg").font(.caption2).foregroundColor(Theme.Color.muted)
+                    Spacer()
+                    Text("160 kg").font(.caption2).foregroundColor(Theme.Color.muted)
+                }
+            }
+
+            // Preferred foot
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Preferred Foot")
+                    .font(.subheadline)
+                    .foregroundColor(Theme.Color.onSurface)
+                Picker("Preferred Foot", selection: $viewModel.preferredFoot) {
+                    Text("Left").tag("left")
+                    Text("Right").tag("right")
+                    Text("Both").tag("both")
+                }
+                .pickerStyle(.segmented)
+            }
+
+            // Foot dominance
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Text("Foot Dominance")
+                        .font(.subheadline)
+                        .foregroundColor(Theme.Color.onSurface)
+                    Spacer()
+                    Text("\(Int(viewModel.footDominance.rounded()))%")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundColor(Theme.Color.muted)
+                }
+                Slider(value: $viewModel.footDominance, in: 0...100, step: 1)
+                    .accentColor(Theme.Color.secondary)
+                HStack {
+                    Text("← Left").font(.caption2).foregroundColor(Theme.Color.muted)
+                    Spacer()
+                    Text("Right →").font(.caption2).foregroundColor(Theme.Color.muted)
+                }
+            }
+        }
+    }
+
+    // MARK: — Submit section
+
+    @ViewBuilder
+    private var submitSection: some View {
+        switch viewModel.submitState {
+        case .idle:
+            Button {
+                Task { await viewModel.submit(using: authManager) }
+            } label: {
+                Text("Complete Setup")
+                    .font(.body.weight(.semibold))
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 50)
+                    .background(viewModel.canSubmit
+                                ? Theme.Color.primary
+                                : Theme.Color.muted.opacity(0.25))
+                    .foregroundColor(viewModel.canSubmit ? .white : Theme.Color.muted)
+                    .cornerRadius(Theme.Radius.sm)
+            }
+            .disabled(!viewModel.canSubmit)
+
+        case .loading:
+            HStack(spacing: Theme.Spacing.sm) {
+                ProgressView().scaleEffect(0.9)
+                Text("Saving profile…")
+                    .font(.subheadline)
+                    .foregroundColor(Theme.Color.muted)
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: 50)
+
+        case .success:
+            HStack(spacing: Theme.Spacing.sm) {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 22))
+                    .foregroundColor(Color(red: 0.18, green: 0.80, blue: 0.44))
+                Text("Profile saved! Opening LFA Player…")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundColor(Theme.Color.onSurface)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .frame(height: 50)
+            .onAppear {
+                Task {
+                    try? await Task.sleep(nanoseconds: 800_000_000)
+                    await dashboardVM.reload(using: authManager)
+                    presentationMode.wrappedValue.dismiss()
+                }
+            }
+
+        case .error(let message):
+            VStack(spacing: Theme.Spacing.sm) {
+                HStack(spacing: 6) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundColor(Theme.Color.error)
+                    Text(message)
+                        .font(.caption)
+                        .foregroundColor(Theme.Color.onSurface)
+                        .multilineTextAlignment(.leading)
+                }
+
+                Button {
+                    viewModel.reset()
+                } label: {
+                    Text("Try Again")
+                        .font(.body.weight(.semibold))
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 44)
+                        .background(Theme.Color.primary)
+                        .foregroundColor(.white)
+                        .cornerRadius(Theme.Radius.sm)
+                }
+            }
+        }
+    }
+
+    // MARK: — Helpers
+
+    private var isSubmitting: Bool {
+        if case .loading = viewModel.submitState { return true }
+        if case .success = viewModel.submitState { return true }
+        return false
+    }
+
+    private var sectionDivider: some View {
+        Divider().padding(.vertical, Theme.Spacing.md)
+    }
+
+    private func sectionHeader(_ emoji: String, title: String) -> some View {
+        HStack(spacing: 6) {
+            Text(emoji)
+            Text(title)
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(Theme.Color.muted)
+                .kerning(0.8)
+        }
+    }
+}

--- a/ios/LFAEducationCenter/Onboarding/LFAOnboardingViewModel.swift
+++ b/ios/LFAEducationCenter/Onboarding/LFAOnboardingViewModel.swift
@@ -1,0 +1,134 @@
+import Foundation
+
+// MARK: — API types
+
+// POST /specialization/lfa-player/onboarding-submit
+// Auth: Bearer JWT (same as all authenticated API calls)
+// Body: JSON  (endpoint uses await request.json())
+private struct OnboardingRequest: Encodable {
+    let position:      String
+    let positions:     [String]
+    let skills:        [String: Int]
+    let footDominance: Double
+    let heightCm:      Int
+    let weightKg:      Int
+    let preferredFoot: String
+    let goals:         String
+    let motivation:    String
+
+    enum CodingKeys: String, CodingKey {
+        case position, positions, skills, goals, motivation
+        case footDominance = "foot_dominance"
+        case heightCm      = "height_cm"
+        case weightKg      = "weight_kg"
+        case preferredFoot = "preferred_foot"
+    }
+}
+
+private struct OnboardingResponse: Decodable {
+    let success: Bool
+    let message: String?
+}
+
+// MARK: — ViewModel
+
+// Manages LFA Player minimum onboarding form state and API submission.
+//
+// Submit sends:
+//   - primary + secondary positions (canonical snake_case)
+//   - height_cm, weight_kg, preferred_foot, foot_dominance
+//   - 44 skill keys × 50 (neutral default; no self-assessment UI in R3C)
+//
+// On success, call dashboardVM.reload() — lfaCardState transitions .setupPending → .active.
+@MainActor
+final class LFAOnboardingViewModel: ObservableObject {
+
+    // MARK: — Position
+
+    @Published var primaryPosition:    FootballPosition? = nil
+    @Published var secondaryPositions: [FootballPosition] = []
+
+    // MARK: — Physique
+
+    @Published var heightCm:      Double = 175    // slider range 120-230
+    @Published var weightKg:      Double = 72     // slider range 35-160
+    @Published var preferredFoot: String = "right"   // "left" | "right" | "both"
+    @Published var footDominance: Double = 50.0       // 0=full left, 100=full right
+
+    // MARK: — Submit state
+
+    enum SubmitState {
+        case idle, loading, success, error(String)
+    }
+    @Published private(set) var submitState: SubmitState = .idle
+
+    // MARK: — Validation
+
+    var canSubmit: Bool { primaryPosition != nil }
+
+    // MARK: — Submit
+
+    func submit(using authManager: AuthManager) async {
+        guard case .idle = submitState else { return }    // duplicate-tap guard
+        guard let primary = primaryPosition else { return }
+
+        submitState = .loading
+
+        let allPositions = ([primary] + secondaryPositions).map { $0.id }
+        let request = OnboardingRequest(
+            position:      primary.id,
+            positions:     allPositions,
+            skills:        Self.defaultSkillPayload,
+            footDominance: footDominance,
+            heightCm:      Int(heightCm.rounded()),
+            weightKg:      Int(weightKg.rounded()),
+            preferredFoot: preferredFoot,
+            goals:         "",
+            motivation:    ""
+        )
+
+        do {
+            let _: OnboardingResponse = try await authManager.authenticatedPost(
+                path: "/specialization/lfa-player/onboarding-submit",
+                body: request
+            )
+            submitState = .success
+
+        } catch APIError.httpError(let code, let detail) where code == 422 {
+            submitState = .error(detail ?? "Validation error. Please check your inputs.")
+
+        } catch APIError.httpError(let code, let detail) where code == 500 {
+            submitState = .error(detail ?? "Server error. Please try again.")
+
+        } catch APIError.unauthorized {
+            submitState = .error("Session expired. Please sign in again.")
+
+        } catch {
+            submitState = .error("Network error. Please check your connection and try again.")
+        }
+    }
+
+    func reset() { submitState = .idle }
+
+    // MARK: — Default 44×50 skill payload
+
+    // The backend stores self_assessment separately from current_level (60.0 baseline).
+    // Sending 50 for all skills means "neutral / not yet self-assessed" in R3C.
+    // R3E (skill sliders) will replace this with user-assessed values.
+    static let defaultSkillPayload: [String: Int] = Dictionary(
+        uniqueKeysWithValues: skillKeys.map { ($0, 50) }
+    )
+
+    // 44 keys from app/skills_config.py get_all_skill_keys() — must match exactly.
+    static let skillKeys: [String] = [
+        "ball_control", "dribbling", "finishing", "shot_power", "long_shots",
+        "volleys", "crossing", "passing", "heading", "tackle",
+        "marking", "shooting", "technique", "creativity", "long_passing",
+        "flair", "touch", "forward_runs", "throwing", "free_kicks",
+        "corners", "penalties", "positioning_off", "positioning_def", "vision",
+        "aggression", "reactions", "composure", "consistency", "tactical_awareness",
+        "anticipation", "concentration", "decisions", "determination", "teamwork",
+        "leadership", "acceleration", "sprint_speed", "agility", "jumping",
+        "strength", "stamina", "balance", "work_rate",
+    ]
+}

--- a/ios/LFAEducationCenter/Onboarding/PitchSelectorView.swift
+++ b/ios/LFAEducationCenter/Onboarding/PitchSelectorView.swift
@@ -1,0 +1,206 @@
+import SwiftUI
+
+// Interactive football pitch for primary + secondary position selection.
+//
+// Layout: landscape pitch (GK left → ST right) with circular tappable nodes.
+// ST has two visual nodes (ST1, ST2) both representing canonical "striker".
+// second_striker and centre_back have no pitch node — shown as chips below.
+//
+// Tap rules:
+//   tap unselected node  → primary (if no primary yet) else secondary (if < 3)
+//   tap primary node     → deselect primary
+//   tap secondary node   → remove from secondary
+//   tap when 3 secondaries already selected → no-op
+struct PitchSelectorView: View {
+
+    @Binding var primaryPosition:    FootballPosition?
+    @Binding var secondaryPositions: [FootballPosition]
+
+    // Inner margin keeps edge nodes (GK at x=0.02, LW at y=0.07) fully visible.
+    private let margin: Double = 14
+    private let nodeSize: Double = 26
+
+    var body: some View {
+        VStack(spacing: 8) {
+            pitchMap
+            noPitchChips
+        }
+    }
+
+    // MARK: — Pitch map
+
+    private var pitchMap: some View {
+        GeometryReader { geo in
+            let innerW = geo.size.width  - 2 * margin
+            let innerH = geo.size.height - 2 * margin
+
+            ZStack {
+                PitchBackground()
+
+                ForEach(FootballPosition.pitchNodes) { node in
+                    PitchNodeButton(
+                        short: node.short,
+                        state: nodeState(positionId: node.positionId)
+                    )
+                    .frame(width: nodeSize, height: nodeSize)
+                    .position(
+                        x: margin + innerW * node.x,
+                        y: margin + innerH * node.y
+                    )
+                    .onTapGesture { handleTap(positionId: node.positionId) }
+                }
+            }
+        }
+        .aspectRatio(1.9, contentMode: .fit)
+        .cornerRadius(6)
+    }
+
+    // MARK: — No-pitch-node chips (SS, CB)
+
+    @ViewBuilder
+    private var noPitchChips: some View {
+        if !FootballPosition.noPitchPositions.isEmpty {
+            HStack(spacing: 6) {
+                Text("Also:")
+                    .font(.caption2)
+                    .foregroundColor(Theme.Color.muted)
+                ForEach(FootballPosition.noPitchPositions) { pos in
+                    Button { handleTap(positionId: pos.id) } label: {
+                        Text(pos.short)
+                            .font(.system(size: 11, weight: .bold))
+                            .foregroundColor(chipTextColor(positionId: pos.id))
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 4)
+                            .background(chipBgColor(positionId: pos.id))
+                            .cornerRadius(4)
+                    }
+                }
+                Spacer()
+            }
+        }
+    }
+
+    // MARK: — State helpers
+
+    private func nodeState(positionId: String) -> PitchNodeState {
+        if primaryPosition?.id == positionId { return .primary }
+        if secondaryPositions.contains(where: { $0.id == positionId }) { return .secondary }
+        return .none
+    }
+
+    private func chipBgColor(positionId: String) -> Color {
+        switch nodeState(positionId: positionId) {
+        case .primary:   return Theme.Color.primary
+        case .secondary: return Theme.Color.secondary
+        case .none:      return Theme.Color.muted.opacity(0.15)
+        }
+    }
+
+    private func chipTextColor(positionId: String) -> Color {
+        nodeState(positionId: positionId) == .none ? Theme.Color.onSurface : .white
+    }
+
+    // MARK: — Tap logic
+
+    private func handleTap(positionId: String) {
+        guard let position = FootballPosition.byId(positionId) else { return }
+
+        if primaryPosition?.id == positionId {
+            primaryPosition = nil
+        } else if secondaryPositions.contains(where: { $0.id == positionId }) {
+            secondaryPositions.removeAll { $0.id == positionId }
+        } else if primaryPosition == nil {
+            primaryPosition = position
+        } else if secondaryPositions.count < 3 {
+            secondaryPositions.append(position)
+        }
+        // max 3 secondary already set — tap ignored silently
+    }
+}
+
+// MARK: — Pitch background
+
+private struct PitchBackground: View {
+    var body: some View {
+        GeometryReader { geo in
+            let w = geo.size.width
+            let h = geo.size.height
+            let paW = w * 0.13
+            let paH = h * 0.44
+
+            ZStack {
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(Color(red: 0.18, green: 0.52, blue: 0.22))
+
+                RoundedRectangle(cornerRadius: 4)
+                    .stroke(Color.white.opacity(0.55), lineWidth: 1.5)
+                    .padding(3)
+
+                // Center line
+                Path { p in
+                    p.move(to:    CGPoint(x: w / 2, y: 4))
+                    p.addLine(to: CGPoint(x: w / 2, y: h - 4))
+                }
+                .stroke(Color.white.opacity(0.4), lineWidth: 1)
+
+                // Center circle
+                let cR = h * 0.16
+                Path { p in
+                    p.addEllipse(in: CGRect(x: w/2 - cR, y: h/2 - cR, width: cR * 2, height: cR * 2))
+                }
+                .stroke(Color.white.opacity(0.4), lineWidth: 1)
+
+                // Left penalty area
+                Path { p in
+                    p.addRect(CGRect(x: 3, y: h/2 - paH/2, width: paW, height: paH))
+                }
+                .stroke(Color.white.opacity(0.38), lineWidth: 1)
+
+                // Right penalty area
+                Path { p in
+                    p.addRect(CGRect(x: w - 3 - paW, y: h/2 - paH/2, width: paW, height: paH))
+                }
+                .stroke(Color.white.opacity(0.38), lineWidth: 1)
+            }
+        }
+    }
+}
+
+// MARK: — Node button
+
+private enum PitchNodeState { case none, primary, secondary }
+
+private struct PitchNodeButton: View {
+    let short: String
+    let state: PitchNodeState
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .fill(bgColor)
+                .shadow(color: .black.opacity(0.28), radius: 2, x: 0, y: 1)
+
+            if state != .none {
+                Circle().stroke(Color.white, lineWidth: 1.5)
+            }
+
+            Text(short)
+                .font(.system(size: short.count > 2 ? 7 : 9, weight: .bold))
+                .foregroundColor(textColor)
+                .lineLimit(1)
+                .minimumScaleFactor(0.5)
+        }
+    }
+
+    private var bgColor: Color {
+        switch state {
+        case .primary:   return Theme.Color.primary
+        case .secondary: return Theme.Color.secondary
+        case .none:      return Color.white.opacity(0.88)
+        }
+    }
+
+    private var textColor: Color {
+        state == .none ? Color.black.opacity(0.8) : .white
+    }
+}

--- a/ios/LFAEducationCenter/Profile/ProfileView.swift
+++ b/ios/LFAEducationCenter/Profile/ProfileView.swift
@@ -1,0 +1,176 @@
+import SwiftUI
+
+// Read-only profile overview — name, email, role, Academy ID link.
+//
+// All data comes from DashboardViewModel.profile (already loaded — no extra fetch).
+// Photo: uses profile photo from Phase 1 (processed → original → placeholder).
+// Edit and mood photos are deferred to a future phase.
+struct ProfileView: View {
+
+    @EnvironmentObject private var authManager:  AuthManager
+    @EnvironmentObject private var dashboardVM:  DashboardViewModel
+
+    @Environment(\.presentationMode) private var presentationMode
+
+    @State private var isShowingAcademyID = false
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                VStack(spacing: 0) {
+                    photoSection
+                    identitySection
+                    academyIDSection
+                    Spacer(minLength: Theme.Spacing.xl)
+                }
+                .padding(.horizontal, Theme.Spacing.md)
+                .padding(.top, Theme.Spacing.lg)
+            }
+            .background(Color(UIColor.systemBackground).ignoresSafeArea())
+            .navigationTitle("Profile")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button {
+                        presentationMode.wrappedValue.dismiss()
+                    } label: {
+                        Image(systemName: "xmark")
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundColor(Theme.Color.onSurface)
+                    }
+                }
+            }
+            .fullScreenCover(isPresented: $isShowingAcademyID) {
+                AcademyIDFullScreenView()
+                    .environmentObject(authManager)
+                    .environmentObject(dashboardVM)
+            }
+        }
+        .navigationViewStyle(.stack)
+    }
+
+    // MARK: — Photo
+
+    private var photoSection: some View {
+        let photoUrl = dashboardVM.profile?.profilePhotoProcessedUrl
+                    ?? dashboardVM.profile?.profilePhotoUrl
+
+        return VStack(spacing: Theme.Spacing.sm) {
+            Group {
+                if let url = photoUrl {
+                    ProfileURLPhotoView(urlPath: url)
+                        .frame(width: 88, height: 88)
+                        .clipShape(Circle())
+                        .overlay(Circle().stroke(Theme.Color.secondary.opacity(0.3), lineWidth: 2))
+                } else {
+                    Circle()
+                        .fill(Theme.Color.muted.opacity(0.08))
+                        .frame(width: 88, height: 88)
+                        .overlay(
+                            Image(systemName: "person.fill")
+                                .font(.system(size: 36))
+                                .foregroundColor(Theme.Color.muted.opacity(0.3))
+                        )
+                }
+            }
+            .padding(.bottom, 4)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.bottom, Theme.Spacing.sm)
+    }
+
+    // MARK: — Identity
+
+    private var identitySection: some View {
+        VStack(spacing: Theme.Spacing.sm) {
+            if let name = dashboardVM.profile?.displayName, !name.isEmpty {
+                Text(name)
+                    .font(.title2.weight(.semibold))
+                    .foregroundColor(Theme.Color.onSurface)
+                    .multilineTextAlignment(.center)
+            }
+
+            Text(dashboardVM.profile?.email ?? "")
+                .font(.subheadline)
+                .foregroundColor(Theme.Color.muted)
+
+            if let role = dashboardVM.profile?.role {
+                Text(role.capitalized)
+                    .font(.caption.weight(.semibold))
+                    .padding(.horizontal, Theme.Spacing.sm)
+                    .padding(.vertical, 4)
+                    .background(Theme.Color.primary.opacity(0.15))
+                    .foregroundColor(Theme.Color.primary)
+                    .cornerRadius(Theme.Radius.sm)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.bottom, Theme.Spacing.lg)
+    }
+
+    // MARK: — Academy ID entry
+
+    private var academyIDSection: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            Text("ACADEMY ID")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(Theme.Color.muted)
+                .kerning(0.8)
+
+            Button { isShowingAcademyID = true } label: {
+                HStack {
+                    Image(systemName: "creditcard.fill")
+                        .font(.system(size: 15))
+                        .foregroundColor(Theme.Color.secondary)
+                        .frame(width: 28)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("My Academy ID")
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundColor(Theme.Color.onSurface)
+                        if let aid = dashboardVM.profile?.lfaAcademyId {
+                            Text(aid)
+                                .font(.system(size: 11, design: .monospaced))
+                                .foregroundColor(Theme.Color.muted)
+                        }
+                    }
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundColor(Theme.Color.muted)
+                }
+                .padding(Theme.Spacing.md)
+                .background(Theme.Color.surface)
+                .cornerRadius(Theme.Radius.md)
+            }
+        }
+    }
+}
+
+// MARK: — URL photo loader (scoped to ProfileView)
+
+private struct ProfileURLPhotoView: View {
+    let urlPath: String
+    @State private var image: UIImage?
+
+    var body: some View {
+        Group {
+            if let img = image {
+                Image(uiImage: img).resizable().scaledToFill()
+            } else {
+                Rectangle()
+                    .fill(Theme.Color.muted.opacity(0.08))
+                    .overlay(ProgressView().scaleEffect(0.7))
+            }
+        }
+        .onAppear { loadImage() }
+    }
+
+    private func loadImage() {
+        guard image == nil,
+              let url = URL(string: APIConfig.baseURL + urlPath) else { return }
+        URLSession.shared.dataTask(with: url) { data, _, _ in
+            guard let data = data, let img = UIImage(data: data) else { return }
+            DispatchQueue.main.async { self.image = img }
+        }.resume()
+    }
+}

--- a/ios/LFAEducationCenter/Shared/QRCodeGenerator.swift
+++ b/ios/LFAEducationCenter/Shared/QRCodeGenerator.swift
@@ -21,9 +21,13 @@ enum QRCodeGenerator {
 
         guard let output = filter.outputImage else { return nil }
 
-        let transform = CGAffineTransform(scaleX: scale, y: scale)
-        let scaled    = output.transformed(by: transform)
+        let scaled = output.transformed(by: CGAffineTransform(scaleX: scale, y: scale))
 
-        return UIImage(ciImage: scaled)
+        // CIImage-backed UIImage does not render in SwiftUI Image(uiImage:).
+        // Rasterise to CGImage via CIContext so both AcademyIDFullScreenView
+        // (200 pt) and AcademyIDCardView (56 pt) display correctly.
+        let context = CIContext()
+        guard let cgImage = context.createCGImage(scaled, from: scaled.extent) else { return nil }
+        return UIImage(cgImage: cgImage)
     }
 }

--- a/ios/LFAEducationCenter/Unlock/UnlockConfirmView.swift
+++ b/ios/LFAEducationCenter/Unlock/UnlockConfirmView.swift
@@ -1,0 +1,236 @@
+import SwiftUI
+
+// Confirm modal for unlocking LFA Football Player (costs 100 CR).
+//
+// Presented as fullScreenCover from MainHubView when lfaCardState == .unlockAvailable.
+//
+// Flow:
+//   1. User sees cost / current balance / balance-after summary
+//   2. Tap "Confirm Unlock" → UnlockViewModel.performUnlock()
+//   3a. Success → brief success view → dashboardVM.reloadAfterUnlock() → auto-dismiss
+//   3b. Error   → error message + "Try Again" / "Cancel"
+//
+// Duplicate tap: blocked by UnlockViewModel.state guard (.idle only).
+// 409 already-unlocked: treated as success (idempotent).
+struct UnlockConfirmView: View {
+
+    @EnvironmentObject private var authManager: AuthManager
+    @EnvironmentObject private var dashboardVM: DashboardViewModel
+    @StateObject         private var viewModel  = UnlockViewModel()
+    @Environment(\.presentationMode) private var presentationMode
+
+    private let cost = 100
+
+    private var balance: Int { dashboardVM.profile?.creditBalance ?? 0 }
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                VStack(spacing: 0) {
+                    heroSection
+                    summarySection
+                    Spacer(minLength: Theme.Spacing.xl)
+                    actionSection
+                    Spacer(minLength: Theme.Spacing.xl)
+                }
+                .padding(.horizontal, Theme.Spacing.md)
+                .padding(.top, Theme.Spacing.lg)
+            }
+            .background(Color(UIColor.systemBackground).ignoresSafeArea())
+            .navigationTitle("Unlock Specialization")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    if !isInProgress {
+                        Button {
+                            presentationMode.wrappedValue.dismiss()
+                        } label: {
+                            Image(systemName: "xmark")
+                                .font(.system(size: 14, weight: .semibold))
+                                .foregroundColor(Theme.Color.onSurface)
+                        }
+                    }
+                }
+            }
+        }
+        .navigationViewStyle(.stack)
+    }
+
+    // MARK: — Hero
+
+    private var heroSection: some View {
+        VStack(spacing: Theme.Spacing.sm) {
+            Text("⚽")
+                .font(.system(size: 56))
+                .padding(.bottom, 4)
+
+            Text("LFA Football Player")
+                .font(.title2.weight(.bold))
+                .foregroundColor(Theme.Color.onSurface)
+                .multilineTextAlignment(.center)
+
+            Text("Unlock this specialization to start your LFA journey.")
+                .font(.subheadline)
+                .foregroundColor(Theme.Color.muted)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, Theme.Spacing.xl)
+    }
+
+    // MARK: — Cost / balance summary
+
+    private var summarySection: some View {
+        VStack(spacing: 1) {
+            summaryRow(label: "Unlock Cost",      value: "\(cost) CR",              valueColor: Theme.Color.error)
+            summaryRow(label: "Your Balance",     value: "\(balance) CR",           valueColor: Theme.Color.onSurface)
+            summaryRow(label: "Balance After",    value: "\(balance - cost) CR",    valueColor: balance >= cost ? Theme.Color.onSurface : Theme.Color.error)
+        }
+        .background(Theme.Color.surface)
+        .cornerRadius(Theme.Radius.md)
+    }
+
+    private func summaryRow(label: String, value: String, valueColor: Color) -> some View {
+        HStack {
+            Text(label)
+                .font(.subheadline)
+                .foregroundColor(Theme.Color.muted)
+            Spacer()
+            Text(value)
+                .font(.subheadline.weight(.semibold))
+                .foregroundColor(valueColor)
+        }
+        .padding(.horizontal, Theme.Spacing.md)
+        .padding(.vertical, 12)
+    }
+
+    // MARK: — Action area (state-driven)
+
+    @ViewBuilder
+    private var actionSection: some View {
+        switch viewModel.state {
+        case .idle:
+            idleActions
+
+        case .loading:
+            VStack(spacing: Theme.Spacing.md) {
+                ProgressView()
+                    .scaleEffect(1.2)
+                Text("Unlocking…")
+                    .font(.subheadline)
+                    .foregroundColor(Theme.Color.muted)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(Theme.Spacing.xl)
+
+        case .success(let newBalance):
+            successView(newBalance: newBalance)
+
+        case .error(let message):
+            errorView(message: message)
+        }
+    }
+
+    private var idleActions: some View {
+        VStack(spacing: Theme.Spacing.sm) {
+            Button {
+                Task { await viewModel.performUnlock(using: authManager) }
+            } label: {
+                Text("Confirm Unlock — \(cost) CR")
+                    .font(.body.weight(.semibold))
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 50)
+                    .background(Theme.Color.primary)
+                    .foregroundColor(.white)
+                    .cornerRadius(Theme.Radius.sm)
+            }
+
+            Button {
+                presentationMode.wrappedValue.dismiss()
+            } label: {
+                Text("Cancel")
+                    .font(.body.weight(.semibold))
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 50)
+                    .background(Theme.Color.muted.opacity(0.10))
+                    .foregroundColor(Theme.Color.muted)
+                    .cornerRadius(Theme.Radius.sm)
+            }
+        }
+    }
+
+    private func successView(newBalance: Int) -> some View {
+        VStack(spacing: Theme.Spacing.md) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 52))
+                .foregroundColor(Color(red: 0.18, green: 0.80, blue: 0.44))
+
+            Text("Unlocked!")
+                .font(.title2.weight(.bold))
+                .foregroundColor(Theme.Color.onSurface)
+
+            Text("LFA Football Player is now active.")
+                .font(.subheadline)
+                .foregroundColor(Theme.Color.muted)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(Theme.Spacing.xl)
+        .onAppear {
+            // Reload dashboard (sets .unlocking state, then fetches fresh profile+license)
+            // then dismiss — short delay so user sees the success tick.
+            Task {
+                try? await Task.sleep(nanoseconds: 1_200_000_000)
+                await dashboardVM.reloadAfterUnlock(using: authManager)
+                presentationMode.wrappedValue.dismiss()
+            }
+        }
+    }
+
+    private func errorView(message: String) -> some View {
+        VStack(spacing: Theme.Spacing.md) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 36))
+                .foregroundColor(Theme.Color.error)
+
+            Text(message)
+                .font(.subheadline)
+                .foregroundColor(Theme.Color.onSurface)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, Theme.Spacing.md)
+
+            Button {
+                viewModel.reset()
+            } label: {
+                Text("Try Again")
+                    .font(.body.weight(.semibold))
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 50)
+                    .background(Theme.Color.primary)
+                    .foregroundColor(.white)
+                    .cornerRadius(Theme.Radius.sm)
+            }
+
+            Button {
+                presentationMode.wrappedValue.dismiss()
+            } label: {
+                Text("Cancel")
+                    .font(.body.weight(.semibold))
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 50)
+                    .background(Theme.Color.muted.opacity(0.10))
+                    .foregroundColor(Theme.Color.muted)
+                    .cornerRadius(Theme.Radius.sm)
+            }
+        }
+        .padding(Theme.Spacing.xl)
+    }
+
+    // MARK: — Helpers
+
+    private var isInProgress: Bool {
+        if case .loading = viewModel.state { return true }
+        if case .success = viewModel.state { return true }
+        return false
+    }
+}

--- a/ios/LFAEducationCenter/Unlock/UnlockViewModel.swift
+++ b/ios/LFAEducationCenter/Unlock/UnlockViewModel.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+// Decoded from POST /specialization/unlock (200 OK).
+private struct UnlockResponse: Decodable {
+    let success:    Bool
+    let message:    String?
+    let newBalance: Int?
+    let licenseId:  Int?
+
+    enum CodingKeys: String, CodingKey {
+        case success, message
+        case newBalance = "new_balance"
+        case licenseId  = "license_id"
+    }
+}
+
+// Manages the specialization unlock POST flow.
+//
+// Endpoint: POST /specialization/unlock
+//   Body: form-encoded  specialization=LFA_PLAYER
+//   Auth: Bearer token (same as all API calls)
+//
+// State machine:
+//   .idle    → user sees confirm UI
+//   .loading → request in-flight, duplicate tap blocked
+//   .success → dashboard reload triggered, view auto-dismisses
+//   .error   → message shown, user can reset and retry
+//
+// 409 Conflict (already unlocked) is treated as success — the intent is fulfilled.
+@MainActor
+final class UnlockViewModel: ObservableObject {
+
+    enum State {
+        case idle
+        case loading
+        case success(newBalance: Int)
+        case error(String)
+    }
+
+    @Published private(set) var state: State = .idle
+
+    // MARK: — Perform unlock
+
+    func performUnlock(using authManager: AuthManager) async {
+        guard case .idle = state else { return }    // duplicate-tap guard
+        state = .loading
+
+        do {
+            let response: UnlockResponse = try await authManager.authenticatedFormPost(
+                path:   "/specialization/unlock",
+                fields: ["specialization": "LFA_PLAYER"]
+            )
+            state = .success(newBalance: response.newBalance ?? 0)
+
+        } catch APIError.httpError(let code, _) where code == 409 {
+            // Already unlocked — intent fulfilled, treat as success.
+            state = .success(newBalance: 0)
+
+        } catch APIError.httpError(let code, let detail) where code == 400 {
+            state = .error(detail ?? "Insufficient credits. Please add more credits and try again.")
+
+        } catch APIError.httpError(let code, let detail) where code == 403 {
+            state = .error(detail ?? "Age requirement not met for LFA Football Player.")
+
+        } catch APIError.unauthorized {
+            state = .error("Session expired. Please sign in again.")
+
+        } catch {
+            state = .error("Network error. Please check your connection and try again.")
+        }
+    }
+
+    // MARK: — Reset (allows retry from error state)
+
+    func reset() { state = .idle }
+}


### PR DESCRIPTION
## Summary

This PR adds the complete iOS LFA Player unlock and onboarding flow, enabling the end-to-end path from the hub to the LFA Player specialization dashboard.

### Commits in this PR

| SHA | Description |
|-----|-------------|
| `b5c40cf3` | feat(ios): Academy ID Phase 2B — My Academy ID full-screen view |
| `3bf664e6` | fix(regression): add AID-17 — registration 500 guard for Phase 2A columns |
| `e8a6952d` | fix(ios): QRCodeGenerator — CIImage to CGImage for SwiftUI compatibility |
| `09e60794` | **R3A** — feat(ios): add hub credits and profile foundation |
| `128368ab` | **R3B** — feat(ios): add LFA player unlock confirmation flow |
| `713e05d1` | **R3C** — feat(ios): add native LFA player minimum onboarding |

---

### R3A — Hub Credits/Profile Foundation (`09e60794`)

- `CreditsView`: balance hero, how-to-get-credits info, transaction history (GET `/api/v1/lfa-player/credits/transactions`)
- `CreditsViewModel`: 404 → empty list (no LFA license yet); loading/loaded/error states
- `CreditTransaction` model: `id`, `transaction_type`, `amount`, `description`, `created_at`
- `ProfileView`: read-only name/email/role/photo/Academy ID (no extra fetch — uses `DashboardViewModel`)
- `MainHubView`: Credits + Profile hub entry buttons; `insufficientCredits` tap → `CreditsView` (no more dead-end)
- `LFASpecTabView` Profile tab: Credits + Profile rows with CR badge

### R3B — Unlock Confirm Flow (`128368ab`)

- `UnlockConfirmView`: cost (100 CR) / current balance / balance-after summary; loading/success/error states; 1.2s success tick → auto-dismiss
- `UnlockViewModel`: `POST /specialization/unlock` (form-urlencoded, Bearer); duplicate-tap guard; 409 → success (idempotent); 400/403/network error states
- `APIClient.formPost()`: `application/x-www-form-urlencoded` POST for FastAPI `Form(...)` endpoints
- `AuthManager.authenticatedFormPost()`: Bearer inject + single 401 refresh wrapper
- `DashboardViewModel`: `.unlocking` state prevents card flash during post-unlock reload; `reloadAfterUnlock()` sets `.unlocking` before fetchData
- `MainHubView`: `.unlockAvailable` tap → `UnlockConfirmView` fullScreenCover (was nil/disabled)

### R3C — Native Minimum Onboarding (`713e05d1`)

- `FootballPosition.swift`: 21-position v2 taxonomy (mirrors `app/utils/football_positions.py`); 20 `PitchNode` structs (ST1/ST2 both → `"striker"`); `second_striker`/`centre_back` as no-pitch chips
- `PitchSelectorView`: landscape SwiftUI pitch, 14pt margin, 1.9:1 aspect; 26pt tappable nodes; primary/secondary tap logic (max 3 secondary); ST dual-node visual
- `LFAOnboardingViewModel`: `canSubmit = primaryPosition != nil` (secondary optional); 44 × 50 default skill payload; `POST /specialization/lfa-player/onboarding-submit` (Bearer JSON); duplicate-tap guard; 422/500/network error states
- `LFAOnboardingView`: pitch + physique sliders (height 120–230, weight 35–160, preferred foot segmented, foot dominance 0–100) in one scrollable view
- `MainHubView`: `.setupPending` → `LFAOnboardingView` fullScreenCover; `isProminent` includes `.setupPending`; subtitle "Tap to complete setup"
- On success: `dashboardVM.reload()` → `onboardingCompleted=true` → `.active` → `LFASpecTabView`

---

### Complete user flow

```
Hub → Need Credits (< 100 CR) → CreditsView
Hub → Unlock Available (≥ 100 CR, no license) → UnlockConfirmView → POST /specialization/unlock
                                                                    → setupPending
Hub → Setup Pending → LFAOnboardingView → POST /specialization/lfa-player/onboarding-submit
                                        → active
Hub → Active → LFASpecTabView (Dashboard / Education / Training / Profile)
```

---

### Backend changes

**None.** All three endpoints existed before this PR:
- `POST /specialization/unlock` (form-urlencoded, Bearer)
- `POST /specialization/lfa-player/onboarding-submit` (JSON, Bearer)
- `GET /api/v1/lfa-player/credits/transactions` (JSON, Bearer)

No DB migrations. No schema changes.

---

### Rollback

```bash
git revert 713e05d1  # R3C
git revert 128368ab  # R3B
git revert 09e60794  # R3A
```

Or hard reset: `git reset --hard 9fb77a09` (main HEAD before this branch).
100% iOS-only — no backend, no DB, safe to revert at any time.

---

## Test plan

- [ ] Hub: `insufficientCredits` → CreditsView (not a dead-end)
- [ ] Hub: `unlockAvailable` → UnlockConfirmView opens; cost/balance/after shown
- [ ] Confirm Unlock → spinner → success → hub card "Setup Pending"
- [ ] Hub balance CR badge decremented by 100
- [ ] 409 already-unlocked handled as success
- [ ] Network error on unlock → "Try Again" works
- [ ] Setup Pending → LFAOnboardingView opens
- [ ] Pitch: tap node → primary (button active); tap secondary; tap to deselect
- [ ] ST1 and ST2 both set/clear `"striker"` correctly
- [ ] SS/CB chip buttons below pitch work
- [ ] Max 3 secondary enforced (4th tap no-op)
- [ ] Complete Setup disabled with no primary; enabled after primary selected
- [ ] Height/weight sliders: value updates correctly
- [ ] Preferred foot segmented: Left/Right/Both
- [ ] Foot dominance slider 0–100
- [ ] Submit → spinner → success → hub card "Open →"
- [ ] Active → tap → LFASpecTabView (Dashboard/Education/Training/Profile)
- [ ] Credits entry on hub → CreditsView; transaction history or empty state
- [ ] Profile entry on hub → ProfileView (name/email/role/photo/Academy ID)
- [ ] Sign Out still works; Back to Hub still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)