### PR TITLE
feat(ios): add R3D native profile photo capture

### DIFF
--- a/ios/LFAEducationCenter.xcodeproj/project.pbxproj
+++ b/ios/LFAEducationCenter.xcodeproj/project.pbxproj
@@ -63,6 +63,9 @@
 		BB000004000000000000054 /* InvoiceItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000056 /* InvoiceItem.swift */; };
 		BB000004000000000000055 /* PendingInvoicesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000057 /* PendingInvoicesViewModel.swift */; };
 		BB000004000000000000056 /* ProfileCompletionCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000058 /* ProfileCompletionCard.swift */; };
+		BB000004000000000000057 /* PhotoPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000059 /* PhotoPicker.swift */; };
+		BB000004000000000000058 /* ProfilePhotoUploadViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000060 /* ProfilePhotoUploadViewModel.swift */; };
+		BB000004000000000000059 /* ProfilePhotoUploadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000061 /* ProfilePhotoUploadView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -124,6 +127,9 @@
 		BB000003000000000000056 /* InvoiceItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvoiceItem.swift; sourceTree = "<group>"; };
 		BB000003000000000000057 /* PendingInvoicesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingInvoicesViewModel.swift; sourceTree = "<group>"; };
 		BB000003000000000000058 /* ProfileCompletionCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileCompletionCard.swift; sourceTree = "<group>"; };
+		BB000003000000000000059 /* PhotoPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoPicker.swift; sourceTree = "<group>"; };
+		BB000003000000000000060 /* ProfilePhotoUploadViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilePhotoUploadViewModel.swift; sourceTree = "<group>"; };
+		BB000003000000000000061 /* ProfilePhotoUploadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilePhotoUploadView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -305,6 +311,9 @@
 			children = (
 				BB000003000000000000045 /* ProfileView.swift */,
 				BB000003000000000000058 /* ProfileCompletionCard.swift */,
+				BB000003000000000000059 /* PhotoPicker.swift */,
+				BB000003000000000000060 /* ProfilePhotoUploadViewModel.swift */,
+				BB000003000000000000061 /* ProfilePhotoUploadView.swift */,
 			);
 			path = Profile;
 			sourceTree = "<group>";
@@ -453,6 +462,9 @@
 				BB000004000000000000054 /* InvoiceItem.swift in Sources */,
 				BB000004000000000000055 /* PendingInvoicesViewModel.swift in Sources */,
 				BB000004000000000000056 /* ProfileCompletionCard.swift in Sources */,
