### PR TITLE
feat(academy-id): dedicated free color system — Phase 1

### DIFF
--- a/alembic/versions/2026_06_09_1100_academy_id_color.py
+++ b/alembic/versions/2026_06_09_1100_academy_id_color.py
@@ -1,0 +1,39 @@
+"""Add academy_id_color to user_licenses
+
+Revision ID: 2026_06_09_1100
+Revises:     2026_06_09_1000
+Create Date: 2026-06-09
+
+Adds a dedicated column to store the active Academy ID card colour for each
+LFA Football Player licence.  This column belongs exclusively to the
+Academy ID colour system (card_type_id='academy_id') and is independent of
+the Player Card / Welcome Card / Challenge Card theme/colour fields.
+
+Default 'official' covers all existing rows without a backfill step.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision      = "2026_06_09_1100"
+down_revision = "2026_06_09_1000"
+branch_labels = None
+depends_on    = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "user_licenses",
+        sa.Column(
+            "academy_id_color",
+            sa.String(50),
+            nullable=False,
+            server_default="official",
+            comment="Active Academy ID card colour (academy_id colour family). "
+                    "Independent of Player/Welcome/Challenge card theme fields.",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("user_licenses", "academy_id_color")

--- a/app/api/api_v1/endpoints/users/profile.py
+++ b/app/api/api_v1/endpoints/users/profile.py
@@ -4,6 +4,7 @@ Self-service profile updates, password reset, profile photo and Academy ID manag
 """
 from typing import Any
 from fastapi import APIRouter, BackgroundTasks, Depends, File, HTTPException, UploadFile, status
+from pydantic import BaseModel
 from sqlalchemy.orm import Session
 from datetime import datetime, timezone
 import json
@@ -25,6 +26,12 @@ from .....services.profile_photo_service import (
 from .....services.academy_id_service import (
     assign_lfa_academy_id,
     ensure_public_token,
+)
+from .....services.academy_id_color_service import (
+    get_all_colors,
+    get_active_color_id,
+    set_active_color,
+    is_valid_color,
 )
 from .....config import settings as _settings
 from .helpers import validate_email_unique, validate_nickname
@@ -256,9 +263,104 @@ def get_academy_id(
     qr_url   = f"/verify/{token}"
     qr_data  = f"{_settings.VERIFY_BASE_URL}/verify/{token}"
 
+    # Active Academy ID colour — stored on the LFA Player licence row.
+    # Returns None (not included in response) if no licence exists yet.
+    lfa_license = (
+        db.query(UserLicense)
+        .filter(
+            UserLicense.user_id == current_user.id,
+            UserLicense.specialization_type == "LFA_FOOTBALL_PLAYER",
+        )
+        .first()
+    )
+    active_color = get_active_color_id(lfa_license) if lfa_license else None
+
     return {
-        "lfa_academy_id": current_user.lfa_academy_id,
-        "public_token":   token,
-        "qr_url":         qr_url,
-        "qr_data":        qr_data,
+        "lfa_academy_id":   current_user.lfa_academy_id,
+        "public_token":     token,
+        "qr_url":           qr_url,
+        "qr_data":          qr_data,
+        "active_color_id":  active_color,
     }
+
+
+# ── Academy ID — Colour system (Phase 1: free colours only) ──────────────────
+
+def _require_lfa_license(db: Session, user: User) -> UserLicense:
+    """Return the user's LFA Football Player licence or raise 404."""
+    lic = (
+        db.query(UserLicense)
+        .filter(
+            UserLicense.user_id == user.id,
+            UserLicense.specialization_type == "LFA_FOOTBALL_PLAYER",
+        )
+        .first()
+    )
+    if not lic:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No LFA Football Player licence found.",
+        )
+    return lic
+
+
+@router.get("/me/academy-id/colors")
+def get_academy_id_colors(
+    db:           Session = Depends(get_db),
+    current_user: User    = Depends(get_current_user),
+) -> Any:
+    """
+    Return the Academy ID colour palette and the user's active colour.
+
+    Phase 1: three free colours (official / ivory / charcoal).
+    All colours have is_owned=true and credit_cost=0.
+    Phase 2 will add premium colours with ownership checks.
+
+    Requires an active LFA Football Player licence (404 otherwise).
+    """
+    lfa_license   = _require_lfa_license(db, current_user)
+    active_color  = get_active_color_id(lfa_license)
+    colors        = get_all_colors()
+
+    return {
+        "active_color_id": active_color,
+        "colors": [
+            {
+                "id":          c.id,
+                "label":       c.label,
+                "dot_color":   c.dot_color,
+                "is_premium":  c.is_premium,
+                "credit_cost": c.credit_cost,
+                "is_owned":    True,   # Phase 1: all colours are free → always owned
+                "sort_order":  c.sort_order,
+            }
+            for c in colors
+        ],
+    }
+
+
+class _ColorSelectRequest(BaseModel):
+    color_id: str
+
+
+@router.post("/me/academy-id/colors/select")
+def select_academy_id_color(
+    payload:      _ColorSelectRequest,
+    db:           Session = Depends(get_db),
+    current_user: User    = Depends(get_current_user),
+) -> Any:
+    """
+    Set the active Academy ID colour for the current user.
+
+    Phase 1: only free colours accepted (official / ivory / charcoal).
+    Returns the new active_color_id on success.
+    """
+    if not is_valid_color(payload.color_id):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Unknown Academy ID colour: {payload.color_id!r}. "
+                   f"Valid options: official, ivory, charcoal.",
+        )
+    lfa_license = _require_lfa_license(db, current_user)
+    new_color   = set_active_color(db, lfa_license, payload.color_id)
+    return {"ok": True, "active_color_id": new_color}

