### PR TITLE
fix(ios/credits): add missing Swift files omitted from PR #255 squash

### DIFF
--- a/ios/LFAEducationCenter.xcodeproj/project.pbxproj
+++ b/ios/LFAEducationCenter.xcodeproj/project.pbxproj
@@ -60,6 +60,8 @@
 		BB000004000000000000051 /* RedeemCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000053 /* RedeemCodeView.swift */; };
 		BB000004000000000000052 /* InvoiceRequestViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000054 /* InvoiceRequestViewModel.swift */; };
 		BB000004000000000000053 /* InvoiceRequestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000055 /* InvoiceRequestView.swift */; };
+		BB000004000000000000054 /* InvoiceItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000056 /* InvoiceItem.swift */; };
+		BB000004000000000000055 /* PendingInvoicesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000057 /* PendingInvoicesViewModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -118,6 +120,8 @@
 		BB000003000000000000053 /* RedeemCodeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedeemCodeView.swift; sourceTree = "<group>"; };
 		BB000003000000000000054 /* InvoiceRequestViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvoiceRequestViewModel.swift; sourceTree = "<group>"; };
 		BB000003000000000000055 /* InvoiceRequestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvoiceRequestView.swift; sourceTree = "<group>"; };
+		BB000003000000000000056 /* InvoiceItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvoiceItem.swift; sourceTree = "<group>"; };
+		BB000003000000000000057 /* PendingInvoicesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingInvoicesViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -288,6 +292,8 @@
 				BB000003000000000000053 /* RedeemCodeView.swift */,
 				BB000003000000000000054 /* InvoiceRequestViewModel.swift */,
 				BB000003000000000000055 /* InvoiceRequestView.swift */,
+				BB000003000000000000056 /* InvoiceItem.swift */,
+				BB000003000000000000057 /* PendingInvoicesViewModel.swift */,
 			);
 			path = Credits;
 			sourceTree = "<group>";
@@ -441,6 +447,8 @@
 				BB000004000000000000051 /* RedeemCodeView.swift in Sources */,
 				BB000004000000000000052 /* InvoiceRequestViewModel.swift in Sources */,
 				BB000004000000000000053 /* InvoiceRequestView.swift in Sources */,
