### PR TITLE
feat(biometric): PR-1 — foundation, feature flag, data model, sanitizer, audit log

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,19 @@ API_TIMEOUT=30
 # Never leave this as localhost in a production deployment.
 VERIFY_BASE_URL=http://localhost:8000
 
+# ── Biometric Face Matching ───────────────────────────────────────────────────
+# BIOMETRIC_FACE_MATCHING_ENABLED — master switch for the biometric pipeline.
+#   false (default) — all biometric endpoints return HTTP 503; no data processed.
+#   true            — requires: DPIA completed, consent v1.0 legally approved,
+#                     written sign-off. NEVER set true without those approvals.
+BIOMETRIC_FACE_MATCHING_ENABLED=false
+#
+# BIOMETRIC_EMBEDDING_KEY — AES-256-GCM key for face embedding encryption.
+#   Generate: python -c "import secrets; print(secrets.token_hex(32))"
+#   Required when BIOMETRIC_FACE_MATCHING_ENABLED=true.
+#   Must be stored in a secret manager in production — NEVER in plaintext.
+BIOMETRIC_EMBEDDING_KEY=
+
 # ── Database ────────────────────────────────────────────────────────────────
 # PostgreSQL connection string
 # Format: postgresql://user:password@host:port/database

--- a/alembic/versions/2026_06_10_1000_add_biometric_foundation.py
+++ b/alembic/versions/2026_06_10_1000_add_biometric_foundation.py
@@ -1,0 +1,163 @@
+"""Add biometric face matching foundation tables and user columns.
+
+Creates:
+  user_biometric_consents    — GDPR Art. 9 explicit consent records
+  user_face_embeddings       — AES-256-GCM encrypted face embeddings (populated PR-4+)
+  biometric_verification_logs — immutable biometric audit trail
+
+Adds to users:
+  face_match_status, face_match_score, face_reference_photo_status,
+  manual_review_required, reviewed_by, reviewed_at, rejection_reason
+
+All new user columns default to NULL / False so the migration is safe for
+existing rows without a backfill step.
+
+No ONNX, embedding generation, or Celery task is added in this migration.
+Feature is controlled by BIOMETRIC_FACE_MATCHING_ENABLED=false (default).
+
+Revision ID: 2026_06_10_1000
+Revises:     2026_06_09_1000
+Create Date: 2026-06-10 10:00:00
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import BYTEA, JSONB, UUID
+
+revision      = "2026_06_10_1000"
+down_revision = "2026_06_09_1000"
+branch_labels = None
+depends_on    = None
+
+
+def upgrade() -> None:
+    # ── 1. user_biometric_consents ────────────────────────────────────────────
+    op.create_table(
+        "user_biometric_consents",
+        sa.Column("id",                 sa.Integer(),     primary_key=True),
+        sa.Column("user_id",            sa.Integer(),     sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("consent_granted_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("consent_version",    sa.String(20),    nullable=False),
+        sa.Column("consent_ip_address", sa.String(45),    nullable=True),
+        sa.Column("consent_user_agent", sa.String(500),   nullable=True),
+        sa.Column("consent_revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("revocation_reason",  sa.String(200),   nullable=True),
+        sa.Column("is_active",          sa.Boolean(),     nullable=False, server_default=sa.text("true")),
+        sa.Column("created_at",         sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.text("NOW()")),
+    )
+    op.create_index("ix_user_biometric_consents_user_id", "user_biometric_consents", ["user_id"])
+    # Enforce one active consent per user at DB level
+    op.create_index(
+        "uq_user_biometric_consents_active_user",
+        "user_biometric_consents",
+        ["user_id"],
+        unique=True,
+        postgresql_where=sa.text("is_active = true"),
+    )
+
+    # ── 2. user_face_embeddings ───────────────────────────────────────────────
+    op.create_table(
+        "user_face_embeddings",
+        sa.Column("id",                   sa.Integer(),  primary_key=True),
+        sa.Column("user_id",              sa.Integer(),  sa.ForeignKey("users.id", ondelete="CASCADE"),
+                  nullable=False, unique=True),
+        sa.Column("embedding_ciphertext", BYTEA(),       nullable=True,
+                  comment="AES-256-GCM ciphertext of 512-dim float32 embedding"),
+        sa.Column("embedding_iv",         BYTEA(),       nullable=True,
+                  comment="12-byte GCM nonce — unique per row"),
+        sa.Column("model_version",        sa.String(100), nullable=True),
+        sa.Column("approved_by",          sa.Integer(),  sa.ForeignKey("users.id"), nullable=True),
+        sa.Column("approved_at",          sa.DateTime(timezone=True), nullable=True),
+        sa.Column("is_active",            sa.Boolean(),  nullable=False, server_default=sa.text("false")),
+        sa.Column("created_at",           sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.text("NOW()")),
+        sa.Column("updated_at",           sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.text("NOW()")),
+    )
+    op.create_index("ix_user_face_embeddings_user_id", "user_face_embeddings", ["user_id"])
+
+    # ── 3. biometric_verification_logs ────────────────────────────────────────
+    op.create_table(
+        "biometric_verification_logs",
+        sa.Column("id",                sa.BigInteger(), primary_key=True),
+        sa.Column("user_id",           sa.Integer(),    sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("event_type",        sa.String(50),   nullable=False),
+        sa.Column("event_result",      sa.String(30),   nullable=True),
+        # face_match_score: internal only — NEVER returned in API responses
+        sa.Column("face_match_score",  sa.Float(),      nullable=True,
+                  comment="Cosine similarity [0,1]. NEVER returned in API responses."),
+        sa.Column("model_version",     sa.String(100),  nullable=True),
+        sa.Column("threshold_used",    sa.Float(),      nullable=True),
+        sa.Column("liveness_metadata", JSONB(),         nullable=True,
+                  comment=(
+                      "High-level liveness metadata only. "
+                      "Allowed: challenge_version, steps_completed, total_duration_ms, "
+                      "retry_count, failure_reason. "
+                      "PROHIBITED: device_model, ios_version, yaw, roll, landmarks, frames."
+                  )),
+        sa.Column("actor_user_id",     sa.Integer(),    sa.ForeignKey("users.id"), nullable=True),
+        sa.Column("actor_ip_address",  sa.String(45),   nullable=True),
+        sa.Column("photo_filename",    sa.String(255),  nullable=True),
+        sa.Column("error_message",     sa.String(500),  nullable=True),
+        sa.Column("created_at",        sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.text("NOW()")),
+    )
+    op.create_index("ix_biometric_logs_user_id",    "biometric_verification_logs", ["user_id"])
+    op.create_index("ix_biometric_logs_event_type", "biometric_verification_logs", ["event_type"])
+    op.create_index("ix_biometric_logs_created_at", "biometric_verification_logs", ["created_at"])
+
+    # ── 4. New columns on users ───────────────────────────────────────────────
+    op.add_column("users", sa.Column(
+        "face_match_status", sa.String(30), nullable=True,
+        comment=(
+            "Biometric state: NULL / reference_pending / verified / failed / "
+            "manual_review_required / consent_revoked / onboarding_liveness_capture"
+        ),
+    ))
+    op.add_column("users", sa.Column(
+        "face_match_score", sa.Float(), nullable=True,
+        comment="Last cosine similarity [0,1]. NEVER returned in API responses.",
+    ))
+    op.add_column("users", sa.Column(
+        "face_reference_photo_status", sa.String(30), nullable=True,
+        comment=(
+            "Reference photo state: NULL / not_set / onboarding_liveness_capture / "
+            "pending_review / approved / rejected"
+        ),
+    ))
+    op.add_column("users", sa.Column(
+        "manual_review_required", sa.Boolean(), nullable=False,
+        server_default=sa.text("false"),
+        comment="True when face match score is in review threshold band",
+    ))
+    op.add_column("users", sa.Column(
+        "reviewed_by", sa.Integer(),
+        sa.ForeignKey("users.id"), nullable=True,
+        comment="Admin user_id who performed manual review",
+    ))
+    op.add_column("users", sa.Column("reviewed_at",      sa.DateTime(timezone=True), nullable=True))
+    op.add_column("users", sa.Column("rejection_reason", sa.String(500),             nullable=True))
+
+
+def downgrade() -> None:
+    # Remove users columns (reverse order of addition)
+    op.drop_column("users", "rejection_reason")
+    op.drop_column("users", "reviewed_at")
+    op.drop_column("users", "reviewed_by")
+    op.drop_column("users", "manual_review_required")
+    op.drop_column("users", "face_reference_photo_status")
+    op.drop_column("users", "face_match_score")
+    op.drop_column("users", "face_match_status")
+
+    # Drop tables (reverse creation order for FK safety)
+    op.drop_index("ix_biometric_logs_created_at", table_name="biometric_verification_logs")
+    op.drop_index("ix_biometric_logs_event_type",  table_name="biometric_verification_logs")
+    op.drop_index("ix_biometric_logs_user_id",     table_name="biometric_verification_logs")
+    op.drop_table("biometric_verification_logs")
+
+    op.drop_index("ix_user_face_embeddings_user_id", table_name="user_face_embeddings")
+    op.drop_table("user_face_embeddings")
+
+    op.drop_index("uq_user_biometric_consents_active_user", table_name="user_biometric_consents")
+    op.drop_index("ix_user_biometric_consents_user_id",     table_name="user_biometric_consents")
+    op.drop_table("user_biometric_consents")

--- a/app/config.py
+++ b/app/config.py
@@ -291,6 +291,20 @@ class Settings(BaseSettings):
     # Production:            https://lfa.hu
     VERIFY_BASE_URL: str = "http://localhost:8000"
 
+    # ── Biometric Face Matching ───────────────────────────────────────────────
+    # BIOMETRIC_FACE_MATCHING_ENABLED controls the entire biometric pipeline.
+    #   false (default) — all biometric endpoints return HTTP 503.
+    #   true            — requires DPIA completion, consent v1.0 legal approval,
+    #                     and written sign-off before setting in production.
+    #
+    # BIOMETRIC_EMBEDDING_KEY — 32-byte AES-256-GCM key for embedding encryption.
+    #   Generate with: python -c "import secrets; print(secrets.token_hex(32))"
+    #   Must be set before BIOMETRIC_FACE_MATCHING_ENABLED=true can be used in
+    #   production. Empty string disables encryption validation in development
+    #   and test environments (no real embeddings stored in those environments).
+    BIOMETRIC_FACE_MATCHING_ENABLED: bool = False
+    BIOMETRIC_EMBEDDING_KEY: str = ""
+
     # ── Slow-query monitoring ──────────────────────────────────────────────────
     # Queries slower than SLOW_QUERY_THRESHOLD_MS are logged to app.slow_query
     # and counted in the slow_queries_total metric.  Raise this value if normal

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -67,6 +67,7 @@ from .vt_challenge import (
     CHALLENGE_COMPATIBLE_GAMES, make_expires_at, get_active_challenge,
 )
 from .user_mood_photos import UserMoodPhoto, MOOD_PHOTO_SLOTS, MoodPhotoStatus
+from .biometric import UserBiometricConsent, UserFaceEmbedding, BiometricVerificationLog
 
 # 🎓 New Track-Based Modular Education System
 from .track import Track, Module, ModuleComponent

--- a/app/models/biometric.py
+++ b/app/models/biometric.py
@@ -1,0 +1,196 @@
+"""
+Biometric face matching models — PR-1 foundation.
+
+Three tables:
+  user_biometric_consents    — GDPR Art. 9 explicit consent records
+  user_face_embeddings       — AES-256-GCM encrypted ArcFace embeddings (PR-4+)
+  biometric_verification_logs — immutable audit trail for every biometric event
+
+Design constraints:
+  - No embedding generation or ONNX dependency in this file (PR-4+).
+  - liveness_metadata JSONB stores only high-level step data; raw sensor
+    values (yaw, roll, landmarks) must never be written here.
+  - face_match_score stored internally for admin use; never returned in API
+    responses (enforced by Pydantic schemas in app/schemas/biometric.py).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import (
+    BigInteger,
+    Boolean,
+    Column,
+    DateTime,
+    Float,
+    ForeignKey,
+    Integer,
+    String,
+)
+from sqlalchemy.dialects.postgresql import BYTEA, JSONB
+from sqlalchemy.orm import relationship
+
+from ..database import Base
+
+
+# ── UserBiometricConsent ──────────────────────────────────────────────────────
+
+class UserBiometricConsent(Base):
+    """
+    GDPR Art. 9 explicit biometric consent record.
+
+    One active row per user (enforced by unique index on user_id WHERE is_active).
+    Revocation sets is_active=False and consent_revoked_at; the row is retained
+    for proof-of-consent obligations (5-year retention per ops runbook).
+    """
+    __tablename__ = "user_biometric_consents"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(
+        Integer,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    # Consent grant
+    consent_granted_at = Column(DateTime(timezone=True), nullable=False,
+                                default=lambda: datetime.now(timezone.utc))
+    consent_version    = Column(String(20), nullable=False,
+                                comment="Consent text version, e.g. 'v1.0'")
+    consent_ip_address = Column(String(45), nullable=True,
+                                comment="IPv4 or IPv6 of the granting request")
+    consent_user_agent = Column(String(500), nullable=True)
+
+    # Revocation
+    consent_revoked_at = Column(DateTime(timezone=True), nullable=True)
+    revocation_reason  = Column(String(200), nullable=True)
+
+    # State
+    is_active  = Column(Boolean, nullable=False, default=True)
+    created_at = Column(DateTime(timezone=True), nullable=False,
+                        default=lambda: datetime.now(timezone.utc))
+
+    user = relationship("User", back_populates="biometric_consents")
+
+
+# ── UserFaceEmbedding ─────────────────────────────────────────────────────────
+
+class UserFaceEmbedding(Base):
+    """
+    AES-256-GCM encrypted ArcFace embedding (512 × float32 = 2048 bytes).
+
+    Populated by Celery task in PR-4. In PR-1 this table exists but stays empty.
+    is_active=False until admin approves the reference photo (or liveness passes).
+
+    Security:
+      embedding_ciphertext — BYTEA, AES-256-GCM ciphertext
+      embedding_iv         — BYTEA, 12-byte GCM nonce (unique per row)
+      The plaintext embedding is NEVER stored or returned via any API.
+    """
+    __tablename__ = "user_face_embeddings"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(
+        Integer,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+
+    # Encrypted embedding (populated by PR-4 Celery task)
+    embedding_ciphertext = Column(BYTEA, nullable=True,
+                                  comment="AES-256-GCM ciphertext of 512-dim float32 vector")
+    embedding_iv         = Column(BYTEA, nullable=True,
+                                  comment="12-byte GCM nonce — unique per row")
+    model_version        = Column(String(100), nullable=True,
+                                  comment="e.g. 'insightface_buffalo_sc_v1'")
+
+    # Reference approval
+    approved_by = Column(Integer, ForeignKey("users.id"), nullable=True,
+                         comment="Admin user_id who approved; NULL for auto-approved liveness")
+    approved_at = Column(DateTime(timezone=True), nullable=True)
+
+    # State
+    is_active  = Column(Boolean, nullable=False, default=False,
+                        comment="False until embedding generated and reference approved")
+    created_at = Column(DateTime(timezone=True), nullable=False,
+                        default=lambda: datetime.now(timezone.utc))
+    updated_at = Column(DateTime(timezone=True), nullable=False,
+                        default=lambda: datetime.now(timezone.utc),
+                        onupdate=lambda: datetime.now(timezone.utc))
+
+    user     = relationship("User", foreign_keys=[user_id], back_populates="face_embedding")
+    approver = relationship("User", foreign_keys=[approved_by])
+
+
+# ── BiometricVerificationLog ──────────────────────────────────────────────────
+
+class BiometricVerificationLog(Base):
+    """
+    Immutable audit trail for every biometric event.
+
+    Rows are INSERT-only — no UPDATE or DELETE via application code.
+    Retention: 5 years (per ops runbook), even after consent revocation.
+
+    liveness_metadata JSONB constraints (enforced by sanitizer before INSERT):
+      Allowed : challenge_version, steps_completed, total_duration_ms,
+                retry_count, failure_reason
+      Forbidden: device_model, ios_version, yaw, roll, pitch, landmarks,
+                 face_landmarks, eye_data, frames, frame_data, pixel_data,
+                 bounding_box, face_rect — and any other sensor/biometric detail
+
+    face_match_score is stored internally for admin / threshold-tuning purposes.
+    It is NEVER returned in any API response (enforced by Pydantic schema).
+    """
+    __tablename__ = "biometric_verification_logs"
+
+    id = Column(BigInteger, primary_key=True, index=True)
+    user_id = Column(
+        Integer,
+        ForeignKey("users.id"),
+        nullable=False,
+        index=True,
+    )
+
+    # Event classification
+    event_type   = Column(String(50), nullable=False, index=True,
+                          comment="See BiometricEventType constants")
+    event_result = Column(String(30), nullable=True,
+                          comment="accepted / rejected / pending / deleted / auto_approved_liveness")
+
+    # Matching metrics — internal only, never exposed via API
+    face_match_score = Column(Float, nullable=True,
+                              comment="Cosine similarity [0,1]. NEVER returned in API responses.")
+    model_version    = Column(String(100), nullable=True)
+    threshold_used   = Column(Float, nullable=True)
+
+    # Liveness metadata — high-level only, sanitized before INSERT
+    liveness_metadata = Column(
+        JSONB,
+        nullable=True,
+        comment=(
+            "High-level liveness challenge metadata. "
+            "Allowed: challenge_version, steps_completed, total_duration_ms, "
+            "retry_count, failure_reason. "
+            "PROHIBITED: device_model, ios_version, yaw, roll, landmarks, frames."
+        ),
+    )
+
+    # Actor (NULL = system action)
+    actor_user_id  = Column(Integer, ForeignKey("users.id"), nullable=True,
+                            comment="Admin user_id for manual actions; NULL for automated events")
+    actor_ip_address = Column(String(45), nullable=True)
+
+    # Reference
+    photo_filename = Column(String(255), nullable=True,
+                            comment="Basename of the photo file; not a full URL")
+    error_message  = Column(String(500), nullable=True)
+
+    created_at = Column(DateTime(timezone=True), nullable=False,
+                        index=True,
+                        default=lambda: datetime.now(timezone.utc))
+
+    user  = relationship("User", foreign_keys=[user_id])
+    actor = relationship("User", foreign_keys=[actor_user_id])

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Boolean, DateTime, ForeignKey, Enum, Index
+from sqlalchemy import Column, Integer, String, Boolean, DateTime, Float, ForeignKey, Enum, Index
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 from datetime import datetime, timezone
@@ -126,6 +126,46 @@ class User(Base):
         default=uuid.uuid4,
         comment="Non-guessable UUID for /verify/{token} QR URL — do not log",
     )
+
+    # 🔬 BIOMETRIC FACE MATCHING: Face verification status (feature flag gated)
+    # All columns nullable; populated only when BIOMETRIC_FACE_MATCHING_ENABLED=true.
+    # face_match_score stored for admin/threshold use — NEVER returned in API responses.
+    face_match_status = Column(
+        String(30),
+        nullable=True,
+        comment=(
+            "Biometric verification state: NULL / reference_pending / verified / "
+            "failed / manual_review_required / consent_revoked / "
+            "onboarding_liveness_capture"
+        ),
+    )
+    face_match_score = Column(
+        Float,
+        nullable=True,
+        comment="Last cosine similarity score [0,1]. NEVER returned in API responses.",
+    )
+    face_reference_photo_status = Column(
+        String(30),
+        nullable=True,
+        comment=(
+            "Reference photo state: NULL / not_set / onboarding_liveness_capture / "
+            "pending_review / approved / rejected"
+        ),
+    )
+    manual_review_required = Column(
+        Boolean,
+        nullable=False,
+        default=False,
+        comment="True when face match score is in review threshold band",
+    )
+    reviewed_by = Column(
+        Integer,
+        ForeignKey("users.id"),
+        nullable=True,
+        comment="Admin user_id who performed manual review",
+    )
+    reviewed_at     = Column(DateTime, nullable=True)
+    rejection_reason = Column(String(500), nullable=True)
 
     # 🪪 PROFILE PHOTO: Academy ID Card photo (Phase 1)
     # Managed via POST/DELETE /api/v1/users/me/profile-photo.
@@ -268,6 +308,21 @@ class User(Base):
         "TournamentBadge",
         back_populates="user",
         cascade="all, delete-orphan"
+    )
+
+    # 🔬 Biometric relationships (feature-flag gated; populated by PR-2+)
+    biometric_consents = relationship(
+        "UserBiometricConsent",
+        back_populates="user",
+        cascade="all, delete-orphan",
+        foreign_keys="UserBiometricConsent.user_id",
+    )
+    face_embedding = relationship(
+        "UserFaceEmbedding",
+        back_populates="user",
+        uselist=False,
+        cascade="all, delete-orphan",
+        foreign_keys="UserFaceEmbedding.user_id",
     )
 
     # 🎓 NEW: Specialization helper properties and methods

