### PR TITLE
feat(ios): add R3H profile completion checklist

### DIFF
--- a/ios/LFAEducationCenter.xcodeproj/project.pbxproj
+++ b/ios/LFAEducationCenter.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		BB000004000000000000053 /* InvoiceRequestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000055 /* InvoiceRequestView.swift */; };
 		BB000004000000000000054 /* InvoiceItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000056 /* InvoiceItem.swift */; };
 		BB000004000000000000055 /* PendingInvoicesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000057 /* PendingInvoicesViewModel.swift */; };
+		BB000004000000000000056 /* ProfileCompletionCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000058 /* ProfileCompletionCard.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -122,6 +123,7 @@
 		BB000003000000000000055 /* InvoiceRequestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvoiceRequestView.swift; sourceTree = "<group>"; };
 		BB000003000000000000056 /* InvoiceItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvoiceItem.swift; sourceTree = "<group>"; };
 		BB000003000000000000057 /* PendingInvoicesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingInvoicesViewModel.swift; sourceTree = "<group>"; };
+		BB000003000000000000058 /* ProfileCompletionCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileCompletionCard.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -302,6 +304,7 @@
 			isa = PBXGroup;
 			children = (
 				BB000003000000000000045 /* ProfileView.swift */,
+				BB000003000000000000058 /* ProfileCompletionCard.swift */,
 			);
 			path = Profile;
 			sourceTree = "<group>";
@@ -449,6 +452,7 @@
 				BB000004000000000000053 /* InvoiceRequestView.swift in Sources */,
 				BB000004000000000000054 /* InvoiceItem.swift in Sources */,
 				BB000004000000000000055 /* PendingInvoicesViewModel.swift in Sources */,