--- a/app/services/academy_id_color_service.py
+++ b/app/services/academy_id_color_service.py
@@ -1,0 +1,108 @@
+"""
+Academy ID dedicated colour service — Phase 1 (free colours only).
+
+This module is completely isolated from the Player Card, Welcome Card, and
+Challenge Card colour/theme systems.  It must NOT import from:
+  - card_color_service
+  - card_theme_service
+  - shop_catalog_service
+
+The academy_id colour family uses card_type_id = 'academy_id' in
+card_color_ownership (Phase 2 will add premium colours there).
+Phase 1 only stores the active colour in user_licenses.academy_id_color.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+from sqlalchemy.orm import Session
+
+from ..models.license import UserLicense
+
+
+# ── Phase 1 Palette — Free colours only ──────────────────────────────────────
+# Visually distinct from Player Card themes (default/midnight/arctic/gold/…).
+# ID-card aesthetic: official document palette — restrained, authoritative.
+
+@dataclass(frozen=True)
+class AcademyIDColor:
+    id:          str
+    label:       str
+    dot_color:   str   # hex — shown in the iOS swatch picker
+    sort_order:  int
+    # Forward-compatible fields for Phase 2 (always False/0 in Phase 1)
+    is_premium:  bool = False
+    credit_cost: int  = 0
+
+
+ACADEMY_ID_COLORS: list[AcademyIDColor] = [
+    AcademyIDColor(
+        id="official",
+        label="Official",
+        dot_color="#b8a06a",   # warm gold — the default card look
+        sort_order=0,
+    ),
+    AcademyIDColor(
+        id="ivory",
+        label="Ivory",
+        dot_color="#d4c5a0",   # soft warm white
+        sort_order=1,
+    ),
+    AcademyIDColor(
+        id="charcoal",
+        label="Charcoal",
+        dot_color="#3a3a3a",   # near-black, elegant dark surface
+        sort_order=2,
+    ),
+]
+
+_VALID_COLOR_IDS: frozenset[str] = frozenset(c.id for c in ACADEMY_ID_COLORS)
+
+
+# ── Read helpers ──────────────────────────────────────────────────────────────
+
+def get_all_colors() -> list[AcademyIDColor]:
+    """Return the full Phase-1 palette, ordered by sort_order."""
+    return ACADEMY_ID_COLORS
+
+
+def get_active_color_id(user_license: UserLicense) -> str:
+    """
+    Return the active Academy ID colour for this licence.
+
+    Falls back to 'official' if the stored value is missing or unknown
+    (handles pre-migration rows and any future data inconsistency).
+    """
+    stored = getattr(user_license, "academy_id_color", None) or "official"
+    return stored if stored in _VALID_COLOR_IDS else "official"
+
+
+def is_valid_color(color_id: str) -> bool:
+    return color_id in _VALID_COLOR_IDS
+
+
+# ── Write helpers ─────────────────────────────────────────────────────────────
+
+def set_active_color(
+    db: Session,
+    user_license: UserLicense,
+    color_id: str,
+) -> str:
+    """
+    Persist the selected colour for this licence.
+
+    Raises ValueError for unknown colour IDs.
+    Phase 1: all colours are free — no ownership or credit check required.
+    Phase 2: premium colour guard will be added before this write.
+
+    Returns the validated colour ID.
+    """
+    if color_id not in _VALID_COLOR_IDS:
+        raise ValueError(
+            f"Unknown Academy ID colour: {color_id!r}. "
+            f"Valid options: {sorted(_VALID_COLOR_IDS)}"
+        )
+    user_license.academy_id_color = color_id
+    db.commit()
+    return color_id

--- a/ios/LFAEducationCenter.xcodeproj/project.pbxproj
+++ b/ios/LFAEducationCenter.xcodeproj/project.pbxproj
@@ -75,6 +75,10 @@
 		BB000004000000000000069 /* MoodPhotoPreviewSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000069 /* MoodPhotoPreviewSheet.swift */; };
 		BB00000400000000000006A /* CompletionCelebrationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000300000000000006A /* CompletionCelebrationStore.swift */; };
 		BB00000400000000000006B /* ProfileCompletionCelebrationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000300000000000006B /* ProfileCompletionCelebrationView.swift */; };
+		BB00000400000000000006C /* AcademyIDColorTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000300000000000006C /* AcademyIDColorTheme.swift */; };
+		BB00000400000000000006D /* AcademyIDColorConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000300000000000006D /* AcademyIDColorConfig.swift */; };
+		BB00000400000000000006E /* AcademyIDColorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000300000000000006E /* AcademyIDColorViewModel.swift */; };
+		BB00000400000000000006F /* AcademyIDColorPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000300000000000006F /* AcademyIDColorPickerView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -148,6 +152,10 @@
 		BB000003000000000000069 /* MoodPhotoPreviewSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoodPhotoPreviewSheet.swift; sourceTree = "<group>"; };
 		BB00000300000000000006A /* CompletionCelebrationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionCelebrationStore.swift; sourceTree = "<group>"; };
 		BB00000300000000000006B /* ProfileCompletionCelebrationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileCompletionCelebrationView.swift; sourceTree = "<group>"; };
+		BB00000300000000000006C /* AcademyIDColorTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcademyIDColorTheme.swift; sourceTree = "<group>"; };
+		BB00000300000000000006D /* AcademyIDColorConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcademyIDColorConfig.swift; sourceTree = "<group>"; };
+		BB00000300000000000006E /* AcademyIDColorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcademyIDColorViewModel.swift; sourceTree = "<group>"; };
+		BB00000300000000000006F /* AcademyIDColorPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcademyIDColorPickerView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -256,6 +264,7 @@
 				BB000003000000000000027 /* SpecializationProgress.swift */,
 				BB000003000000000000028 /* SkillProfile.swift */,
 				BB000003000000000000039 /* AcademyIDResponse.swift */,
+				BB00000300000000000006C /* AcademyIDColorTheme.swift */,
 				BB000003000000000000042 /* CreditTransaction.swift */,
 			);
 			path = Models;
@@ -272,6 +281,9 @@
 				BB000003000000000000037 /* AcademyIDCardView.swift */,
 				BB000003000000000000040 /* AcademyIDViewModel.swift */,
 				BB000003000000000000041 /* AcademyIDFullScreenView.swift */,
+				BB00000300000000000006D /* AcademyIDColorConfig.swift */,
+				BB00000300000000000006E /* AcademyIDColorViewModel.swift */,
+				BB00000300000000000006F /* AcademyIDColorPickerView.swift */,
 			);
 			path = Auth;
 			sourceTree = "<group>";
@@ -501,6 +513,10 @@
 				BB000004000000000000069 /* MoodPhotoPreviewSheet.swift in Sources */,
 				BB00000400000000000006A /* CompletionCelebrationStore.swift in Sources */,
 				BB00000400000000000006B /* ProfileCompletionCelebrationView.swift in Sources */,
+				BB00000400000000000006C /* AcademyIDColorTheme.swift in Sources */,
+				BB00000400000000000006D /* AcademyIDColorConfig.swift in Sources */,
+				BB00000400000000000006E /* AcademyIDColorViewModel.swift in Sources */,
+				BB00000400000000000006F /* AcademyIDColorPickerView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/LFAEducationCenter/Auth/AcademyIDCardView.swift
+++ b/ios/LFAEducationCenter/Auth/AcademyIDCardView.swift
@@ -16,6 +16,9 @@ import SwiftUI
 //
 // QR: generated from publicToken via QRCodeGenerator (CoreImage, no external dep).
 //   nil → placeholder qrcode SF Symbol shown instead.
+//
+// colorConfig: optional AcademyIDColorConfig — nil = official (default system surface).
+//   RegisterView and other registration-flow call sites pass nil for backward compat.
 struct AcademyIDCardView: View {
     let firstName:                String?
     let lastName:                 String?
@@ -32,24 +35,38 @@ struct AcademyIDCardView: View {
     // Phase 2A — Academy ID fields (nil during registration flow, set from /me after login)
     let lfaAcademyId:             String?   // "LFA-2026-00142" — shown on card
     let publicToken:              String?   // UUID for QR — build with VERIFY_BASE_URL
+    // Colour system — nil = official appearance (backward-compatible default)
+    let colorConfig:              AcademyIDColorConfig?
+
+    // MARK: — Derived colours (fall back to system tokens when colorConfig is nil)
+
+    private var cardSurface:       Color  { colorConfig?.surfaceColor ?? Theme.Color.surface }
+    private var cardBorderColor:   Color  { colorConfig?.borderColor  ?? Color(hex: "#b8a06a") }
+    private var cardBorderOpacity: Double { colorConfig?.borderOpacity ?? 0.28 }
+    private var textValue:         Color  { colorConfig?.valueColor   ?? Theme.Color.onSurface }
+    private var textLabel:         Color  { colorConfig?.labelColor   ?? Theme.Color.muted }
+    private var textMuted:         Color  { colorConfig?.mutedColor   ?? Theme.Color.muted.opacity(0.4) }
+    private var textBrand:         Color  { colorConfig?.brandAccent  ?? Theme.Color.secondary }
+    private var photoBorder:       Color  { colorConfig?.panelBorder  ?? Theme.Color.secondary.opacity(0.3) }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             headerRow
-            Divider().background(Theme.Color.secondary.opacity(0.2))
+            Divider().background(cardBorderColor.opacity(0.20))
             bodyRows
-            Divider().background(Theme.Color.secondary.opacity(0.12))
+            Divider().background(cardBorderColor.opacity(0.12))
             specSlotsRow
-            Divider().background(Theme.Color.secondary.opacity(0.12))
+            Divider().background(cardBorderColor.opacity(0.12))
             footerRow
         }
-        .background(Theme.Color.surface)
+        .background(cardSurface)
         .cornerRadius(Theme.Radius.md)
         .overlay(
             RoundedRectangle(cornerRadius: Theme.Radius.md)
-                .stroke(Theme.Color.secondary.opacity(0.28), lineWidth: 1)
+                .stroke(cardBorderColor.opacity(cardBorderOpacity), lineWidth: 1)
         )
         .shadow(color: .black.opacity(0.06), radius: 6, x: 0, y: 2)
+        .animation(.easeInOut(duration: 0.25), value: colorConfig?.id)
     }
 
     // MARK: — Header
@@ -63,15 +80,15 @@ struct AcademyIDCardView: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text("LION FOOTBALL ACADEMY")
                     .font(.system(size: 9, weight: .bold))
-                    .foregroundColor(Theme.Color.secondary)
+                    .foregroundColor(textBrand)
                 Text("LFA EDUCATION CENTER")
                     .font(.system(size: 7, weight: .medium))
-                    .foregroundColor(Theme.Color.muted)
+                    .foregroundColor(textLabel)
             }
             Spacer()
             Text("ACADEMY ID")
                 .font(.system(size: 7, weight: .bold))
-                .foregroundColor(Theme.Color.muted)
+                .foregroundColor(textLabel)
                 .tracking(0.8)
         }
         .padding(.horizontal, 14)
@@ -82,14 +99,10 @@ struct AcademyIDCardView: View {
 
     private var bodyRows: some View {
         HStack(alignment: .top, spacing: 14) {
-            // Portrait photo panel (ID-card style, not circular)
             photoPanel
-
-            // Data column
             VStack(alignment: .leading, spacing: 7) {
                 fieldBlock(label: "FULL NAME", value: fullName)
                 fieldBlock(label: "NICKNAME",  value: nickname)
-
                 HStack(spacing: 0) {
                     fieldBlock(label: "AGE",         value: age.map { "\($0) years" })
                     Spacer()
@@ -97,7 +110,6 @@ struct AcademyIDCardView: View {
                     Spacer()
                     fieldBlock(label: "GENDER",      value: genderDisplay, align: .trailing)
                 }
-
                 fieldBlock(label: "LOCATION", value: locationDisplay)
             }
         }
@@ -111,7 +123,7 @@ struct AcademyIDCardView: View {
         HStack(spacing: 0) {
             Text("SPECIALIZATION")
                 .font(.system(size: 7, weight: .semibold))
-                .foregroundColor(Theme.Color.muted)
+                .foregroundColor(textLabel)
             Spacer()
             HStack(spacing: 12) {
                 specSlot("⚽")
@@ -128,12 +140,10 @@ struct AcademyIDCardView: View {
 
     private var footerRow: some View {
         HStack(alignment: .center, spacing: 10) {
-
-            // Left: lfa_academy_id + ACCESS VERIFIED badge
             VStack(alignment: .leading, spacing: 5) {
                 Text(lfaAcademyId ?? "LFA-????-?????")
                     .font(.system(size: 8, weight: .bold, design: .monospaced))
-                    .foregroundColor(lfaAcademyId != nil ? Theme.Color.muted : Theme.Color.muted.opacity(0.35))
+                    .foregroundColor(lfaAcademyId != nil ? textLabel : textLabel.opacity(0.35))
                 if isVerified {
                     HStack(spacing: 4) {
                         Image(systemName: "checkmark.shield.fill")
@@ -152,8 +162,6 @@ struct AcademyIDCardView: View {
             .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isVerified)
 
             Spacer()
-
-            // Right: QR code (56×56 pt)
             qrPanel
         }
         .padding(.horizontal, 14)
@@ -168,7 +176,7 @@ struct AcademyIDCardView: View {
                from: "\(APIConfig.verifyBaseURL)/verify/\(token)"
            ) {
             Image(uiImage: qrImage)
-                .interpolation(.none)           // crisp pixels, no blur
+                .interpolation(.none)
                 .resizable()
                 .scaledToFit()
                 .frame(width: 56, height: 56)
@@ -176,24 +184,21 @@ struct AcademyIDCardView: View {
                 .cornerRadius(4)
                 .overlay(
                     RoundedRectangle(cornerRadius: 4)
-                        .stroke(Theme.Color.secondary.opacity(0.2), lineWidth: 0.5)
+                        .stroke(photoBorder, lineWidth: 0.5)
                 )
         } else {
-            // Placeholder when publicToken not yet available (registration flow)
             RoundedRectangle(cornerRadius: 4)
-                .fill(Theme.Color.muted.opacity(0.06))
+                .fill(textMuted.opacity(0.15))
                 .frame(width: 56, height: 56)
                 .overlay(
                     Image(systemName: "qrcode")
                         .font(.system(size: 22))
-                        .foregroundColor(Theme.Color.muted.opacity(0.20))
+                        .foregroundColor(textMuted)
                 )
         }
     }
 
     // MARK: — Portrait photo panel (ID-card style, 80×104pt, not circular)
-    //
-    // Priority: processedURL → originalURL → local UIImage → silhouette
 
     private var photoPanel: some View {
         ZStack {
@@ -209,16 +214,16 @@ struct AcademyIDCardView: View {
                     .frame(width: 80, height: 104).clipped()
             } else {
                 Rectangle()
-                    .fill(Theme.Color.muted.opacity(0.06))
+                    .fill(textMuted.opacity(0.15))
                     .frame(width: 80, height: 104)
                     .overlay(
                         VStack(spacing: 5) {
                             Image(systemName: "person.fill")
                                 .font(.system(size: 30))
-                                .foregroundColor(Theme.Color.muted.opacity(0.22))
+                                .foregroundColor(textMuted)
                             Text("PHOTO")
                                 .font(.system(size: 6.5, weight: .semibold))
-                                .foregroundColor(Theme.Color.muted.opacity(0.22))
+                                .foregroundColor(textMuted)
                         }
                     )
             }
@@ -226,10 +231,9 @@ struct AcademyIDCardView: View {
         .clipShape(RoundedRectangle(cornerRadius: 6))
         .overlay(
             RoundedRectangle(cornerRadius: 6)
-                .stroke(Theme.Color.secondary.opacity(0.3), lineWidth: 1)
+                .stroke(photoBorder, lineWidth: 1)
         )
     }
-
 
     // MARK: — Field block
 
@@ -238,18 +242,18 @@ struct AcademyIDCardView: View {
         VStack(alignment: align, spacing: 2) {
             Text(label)
                 .font(.system(size: 7, weight: .semibold))
-                .foregroundColor(Theme.Color.muted)
+                .foregroundColor(textLabel)
             if let v = value {
                 Text(v)
                     .font(.system(size: 12, weight: .semibold))
-                    .foregroundColor(Theme.Color.onSurface)
+                    .foregroundColor(textValue)
                     .lineLimit(1)
                     .minimumScaleFactor(0.75)
                     .transition(.opacity)
             } else {
                 Text("———")
                     .font(.system(size: 12, weight: .semibold))
-                    .foregroundColor(Theme.Color.muted.opacity(0.28))
+                    .foregroundColor(textMuted)
                     .transition(.opacity)
             }
         }
@@ -263,7 +267,7 @@ struct AcademyIDCardView: View {
             Text(icon).font(.system(size: 10))
             Text("—")
                 .font(.system(size: 9, weight: .semibold))
-                .foregroundColor(Theme.Color.muted.opacity(0.4))
+                .foregroundColor(textMuted)
         }
     }
 
@@ -274,8 +278,6 @@ struct AcademyIDCardView: View {
         return parts.isEmpty ? nil : parts.joined(separator: " ")
     }
 
-    // Full nationality display for ID card: flag emoji + full country name.
-    // Returns nil for empty string so fieldBlock shows "———" placeholder instead of a space.
     private var nationalityDisplay: String? {
         guard !nationality.isEmpty else { return nil }
         let flags: [String: String] = [
@@ -294,7 +296,6 @@ struct AcademyIDCardView: View {
         return flag.isEmpty ? name : "\(flag) \(name)"
     }
 
-    // Full gender display for ID card — no abbreviation.
     private var genderDisplay: String? {
         switch gender {
         case "Male", "Female", "Other": return gender
@@ -310,8 +311,6 @@ struct AcademyIDCardView: View {
 
 // MARK: — URL-based image loader (iOS 14 compatible, no AsyncImage)
 
-// Loads an image from a server-relative path (e.g. "/static/uploads/profile_photos/...").
-// Prepends APIConfig.baseURL. Caches loaded UIImage in @State so re-renders don't refetch.
 private struct URLPhotoView: View {
     let urlPath: String
     @State private var image: UIImage? = nil
@@ -325,10 +324,7 @@ private struct URLPhotoView: View {
             } else {
                 Rectangle()
                     .fill(Theme.Color.muted.opacity(0.08))
-                    .overlay(
-                        ProgressView()
-                            .scaleEffect(0.6)
-                    )
+                    .overlay(ProgressView().scaleEffect(0.6))
             }
         }
         .onAppear { loadImage() }

--- a/ios/LFAEducationCenter/Auth/AcademyIDColorConfig.swift
+++ b/ios/LFAEducationCenter/Auth/AcademyIDColorConfig.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+
+// iOS-side rendering tokens for the Academy ID card colour system.
+//
+// The backend returns colour IDs (e.g. "ivory"), not CSS variables.
+// This struct maps those IDs to SwiftUI Color values and derived text tones,
+// keeping the card rendering fully native and independent of the backend's
+// web-card CSS variable system.
+//
+// Phase 1: official / ivory / charcoal (all flat colours, no gradient).
+// Phase 2: will add gradient-capable colours (surfaceEnd non-nil).
+
+struct AcademyIDColorConfig {
+
+    let id:            String
+    let surfaceColor:  Color    // card background (flat in Phase 1)
+    let borderColor:   Color
+    let borderOpacity: Double
+    let isLightSurface: Bool   // true = dark text; false = white text
+
+    // MARK: — Derived text tones
+
+    /// Primary value text (field values, full name, etc.)
+    var valueColor:  Color { isLightSurface ? Color(UIColor.label) : .white }
+
+    /// Secondary label text (field name caps: "FULL NAME", "AGE"…)
+    var labelColor:  Color { isLightSurface ? Color(UIColor.secondaryLabel) : Color.white.opacity(0.55) }
+
+    /// Faint placeholder text ("———", spec "—")
+    var mutedColor:  Color { isLightSurface ? Color(UIColor.secondaryLabel).opacity(0.4) : Color.white.opacity(0.28) }
+
+    /// Brand accent (header "LION FOOTBALL ACADEMY")
+    var brandAccent: Color { isLightSurface ? Color(hex: "#b8a06a") : Color.white.opacity(0.80) }
+
+    /// Photo panel / QR border tint
+    var panelBorder: Color { isLightSurface ? Color(hex: "#b8a06a").opacity(0.30) : Color.white.opacity(0.15) }
+
+    // MARK: — Static resolver
+
+    /// Map a backend colour ID to the iOS rendering config.
+    /// Unknown IDs fall back to "official" (the default white card appearance).
+    static func resolve(_ colorId: String) -> AcademyIDColorConfig {
+        switch colorId {
+
+        case "ivory":
+            return AcademyIDColorConfig(
+                id:            "ivory",
+                surfaceColor:  Color(red: 253/255, green: 250/255, blue: 244/255),
+                borderColor:   Color(hex: "#b8a06a"),
+                borderOpacity: 0.40,
+                isLightSurface: true
+            )
+
+        case "charcoal":
+            return AcademyIDColorConfig(
+                id:            "charcoal",
+                surfaceColor:  Color(red: 28/255, green: 28/255, blue: 30/255),
+                borderColor:   .white,
+                borderOpacity: 0.18,
+                isLightSurface: false
+            )
+
+        default: // "official" and unknown → existing system appearance
+            return AcademyIDColorConfig(
+                id:            "official",
+                surfaceColor:  Color(UIColor.secondarySystemBackground),
+                borderColor:   Color(hex: "#b8a06a"),
+                borderOpacity: 0.28,
+                isLightSurface: true
+            )
+        }
+    }
+}
+
+// MARK: — Hex colour initialiser (iOS 14 compatible)
+
+extension Color {
+    init(hex: String) {
+        let h = hex.trimmingCharacters(in: .init(charactersIn: "#"))
+        var rgb: UInt64 = 0
+        Scanner(string: h).scanHexInt64(&rgb)
+        let r = Double((rgb >> 16) & 0xFF) / 255
+        let g = Double((rgb >>  8) & 0xFF) / 255
+        let b = Double( rgb        & 0xFF) / 255
+        self.init(red: r, green: g, blue: b)
+    }
+}

--- a/ios/LFAEducationCenter/Auth/AcademyIDColorPickerView.swift
+++ b/ios/LFAEducationCenter/Auth/AcademyIDColorPickerView.swift
@@ -1,0 +1,152 @@
+import SwiftUI
+
+// Academy ID colour picker sheet — Phase 1 (free colours only).
+//
+// Shows the three free swatches: Official / Ivory / Charcoal.
+// Tap → optimistic select via AcademyIDColorViewModel.
+// Active colour has a checkmark overlay.
+// No premium section, no crown icon, no locked state — Phase 2 only.
+//
+// Reduce Motion: colour change is always a crossfade in the card;
+// the sheet itself uses the system sheet animation.
+
+struct AcademyIDColorPickerView: View {
+
+    @EnvironmentObject private var authManager: AuthManager
+    @ObservedObject var colorVM: AcademyIDColorViewModel
+    @Environment(\.presentationMode) private var presentationMode
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    private let swatchSize: CGFloat = 44
+
+    var body: some View {
+        NavigationView {
+            VStack(alignment: .leading, spacing: 0) {
+
+                // Error banner (non-intrusive, dismissible)
+                if let err = colorVM.errorMessage {
+                    HStack(spacing: Theme.Spacing.sm) {
+                        Image(systemName: "exclamationmark.circle")
+                            .font(.system(size: 13))
+                        Text(err)
+                            .font(.system(size: 12))
+                        Spacer()
+                        Button { colorVM.errorMessage = nil } label: {
+                            Image(systemName: "xmark")
+                                .font(.system(size: 11))
+                        }
+                    }
+                    .foregroundColor(.red)
+                    .padding(.horizontal, Theme.Spacing.md)
+                    .padding(.vertical, Theme.Spacing.sm)
+                    .background(Color.red.opacity(0.08))
+                }
+
+                // Swatch grid
+                if colorVM.colors.isEmpty {
+                    Spacer()
+                    if colorVM.isLoading {
+                        ProgressView()
+                            .frame(maxWidth: .infinity)
+                    } else {
+                        Text("No styles available.")
+                            .font(.subheadline)
+                            .foregroundColor(Theme.Color.muted)
+                            .frame(maxWidth: .infinity)
+                    }
+                    Spacer()
+                } else {
+                    swatchRow
+                        .padding(.horizontal, Theme.Spacing.md)
+                        .padding(.top, Theme.Spacing.lg)
+                }
+
+                Spacer()
+            }
+            .navigationTitle("ID Card Style")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Done") { presentationMode.wrappedValue.dismiss() }
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundColor(Theme.Color.primary)
+                }
+            }
+        }
+        .navigationViewStyle(.stack)
+    }
+
+    // MARK: — Swatch row
+
+    private var swatchRow: some View {
+        HStack(spacing: Theme.Spacing.lg) {
+            ForEach(colorVM.colors) { theme in
+                swatchButton(theme)
+            }
+            Spacer()
+        }
+    }
+
+    @ViewBuilder
+    private func swatchButton(_ theme: AcademyIDColorTheme) -> some View {
+        let isActive = colorVM.activeColorId == theme.id
+
+        Button {
+            let animation: Animation = reduceMotion
+                ? .easeInOut(duration: 0.20)
+                : .spring(response: 0.30, dampingFraction: 0.75)
+            withAnimation(animation) {
+                Task { await colorVM.select(colorId: theme.id, using: authManager) }
+            }
+        } label: {
+            VStack(spacing: 6) {
+                ZStack {
+                    // Dot colour circle
+                    Circle()
+                        .fill(Color(hex: theme.dotColor))
+                        .frame(width: swatchSize, height: swatchSize)
+                        .overlay(
+                            Circle()
+                                .stroke(
+                                    isActive ? Theme.Color.primary : Color.clear,
+                                    lineWidth: 2.5
+                                )
+                        )
+                        .shadow(
+                            color: isActive ? Theme.Color.primary.opacity(0.30) : .clear,
+                            radius: 4
+                        )
+
+                    // Checkmark for active colour
+                    if isActive {
+                        Image(systemName: "checkmark")
+                            .font(.system(size: 14, weight: .bold))
+                            .foregroundColor(checkmarkColor(for: theme.dotColor))
+                            .transition(.scale.combined(with: .opacity))
+                    }
+                }
+                .animation(.spring(response: 0.25, dampingFraction: 0.70), value: isActive)
+
+                Text(theme.label)
+                    .font(.system(size: 11, weight: isActive ? .semibold : .regular))
+                    .foregroundColor(isActive ? Theme.Color.primary : Theme.Color.muted)
+            }
+        }
+        .buttonStyle(.plain)
+        .disabled(colorVM.isLoading)
+    }
+
+    // MARK: — Checkmark colour (white on dark swatches, dark on light)
+
+    private func checkmarkColor(for hexColor: String) -> Color {
+        // Charcoal swatch is near-black → white checkmark; others → dark
+        let h = hexColor.trimmingCharacters(in: .init(charactersIn: "#"))
+        var rgb: UInt64 = 0
+        Scanner(string: h).scanHexInt64(&rgb)
+        let r = Double((rgb >> 16) & 0xFF) * 299
+        let g = Double((rgb >>  8) & 0xFF) * 587
+        let b = Double( rgb        & 0xFF) * 114
+        let brightness = (r + g + b) / (255 * 1000)
+        return brightness < 0.40 ? .white : .black.opacity(0.75)
+    }
+}

--- a/ios/LFAEducationCenter/Auth/AcademyIDColorViewModel.swift
+++ b/ios/LFAEducationCenter/Auth/AcademyIDColorViewModel.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+// ViewModel for the Academy ID card colour picker.
+//
+// Loads the colour palette from GET /api/v1/users/me/academy-id/colors.
+// Persists the active selection via POST /api/v1/users/me/academy-id/colors/select.
+//
+// Optimistic update: activeColorId switches immediately on tap; if the API
+// call fails the previous colour is restored and errorMessage is set.
+//
+// Phase 1: three free colours — no credit deduction, no ownership checks.
+// Phase 2 will add unlock logic before calling select.
+
+@MainActor
+final class AcademyIDColorViewModel: ObservableObject {
+
+    @Published private(set) var colors:        [AcademyIDColorTheme] = []
+    @Published private(set) var activeColorId: String                = "official"
+    @Published private(set) var isLoading:     Bool                  = false
+    @Published           var errorMessage:     String?               = nil
+
+    // MARK: — Load colour list (no-op if already loaded)
+
+    func load(using authManager: AuthManager) async {
+        guard colors.isEmpty else { return }
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            let response: AcademyIDColorsResponse = try await authManager.authenticatedGet(
+                path: "/api/v1/users/me/academy-id/colors"
+            )
+            colors        = response.colors.sorted { $0.sortOrder < $1.sortOrder }
+            activeColorId = response.activeColorId
+        } catch {
+            // Non-fatal: colour picker falls back to "official" appearance if unavailable.
+            errorMessage = "Could not load card styles."
+        }
+    }
+
+    // MARK: — Select a colour (optimistic + rollback)
+
+    func select(colorId: String, using authManager: AuthManager) async {
+        guard colorId != activeColorId else { return }
+
+        let previous      = activeColorId
+        activeColorId     = colorId   // optimistic update
+        errorMessage      = nil
+
+        do {
+            struct Payload:  Encodable  { let colorId: String
+                enum CodingKeys: String, CodingKey { case colorId = "color_id" } }
+            struct Response: Decodable  { let ok: Bool; let activeColorId: String
+                enum CodingKeys: String, CodingKey { case ok; case activeColorId = "active_color_id" } }
+
+            let _: Response = try await authManager.authenticatedPost(
+                path: "/api/v1/users/me/academy-id/colors/select",
+                body: Payload(colorId: colorId)
+            )
+        } catch {
+            activeColorId = previous   // rollback
+            errorMessage  = "Could not apply style. Check your connection."
+        }
+    }
+}

--- a/ios/LFAEducationCenter/Auth/AcademyIDFullScreenView.swift
+++ b/ios/LFAEducationCenter/Auth/AcademyIDFullScreenView.swift
@@ -68,11 +68,18 @@ struct AcademyIDFullScreenView: View {
     @EnvironmentObject private var authManager: AuthManager
     @EnvironmentObject private var dashboardVM: DashboardViewModel
     @StateObject         private var viewModel  = AcademyIDViewModel()
+    @StateObject         private var colorVM    = AcademyIDColorViewModel()
 
     @Environment(\.presentationMode) private var presentationMode
 
-    @State private var brightnessBoostActive = false
+    @State private var brightnessBoostActive  = false
     @State private var originalBrightness: CGFloat = UIScreen.main.brightness
+    @State private var isShowingColorPicker   = false
+
+    // Resolved colour config from the active colour ID
+    private var activeColorConfig: AcademyIDColorConfig {
+        AcademyIDColorConfig.resolve(colorVM.activeColorId)
+    }
 
     var body: some View {
         NavigationView {
@@ -107,19 +114,37 @@ struct AcademyIDFullScreenView: View {
                     }
                 }
                 ToolbarItem(placement: .navigationBarTrailing) {
-                    Button {
-                        Task { await viewModel.reload(using: authManager, profile: dashboardVM.profile) }
-                    } label: {
-                        Image(systemName: "arrow.clockwise")
-                            .font(.system(size: 14, weight: .semibold))
-                            .foregroundColor(Theme.Color.primary)
+                    HStack(spacing: Theme.Spacing.sm) {
+                        // Colour picker — only shown when licence exists (colour data available)
+                        if dashboardVM.lfaLicense != nil {
+                            Button { isShowingColorPicker = true } label: {
+                                Image(systemName: "paintpalette")
+                                    .font(.system(size: 14, weight: .semibold))
+                                    .foregroundColor(Theme.Color.primary)
+                            }
+                        }
+                        // Reload
+                        Button {
+                            Task { await viewModel.reload(using: authManager, profile: dashboardVM.profile) }
+                        } label: {
+                            Image(systemName: "arrow.clockwise")
+                                .font(.system(size: 14, weight: .semibold))
+                                .foregroundColor(Theme.Color.primary)
+                        }
+                        .disabled(isReloading)
                     }
-                    .disabled(isReloading)
                 }
             }
         }
         .navigationViewStyle(.stack)
-        .onAppear { Task { await viewModel.load(using: authManager, profile: dashboardVM.profile) } }
+        .sheet(isPresented: $isShowingColorPicker) {
+            AcademyIDColorPickerView(colorVM: colorVM)
+                .environmentObject(authManager)
+        }
+        .onAppear {
+            Task { await viewModel.load(using: authManager, profile: dashboardVM.profile) }
+            Task { await colorVM.load(using: authManager) }
+        }
         .onDisappear { restoreBrightness() }
         // If the slow path just lazy-assigned a new Academy ID, reload the dashboard so
         // ProfileView subtitle and ProfileCompletionScore.academyID (+10%) update immediately.
@@ -162,7 +187,8 @@ struct AcademyIDFullScreenView: View {
             lfaAcademyId:             viewModel.loadState.response?.lfaAcademyId
                                       ?? dashboardVM.profile?.lfaAcademyId,
             publicToken:              viewModel.loadState.response?.publicToken
-                                      ?? dashboardVM.profile?.publicToken
+                                      ?? dashboardVM.profile?.publicToken,
+            colorConfig:              activeColorConfig
         )
     }
 

--- a/ios/LFAEducationCenter/Auth/AcademyIDViewModel.swift
+++ b/ios/LFAEducationCenter/Auth/AcademyIDViewModel.swift
@@ -6,6 +6,8 @@ import Foundation
 //   Fast path — publicToken already in UserProfile (from /users/me cache):
 //     qr_data is assembled locally from APIConfig.verifyBaseURL.
 //     Works offline once the token is cached.
+//     activeColorId is nil on the fast path — AcademyIDColorViewModel loads
+//     the colour independently from /me/academy-id/colors.
 //   Slow path — publicToken == nil (first-ever access or fresh install):
 //     Calls GET /api/v1/users/me/academy-id which lazy-assigns the ID on the
 //     backend and returns the complete response including qr_data.
@@ -56,15 +58,17 @@ final class AcademyIDViewModel: ObservableObject {
         loadState = .loading
 
         // Fast path: token already known → assemble qr_data locally, no network needed.
+        // activeColorId is nil here; AcademyIDColorViewModel handles it independently.
         if !forceRemote,
            let token = profile?.publicToken,
            let aid   = profile?.lfaAcademyId {
             let qrData = APIConfig.verifyBaseURL + "/verify/" + token
             loadState = .loaded(AcademyIDResponse(
-                lfaAcademyId: aid,
-                publicToken:  token,
-                qrUrl:        "/verify/" + token,
-                qrData:       qrData
+                lfaAcademyId:  aid,
+                publicToken:   token,
+                qrUrl:         "/verify/" + token,
+                qrData:        qrData,
+                activeColorId: nil
             ))
             return
         }
@@ -79,10 +83,11 @@ final class AcademyIDViewModel: ObservableObject {
             // backend's VERIFY_BASE_URL default (which may be localhost in dev).
             let iosQrData = APIConfig.verifyBaseURL + "/verify/" + response.publicToken
             loadState = .loaded(AcademyIDResponse(
-                lfaAcademyId: response.lfaAcademyId,
-                publicToken:  response.publicToken,
-                qrUrl:        response.qrUrl,
-                qrData:       iosQrData
+                lfaAcademyId:  response.lfaAcademyId,
+                publicToken:   response.publicToken,
+                qrUrl:         response.qrUrl,
+                qrData:        iosQrData,
+                activeColorId: response.activeColorId
             ))
         } catch {
             loadState = .error("Could not load Academy ID. Check your connection.")

--- a/ios/LFAEducationCenter/Auth/RegisterView.swift
+++ b/ios/LFAEducationCenter/Auth/RegisterView.swift
@@ -185,7 +185,8 @@ struct RegisterView: View {
                         profilePhotoProcessedURL: nil,
                         isVerified:               false,  // registration preview — invite valid ≠ ID card verified
                         lfaAcademyId:             nil,   // assigned by backend after registration
-                        publicToken:              nil    // QR shows placeholder until /me/academy-id
+                        publicToken:              nil,   // QR shows placeholder until /me/academy-id
+                        colorConfig:              nil    // official appearance during registration preview
                     )
                     .padding(.horizontal, Theme.Spacing.md)
 

--- a/ios/LFAEducationCenter/Models/AcademyIDColorTheme.swift
+++ b/ios/LFAEducationCenter/Models/AcademyIDColorTheme.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+// Decoded from GET /api/v1/users/me/academy-id/colors.
+//
+// Phase 1: three free colours (official / ivory / charcoal).
+// All Phase-1 colours have is_premium=false, credit_cost=0, is_owned=true.
+// Phase 2 will add premium colours; the schema is forward-compatible.
+
+struct AcademyIDColorTheme: Decodable, Identifiable {
+    let id:         String
+    let label:      String
+    let dotColor:   String   // hex — used in the swatch picker circle
+    let isPremium:  Bool
+    let creditCost: Int
+    let isOwned:    Bool
+    let sortOrder:  Int
+
+    enum CodingKeys: String, CodingKey {
+        case id, label
+        case dotColor   = "dot_color"
+        case isPremium  = "is_premium"
+        case creditCost = "credit_cost"
+        case isOwned    = "is_owned"
+        case sortOrder  = "sort_order"
+    }
+}
+
+struct AcademyIDColorsResponse: Decodable {
+    let activeColorId: String
+    let colors:        [AcademyIDColorTheme]
+
+    enum CodingKeys: String, CodingKey {
+        case activeColorId = "active_color_id"
+        case colors
+    }
+}

--- a/ios/LFAEducationCenter/Models/AcademyIDResponse.swift
+++ b/ios/LFAEducationCenter/Models/AcademyIDResponse.swift
@@ -6,15 +6,20 @@ import Foundation
 // qr_data is the absolute URL to encode in the QR code:
 //   {VERIFY_BASE_URL}/verify/{public_token}
 struct AcademyIDResponse: Decodable {
-    let lfaAcademyId: String
-    let publicToken:  String
-    let qrUrl:        String  // relative: /verify/{token}
-    let qrData:       String  // absolute: https://lfa.hu/verify/{token}
+    let lfaAcademyId:  String
+    let publicToken:   String
+    let qrUrl:         String   // relative: /verify/{token}
+    let qrData:        String   // absolute: https://lfa.hu/verify/{token}
+    // Active Academy ID colour — nil when no LFA Player licence exists.
+    // AcademyIDColorViewModel is the authoritative source; this field is
+    // informational only (can seed the fast path if needed in Phase 2).
+    let activeColorId: String?
 
     enum CodingKeys: String, CodingKey {
-        case lfaAcademyId = "lfa_academy_id"
-        case publicToken  = "public_token"
-        case qrUrl        = "qr_url"
-        case qrData       = "qr_data"
+        case lfaAcademyId  = "lfa_academy_id"
+        case publicToken   = "public_token"
+        case qrUrl         = "qr_url"
+        case qrData        = "qr_data"
+        case activeColorId = "active_color_id"
     }
 }

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -22319,6 +22319,19 @@
         "title": "_CardVariantRequest",
         "type": "object"
       },
+      "_ColorSelectRequest": {
+        "properties": {
+          "color_id": {
+            "title": "Color Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "color_id"
+        ],
+        "title": "_ColorSelectRequest",
+        "type": "object"
+      },
       "_HighlightVideoRequest": {
         "properties": {
           "video_url": {
@@ -59869,6 +59882,82 @@
           }
         ],
         "summary": "Get Academy Id",
+        "tags": [
+          "users",
+          "users"
+        ]
+      }
+    },
+    "/api/v1/users/me/academy-id/colors": {
+      "get": {
+        "description": "Return the Academy ID colour palette and the user's active colour.\n\nPhase 1: three free colours (official / ivory / charcoal).\nAll colours have is_owned=true and credit_cost=0.\nPhase 2 will add premium colours with ownership checks.\n\nRequires an active LFA Football Player licence (404 otherwise).",
+        "operationId": "get_academy_id_colors_api_v1_users_me_academy_id_colors_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Get Academy Id Colors Api V1 Users Me Academy Id Colors Get"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get Academy Id Colors",
+        "tags": [
+          "users",
+          "users"
+        ]
+      }
+    },
+    "/api/v1/users/me/academy-id/colors/select": {
+      "post": {
+        "description": "Set the active Academy ID colour for the current user.\n\nPhase 1: only free colours accepted (official / ivory / charcoal).\nReturns the new active_color_id on success.",
+        "operationId": "select_academy_id_color_api_v1_users_me_academy_id_colors_select_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/_ColorSelectRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Select Academy Id Color Api V1 Users Me Academy Id Colors Select Post"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Select Academy Id Color",
         "tags": [
           "users",
           "users"

--- a/tests/unit/api/endpoints/test_academy_id_colors.py
+++ b/tests/unit/api/endpoints/test_academy_id_colors.py
@@ -1,0 +1,244 @@
+"""
+Academy ID Color System — Phase 1 unit tests.
+
+AIC-01  GET /me/academy-id/colors — no licence → 404
+AIC-02  GET /me/academy-id/colors — with licence → 3 free colours, all is_owned=True
+AIC-03  GET /me/academy-id/colors — active_color_id reflects stored value
+AIC-04  POST /me/academy-id/colors/select — unknown color_id → 400
+AIC-05  POST /me/academy-id/colors/select — valid ivory → active_color_id updated
+AIC-06  POST /me/academy-id/colors/select — no licence → 404
+AIC-07  GET /me/academy-id — includes active_color_id (licence present)
+AIC-08  GET /me/academy-id — active_color_id=None when no licence
+AIC-09  academy_id_color_service is isolated from Player/Welcome card systems
+AIC-10  get_active_color_id falls back to 'official' for unknown/NULL value
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.api.api_v1.endpoints.users.profile import (
+    get_academy_id_colors,
+    select_academy_id_color,
+)
+from app.services.academy_id_color_service import (
+    ACADEMY_ID_COLORS,
+    get_active_color_id,
+    get_all_colors,
+    is_valid_color,
+    set_active_color,
+)
+
+_BASE = "app.api.api_v1.endpoints.users.profile"
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _user(uid: int = 1):
+    u = MagicMock()
+    u.id  = uid
+    u.lfa_academy_id = "LFA-2026-00001"
+    u.public_token   = "test-token-uuid"
+    return u
+
+
+def _license(color: str = "official", spec: str = "LFA_FOOTBALL_PLAYER"):
+    lic = MagicMock()
+    lic.specialization_type = spec
+    lic.academy_id_color    = color
+    return lic
+
+
+def _db_with_license(lic):
+    """DB mock whose .query().filter().first() returns lic."""
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = lic
+    return db
+
+
+def _db_no_license():
+    """DB mock with no licence row."""
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = None
+    return db
+
+
+class _SelectPayload:
+    def __init__(self, color_id: str):
+        self.color_id = color_id
+
+
+# ── AIC-01 ────────────────────────────────────────────────────────────────────
+
+def test_aic_01_colors_no_licence_raises_404():
+    """GET /me/academy-id/colors with no LFA licence → 404."""
+    with pytest.raises(HTTPException) as exc:
+        get_academy_id_colors(db=_db_no_license(), current_user=_user())
+    assert exc.value.status_code == 404
+
+
+# ── AIC-02 ────────────────────────────────────────────────────────────────────
+
+def test_aic_02_colors_returns_three_free_colors():
+    """GET /me/academy-id/colors with licence → 3 colours, all is_owned=True, credit_cost=0."""
+    db  = _db_with_license(_license())
+    res = get_academy_id_colors(db=db, current_user=_user())
+
+    assert res["active_color_id"] == "official"
+    colors = res["colors"]
+    assert len(colors) == 3
+    ids = {c["id"] for c in colors}
+    assert ids == {"official", "ivory", "charcoal"}
+    for c in colors:
+        assert c["is_owned"]    is True
+        assert c["credit_cost"] == 0
+        assert c["is_premium"]  is False
+        assert "dot_color" in c
+        assert "sort_order" in c
+
+
+# ── AIC-03 ────────────────────────────────────────────────────────────────────
+
+def test_aic_03_colors_reflects_stored_active_color():
+    """active_color_id matches what is stored on the licence."""
+    db  = _db_with_license(_license(color="charcoal"))
+    res = get_academy_id_colors(db=db, current_user=_user())
+    assert res["active_color_id"] == "charcoal"
+
+
+# ── AIC-04 ────────────────────────────────────────────────────────────────────
+
+def test_aic_04_select_unknown_color_raises_400():
+    """POST select with unknown color_id → 400."""
+    with pytest.raises(HTTPException) as exc:
+        select_academy_id_color(
+            payload=_SelectPayload("royal_navy"),   # Phase 2 colour — not valid yet
+            db=_db_with_license(_license()),
+            current_user=_user(),
+        )
+    assert exc.value.status_code == 400
+    assert "royal_navy" in exc.value.detail
+
+
+# ── AIC-05 ────────────────────────────────────────────────────────────────────
+
+def test_aic_05_select_ivory_updates_color():
+    """POST select ivory → active_color_id = 'ivory', DB committed."""
+    lic = _license(color="official")
+    db  = _db_with_license(lic)
+
+    res = select_academy_id_color(
+        payload=_SelectPayload("ivory"),
+        db=db,
+        current_user=_user(),
+    )
+
+    assert res["ok"] is True
+    assert res["active_color_id"] == "ivory"
+    assert lic.academy_id_color == "ivory"
+    db.commit.assert_called_once()
+
+
+# ── AIC-06 ────────────────────────────────────────────────────────────────────
+
+def test_aic_06_select_no_licence_raises_404():
+    """POST select with no licence → 404."""
+    with pytest.raises(HTTPException) as exc:
+        select_academy_id_color(
+            payload=_SelectPayload("charcoal"),
+            db=_db_no_license(),
+            current_user=_user(),
+        )
+    assert exc.value.status_code == 404
+
+
+# ── AIC-07 ────────────────────────────────────────────────────────────────────
+
+def test_aic_07_get_academy_id_includes_active_color():
+    """GET /me/academy-id response includes active_color_id when licence present."""
+    from app.api.api_v1.endpoints.users.profile import get_academy_id
+
+    user = _user()
+    lic  = _license(color="ivory")
+    db   = MagicMock()
+    # Sequence: query().filter().first() called for licence
+    db.query.return_value.filter.return_value.first.return_value = lic
+
+    with patch(f"{_BASE}.assign_lfa_academy_id"), \
+         patch(f"{_BASE}.ensure_public_token"):
+        res = get_academy_id(db=db, current_user=user)
+
+    assert "active_color_id" in res
+    assert res["active_color_id"] == "ivory"
+
+
+# ── AIC-08 ────────────────────────────────────────────────────────────────────
+
+def test_aic_08_get_academy_id_active_color_none_without_licence():
+    """GET /me/academy-id returns active_color_id=None when no licence exists."""
+    from app.api.api_v1.endpoints.users.profile import get_academy_id
+
+    user = _user()
+    db   = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = None
+
+    with patch(f"{_BASE}.assign_lfa_academy_id"), \
+         patch(f"{_BASE}.ensure_public_token"):
+        res = get_academy_id(db=db, current_user=user)
+
+    assert res["active_color_id"] is None
+
+
+# ── AIC-09 ────────────────────────────────────────────────────────────────────
+
+def test_aic_09_color_service_is_isolated():
+    """academy_id_color_service must not import Player/Welcome/Challenge services."""
+    import importlib, ast, pathlib
+
+    src = pathlib.Path(
+        "app/services/academy_id_color_service.py"
+    ).read_text()
+    tree = ast.parse(src)
+
+    forbidden = {
+        "card_color_service",
+        "card_theme_service",
+        "shop_catalog_service",
+    }
+    imported = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            names = (
+                [alias.name for alias in node.names]
+                if isinstance(node, ast.Import)
+                else ([node.module] if node.module else [])
+            )
+            for name in names:
+                for f in forbidden:
+                    if f in (name or ""):
+                        imported.add(f)
+
+    assert not imported, (
+        f"academy_id_color_service must not import: {imported}"
+    )
+
+
+# ── AIC-10 ────────────────────────────────────────────────────────────────────
+
+def test_aic_10_get_active_color_id_fallback():
+    """get_active_color_id falls back to 'official' for NULL/unknown values."""
+    lic_null    = _license(color=None)
+    lic_unknown = _license(color="royal_navy")   # Phase 2, not valid in Phase 1
+    lic_empty   = _license(color="")
+
+    assert get_active_color_id(lic_null)    == "official"
+    assert get_active_color_id(lic_unknown) == "official"
+    assert get_active_color_id(lic_empty)   == "official"
+    assert get_active_color_id(_license(color="ivory")) == "ivory"