--- a/app/schemas/biometric.py
+++ b/app/schemas/biometric.py
@@ -1,0 +1,126 @@
+"""
+Biometric Pydantic schemas — PR-1 foundation.
+
+Design rules enforced structurally (compile/import time):
+  1. face_match_score is ABSENT from every response schema.
+     It is stored in BiometricVerificationLog for admin/threshold use
+     but must never appear in any API response dict.
+  2. embedding_ciphertext / embedding_iv are ABSENT from every schema.
+  3. LivenessMetadata only exposes the five allowed fields.
+     Unknown extra fields are rejected (model_config extra="forbid").
+  4. BiometricVerificationLogOut excludes face_match_score explicitly.
+
+Any PR that introduces a new response schema must ensure face_match_score
+and embedding-related fields remain absent.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# ── Liveness metadata ─────────────────────────────────────────────────────────
+
+_FAILURE_REASON_VALUES = {"timeout", "face_lost", "multiple_faces", "max_retries", "capture_error"}
+
+
+class LivenessMetadata(BaseModel):
+    """
+    High-level liveness challenge metadata.
+
+    extra="forbid" ensures that forbidden fields (yaw, roll, device_model,
+    ios_version, landmarks, frames, etc.) are rejected at API ingestion time.
+    The liveness_metadata_sanitizer provides a third layer of defence for
+    any code path that bypasses schema validation.
+    """
+    model_config = ConfigDict(extra="forbid")
+
+    challenge_version: str = Field(
+        ...,
+        max_length=20,
+        description="Challenge spec version, e.g. 'v1.0'",
+    )
+    steps_completed: List[str] = Field(
+        default_factory=list,
+        max_length=10,
+        description="Ordered list of completed challenge steps",
+    )
+    total_duration_ms: int = Field(
+        ...,
+        ge=0,
+        le=120_000,
+        description="Wall-clock duration from challenge start to completion/failure (ms)",
+    )
+    retry_count: int = Field(
+        ...,
+        ge=0,
+        le=10,
+        description="Number of challenge retries in this session",
+    )
+    failure_reason: Optional[str] = Field(
+        default=None,
+        description="Only set when challenge failed; null on success",
+    )
+
+    # NOTE: face_match_score, yaw, roll, device_model, ios_version,
+    # landmarks, frames — deliberately absent. Adding them here would
+    # violate the data-minimization requirement.
+
+
+# ── Consent schemas ───────────────────────────────────────────────────────────
+
+class BiometricConsentStatusOut(BaseModel):
+    """Read-only view of the user's biometric consent state."""
+    has_consent: bool
+    granted_at:  Optional[datetime] = None
+    version:     Optional[str]      = None
+    revoked_at:  Optional[datetime] = None
+    is_active:   bool               = False
+
+    # face_match_score ABSENT — enforced by schema structure
+
+
+# ── Verification status (GET /me/profile-photo/verification-status) ───────────
+
+class BiometricVerificationStatusOut(BaseModel):
+    """
+    Current biometric verification state returned to the client.
+
+    face_match_score is intentionally absent — clients must not receive
+    the raw similarity score; only the classified status is exposed.
+    """
+    face_match_status:           Optional[str] = None
+    face_reference_photo_status: Optional[str] = None
+    has_biometric_consent:       bool          = False
+    manual_review_required:      bool          = False
+
+    # face_match_score ABSENT — structural enforcement
+
+
+# ── Audit log output (admin) ──────────────────────────────────────────────────
+
+class BiometricVerificationLogOut(BaseModel):
+    """
+    Admin-facing audit log entry.
+
+    face_match_score is excluded even from admin responses —
+    threshold tuning uses the database directly, not the API.
+    """
+    id:               int
+    user_id:          int
+    event_type:       str
+    event_result:     Optional[str]      = None
+    model_version:    Optional[str]      = None
+    threshold_used:   Optional[float]    = None
+    liveness_metadata: Optional[dict]    = None
+    actor_user_id:    Optional[int]      = None
+    actor_ip_address: Optional[str]      = None
+    photo_filename:   Optional[str]      = None
+    error_message:    Optional[str]      = None
+    created_at:       datetime
+
+    # face_match_score ABSENT — structural enforcement
+    # embedding_ciphertext ABSENT — structural enforcement
+
+    model_config = ConfigDict(from_attributes=True, protected_namespaces=())

