### PR TITLE
feat(biometric): PR-4 — AES-256-GCM embedding encryption + Celery task architecture

### DIFF
--- a/app/celery_app.py
+++ b/app/celery_app.py
@@ -30,6 +30,7 @@ def create_celery() -> Celery:
         include=[
             "app.tasks.tournament_tasks",
             "app.tasks.mood_photo_tasks",
+            "app.tasks.biometric_tasks",
         ],
     )
 
@@ -62,21 +63,30 @@ def create_celery() -> Celery:
         },
         # Routing
         task_routes={
-            "app.tasks.tournament_tasks.generate_sessions_task": {"queue": "tournaments"},
-            "app.tasks.mood_photo_tasks.remove_background_task": {"queue": "mood_photos"},
+            "app.tasks.tournament_tasks.generate_sessions_task":                   {"queue": "tournaments"},
+            "app.tasks.mood_photo_tasks.remove_background_task":                   {"queue": "mood_photos"},
+            "app.tasks.biometric_tasks.biometric_generate_embedding_task":         {"queue": "biometric_embeddings"},
+            "app.tasks.biometric_tasks.biometric_delete_embedding_task":           {"queue": "biometric_embeddings"},
         },
         # Queues
         task_default_queue="default",
         task_queues={
-            "default":     {},
-            "tournaments": {},
-            "mood_photos": {},
+            "default":              {},
+            "tournaments":          {},
+            "mood_photos":          {},
+            "biometric_embeddings": {},
         },
         # Rate limiting (protect DB under heavy load)
         task_annotations={
             "app.tasks.tournament_tasks.generate_sessions_task": {
-                "rate_limit": "10/m",  # max 10 large-tournament generations per minute
-            }
+                "rate_limit": "10/m",
+            },
+            "app.tasks.biometric_tasks.biometric_generate_embedding_task": {
+                "rate_limit": "30/m",
+            },
+            "app.tasks.biometric_tasks.biometric_delete_embedding_task": {
+                "rate_limit": "60/m",
+            },
         },
     )
 

--- a/app/config.py
+++ b/app/config.py
@@ -304,6 +304,10 @@ class Settings(BaseSettings):
     #   and test environments (no real embeddings stored in those environments).
     BIOMETRIC_FACE_MATCHING_ENABLED: bool = False
     BIOMETRIC_EMBEDDING_KEY: str = ""
+    # Provider: "fake" (PR-4, no ONNX) | "onnx" (PR-5, InsightFace)
+    BIOMETRIC_EMBEDDING_PROVIDER: str = "fake"
+    # True only in test/dev — allows empty BIOMETRIC_EMBEDDING_KEY without raising
+    BIOMETRIC_ENCRYPTION_ALLOW_TEST_KEY: bool = False
 
     # ── Slow-query monitoring ──────────────────────────────────────────────────
     # Queries slower than SLOW_QUERY_THRESHOLD_MS are logged to app.slow_query

--- a/app/services/biometric/consent_service.py
+++ b/app/services/biometric/consent_service.py
@@ -32,7 +32,6 @@ from app.services.biometric.audit_log import (
     BiometricAuditLogger,
     EVT_CONSENT_GRANTED,
     EVT_CONSENT_REVOKED,
-    EVT_EMBEDDING_DELETED,
 )
 
 logger = logging.getLogger(__name__)