+				BB000004000000000000054 /* InvoiceItem.swift in Sources */,
+				BB000004000000000000055 /* PendingInvoicesViewModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/LFAEducationCenter/Credits/InvoiceItem.swift
+++ b/ios/LFAEducationCenter/Credits/InvoiceItem.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+// Decoded from GET /api/v1/invoices/my-invoices (Bearer auth).
+// Represents one invoice request created by the current user.
+struct InvoiceItem: Decodable, Identifiable {
+    let id:               Int
+    let paymentReference: String
+    let amountEur:        Double
+    let creditAmount:     Int
+    let status:           String   // "pending" | "paid" | "verified" | "cancelled"
+    let createdAt:        String?
+    let verifiedAt:       String?
+
+    enum CodingKeys: String, CodingKey {
+        case id, status
+        case paymentReference = "payment_reference"
+        case amountEur        = "amount_eur"
+        case creditAmount     = "credit_amount"
+        case createdAt        = "created_at"
+        case verifiedAt       = "verified_at"
+    }
+
+    var isPending:    Bool   { status.lowercased() == "pending" }
+    var isVerified:   Bool   { status.lowercased() == "verified" }
+    var statusLabel:  String { status.capitalized }
+    var priceLabel:   String { String(format: "€%.0f", amountEur) }
+    var creditsLabel: String { "\(creditAmount) CR" }
+
+    func formattedDate(_ iso: String?) -> String {
+        guard let iso else { return "" }
+        for opts: ISO8601DateFormatter.Options in [
+            [.withInternetDateTime, .withFractionalSeconds],
+            [.withInternetDateTime]
+        ] {
+            let f = ISO8601DateFormatter()
+            f.formatOptions = opts
+            if let date = f.date(from: iso) {
+                let out = DateFormatter()
+                out.dateStyle = .medium
+                out.timeStyle = .none
+                return out.string(from: date)
+            }
+        }
+        return String(iso.prefix(10))
+    }
+
+    var createdAtFormatted:  String { formattedDate(createdAt) }
+    var verifiedAtFormatted: String { formattedDate(verifiedAt) }
+}

--- a/ios/LFAEducationCenter/Credits/InvoiceRequestView.swift
+++ b/ios/LFAEducationCenter/Credits/InvoiceRequestView.swift
@@ -6,14 +6,19 @@ import SwiftUI
 // The backend creates a pending InvoiceRequest and returns a payment reference.
 // Credits are added ONLY after an administrator verifies the bank transfer.
 //
+// Success state is PERSISTENT — user must explicitly copy the reference before closing.
+// "Copy Reference & Close" = primary action.
+// "Close Without Copying" = secondary, triggers confirmation alert.
+//
 // API: POST /api/v1/users/request-invoice (Bearer JSON)
-// No immediate credit jóváírás — pending admin approval.
 struct InvoiceRequestView: View {
 
     @EnvironmentObject private var authManager: AuthManager
     @EnvironmentObject private var dashboardVM: DashboardViewModel
     @StateObject         private var viewModel  = InvoiceRequestViewModel()
     @Environment(\.presentationMode) private var presentationMode
+
+    @State private var showCloseWarning = false
 
     var body: some View {
         NavigationView {
@@ -33,13 +38,29 @@ struct InvoiceRequestView: View {
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
                     if !isLoading {
-                        Button { presentationMode.wrappedValue.dismiss() } label: {
+                        Button {
+                            if case .success = viewModel.state {
+                                showCloseWarning = true
+                            } else {
+                                presentationMode.wrappedValue.dismiss()
+                            }
+                        } label: {
                             Image(systemName: "xmark")
                                 .font(.system(size: 14, weight: .semibold))
                                 .foregroundColor(Theme.Color.onSurface)
                         }
                     }
                 }
+            }
+            .alert(isPresented: $showCloseWarning) {
+                Alert(
+                    title: Text("Leave Without Copying?"),
+                    message: Text("You will need the payment reference to complete your bank transfer."),
+                    primaryButton: .destructive(Text("Leave Anyway")) {
+                        presentationMode.wrappedValue.dismiss()
+                    },
+                    secondaryButton: .cancel(Text("Stay"))
+                )
             }
         }
         .navigationViewStyle(.stack)
@@ -66,29 +87,33 @@ struct InvoiceRequestView: View {
         .padding(.vertical, Theme.Spacing.lg)
     }
 
-    // MARK: — Package picker
+    // MARK: — Package picker (hidden when success state shown)
 
+    @ViewBuilder
     private var packageSection: some View {
-        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
-            Text("SELECT PACKAGE")
-                .font(.system(size: 10, weight: .semibold))
-                .foregroundColor(Theme.Color.muted)
-                .kerning(0.8)
-                .padding(.top, Theme.Spacing.sm)
+        if case .success = viewModel.state {
+            EmptyView()
+        } else {
+            VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+                Text("SELECT PACKAGE")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundColor(Theme.Color.muted)
+                    .kerning(0.8)
+                    .padding(.top, Theme.Spacing.sm)
 
-            VStack(spacing: 1) {
-                ForEach(CreditPackage.allCases) { pkg in
-                    packageRow(pkg)
+                VStack(spacing: 1) {
+                    ForEach(CreditPackage.allCases) { pkg in
+                        packageRow(pkg)
+                    }
                 }
+                .background(Theme.Color.surface)
+                .cornerRadius(Theme.Radius.md)
             }
-            .background(Theme.Color.surface)
-            .cornerRadius(Theme.Radius.md)
         }
     }
 
     private func packageRow(_ pkg: CreditPackage) -> some View {
         let isSelected = viewModel.selectedPackage == pkg
-
         return Button { viewModel.selectedPackage = pkg } label: {
             HStack(spacing: Theme.Spacing.sm) {
                 Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
@@ -199,10 +224,11 @@ struct InvoiceRequestView: View {
         }
     }
 
-    // MARK: — Success view
+    // MARK: — Persistent success view
 
     private func successView(result: InvoiceResult) -> some View {
         VStack(alignment: .leading, spacing: Theme.Spacing.md) {
+
             HStack(spacing: 8) {
                 Image(systemName: "checkmark.circle.fill")
                     .font(.system(size: 22))
@@ -212,41 +238,67 @@ struct InvoiceRequestView: View {
                     .foregroundColor(Theme.Color.onSurface)
             }
 
+            // Reference highlight card
+            VStack(alignment: .leading, spacing: 6) {
+                Text("PAYMENT REFERENCE")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundColor(Theme.Color.muted)
+                    .kerning(0.8)
+
+                Text(result.paymentReference)
+                    .font(.system(size: 15, weight: .bold, design: .monospaced))
+                    .foregroundColor(Theme.Color.primary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(Theme.Spacing.md)
+            .background(Theme.Color.primary.opacity(0.07))
+            .cornerRadius(Theme.Radius.sm)
+
+            // Detail rows
             VStack(spacing: 1) {
-                resultRow(label: "Payment Reference", value: result.paymentReference, isMonospaced: true)
-                resultRow(label: "Amount", value: String(format: "€%.2f", result.amountEur), isMonospaced: false)
-                resultRow(label: "Credits on approval", value: "\(result.creditAmount) CR", isMonospaced: false)
-                resultRow(label: "Status", value: result.status.capitalized, isMonospaced: false)
+                resultRow(label: "Amount",             value: String(format: "€%.2f", result.amountEur))
+                resultRow(label: "Credits on approval", value: "\(result.creditAmount) CR")
+                resultRow(label: "Status",              value: result.status.capitalized)
+                if let date = result.createdAt {
+                    resultRow(label: "Requested",       value: formatDate(date))
+                }
             }
             .background(Theme.Color.surface)
             .cornerRadius(Theme.Radius.md)
 
-            // Copy reference button
-            Button {
-                UIPasteboard.general.string = result.paymentReference
-            } label: {
-                Label("Copy Payment Reference", systemImage: "doc.on.doc")
-                    .font(.subheadline.weight(.semibold))
-                    .frame(maxWidth: .infinity)
-                    .frame(height: 44)
-                    .background(Theme.Color.primary.opacity(0.12))
-                    .foregroundColor(Theme.Color.primary)
-                    .cornerRadius(Theme.Radius.sm)
+            // Admin notice
+            HStack(alignment: .top, spacing: 8) {
+                Image(systemName: "info.circle")
+                    .foregroundColor(Theme.Color.secondary)
+                    .padding(.top, 1)
+                Text("Include this reference in your bank transfer description. Credits will be added after your payment is verified by an administrator.")
+                    .font(.caption)
+                    .foregroundColor(Theme.Color.muted)
+                    .fixedSize(horizontal: false, vertical: true)
             }
 
-            Text("Include this reference in your bank transfer description. Credits will be added to your account after your payment is verified by an administrator.")
-                .font(.caption)
-                .foregroundColor(Theme.Color.muted)
-                .fixedSize(horizontal: false, vertical: true)
-
-            Button { presentationMode.wrappedValue.dismiss() } label: {
-                Text("Done")
+            // Primary action: Copy & Close
+            Button {
+                UIPasteboard.general.string = result.paymentReference
+                presentationMode.wrappedValue.dismiss()
+            } label: {
+                Label("Copy Reference & Close", systemImage: "doc.on.doc.fill")
                     .font(.body.weight(.semibold))
                     .frame(maxWidth: .infinity)
-                    .frame(height: 48)
+                    .frame(height: 50)
                     .background(Theme.Color.primary)
                     .foregroundColor(.white)
                     .cornerRadius(Theme.Radius.sm)
+            }
+
+            // Secondary action: Close without copying
+            Button { showCloseWarning = true } label: {
+                Text("Close Without Copying")
+                    .font(.caption)
+                    .foregroundColor(Theme.Color.muted)
+                    .frame(maxWidth: .infinity)
             }
         }
         .padding(Theme.Spacing.md)
@@ -255,19 +307,15 @@ struct InvoiceRequestView: View {
         .padding(.top, Theme.Spacing.md)
     }
 
-    private func resultRow(label: String, value: String, isMonospaced: Bool) -> some View {
+    private func resultRow(label: String, value: String) -> some View {
         HStack {
             Text(label)
                 .font(.caption)
                 .foregroundColor(Theme.Color.muted)
             Spacer()
             Text(value)
-                .font(isMonospaced
-                      ? .system(size: 13, weight: .semibold, design: .monospaced)
-                      : .subheadline.weight(.semibold))
+                .font(.subheadline.weight(.semibold))
                 .foregroundColor(Theme.Color.onSurface)
-                .lineLimit(1)
-                .minimumScaleFactor(0.7)
         }
         .padding(.horizontal, Theme.Spacing.md)
         .padding(.vertical, 10)
@@ -278,5 +326,23 @@ struct InvoiceRequestView: View {
     private var isLoading: Bool {
         if case .loading = viewModel.state { return true }
         return false
+    }
+
+    private func formatDate(_ iso: String) -> String {
+        // Try with fractional seconds first, then without
+        for formatOptions: ISO8601DateFormatter.Options in [
+            [.withInternetDateTime, .withFractionalSeconds],
+            [.withInternetDateTime]
+        ] {
+            let f = ISO8601DateFormatter()
+            f.formatOptions = formatOptions
+            if let date = f.date(from: iso) {
+                let out = DateFormatter()
+                out.dateStyle = .medium
+                out.timeStyle = .none
+                return out.string(from: date)
+            }
+        }
+        return String(iso.prefix(10))
     }
 }

--- a/ios/LFAEducationCenter/Credits/InvoiceRequestViewModel.swift
+++ b/ios/LFAEducationCenter/Credits/InvoiceRequestViewModel.swift
@@ -53,10 +53,12 @@ private struct InvoiceRequestBody: Encodable {
 }
 
 struct InvoiceResult {
+    let invoiceId:        Int?
     let paymentReference: String
     let amountEur:        Double
     let creditAmount:     Int
     let status:           String
+    let createdAt:        String?   // ISO 8601 string from backend
 }
 
 private struct InvoiceResponse: Decodable {
@@ -66,12 +68,14 @@ private struct InvoiceResponse: Decodable {
     let creditAmount:     Int?
     let status:           String?
     let message:          String?
+    let createdAt:        String?
 
     enum CodingKeys: String, CodingKey {
         case id, status, message
         case paymentReference = "payment_reference"
         case amountEur        = "amount_eur"
         case creditAmount     = "credit_amount"
+        case createdAt        = "created_at"
     }
 }
 
@@ -81,7 +85,7 @@ private struct InvoiceResponse: Decodable {
 //
 // API: POST /api/v1/users/request-invoice (Bearer JSON)
 // Request: { "package_type": "PACKAGE_500", "specialization_type": "LFA_FOOTBALL_PLAYER" }
-// Response: payment_reference, amount_eur, credit_amount, status="pending"
+// Response: payment_reference, amount_eur, credit_amount, status="pending", created_at
 //
 // IMPORTANT: No immediate credit jóváírás — admin verifies bank transfer, then credits added.
 @MainActor
@@ -118,10 +122,12 @@ final class InvoiceRequestViewModel: ObservableObject {
                 return
             }
             state = .success(InvoiceResult(
+                invoiceId:        resp.id,
                 paymentReference: ref,
                 amountEur:        eur,
                 creditAmount:     cr,
-                status:           resp.status ?? "pending"
+                status:           resp.status ?? "pending",
+                createdAt:        resp.createdAt
             ))
         } catch APIError.httpError(let code, let detail) where code == 409 {
             state = .error(detail ?? "You already have a pending invoice. Complete your existing payment first.")

--- a/ios/LFAEducationCenter/Credits/PendingInvoicesViewModel.swift
+++ b/ios/LFAEducationCenter/Credits/PendingInvoicesViewModel.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+// Fetches the user's invoice list from GET /api/v1/invoices/my-invoices (Bearer).
+// Filters to pending invoices for display in the CreditsView Pending Invoices section.
+//
+// The section only renders if pendingInvoices is non-empty — no empty state shown
+// (absence of pending invoices is the normal/happy state).
+@MainActor
+final class PendingInvoicesViewModel: ObservableObject {
+
+    enum LoadState {
+        case idle
+        case loading
+        case loaded([InvoiceItem])
+        case error(String)
+    }
+
+    @Published private(set) var loadState: LoadState = .idle
+
+    var pendingInvoices: [InvoiceItem] {
+        if case .loaded(let items) = loadState {
+            return items.filter { $0.isPending }
+        }
+        return []
+    }
+
+    var hasPending: Bool { !pendingInvoices.isEmpty }
+
+    // MARK: — Load (guarded)
+
+    func load(using authManager: AuthManager) async {
+        guard case .idle = loadState else { return }
+        await fetch(using: authManager)
+    }
+
+    func reload(using authManager: AuthManager) async {
+        loadState = .idle
+        await fetch(using: authManager)
+    }
+
+    // MARK: — Private
+
+    private func fetch(using authManager: AuthManager) async {
+        loadState = .loading
+        do {
+            let items: [InvoiceItem] = try await authManager.authenticatedGet(
+                path: "/api/v1/invoices/my-invoices"
+            )
+            loadState = .loaded(items)
+        } catch {
+            // Error is silent — pending invoices section simply stays hidden
+            loadState = .loaded([])
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- `InvoiceItem.swift` and `PendingInvoicesViewModel.swift` were never staged/pushed during PR #255 — they existed only as local working-tree files
- `project.pbxproj` registration for these two files was also missing from the squash commit
- `InvoiceRequestView.swift` and `InvoiceRequestViewModel.swift` had local modifications (persistent success state, Copy & Close alert, createdAt) that were never committed

Without this fix the iOS project fails to compile on `main` (`PendingInvoicesViewModel` and `InvoiceItem` are referenced in `CreditsView.swift` but undefined).

## Test plan

- [x] iOS build: `BUILD SUCCEEDED`, 0 errors, 0 warnings
- [x] All 5 files compile cleanly with existing codebase
- [x] No backend changes; Python test suite unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)