--- a/app/services/biometric/__init__.py
+++ b/app/services/biometric/__init__.py
@@ -1,0 +1,1 @@
+"""Biometric face matching service package — PR-1 foundation."""

--- a/app/services/biometric/audit_log.py
+++ b/app/services/biometric/audit_log.py
@@ -1,0 +1,153 @@
+"""
+Biometric audit logger.
+
+Single entry point for all biometric event logging. Uses
+BiometricVerificationLog (dedicated table, separate from the generic
+AuditLog) to provide a tamper-evident, insert-only audit trail.
+
+Event type constants are defined here so every caller imports from
+one canonical location — preventing string drift across PRs.
+
+Design rules enforced here:
+  1. face_match_score is accepted as an argument for storage but is
+     NEVER returned to callers and NEVER written to any response dict.
+  2. liveness_metadata is sanitized via liveness_metadata_sanitizer
+     before every INSERT — forbidden fields cannot reach the DB.
+  3. Logging failures are caught and re-raised as logged warnings;
+     a failed audit write must not crash the calling request.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from app.models.biometric import BiometricVerificationLog
+from app.services.biometric.liveness_metadata_sanitizer import sanitize_liveness_metadata
+
+logger = logging.getLogger(__name__)
+
+# ── Event type constants ──────────────────────────────────────────────────────
+
+# Consent lifecycle
+EVT_CONSENT_GRANTED = "consent_granted"
+EVT_CONSENT_REVOKED = "consent_revoked"
+
+# Reference photo lifecycle
+EVT_REFERENCE_SUBMITTED             = "reference_submitted"
+EVT_REFERENCE_APPROVED              = "reference_approved"
+EVT_REFERENCE_REJECTED              = "reference_rejected"
+EVT_REFERENCE_REPLACED              = "reference_replaced"
+EVT_REFERENCE_AUTO_APPROVED_LIVENESS = "reference_auto_approved_liveness"
+
+# Liveness challenge events
+EVT_LIVENESS_STARTED    = "liveness_started"
+EVT_LIVENESS_STEP_PASSED = "liveness_step_passed"
+EVT_LIVENESS_FAILED     = "liveness_failed"
+EVT_LIVENESS_COMPLETED  = "liveness_completed"
+
+# Face matching events
+EVT_MATCH_SUCCESS          = "match_success"
+EVT_MATCH_FAILED           = "match_failed"
+EVT_MATCH_REVIEW_REQUIRED  = "match_review_required"
+
+# Admin / system actions
+EVT_ADMIN_OVERRIDE   = "admin_override"
+EVT_EMBEDDING_DELETED = "embedding_deleted"
+EVT_GDPR_DELETE      = "gdpr_delete_requested"
+
+# Upload validation
+EVT_UPLOAD_NO_FACE        = "upload_rejected_no_face"
+EVT_UPLOAD_MULTIPLE_FACES = "upload_rejected_multiple_faces"
+
+# Complete set — used by test_audit_completeness to ensure coverage
+ALL_EVENT_TYPES: frozenset[str] = frozenset({
+    EVT_CONSENT_GRANTED,
+    EVT_CONSENT_REVOKED,
+    EVT_REFERENCE_SUBMITTED,
+    EVT_REFERENCE_APPROVED,
+    EVT_REFERENCE_REJECTED,
+    EVT_REFERENCE_REPLACED,
+    EVT_REFERENCE_AUTO_APPROVED_LIVENESS,
+    EVT_LIVENESS_STARTED,
+    EVT_LIVENESS_STEP_PASSED,
+    EVT_LIVENESS_FAILED,
+    EVT_LIVENESS_COMPLETED,
+    EVT_MATCH_SUCCESS,
+    EVT_MATCH_FAILED,
+    EVT_MATCH_REVIEW_REQUIRED,
+    EVT_ADMIN_OVERRIDE,
+    EVT_EMBEDDING_DELETED,
+    EVT_GDPR_DELETE,
+    EVT_UPLOAD_NO_FACE,
+    EVT_UPLOAD_MULTIPLE_FACES,
+})
+
+# ── BiometricAuditLogger ──────────────────────────────────────────────────────
+
+
+class BiometricAuditLogger:
+    """
+    Writes a row to biometric_verification_logs.
+
+    face_match_score is accepted and stored for internal admin use but
+    is deliberately excluded from every return value and response schema.
+    """
+
+    def __init__(self, db: Session) -> None:
+        self._db = db
+
+    def log(
+        self,
+        *,
+        user_id: int,
+        event_type: str,
+        event_result: str | None = None,
+        face_match_score: float | None = None,   # stored, NEVER returned
+        model_version: str | None = None,
+        threshold_used: float | None = None,
+        liveness_metadata: dict[str, Any] | None = None,
+        actor_user_id: int | None = None,
+        actor_ip_address: str | None = None,
+        photo_filename: str | None = None,
+        error_message: str | None = None,
+    ) -> BiometricVerificationLog:
+        """
+        Insert a biometric audit log row.
+
+        liveness_metadata is sanitized before INSERT — forbidden fields
+        (device_model, ios_version, yaw, roll, landmarks, frames, etc.)
+        are stripped silently and a WARNING is emitted for each one.
+
+        Raises RuntimeError if the INSERT fails, so callers can decide
+        whether to abort the parent transaction or continue.
+        """
+        safe_metadata = sanitize_liveness_metadata(liveness_metadata)
+
+        entry = BiometricVerificationLog(
+            user_id=user_id,
+            event_type=event_type,
+            event_result=event_result,
+            face_match_score=face_match_score,  # internal only
+            model_version=model_version,
+            threshold_used=threshold_used,
+            liveness_metadata=safe_metadata,
+            actor_user_id=actor_user_id,
+            actor_ip_address=actor_ip_address,
+            photo_filename=photo_filename,
+            error_message=error_message,
+            created_at=datetime.now(timezone.utc),
+        )
+        try:
+            self._db.add(entry)
+            self._db.flush()
+        except Exception as exc:
+            logger.warning(
+                "biometric_audit_log_write_failed user_id=%s event_type=%s error=%s",
+                user_id, event_type, exc,
+            )
+            raise RuntimeError(f"Audit log write failed: {exc}") from exc
+
+        return entry

--- a/app/services/biometric/feature_flag.py
+++ b/app/services/biometric/feature_flag.py
@@ -1,0 +1,41 @@
+"""
+Biometric feature flag guard.
+
+All biometric endpoints must depend on require_biometric_enabled().
+When BIOMETRIC_FACE_MATCHING_ENABLED=false (default), every biometric
+endpoint returns HTTP 503 — no data is accessed or written.
+"""
+from __future__ import annotations
+
+from fastapi import HTTPException
+
+from app.config import settings
+
+
+def is_biometric_enabled() -> bool:
+    """Return True when the biometric feature flag is on."""
+    return settings.BIOMETRIC_FACE_MATCHING_ENABLED
+
+
+async def require_biometric_enabled() -> None:
+    """
+    FastAPI dependency — raises 503 when biometric feature is disabled.
+
+    Usage::
+
+        @router.post("/me/biometric-consent")
+        async def grant_consent(
+            _: None = Depends(require_biometric_enabled),
+            ...
+        ):
+            ...
+    """
+    if not is_biometric_enabled():
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "Biometric face matching is not enabled on this server. "
+                "Set BIOMETRIC_FACE_MATCHING_ENABLED=true after completing "
+                "DPIA and obtaining legal approval."
+            ),
+        )

--- a/app/services/biometric/liveness_metadata_sanitizer.py
+++ b/app/services/biometric/liveness_metadata_sanitizer.py
@@ -1,0 +1,162 @@
+"""
+Liveness metadata sanitizer — PR-1 foundation.
+
+Enforces the data-minimization requirement from the audit plan:
+  Allowed  : challenge_version, steps_completed, total_duration_ms,
+              retry_count, failure_reason
+  Forbidden: device_model, ios_version, yaw, roll, pitch, landmarks,
+             face_landmarks, eye_data, frames, frame_data, pixel_data,
+             bounding_box, face_rect — and any other raw sensor/biometric value
+
+Called by BiometricAuditLogger before every DB INSERT so that tainted
+input from an API caller can never reach the biometric_verification_logs
+table regardless of schema-level validation.
+
+Three layers of protection against forbidden fields reaching the DB:
+  Layer 1 — iOS struct (LivenessMetadata) cannot encode forbidden fields
+             (structural, compile-time enforcement in Swift).
+  Layer 2 — Pydantic LivenessMetadata schema rejects unknown fields
+             (validated in PR-3 endpoint).
+  Layer 3 — THIS sanitizer (runtime, unconditional, before every INSERT).
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# ── Policy sets ──────────────────────────────────────────────────────────────
+
+_ALLOWED_FIELDS: frozenset[str] = frozenset({
+    "challenge_version",
+    "steps_completed",
+    "total_duration_ms",
+    "retry_count",
+    "failure_reason",
+})
+
+# Known forbidden keys — presence triggers a WARNING for audit/debugging.
+# Unknown keys not in this set are also stripped (allow-list approach).
+_KNOWN_FORBIDDEN_FIELDS: frozenset[str] = frozenset({
+    "device_model",
+    "ios_version",
+    "os_version",
+    "app_version",
+    "yaw",
+    "roll",
+    "pitch",
+    "landmarks",
+    "face_landmarks",
+    "eye_data",
+    "left_eye",
+    "right_eye",
+    "frames",
+    "frame_data",
+    "pixel_data",
+    "bounding_box",
+    "face_rect",
+    "face_confidence",
+    "raw_score",
+    "embedding",
+    "face_match_score",
+})
+
+# ── Type constraints ──────────────────────────────────────────────────────────
+
+_FAILURE_REASON_WHITELIST: frozenset[str] = frozenset({
+    "timeout",
+    "face_lost",
+    "multiple_faces",
+    "max_retries",
+    "capture_error",
+})
+
+_MAX_CHALLENGE_VERSION_LEN = 20
+_MAX_STEPS_ITEMS           = 10
+_MAX_STEP_NAME_LEN         = 50
+_MAX_TOTAL_DURATION_MS     = 120_000   # 2 minutes
+_MAX_RETRY_COUNT           = 10
+
+
+# ── Public API ────────────────────────────────────────────────────────────────
+
+def sanitize_liveness_metadata(
+    raw: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """
+    Return a sanitized copy containing only allowed fields with valid types.
+
+    - Forbidden fields are silently dropped (WARNING logged for known ones).
+    - Unknown fields not in _ALLOWED_FIELDS are silently dropped.
+    - Type or range failures cause the individual field to be dropped.
+    - Returns None when input is None or the sanitized dict is empty.
+
+    This function NEVER raises — callers should not catch exceptions from it.
+    """
+    if not raw:
+        return None
+
+    if not isinstance(raw, dict):
+        logger.warning("sanitize_liveness_metadata: expected dict, got %s — discarding", type(raw).__name__)
+        return None
+
+    # Warn on known forbidden keys present in input
+    for key in _KNOWN_FORBIDDEN_FIELDS:
+        if key in raw:
+            logger.warning(
+                "sanitize_liveness_metadata: forbidden field %r present in input — discarding",
+                key,
+            )
+
+    result: dict[str, Any] = {}
+
+    # challenge_version
+    if "challenge_version" in raw:
+        val = raw["challenge_version"]
+        if isinstance(val, str) and len(val) <= _MAX_CHALLENGE_VERSION_LEN:
+            result["challenge_version"] = val
+        else:
+            logger.warning("sanitize_liveness_metadata: challenge_version invalid — dropped")
+
+    # steps_completed
+    if "steps_completed" in raw:
+        val = raw["steps_completed"]
+        if (
+            isinstance(val, list)
+            and len(val) <= _MAX_STEPS_ITEMS
+            and all(isinstance(s, str) and len(s) <= _MAX_STEP_NAME_LEN for s in val)
+        ):
+            result["steps_completed"] = val
+        else:
+            logger.warning("sanitize_liveness_metadata: steps_completed invalid — dropped")
+
+    # total_duration_ms
+    if "total_duration_ms" in raw:
+        val = raw["total_duration_ms"]
+        if isinstance(val, int) and 0 <= val <= _MAX_TOTAL_DURATION_MS:
+            result["total_duration_ms"] = val
+        else:
+            logger.warning("sanitize_liveness_metadata: total_duration_ms invalid — dropped")
+
+    # retry_count
+    if "retry_count" in raw:
+        val = raw["retry_count"]
+        if isinstance(val, int) and 0 <= val <= _MAX_RETRY_COUNT:
+            result["retry_count"] = val
+        else:
+            logger.warning("sanitize_liveness_metadata: retry_count invalid — dropped")
+
+    # failure_reason
+    if "failure_reason" in raw:
+        val = raw["failure_reason"]
+        if isinstance(val, str) and val in _FAILURE_REASON_WHITELIST:
+            result["failure_reason"] = val
+        elif val is None:
+            pass   # None is valid (no failure)
+        else:
+            logger.warning(
+                "sanitize_liveness_metadata: failure_reason %r not in whitelist — dropped", val
+            )
+
+    return result if result else None

--- a/tests/biometric/__init__.py
+++ b/tests/biometric/__init__.py
@@ -1,0 +1,1 @@
+"""Biometric face matching test suite — PR-1 foundation."""

--- a/tests/biometric/conftest.py
+++ b/tests/biometric/conftest.py
@@ -1,0 +1,80 @@
+"""
+Biometric test fixtures.
+
+Uses the same transactional SAVEPOINT pattern as tests/unit/conftest.py
+for full test isolation without database pollution between tests.
+"""
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import event
+from sqlalchemy.orm import sessionmaker
+
+from app.database import engine
+from app.models.user import User, UserRole
+from app.services.biometric.audit_log import BiometricAuditLogger
+
+
+@pytest.fixture(scope="function")
+def db():
+    """
+    Transactional PostgreSQL session with SAVEPOINT-based rollback.
+    Every test gets a clean slate; commits only affect the SAVEPOINT.
+    """
+    connection  = engine.connect()
+    transaction = connection.begin()
+    Session     = sessionmaker(autocommit=False, autoflush=False, bind=connection)
+    session     = Session()
+    nested      = connection.begin_nested()
+
+    @event.listens_for(session, "after_transaction_end")
+    def restart_savepoint(session, txn):
+        if txn.nested and not txn._parent.nested:
+            session.begin_nested()
+
+    try:
+        yield session
+    finally:
+        session.close()
+        transaction.rollback()
+        connection.close()
+
+
+@pytest.fixture()
+def admin_user(db):
+    user = User(
+        name="Test Admin",
+        email="admin_biometric@test.com",
+        password_hash="hashed",
+        role=UserRole.ADMIN,
+    )
+    db.add(user)
+    db.flush()
+    return user
+
+
+@pytest.fixture()
+def student_user(db):
+    user = User(
+        name="Test Student",
+        email="student_biometric@test.com",
+        password_hash="hashed",
+        role=UserRole.STUDENT,
+    )
+    db.add(user)
+    db.flush()
+    return user
+
+
+@pytest.fixture()
+def audit_logger(db):
+    return BiometricAuditLogger(db)
+
+
+@pytest.fixture()
+def biometric_feature_enabled(monkeypatch):
+    """Override the feature flag to True for tests that need it active."""
+    monkeypatch.setattr("app.config.settings.BIOMETRIC_FACE_MATCHING_ENABLED", True)
+    monkeypatch.setattr(
+        "app.services.biometric.feature_flag.settings.BIOMETRIC_FACE_MATCHING_ENABLED", True
+    )

--- a/tests/biometric/test_audit_log.py
+++ b/tests/biometric/test_audit_log.py
@@ -1,0 +1,198 @@
+"""
+Audit log tests.
+
+BMA-01  log() inserts a BiometricVerificationLog row
+BMA-02  event_type stored correctly
+BMA-03  liveness_metadata stored after sanitization (forbidden field stripped)
+BMA-04  face_match_score stored in DB row but absent from log() return value dict
+BMA-05  face_match_score stored in DB — column present on model instance
+BMA-06  face_match_score NOT returned by BiometricVerificationLogOut schema
+BMA-07  ALL_EVENT_TYPES set is non-empty and contains liveness events
+BMA-08  log() raises RuntimeError when DB is closed (write failure)
+BMA-09  actor_user_id stored when provided
+BMA-10  liveness_metadata=None → liveness_metadata column is NULL in DB
+BMA-11  Forbidden field in liveness_metadata never reaches DB column
+BMA-12  embedding_ciphertext / embedding_iv absent from BiometricVerificationLogOut
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.models.biometric import BiometricVerificationLog
+from app.schemas.biometric import BiometricVerificationLogOut
+from app.services.biometric.audit_log import (
+    ALL_EVENT_TYPES,
+    EVT_CONSENT_GRANTED,
+    EVT_LIVENESS_COMPLETED,
+    EVT_LIVENESS_FAILED,
+    EVT_LIVENESS_STARTED,
+    EVT_LIVENESS_STEP_PASSED,
+    EVT_REFERENCE_AUTO_APPROVED_LIVENESS,
+    BiometricAuditLogger,
+)
+
+
+# ── BMA-01 / BMA-02 ──────────────────────────────────────────────────────────
+
+def test_bma01_log_inserts_row(db, student_user):
+    logger = BiometricAuditLogger(db)
+    logger.log(user_id=student_user.id, event_type=EVT_CONSENT_GRANTED)
+    rows = db.query(BiometricVerificationLog).filter_by(user_id=student_user.id).all()
+    assert len(rows) == 1
+
+
+def test_bma02_event_type_stored(db, student_user):
+    logger = BiometricAuditLogger(db)
+    logger.log(user_id=student_user.id, event_type=EVT_LIVENESS_COMPLETED)
+    row = db.query(BiometricVerificationLog).filter_by(user_id=student_user.id).first()
+    assert row.event_type == EVT_LIVENESS_COMPLETED
+
+
+# ── BMA-03  liveness_metadata sanitized before storage ───────────────────────
+
+def test_bma03_liveness_metadata_sanitized(db, student_user):
+    raw_metadata = {
+        "challenge_version": "v1.0",
+        "steps_completed": ["centered", "head_left"],
+        "total_duration_ms": 8000,
+        "retry_count": 0,
+        "device_model": "iPhone 15",   # FORBIDDEN — must be stripped
+        "yaw": 0.35,                   # FORBIDDEN — must be stripped
+    }
+    logger = BiometricAuditLogger(db)
+    logger.log(
+        user_id=student_user.id,
+        event_type=EVT_LIVENESS_COMPLETED,
+        liveness_metadata=raw_metadata,
+    )
+    row = db.query(BiometricVerificationLog).filter_by(user_id=student_user.id).first()
+    stored = row.liveness_metadata
+    assert stored is not None
+    assert "device_model" not in stored
+    assert "yaw" not in stored
+    assert stored["challenge_version"] == "v1.0"
+    assert stored["steps_completed"] == ["centered", "head_left"]
+
+
+# ── BMA-04 / BMA-05  face_match_score stored but not in return ───────────────
+
+def test_bma04_face_match_score_stored_in_db(db, student_user):
+    logger = BiometricAuditLogger(db)
+    entry  = logger.log(
+        user_id=student_user.id,
+        event_type=EVT_LIVENESS_COMPLETED,
+        face_match_score=0.73,
+    )
+    # The model instance has the value
+    assert entry.face_match_score == pytest.approx(0.73)
+    # Reload from DB to confirm persistence
+    row = db.get(BiometricVerificationLog, entry.id)
+    assert row.face_match_score == pytest.approx(0.73)
+
+
+def test_bma05_log_return_is_model_instance_not_dict(db, student_user):
+    logger = BiometricAuditLogger(db)
+    entry  = logger.log(user_id=student_user.id, event_type=EVT_CONSENT_GRANTED)
+    assert isinstance(entry, BiometricVerificationLog)
+
+
+# ── BMA-06  Pydantic schema excludes face_match_score ────────────────────────
+
+def test_bma06_schema_excludes_face_match_score(db, student_user):
+    logger = BiometricAuditLogger(db)
+    entry  = logger.log(
+        user_id=student_user.id,
+        event_type=EVT_LIVENESS_COMPLETED,
+        face_match_score=0.80,
+    )
+    db.refresh(entry)
+    out = BiometricVerificationLogOut.model_validate(entry)
+    out_dict = out.model_dump()
+    assert "face_match_score" not in out_dict
+    # Double-check the value is not smuggled under an alias
+    for v in out_dict.values():
+        assert v != pytest.approx(0.80), "face_match_score value leaked into schema output"
+
+
+# ── BMA-07  ALL_EVENT_TYPES ───────────────────────────────────────────────────
+
+def test_bma07_all_event_types_non_empty():
+    assert len(ALL_EVENT_TYPES) > 0
+
+
+def test_bma07_liveness_events_in_all_event_types():
+    for evt in (
+        EVT_LIVENESS_STARTED,
+        EVT_LIVENESS_STEP_PASSED,
+        EVT_LIVENESS_FAILED,
+        EVT_LIVENESS_COMPLETED,
+        EVT_REFERENCE_AUTO_APPROVED_LIVENESS,
+    ):
+        assert evt in ALL_EVENT_TYPES, f"{evt!r} missing from ALL_EVENT_TYPES"
+
+
+# ── BMA-08  RuntimeError on write failure ────────────────────────────────────
+
+def test_bma08_raises_runtime_error_on_db_failure(db, student_user):
+    logger = BiometricAuditLogger(db)
+    # Close the underlying connection to force a write failure
+    db.close()
+    with pytest.raises(RuntimeError):
+        logger.log(user_id=student_user.id, event_type=EVT_CONSENT_GRANTED)
+
+
+# ── BMA-09  actor_user_id ─────────────────────────────────────────────────────
+
+def test_bma09_actor_user_id_stored(db, student_user, admin_user):
+    logger = BiometricAuditLogger(db)
+    entry  = logger.log(
+        user_id=student_user.id,
+        event_type=EVT_LIVENESS_COMPLETED,
+        actor_user_id=admin_user.id,
+    )
+    assert entry.actor_user_id == admin_user.id
+
+
+# ── BMA-10  liveness_metadata None → NULL ────────────────────────────────────
+
+def test_bma10_none_metadata_stored_as_null(db, student_user):
+    logger = BiometricAuditLogger(db)
+    entry  = logger.log(
+        user_id=student_user.id,
+        event_type=EVT_CONSENT_GRANTED,
+        liveness_metadata=None,
+    )
+    assert entry.liveness_metadata is None
+
+
+# ── BMA-11  Forbidden field in liveness_metadata never in DB ─────────────────
+
+def test_bma11_forbidden_field_never_reaches_db(db, student_user):
+    logger = BiometricAuditLogger(db)
+    logger.log(
+        user_id=student_user.id,
+        event_type=EVT_LIVENESS_COMPLETED,
+        liveness_metadata={
+            "challenge_version": "v1.0",
+            "steps_completed": [],
+            "total_duration_ms": 1000,
+            "retry_count": 0,
+            "embedding": [0.1] * 512,       # forbidden
+            "face_match_score": 0.95,        # forbidden
+            "ios_version": "18.2",           # forbidden
+        },
+    )
+    row = db.query(BiometricVerificationLog).filter_by(user_id=student_user.id).first()
+    stored = row.liveness_metadata or {}
+    assert "embedding" not in stored
+    assert "face_match_score" not in stored
+    assert "ios_version" not in stored
+
+
+# ── BMA-12  Pydantic schema excludes embedding fields ────────────────────────
+
+def test_bma12_schema_excludes_embedding_fields():
+    schema_fields = set(BiometricVerificationLogOut.model_fields.keys())
+    assert "embedding_ciphertext" not in schema_fields
+    assert "embedding_iv" not in schema_fields
+    assert "face_match_score" not in schema_fields

--- a/tests/biometric/test_feature_flag.py
+++ b/tests/biometric/test_feature_flag.py
@@ -1,0 +1,60 @@
+"""
+Feature flag tests.
+
+BMF-01  is_biometric_enabled() returns False by default
+BMF-02  is_biometric_enabled() returns True when monkeypatched
+BMF-03  require_biometric_enabled() raises HTTPException 503 when flag off
+BMF-04  require_biometric_enabled() does NOT raise when flag on
+BMF-05  503 detail message references BIOMETRIC_FACE_MATCHING_ENABLED
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from fastapi import HTTPException
+
+from app.services.biometric.feature_flag import (
+    is_biometric_enabled,
+    require_biometric_enabled,
+)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ── BMF-01 / BMF-02 ──────────────────────────────────────────────────────────
+
+def test_bmf01_flag_off_by_default():
+    assert is_biometric_enabled() is False
+
+
+def test_bmf02_flag_on_when_patched(monkeypatch):
+    monkeypatch.setattr(
+        "app.services.biometric.feature_flag.settings.BIOMETRIC_FACE_MATCHING_ENABLED",
+        True,
+    )
+    assert is_biometric_enabled() is True
+
+
+# ── BMF-03 / BMF-04 / BMF-05 ─────────────────────────────────────────────────
+
+def test_bmf03_require_raises_503_when_flag_off():
+    with pytest.raises(HTTPException) as exc_info:
+        _run(require_biometric_enabled())
+    assert exc_info.value.status_code == 503
+
+
+def test_bmf04_require_does_not_raise_when_flag_on(monkeypatch):
+    monkeypatch.setattr(
+        "app.services.biometric.feature_flag.settings.BIOMETRIC_FACE_MATCHING_ENABLED",
+        True,
+    )
+    _run(require_biometric_enabled())   # must not raise
+
+
+def test_bmf05_503_detail_mentions_flag():
+    with pytest.raises(HTTPException) as exc_info:
+        _run(require_biometric_enabled())
+    assert "BIOMETRIC_FACE_MATCHING_ENABLED" in exc_info.value.detail

--- a/tests/biometric/test_liveness_metadata_sanitizer.py
+++ b/tests/biometric/test_liveness_metadata_sanitizer.py
@@ -1,0 +1,227 @@
+"""
+Sanitizer tests — liveness_metadata_sanitizer.py
+
+BMS-01  None input returns None
+BMS-02  Empty dict returns None
+BMS-03  All allowed fields preserved intact
+BMS-04  Known forbidden field device_model is dropped
+BMS-05  Known forbidden field ios_version is dropped
+BMS-06  Known forbidden field yaw is dropped
+BMS-07  Known forbidden field roll is dropped
+BMS-08  Known forbidden field landmarks is dropped
+BMS-09  Known forbidden field frames is dropped
+BMS-10  Known forbidden field face_match_score is dropped
+BMS-11  Known forbidden field embedding is dropped
+BMS-12  Unknown non-forbidden field also dropped (allow-list policy)
+BMS-13  forbidden field triggers WARNING log
+BMS-14  Mix: allowed + forbidden — allowed kept, forbidden dropped
+BMS-15  challenge_version too long — dropped
+BMS-16  steps_completed exceeds max items — dropped
+BMS-17  steps_completed contains too-long item — dropped
+BMS-18  total_duration_ms exceeds ceiling — dropped
+BMS-19  total_duration_ms negative — dropped
+BMS-20  total_duration_ms is float, not int — dropped
+BMS-21  retry_count exceeds max — dropped
+BMS-22  failure_reason not in whitelist — dropped
+BMS-23  failure_reason None is preserved as absent (not stored)
+BMS-24  All failure_reason whitelist values accepted
+BMS-25  non-dict input returns None (no exception)
+BMS-26  Result contains no face_match_score key under any input
+BMS-27  Result contains no embedding key under any input
+BMS-28  Result contains no yaw key under any input
+"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from app.services.biometric.liveness_metadata_sanitizer import (
+    _FAILURE_REASON_WHITELIST,
+    sanitize_liveness_metadata,
+)
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+_VALID = {
+    "challenge_version": "v1.0",
+    "steps_completed": ["centered", "head_left", "head_right"],
+    "total_duration_ms": 12400,
+    "retry_count": 1,
+    "failure_reason": None,
+}
+
+
+def _clean():
+    """Return a copy of _VALID without None values (mirrors real iOS payload)."""
+    return {k: v for k, v in _VALID.items() if v is not None}
+
+
+# ── BMS-01 / BMS-02 ──────────────────────────────────────────────────────────
+
+def test_bms01_none_returns_none():
+    assert sanitize_liveness_metadata(None) is None
+
+
+def test_bms02_empty_dict_returns_none():
+    assert sanitize_liveness_metadata({}) is None
+
+
+# ── BMS-03  All allowed fields ────────────────────────────────────────────────
+
+def test_bms03_all_allowed_fields_preserved():
+    payload = {
+        "challenge_version": "v1.0",
+        "steps_completed": ["centered", "head_left"],
+        "total_duration_ms": 5000,
+        "retry_count": 0,
+        "failure_reason": "timeout",
+    }
+    result = sanitize_liveness_metadata(payload)
+    assert result == payload
+
+
+# ── BMS-04 … BMS-12  Forbidden / unknown fields dropped ──────────────────────
+
+@pytest.mark.parametrize("forbidden_key,value", [
+    ("device_model",     "iPhone 15 Pro"),
+    ("ios_version",      "18.2"),
+    ("yaw",              0.35),
+    ("roll",             -0.12),
+    ("landmarks",        [[0.1, 0.2], [0.3, 0.4]]),
+    ("frames",           [{"ts": 1000}]),
+    ("face_match_score", 0.72),
+    ("embedding",        [0.1] * 512),
+    ("bounding_box",     {"x": 0.1, "y": 0.2, "w": 0.5, "h": 0.6}),
+])
+def test_forbidden_field_dropped(forbidden_key, value):
+    payload = {**_clean(), forbidden_key: value}
+    result  = sanitize_liveness_metadata(payload)
+    assert result is not None
+    assert forbidden_key not in result
+
+
+def test_bms12_unknown_non_forbidden_field_dropped():
+    payload = {**_clean(), "future_field": "some_value"}
+    result  = sanitize_liveness_metadata(payload)
+    assert "future_field" not in result
+
+
+# ── BMS-13  WARNING log on known forbidden field ──────────────────────────────
+
+def test_bms13_forbidden_field_triggers_warning(caplog):
+    payload = {**_clean(), "device_model": "iPhone 15 Pro"}
+    with caplog.at_level(logging.WARNING, logger="app.services.biometric.liveness_metadata_sanitizer"):
+        sanitize_liveness_metadata(payload)
+    assert any("device_model" in rec.message for rec in caplog.records)
+
+
+# ── BMS-14  Mix ───────────────────────────────────────────────────────────────
+
+def test_bms14_mix_allowed_and_forbidden():
+    payload = {
+        "challenge_version": "v1.0",
+        "steps_completed": ["centered"],
+        "total_duration_ms": 3000,
+        "retry_count": 0,
+        "device_model": "iPhone 15",
+        "yaw": 0.35,
+        "ios_version": "18.2",
+    }
+    result = sanitize_liveness_metadata(payload)
+    assert result["challenge_version"] == "v1.0"
+    assert result["steps_completed"] == ["centered"]
+    assert "device_model" not in result
+    assert "yaw" not in result
+    assert "ios_version" not in result
+
+
+# ── BMS-15 … BMS-24  Type / range validation ─────────────────────────────────
+
+def test_bms15_challenge_version_too_long():
+    payload = {**_clean(), "challenge_version": "v" + "1" * 25}
+    result  = sanitize_liveness_metadata(payload)
+    assert "challenge_version" not in result
+
+
+def test_bms16_steps_completed_exceeds_max():
+    payload = {**_clean(), "steps_completed": [f"step_{i}" for i in range(11)]}
+    result  = sanitize_liveness_metadata(payload)
+    assert "steps_completed" not in result
+
+
+def test_bms17_steps_completed_item_too_long():
+    payload = {**_clean(), "steps_completed": ["x" * 51]}
+    result  = sanitize_liveness_metadata(payload)
+    assert "steps_completed" not in result
+
+
+def test_bms18_total_duration_ms_exceeds_ceiling():
+    payload = {**_clean(), "total_duration_ms": 200_000}
+    result  = sanitize_liveness_metadata(payload)
+    assert "total_duration_ms" not in result
+
+
+def test_bms19_total_duration_ms_negative():
+    payload = {**_clean(), "total_duration_ms": -1}
+    result  = sanitize_liveness_metadata(payload)
+    assert "total_duration_ms" not in result
+
+
+def test_bms20_total_duration_ms_float_not_accepted():
+    payload = {**_clean(), "total_duration_ms": 5000.5}
+    result  = sanitize_liveness_metadata(payload)
+    assert "total_duration_ms" not in result
+
+
+def test_bms21_retry_count_exceeds_max():
+    payload = {**_clean(), "retry_count": 11}
+    result  = sanitize_liveness_metadata(payload)
+    assert "retry_count" not in result
+
+
+def test_bms22_failure_reason_not_in_whitelist():
+    payload = {**_clean(), "failure_reason": "sql_injection_payload'; DROP TABLE users;--"}
+    result  = sanitize_liveness_metadata(payload)
+    assert "failure_reason" not in result
+
+
+def test_bms23_failure_reason_none_not_stored():
+    payload = {"challenge_version": "v1.0", "steps_completed": [], "total_duration_ms": 1000,
+               "retry_count": 0, "failure_reason": None}
+    result  = sanitize_liveness_metadata(payload)
+    assert "failure_reason" not in result
+
+
+@pytest.mark.parametrize("reason", list(_FAILURE_REASON_WHITELIST))
+def test_bms24_failure_reason_whitelist_accepted(reason):
+    payload = {**_clean(), "failure_reason": reason}
+    result  = sanitize_liveness_metadata(payload)
+    assert result["failure_reason"] == reason
+
+
+# ── BMS-25  Non-dict input ────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("bad_input", ["string", 42, [1, 2, 3], True])
+def test_bms25_non_dict_returns_none(bad_input):
+    assert sanitize_liveness_metadata(bad_input) is None  # type: ignore[arg-type]
+
+
+# ── BMS-26 / BMS-27 / BMS-28  Forbidden keys structurally absent ─────────────
+
+def test_bms26_face_match_score_never_in_result():
+    payload = {**_clean(), "face_match_score": 0.95}
+    result  = sanitize_liveness_metadata(payload)
+    assert result is None or "face_match_score" not in result
+
+
+def test_bms27_embedding_never_in_result():
+    payload = {**_clean(), "embedding": [0.1] * 512}
+    result  = sanitize_liveness_metadata(payload)
+    assert result is None or "embedding" not in result
+
+
+def test_bms28_yaw_never_in_result():
+    payload = {**_clean(), "yaw": 0.35}
+    result  = sanitize_liveness_metadata(payload)
+    assert result is None or "yaw" not in result

--- a/tests/biometric/test_migration.py
+++ b/tests/biometric/test_migration.py
@@ -1,0 +1,136 @@
+"""
+Migration verification tests.
+
+BMG-01  Table user_biometric_consents exists with required columns
+BMG-02  Table user_face_embeddings exists with required columns
+BMG-03  Table biometric_verification_logs exists with required columns
+BMG-04  users table has face_match_status column
+BMG-05  users table has face_match_score column
+BMG-06  users table has face_reference_photo_status column
+BMG-07  users table has manual_review_required column (NOT NULL, default false)
+BMG-08  biometric_verification_logs.face_match_score column exists (internal)
+BMG-09  biometric_verification_logs.liveness_metadata is JSONB type
+BMG-10  Index ix_user_biometric_consents_user_id exists
+BMG-11  Index ix_user_face_embeddings_user_id exists
+BMG-12  Indexes ix_biometric_logs_user_id, _event_type, _created_at exist
+"""
+from __future__ import annotations
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+from app.database import engine
+
+
+@pytest.fixture(scope="module")
+def inspector():
+    return inspect(engine)
+
+
+# ── Table existence ───────────────────────────────────────────────────────────
+
+def test_bmg_tables_exist(inspector):
+    tables = inspector.get_table_names()
+    for table in (
+        "user_biometric_consents",
+        "user_face_embeddings",
+        "biometric_verification_logs",
+    ):
+        assert table in tables, f"Table {table!r} not found"
+
+
+# ── Column existence helpers ──────────────────────────────────────────────────
+
+def _col_names(inspector, table: str) -> set[str]:
+    return {c["name"] for c in inspector.get_columns(table)}
+
+
+def test_bmg01_user_biometric_consents_columns(inspector):
+    cols = _col_names(inspector, "user_biometric_consents")
+    for expected in (
+        "id", "user_id", "consent_granted_at", "consent_version",
+        "consent_ip_address", "consent_user_agent",
+        "consent_revoked_at", "revocation_reason",
+        "is_active", "created_at",
+    ):
+        assert expected in cols, f"Column {expected!r} missing from user_biometric_consents"
+
+
+def test_bmg02_user_face_embeddings_columns(inspector):
+    cols = _col_names(inspector, "user_face_embeddings")
+    for expected in (
+        "id", "user_id", "embedding_ciphertext", "embedding_iv",
+        "model_version", "approved_by", "approved_at",
+        "is_active", "created_at", "updated_at",
+    ):
+        assert expected in cols, f"Column {expected!r} missing from user_face_embeddings"
+
+
+def test_bmg03_biometric_verification_logs_columns(inspector):
+    cols = _col_names(inspector, "biometric_verification_logs")
+    for expected in (
+        "id", "user_id", "event_type", "event_result",
+        "face_match_score",        # internal — stored, never returned via API
+        "model_version", "threshold_used", "liveness_metadata",
+        "actor_user_id", "actor_ip_address",
+        "photo_filename", "error_message", "created_at",
+    ):
+        assert expected in cols, f"Column {expected!r} missing from biometric_verification_logs"
+
+
+def test_bmg04_users_face_match_status(inspector):
+    assert "face_match_status" in _col_names(inspector, "users")
+
+
+def test_bmg05_users_face_match_score(inspector):
+    assert "face_match_score" in _col_names(inspector, "users")
+
+
+def test_bmg06_users_face_reference_photo_status(inspector):
+    assert "face_reference_photo_status" in _col_names(inspector, "users")
+
+
+def test_bmg07_users_manual_review_required(inspector):
+    cols_info = {c["name"]: c for c in inspector.get_columns("users")}
+    col = cols_info.get("manual_review_required")
+    assert col is not None, "manual_review_required column missing"
+    assert not col["nullable"], "manual_review_required should be NOT NULL"
+
+
+def test_bmg08_biometric_logs_face_match_score_internal(inspector):
+    cols_info = {c["name"]: c for c in inspector.get_columns("biometric_verification_logs")}
+    assert "face_match_score" in cols_info
+
+
+def test_bmg09_liveness_metadata_is_jsonb(inspector):
+    cols_info = {c["name"]: c for c in inspector.get_columns("biometric_verification_logs")}
+    col = cols_info.get("liveness_metadata")
+    assert col is not None
+    # SQLAlchemy inspector returns dialect-specific type; check type name string
+    type_str = str(col["type"]).upper()
+    assert "JSON" in type_str, f"Expected JSONB, got {type_str}"
+
+
+# ── Index existence ───────────────────────────────────────────────────────────
+
+def _index_names(inspector, table: str) -> set[str]:
+    return {idx["name"] for idx in inspector.get_indexes(table)}
+
+
+def test_bmg10_consent_user_index(inspector):
+    assert "ix_user_biometric_consents_user_id" in _index_names(inspector, "user_biometric_consents")
+
+
+def test_bmg11_embedding_user_index(inspector):
+    assert "ix_user_face_embeddings_user_id" in _index_names(inspector, "user_face_embeddings")
+
+
+def test_bmg12_log_indexes(inspector):
+    idx = _index_names(inspector, "biometric_verification_logs")
+    for expected in (
+        "ix_biometric_logs_user_id",
+        "ix_biometric_logs_event_type",
+        "ix_biometric_logs_created_at",
+    ):
+        assert expected in idx, f"Index {expected!r} missing"

--- a/tests/biometric/test_models.py
+++ b/tests/biometric/test_models.py
@@ -1,0 +1,135 @@
+"""
+Biometric model tests.
+
+BMM-01  UserBiometricConsent can be created and flushed
+BMM-02  UserBiometricConsent.is_active defaults to True
+BMM-03  UserFaceEmbedding can be created with is_active=False (default)
+BMM-04  BiometricVerificationLog.face_match_score stored in DB
+BMM-05  BiometricVerificationLog.liveness_metadata JSONB stored and retrieved
+BMM-06  User.face_match_status column exists and is nullable
+BMM-07  User.face_match_score column exists and is nullable (internal only)
+BMM-08  User.face_reference_photo_status column exists
+BMM-09  User.manual_review_required defaults to False
+BMM-10  User.biometric_consents relationship accessible
+BMM-11  User.face_embedding relationship accessible (None when no embedding)
+BMM-12  BiometricVerificationLog inserted without liveness_metadata (null ok)
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.models.biometric import (
+    BiometricVerificationLog,
+    UserBiometricConsent,
+    UserFaceEmbedding,
+)
+from app.models.user import User
+
+
+# ── BMM-01 / BMM-02 ──────────────────────────────────────────────────────────
+
+def test_bmm01_consent_created(db, student_user):
+    from datetime import datetime, timezone
+    consent = UserBiometricConsent(
+        user_id=student_user.id,
+        consent_granted_at=datetime.now(timezone.utc),
+        consent_version="v1.0",
+    )
+    db.add(consent)
+    db.flush()
+    assert consent.id is not None
+
+
+def test_bmm02_consent_is_active_default(db, student_user):
+    from datetime import datetime, timezone
+    consent = UserBiometricConsent(
+        user_id=student_user.id,
+        consent_granted_at=datetime.now(timezone.utc),
+        consent_version="v1.0",
+    )
+    db.add(consent)
+    db.flush()
+    assert consent.is_active is True
+
+
+# ── BMM-03  UserFaceEmbedding ─────────────────────────────────────────────────
+
+def test_bmm03_embedding_is_active_false_default(db, student_user):
+    emb = UserFaceEmbedding(user_id=student_user.id)
+    db.add(emb)
+    db.flush()
+    assert emb.is_active is False
+    assert emb.embedding_ciphertext is None   # not populated until PR-4
+
+
+# ── BMM-04 / BMM-05  BiometricVerificationLog ─────────────────────────────────
+
+def test_bmm04_log_face_match_score_stored(db, student_user):
+    row = BiometricVerificationLog(
+        user_id=student_user.id,
+        event_type="match_success",
+        face_match_score=0.82,
+    )
+    db.add(row)
+    db.flush()
+    db.refresh(row)
+    assert row.face_match_score == pytest.approx(0.82)
+
+
+def test_bmm05_log_liveness_metadata_jsonb(db, student_user):
+    metadata = {
+        "challenge_version": "v1.0",
+        "steps_completed": ["centered", "head_left"],
+        "total_duration_ms": 9500,
+        "retry_count": 0,
+    }
+    row = BiometricVerificationLog(
+        user_id=student_user.id,
+        event_type="liveness_completed",
+        liveness_metadata=metadata,
+    )
+    db.add(row)
+    db.flush()
+    db.refresh(row)
+    assert row.liveness_metadata["challenge_version"] == "v1.0"
+    assert row.liveness_metadata["steps_completed"] == ["centered", "head_left"]
+
+
+# ── BMM-06 … BMM-09  User columns ────────────────────────────────────────────
+
+def test_bmm06_user_face_match_status_nullable(db, student_user):
+    assert student_user.face_match_status is None
+
+
+def test_bmm07_user_face_match_score_nullable(db, student_user):
+    assert student_user.face_match_score is None
+
+
+def test_bmm08_user_face_reference_photo_status_nullable(db, student_user):
+    assert student_user.face_reference_photo_status is None
+
+
+def test_bmm09_user_manual_review_required_defaults_false(db, student_user):
+    assert student_user.manual_review_required is False
+
+
+# ── BMM-10 / BMM-11  Relationships ───────────────────────────────────────────
+
+def test_bmm10_user_biometric_consents_relationship(db, student_user):
+    assert student_user.biometric_consents == []
+
+
+def test_bmm11_user_face_embedding_relationship_none(db, student_user):
+    assert student_user.face_embedding is None
+
+
+# ── BMM-12  Log without liveness_metadata ────────────────────────────────────
+
+def test_bmm12_log_without_metadata_ok(db, student_user):
+    row = BiometricVerificationLog(
+        user_id=student_user.id,
+        event_type="consent_granted",
+    )
+    db.add(row)
+    db.flush()
+    assert row.liveness_metadata is None


### PR DESCRIPTION
## Summary

Introduces the biometric face matching infrastructure under a **default-off feature flag** (`BIOMETRIC_FACE_MATCHING_ENABLED=false`). All biometric endpoints return HTTP 503 until the flag is explicitly enabled — which requires DPIA completion and legal approval (see Production Blockers below).

This is the first PR in an 8-PR series implementing a liveness-challenge-based face matching pipeline for Academy ID verification.

---

## Scope (what IS in this PR)

- **Feature flag** — `BIOMETRIC_FACE_MATCHING_ENABLED=false` (default) in `app/config.py`; `BIOMETRIC_EMBEDDING_KEY` placeholder
- **Data models** — `UserBiometricConsent`, `UserFaceEmbedding`, `BiometricVerificationLog` (`app/models/biometric.py`)
- **User model columns** — `face_match_status`, `face_match_score` (internal only), `face_reference_photo_status`, `manual_review_required`, `reviewed_by`, `reviewed_at`, `rejection_reason`
- **Alembic migration** — `2026_06_10_1000`: 3 new tables + 7 users columns; `down_revision = 2026_06_09_1000`; downgrade supported
- **Feature flag guard** — `require_biometric_enabled()` FastAPI dependency; raises 503 when flag is off
- **Audit logger** — `BiometricAuditLogger` + `ALL_EVENT_TYPES` constants (including `liveness_started`, `liveness_step_passed`, `liveness_failed`, `liveness_completed`, `reference_auto_approved_liveness`)
- **Liveness metadata sanitizer** — allow-list enforcing only 5 fields (`challenge_version`, `steps_completed`, `total_duration_ms`, `retry_count`, `failure_reason`); strips `device_model`, `ios_version`, `yaw`, `roll`, `landmarks`, `frames`, `embedding`, `face_match_score` and all other sensor/biometric detail before every DB INSERT
- **Pydantic schemas** — `LivenessMetadata` (`extra="forbid"`), `BiometricConsentStatusOut`, `BiometricVerificationStatusOut`, `BiometricVerificationLogOut`; `face_match_score` and `embedding_*` fields structurally absent from all response types
- **Test suite** — 79 tests across 5 files (sanitizer × 28, migration × 13, models × 12, audit log × 12, feature flag × 5)

---

## Out of Scope (explicitly NOT in this PR)

- ❌ ONNX / InsightFace / face embedding model
- ❌ Embedding generation or encryption
- ❌ Celery biometric task queue
- ❌ iOS changes (zero Swift files modified)
- ❌ Admin review UI
- ❌ Consent API endpoints (PR-2)
- ❌ Reference photo endpoints (PR-3)
- ❌ Face matching pipeline (PR-5)
- ❌ Production biometric data processing

---

## Evidence

```
# Diff contains exactly 18 files — no academy-id-color-system, no iOS
git diff main...feat/biometric-pr1-foundation --name-only | wc -l
→ 18

git diff main...feat/biometric-pr1-foundation --name-only | grep academy
→ (empty)

git diff main...feat/biometric-pr1-foundation --name-only | grep ios
→ (empty)

# Migration chain (main HEAD = 2026_06_09_1000)
alembic downgrade -1
→ Running downgrade 2026_06_10_1000 -> 2026_06_09_1000

alembic upgrade head
→ Running upgrade 2026_06_09_1000 -> 2026_06_10_1000

alembic heads
→ 2026_06_10_1000 (head)   ← single head, no branch

# Tests
pytest tests/biometric/   →  79 passed, 0 failed
pytest tests/unit/        →  12 904 passed, 1 skipped, 21 xfailed, 1 xpassed
```

### Metadata sanitizer evidence (key tests)

| Test | What it proves |
|---|---|
| BMS-04…BMS-11 | 9 forbidden fields each dropped individually |
| BMS-26 | `face_match_score` never in sanitizer output |
| BMS-27 | `embedding` never in sanitizer output |
| BMS-28 | `yaw` never in sanitizer output |
| BMA-06 | `face_match_score` structurally absent from `BiometricVerificationLogOut` Pydantic schema |
| BMA-11 | DB-verified: `embedding`, `face_match_score`, `ios_version` not stored even when sent in input |
| BMA-12 | `embedding_ciphertext`, `embedding_iv`, `face_match_score` absent from schema `model_fields` |

---

## Production Blockers

`BIOMETRIC_FACE_MATCHING_ENABLED=true` **must not** be set in production until ALL of the following are cleared:

1. **DPIA** (Data Protection Impact Assessment) completed and documented; NAIH consultation if high-risk
2. **Biometric consent text v1.0** legally approved (the version string is locked in the DB per consent record)
3. **Privacy policy / adatkezelési tájékoztató** updated: liveness challenge, biometric category, retention, deletion rights, non-KYC scope
4. **`BIOMETRIC_EMBEDDING_KEY`** production key in secret manager (not plaintext `.env`)
5. **Explicit written sign-off** on `BIOMETRIC_FACE_MATCHING_ENABLED=true` for production

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)