@@ -172,10 +171,16 @@ def revoke_consent(
 
     db.flush()
 
-    # 4. Schedule physical deletion (placeholder — Celery task in PR-4)
+    # 4. Schedule physical deletion via Celery ETA task (PR-4)
     scheduled_deletion = now + timedelta(days=EMBEDDING_DELETION_DELAY_DAYS)
-    _schedule_embedding_deletion_placeholder(
-        db=db, user_id=user.id, delete_after=scheduled_deletion, ip_address=ip_address
+    from app.tasks.biometric_tasks import biometric_delete_embedding_task
+    biometric_delete_embedding_task.apply_async(
+        args=[user.id],
+        eta=scheduled_deletion,
+    )
+    logger.info(
+        "biometric_embedding_deletion_scheduled user_id=%d delete_after=%s",
+        user.id, scheduled_deletion.isoformat(),
     )
 
     # 5. Audit log
@@ -189,35 +194,3 @@ def revoke_consent(
     return consent
 
 
-def _schedule_embedding_deletion_placeholder(
-    *,
-    db: Session,
-    user_id: int,
-    delete_after: datetime,
-    ip_address: Optional[str] = None,
-) -> None:
-    """
-    Placeholder for scheduling physical embedding deletion after consent revocation.
-
-    In PR-4 this becomes a real Celery task:
-        delete_embedding_task.apply_async(args=[user_id], eta=delete_after)
-
-    For now: logs the intent as an audit event so the audit trail is complete.
-    The embedding has already been soft-deleted (is_active=False) at this point.
-    """
-    logger.info(
-        "biometric_embedding_deletion_scheduled user_id=%d delete_after=%s "
-        "(Celery task pending PR-4)",
-        user_id, delete_after.isoformat(),
-    )
-
-    BiometricAuditLogger(db).log(
-        user_id          = user_id,
-        event_type       = EVT_EMBEDDING_DELETED,
-        event_result     = "pending",
-        actor_ip_address = ip_address,
-        error_message    = (
-            f"Physical deletion scheduled for {delete_after.date().isoformat()}. "
-            "Celery task not yet implemented (PR-4)."
-        ),
-    )

--- a/app/services/biometric/embedding_service.py
+++ b/app/services/biometric/embedding_service.py
@@ -1,0 +1,174 @@
+"""
+Embedding provider abstraction and storage/deletion service — PR-4.
+
+Design rules enforced here:
+  1. AbstractEmbeddingProvider.generate() returns list[float] only.
+     Raw image bytes are consumed and NOT stored, logged, or returned.
+  2. FakeEmbeddingProvider: deterministic 512-dim unit vector from SHA-256 hash.
+     NO onnxruntime, NO insightface — test/dev only.
+  3. OnnxEmbeddingProvider: planned for PR-5 — raises NotImplementedError here.
+  4. store_embedding(): AES-256-GCM encrypt → INSERT/UPDATE user_face_embeddings.
+     is_active=False (approval gate not yet implemented — PR-6).
+     Plaintext embedding is deleted from memory immediately after encrypt().
+  5. delete_embedding(): physical DELETE from user_face_embeddings.
+     Returns True if row existed, False if idempotent no-op.
+  6. face_match_score is never read, written, or returned by this module.
+
+Not production-ready. DPIA/DPO approval pending.
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+import struct
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.models.biometric import UserFaceEmbedding
+from app.services.biometric.encryption_service import BiometricEncryptionService
+
+logger = logging.getLogger(__name__)
+
+_FAKE_MODEL_VERSION = "fake_v1"
+_EMBED_DIM = 512
+
+
+# ── Provider abstraction ───────────────────────────────────────────────────────
+
+class AbstractEmbeddingProvider:
+    """Base class — all embedding backends must implement generate()."""
+
+    def generate(self, image_bytes: bytes) -> list[float]:
+        raise NotImplementedError
+
+
+class FakeEmbeddingProvider(AbstractEmbeddingProvider):
+    """
+    Deterministic fake embedding provider for tests and development.
+
+    Returns a 512-dim unit vector seeded from SHA-256(image_bytes).
+    Produces the same output for identical inputs (deterministic).
+
+    IMPORTANT:
+      - No onnxruntime import
+      - No InsightFace import
+      - Not suitable for real biometric matching
+      - Used only when BIOMETRIC_EMBEDDING_PROVIDER=fake (default in PR-4)
+    """
+
+    def generate(self, image_bytes: bytes) -> list[float]:
+        """
+        Generate a deterministic 512-dim unit float32 vector.
+        image_bytes is consumed for seeding only — never stored or logged.
+
+        Note: SHA-256 output bytes can decode to IEEE 754 special values
+        (NaN, Inf) when interpreted as float32. These are replaced with 0.0
+        to keep the vector finite and the L2 norm well-defined.
+        """
+        seed = hashlib.sha256(image_bytes).digest()
+        raw_floats: list[float] = []
+        while len(raw_floats) < _EMBED_DIM:
+            seed = hashlib.sha256(seed).digest()
+            # 32 bytes → 8 float32 values (4 bytes each)
+            batch = list(struct.unpack("<8f", seed))
+            # Replace NaN / Inf with 0.0 (IEEE 754 special values from raw bytes)
+            batch = [0.0 if (v != v or v == float("inf") or v == float("-inf")) else v for v in batch]
+            raw_floats.extend(batch)
+        embedding = raw_floats[:_EMBED_DIM]
+
+        # Normalize to unit vector (L2 norm)
+        magnitude = sum(v * v for v in embedding) ** 0.5
+        if magnitude > 0:
+            embedding = [v / magnitude for v in embedding]
+        else:
+            # Degenerate case: all zeros → uniform unit vector
+            embedding = [1.0 / (_EMBED_DIM ** 0.5)] * _EMBED_DIM
+        return embedding
+
+
+# ── Provider factory ───────────────────────────────────────────────────────────
+
+def get_embedding_provider() -> AbstractEmbeddingProvider:
+    """
+    Return the active embedding provider based on BIOMETRIC_EMBEDDING_PROVIDER.
+
+    PR-4: only 'fake' is supported.
+    'onnx' is reserved for PR-5 (InsightFace buffalo_sc_v1).
+    """
+    provider = getattr(settings, "BIOMETRIC_EMBEDDING_PROVIDER", "fake")
+    if provider == "fake":
+        return FakeEmbeddingProvider()
+    if provider == "onnx":
+        raise NotImplementedError(
+            "OnnxEmbeddingProvider not implemented — planned for PR-5. "
+            "Set BIOMETRIC_EMBEDDING_PROVIDER=fake for development."
+        )
+    raise ValueError(f"Unknown BIOMETRIC_EMBEDDING_PROVIDER: {provider!r}")
+
+
+# ── Storage and deletion ───────────────────────────────────────────────────────
+
+def store_embedding(
+    *,
+    db: Session,
+    user_id: int,
+    embedding: list[float],
+    model_version: str,
+) -> UserFaceEmbedding:
+    """
+    AES-256-GCM encrypt and INSERT/UPDATE user_face_embeddings.
+
+    is_active is set to False — embedding is stored but not yet approved.
+    Approval gate (face_match_status → verified) is implemented in PR-6.
+
+    Idempotent: if a row already exists for user_id, it is overwritten.
+    This handles the re-consent scenario (user revoked and re-enrolled).
+
+    Plaintext embedding bytes are deleted from memory immediately after
+    encryption — they are NEVER stored in DB or written to any log.
+    """
+    enc = BiometricEncryptionService()
+    plaintext = enc.embedding_to_bytes(embedding)
+    ciphertext, iv = enc.encrypt(plaintext)
+    del plaintext  # plaintext protection — never persisted or logged
+
+    row = db.query(UserFaceEmbedding).filter_by(user_id=user_id).first()
+    if row is None:
+        row = UserFaceEmbedding(user_id=user_id)
+        db.add(row)
+
+    row.embedding_ciphertext = ciphertext
+    row.embedding_iv         = iv
+    row.model_version        = model_version
+    row.is_active            = False   # NOT verified — approval gate in PR-6
+    row.updated_at           = datetime.now(timezone.utc)
+    db.flush()
+
+    logger.info(
+        "biometric_embedding_stored user_id=%s model_version=%s is_active=False",
+        user_id, model_version,
+    )
+    return row
+
+
+def delete_embedding(
+    *,
+    db: Session,
+    user_id: int,
+) -> bool:
+    """
+    Physically DELETE the face embedding row for user_id.
+
+    Returns True if a row was found and deleted.
+    Returns False if no row exists (idempotent no-op).
+    Audit log is written by the caller (biometric_tasks.py).
+    """
+    row = db.query(UserFaceEmbedding).filter_by(user_id=user_id).first()
+    if row is None:
+        return False
+    db.delete(row)
+    db.flush()
+    return True

--- a/app/services/biometric/encryption_service.py
+++ b/app/services/biometric/encryption_service.py
@@ -1,0 +1,121 @@
+"""
+AES-256-GCM encryption service for biometric face embeddings — PR-4.
+
+Design rules enforced here:
+  1. Plaintext embedding is NEVER stored, logged, or returned.
+     Only (ciphertext, iv) leaves this service.
+  2. Key is loaded once at instantiation; empty key raises ValueError
+     unless BIOMETRIC_ENCRYPTION_ALLOW_TEST_KEY=True (dev/test only).
+  3. Each encrypt() call generates a fresh 12-byte random IV (nonce).
+     IV uniqueness is critical for AES-GCM security.
+  4. decrypt() raises ValueError on authentication failure (tamper detection).
+  5. No face_match_score, yaw, roll, landmarks, or raw sensor data
+     is ever passed through this service.
+
+Not production-ready. DPIA/DPO approval pending.
+"""
+from __future__ import annotations
+
+import os
+import struct
+
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+from app.config import settings
+
+_TEST_KEY_HEX = "00" * 32   # 32 zero bytes — deterministic, NOT secure, test only
+
+
+class BiometricEncryptionService:
+    """AES-256-GCM encrypt/decrypt for 512-dim face embeddings."""
+
+    _IV_LENGTH   = 12    # bytes — NIST recommended for AES-GCM
+    _KEY_BYTES   = 32    # bytes — AES-256
+    _EMBED_DIM   = 512   # float32 dimensions
+    _EMBED_BYTES = _EMBED_DIM * 4  # 2048 bytes
+
+    def __init__(self) -> None:
+        self._key: bytes = self._load_and_validate_key()
+
+    # ── Key loading ────────────────────────────────────────────────────────────
+
+    def _load_and_validate_key(self) -> bytes:
+        """
+        Load BIOMETRIC_EMBEDDING_KEY from settings.
+
+        Raises ValueError if:
+          - key is empty and BIOMETRIC_ENCRYPTION_ALLOW_TEST_KEY is False
+          - key is not valid hex
+          - decoded key is not exactly 32 bytes
+
+        In test/dev environments with BIOMETRIC_ENCRYPTION_ALLOW_TEST_KEY=True,
+        an empty key is replaced with a deterministic 32-byte zero key.
+        This test key is NOT secure and MUST NOT be used in production.
+        """
+        raw = settings.BIOMETRIC_EMBEDDING_KEY
+        if not raw:
+            if settings.BIOMETRIC_ENCRYPTION_ALLOW_TEST_KEY:
+                return bytes.fromhex(_TEST_KEY_HEX)
+            raise ValueError(
+                "BIOMETRIC_EMBEDDING_KEY must not be empty. "
+                "Generate with: python -c \"import secrets; print(secrets.token_hex(32))\""
+            )
+        try:
+            key_bytes = bytes.fromhex(raw)
+        except ValueError as exc:
+            raise ValueError(
+                f"BIOMETRIC_EMBEDDING_KEY is not valid hex: {exc}"
+            ) from exc
+        if len(key_bytes) != self._KEY_BYTES:
+            raise ValueError(
+                f"BIOMETRIC_EMBEDDING_KEY must decode to {self._KEY_BYTES} bytes "
+                f"(got {len(key_bytes)}). "
+                f"Generate with: python -c \"import secrets; print(secrets.token_hex(32))\""
+            )
+        return key_bytes
+
+    # ── Encryption / decryption ────────────────────────────────────────────────
+
+    def encrypt(self, plaintext: bytes) -> tuple[bytes, bytes]:
+        """
+        Encrypt plaintext with AES-256-GCM.
+
+        Returns (ciphertext, iv) — both bytes, suitable for BYTEA storage.
+        iv is 12 bytes, randomly generated; unique per call.
+        The GCM authentication tag is appended to ciphertext by cryptography lib.
+        Plaintext is NOT stored or returned.
+        """
+        iv = os.urandom(self._IV_LENGTH)
+        aesgcm = AESGCM(self._key)
+        ciphertext = aesgcm.encrypt(iv, plaintext, None)
+        return ciphertext, iv
+
+    def decrypt(self, ciphertext: bytes, iv: bytes) -> bytes:
+        """
+        Decrypt ciphertext with AES-256-GCM.
+
+        Raises ValueError on authentication failure (tamper detection).
+        The returned plaintext must NOT be logged or stored.
+        """
+        aesgcm = AESGCM(self._key)
+        try:
+            return aesgcm.decrypt(iv, ciphertext, None)
+        except Exception as exc:
+            raise ValueError(f"AES-GCM authentication failed — ciphertext may be tampered: {exc}") from exc
+
+    # ── Embedding serialization ────────────────────────────────────────────────
+
+    def embedding_to_bytes(self, embedding: list[float]) -> bytes:
+        """
+        Serialize a 512-dim float32 embedding list to 2048-byte little-endian binary.
+        The resulting bytes are suitable as AES-GCM plaintext input.
+        """
+        return struct.pack(f"<{len(embedding)}f", *embedding)
+
+    def bytes_to_embedding(self, raw: bytes) -> list[float]:
+        """
+        Deserialize 2048-byte little-endian binary to a 512-dim float32 list.
+        Used for decrypt→deserialize in future face matching (PR-6).
+        """
+        n = len(raw) // 4
+        return list(struct.unpack(f"<{n}f", raw))

--- a/app/services/biometric/liveness_service.py
+++ b/app/services/biometric/liveness_service.py
@@ -130,10 +130,14 @@ def submit_liveness_result(
         actor_ip_address=ip_address,
     )
 
-    # ── 7. Embedding generation placeholder (PR-4 Celery task) ───────────────
+    # ── 7. Dispatch embedding generation Celery task ──────────────────────────
+    from app.tasks.biometric_tasks import biometric_generate_embedding_task
+    biometric_generate_embedding_task.apply_async(
+        args=[user.id, photo_filename],
+        countdown=5,
+    )
     logger.info(
-        "biometric_embedding_generation_pending user_id=%s source=%s "
-        "(Celery task in PR-4 — not implemented yet)",
+        "biometric_generate_embedding_task dispatched user_id=%s source=%s",
         user.id, source,
     )
 

--- a/app/tasks/biometric_tasks.py
+++ b/app/tasks/biometric_tasks.py
@@ -1,0 +1,293 @@
+"""
+Biometric Celery tasks — PR-4.
+
+Tasks:
+  biometric_generate_embedding_task — generate and store AES-256-GCM encrypted embedding
+  biometric_delete_embedding_task   — physically delete embedding after consent revocation
+
+Queue: biometric_embeddings (dedicated, separate from tournaments / mood_photos)
+
+Design rules enforced here:
+  1. Raw image bytes are used only as a seed — never stored or logged.
+  2. Plaintext embedding is deleted from memory immediately after encryption.
+  3. face_match_score, yaw, roll, landmarks, frames are NEVER logged.
+  4. Feature flag guard: tasks abort without retry if flag is off.
+  5. Consent guard: generate task aborts without retry if consent revoked.
+  6. Idempotency: generate skips if active embedding already exists.
+  7. Retry: exponential backoff on transient failures; explicit audit on max retries.
+  8. No onnxruntime, no InsightFace, no face matching in PR-4.
+
+Not production-ready. DPIA/DPO approval pending.
+"""
+from __future__ import annotations
+
+import logging
+import os
+
+from app.celery_app import celery_app
+from app.database import SessionLocal
+
+logger = logging.getLogger(__name__)
+
+_FAKE_MODEL_VERSION = "fake_v1"
+
+
+# ── biometric_generate_embedding_task ─────────────────────────────────────────
+
+@celery_app.task(
+    bind=True,
+    name="app.tasks.biometric_tasks.biometric_generate_embedding_task",
+    queue="biometric_embeddings",
+    max_retries=3,
+    acks_late=True,
+    reject_on_worker_lost=True,
+)
+def biometric_generate_embedding_task(
+    self,
+    user_id: int,
+    photo_filename: str | None,
+) -> None:
+    """
+    Generate and store an AES-256-GCM encrypted face embedding.
+
+    Steps:
+      1. Feature flag guard — ABORT (no retry) if flag off
+      2. Load user — ABORT if not found
+      3. Consent check — ABORT (no retry) if revoked; audit EVT_REFERENCE_REJECTED
+      4. Idempotency — SKIP if is_active embedding already exists
+      5. Build image seed bytes from photo_filename (PR-4 fake; real file load in PR-5)
+      6. FakeEmbeddingProvider.generate() — no ONNX, no InsightFace
+      7. store_embedding() — encrypt + INSERT/UPDATE; is_active=False
+      8. Audit EVT_REFERENCE_AUTO_APPROVED_LIVENESS (event_result=completed)
+      FAILURE: EVT_REFERENCE_REJECTED + exponential retry (60s → 180s → 540s)
+      MAX RETRIES: EVT_REFERENCE_REJECTED(max_retries_exceeded) + CRITICAL log
+    """
+    from app.config import settings
+    from app.models.biometric import UserBiometricConsent, UserFaceEmbedding
+    from app.models.user import User
+    from app.services.biometric.audit_log import (
+        BiometricAuditLogger,
+        EVT_REFERENCE_AUTO_APPROVED_LIVENESS,
+        EVT_REFERENCE_REJECTED,
+    )
+    from app.services.biometric.embedding_service import (
+        FakeEmbeddingProvider,
+        store_embedding,
+    )
+
+    db = SessionLocal()
+    try:
+        # ── 1. Feature flag guard ─────────────────────────────────────────────
+        if not settings.BIOMETRIC_FACE_MATCHING_ENABLED:
+            logger.warning(
+                "biometric_generate_embedding_task: feature flag off — aborting user_id=%s",
+                user_id,
+            )
+            return
+
+        # ── 2. Load user ──────────────────────────────────────────────────────
+        user = db.query(User).filter_by(id=user_id).first()
+        if user is None:
+            logger.warning(
+                "biometric_generate_embedding_task: user_id=%s not found — aborting",
+                user_id,
+            )
+            return
+
+        # ── 3. Consent check (no retry on revoked) ────────────────────────────
+        active_consent = (
+            db.query(UserBiometricConsent)
+            .filter_by(user_id=user_id, is_active=True)
+            .first()
+        )
+        if not active_consent:
+            logger.warning(
+                "biometric_generate_embedding_task: no active consent for user_id=%s — aborting",
+                user_id,
+            )
+            BiometricAuditLogger(db).log(
+                user_id=user_id,
+                event_type=EVT_REFERENCE_REJECTED,
+                event_result="failed",
+                error_message="consent_revoked_before_embedding_generation",
+            )
+            db.commit()
+            return
+
+        # ── 4. Idempotency check ──────────────────────────────────────────────
+        existing = (
+            db.query(UserFaceEmbedding)
+            .filter_by(user_id=user_id, is_active=True)
+            .first()
+        )
+        if existing:
+            logger.warning(
+                "biometric_generate_embedding_task: active embedding exists for user_id=%s — skipping",
+                user_id,
+            )
+            return
+
+        # ── 5. Build image seed (PR-4: filename-based; PR-5: real file bytes) ─
+        # photo_filename is basename only (validated upstream by liveness_service).
+        # Raw bytes are used only as deterministic seed — never stored or logged.
+        if photo_filename:
+            if os.path.basename(photo_filename) != photo_filename:
+                logger.error(
+                    "biometric_generate_embedding_task: unsafe photo_filename for user_id=%s — aborting",
+                    user_id,
+                )
+                return
+            image_seed = photo_filename.encode("utf-8")
+        else:
+            image_seed = f"user_{user_id}".encode("utf-8")
+
+        # ── 6. Generate embedding (FakeEmbeddingProvider — no ONNX) ──────────
+        provider = FakeEmbeddingProvider()
+        embedding = provider.generate(image_seed)
+
+        # ── 7. Encrypt and store ──────────────────────────────────────────────
+        store_embedding(
+            db=db,
+            user_id=user_id,
+            embedding=embedding,
+            model_version=_FAKE_MODEL_VERSION,
+        )
+        del embedding   # plaintext protection
+
+        # ── 8. Audit log ──────────────────────────────────────────────────────
+        BiometricAuditLogger(db).log(
+            user_id=user_id,
+            event_type=EVT_REFERENCE_AUTO_APPROVED_LIVENESS,
+            event_result="completed",
+            model_version=_FAKE_MODEL_VERSION,
+        )
+        db.commit()
+        logger.info(
+            "biometric_generate_embedding_task: completed for user_id=%s model=%s",
+            user_id, _FAKE_MODEL_VERSION,
+        )
+
+    except Exception as exc:
+        db.rollback()
+        retries = self.request.retries
+
+        if retries >= self.max_retries:
+            logger.critical(
+                "biometric_generate_embedding_task: max_retries=%d exceeded for user_id=%s error=%s",
+                self.max_retries, user_id, exc,
+            )
+            try:
+                from app.services.biometric.audit_log import BiometricAuditLogger, EVT_REFERENCE_REJECTED
+                BiometricAuditLogger(db).log(
+                    user_id=user_id,
+                    event_type=EVT_REFERENCE_REJECTED,
+                    event_result="failed",
+                    error_message="max_retries_exceeded",
+                )
+                db.commit()
+            except Exception:
+                pass
+            return
+
+        countdown = 60 * (3 ** retries)  # 60s → 180s → 540s
+        logger.error(
+            "biometric_generate_embedding_task: failed for user_id=%s retry=%d/%d in %ds: %s",
+            user_id, retries + 1, self.max_retries, countdown, exc,
+        )
+        raise self.retry(exc=exc, countdown=countdown)
+
+    finally:
+        db.close()
+
+
+# ── biometric_delete_embedding_task ───────────────────────────────────────────
+
+@celery_app.task(
+    bind=True,
+    name="app.tasks.biometric_tasks.biometric_delete_embedding_task",
+    queue="biometric_embeddings",
+    max_retries=5,
+    acks_late=True,
+    reject_on_worker_lost=True,
+)
+def biometric_delete_embedding_task(self, user_id: int) -> None:
+    """
+    Physically DELETE the face embedding after consent revocation.
+
+    ETA-scheduled from consent_service.revoke_consent():
+        biometric_delete_embedding_task.apply_async(args=[user_id], eta=delete_after)
+
+    Steps:
+      1. Load user — ABORT if not found (log WARNING)
+      2. delete_embedding() — physical DELETE from user_face_embeddings
+      3. Audit EVT_EMBEDDING_DELETED (event_result=completed)
+      NOT FOUND: idempotent success (log WARNING, audit completed)
+      FAILURE: retry (max 5, backoff 300s → 600s → ...)
+      MAX RETRIES: EVT_EMBEDDING_DELETED(failed) + CRITICAL log
+    """
+    from app.models.user import User
+    from app.services.biometric.audit_log import BiometricAuditLogger, EVT_EMBEDDING_DELETED
+    from app.services.biometric.embedding_service import delete_embedding
+
+    db = SessionLocal()
+    try:
+        # ── 1. Load user ──────────────────────────────────────────────────────
+        user = db.query(User).filter_by(id=user_id).first()
+        if user is None:
+            logger.warning(
+                "biometric_delete_embedding_task: user_id=%s not found — aborting",
+                user_id,
+            )
+            return
+
+        # ── 2. Physical delete ────────────────────────────────────────────────
+        deleted = delete_embedding(db=db, user_id=user_id)
+        if not deleted:
+            logger.warning(
+                "biometric_delete_embedding_task: no embedding row for user_id=%s — idempotent success",
+                user_id,
+            )
+
+        # ── 3. Audit log ──────────────────────────────────────────────────────
+        BiometricAuditLogger(db).log(
+            user_id=user_id,
+            event_type=EVT_EMBEDDING_DELETED,
+            event_result="completed",
+        )
+        db.commit()
+        logger.info(
+            "biometric_delete_embedding_task: completed for user_id=%s deleted=%s",
+            user_id, deleted,
+        )
+
+    except Exception as exc:
+        db.rollback()
+        retries = self.request.retries
+
+        if retries >= self.max_retries:
+            logger.critical(
+                "biometric_delete_embedding_task: max_retries=%d exceeded for user_id=%s error=%s",
+                self.max_retries, user_id, exc,
+            )
+            try:
+                from app.services.biometric.audit_log import BiometricAuditLogger, EVT_EMBEDDING_DELETED
+                BiometricAuditLogger(db).log(
+                    user_id=user_id,
+                    event_type=EVT_EMBEDDING_DELETED,
+                    event_result="failed",
+                    error_message="max_retries_exceeded",
+                )
+                db.commit()
+            except Exception:
+                pass
+            return
+
+        countdown = 300 * (2 ** retries)  # 300s → 600s → 1200s → ...
+        logger.error(
+            "biometric_delete_embedding_task: failed for user_id=%s retry=%d/%d in %ds: %s",
+            user_id, retries + 1, self.max_retries, countdown, exc,
+        )
+        raise self.retry(exc=exc, countdown=countdown)
+
+    finally:
+        db.close()

--- a/tests/biometric/conftest.py
+++ b/tests/biometric/conftest.py
@@ -6,6 +6,8 @@ for full test isolation without database pollution between tests.
 """
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 from sqlalchemy import event
 from sqlalchemy.orm import sessionmaker
@@ -106,6 +108,21 @@ def allow_test_key(monkeypatch):
 def fake_provider_enabled(monkeypatch):
     """Ensures BIOMETRIC_EMBEDDING_PROVIDER=fake (default, but explicit for clarity)."""
     monkeypatch.setattr("app.config.settings.BIOMETRIC_EMBEDDING_PROVIDER", "fake")
+
+
+@pytest.fixture(autouse=True)
+def _mock_celery_task_dispatch():
+    """
+    Auto-mock biometric Celery task dispatch in all biometric tests.
+    Prevents kombu/Redis connection errors in CI where no broker is running.
+    Tests that need real eager execution use the celery_eager fixture explicitly.
+    """
+    with patch(
+        "app.tasks.biometric_tasks.biometric_generate_embedding_task.apply_async"
+    ) as _gen, patch(
+        "app.tasks.biometric_tasks.biometric_delete_embedding_task.apply_async"
+    ) as _del:
+        yield {"generate": _gen, "delete": _del}
 
 
 @pytest.fixture()

--- a/tests/biometric/conftest.py
+++ b/tests/biometric/conftest.py
@@ -78,3 +78,45 @@ def biometric_feature_enabled(monkeypatch):
     monkeypatch.setattr(
         "app.services.biometric.feature_flag.settings.BIOMETRIC_FACE_MATCHING_ENABLED", True
     )
+
+
+# ── PR-4 fixtures ─────────────────────────────────────────────────────────────
+
+_TEST_EMBEDDING_KEY = "ab" * 32   # 64 hex chars = 32 bytes, NOT secure, test only
+
+
+@pytest.fixture()
+def encryption_test_key(monkeypatch):
+    """
+    Sets a valid test AES-256 key for encryption service tests.
+    This key is NOT secure and must never be used in production.
+    """
+    monkeypatch.setattr("app.config.settings.BIOMETRIC_EMBEDDING_KEY", _TEST_EMBEDDING_KEY)
+    monkeypatch.setattr("app.config.settings.BIOMETRIC_ENCRYPTION_ALLOW_TEST_KEY", False)
+
+
+@pytest.fixture()
+def allow_test_key(monkeypatch):
+    """Enables the test-key fallback (empty BIOMETRIC_EMBEDDING_KEY → zero key)."""
+    monkeypatch.setattr("app.config.settings.BIOMETRIC_EMBEDDING_KEY", "")
+    monkeypatch.setattr("app.config.settings.BIOMETRIC_ENCRYPTION_ALLOW_TEST_KEY", True)
+
+
+@pytest.fixture()
+def fake_provider_enabled(monkeypatch):
+    """Ensures BIOMETRIC_EMBEDDING_PROVIDER=fake (default, but explicit for clarity)."""
+    monkeypatch.setattr("app.config.settings.BIOMETRIC_EMBEDDING_PROVIDER", "fake")
+
+
+@pytest.fixture()
+def celery_eager(monkeypatch):
+    """
+    Run Celery tasks synchronously (no broker needed).
+    Pairs with patching SessionLocal to inject the test DB session.
+    """
+    from app.celery_app import celery_app
+    celery_app.conf.task_always_eager = True
+    celery_app.conf.task_eager_propagates = True
+    yield
+    celery_app.conf.task_always_eager = False
+    celery_app.conf.task_eager_propagates = False

--- a/tests/biometric/test_biometric_tasks.py
+++ b/tests/biometric/test_biometric_tasks.py
@@ -1,0 +1,337 @@
+"""
+Biometric Celery task tests.
+
+Strategy: tasks are run synchronously via task_always_eager=True (celery_eager fixture)
+and SessionLocal is patched to use the test DB session (SAVEPOINT-isolated).
+
+BBT-01  generate task happy path: embedding stored + audit EVT_REFERENCE_AUTO_APPROVED_LIVENESS
+BBT-02  generate task: active embedding exists → SKIP (idempotent, audit not duplicated)
+BBT-03  generate task: no active consent → ABORT + EVT_REFERENCE_REJECTED
+BBT-04  generate task: feature flag off → ABORT, no retry, no embedding stored
+BBT-05  generate task: unsafe photo_filename → ABORT (path traversal rejected)
+BBT-06  generate task: transient failure → retries (mock store_embedding to raise)
+BBT-07  generate task: plaintext never logged (caplog check)
+BBT-08  delete task happy path: row deleted + audit EVT_EMBEDDING_DELETED(completed)
+BBT-09  delete task: no row → idempotent success + audit(completed)
+BBT-10  delete task: user not found → ABORT, no audit
+BBT-11  delete task: max retries exceeded → EVT_EMBEDDING_DELETED(failed) via service mock
+BBT-12  biometric_tasks module: no onnxruntime import (AST check)
+BBT-13  liveness_service: biometric_generate_embedding_task.apply_async called
+BBT-14  consent_service revoke: biometric_delete_embedding_task.apply_async called with eta
+"""
+from __future__ import annotations
+
+import ast
+import inspect
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from app.models.biometric import BiometricVerificationLog, UserFaceEmbedding
+from app.services.biometric.audit_log import (
+    EVT_EMBEDDING_DELETED,
+    EVT_REFERENCE_AUTO_APPROVED_LIVENESS,
+    EVT_REFERENCE_REJECTED,
+)
+from app.tasks.biometric_tasks import (
+    biometric_delete_embedding_task,
+    biometric_generate_embedding_task,
+)
+
+_GEN_TASK_PATH = "app.tasks.biometric_tasks.biometric_generate_embedding_task"
+_DEL_TASK_PATH = "app.tasks.biometric_tasks.biometric_delete_embedding_task"
+_SESSION_PATH  = "app.tasks.biometric_tasks.SessionLocal"
+
+
+def _grant_consent(db, user):
+    from app.services.biometric.consent_service import grant_consent
+    grant_consent(db=db, user=user, consent_version="v1.0")
+    db.flush()
+
+
+def _store_active_embedding(db, user_id):
+    from app.services.biometric.embedding_service import FakeEmbeddingProvider, store_embedding
+    emb = FakeEmbeddingProvider().generate(b"seed")
+    row = store_embedding(db=db, user_id=user_id, embedding=emb, model_version="fake_v1")
+    row.is_active = True
+    db.flush()
+    return row
+
+
+# ── BBT-01 ────────────────────────────────────────────────────────────────────
+
+def test_bbt01_generate_happy_path(
+    db, student_user, biometric_feature_enabled, encryption_test_key, celery_eager
+):
+    _grant_consent(db, student_user)
+
+    with patch(_SESSION_PATH, return_value=db):
+        db.close = lambda: None
+        biometric_generate_embedding_task.apply(args=[student_user.id, "photo.jpg"])
+
+    row = db.query(UserFaceEmbedding).filter_by(user_id=student_user.id).first()
+    assert row is not None
+    assert row.embedding_ciphertext is not None
+
+    logs = db.query(BiometricVerificationLog).filter(
+        BiometricVerificationLog.user_id == student_user.id,
+        BiometricVerificationLog.event_type == EVT_REFERENCE_AUTO_APPROVED_LIVENESS,
+        BiometricVerificationLog.event_result == "completed",
+    ).all()
+    assert logs, "Expected EVT_REFERENCE_AUTO_APPROVED_LIVENESS(completed) audit row"
+
+
+# ── BBT-02 ────────────────────────────────────────────────────────────────────
+
+def test_bbt02_generate_skips_active_embedding(
+    db, student_user, biometric_feature_enabled, encryption_test_key, celery_eager
+):
+    _grant_consent(db, student_user)
+    _store_active_embedding(db, student_user.id)
+
+    with patch(_SESSION_PATH, return_value=db):
+        db.close = lambda: None
+        biometric_generate_embedding_task.apply(args=[student_user.id, "photo.jpg"])
+
+    count = db.query(UserFaceEmbedding).filter_by(user_id=student_user.id).count()
+    assert count == 1, "Should skip — active embedding already exists"
+
+
+# ── BBT-03 ────────────────────────────────────────────────────────────────────
+
+def test_bbt03_generate_aborts_no_consent(
+    db, student_user, biometric_feature_enabled, encryption_test_key, celery_eager
+):
+    with patch(_SESSION_PATH, return_value=db):
+        db.close = lambda: None
+        biometric_generate_embedding_task.apply(args=[student_user.id, "photo.jpg"])
+
+    logs = db.query(BiometricVerificationLog).filter(
+        BiometricVerificationLog.user_id == student_user.id,
+        BiometricVerificationLog.event_type == EVT_REFERENCE_REJECTED,
+        BiometricVerificationLog.event_result == "failed",
+    ).all()
+    assert logs, "Expected EVT_REFERENCE_REJECTED when consent missing"
+    assert any("consent_revoked" in (l.error_message or "") for l in logs)
+
+
+# ── BBT-04 ────────────────────────────────────────────────────────────────────
+
+def test_bbt04_generate_aborts_flag_off(
+    db, student_user, encryption_test_key, celery_eager
+):
+    # biometric_feature_enabled NOT active
+    with patch(_SESSION_PATH, return_value=db):
+        db.close = lambda: None
+        biometric_generate_embedding_task.apply(args=[student_user.id, "photo.jpg"])
+
+    assert db.query(UserFaceEmbedding).filter_by(user_id=student_user.id).count() == 0
+
+
+# ── BBT-05 ────────────────────────────────────────────────────────────────────
+
+def test_bbt05_generate_rejects_path_traversal(
+    db, student_user, biometric_feature_enabled, encryption_test_key, celery_eager
+):
+    _grant_consent(db, student_user)
+
+    with patch(_SESSION_PATH, return_value=db):
+        db.close = lambda: None
+        biometric_generate_embedding_task.apply(args=[student_user.id, "../etc/passwd"])
+
+    assert db.query(UserFaceEmbedding).filter_by(user_id=student_user.id).count() == 0
+
+
+# ── BBT-06 ────────────────────────────────────────────────────────────────────
+
+def test_bbt06_generate_retries_on_failure(
+    db, student_user, biometric_feature_enabled, encryption_test_key, celery_eager
+):
+    """
+    When store_embedding raises a transient error, the task should retry.
+    With task_eager_propagates=True, the retry exception propagates.
+    """
+    _grant_consent(db, student_user)
+    call_count = {"n": 0}
+
+    def exploding_store(**kwargs):
+        call_count["n"] += 1
+        raise RuntimeError("transient DB failure")
+
+    with patch(_SESSION_PATH, return_value=db), \
+         patch("app.services.biometric.embedding_service.store_embedding", side_effect=exploding_store):
+        db.close = lambda: None
+        try:
+            biometric_generate_embedding_task.apply(args=[student_user.id, "photo.jpg"])
+        except Exception:
+            pass  # Celery propagates retry exceptions in eager mode
+
+    # store_embedding was called at least once (proving the task ran)
+    assert call_count["n"] >= 1
+
+
+# ── BBT-07 ────────────────────────────────────────────────────────────────────
+
+def test_bbt07_generate_plaintext_not_logged(
+    db, student_user, biometric_feature_enabled, encryption_test_key, celery_eager, caplog
+):
+    _grant_consent(db, student_user)
+
+    with patch(_SESSION_PATH, return_value=db), \
+         caplog.at_level(logging.DEBUG):
+        db.close = lambda: None
+        biometric_generate_embedding_task.apply(args=[student_user.id, "photo.jpg"])
+
+    # No float vector arrays in log output
+    for record in caplog.records:
+        msg = record.getMessage()
+        assert "0.001953" not in msg  # typical float32 value from embedding
+
+
+# ── BBT-08 ────────────────────────────────────────────────────────────────────
+
+def test_bbt08_delete_happy_path(
+    db, student_user, encryption_test_key, celery_eager
+):
+    _store_active_embedding(db, student_user.id)
+
+    with patch(_SESSION_PATH, return_value=db):
+        db.close = lambda: None
+        biometric_delete_embedding_task.apply(args=[student_user.id])
+
+    assert db.query(UserFaceEmbedding).filter_by(user_id=student_user.id).count() == 0
+    logs = db.query(BiometricVerificationLog).filter(
+        BiometricVerificationLog.user_id == student_user.id,
+        BiometricVerificationLog.event_type == EVT_EMBEDDING_DELETED,
+        BiometricVerificationLog.event_result == "completed",
+    ).all()
+    assert logs, "Expected EVT_EMBEDDING_DELETED(completed)"
+
+
+# ── BBT-09 ────────────────────────────────────────────────────────────────────
+
+def test_bbt09_delete_idempotent_no_row(db, student_user, celery_eager):
+    with patch(_SESSION_PATH, return_value=db):
+        db.close = lambda: None
+        biometric_delete_embedding_task.apply(args=[student_user.id])
+
+    logs = db.query(BiometricVerificationLog).filter(
+        BiometricVerificationLog.user_id == student_user.id,
+        BiometricVerificationLog.event_type == EVT_EMBEDDING_DELETED,
+        BiometricVerificationLog.event_result == "completed",
+    ).all()
+    assert logs, "Idempotent: audit(completed) even if no row existed"
+
+
+# ── BBT-10 ────────────────────────────────────────────────────────────────────
+
+def test_bbt10_delete_user_not_found(db, celery_eager):
+    with patch(_SESSION_PATH, return_value=db):
+        db.close = lambda: None
+        biometric_delete_embedding_task.apply(args=[99999999])
+
+    # No audit log row created for non-existent user
+    logs = db.query(BiometricVerificationLog).filter(
+        BiometricVerificationLog.event_type == EVT_EMBEDDING_DELETED,
+    ).all()
+    assert not logs, "No audit row when user not found"
+
+
+# ── BBT-11 ────────────────────────────────────────────────────────────────────
+
+def test_bbt11_delete_max_retries_critical_log(db, student_user, celery_eager, caplog):
+    """
+    When delete_embedding raises and max_retries is reached (max_retries=0),
+    a CRITICAL log message is emitted.
+    We mock db.rollback() to protect the test SAVEPOINT from being destroyed.
+    """
+    from unittest.mock import MagicMock
+
+    def exploding_delete(**kwargs):
+        raise RuntimeError("delete failed")
+
+    original_max = biometric_delete_embedding_task.max_retries
+    biometric_delete_embedding_task.max_retries = 0
+
+    try:
+        with patch(_SESSION_PATH, return_value=db), \
+             patch("app.services.biometric.embedding_service.delete_embedding", side_effect=exploding_delete), \
+             patch.object(db, "rollback", MagicMock()), \
+             caplog.at_level(logging.CRITICAL, logger="app.tasks.biometric_tasks"):
+            db.close = lambda: None
+            try:
+                biometric_delete_embedding_task.apply(args=[student_user.id])
+            except Exception:
+                pass
+    finally:
+        biometric_delete_embedding_task.max_retries = original_max
+
+    critical_msgs = [r.getMessage() for r in caplog.records if r.levelno >= logging.CRITICAL]
+    assert any("max_retries" in m for m in critical_msgs), (
+        f"Expected CRITICAL log. Got: {critical_msgs}"
+    )
+
+
+# ── BBT-12 ────────────────────────────────────────────────────────────────────
+
+def test_bbt12_tasks_module_no_onnxruntime_import():
+    import app.tasks.biometric_tasks as mod
+    src = inspect.getsource(mod)
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            names = [a.name for a in node.names]
+            module = getattr(node, "module", "") or ""
+            assert "onnxruntime" not in module, "onnxruntime import found in biometric_tasks"
+            assert not any("onnxruntime" in n for n in names)
+            assert "insightface" not in module, "insightface import found in biometric_tasks"
+
+
+# ── BBT-13 ────────────────────────────────────────────────────────────────────
+
+def test_bbt13_liveness_service_dispatches_generate_task(
+    db, student_user, biometric_feature_enabled
+):
+    from app.services.biometric.consent_service import grant_consent
+    grant_consent(db=db, user=student_user, consent_version="v1.0")
+    db.flush()
+
+    from app.services.biometric.liveness_service import submit_liveness_result
+
+    metadata = {
+        "challenge_version": "v1.0",
+        "steps_completed": ["center"],
+        "total_duration_ms": 3000,
+        "retry_count": 0,
+    }
+
+    with patch(f"{_GEN_TASK_PATH}.apply_async") as mock_dispatch:
+        submit_liveness_result(
+            db=db, user=student_user, liveness_metadata=metadata,
+            source="onboarding_liveness", photo_filename="ref.jpg",
+        )
+
+    mock_dispatch.assert_called_once()
+    call_args = mock_dispatch.call_args
+    dispatched_args = call_args.kwargs.get("args") or (call_args.args[0] if call_args.args else [])
+    assert student_user.id in dispatched_args, "user_id must be in apply_async args"
+    assert "countdown" in call_args.kwargs, "countdown must be set for delayed dispatch"
+
+
+# ── BBT-14 ────────────────────────────────────────────────────────────────────
+
+def test_bbt14_consent_revoke_dispatches_delete_task_with_eta(
+    db, student_user, biometric_feature_enabled
+):
+    from app.services.biometric.consent_service import grant_consent, revoke_consent
+    grant_consent(db=db, user=student_user, consent_version="v1.0")
+    db.flush()
+
+    with patch(f"{_DEL_TASK_PATH}.apply_async") as mock_dispatch:
+        revoke_consent(db=db, user=student_user)
+
+    mock_dispatch.assert_called_once()
+    kwargs = mock_dispatch.call_args.kwargs
+    assert "eta" in kwargs, "delete task must be dispatched with eta= (delayed physical deletion)"
+    assert kwargs["args"] == [student_user.id]

--- a/tests/biometric/test_consent_service.py
+++ b/tests/biometric/test_consent_service.py
@@ -169,15 +169,23 @@ def test_bcs16_revoke_logs_consent_revoked(db, student_user):
     assert row is not None
 
 
-def test_bcs17_revoke_logs_embedding_deleted_placeholder(db, student_user):
+def test_bcs17_revoke_dispatches_celery_delete_task(db, student_user):
+    """
+    PR-4: revoke_consent dispatches biometric_delete_embedding_task via Celery apply_async
+    (replaces the PR-2 placeholder that wrote an EVT_EMBEDDING_DELETED(pending) log row).
+    """
+    from unittest.mock import patch
     grant_consent(db=db, user=student_user, consent_version="v1.0")
-    revoke_consent(db=db, user=student_user)
-    row = db.query(BiometricVerificationLog).filter_by(
-        user_id=student_user.id, event_type=EVT_EMBEDDING_DELETED
-    ).first()
-    assert row is not None
-    assert row.event_result == "pending"     # placeholder — not yet deleted
-    assert "PR-4" in (row.error_message or "")
+
+    with patch(
+        "app.tasks.biometric_tasks.biometric_delete_embedding_task.apply_async"
+    ) as mock_dispatch:
+        revoke_consent(db=db, user=student_user)
+
+    mock_dispatch.assert_called_once()
+    kwargs = mock_dispatch.call_args.kwargs
+    assert kwargs["args"] == [student_user.id]
+    assert "eta" in kwargs, "delete task must be scheduled with ETA (30-day delayed deletion)"
 
 
 def test_bcs18_revoke_no_embedding_no_error(db, student_user):

--- a/tests/biometric/test_embedding_service.py
+++ b/tests/biometric/test_embedding_service.py
@@ -1,0 +1,170 @@
+"""
+Biometric embedding service tests.
+
+BES-01  FakeEmbeddingProvider.generate() returns 512-dim float list
+BES-02  FakeEmbeddingProvider deterministic (same input → same output)
+BES-03  FakeEmbeddingProvider result is a unit vector (L2 norm ≈ 1.0)
+BES-04  FakeEmbeddingProvider — no onnxruntime import in module
+BES-05  store_embedding() inserts a row into user_face_embeddings
+BES-06  store_embedding() ciphertext and iv are non-None bytes
+BES-07  store_embedding() is_active=False (not approved — PR-6 gate)
+BES-08  store_embedding() plaintext never equals ciphertext in DB
+BES-09  store_embedding() idempotent: second call overwrites, no duplicate
+BES-10  delete_embedding() returns True and removes the row
+BES-11  delete_embedding() returns False when no row exists (idempotent)
+BES-12  get_embedding_provider() "fake" → FakeEmbeddingProvider
+BES-13  get_embedding_provider() "onnx" → NotImplementedError (PR-5)
+BES-14  face_match_score absent from store_embedding() return value
+"""
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from app.models.biometric import UserFaceEmbedding
+from app.services.biometric.embedding_service import (
+    FakeEmbeddingProvider,
+    delete_embedding,
+    get_embedding_provider,
+    store_embedding,
+)
+
+
+# ── BES-01 ────────────────────────────────────────────────────────────────────
+
+def test_bes01_fake_provider_returns_512_dim(fake_provider_enabled):
+    provider = FakeEmbeddingProvider()
+    result = provider.generate(b"test_image_bytes")
+    assert isinstance(result, list)
+    assert len(result) == 512
+    assert all(isinstance(v, float) for v in result)
+
+
+# ── BES-02 ────────────────────────────────────────────────────────────────────
+
+def test_bes02_fake_provider_deterministic(fake_provider_enabled):
+    provider = FakeEmbeddingProvider()
+    seed = b"deterministic_seed"
+    r1 = provider.generate(seed)
+    r2 = provider.generate(seed)
+    assert r1 == r2
+
+
+# ── BES-03 ────────────────────────────────────────────────────────────────────
+
+def test_bes03_fake_provider_unit_vector(fake_provider_enabled):
+    provider = FakeEmbeddingProvider()
+    embedding = provider.generate(b"unit_test")
+    norm = sum(v * v for v in embedding) ** 0.5
+    assert abs(norm - 1.0) < 1e-5, f"L2 norm should be ~1.0, got {norm}"
+
+
+# ── BES-04 ────────────────────────────────────────────────────────────────────
+
+def test_bes04_fake_provider_no_onnxruntime_import():
+    import app.services.biometric.embedding_service as mod
+    src = inspect.getsource(mod)
+    assert "onnxruntime" not in src or "NO onnxruntime" in src
+    # AST-level check: no import onnxruntime statement
+    import ast
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            names = [a.name for a in node.names]
+            mod_name = getattr(node, "module", "") or ""
+            assert "onnxruntime" not in mod_name
+            assert not any("onnxruntime" in n for n in names)
+
+
+# ── BES-05 ────────────────────────────────────────────────────────────────────
+
+def test_bes05_store_embedding_inserts_row(db, student_user, encryption_test_key):
+    provider = FakeEmbeddingProvider()
+    embedding = provider.generate(b"seed")
+    row = store_embedding(db=db, user_id=student_user.id, embedding=embedding, model_version="fake_v1")
+    assert row is not None
+    db_row = db.query(UserFaceEmbedding).filter_by(user_id=student_user.id).first()
+    assert db_row is not None
+
+
+# ── BES-06 ────────────────────────────────────────────────────────────────────
+
+def test_bes06_store_embedding_ciphertext_iv_nonnull(db, student_user, encryption_test_key):
+    embedding = FakeEmbeddingProvider().generate(b"seed")
+    row = store_embedding(db=db, user_id=student_user.id, embedding=embedding, model_version="fake_v1")
+    assert row.embedding_ciphertext is not None
+    assert isinstance(row.embedding_ciphertext, bytes)
+    assert row.embedding_iv is not None
+    assert isinstance(row.embedding_iv, bytes)
+    assert len(row.embedding_iv) == 12
+
+
+# ── BES-07 ────────────────────────────────────────────────────────────────────
+
+def test_bes07_store_embedding_is_active_false(db, student_user, encryption_test_key):
+    embedding = FakeEmbeddingProvider().generate(b"seed")
+    row = store_embedding(db=db, user_id=student_user.id, embedding=embedding, model_version="fake_v1")
+    assert row.is_active is False, "is_active must be False — approval gate is PR-6"
+
+
+# ── BES-08 ────────────────────────────────────────────────────────────────────
+
+def test_bes08_plaintext_not_in_db(db, student_user, encryption_test_key):
+    from app.services.biometric.encryption_service import BiometricEncryptionService
+    embedding = FakeEmbeddingProvider().generate(b"plaintext_test")
+    row = store_embedding(db=db, user_id=student_user.id, embedding=embedding, model_version="fake_v1")
+    svc = BiometricEncryptionService()
+    plaintext_bytes = svc.embedding_to_bytes(embedding)
+    assert row.embedding_ciphertext != plaintext_bytes, "Plaintext must not equal ciphertext in DB"
+
+
+# ── BES-09 ────────────────────────────────────────────────────────────────────
+
+def test_bes09_store_embedding_idempotent(db, student_user, encryption_test_key):
+    embedding = FakeEmbeddingProvider().generate(b"seed")
+    store_embedding(db=db, user_id=student_user.id, embedding=embedding, model_version="fake_v1")
+    store_embedding(db=db, user_id=student_user.id, embedding=embedding, model_version="fake_v1")
+    count = db.query(UserFaceEmbedding).filter_by(user_id=student_user.id).count()
+    assert count == 1, f"Expected 1 row (idempotent overwrite), got {count}"
+
+
+# ── BES-10 ────────────────────────────────────────────────────────────────────
+
+def test_bes10_delete_embedding_returns_true_removes_row(db, student_user, encryption_test_key):
+    embedding = FakeEmbeddingProvider().generate(b"seed")
+    store_embedding(db=db, user_id=student_user.id, embedding=embedding, model_version="fake_v1")
+    result = delete_embedding(db=db, user_id=student_user.id)
+    assert result is True
+    assert db.query(UserFaceEmbedding).filter_by(user_id=student_user.id).count() == 0
+
+
+# ── BES-11 ────────────────────────────────────────────────────────────────────
+
+def test_bes11_delete_embedding_returns_false_when_no_row(db, student_user):
+    result = delete_embedding(db=db, user_id=student_user.id)
+    assert result is False
+
+
+# ── BES-12 ────────────────────────────────────────────────────────────────────
+
+def test_bes12_get_provider_fake(fake_provider_enabled):
+    provider = get_embedding_provider()
+    assert isinstance(provider, FakeEmbeddingProvider)
+
+
+# ── BES-13 ────────────────────────────────────────────────────────────────────
+
+def test_bes13_get_provider_onnx_raises(monkeypatch):
+    monkeypatch.setattr("app.config.settings.BIOMETRIC_EMBEDDING_PROVIDER", "onnx")
+    with pytest.raises(NotImplementedError, match="PR-5"):
+        get_embedding_provider()
+
+
+# ── BES-14 ────────────────────────────────────────────────────────────────────
+
+def test_bes14_store_embedding_no_face_match_score(db, student_user, encryption_test_key):
+    embedding = FakeEmbeddingProvider().generate(b"seed")
+    row = store_embedding(db=db, user_id=student_user.id, embedding=embedding, model_version="fake_v1")
+    # UserFaceEmbedding has no face_match_score column
+    assert not hasattr(row, "face_match_score"), "face_match_score must not be on embedding row"

--- a/tests/biometric/test_encryption_service.py
+++ b/tests/biometric/test_encryption_service.py
@@ -1,0 +1,130 @@
+"""
+Biometric AES-256-GCM encryption service tests.
+
+BENC-01  encrypt() returns (ciphertext, iv) tuple
+BENC-02  iv is always 12 bytes
+BENC-03  ciphertext differs from plaintext
+BENC-04  decrypt(encrypt(x)) == x — full round-trip
+BENC-05  different plaintext → different ciphertext
+BENC-06  each encrypt() call produces different iv (random per call)
+BENC-07  tampered ciphertext → ValueError (GCM authentication)
+BENC-08  tampered iv → ValueError
+BENC-09  empty key + ALLOW_TEST_KEY=False → ValueError
+BENC-10  embedding_to_bytes / bytes_to_embedding round-trip (512-dim)
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.services.biometric.encryption_service import BiometricEncryptionService
+
+
+# ── BENC-01 ───────────────────────────────────────────────────────────────────
+
+def test_benc01_encrypt_returns_ciphertext_iv_tuple(encryption_test_key):
+    svc = BiometricEncryptionService()
+    result = svc.encrypt(b"hello biometric")
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+    ciphertext, iv = result
+    assert isinstance(ciphertext, bytes)
+    assert isinstance(iv, bytes)
+
+
+# ── BENC-02 ───────────────────────────────────────────────────────────────────
+
+def test_benc02_iv_is_always_12_bytes(encryption_test_key):
+    svc = BiometricEncryptionService()
+    for _ in range(5):
+        _, iv = svc.encrypt(b"test")
+        assert len(iv) == 12
+
+
+# ── BENC-03 ───────────────────────────────────────────────────────────────────
+
+def test_benc03_ciphertext_differs_from_plaintext(encryption_test_key):
+    svc = BiometricEncryptionService()
+    plaintext = b"plaintext embedding data"
+    ciphertext, _ = svc.encrypt(plaintext)
+    assert ciphertext != plaintext
+
+
+# ── BENC-04 ───────────────────────────────────────────────────────────────────
+
+def test_benc04_decrypt_encrypt_roundtrip(encryption_test_key):
+    svc = BiometricEncryptionService()
+    original = b"\x01\x02\x03" * 100
+    ciphertext, iv = svc.encrypt(original)
+    recovered = svc.decrypt(ciphertext, iv)
+    assert recovered == original
+
+
+# ── BENC-05 ───────────────────────────────────────────────────────────────────
+
+def test_benc05_different_plaintext_different_ciphertext(encryption_test_key):
+    svc = BiometricEncryptionService()
+    ct1, iv1 = svc.encrypt(b"plaintext A")
+    ct2, iv2 = svc.encrypt(b"plaintext B")
+    assert ct1 != ct2
+
+
+# ── BENC-06 ───────────────────────────────────────────────────────────────────
+
+def test_benc06_each_encrypt_produces_different_iv(encryption_test_key):
+    svc = BiometricEncryptionService()
+    ivs = set()
+    for _ in range(10):
+        _, iv = svc.encrypt(b"same plaintext")
+        ivs.add(iv)
+    # All 10 IVs should be unique (random per call)
+    assert len(ivs) == 10
+
+
+# ── BENC-07 ───────────────────────────────────────────────────────────────────
+
+def test_benc07_tampered_ciphertext_raises_value_error(encryption_test_key):
+    svc = BiometricEncryptionService()
+    ciphertext, iv = svc.encrypt(b"sensitive embedding")
+    tampered = bytes([ciphertext[0] ^ 0xFF]) + ciphertext[1:]
+    with pytest.raises(ValueError):
+        svc.decrypt(tampered, iv)
+
+
+# ── BENC-08 ───────────────────────────────────────────────────────────────────
+
+def test_benc08_tampered_iv_raises_value_error(encryption_test_key):
+    svc = BiometricEncryptionService()
+    ciphertext, iv = svc.encrypt(b"sensitive embedding")
+    tampered_iv = bytes([iv[0] ^ 0xFF]) + iv[1:]
+    with pytest.raises(ValueError):
+        svc.decrypt(ciphertext, tampered_iv)
+
+
+# ── BENC-09 ───────────────────────────────────────────────────────────────────
+
+def test_benc09_empty_key_raises_value_error(monkeypatch):
+    monkeypatch.setattr("app.config.settings.BIOMETRIC_EMBEDDING_KEY", "")
+    monkeypatch.setattr("app.config.settings.BIOMETRIC_ENCRYPTION_ALLOW_TEST_KEY", False)
+    with pytest.raises(ValueError, match="BIOMETRIC_EMBEDDING_KEY"):
+        BiometricEncryptionService()
+
+
+# ── BENC-10 ───────────────────────────────────────────────────────────────────
+
+def test_benc10_embedding_serialization_roundtrip(encryption_test_key):
+    svc = BiometricEncryptionService()
+    original = [float(i) / 512.0 for i in range(512)]
+    raw = svc.embedding_to_bytes(original)
+    assert len(raw) == 512 * 4   # 2048 bytes
+    recovered = svc.bytes_to_embedding(raw)
+    assert len(recovered) == 512
+    for a, b in zip(original, recovered):
+        assert abs(a - b) < 1e-6, f"float32 round-trip mismatch: {a} vs {b}"
+
+
+# ── Extra: ALLOW_TEST_KEY path ────────────────────────────────────────────────
+
+def test_benc_allow_test_key_enables_empty_key(allow_test_key):
+    svc = BiometricEncryptionService()
+    ct, iv = svc.encrypt(b"test data")
+    assert svc.decrypt(ct, iv) == b"test data"

--- a/tests/biometric/test_liveness_service.py
+++ b/tests/biometric/test_liveness_service.py
@@ -169,17 +169,26 @@ def test_bcls08_duplicate_submission_raises_409(db, student_user, biometric_feat
     assert exc.value.status_code == 409
 
 
-# ── BCLS-09 — embedding placeholder log, no Celery task ──────────────────────
+# ── BCLS-09 — Celery generate task dispatched (PR-4) ─────────────────────────
 
-def test_bcls09_embedding_placeholder_logged(db, student_user, biometric_feature_enabled, caplog):
+def test_bcls09_celery_generate_task_dispatched(db, student_user, biometric_feature_enabled, caplog):
+    """
+    PR-4: liveness_service dispatches biometric_generate_embedding_task via apply_async.
+    Replaces the PR-2/3 placeholder log message test.
+    """
+    from unittest.mock import patch
     _grant_consent(db, student_user)
-    with caplog.at_level(logging.INFO, logger="app.services.biometric.liveness_service"):
+
+    with patch(
+        "app.tasks.biometric_tasks.biometric_generate_embedding_task.apply_async"
+    ) as mock_dispatch, caplog.at_level(logging.INFO, logger="app.services.biometric.liveness_service"):
         submit_liveness_result(
             db=db, user=student_user, liveness_metadata=_VALID_METADATA,
             source="onboarding_liveness", photo_filename=None,
         )
-    assert "biometric_embedding_generation_pending" in caplog.text
-    assert "PR-4" in caplog.text
+
+    mock_dispatch.assert_called_once()
+    assert "dispatched" in caplog.text
 
 
 # ── BCLS-10 — db.flush() called ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `BiometricEncryptionService` — AES-256-GCM encrypt/decrypt, per-row random IV, key validation
- `FakeEmbeddingProvider` — deterministic 512-dim unit vector, **no onnxruntime, no InsightFace**
- `store_embedding()` / `delete_embedding()` — encrypt + INSERT/UPSERT; `is_active=False` (approval gate PR-6)
- `biometric_generate_embedding_task` — Celery, `biometric_embeddings` queue, max_retries=3, expo backoff
- `biometric_delete_embedding_task` — ETA-scheduled physical deletion, max_retries=5
- `liveness_service` placeholder log → real `apply_async(countdown=5)`
- `consent_service` deletion placeholder → real `apply_async(eta=delete_after)`
- 39 new tests: BENC-01..11, BES-01..14, BBT-01..14; 13 106 total PASS

## Scope confirmations (all CLEAN)

- No onnxruntime / InsightFace import (AST-verified by BBT-12 + BES-04)
- No iOS / Swift changes
- No valódi face matching
- No face_match_score in any response or return value
- No raw image bytes / embedding plaintext in any log
- No Alembic migration (user_face_embeddings table exists from PR-1)
- No route count change (878 unchanged)
- `BIOMETRIC_FACE_MATCHING_ENABLED=false` remains default
- `is_active=False` on stored embeddings — approval gate deferred to PR-6

## Production / legal blockers (unchanged)

- DPIA / GDPR Art. 35 — DPO approval PENDING
- `BIOMETRIC_EMBEDDING_KEY` production beállítása szükséges
- `BIOMETRIC_FACE_MATCHING_ENABLED=true` — all gates required before enabling
- Bias/fairness audit — PENDING (relevant when ONNX added in PR-5)

Not KYC. Not production-ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)