### PR TITLE
feat(r3m): add native mood photos flow

### DIFF
--- a/app/api/api_v1/api.py
+++ b/app/api/api_v1/api.py
@@ -70,6 +70,7 @@ from .endpoints import (
     license_renewal,
 )
 from .endpoints.lfa_player import self_assessment as lfa_player_self_assessment
+from .endpoints.lfa_player import mood_photos as lfa_player_mood_photos
 from .endpoints.periods import lfa_player_generators
 
 # ── TOURNAMENTS ───────────────────────────────────────────────────────────────
@@ -163,6 +164,7 @@ api_router.include_router(coupons.router, prefix="", tags=["coupons"])
 api_router.include_router(invitation_codes.router, prefix="", tags=["invitation-codes"])
 api_router.include_router(lfa_player.router, prefix="/lfa-player", tags=["lfa-player"])
 api_router.include_router(lfa_player_self_assessment.router, prefix="/lfa-player", tags=["lfa-player"])
+api_router.include_router(lfa_player_mood_photos.router, prefix="/lfa-player", tags=["lfa-player"])
 api_router.include_router(gancuju.router, prefix="/gancuju", tags=["gancuju"])
 api_router.include_router(internship.router, prefix="/internship", tags=["internship"])
 api_router.include_router(coach.router, prefix="/coach", tags=["coach"])

--- a/app/api/api_v1/endpoints/lfa_player/mood_photos.py
+++ b/app/api/api_v1/endpoints/lfa_player/mood_photos.py
@@ -1,0 +1,333 @@
+"""
+LFA Football Player — Native Mood Photos API
+=============================================
+Bearer-token equivalents of the web-session mood photo routes.
+Delegates entirely to app.services.mood_photo_service — no logic duplication.
+
+Endpoints:
+  GET    /api/v1/lfa-player/mood-photos                      — list all 9 slots
+  POST   /api/v1/lfa-player/mood-photos/{slot}/upload        — upload a slot
+  DELETE /api/v1/lfa-player/mood-photos/{slot}               — delete a slot
+  POST   /api/v1/lfa-player/mood-photos/{slot}/remove-bg     — trigger BG removal
+  GET    /api/v1/lfa-player/mood-photos/{slot}/status        — poll slot status
+
+Completion rule (iOS):
+  phase_a_complete = True when all 6 Phase-A slots have original_url IS NOT NULL.
+  Status 'uploaded', 'processing', 'ready', and 'failed' all count — only
+  background removal outcome is excluded from completion gating.
+"""
+
+from __future__ import annotations
+
+import io
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, BackgroundTasks, Depends, File, HTTPException, UploadFile, status
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from .....database import get_db
+from .....dependencies import get_current_user
+from .....models.user import User
+from .....models.license import UserLicense
+from .....models.user_mood_photos import MOOD_PHOTO_SLOTS, MoodPhotoStatus, UserMoodPhoto
+from .....services.mood_photo_service import (
+    save_mood_photo,
+    delete_mood_photo,
+    get_mood_photos_for_user,
+    check_bg_removal_rate_limit,
+    set_status_processing,
+    apply_removal_result,
+    apply_removal_failure,
+    reset_processing,
+    MOOD_PHOTO_DIR,
+)
+from .....config import settings
+
+router = APIRouter()
+
+# ── Slot metadata (mirrors web route _SLOT_META) ──────────────────────────────
+
+_PHASE_A = (
+    "mood_intro_neutral",
+    "mood_happy_smile",
+    "mood_celebration",
+    "mood_sad_disappointed",
+    "mood_angry_competitive",
+    "mood_surprised_shocked",
+)
+
+_PHASE_B = (
+    "mood_focused_ready",
+    "mood_confident",
+    "mood_proud",
+)
+
+_SLOT_META: dict[str, dict[str, str]] = {
+    "mood_intro_neutral":     {"label": "Neutral",     "phase": "A"},
+    "mood_happy_smile":       {"label": "Happy",       "phase": "A"},
+    "mood_celebration":       {"label": "Celebration", "phase": "A"},
+    "mood_sad_disappointed":  {"label": "Sad",         "phase": "A"},
+    "mood_angry_competitive": {"label": "Angry",       "phase": "A"},
+    "mood_surprised_shocked": {"label": "Surprised",   "phase": "A"},
+    "mood_focused_ready":     {"label": "Focused",     "phase": "B"},
+    "mood_confident":         {"label": "Confident",   "phase": "B"},
+    "mood_proud":             {"label": "Proud",       "phase": "B"},
+}
+
+_ORDERED_SLOTS = list(_PHASE_A) + list(_PHASE_B)
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _is_timed_out(record: UserMoodPhoto) -> bool:
+    if record.status != MoodPhotoStatus.processing.value:
+        return False
+    if record.updated_at is None:
+        return False
+    elapsed = (datetime.now(timezone.utc) - record.updated_at).total_seconds()
+    return elapsed > settings.PROCESSING_TIMEOUT_SECONDS
+
+
+def _slot_dict(slot: str, record: UserMoodPhoto | None) -> dict[str, Any]:
+    meta = _SLOT_META[slot]
+    if record is None:
+        return {
+            "slot":               slot,
+            "label":              meta["label"],
+            "phase":              meta["phase"],
+            "status":             None,
+            "original_url":       None,
+            "processed_png_url":  None,
+            "processing_timed_out": False,
+        }
+    return {
+        "slot":               slot,
+        "label":              meta["label"],
+        "phase":              meta["phase"],
+        "status":             record.status,
+        "original_url":       record.original_url,
+        "processed_png_url":  record.processed_png_url,
+        "processing_timed_out": _is_timed_out(record),
+    }
+
+
+def _validate_slot(slot: str) -> None:
+    if slot not in MOOD_PHOTO_SLOTS:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                            detail=f"Invalid slot: {slot!r}")
+
+
+def _get_license_id(user_id: int, db: Session) -> int | None:
+    lic = db.query(UserLicense).filter(
+        UserLicense.user_id == user_id,
+        UserLicense.specialization_type == "LFA_FOOTBALL_PLAYER",
+    ).first()
+    return lic.id if lic else None
+
+
+# ── In-process BG removal runner (same pattern as web route) ──────────────────
+
+def _run_bg_removal(user_id: int, slot: str, original_url: str) -> None:
+    """Run background removal in a FastAPI BackgroundTask thread."""
+    from .....database import SessionLocal
+    from .....services.background_removal import get_processor
+
+    db = SessionLocal()
+    try:
+        processor = get_processor()
+        orig_path = MOOD_PHOTO_DIR / Path(original_url).name
+        if not orig_path.exists():
+            apply_removal_failure(user_id, slot, db)
+            return
+
+        output_bytes = processor.remove_background(orig_path.read_bytes())
+        ts = int(time.time())
+        proc_filename = f"{user_id}_mood_{slot}_proc_{ts}.png"
+        (MOOD_PHOTO_DIR / proc_filename).write_bytes(output_bytes)
+        processed_url = f"/static/uploads/mood_photos/{proc_filename}"
+        apply_removal_result(user_id, slot, processed_url, db)
+    except Exception:
+        apply_removal_failure(user_id, slot, db)
+    finally:
+        db.close()
+
+
+# ── GET /mood-photos ──────────────────────────────────────────────────────────
+
+@router.get("/mood-photos")
+def list_mood_photos(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """
+    Return all 9 mood photo slots for the current user.
+
+    phase_a_complete is True when all 6 Phase-A slots have original_url set
+    (status may be uploaded / processing / ready / failed — all count).
+    """
+    by_slot = get_mood_photos_for_user(current_user.id, db)
+
+    slots = [_slot_dict(s, by_slot.get(s)) for s in _ORDERED_SLOTS]
+
+    phase_a_count = sum(
+        1 for s in _PHASE_A if by_slot.get(s) is not None
+    )
+
+    return {
+        "slots":                slots,
+        "phase_a_uploaded_count": phase_a_count,
+        "phase_a_complete":       phase_a_count == len(_PHASE_A),
+    }
+
+
+# ── POST /mood-photos/{slot}/upload ──────────────────────────────────────────
+
+@router.post("/mood-photos/{slot}/upload")
+async def upload_mood_photo(
+    slot:             str,
+    background_tasks: BackgroundTasks,
+    photo:            UploadFile = File(...),
+    db:               Session    = Depends(get_db),
+    current_user:     User       = Depends(get_current_user),
+):
+    """
+    Upload (or replace) a mood photo slot.
+
+    Accepts JPEG, PNG, or WebP ≤ 5 MB.
+    If BG_REMOVAL_PROCESSOR is not 'null', auto-triggers background removal.
+    Returns the updated slot dict.
+    """
+    _validate_slot(slot)
+
+    file_bytes   = await photo.read()
+    content_type = photo.content_type or "image/jpeg"
+    license_id   = _get_license_id(current_user.id, db)
+
+    try:
+        record = save_mood_photo(
+            file_bytes=file_bytes,
+            content_type=content_type,
+            user_id=current_user.id,
+            slot=slot,
+            db=db,
+            license_id=license_id,
+        )
+        db.commit()
+        db.refresh(record)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+
+    # Auto-trigger BG removal if processor is active
+    if settings.BG_REMOVAL_PROCESSOR != "null":
+        if check_bg_removal_rate_limit(current_user.id):
+            set_status_processing(current_user.id, slot, db)
+            db.commit()
+            db.refresh(record)
+            background_tasks.add_task(
+                _run_bg_removal, current_user.id, slot, record.original_url
+            )
+
+    return _slot_dict(slot, record)
+
+
+# ── DELETE /mood-photos/{slot} ────────────────────────────────────────────────
+
+@router.delete("/mood-photos/{slot}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_mood_photo_endpoint(
+    slot:         str,
+    db:           Session = Depends(get_db),
+    current_user: User    = Depends(get_current_user),
+):
+    """Delete a mood photo slot. Idempotent — no-op if slot has no photo."""
+    _validate_slot(slot)
+    delete_mood_photo(current_user.id, slot, db)
+    db.commit()
+
+
+# ── POST /mood-photos/{slot}/remove-bg ───────────────────────────────────────
+
+@router.post("/mood-photos/{slot}/remove-bg")
+def trigger_bg_removal(
+    slot:             str,
+    background_tasks: BackgroundTasks,
+    db:               Session = Depends(get_db),
+    current_user:     User    = Depends(get_current_user),
+):
+    """
+    Manually trigger background removal for a slot.
+
+    No-op if slot is already processing or ready.
+    Rate-limited: 3 triggers per 60 s per user.
+    """
+    _validate_slot(slot)
+
+    record = (
+        db.query(UserMoodPhoto)
+        .filter_by(user_id=current_user.id, slot=slot)
+        .first()
+    )
+    if record is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
+                            detail="No uploaded photo for this slot.")
+
+    if record.status in (MoodPhotoStatus.processing.value, MoodPhotoStatus.ready.value):
+        return _slot_dict(slot, record)
+
+    if not check_bg_removal_rate_limit(current_user.id):
+        raise HTTPException(status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                            detail="Too many background removal requests. Try again shortly.")
+
+    orig_path = MOOD_PHOTO_DIR / Path(record.original_url).name
+    if not orig_path.exists():
+        apply_removal_failure(current_user.id, slot, db)
+        db.commit()
+        db.refresh(record)
+        return _slot_dict(slot, record)
+
+    set_status_processing(current_user.id, slot, db)
+    db.commit()
+    db.refresh(record)
+    background_tasks.add_task(
+        _run_bg_removal, current_user.id, slot, record.original_url
+    )
+    return _slot_dict(slot, record)
+
+
+# ── GET /mood-photos/{slot}/status ───────────────────────────────────────────
+
+@router.get("/mood-photos/{slot}/status")
+def get_slot_status(
+    slot:         str,
+    db:           Session = Depends(get_db),
+    current_user: User    = Depends(get_current_user),
+):
+    """
+    Poll the processing status of a single slot.
+
+    Returns processing_timed_out=True when status='processing' and the
+    record has not been updated within PROCESSING_TIMEOUT_SECONDS.
+    """
+    _validate_slot(slot)
+
+    record = (
+        db.query(UserMoodPhoto)
+        .filter_by(user_id=current_user.id, slot=slot)
+        .first()
+    )
+    if record is None:
+        return {
+            "status":               "not_uploaded",
+            "processed_png_url":    None,
+            "updated_at":           None,
+            "processing_timed_out": False,
+        }
+    return {
+        "status":               record.status,
+        "processed_png_url":    record.processed_png_url,
+        "updated_at":           record.updated_at.isoformat() if record.updated_at else None,
+        "processing_timed_out": _is_timed_out(record),
+    }