+				BB000004000000000000056 /* ProfileCompletionCard.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/LFAEducationCenter/Dashboard/DashboardView.swift
+++ b/ios/LFAEducationCenter/Dashboard/DashboardView.swift
@@ -4,6 +4,8 @@ struct DashboardView: View {
     @EnvironmentObject var authManager: AuthManager
     @EnvironmentObject var dashboardVM: DashboardViewModel
 
+    @State private var isShowingProfile = false
+
     var body: some View {
         NavigationView {
             Group {
@@ -25,6 +27,11 @@ struct DashboardView: View {
         .navigationViewStyle(.stack)
         .onAppear {
             Task { await dashboardVM.load(using: authManager) }
+        }
+        .fullScreenCover(isPresented: $isShowingProfile) {
+            ProfileView()
+                .environmentObject(authManager)
+                .environmentObject(dashboardVM)
         }
     }
 
@@ -76,6 +83,15 @@ struct DashboardView: View {
 
                 // LFA Player license — from /api/v1/lfa-player/licenses/me
                 LFALicenseCard(license: dashboardVM.lfaLicense)
+
+                if dashboardVM.lfaLicense?.onboardingCompleted == true {
+                    let score = ProfileCompletionScore.compute(
+                        profile: profile,
+                        lfaLicense: dashboardVM.lfaLicense
+                    )
+                    ProfileCompletionCard(score: score,
+                                         onViewAll: { isShowingProfile = true })
+                }
 
                 // Overall progress from /api/v1/licenses/dashboard — shown if decode succeeds
                 if let progress = dashboardVM.dashboard?.overallProgress {

--- a/ios/LFAEducationCenter/Profile/ProfileCompletionCard.swift
+++ b/ios/LFAEducationCenter/Profile/ProfileCompletionCard.swift
@@ -190,7 +190,8 @@ struct ProfileCompletionSection: View {
             row(icon: "creditcard.fill",
                 title: "Academy ID",
                 subtitle: "Your LFA Football Player ID",
-                state: score.academyID > 0 ? .complete : .incomplete(action: onAcademyIDTap))
+                state: score.academyID > 0 ? .complete : .incomplete(action: onAcademyIDTap),
+                tapAction: onAcademyIDTap)
 
             row(icon: "camera.fill",
                 title: "Profile Photo",
@@ -218,9 +219,12 @@ struct ProfileCompletionSection: View {
 
     @ViewBuilder
     private func row(icon: String, title: String,
-                     subtitle: String, state: CompletionRowState) -> some View {
+                     subtitle: String, state: CompletionRowState,
+                     tapAction: (() -> Void)? = nil) -> some View {
         let content = rowContent(icon: icon, title: title, subtitle: subtitle, state: state)
         switch state {
+        case .complete where tapAction != nil:
+            Button(action: tapAction!) { content }
         case .incomplete(let action) where action != nil:
             Button(action: action!) { content }
         case .upcoming, .locked:

--- a/ios/LFAEducationCenter/Profile/ProfileCompletionCard.swift
+++ b/ios/LFAEducationCenter/Profile/ProfileCompletionCard.swift
@@ -1,0 +1,297 @@
+import SwiftUI
+
+// MARK: — Completion score
+
+// Client-side profile completion score — no extra API call.
+// All data comes from already-loaded DashboardViewModel.
+//
+// Weights (total = 100):
+//   Position & Physical  30  ← lfaLicense.onboardingCompleted
+//   Academy ID           10  ← profile.lfaAcademyId != nil
+//   Profile Photo        15  ← profile.profilePhotoUrl != nil
+//   Goals & Motivation   15  ← R3F (always 0 until implemented)
+//   Skill Assessment     20  ← R3E (always 0 until implemented)
+//   Mood Photos          10  ← R3D (always 0 until implemented)
+struct ProfileCompletionScore {
+    let positionPhysical: Int
+    let academyID:        Int
+    let profilePhoto:     Int
+    let goalsMotivation:  Int   // R3F
+    let skillAssessment:  Int   // R3E
+    let moodPhotos:       Int   // R3D
+
+    var total: Int {
+        positionPhysical + academyID + profilePhoto
+        + goalsMotivation + skillAssessment + moodPhotos
+    }
+    var fraction: Double { min(Double(total) / 100.0, 1.0) }
+
+    static func compute(profile: UserProfile,
+                        lfaLicense: LFAPlayerLicense?) -> ProfileCompletionScore {
+        ProfileCompletionScore(
+            positionPhysical: lfaLicense?.onboardingCompleted == true ? 30 : 0,
+            academyID:        profile.lfaAcademyId != nil ? 10 : 0,
+            profilePhoto:     profile.profilePhotoUrl != nil ? 15 : 0,
+            goalsMotivation:  0,
+            skillAssessment:  0,
+            moodPhotos:       0
+        )
+    }
+}
+
+// MARK: — Row state
+
+enum CompletionRowState {
+    case complete
+    case incomplete(action: (() -> Void)?)
+    case upcoming(String)   // module tag: "R3F", "R3E", "R3D"
+    case locked
+}
+
+// MARK: — Dashboard compact card
+
+// Shown below LFALicenseCard when onboarding is complete.
+// Displays overall %, progress bar, 2 top missing items, and a CTA.
+struct ProfileCompletionCard: View {
+    let score: ProfileCompletionScore
+    let onViewAll: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            headerRow
+            ProgressView(value: score.fraction)
+                .accentColor(Theme.Color.primary)
+            motivationText
+            missingItems
+            viewAllButton
+        }
+        .padding(Theme.Spacing.md)
+        .background(Theme.Color.surface)
+        .cornerRadius(Theme.Radius.md)
+    }
+
+    private var headerRow: some View {
+        HStack {
+            Image(systemName: "person.text.rectangle.fill")
+                .foregroundColor(Theme.Color.primary)
+            Text("Your Player Profile")
+                .font(.subheadline.weight(.semibold))
+                .foregroundColor(Theme.Color.onSurface)
+            Spacer()
+            Text("\(score.total)%")
+                .font(.subheadline.weight(.bold))
+                .foregroundColor(Theme.Color.primary)
+        }
+    }
+
+    private var motivationText: some View {
+        Text("Your profile is ready. Add more details to unlock richer cards and insights.")
+            .font(.caption)
+            .foregroundColor(Theme.Color.muted)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
+    @ViewBuilder
+    private var missingItems: some View {
+        if score.goalsMotivation == 0 {
+            missingPill(icon: "target",
+                        label: "Goals & Motivation")
+        }
+        if score.skillAssessment == 0 {
+            missingPill(icon: "slider.horizontal.3",
+                        label: "Skill Assessment")
+        }
+    }
+
+    private func missingPill(icon: String, label: String) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: icon)
+                .font(.system(size: 11))
+                .foregroundColor(Theme.Color.muted)
+            Text(label)
+                .font(.caption)
+                .foregroundColor(Theme.Color.muted)
+            Spacer()
+            Text("Coming Next")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(Theme.Color.secondary)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(Theme.Color.secondary.opacity(0.10))
+                .cornerRadius(4)
+        }
+    }
+
+    private var viewAllButton: some View {
+        Button(action: onViewAll) {
+            HStack {
+                Spacer()
+                Text("Complete Profile")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundColor(Theme.Color.primary)
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(Theme.Color.primary)
+                Spacer()
+            }
+        }
+        .padding(.top, 2)
+    }
+}
+
+// MARK: — ProfileView full section
+
+// Full checklist shown in ProfileView.
+// Academy ID row is tappable; all future modules are "Coming Next".
+struct ProfileCompletionSection: View {
+    let score:           ProfileCompletionScore
+    let onAcademyIDTap:  () -> Void
+
+    private static let successGreen = Color(red: 0.18, green: 0.80, blue: 0.44)
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            sectionHeader
+            ProgressView(value: score.fraction)
+                .accentColor(Theme.Color.primary)
+            motivationText
+            checklistRows
+        }
+    }
+
+    private var sectionHeader: some View {
+        HStack {
+            Text("PROFILE COMPLETION")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(Theme.Color.muted)
+                .kerning(0.8)
+            Spacer()
+            Text("\(score.total)%")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(Theme.Color.primary)
+        }
+    }
+
+    private var motivationText: some View {
+        Text("Your player profile is ready. Add more details to unlock richer cards and insights.")
+            .font(.caption)
+            .foregroundColor(Theme.Color.muted)
+            .fixedSize(horizontal: false, vertical: true)
+            .padding(.bottom, 4)
+    }
+
+    private var checklistRows: some View {
+        VStack(spacing: 1) {
+            row(icon: "figure.run",
+                title: "Position & Physical",
+                subtitle: "Primary position, height, weight, foot",
+                state: score.positionPhysical > 0 ? .complete : .incomplete(action: nil))
+
+            row(icon: "creditcard.fill",
+                title: "Academy ID",
+                subtitle: "Your LFA Football Player ID",
+                state: score.academyID > 0 ? .complete : .incomplete(action: onAcademyIDTap))
+
+            row(icon: "camera.fill",
+                title: "Profile Photo",
+                subtitle: "Your player profile photo",
+                state: score.profilePhoto > 0 ? .complete : .upcoming("R3D"))
+
+            row(icon: "target",
+                title: "Goals & Motivation",
+                subtitle: "Your football goals and drive",
+                state: score.goalsMotivation > 0 ? .complete : .upcoming("R3F"))
+
+            row(icon: "slider.horizontal.3",
+                title: "Skill Assessment",
+                subtitle: "Rate your 44 technical & mental skills",
+                state: score.skillAssessment > 0 ? .complete : .upcoming("R3E"))
+
+            row(icon: "photo.on.rectangle",
+                title: "Mood Photos",
+                subtitle: "Match-ready expressions for your card",
+                state: score.moodPhotos > 0 ? .complete : .upcoming("R3D"))
+        }
+        .background(Theme.Color.surface)
+        .cornerRadius(Theme.Radius.md)
+    }
+
+    @ViewBuilder
+    private func row(icon: String, title: String,
+                     subtitle: String, state: CompletionRowState) -> some View {
+        let content = rowContent(icon: icon, title: title, subtitle: subtitle, state: state)
+        switch state {
+        case .incomplete(let action) where action != nil:
+            Button(action: action!) { content }
+        case .upcoming, .locked:
+            content.opacity(0.65)
+        default:
+            content
+        }
+    }
+
+    private func rowContent(icon: String, title: String,
+                             subtitle: String, state: CompletionRowState) -> some View {
+        HStack(spacing: Theme.Spacing.sm) {
+            Image(systemName: icon)
+                .font(.system(size: 15))
+                .foregroundColor(iconColor(state))
+                .frame(width: 28)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundColor(titleColor(state))
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundColor(Theme.Color.muted)
+            }
+            Spacer()
+            trailingView(state)
+        }
+        .padding(.horizontal, Theme.Spacing.md)
+        .padding(.vertical, 10)
+    }
+
+    @ViewBuilder
+    private func trailingView(_ state: CompletionRowState) -> some View {
+        switch state {
+        case .complete:
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 16))
+                .foregroundColor(Self.successGreen)
+        case .incomplete(let action):
+            if action != nil {
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(Theme.Color.muted)
+            }
+        case .upcoming:
+            Text("Coming Next")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(Theme.Color.secondary)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(Theme.Color.secondary.opacity(0.10))
+                .cornerRadius(4)
+        case .locked:
+            Image(systemName: "lock")
+                .font(.system(size: 13))
+                .foregroundColor(Theme.Color.muted)
+        }
+    }
+
+    private func iconColor(_ state: CompletionRowState) -> Color {
+        switch state {
+        case .complete:             return Self.successGreen
+        case .incomplete:           return Theme.Color.primary
+        default:                    return Theme.Color.muted
+        }
+    }
+
+    private func titleColor(_ state: CompletionRowState) -> Color {
+        switch state {
+        case .complete, .incomplete: return Theme.Color.onSurface
+        default:                     return Theme.Color.muted
+        }
+    }
+}

--- a/ios/LFAEducationCenter/Profile/ProfileView.swift
+++ b/ios/LFAEducationCenter/Profile/ProfileView.swift
@@ -21,6 +21,7 @@ struct ProfileView: View {
                     photoSection
                     identitySection
                     academyIDSection
+                    completionSection
                     Spacer(minLength: Theme.Spacing.xl)
                 }
                 .padding(.horizontal, Theme.Spacing.md)
@@ -106,6 +107,20 @@ struct ProfileView: View {
         }
         .frame(maxWidth: .infinity)
         .padding(.bottom, Theme.Spacing.lg)
+    }
+
+    // MARK: — Profile completion checklist
+
+    @ViewBuilder
+    private var completionSection: some View {
+        if let profile = dashboardVM.profile,
+           dashboardVM.lfaLicense?.onboardingCompleted == true {
+            let score = ProfileCompletionScore.compute(profile: profile,
+                                                       lfaLicense: dashboardVM.lfaLicense)
+            ProfileCompletionSection(score: score,
+                                     onAcademyIDTap: { isShowingAcademyID = true })
+                .padding(.top, Theme.Spacing.lg)
+        }
     }
 
     // MARK: — Academy ID entry


### PR DESCRIPTION
## Summary

- **DashboardView**: `ProfileCompletionCard` shown below `LFALicenseCard` when `lfaLicense.onboardingCompleted == true`; "Complete Profile →" CTA opens `ProfileView` as `fullScreenCover`
- **ProfileView**: `ProfileCompletionSection` (6-row checklist) shown below Academy ID section; Academy ID row tappable in both complete and incomplete state; Coming Next rows are passive (0.65 opacity, no action)
- **ProfileCompletionCard.swift** (new): `ProfileCompletionScore` (client-side, 6 weights: 30/10/15/15/20/10), `ProfileCompletionCard`, `ProfileCompletionSection`, `CompletionRowState`; registered in `project.pbxproj`

## Scope

- iOS-only — no backend, no DB migration, no new API endpoints
- No invoice reward UX, no goals form, no skill quick rating, no mood photo upload
- Goals & Motivation (R3F), Skill Assessment (R3E), Mood Photos (R3D): hardcoded 0 — marked "Coming Next"

## Completion score weights

| Category | Weight | Complete when |
|---|---|---|
| Position & Physical | 30% | `lfaLicense.onboardingCompleted == true` |
| Academy ID | 10% | `profile.lfaAcademyId != nil` |
| Profile Photo | 15% | `profile.profilePhotoUrl != nil` |
| Goals & Motivation | 15% | R3F — always 0 |
| Skill Assessment | 20% | R3E — always 0 |
| Mood Photos | 10% | R3D — always 0 |

## Build

```
** BUILD SUCCEEDED **
Errors:   0
Swift warnings: 0
```

## Commits

- `8878c912` feat(ios): add R3H profile completion checklist card
- `d2db9ff9` fix(ios): Academy ID row tappable when complete in ProfileCompletionSection

## Rollback

```bash
git revert d2db9ff9 8878c912 --no-edit
```

No backend / DB revert needed.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)