+				BB000004000000000000057 /* PhotoPicker.swift in Sources */,
+				BB000004000000000000058 /* ProfilePhotoUploadViewModel.swift in Sources */,
+				BB000004000000000000059 /* ProfilePhotoUploadView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/LFAEducationCenter/Auth/AcademyIDCardView.swift
+++ b/ios/LFAEducationCenter/Auth/AcademyIDCardView.swift
@@ -274,8 +274,10 @@ struct AcademyIDCardView: View {
         return parts.isEmpty ? nil : parts.joined(separator: " ")
     }
 
-    // Short nationality for narrow column: just the flag + ISO code
+    // Short nationality for narrow column: just the flag + ISO code.
+    // Returns nil for empty string so fieldBlock shows "———" placeholder instead of a space.
     private var nationalityShort: String? {
+        guard !nationality.isEmpty else { return nil }
         let flags: [String: String] = [
             "HU": "🇭🇺", "AT": "🇦🇹", "DE": "🇩🇪", "SK": "🇸🇰",
             "RO": "🇷🇴", "RS": "🇷🇸", "HR": "🇭🇷", "SI": "🇸🇮",

--- a/ios/LFAEducationCenter/Auth/AcademyIDFullScreenView.swift
+++ b/ios/LFAEducationCenter/Auth/AcademyIDFullScreenView.swift
@@ -89,12 +89,12 @@ struct AcademyIDFullScreenView: View {
         AcademyIDCardView(
             firstName:                cardFirstName,
             lastName:                 cardLastName,
-            nickname:                 nil,
+            nickname:                 dashboardVM.profile?.nickname,
             age:                      dashboardVM.profile?.calculatedAge,
-            nationality:              "",
-            gender:                   nil,
-            city:                     nil,
-            country:                  nil,
+            nationality:              dashboardVM.profile?.nationality ?? "",
+            gender:                   dashboardVM.profile?.gender,
+            city:                     nil,   // Part B: city not yet in /users/me response
+            country:                  nil,   // Part B: country not yet in /users/me response
             profileImage:             nil,
             profilePhotoURL:          dashboardVM.profile?.profilePhotoUrl,
             profilePhotoProcessedURL: dashboardVM.profile?.profilePhotoProcessedUrl,

--- a/ios/LFAEducationCenter/Auth/AcademyIDFullScreenView.swift
+++ b/ios/LFAEducationCenter/Auth/AcademyIDFullScreenView.swift
@@ -4,12 +4,14 @@ import UIKit
 // Full-screen My Academy ID view — suitable for on-site verification.
 //
 // Layout (scrollable):
-//   Profile photo (96pt circle, processed → original → placeholder)
-//   Full name + lfa_academy_id (amber monospaced)
-//   Verified LFA Member badge
-//   Chip row: Member since YYYY | Specialization
-//   QR code (200×200pt, white background) — tap to toggle brightness boost
+//   AcademyIDCardView  — same component shown in RegisterView, now with real user data
+//   Divider
+//   QR scan panel      — 200×200pt, white background, tap to boost brightness
 //   Hint + verify URL
+//
+// Visual consistency: uses the identical AcademyIDCardView component as the
+// registration preview, so the user sees the same card identity both during
+// registration and later in "My Academy ID".
 //
 // Brightness boost:
 //   tap QR → UIScreen.main.brightness = 1.0
@@ -32,10 +34,10 @@ struct AcademyIDFullScreenView: View {
         NavigationView {
             ScrollView {
                 VStack(spacing: 0) {
-                    photoSection
-                    nameSection
-                    verifiedBadge
-                    chipRow
+                    cardSection
+                    Divider()
+                        .background(Theme.Color.secondary.opacity(0.15))
+                        .padding(.vertical, Theme.Spacing.lg)
                     qrSection
                     Spacer(minLength: Theme.Spacing.xl)
                 }
@@ -81,106 +83,30 @@ struct AcademyIDFullScreenView: View {
         }
     }
 
-    // MARK: — Profile photo
+    // MARK: — Academy ID card (same component as RegisterView preview)
 
-    private var photoSection: some View {
-        let photoUrl = dashboardVM.profile?.profilePhotoProcessedUrl
-                    ?? dashboardVM.profile?.profilePhotoUrl
-
-        return Group {
-            if let url = photoUrl {
-                URLPhotoView(urlPath: url)
-                    .frame(width: 96, height: 96)
-                    .clipShape(Circle())
-                    .overlay(Circle().stroke(Theme.Color.secondary.opacity(0.4), lineWidth: 2))
-            } else {
-                Circle()
-                    .fill(Theme.Color.muted.opacity(0.08))
-                    .frame(width: 96, height: 96)
-                    .overlay(
-                        Image(systemName: "person.fill")
-                            .font(.system(size: 40))
-                            .foregroundColor(Theme.Color.muted.opacity(0.3))
-                    )
-            }
-        }
-        .padding(.bottom, Theme.Spacing.md)
-    }
-
-    // MARK: — Name + Academy ID
-
-    private var nameSection: some View {
-        VStack(spacing: 6) {
-            if let name = dashboardVM.profile?.displayName, !name.isEmpty {
-                Text(name)
-                    .font(.title2.weight(.semibold))
-                    .foregroundColor(Theme.Color.onSurface)
-                    .multilineTextAlignment(.center)
-            }
-
-            if let aid = viewModel.loadState.response?.lfaAcademyId
-                      ?? dashboardVM.profile?.lfaAcademyId {
-                Text(aid)
-                    .font(.system(size: 15, weight: .bold, design: .monospaced))
-                    .foregroundColor(Color(red: 0.91, green: 0.72, blue: 0.29)) // amber
-                    .kerning(1.2)
-            }
-        }
-        .padding(.bottom, Theme.Spacing.md)
-    }
-
-    // MARK: — Verified badge
-
-    private var verifiedBadge: some View {
-        HStack(spacing: 8) {
-            Image(systemName: "checkmark.seal.fill")
-                .font(.system(size: 16))
-            Text("Verified LFA Member")
-                .font(.subheadline.weight(.semibold))
-        }
-        .foregroundColor(Color(red: 0.18, green: 0.80, blue: 0.44)) // green
-        .padding(.horizontal, Theme.Spacing.md)
-        .padding(.vertical, 10)
-        .background(Color(red: 0.18, green: 0.80, blue: 0.44).opacity(0.12))
-        .cornerRadius(Theme.Radius.md)
-        .padding(.bottom, Theme.Spacing.sm)
-    }
-
-    // MARK: — Chip row: Member since + Specialization
-
-    private var chipRow: some View {
-        HStack(spacing: Theme.Spacing.sm) {
-            if let year = memberSinceYear {
-                chip(label: "Member since", value: "\(year)")
-            }
-            chip(label: "Specialization", value: specializationLabel)
-        }
-        .padding(.bottom, Theme.Spacing.lg)
-    }
-
-    private func chip(label: String, value: String) -> some View {
-        VStack(spacing: 3) {
-            Text(label.uppercased())
-                .font(.system(size: 9, weight: .semibold))
-                .foregroundColor(Theme.Color.muted)
-                .kerning(0.5)
-            Text(value)
-                .font(.system(size: 12, weight: .semibold))
-                .foregroundColor(Theme.Color.onSurface)
-                .multilineTextAlignment(.center)
-        }
-        .padding(.horizontal, Theme.Spacing.sm)
-        .padding(.vertical, 8)
-        .frame(maxWidth: .infinity)
-        .background(Theme.Color.surface)
-        .cornerRadius(Theme.Radius.sm)
-        .overlay(
-            RoundedRectangle(cornerRadius: Theme.Radius.sm)
-                .stroke(Theme.Color.secondary.opacity(0.15), lineWidth: 1)
+    private var cardSection: some View {
+        AcademyIDCardView(
+            firstName:                cardFirstName,
+            lastName:                 cardLastName,
+            nickname:                 nil,
+            age:                      dashboardVM.profile?.calculatedAge,
+            nationality:              "",
+            gender:                   nil,
+            city:                     nil,
+            country:                  nil,
+            profileImage:             nil,
+            profilePhotoURL:          dashboardVM.profile?.profilePhotoUrl,
+            profilePhotoProcessedURL: dashboardVM.profile?.profilePhotoProcessedUrl,
+            isVerified:               true,
+            lfaAcademyId:             viewModel.loadState.response?.lfaAcademyId
+                                      ?? dashboardVM.profile?.lfaAcademyId,
+            publicToken:              viewModel.loadState.response?.publicToken
+                                      ?? dashboardVM.profile?.publicToken
         )
     }
 
-    // MARK: — QR section
+    // MARK: — QR scan panel (200×200, brightness boost)
 
     @ViewBuilder
     private var qrSection: some View {
@@ -222,7 +148,6 @@ struct AcademyIDFullScreenView: View {
                     .onTapGesture { toggleBrightness() }
             }
 
-            // Brightness hint
             HStack(spacing: 5) {
                 Image(systemName: brightnessBoostActive ? "sun.max.fill" : "sun.min")
                     .font(.system(size: 11))
@@ -234,7 +159,6 @@ struct AcademyIDFullScreenView: View {
             .foregroundColor(brightnessBoostActive ? Theme.Color.secondary : Theme.Color.muted)
             .animation(.easeInOut(duration: 0.2), value: brightnessBoostActive)
 
-            // Verify URL (tiny, muted — for transparency)
             Text(qrData)
                 .font(.system(size: 8))
                 .foregroundColor(Theme.Color.muted.opacity(0.5))
@@ -286,73 +210,23 @@ struct AcademyIDFullScreenView: View {
         }
     }
 
-    // MARK: — Computed helpers
+    // MARK: — Helpers
 
     private var isReloading: Bool {
         if case .loading = viewModel.loadState { return true }
         return false
     }
 
-    private var memberSinceYear: Int? {
-        // Could come from profile if it had created_at — use lfaAcademyId year as proxy
-        guard let aid = viewModel.loadState.response?.lfaAcademyId
-                     ?? dashboardVM.profile?.lfaAcademyId,
-              aid.count >= 8 else { return nil }
-        // Format: LFA-YYYY-NNNNN — year is characters 4..7
-        let start = aid.index(aid.startIndex, offsetBy: 4)
-        let end   = aid.index(start, offsetBy: 4)
-        return Int(String(aid[start..<end]))
+    // Split displayName ("R2Test Beta") → firstName ("R2Test") / lastName ("Beta")
+    private var cardFirstName: String? {
+        guard let name = dashboardVM.profile?.displayName, !name.isEmpty else { return nil }
+        return name.split(separator: " ", maxSplits: 1).first.map(String.init)
     }
 
-    private var specializationLabel: String {
-        // Primary: lfaLicense from DashboardViewModel
-        if let spec = dashboardVM.lfaLicense?.specializationType {
-            return specLabel(spec) ?? spec
-        }
-        // Fallback: first active license from profile
-        if let active = dashboardVM.profile?.licenses?.first(where: { $0.isActive }) {
-            return specLabel(active.specializationType) ?? active.specializationType
-        }
-        return "No active specialization"
-    }
-
-    private func specLabel(_ raw: String) -> String? {
-        let map: [String: String] = [
-            "lfa_football_player": "LFA Football Player",
-            "lfa_coach":           "LFA Coach",
-            "gancuju_player":      "GānCuju Player",
-            "internship":          "Internship",
-        ]
-        return map[raw.lowercased()]
-    }
-}
-
-
-// MARK: — URL photo loader (reused from AcademyIDCardView, scoped privately)
-
-private struct URLPhotoView: View {
-    let urlPath: String
-    @State private var image: UIImage?
-
-    var body: some View {
-        Group {
-            if let img = image {
-                Image(uiImage: img).resizable().scaledToFill()
-            } else {
-                Rectangle()
-                    .fill(Theme.Color.muted.opacity(0.08))
-                    .overlay(ProgressView().scaleEffect(0.7))
-            }
-        }
-        .onAppear { loadImage() }
-    }
-
-    private func loadImage() {
-        guard image == nil,
-              let url = URL(string: APIConfig.baseURL + urlPath) else { return }
-        URLSession.shared.dataTask(with: url) { data, _, _ in
-            guard let data = data, let img = UIImage(data: data) else { return }
-            DispatchQueue.main.async { self.image = img }
-        }.resume()
+    private var cardLastName: String? {
+        guard let name = dashboardVM.profile?.displayName else { return nil }
+        let parts = name.split(separator: " ", maxSplits: 1)
+        guard parts.count > 1 else { return nil }
+        return String(parts[1])
     }
 }

--- a/ios/LFAEducationCenter/Auth/AcademyIDFullScreenView.swift
+++ b/ios/LFAEducationCenter/Auth/AcademyIDFullScreenView.swift
@@ -93,8 +93,8 @@ struct AcademyIDFullScreenView: View {
             age:                      dashboardVM.profile?.calculatedAge,
             nationality:              dashboardVM.profile?.nationality ?? "",
             gender:                   dashboardVM.profile?.gender,
-            city:                     nil,   // Part B: city not yet in /users/me response
-            country:                  nil,   // Part B: country not yet in /users/me response
+            city:                     dashboardVM.profile?.city,
+            country:                  dashboardVM.profile?.country,
             profileImage:             nil,
             profilePhotoURL:          dashboardVM.profile?.profilePhotoUrl,
             profilePhotoProcessedURL: dashboardVM.profile?.profilePhotoProcessedUrl,

--- a/ios/LFAEducationCenter/Auth/AcademyIDFullScreenView.swift
+++ b/ios/LFAEducationCenter/Auth/AcademyIDFullScreenView.swift
@@ -71,6 +71,14 @@ struct AcademyIDFullScreenView: View {
         .navigationViewStyle(.stack)
         .onAppear { Task { await viewModel.load(using: authManager, profile: dashboardVM.profile) } }
         .onDisappear { restoreBrightness() }
+        // If the slow path just lazy-assigned a new Academy ID, reload the dashboard so
+        // ProfileView subtitle and ProfileCompletionScore.academyID (+10%) update immediately.
+        .onChange(of: viewModel.loadState.isLoaded) { isLoaded in
+            guard isLoaded,
+                  dashboardVM.profile?.lfaAcademyId == nil,
+                  viewModel.loadState.response?.lfaAcademyId != nil else { return }
+            Task { await dashboardVM.reload(using: authManager) }
+        }
     }
 
     // MARK: — Profile photo

--- a/ios/LFAEducationCenter/Auth/AcademyIDViewModel.swift
+++ b/ios/LFAEducationCenter/Auth/AcademyIDViewModel.swift
@@ -74,7 +74,16 @@ final class AcademyIDViewModel: ObservableObject {
             let response: AcademyIDResponse = try await authManager.authenticatedGet(
                 path: "/api/v1/users/me/academy-id"
             )
-            loadState = .loaded(response)
+            // Rebuild qrData using APIConfig.verifyBaseURL so fast path and slow path
+            // always produce the same QR URL on this iOS client, regardless of the
+            // backend's VERIFY_BASE_URL default (which may be localhost in dev).
+            let iosQrData = APIConfig.verifyBaseURL + "/verify/" + response.publicToken
+            loadState = .loaded(AcademyIDResponse(
+                lfaAcademyId: response.lfaAcademyId,
+                publicToken:  response.publicToken,
+                qrUrl:        response.qrUrl,
+                qrData:       iosQrData
+            ))
         } catch {
             loadState = .error("Could not load Academy ID. Check your connection.")
         }

--- a/ios/LFAEducationCenter/Auth/AuthManager.swift
+++ b/ios/LFAEducationCenter/Auth/AuthManager.swift
@@ -209,6 +209,30 @@ final class AuthManager: ObservableObject {
         }
     }
 
+    // Multipart POST with automatic Bearer inject, single 401 refresh + retry.
+    // Used for file upload endpoints (e.g. POST /api/v1/users/me/profile-photo).
+    func authenticatedMultipartPost<T: Decodable>(
+        path:      String,
+        imageData: Data,
+        mimeType:  String,
+        fieldName: String = "photo"
+    ) async throws -> T {
+        guard let token = accessToken else { logout(); throw APIError.unauthorized }
+        do {
+            return try await APIClient.multipartPost(
+                path: path, imageData: imageData,
+                mimeType: mimeType, fieldName: fieldName, token: token
+            )
+        } catch APIError.httpError(401, _) {
+            let refreshed = await performRefresh()
+            guard refreshed, let newToken = accessToken else { throw APIError.unauthorized }
+            return try await APIClient.multipartPost(
+                path: path, imageData: imageData,
+                mimeType: mimeType, fieldName: fieldName, token: newToken
+            )
+        }
+    }
+
     // Form-encoded POST with automatic Bearer inject, single 401 refresh + retry.
     // Used for FastAPI endpoints that declare Form(...) parameters.
     func authenticatedFormPost<T: Decodable>(path: String, fields: [String: String]) async throws -> T {

--- a/ios/LFAEducationCenter/Models/UserProfile.swift
+++ b/ios/LFAEducationCenter/Models/UserProfile.swift
@@ -15,6 +15,9 @@ struct UserProfile: Decodable {
     let xpBalance:           Int?          // xp_balance — Phase E stat display
     let onboardingCompleted: Bool?
     let position:            String?       // football position
+    let nickname:            String?       // nickname — shown on Academy ID card
+    let gender:              String?       // "Male" / "Female" / "Other"
+    let nationality:         String?       // ISO 3166-1 alpha-2, e.g. "HU"
     let city:                String?       // city — shown on Academy ID card LOCATION field
     let country:             String?       // country — shown on Academy ID card LOCATION field
     let dateOfBirth:                 String?       // date_of_birth — ISO 8601
@@ -47,7 +50,8 @@ struct UserProfile: Decodable {
     }
 
     enum CodingKeys: String, CodingKey {
-        case id, name, email, role, position, city, country
+        case id, name, email, role, position
+        case nickname, gender, nationality, city, country
         case creditBalance       = "credit_balance"
         case xpBalance           = "xp_balance"
         case onboardingCompleted = "onboarding_completed"

--- a/ios/LFAEducationCenter/Networking/APIClient.swift
+++ b/ios/LFAEducationCenter/Networking/APIClient.swift
@@ -18,6 +18,26 @@ enum APIClient {
         return try await execute(request)
     }
 
+    // MARK: — POST (Multipart/form-data)
+    // Used for file upload endpoints (e.g. POST /api/v1/users/me/profile-photo).
+    // fieldName must match the FastAPI File(...) parameter name.
+
+    static func multipartPost<T: Decodable>(
+        path:      String,
+        imageData: Data,
+        mimeType:  String,
+        fieldName: String = "photo",
+        token:     String? = nil
+    ) async throws -> T {
+        let boundary = "Boundary-\(UUID().uuidString)"
+        var request  = try buildMultipartRequest(path: path, boundary: boundary, token: token)
+        request.httpBody = buildMultipartBody(
+            imageData: imageData, mimeType: mimeType,
+            fieldName: fieldName, boundary: boundary
+        )
+        return try await execute(request)
+    }
+
     // MARK: — POST (Form-encoded)
     // Used by endpoints that declare FastAPI Form(...) parameters (e.g. /specialization/unlock).
 
@@ -58,6 +78,33 @@ enum APIClient {
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }
         return request
+    }
+
+    private static func buildMultipartRequest(path: String, boundary: String, token: String?) throws -> URLRequest {
+        guard let url = URL(string: APIConfig.baseURL + path) else {
+            throw APIError.invalidURL
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        if let token = token {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        return request
+    }
+
+    private static func buildMultipartBody(
+        imageData: Data, mimeType: String, fieldName: String, boundary: String
+    ) -> Data {
+        var body = Data()
+        let crlf = "\r\n"
+        body.append(Data("--\(boundary)\(crlf)".utf8))
+        body.append(Data("Content-Disposition: form-data; name=\"\(fieldName)\"; filename=\"photo.jpg\"\(crlf)".utf8))
+        body.append(Data("Content-Type: \(mimeType)\(crlf)\(crlf)".utf8))
+        body.append(imageData)
+        body.append(Data("\(crlf)--\(boundary)--\(crlf)".utf8))
+        return body
     }
 
     private static func buildFormRequest(path: String, token: String?) throws -> URLRequest {

--- a/ios/LFAEducationCenter/Profile/PhotoPicker.swift
+++ b/ios/LFAEducationCenter/Profile/PhotoPicker.swift
@@ -1,0 +1,44 @@
+import PhotosUI
+import SwiftUI
+
+// UIViewControllerRepresentable wrapping PHPickerViewController.
+// Single-image selection, no crop, no camera — MVP scope.
+// Calls onImagePicked on the main thread when the user confirms selection.
+// Dismisses the picker automatically (picker.dismiss is called by the coordinator).
+// Named ProfilePhotoPicker to avoid collision with the private PhotoPicker in RegisterView.
+struct ProfilePhotoPicker: UIViewControllerRepresentable {
+
+    let onImagePicked: (UIImage) -> Void
+
+    func makeUIViewController(context: Context) -> PHPickerViewController {
+        var config            = PHPickerConfiguration(photoLibrary: .shared())
+        config.filter         = .images
+        config.selectionLimit = 1
+        let picker            = PHPickerViewController(configuration: config)
+        picker.delegate       = context.coordinator
+        return picker
+    }
+
+    func updateUIViewController(_ uiViewController: PHPickerViewController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator { Coordinator(onImagePicked: onImagePicked) }
+
+    final class Coordinator: NSObject, PHPickerViewControllerDelegate {
+        private let onImagePicked: (UIImage) -> Void
+
+        init(onImagePicked: @escaping (UIImage) -> Void) {
+            self.onImagePicked = onImagePicked
+        }
+
+        func picker(_ picker: PHPickerViewController,
+                    didFinishPicking results: [PHPickerResult]) {
+            picker.dismiss(animated: true)
+            guard let result = results.first,
+                  result.itemProvider.canLoadObject(ofClass: UIImage.self) else { return }
+            result.itemProvider.loadObject(ofClass: UIImage.self) { [weak self] object, _ in
+                guard let image = object as? UIImage else { return }
+                DispatchQueue.main.async { self?.onImagePicked(image) }
+            }
+        }
+    }
+}

--- a/ios/LFAEducationCenter/Profile/ProfileCompletionCard.swift
+++ b/ios/LFAEducationCenter/Profile/ProfileCompletionCard.swift
@@ -146,6 +146,7 @@ struct ProfileCompletionCard: View {
 struct ProfileCompletionSection: View {
     let score:           ProfileCompletionScore
     let onAcademyIDTap:  () -> Void
+    let onPhotoTap:      () -> Void
 
     private static let successGreen = Color(red: 0.18, green: 0.80, blue: 0.44)
 
@@ -196,7 +197,8 @@ struct ProfileCompletionSection: View {
             row(icon: "camera.fill",
                 title: "Profile Photo",
                 subtitle: "Your player profile photo",
-                state: score.profilePhoto > 0 ? .complete : .upcoming("R3D"))
+                state: score.profilePhoto > 0 ? .complete : .incomplete(action: onPhotoTap),
+                tapAction: score.profilePhoto > 0 ? onPhotoTap : nil)
 
             row(icon: "target",
                 title: "Goals & Motivation",

--- a/ios/LFAEducationCenter/Profile/ProfilePhotoUploadView.swift
+++ b/ios/LFAEducationCenter/Profile/ProfilePhotoUploadView.swift
@@ -1,0 +1,203 @@
+import SwiftUI
+
+// Full-screen photo upload flow.
+//
+// State machine (PhotoUploadState):
+//   idle      → picker sheet → preview(image) → uploading → success
+//                                                          → error(msg) → retry → preview
+//
+// On success: calls onSuccess() which triggers dashboardVM.reload() in the caller.
+// BG removal runs server-side; MVP treats "uploaded" and "processing" both as success.
+// Picker is opened automatically on appear when state == .idle.
+struct ProfilePhotoUploadView: View {
+
+    @EnvironmentObject private var authManager: AuthManager
+    @Environment(\.presentationMode) private var presentationMode
+
+    let onSuccess: () -> Void
+
+    @StateObject private var vm             = ProfilePhotoUploadViewModel()
+    @State       private var isShowingPicker = false
+
+    var body: some View {
+        NavigationView {
+            VStack(spacing: Theme.Spacing.lg) {
+                Spacer(minLength: Theme.Spacing.xl)
+                photoArea
+                actionArea
+                Spacer()
+            }
+            .padding(.horizontal, Theme.Spacing.lg)
+            .background(Color(UIColor.systemBackground).ignoresSafeArea())
+            .navigationTitle("Profile Photo")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button {
+                        presentationMode.wrappedValue.dismiss()
+                    } label: {
+                        Image(systemName: "xmark")
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundColor(Theme.Color.onSurface)
+                    }
+                    .disabled(isUploading)
+                }
+            }
+            .sheet(isPresented: $isShowingPicker) {
+                ProfilePhotoPicker { image in
+                    vm.selectImage(image)
+                }
+            }
+        }
+        .navigationViewStyle(.stack)
+        .onAppear {
+            if case .idle = vm.state { isShowingPicker = true }
+        }
+        .onChange(of: successTriggered) { triggered in
+            if triggered {
+                onSuccess()
+                presentationMode.wrappedValue.dismiss()
+            }
+        }
+    }
+
+    // MARK: — Photo area
+
+    @ViewBuilder
+    private var photoArea: some View {
+        switch vm.state {
+        case .idle:
+            placeholderCircle
+
+        case .preview(let image):
+            Image(uiImage: image)
+                .resizable()
+                .scaledToFill()
+                .frame(width: 140, height: 140)
+                .clipShape(Circle())
+                .overlay(Circle().stroke(Theme.Color.primary.opacity(0.4), lineWidth: 2))
+
+        case .uploading:
+            ZStack {
+                Circle()
+                    .fill(Theme.Color.muted.opacity(0.08))
+                    .frame(width: 140, height: 140)
+                ProgressView()
+                    .scaleEffect(1.4)
+                    .accentColor(Theme.Color.primary)
+            }
+
+        case .success:
+            ZStack {
+                Circle()
+                    .fill(Color(red: 0.18, green: 0.80, blue: 0.44).opacity(0.12))
+                    .frame(width: 140, height: 140)
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 56))
+                    .foregroundColor(Color(red: 0.18, green: 0.80, blue: 0.44))
+            }
+
+        case .error:
+            placeholderCircle
+        }
+    }
+
+    private var placeholderCircle: some View {
+        Circle()
+            .fill(Theme.Color.muted.opacity(0.08))
+            .frame(width: 140, height: 140)
+            .overlay(
+                Image(systemName: "person.fill")
+                    .font(.system(size: 56))
+                    .foregroundColor(Theme.Color.muted.opacity(0.3))
+            )
+    }
+
+    // MARK: — Action area
+
+    @ViewBuilder
+    private var actionArea: some View {
+        switch vm.state {
+        case .idle:
+            choosePhotoButton
+
+        case .preview:
+            VStack(spacing: Theme.Spacing.md) {
+                uploadButton
+                choosePhotoButton
+            }
+
+        case .uploading:
+            Text("Uploading…")
+                .font(.subheadline)
+                .foregroundColor(Theme.Color.muted)
+
+        case .success:
+            Text("Photo uploaded successfully.")
+                .font(.subheadline.weight(.semibold))
+                .foregroundColor(Color(red: 0.18, green: 0.80, blue: 0.44))
+                .multilineTextAlignment(.center)
+
+        case .error(let message):
+            VStack(spacing: Theme.Spacing.md) {
+                Text(message)
+                    .font(.subheadline)
+                    .foregroundColor(Theme.Color.error)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
+                choosePhotoButton
+            }
+        }
+    }
+
+    private var uploadButton: some View {
+        Button {
+            Task { await vm.upload(using: authManager) }
+        } label: {
+            Text("Upload Photo")
+                .font(.body.weight(.semibold))
+                .frame(maxWidth: .infinity)
+                .frame(height: 48)
+                .background(Theme.Color.primary)
+                .foregroundColor(.white)
+                .cornerRadius(Theme.Radius.sm)
+        }
+        .disabled(isUploading)
+    }
+
+    private var choosePhotoButton: some View {
+        Button {
+            isShowingPicker = true
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "photo.on.rectangle")
+                    .font(.system(size: 15))
+                Text(hasPreview ? "Choose Different Photo" : "Choose Photo")
+                    .font(.body.weight(.semibold))
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: 48)
+            .background(Theme.Color.primary.opacity(0.10))
+            .foregroundColor(Theme.Color.primary)
+            .cornerRadius(Theme.Radius.sm)
+        }
+        .disabled(isUploading)
+    }
+
+    // MARK: — Helpers
+
+    private var isUploading: Bool {
+        if case .uploading = vm.state { return true }
+        return false
+    }
+
+    private var hasPreview: Bool {
+        if case .preview = vm.state { return true }
+        return false
+    }
+
+    private var successTriggered: Bool {
+        if case .success = vm.state { return true }
+        return false
+    }
+}

--- a/ios/LFAEducationCenter/Profile/ProfilePhotoUploadViewModel.swift
+++ b/ios/LFAEducationCenter/Profile/ProfilePhotoUploadViewModel.swift
@@ -1,0 +1,82 @@
+import UIKit
+
+// MARK: — Response
+
+private struct ProfilePhotoUploadResponse: Decodable {
+    let profilePhotoUrl: String
+    let status:          String
+    enum CodingKeys: String, CodingKey {
+        case profilePhotoUrl = "profile_photo_url"
+        case status
+    }
+}
+
+// MARK: — State
+
+enum PhotoUploadState {
+    case idle
+    case preview(UIImage)   // image selected, not yet uploaded
+    case uploading          // POST in flight
+    case success            // 201 received
+    case error(String)      // user-readable message
+}
+
+// MARK: — ViewModel
+
+@MainActor
+final class ProfilePhotoUploadViewModel: ObservableObject {
+
+    @Published private(set) var state: PhotoUploadState = .idle
+
+    // 5 MB hard cap — mirrors backend _MAX_BYTES
+    private let maxBytes = 5 * 1024 * 1024
+
+    func selectImage(_ image: UIImage) {
+        state = .preview(image)
+    }
+
+    func upload(using authManager: AuthManager) async {
+        guard case .preview(let image) = state else { return }
+
+        // JPEG at 0.85 quality — MIME image/jpeg, FastAPI field name "photo"
+        guard let jpegData = image.jpegData(compressionQuality: 0.85) else {
+            state = .error("Could not process the selected image. Please try another photo.")
+            return
+        }
+
+        if jpegData.count > maxBytes {
+            state = .error("The selected photo is too large (max 5 MB). Please choose a smaller image.")
+            return
+        }
+
+        state = .uploading
+
+        do {
+            let _: ProfilePhotoUploadResponse = try await authManager.authenticatedMultipartPost(
+                path:      "/api/v1/users/me/profile-photo",
+                imageData: jpegData,
+                mimeType:  "image/jpeg",
+                fieldName: "photo"
+            )
+            state = .success
+
+        } catch APIError.httpError(let code, let detail) {
+            switch code {
+            case 400:
+                state = .error(detail ?? "Invalid photo. Please choose a JPEG, PNG, or WEBP image under 5 MB.")
+            case 401:
+                state = .error("Your session has expired. Please sign in again.")
+            default:
+                state = .error("Upload failed (error \(code)). Please try again.")
+            }
+        } catch APIError.unauthorized {
+            state = .error("Your session has expired. Please sign in again.")
+        } catch {
+            state = .error("Network error. Check your connection and try again.")
+        }
+    }
+
+    func reset() {
+        state = .idle
+    }
+}

--- a/ios/LFAEducationCenter/Profile/ProfileView.swift
+++ b/ios/LFAEducationCenter/Profile/ProfileView.swift
@@ -12,7 +12,8 @@ struct ProfileView: View {
 
     @Environment(\.presentationMode) private var presentationMode
 
-    @State private var isShowingAcademyID = false
+    @State private var isShowingAcademyID   = false
+    @State private var isShowingPhotoUpload = false
 
     var body: some View {
         NavigationView {
@@ -46,6 +47,13 @@ struct ProfileView: View {
                     .environmentObject(authManager)
                     .environmentObject(dashboardVM)
             }
+            .fullScreenCover(isPresented: $isShowingPhotoUpload) {
+                ProfilePhotoUploadView {
+                    Task { await dashboardVM.reload(using: authManager) }
+                }
+                .environmentObject(authManager)
+                .environmentObject(dashboardVM)
+            }
         }
         .navigationViewStyle(.stack)
     }
@@ -57,22 +65,37 @@ struct ProfileView: View {
                     ?? dashboardVM.profile?.profilePhotoUrl
 
         return VStack(spacing: Theme.Spacing.sm) {
-            Group {
-                if let url = photoUrl {
-                    ProfileURLPhotoView(urlPath: url)
-                        .frame(width: 88, height: 88)
-                        .clipShape(Circle())
-                        .overlay(Circle().stroke(Theme.Color.secondary.opacity(0.3), lineWidth: 2))
-                } else {
-                    Circle()
-                        .fill(Theme.Color.muted.opacity(0.08))
-                        .frame(width: 88, height: 88)
-                        .overlay(
-                            Image(systemName: "person.fill")
-                                .font(.system(size: 36))
-                                .foregroundColor(Theme.Color.muted.opacity(0.3))
-                        )
+            Button { isShowingPhotoUpload = true } label: {
+                Group {
+                    if let url = photoUrl {
+                        ProfileURLPhotoView(urlPath: url)
+                            .frame(width: 88, height: 88)
+                            .clipShape(Circle())
+                            .overlay(Circle().stroke(Theme.Color.secondary.opacity(0.3), lineWidth: 2))
+                    } else {
+                        Circle()
+                            .fill(Theme.Color.muted.opacity(0.08))
+                            .frame(width: 88, height: 88)
+                            .overlay(
+                                Image(systemName: "person.fill")
+                                    .font(.system(size: 36))
+                                    .foregroundColor(Theme.Color.muted.opacity(0.3))
+                            )
+                    }
                 }
+                // Camera badge — bottom trailing corner (iOS 13-compatible overlay form)
+                .overlay(
+                    Circle()
+                        .fill(Theme.Color.primary)
+                        .frame(width: 26, height: 26)
+                        .overlay(
+                            Image(systemName: "camera.fill")
+                                .font(.system(size: 11))
+                                .foregroundColor(.white)
+                        )
+                        .offset(x: 2, y: 2),
+                    alignment: .bottomTrailing
+                )
             }
             .padding(.bottom, 4)
         }
@@ -118,7 +141,8 @@ struct ProfileView: View {
             let score = ProfileCompletionScore.compute(profile: profile,
                                                        lfaLicense: dashboardVM.lfaLicense)
             ProfileCompletionSection(score: score,
-                                     onAcademyIDTap: { isShowingAcademyID = true })
+                                     onAcademyIDTap: { isShowingAcademyID = true },
+                                     onPhotoTap:     { isShowingPhotoUpload = true })
                 .padding(.top, Theme.Spacing.lg)
         }
     }


### PR DESCRIPTION
## Summary

- **ProfilePhotoUploadView**: fullScreenCover — auto-opens PHPicker on appear, image preview, Upload Photo CTA, loading / success / error states; on success triggers `dashboardVM.reload()` and dismisses
- **ProfilePhotoPicker** (`PhotoPicker.swift`): `UIViewControllerRepresentable` wrapping `PHPickerViewController` — callback-based, renamed from `PhotoPicker` to avoid collision with `RegisterView`'s existing private struct
- **ProfilePhotoUploadViewModel**: `PhotoUploadState` machine (idle / preview / uploading / success / error), JPEG 0.85 compression, 5 MB client-side guard, user-friendly error messages for 400/401/network/timeout
- **APIClient**: `multipartPost<T>` static method + RFC 2046-correct body builder (CRLF, `Data(…utf8)` appends, iOS 13-compatible)
- **AuthManager**: `authenticatedMultipartPost<T>` — Bearer inject + single 401 refresh/retry, matches `authenticatedFormPost` pattern
- **ProfileView**: photo header circle tappable (camera badge, iOS 13-compatible overlay), `isShowingPhotoUpload` state, `ProfilePhotoUploadView` fullScreenCover
- **ProfileCompletionCard**: `ProfileCompletionSection` gains `onPhotoTap` param; Profile Photo row `.upcoming("R3D")` → `.incomplete(action: onPhotoTap)`; complete state allows re-upload via `tapAction`

## Changed files (8 files, +454 / −16)

| File | Type |
|---|---|
| `ios/LFAEducationCenter/Profile/PhotoPicker.swift` | new |
| `ios/LFAEducationCenter/Profile/ProfilePhotoUploadView.swift` | new |
| `ios/LFAEducationCenter/Profile/ProfilePhotoUploadViewModel.swift` | new |
| `ios/LFAEducationCenter/Networking/APIClient.swift` | modified |
| `ios/LFAEducationCenter/Auth/AuthManager.swift` | modified |
| `ios/LFAEducationCenter/Profile/ProfileView.swift` | modified |
| `ios/LFAEducationCenter/Profile/ProfileCompletionCard.swift` | modified |
| `ios/LFAEducationCenter.xcodeproj/project.pbxproj` | modified |

## Build

```
** BUILD SUCCEEDED **
Errors:   0
Swift warnings: 0
```

## Manual smoke checklist

- [ ] r2.testb@e2e.lfa (LFA-2026-00240) — no photo pre-upload → Profile Photo row tappable
- [ ] Header photo circle tap → ProfilePhotoUploadView opens, picker auto-launches
- [ ] Profile Photo checklist row tap → same view
- [ ] PHPicker → select image → preview shown
- [ ] "Upload Photo" tap → loading spinner
- [ ] Upload success → green checkmark + dismiss
- [ ] ProfileView header shows uploaded photo
- [ ] Completion score +15% (e.g. 40% → 55%)
- [ ] AcademyIDFullScreenView shows refreshed photo after reload
- [ ] >5 MB image → user-friendly error before upload
- [ ] Network error → "Network error. Check your connection and try again."
- [ ] 401 → refresh/retry or "Your session has expired. Please sign in again."

## BG removal

MVP: no polling, no manual toggle. If `BG_REMOVAL_PROCESSOR="null"` (default) upload response `status="uploaded"` → success. If `"rembg"` active → `status="processing"` → treated as success; `processed_url` populates on next `dashboardVM.reload()`.

## Scope exclusions

mood photo upload · player card generation · skill rating · goals form · profile edit PATCH · camera capture · crop editor · manual BG removal toggle · polling loop · DELETE photo · invoice reward UX

## Rollback

```bash
git revert 0b151085 --no-edit
```

No backend / DB rollback needed.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)