--- a/ios/LFAEducationCenter.xcodeproj/project.pbxproj
+++ b/ios/LFAEducationCenter.xcodeproj/project.pbxproj
@@ -69,6 +69,9 @@
 		BB000004000000000000059 /* ProfilePhotoUploadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000061 /* ProfilePhotoUploadView.swift */; };
 		BB000004000000000000060 /* BaselineSelfRatingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000062 /* BaselineSelfRatingViewModel.swift */; };
 		BB000004000000000000061 /* BaselineSelfRatingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000063 /* BaselineSelfRatingView.swift */; };
+		BB000004000000000000062 /* MoodPhotosViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000064 /* MoodPhotosViewModel.swift */; };
+		BB000004000000000000063 /* MoodPhotoSlotCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000065 /* MoodPhotoSlotCard.swift */; };
+		BB000004000000000000064 /* MoodPhotosView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000066 /* MoodPhotosView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -136,6 +139,9 @@
 		BB000003000000000000061 /* ProfilePhotoUploadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilePhotoUploadView.swift; sourceTree = "<group>"; };
 		BB000003000000000000062 /* BaselineSelfRatingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaselineSelfRatingViewModel.swift; sourceTree = "<group>"; };
 		BB000003000000000000063 /* BaselineSelfRatingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaselineSelfRatingView.swift; sourceTree = "<group>"; };
+		BB000003000000000000064 /* MoodPhotosViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoodPhotosViewModel.swift; sourceTree = "<group>"; };
+		BB000003000000000000065 /* MoodPhotoSlotCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoodPhotoSlotCard.swift; sourceTree = "<group>"; };
+		BB000003000000000000066 /* MoodPhotosView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoodPhotosView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -323,6 +329,9 @@
 				BB000003000000000000061 /* ProfilePhotoUploadView.swift */,
 				BB000003000000000000062 /* BaselineSelfRatingViewModel.swift */,
 				BB000003000000000000063 /* BaselineSelfRatingView.swift */,
+				BB000003000000000000064 /* MoodPhotosViewModel.swift */,
+				BB000003000000000000065 /* MoodPhotoSlotCard.swift */,
+				BB000003000000000000066 /* MoodPhotosView.swift */,
 			);
 			path = Profile;
 			sourceTree = "<group>";
@@ -477,6 +486,9 @@
 				BB000004000000000000059 /* ProfilePhotoUploadView.swift in Sources */,
 				BB000004000000000000060 /* BaselineSelfRatingViewModel.swift in Sources */,
 				BB000004000000000000061 /* BaselineSelfRatingView.swift in Sources */,