--- a/tests/unit/api/web_routes/test_card_editor_ce2.py
+++ b/tests/unit/api/web_routes/test_card_editor_ce2.py
@@ -430,9 +430,9 @@ class TestCE216WelcomeEditorUnchanged:
 
 class TestCE217RouteCount:
     def test_openapi_snapshot_route_count_unchanged(self):
-        """feat/r3f adds POST /api/v1/lfa-player/self-assessment — snapshot path count must equal 869."""
+        """Academy ID colour system Phase 1 adds 2 new routes — snapshot path count must equal 876."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 874, (
-            f"Expected 869 routes (868 prior baseline + 1 lfa-player/self-assessment route), got {len(paths)}."
+        assert len(paths) == 876, (
+            f"Expected 876 routes (874 prior baseline + 2 academy-id colour routes), got {len(paths)}."
         )

--- a/tests/unit/api/web_routes/test_card_editor_cs_s1.py
+++ b/tests/unit/api/web_routes/test_card_editor_cs_s1.py
@@ -294,7 +294,7 @@ class TestS109S110RouteAndSnapshot:
         """S1-09 (updated r3-credits-v2): route count is 868 (+1 invitation-codes/redeem-authenticated)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 874, (
+        assert len(paths) == 876, (
             f"Expected 868 routes (867 prior baseline + 1 invitation-codes/redeem-authenticated), got {len(paths)}"
         )
 

--- a/tests/unit/api/web_routes/test_card_editor_ref_p2.py
+++ b/tests/unit/api/web_routes/test_card_editor_ref_p2.py
@@ -287,7 +287,7 @@ class TestP227to29RouteAndOpenAPI:
         """P2-27: Route count = 846 (CS-S2A +1 /card-studio/player)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 874, f"Expected 846 routes, got {len(paths)}"
+        assert len(paths) == 876, f"Expected 846 routes, got {len(paths)}"
 
     def test_p2_28_openapi_snapshot_match(self):
         """P2-28: OpenAPI snapshot matches live API paths."""

--- a/tests/unit/api/web_routes/test_card_studio_challenge.py
+++ b/tests/unit/api/web_routes/test_card_studio_challenge.py
@@ -294,7 +294,7 @@ class TestCCS11RouteCount:
         """CCS-11: route count updated to 842 after CE-3.8 (+3 from-mood endpoints)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 874, (
+        assert len(paths) == 876, (
             f"Expected 845 routes (842 CE-3.7+CE-3.8 baseline + 2 CS-S0 card-studio routes), got {len(paths)}."
         )
 

--- a/tests/unit/api/web_routes/test_card_studio_landing.py
+++ b/tests/unit/api/web_routes/test_card_studio_landing.py
@@ -159,7 +159,7 @@ class TestCEL12RouteCount:
         """CEL-12: route count 844 (unchanged — redirect is handler change, not new route)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 874, (
+        assert len(paths) == 876, (
             f"Expected 845 routes (redirect handler change does not add routes), got {len(paths)}."
         )
 

--- a/tests/unit/api/web_routes/test_card_studio_shell.py
+++ b/tests/unit/api/web_routes/test_card_studio_shell.py
@@ -326,7 +326,7 @@ class TestCSS21to23RouteConfirmations:
         """CSS-21: adding 2 card-studio routes raises count from 842 to 844."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 874, (
+        assert len(paths) == 876, (
             f"Expected 845 routes (842 baseline + 2 new /card-studio routes), got {len(paths)}"
         )
 

--- a/tests/unit/api/web_routes/test_card_studio_welcome.py
+++ b/tests/unit/api/web_routes/test_card_studio_welcome.py
@@ -325,7 +325,7 @@ class TestCEW18RouteCount:
         """CEW-18: route count baseline check (updated by CE-3.8 to 842)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 874, (
+        assert len(paths) == 876, (
             f"Expected 842 routes (839 CE-3.7 baseline + 3 from-mood endpoints), got {len(paths)}."
         )
 
@@ -678,7 +678,7 @@ class TestCEW44to51TemplateMoodPicker:
         """CEW-47: CE-3.8 adds 3 from-mood routes → total 842."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 874, (
+        assert len(paths) == 876, (
             f"Expected 845 routes (842 baseline + 2 CS-S0 routes), got {len(paths)}"
         )
 

--- a/tests/unit/api/web_routes/test_cc_design_1.py
+++ b/tests/unit/api/web_routes/test_cc_design_1.py
@@ -780,7 +780,7 @@ class TestCCD22to23RouteSnapshot:
         """CCD-22: Route count is 851 (CC-DESIGN-1 SNAPSHOT adds POST /challenges/{id}/card/photo)."""
         from app.main import app
         count = len(app.openapi().get("paths", {}))
-        assert count == 874, f"Expected 851, got {count}"
+        assert count == 876, f"Expected 851, got {count}"
 
     def test_ccd_23_openapi_snapshot_match(self):
         """CCD-23: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_cs_color_1.py
+++ b/tests/unit/api/web_routes/test_cs_color_1.py
@@ -382,7 +382,7 @@ class TestCSCOL15to16RouteAndSnapshot:
         """CSCOL-15: route count = 845 (+1 POST /dashboard/wc-card-theme)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 874, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 876, f"Expected 845 routes, got {len(paths)}"
 
     def test_cscol_16_openapi_snapshot_includes_wc_card_theme(self):
         """CSCOL-16: OpenAPI snapshot includes /dashboard/wc-card-theme."""

--- a/tests/unit/api/web_routes/test_cs_s2a.py
+++ b/tests/unit/api/web_routes/test_cs_s2a.py
@@ -40,7 +40,7 @@ class TestS2A01to02RouteRegistration:
         """S2A-02 (updated CS-S4A): Total route count is 847 (CS-S2A+CS-S4A)."""
         from app.main import app
         count = len(app.openapi().get("paths", {}))
-        assert count == 874, f"Expected 847 routes, got {count}"
+        assert count == 876, f"Expected 847 routes, got {count}"
 
 
 # ── S2A-03..08: _resolve_player_context logic ────────────────────────────────

--- a/tests/unit/api/web_routes/test_cs_s4a.py
+++ b/tests/unit/api/web_routes/test_cs_s4a.py
@@ -152,7 +152,7 @@ class TestS4A12to13RouteAndSnapshot:
         """S4A-12: Route count == 851 (CC-DESIGN-1 SNAPSHOT adds +1 POST /challenges/{id}/card/photo)."""
         from app.main import app
         count = len(app.openapi().get("paths", {}))
-        assert count == 874, f"Expected 851 routes, got {count}"
+        assert count == 876, f"Expected 851 routes, got {count}"
 
     def test_s4a_13_openapi_snapshot_match(self):
         """S4A-13: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_family_color_shop.py
+++ b/tests/unit/api/web_routes/test_family_color_shop.py
@@ -223,7 +223,7 @@ class TestRouteRegistration:
     def test_ts_13_route_count_836(self):
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 874, (
+        assert len(paths) == 876, (
             f"Expected 845 routes (842 CE-3.7+CE-3.8 baseline + 2 CS-S0 card-studio routes), got {len(paths)}."
         )
 

--- a/tests/unit/api/web_routes/test_shop_3a.py
+++ b/tests/unit/api/web_routes/test_shop_3a.py
@@ -194,7 +194,7 @@ class TestS3A13to14RouteAndSnapshot:
         """S3A-13: Route count = 845 (template deletion does not affect routes)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 874, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 876, f"Expected 845 routes, got {len(paths)}"
 
     def test_s3a_14_openapi_snapshot_match(self):
         """S3A-14: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_shop_3b1.py
+++ b/tests/unit/api/web_routes/test_shop_3b1.py
@@ -158,7 +158,7 @@ class TestS3B112to13RouteAndSnapshot:
         """S3B1-12: Route count = 845 (test cleanup does not affect routes)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 874, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 876, f"Expected 845 routes, got {len(paths)}"
 
     def test_s3b1_13_openapi_snapshot_match(self):
         """S3B1-13: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_shop_3b2.py
+++ b/tests/unit/api/web_routes/test_shop_3b2.py
@@ -192,7 +192,7 @@ class TestS3B215to16RouteAndSnapshot:
         """S3B2-15: Route count = 845 (template deletion does not affect routes)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 874, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 876, f"Expected 845 routes, got {len(paths)}"
 
     def test_s3b2_16_openapi_snapshot_match(self):
         """S3B2-16: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_shop_unified.py
+++ b/tests/unit/api/web_routes/test_shop_unified.py
@@ -271,7 +271,7 @@ class TestSHOP14to15RouteAndSnapshot:
         """SHOP-14: route count = 845 (no new routes in SHOP-1)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 874, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 876, f"Expected 845 routes, got {len(paths)}"
 
     def test_shop_15_openapi_snapshot_match(self):
         """SHOP-15: OpenAPI snapshot matches live API."""


### PR DESCRIPTION
## Scope

Academy ID saját, dedikált free color system — teljesen izolált a Player Card, Welcome Card, Challenge Card és minden egyéb social/export kártya témarendszertől.

**Phase 1 — free colours only:**
- `official` / `ivory` / `charcoal`
- Külön `academy_id_color` mező a `user_licenses` táblán
- Külön backend endpointok (`/me/academy-id/colors/*`)
- iOS color picker sheet (3 swatch, no premium section)
- **Nincs prémium szín, nincs credit levonás, nincs card_color_ownership, nincs custom gradient**

---

## Backend (TS-2A)

- **Migration** `2026_06_09_1100`: `user_licenses.academy_id_color VARCHAR(50) NOT NULL DEFAULT 'official'` — backfill-free, rollback-safe
- **`app/services/academy_id_color_service.py`** (új, izolált): `get_all_colors()`, `get_active_color_id()`, `set_active_color()` — nincs import a Player/Welcome/Challenge service-ekből
- **`GET /api/v1/users/me/academy-id/colors`** → `{active_color_id, colors[]}` — 404 ha nincs LFA licence
- **`POST /api/v1/users/me/academy-id/colors/select`** → `{ok, active_color_id}` — 400 ismeretlen color_id-re, 404 nincs licence
- **`GET /api/v1/users/me/academy-id`** (meglévő, bővített) → `active_color_id` mező hozzáadva

---

## iOS (TS-2B)

- **`AcademyIDColorTheme.swift`** — API response model (`id`, `label`, `dot_color`, `is_premium`, `credit_cost`, `is_owned`, `sort_order`)
- **`AcademyIDColorConfig.swift`** — iOS rendering tokenek (`surfaceColor`, `borderColor`, `isLightSurface`); `Color(hex:)` extension; static resolver
- **`AcademyIDColorViewModel.swift`** — load + optimistic select + rollback API hiba esetén
- **`AcademyIDColorPickerView.swift`** — 3-swatch sheet, aktív szín checkmark, nincs premium section
- **`AcademyIDCardView.swift`** — `colorConfig: AcademyIDCardColorConfig?` opcionális param; derived text/border/surface computed vars; `.animation` on `colorConfig.id`
- **`AcademyIDFullScreenView.swift`** — `@StateObject colorVM`, 🎨 toolbar gomb (csak ha licence létezik), `.sheet` color picker, `activeColorConfig` átadva a kártyának
- **`RegisterView.swift`** — `colorConfig: nil` backward-compatible

---

## Scope guard

| Rendszer | Állapot |
|---|---|
| Player Card / Welcome Card / Challenge Card | ✅ Érintetlen |
| `card_color_service.py` | ✅ Unmodified |
| `card_theme_service.py` | ✅ Unmodified |
| Licence unlock logika | ✅ Érintetlen |
| Onboarding | ✅ Érintetlen |
| Profile completion | ✅ Érintetlen |
| ID card verified logika | ✅ Érintetlen |
| `card_color_ownership` tábla | ✅ Érintetlen (Phase 2) |
| Credit levonás | ✅ Nincs |
| Prémium szín | ✅ Nincs |
| Custom gradient | ✅ Nincs (Phase 3) |

---

## Tesztek

- **Backend AIC-01..10**: 10/10 PASS
- **Full unit suite**: 12 914 passed, 0 failed
- **OpenAPI snapshot**: PASS (876 routes)
- **iOS build**: `** BUILD SUCCEEDED **`

---

## Rollback

```bash
git revert 6cbe1276   # TS-2B iOS
git revert bd512197   # TS-2A backend
python -m alembic downgrade 2026_06_09_1000   # DROP COLUMN academy_id_color
```

Adatvesztés: csak szín-preferencia (visszaáll DEFAULT 'official'). Nincs FK, nincs cascade.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)