+				BB000004000000000000062 /* MoodPhotosViewModel.swift in Sources */,
+				BB000004000000000000063 /* MoodPhotoSlotCard.swift in Sources */,
+				BB000004000000000000064 /* MoodPhotosView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/LFAEducationCenter/Auth/AuthManager.swift
+++ b/ios/LFAEducationCenter/Auth/AuthManager.swift
@@ -233,6 +233,18 @@ final class AuthManager: ObservableObject {
         }
     }
 
+    // DELETE with no response body (204) — Bearer inject, single 401 refresh + retry.
+    func authenticatedDeleteNoContent(path: String) async throws {
+        guard let token = accessToken else { logout(); throw APIError.unauthorized }
+        do {
+            try await APIClient.deleteNoContent(path: path, token: token)
+        } catch APIError.httpError(401, _) {
+            let refreshed = await performRefresh()
+            guard refreshed, let newToken = accessToken else { throw APIError.unauthorized }
+            try await APIClient.deleteNoContent(path: path, token: newToken)
+        }
+    }
+
     // Form-encoded POST with automatic Bearer inject, single 401 refresh + retry.
     // Used for FastAPI endpoints that declare Form(...) parameters.
     func authenticatedFormPost<T: Decodable>(path: String, fields: [String: String]) async throws -> T {

--- a/ios/LFAEducationCenter/Dashboard/DashboardView.swift
+++ b/ios/LFAEducationCenter/Dashboard/DashboardView.swift
@@ -88,7 +88,8 @@ struct DashboardView: View {
                     let score = ProfileCompletionScore.compute(
                         profile:             profile,
                         lfaLicense:          dashboardVM.lfaLicense,
-                        selfRatingCompleted: dashboardVM.selfRatingCompleted
+                        selfRatingCompleted: dashboardVM.selfRatingCompleted,
+                        moodPhotosCompleted: dashboardVM.moodPhotosCompleted
                     )
                     ProfileCompletionCard(score: score,
                                          onViewAll: { isShowingProfile = true })

--- a/ios/LFAEducationCenter/Dashboard/DashboardViewModel.swift
+++ b/ios/LFAEducationCenter/Dashboard/DashboardViewModel.swift
@@ -55,7 +55,8 @@ final class DashboardViewModel: ObservableObject {
     @Published private(set) var lfaLicense:         LFAPlayerLicense?  = nil
     @Published private(set) var dashboard:          LicenseDashboard?  = nil
     @Published private(set) var licenses:           [UserLicense]      = []  // GānCuju, reserved
-    @Published private(set) var selfRatingCompleted: Bool              = false
+    @Published private(set) var selfRatingCompleted:  Bool              = false
+    @Published private(set) var moodPhotosCompleted: Bool              = false
 
     // MARK: — LFA Card State
 
@@ -83,7 +84,8 @@ final class DashboardViewModel: ObservableObject {
         lfaLicense          = nil
         dashboard           = nil
         licenses            = []
-        selfRatingCompleted = false
+        selfRatingCompleted  = false
+        moodPhotosCompleted  = false
         await fetchData(using: authManager)
     }
 
@@ -97,7 +99,8 @@ final class DashboardViewModel: ObservableObject {
         lfaLicense          = nil
         dashboard           = nil
         licenses            = []
-        selfRatingCompleted = false
+        selfRatingCompleted  = false
+        moodPhotosCompleted  = false
         await fetchData(using: authManager)
     }
 
@@ -109,7 +112,8 @@ final class DashboardViewModel: ObservableObject {
         lfaLicense          = nil
         dashboard           = nil
         licenses            = []
-        selfRatingCompleted = false
+        selfRatingCompleted  = false
+        moodPhotosCompleted  = false
     }
 
     // MARK: — Private
@@ -141,13 +145,24 @@ final class DashboardViewModel: ObservableObject {
                 path: "/api/v1/licenses/me"
             )) ?? []
 
-            // 5. Goals & Motivation completion — non-fatal.
-            //    Returns {completed: bool} for the user's most recent license.
+            // 5. Baseline Self-Rating completion — non-fatal.
+            //    Returns {completed: bool} when self_assessment_completed flag is set.
             //    404 (no license) or any decode error → false.
             struct MotivationCheck: Decodable { let completed: Bool }
             selfRatingCompleted = (try? await authManager.authenticatedGet(
                 path: "/api/v1/licenses/motivation-assessment"
             ) as MotivationCheck)?.completed ?? false
+
+            // 6. Mood Photos completion — non-fatal.
+            //    Returns {phase_a_complete: bool} when all 6 Phase-A slots are uploaded.
+            //    404 or decode error → false.
+            struct MoodCheck: Decodable {
+                let phaseAComplete: Bool
+                enum CodingKeys: String, CodingKey { case phaseAComplete = "phase_a_complete" }
+            }
+            moodPhotosCompleted = (try? await authManager.authenticatedGet(
+                path: "/api/v1/lfa-player/mood-photos"
+            ) as MoodCheck)?.phaseAComplete ?? false
 
             loadState = .loaded
 

--- a/ios/LFAEducationCenter/Networking/APIClient.swift
+++ b/ios/LFAEducationCenter/Networking/APIClient.swift
@@ -54,6 +54,19 @@ enum APIClient {
         return try await execute(request)
     }
 
+    // MARK: — DELETE (No Content — 204)
+
+    static func deleteNoContent(path: String, token: String? = nil) async throws {
+        let request = try buildRequest(path: path, method: "DELETE", token: token)
+        let (_, response) = try await perform(request)
+        guard let http = response as? HTTPURLResponse else {
+            throw APIError.networkError(URLError(.badServerResponse))
+        }
+        guard (200...299).contains(http.statusCode) else {
+            throw APIError.httpError(statusCode: http.statusCode, detail: nil)
+        }
+    }
+
     // MARK: — GET
 
     static func get<T: Decodable>(

--- a/ios/LFAEducationCenter/Profile/MoodPhotoSlotCard.swift
+++ b/ios/LFAEducationCenter/Profile/MoodPhotoSlotCard.swift
@@ -1,0 +1,201 @@
+import SwiftUI
+
+// Async image loader — loads a relative URL path using the configured base URL.
+// Private to this file; mirrors ProfileURLPhotoView in ProfileView.swift.
+private struct MoodPhotoThumbnail: View {
+    let urlPath: String
+    @State private var image: UIImage?
+
+    var body: some View {
+        Group {
+            if let img = image {
+                Image(uiImage: img).resizable().scaledToFill()
+            } else {
+                Rectangle()
+                    .fill(Theme.Color.muted.opacity(0.08))
+                    .overlay(ProgressView().scaleEffect(0.6))
+            }
+        }
+        .onAppear { loadImage() }
+    }
+
+    private func loadImage() {
+        guard image == nil,
+              let url = URL(string: APIConfig.baseURL + urlPath) else { return }
+        URLSession.shared.dataTask(with: url) { data, _, _ in
+            guard let data = data, let img = UIImage(data: data) else { return }
+            DispatchQueue.main.async { self.image = img }
+        }.resume()
+    }
+}
+
+// Per-slot card for the Mood Photos screen.
+// Shows thumbnail (if uploaded), label, upload / delete / BG removal controls,
+// and processing / ready / failed state indicators.
+struct MoodPhotoSlotCard: View {
+
+    let slot:         MoodPhotoSlotData
+    let isUploading:  Bool          // this slot is currently uploading
+    let onUpload:     () -> Void    // triggers PhotoPicker
+    let onDelete:     () -> Void
+    let onRemoveBg:   () -> Void
+    let onReset:      () -> Void    // reset stuck processing
+
+    private static let successGreen = Color(red: 0.18, green: 0.80, blue: 0.44)
+
+    var body: some View {
+        HStack(spacing: Theme.Spacing.md) {
+            thumbnail
+            VStack(alignment: .leading, spacing: 4) {
+                Text(slot.label)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundColor(Theme.Color.onSurface)
+                statusLine
+            }
+            Spacer()
+            actionButtons
+        }
+        .padding(Theme.Spacing.md)
+        .background(Theme.Color.surface)
+        .cornerRadius(Theme.Radius.md)
+    }
+
+    // MARK: — Thumbnail
+
+    @ViewBuilder
+    private var thumbnail: some View {
+        if isUploading {
+            RoundedRectangle(cornerRadius: Theme.Radius.sm)
+                .fill(Theme.Color.primary.opacity(0.08))
+                .frame(width: 56, height: 56)
+                .overlay(ProgressView().scaleEffect(0.7))
+        } else if let url = slot.processedPngUrl ?? slot.originalUrl {
+            MoodPhotoThumbnail(urlPath: url)
+                .frame(width: 56, height: 56)
+                .clipShape(RoundedRectangle(cornerRadius: Theme.Radius.sm))
+        } else {
+            RoundedRectangle(cornerRadius: Theme.Radius.sm)
+                .fill(Theme.Color.muted.opacity(0.15))
+                .frame(width: 56, height: 56)
+                .overlay(
+                    Image(systemName: "camera.fill")
+                        .font(.system(size: 20))
+                        .foregroundColor(Theme.Color.muted)
+                )
+        }
+    }
+
+    // MARK: — Status line
+
+    @ViewBuilder
+    private var statusLine: some View {
+        switch slot.status {
+        case "uploaded":
+            Text("Uploaded")
+                .font(.caption)
+                .foregroundColor(Theme.Color.muted)
+        case "processing":
+            if slot.processingTimedOut {
+                HStack(spacing: 4) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.caption)
+                        .foregroundColor(Theme.Color.warning)
+                    Text("Timed out — tap Reset")
+                        .font(.caption)
+                        .foregroundColor(Theme.Color.warning)
+                }
+            } else {
+                HStack(spacing: 4) {
+                    ProgressView().scaleEffect(0.6)
+                    Text("Processing…")
+                        .font(.caption)
+                        .foregroundColor(Theme.Color.muted)
+                }
+            }
+        case "ready":
+            HStack(spacing: 4) {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.caption)
+                    .foregroundColor(Self.successGreen)
+                Text("Background removed")
+                    .font(.caption)
+                    .foregroundColor(Self.successGreen)
+            }
+        case "failed":
+            HStack(spacing: 4) {
+                Image(systemName: "exclamationmark.circle.fill")
+                    .font(.caption)
+                    .foregroundColor(Theme.Color.error)
+                Text("BG removal failed — tap Retry")
+                    .font(.caption)
+                    .foregroundColor(Theme.Color.error)
+            }
+        default:
+            Text("No photo yet")
+                .font(.caption)
+                .foregroundColor(Theme.Color.muted)
+        }
+    }
+
+    // MARK: — Action buttons
+
+    @ViewBuilder
+    private var actionButtons: some View {
+        if isUploading {
+            EmptyView()
+        } else if slot.hasPhoto {
+            HStack(spacing: 8) {
+                if slot.status == "processing" && slot.processingTimedOut {
+                    iconButton(systemName: "arrow.counterclockwise", color: Theme.Color.warning, action: onReset)
+                } else if slot.status == "uploaded" || slot.status == "failed" {
+                    iconButton(systemName: "wand.and.stars", color: Theme.Color.secondary, action: onRemoveBg)
+                }
+                iconButton(systemName: "trash", color: Theme.Color.error, action: onDelete)
+            }
+        } else {
+            iconButton(systemName: "plus.circle.fill", color: Theme.Color.primary, action: onUpload)
+        }
+    }
+
+    private func iconButton(systemName: String, color: Color, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Image(systemName: systemName)
+                .font(.system(size: 20))
+                .foregroundColor(color)
+        }
+    }
+}
+
+// MARK: — Coming Soon card (Phase-B)
+
+struct MoodPhotoSlotComingSoonCard: View {
+    let label: String
+
+    var body: some View {
+        HStack(spacing: Theme.Spacing.md) {
+            RoundedRectangle(cornerRadius: Theme.Radius.sm)
+                .fill(Theme.Color.muted.opacity(0.10))
+                .frame(width: 56, height: 56)
+                .overlay(
+                    Image(systemName: "camera.fill")
+                        .font(.system(size: 20))
+                        .foregroundColor(Theme.Color.muted.opacity(0.4))
+                )
+            Text(label)
+                .font(.subheadline.weight(.semibold))
+                .foregroundColor(Theme.Color.muted)
+            Spacer()
+            Text("Coming Soon")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(Theme.Color.secondary)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(Theme.Color.secondary.opacity(0.10))
+                .cornerRadius(4)
+        }
+        .padding(Theme.Spacing.md)
+        .background(Theme.Color.surface)
+        .cornerRadius(Theme.Radius.md)
+        .opacity(0.65)
+    }
+}

--- a/ios/LFAEducationCenter/Profile/MoodPhotosView.swift
+++ b/ios/LFAEducationCenter/Profile/MoodPhotosView.swift
@@ -1,0 +1,187 @@
+import SwiftUI
+
+// Mood Photos — upload up to 6 Phase-A mood expression photos.
+//
+// Presented as fullScreenCover from ProfileView.
+// Phase-A (6 slots): tappable — upload / delete / BG removal
+// Phase-B (3 slots): Coming Soon — not tappable, not completion-blocking
+//
+// Completion: phase_a_complete == true (all 6 Phase-A slots have original_url)
+// On dismiss: onDismiss() → dashboardVM.reload() → ProfileCompletionScore +10
+struct MoodPhotosView: View {
+
+    @EnvironmentObject private var authManager: AuthManager
+    @Environment(\.presentationMode) private var presentationMode
+
+    let onDismiss: () -> Void
+
+    @StateObject private var vm = MoodPhotosViewModel()
+
+    // PhotoPicker state
+    @State private var showingPickerForSlot: String? = nil
+    @State private var pickerImage: UIImage? = nil
+
+    var body: some View {
+        NavigationView {
+            Group {
+                switch vm.loadState {
+                case .idle, .loading:
+                    loadingView
+                case .loaded:
+                    loadedView
+                case .error(let msg):
+                    errorView(msg)
+                }
+            }
+            .navigationTitle("Mood Photos")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button {
+                        onDismiss()
+                        presentationMode.wrappedValue.dismiss()
+                    } label: {
+                        Image(systemName: "xmark")
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundColor(Theme.Color.onSurface)
+                    }
+                }
+            }
+        }
+        .navigationViewStyle(.stack)
+        .onAppear { Task { await vm.load(using: authManager) } }
+        // PhotoPicker sheet
+        .sheet(isPresented: Binding(
+            get: { showingPickerForSlot != nil },
+            set: { if !$0 { showingPickerForSlot = nil } }
+        )) {
+            ProfilePhotoPicker { image in
+                pickerImage = image
+                showingPickerForSlot = nil
+            }
+        }
+        // Upload when pickerImage arrives
+        .onChange(of: pickerImage) { image in
+            guard let image, let slot = showingPickerForSlot ?? lastPickedSlot else { return }
+            lastPickedSlot = nil
+            Task { await vm.upload(image: image, slot: slot, using: authManager) }
+            pickerImage = nil
+        }
+        // Upload error alert (iOS 14-compatible)
+        .alert(isPresented: Binding(
+            get: { vm.uploadError != nil },
+            set: { if !$0 { vm.uploadError = nil } }
+        )) {
+            Alert(
+                title: Text("Upload Error"),
+                message: Text(vm.uploadError ?? ""),
+                dismissButton: .default(Text("OK")) { vm.uploadError = nil }
+            )
+        }
+    }
+
+    // Tracks which slot was waiting for the picker (needed after sheet dismissal)
+    @State private var lastPickedSlot: String? = nil
+
+    // MARK: — Loading
+
+    private var loadingView: some View {
+        VStack { Spacer(); ProgressView("Loading…").foregroundColor(Theme.Color.muted); Spacer() }
+    }
+
+    // MARK: — Error
+
+    private func errorView(_ message: String) -> some View {
+        VStack(spacing: Theme.Spacing.lg) {
+            Spacer()
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 44))
+                .foregroundColor(Theme.Color.warning)
+            Text(message)
+                .font(.subheadline)
+                .foregroundColor(Theme.Color.muted)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, Theme.Spacing.xl)
+            Button("Retry") { Task { await vm.reload(using: authManager) } }
+                .font(.body.weight(.semibold))
+                .foregroundColor(Theme.Color.primary)
+            Spacer()
+        }
+    }
+
+    // MARK: — Loaded
+
+    private var loadedView: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Theme.Spacing.lg) {
+                subtitleSection
+                phaseASection
+                phaseBSection
+                Spacer(minLength: Theme.Spacing.xl)
+            }
+            .padding(Theme.Spacing.md)
+        }
+    }
+
+    private var subtitleSection: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Upload a photo for each mood. These will appear on your player card based on match results.")
+                .font(.subheadline)
+                .foregroundColor(Theme.Color.muted)
+                .fixedSize(horizontal: false, vertical: true)
+            Text("\(vm.phaseACount)/6 uploaded")
+                .font(.caption.weight(.semibold))
+                .foregroundColor(vm.phaseAComplete ? Color(red: 0.18, green: 0.80, blue: 0.44) : Theme.Color.primary)
+                .padding(.top, 2)
+        }
+    }
+
+    // MARK: — Phase-A section
+
+    private var phaseASection: some View {
+        let phaseA = vm.slots.filter { $0.phase == "A" }
+        return VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            sectionHeader("MATCH MOODS")
+            VStack(spacing: Theme.Spacing.sm) {
+                ForEach(phaseA) { slot in
+                    MoodPhotoSlotCard(
+                        slot:        slot,
+                        isUploading: vm.uploadingSlot == slot.slot,
+                        onUpload:    { beginUpload(slot: slot.slot) },
+                        onDelete:    { Task { await vm.delete(slot: slot.slot, using: authManager) } },
+                        onRemoveBg:  { Task { await vm.triggerBgRemoval(slot: slot.slot, using: authManager) } },
+                        onReset:     { Task { await vm.resetProcessing(slot: slot.slot, using: authManager) } }
+                    )
+                }
+            }
+        }
+    }
+
+    // MARK: — Phase-B section
+
+    private var phaseBSection: some View {
+        let phaseB = vm.slots.filter { $0.phase == "B" }
+        return VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            sectionHeader("MORE MOODS")
+            VStack(spacing: Theme.Spacing.sm) {
+                ForEach(phaseB) { slot in
+                    MoodPhotoSlotComingSoonCard(label: slot.label)
+                }
+            }
+        }
+    }
+
+    // MARK: — Helpers
+
+    private func sectionHeader(_ title: String) -> some View {
+        Text(title)
+            .font(.system(size: 10, weight: .semibold))
+            .foregroundColor(Theme.Color.muted)
+            .kerning(0.8)
+    }
+
+    private func beginUpload(slot: String) {
+        lastPickedSlot      = slot
+        showingPickerForSlot = slot
+    }
+}

--- a/ios/LFAEducationCenter/Profile/MoodPhotosViewModel.swift
+++ b/ios/LFAEducationCenter/Profile/MoodPhotosViewModel.swift
@@ -1,0 +1,262 @@
+import Foundation
+import UIKit
+
+// MARK: — Response models
+
+struct MoodPhotoSlotData: Decodable, Identifiable {
+    var id: String { slot }
+    let slot:               String
+    let label:              String
+    let phase:              String
+    let status:             String?
+    let originalUrl:        String?
+    let processedPngUrl:    String?
+    let processingTimedOut: Bool
+
+    var hasPhoto: Bool { originalUrl != nil }
+
+    enum CodingKeys: String, CodingKey {
+        case slot, label, phase, status
+        case originalUrl        = "original_url"
+        case processedPngUrl    = "processed_png_url"
+        case processingTimedOut = "processing_timed_out"
+    }
+}
+
+private struct MoodPhotosListResponse: Decodable {
+    let slots:                [MoodPhotoSlotData]
+    let phaseAUploadedCount:  Int
+    let phaseAComplete:       Bool
+
+    enum CodingKeys: String, CodingKey {
+        case slots
+        case phaseAUploadedCount = "phase_a_uploaded_count"
+        case phaseAComplete      = "phase_a_complete"
+    }
+}
+
+// Empty body for void-body POSTs (remove-bg)
+private struct _EmptyBody: Encodable {}
+
+// MARK: — State
+
+enum MoodPhotosLoadState { case idle, loading, loaded, error(String) }
+enum SlotUploadState     { case idle, uploading, error(String) }
+
+// MARK: — ViewModel
+
+// Manages the 6 Phase-A + 3 Phase-B mood photo slots.
+// GET  /api/v1/lfa-player/mood-photos         — load / reload all slots
+// POST /api/v1/lfa-player/mood-photos/{slot}/upload   — upload one slot
+// DELETE /api/v1/lfa-player/mood-photos/{slot}        — delete one slot
+// POST /api/v1/lfa-player/mood-photos/{slot}/remove-bg — trigger BG removal
+// GET  /api/v1/lfa-player/mood-photos/{slot}/status   — poll processing status
+@MainActor
+final class MoodPhotosViewModel: ObservableObject {
+
+    @Published private(set) var slots:           [MoodPhotoSlotData] = []
+    @Published private(set) var phaseACount:     Int  = 0
+    @Published private(set) var phaseAComplete:  Bool = false
+    @Published private(set) var loadState:       MoodPhotosLoadState = .idle
+    @Published var uploadingSlot: String? = nil
+    @Published var uploadError:   String? = nil
+
+    // Polling timer handle — one per processing slot
+    private var pollTasks: [String: Task<Void, Never>] = [:]
+
+    // MARK: — Load
+
+    func load(using authManager: AuthManager) async {
+        guard case .idle = loadState else { return }
+        loadState = .loading
+        await fetch(using: authManager)
+    }
+
+    func reload(using authManager: AuthManager) async {
+        loadState = .idle
+        await fetch(using: authManager)
+    }
+
+    private func fetch(using authManager: AuthManager) async {
+        loadState = .loading
+        do {
+            let response: MoodPhotosListResponse = try await authManager.authenticatedGet(
+                path: "/api/v1/lfa-player/mood-photos"
+            )
+            slots          = response.slots
+            phaseACount    = response.phaseAUploadedCount
+            phaseAComplete = response.phaseAComplete
+            loadState      = .loaded
+            startPollingForProcessingSlots(using: authManager)
+        } catch {
+            loadState = .error("Could not load mood photos. Check your connection.")
+        }
+    }
+
+    // MARK: — Upload
+
+    func upload(image: UIImage, slot: String, using authManager: AuthManager) async {
+        guard let jpegData = image.jpegData(compressionQuality: 0.85) else {
+            uploadError = "Could not process the selected image."
+            return
+        }
+        if jpegData.count > 5 * 1024 * 1024 {
+            uploadError = "Photo too large (max 5 MB)."
+            return
+        }
+        uploadError   = nil
+        uploadingSlot = slot
+
+        do {
+            let updated: MoodPhotoSlotData = try await authManager.authenticatedMultipartPost(
+                path:      "/api/v1/lfa-player/mood-photos/\(slot)/upload",
+                imageData: jpegData,
+                mimeType:  "image/jpeg",
+                fieldName: "photo"
+            )
+            updateSlot(updated)
+            recalcPhaseA()
+            if updated.status == "processing" {
+                startPoll(slot: slot, using: authManager)
+            }
+        } catch APIError.httpError(let code, let detail) {
+            uploadError = detail ?? "Upload failed (error \(code))."
+        } catch {
+            uploadError = "Network error. Check your connection."
+        }
+        uploadingSlot = nil
+    }
+
+    // MARK: — Delete
+
+    func delete(slot: String, using authManager: AuthManager) async {
+        do {
+            try await authManager.authenticatedDeleteNoContent(
+                path: "/api/v1/lfa-player/mood-photos/\(slot)"
+            )
+            stopPoll(slot: slot)
+            clearSlot(slot)
+            recalcPhaseA()
+        } catch {
+            // Non-fatal — the slot UI stays as-is
+        }
+    }
+
+    // MARK: — Remove BG
+
+    func triggerBgRemoval(slot: String, using authManager: AuthManager) async {
+        do {
+            let updated: MoodPhotoSlotData = try await authManager.authenticatedPost(
+                path: "/api/v1/lfa-player/mood-photos/\(slot)/remove-bg",
+                body: _EmptyBody()
+            )
+            updateSlot(updated)
+            if updated.status == "processing" {
+                startPoll(slot: slot, using: authManager)
+            }
+        } catch {
+            // Non-fatal
+        }
+    }
+
+    // MARK: — Reset stuck processing
+
+    func resetProcessing(slot: String, using authManager: AuthManager) async {
+        do {
+            let updated: MoodPhotoSlotData = try await authManager.authenticatedPost(
+                path: "/api/v1/lfa-player/mood-photos/\(slot)/remove-bg",
+                body: _EmptyBody()
+            )
+            stopPoll(slot: slot)
+            updateSlot(updated)
+        } catch {
+            // Non-fatal
+        }
+    }
+
+    // MARK: — Polling
+
+    private func startPollingForProcessingSlots(using authManager: AuthManager) {
+        for slot in slots where slot.status == "processing" {
+            startPoll(slot: slot.slot, using: authManager)
+        }
+    }
+
+    private func startPoll(slot: String, using authManager: AuthManager) {
+        guard pollTasks[slot] == nil else { return }
+        pollTasks[slot] = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 3_000_000_000) // 3s
+                guard let self else { return }
+                await self.pollSlot(slot: slot, using: authManager)
+                if let current = self.slots.first(where: { $0.slot == slot }),
+                   current.status != "processing" {
+                    self.stopPoll(slot: slot)
+                    return
+                }
+            }
+        }
+    }
+
+    private func stopPoll(slot: String) {
+        pollTasks[slot]?.cancel()
+        pollTasks[slot] = nil
+    }
+
+    private func pollSlot(slot: String, using authManager: AuthManager) async {
+        struct StatusResponse: Decodable {
+            let status:             String
+            let processedPngUrl:    String?
+            let updatedAt:          String?
+            let processingTimedOut: Bool
+            enum CodingKeys: String, CodingKey {
+                case status
+                case processedPngUrl    = "processed_png_url"
+                case updatedAt          = "updated_at"
+                case processingTimedOut = "processing_timed_out"
+            }
+        }
+        guard let resp: StatusResponse = try? await authManager.authenticatedGet(
+            path: "/api/v1/lfa-player/mood-photos/\(slot)/status"
+        ) else { return }
+
+        if let idx = slots.firstIndex(where: { $0.slot == slot }) {
+            let old = slots[idx]
+            slots[idx] = MoodPhotoSlotData(
+                slot:               old.slot,
+                label:              old.label,
+                phase:              old.phase,
+                status:             resp.status,
+                originalUrl:        old.originalUrl,
+                processedPngUrl:    resp.processedPngUrl,
+                processingTimedOut: resp.processingTimedOut
+            )
+        }
+    }
+
+    // MARK: — Helpers
+
+    private func updateSlot(_ updated: MoodPhotoSlotData) {
+        if let idx = slots.firstIndex(where: { $0.slot == updated.slot }) {
+            slots[idx] = updated
+        }
+    }
+
+    private func clearSlot(_ slot: String) {
+        if let idx = slots.firstIndex(where: { $0.slot == slot }) {
+            let old = slots[idx]
+            slots[idx] = MoodPhotoSlotData(
+                slot: old.slot, label: old.label, phase: old.phase,
+                status: nil, originalUrl: nil, processedPngUrl: nil,
+                processingTimedOut: false
+            )
+        }
+    }
+
+    private func recalcPhaseA() {
+        let phaseA = ["mood_intro_neutral","mood_happy_smile","mood_celebration",
+                      "mood_sad_disappointed","mood_angry_competitive","mood_surprised_shocked"]
+        phaseACount    = slots.filter { phaseA.contains($0.slot) && $0.hasPhoto }.count
+        phaseAComplete = phaseACount == 6
+    }
+}

--- a/ios/LFAEducationCenter/Profile/ProfileCompletionCard.swift
+++ b/ios/LFAEducationCenter/Profile/ProfileCompletionCard.swift
@@ -29,14 +29,15 @@ struct ProfileCompletionScore {
 
     static func compute(profile: UserProfile,
                         lfaLicense: LFAPlayerLicense?,
-                        selfRatingCompleted: Bool = false) -> ProfileCompletionScore {
+                        selfRatingCompleted: Bool = false,
+                        moodPhotosCompleted: Bool = false) -> ProfileCompletionScore {
         ProfileCompletionScore(
             positionPhysical:  lfaLicense?.onboardingCompleted == true ? 30 : 0,
             academyID:         profile.lfaAcademyId != nil ? 10 : 0,
             profilePhoto:      profile.profilePhotoUrl != nil ? 15 : 0,
             baselineSelfRating: selfRatingCompleted ? 15 : 0,
             skillAssessment:   0,
-            moodPhotos:        0
+            moodPhotos:        moodPhotosCompleted ? 10 : 0
         )
     }
 }
@@ -99,6 +100,10 @@ struct ProfileCompletionCard: View {
             missingPill(icon: "chart.bar.doc.horizontal",
                         label: "Baseline Self-Rating")
         }
+        if score.moodPhotos == 0 {
+            missingPill(icon: "photo.on.rectangle",
+                        label: "Mood Photos")
+        }
         if score.skillAssessment == 0 {
             missingPill(icon: "slider.horizontal.3",
                         label: "Skill Assessment")
@@ -144,12 +149,13 @@ struct ProfileCompletionCard: View {
 // MARK: — ProfileView full section
 
 // Full checklist shown in ProfileView.
-// Academy ID, Profile Photo, and Baseline Self-Rating rows are tappable.
+// Academy ID, Profile Photo, Baseline Self-Rating, and Mood Photos rows are tappable.
 struct ProfileCompletionSection: View {
     let score:                   ProfileCompletionScore
     let onAcademyIDTap:          () -> Void
     let onPhotoTap:              () -> Void
     let onBaselineSelfRatingTap: () -> Void
+    let onMoodPhotosTap:         () -> Void
 
     private static let successGreen = Color(red: 0.18, green: 0.80, blue: 0.44)
 
@@ -222,7 +228,8 @@ struct ProfileCompletionSection: View {
             row(icon: "photo.on.rectangle",
                 title: "Mood Photos",
                 subtitle: "Match-ready expressions for your card",
-                state: score.moodPhotos > 0 ? .complete : .upcoming("R3D"))
+                state: score.moodPhotos > 0 ? .complete : .incomplete(action: onMoodPhotosTap),
+                tapAction: onMoodPhotosTap)
         }
         .background(Theme.Color.surface)
         .cornerRadius(Theme.Radius.md)

--- a/ios/LFAEducationCenter/Profile/ProfileView.swift
+++ b/ios/LFAEducationCenter/Profile/ProfileView.swift
@@ -15,6 +15,7 @@ struct ProfileView: View {
     @State private var isShowingAcademyID       = false
     @State private var isShowingPhotoUpload     = false
     @State private var isShowingBaselineSelfRating = false
+    @State private var isShowingMoodPhotos         = false
 
     var body: some View {
         NavigationView {
@@ -57,6 +58,13 @@ struct ProfileView: View {
             }
             .fullScreenCover(isPresented: $isShowingBaselineSelfRating) {
                 BaselineSelfRatingView {
+                    Task { await dashboardVM.reload(using: authManager) }
+                }
+                .environmentObject(authManager)
+                .environmentObject(dashboardVM)
+            }
+            .fullScreenCover(isPresented: $isShowingMoodPhotos) {
+                MoodPhotosView {
                     Task { await dashboardVM.reload(using: authManager) }
                 }
                 .environmentObject(authManager)
@@ -149,13 +157,15 @@ struct ProfileView: View {
             let score = ProfileCompletionScore.compute(
                 profile:             profile,
                 lfaLicense:          dashboardVM.lfaLicense,
-                selfRatingCompleted: dashboardVM.selfRatingCompleted
+                selfRatingCompleted: dashboardVM.selfRatingCompleted,
+                moodPhotosCompleted: dashboardVM.moodPhotosCompleted
             )
             ProfileCompletionSection(
                 score:                   score,
                 onAcademyIDTap:          { isShowingAcademyID = true },
                 onPhotoTap:              { isShowingPhotoUpload = true },
-                onBaselineSelfRatingTap: { isShowingBaselineSelfRating = true }
+                onBaselineSelfRatingTap: { isShowingBaselineSelfRating = true },
+                onMoodPhotosTap:         { isShowingMoodPhotos = true }
             )
                 .padding(.top, Theme.Spacing.lg)
         }

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -16204,6 +16204,220 @@
         ]
       }
     },
+    "/api/v1/lfa-player/mood-photos": {
+      "get": {
+        "tags": [
+          "lfa-player"
+        ],
+        "summary": "List Mood Photos",
+        "description": "Return all 9 mood photo slots for the current user.\n\nphase_a_complete is True when all 6 Phase-A slots have original_url set\n(status may be uploaded / processing / ready / failed \u2014 all count).",
+        "operationId": "list_mood_photos_api_v1_lfa_player_mood_photos_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/lfa-player/mood-photos/{slot}/upload": {
+      "post": {
+        "tags": [
+          "lfa-player"
+        ],
+        "summary": "Upload Mood Photo",
+        "description": "Upload (or replace) a mood photo slot.\n\nAccepts JPEG, PNG, or WebP \u2264 5 MB.\nIf BG_REMOVAL_PROCESSOR is not 'null', auto-triggers background removal.\nReturns the updated slot dict.",
+        "operationId": "upload_mood_photo_api_v1_lfa_player_mood_photos__slot__upload_post",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "slot",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Slot"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_upload_mood_photo_api_v1_lfa_player_mood_photos__slot__upload_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/lfa-player/mood-photos/{slot}": {
+      "delete": {
+        "tags": [
+          "lfa-player"
+        ],
+        "summary": "Delete Mood Photo Endpoint",
+        "description": "Delete a mood photo slot. Idempotent \u2014 no-op if slot has no photo.",
+        "operationId": "delete_mood_photo_endpoint_api_v1_lfa_player_mood_photos__slot__delete",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "slot",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Slot"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/lfa-player/mood-photos/{slot}/remove-bg": {
+      "post": {
+        "tags": [
+          "lfa-player"
+        ],
+        "summary": "Trigger Bg Removal",
+        "description": "Manually trigger background removal for a slot.\n\nNo-op if slot is already processing or ready.\nRate-limited: 3 triggers per 60 s per user.",
+        "operationId": "trigger_bg_removal_api_v1_lfa_player_mood_photos__slot__remove_bg_post",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "slot",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Slot"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/lfa-player/mood-photos/{slot}/status": {
+      "get": {
+        "tags": [
+          "lfa-player"
+        ],
+        "summary": "Get Slot Status",
+        "description": "Poll the processing status of a single slot.\n\nReturns processing_timed_out=True when status='processing' and the\nrecord has not been updated within PROCESSING_TIMEOUT_SECONDS.",
+        "operationId": "get_slot_status_api_v1_lfa_player_mood_photos__slot__status_get",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "slot",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Slot"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/gancuju/licenses": {
       "get": {
         "tags": [
@@ -49285,6 +49499,20 @@
           "invited_user_id"
         ],
         "title": "Body_team_invite_teams__team_id__invite_post"
+      },
+      "Body_upload_mood_photo_api_v1_lfa_player_mood_photos__slot__upload_post": {
+        "properties": {
+          "photo": {
+            "type": "string",
+            "format": "binary",
+            "title": "Photo"
+          }
+        },
+        "type": "object",
+        "required": [
+          "photo"
+        ],
+        "title": "Body_upload_mood_photo_api_v1_lfa_player_mood_photos__slot__upload_post"
       },
       "Body_upload_profile_photo_api_v1_users_me_profile_photo_post": {
         "properties": {

--- a/tests/unit/api/web_routes/test_card_editor_ce2.py
+++ b/tests/unit/api/web_routes/test_card_editor_ce2.py
@@ -433,6 +433,6 @@ class TestCE217RouteCount:
         """feat/r3f adds POST /api/v1/lfa-player/self-assessment — snapshot path count must equal 869."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 869, (
+        assert len(paths) == 874, (
             f"Expected 869 routes (868 prior baseline + 1 lfa-player/self-assessment route), got {len(paths)}."
         )

--- a/tests/unit/api/web_routes/test_card_editor_cs_s1.py
+++ b/tests/unit/api/web_routes/test_card_editor_cs_s1.py
@@ -294,7 +294,7 @@ class TestS109S110RouteAndSnapshot:
         """S1-09 (updated r3-credits-v2): route count is 868 (+1 invitation-codes/redeem-authenticated)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 869, (
+        assert len(paths) == 874, (
             f"Expected 868 routes (867 prior baseline + 1 invitation-codes/redeem-authenticated), got {len(paths)}"
         )
 

--- a/tests/unit/api/web_routes/test_card_editor_ref_p2.py
+++ b/tests/unit/api/web_routes/test_card_editor_ref_p2.py
@@ -287,7 +287,7 @@ class TestP227to29RouteAndOpenAPI:
         """P2-27: Route count = 846 (CS-S2A +1 /card-studio/player)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 869, f"Expected 846 routes, got {len(paths)}"
+        assert len(paths) == 874, f"Expected 846 routes, got {len(paths)}"
 
     def test_p2_28_openapi_snapshot_match(self):
         """P2-28: OpenAPI snapshot matches live API paths."""

--- a/tests/unit/api/web_routes/test_card_studio_challenge.py
+++ b/tests/unit/api/web_routes/test_card_studio_challenge.py
@@ -294,7 +294,7 @@ class TestCCS11RouteCount:
         """CCS-11: route count updated to 842 after CE-3.8 (+3 from-mood endpoints)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 869, (
+        assert len(paths) == 874, (
             f"Expected 845 routes (842 CE-3.7+CE-3.8 baseline + 2 CS-S0 card-studio routes), got {len(paths)}."
         )
 

--- a/tests/unit/api/web_routes/test_card_studio_landing.py
+++ b/tests/unit/api/web_routes/test_card_studio_landing.py
@@ -159,7 +159,7 @@ class TestCEL12RouteCount:
         """CEL-12: route count 844 (unchanged — redirect is handler change, not new route)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 869, (
+        assert len(paths) == 874, (
             f"Expected 845 routes (redirect handler change does not add routes), got {len(paths)}."
         )
 

--- a/tests/unit/api/web_routes/test_card_studio_shell.py
+++ b/tests/unit/api/web_routes/test_card_studio_shell.py
@@ -326,7 +326,7 @@ class TestCSS21to23RouteConfirmations:
         """CSS-21: adding 2 card-studio routes raises count from 842 to 844."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 869, (
+        assert len(paths) == 874, (
             f"Expected 845 routes (842 baseline + 2 new /card-studio routes), got {len(paths)}"
         )
 

--- a/tests/unit/api/web_routes/test_card_studio_welcome.py
+++ b/tests/unit/api/web_routes/test_card_studio_welcome.py
@@ -325,7 +325,7 @@ class TestCEW18RouteCount:
         """CEW-18: route count baseline check (updated by CE-3.8 to 842)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 869, (
+        assert len(paths) == 874, (
             f"Expected 842 routes (839 CE-3.7 baseline + 3 from-mood endpoints), got {len(paths)}."
         )
 
@@ -678,7 +678,7 @@ class TestCEW44to51TemplateMoodPicker:
         """CEW-47: CE-3.8 adds 3 from-mood routes → total 842."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 869, (
+        assert len(paths) == 874, (
             f"Expected 845 routes (842 baseline + 2 CS-S0 routes), got {len(paths)}"
         )
 

--- a/tests/unit/api/web_routes/test_cc_design_1.py
+++ b/tests/unit/api/web_routes/test_cc_design_1.py
@@ -780,7 +780,7 @@ class TestCCD22to23RouteSnapshot:
         """CCD-22: Route count is 851 (CC-DESIGN-1 SNAPSHOT adds POST /challenges/{id}/card/photo)."""
         from app.main import app
         count = len(app.openapi().get("paths", {}))
-        assert count == 869, f"Expected 851, got {count}"
+        assert count == 874, f"Expected 851, got {count}"
 
     def test_ccd_23_openapi_snapshot_match(self):
         """CCD-23: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_cs_color_1.py
+++ b/tests/unit/api/web_routes/test_cs_color_1.py
@@ -382,7 +382,7 @@ class TestCSCOL15to16RouteAndSnapshot:
         """CSCOL-15: route count = 845 (+1 POST /dashboard/wc-card-theme)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 869, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 874, f"Expected 845 routes, got {len(paths)}"
 
     def test_cscol_16_openapi_snapshot_includes_wc_card_theme(self):
         """CSCOL-16: OpenAPI snapshot includes /dashboard/wc-card-theme."""

--- a/tests/unit/api/web_routes/test_cs_s2a.py
+++ b/tests/unit/api/web_routes/test_cs_s2a.py
@@ -40,7 +40,7 @@ class TestS2A01to02RouteRegistration:
         """S2A-02 (updated CS-S4A): Total route count is 847 (CS-S2A+CS-S4A)."""
         from app.main import app
         count = len(app.openapi().get("paths", {}))
-        assert count == 869, f"Expected 847 routes, got {count}"
+        assert count == 874, f"Expected 847 routes, got {count}"
 
 
 # ── S2A-03..08: _resolve_player_context logic ────────────────────────────────

--- a/tests/unit/api/web_routes/test_cs_s4a.py
+++ b/tests/unit/api/web_routes/test_cs_s4a.py
@@ -152,7 +152,7 @@ class TestS4A12to13RouteAndSnapshot:
         """S4A-12: Route count == 851 (CC-DESIGN-1 SNAPSHOT adds +1 POST /challenges/{id}/card/photo)."""
         from app.main import app
         count = len(app.openapi().get("paths", {}))
-        assert count == 869, f"Expected 851 routes, got {count}"
+        assert count == 874, f"Expected 851 routes, got {count}"
 
     def test_s4a_13_openapi_snapshot_match(self):
         """S4A-13: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_family_color_shop.py
+++ b/tests/unit/api/web_routes/test_family_color_shop.py
@@ -223,7 +223,7 @@ class TestRouteRegistration:
     def test_ts_13_route_count_836(self):
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 869, (
+        assert len(paths) == 874, (
             f"Expected 845 routes (842 CE-3.7+CE-3.8 baseline + 2 CS-S0 card-studio routes), got {len(paths)}."
         )
 

--- a/tests/unit/api/web_routes/test_shop_3a.py
+++ b/tests/unit/api/web_routes/test_shop_3a.py
@@ -194,7 +194,7 @@ class TestS3A13to14RouteAndSnapshot:
         """S3A-13: Route count = 845 (template deletion does not affect routes)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 869, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 874, f"Expected 845 routes, got {len(paths)}"
 
     def test_s3a_14_openapi_snapshot_match(self):
         """S3A-14: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_shop_3b1.py
+++ b/tests/unit/api/web_routes/test_shop_3b1.py
@@ -158,7 +158,7 @@ class TestS3B112to13RouteAndSnapshot:
         """S3B1-12: Route count = 845 (test cleanup does not affect routes)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 869, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 874, f"Expected 845 routes, got {len(paths)}"
 
     def test_s3b1_13_openapi_snapshot_match(self):
         """S3B1-13: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_shop_3b2.py
+++ b/tests/unit/api/web_routes/test_shop_3b2.py
@@ -192,7 +192,7 @@ class TestS3B215to16RouteAndSnapshot:
         """S3B2-15: Route count = 845 (template deletion does not affect routes)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 869, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 874, f"Expected 845 routes, got {len(paths)}"
 
     def test_s3b2_16_openapi_snapshot_match(self):
         """S3B2-16: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_shop_unified.py
+++ b/tests/unit/api/web_routes/test_shop_unified.py
@@ -271,7 +271,7 @@ class TestSHOP14to15RouteAndSnapshot:
         """SHOP-14: route count = 845 (no new routes in SHOP-1)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 869, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 874, f"Expected 845 routes, got {len(paths)}"
 
     def test_shop_15_openapi_snapshot_match(self):
         """SHOP-15: OpenAPI snapshot matches live API."""


### PR DESCRIPTION
## Summary

- Adds native **Mood Photos** upload/management flow for iOS LFA Football Player
- Adds 5 Bearer-token `/api/v1/lfa-player/mood-photos/*` endpoints; fully reuses existing `mood_photo_service.py` — no logic duplication
- Supports **Phase-A 6 required mood photo slots** (Neutral / Happy / Celebration / Sad / Angry / Surprised)
- Phase-B slots (Focused / Confident / Proud) shown as **Coming Soon** — not tappable, not a completion requirement
- Adds upload / delete / remove-bg trigger / status polling
- **Mood Photos +10** ProfileCompletion score when Phase-A 6/6 have `original_url IS NOT NULL`
- BG removal outcome does **not** block completion (`uploaded`, `processing`, `ready`, `failed` all count)
- Does not touch R3F / Baseline Self-Rating, payment, credit, player card generation, or onboarding reset

## Merge checklist

| Check | |
|---|---|
| 5 new Bearer API endpoints | ✅ |
| Route count 869→874 (+5) | ✅ |
| OpenAPI snapshot updated | ✅ |
| Phase-A 6 slots required | ✅ |
| Phase-B not completion-blocking | ✅ |
| `original_url IS NOT NULL` completion | ✅ |
| BG removal not blocking +10 | ✅ |
| Mood Photos row tappable when incomplete | ✅ |
| Mood Photos row checkmark when complete | ✅ |
| Dashboard/Profile +10 on reload | ✅ |
| R3F / Baseline Self-Rating untouched | ✅ |
| Payment / credit / card generation untouched | ✅ |

## New files

**Backend:**
- `app/api/api_v1/endpoints/lfa_player/mood_photos.py`

**iOS:**
- `ios/LFAEducationCenter/Profile/MoodPhotosView.swift`
- `ios/LFAEducationCenter/Profile/MoodPhotosViewModel.swift`
- `ios/LFAEducationCenter/Profile/MoodPhotoSlotCard.swift`

## Test plan

- [ ] Login → Dashboard → ProfileCompletionCard shows "Mood Photos" missing pill
- [ ] "Complete Profile" → ProfileView → "Mood Photos" sor tappable
- [ ] Tap → MoodPhotosView opens, "0/6 uploaded"
- [ ] Phase-A 6 cards visible, Phase-B 3 Coming Soon
- [ ] [+] Upload → PhotoPicker → select image → thumbnail appears, "Uploaded" status
- [ ] Delete → slot goes back to empty
- [ ] 6/6 upload → "6/6 uploaded", phase_a_complete = true
- [ ] Dismiss → reload → Mood Photos row ✅, Dashboard score +10
- [ ] `DELETE /api/v1/lfa-player/mood-photos/{slot}` → 204
- [ ] `GET /api/v1/lfa-player/mood-photos/{slot}/status` → correct status
- [ ] Invalid slot → 422

🤖 Generated with [Claude Code](https://claude.com/claude-code)