### PR TITLE
docs(biometric): update status headers — ACCEPTED FOR ENGINEERING

### DIFF
--- a/docs/biometric/ARCHITECTURE_EMBEDDING_PLAN.md
+++ b/docs/biometric/ARCHITECTURE_EMBEDDING_PLAN.md
@@ -1,7 +1,9 @@
 # Embedding Generálás — Architekturális Terv (PR-4+ scope)
 
-> **Státusz:** TERV — implementáció PR-4-ban kezdődik.
-> Jelen dokumentum tervező jellegű; semmiféle kód nincs még implementálva.
+> **Engineering/Product státusz:** ✅ ACCEPTED FOR ENGINEERING (Zoltán + ChatGPT szakmai review, 2026-06-10)
+> **Legal/DPO státusz:** ⏳ LEGAL/DPO REVIEW ONLY IF PRODUCTION ACTIVATION — not required for development phases
+> **Production aktiválás:** ⛔ NOT PRODUCTION ACTIVE — architekturális terv, `BIOMETRIC_FACE_MATCHING_ENABLED=false`
+> **Implementációs státusz:** PR-4 MERGED (AES-256-GCM + FakeEmbeddingProvider + Celery tasks). PR-5 (ONNX) tervező fázisban.
 
 ---
 

--- a/docs/biometric/DPIA_TEMPLATE.md
+++ b/docs/biometric/DPIA_TEMPLATE.md
@@ -1,12 +1,15 @@
 # DPIA — Biometrikus Arcfelismerés (LFA Practice Booking System)
 ## Data Protection Impact Assessment — GDPR Art. 35 sablon
 
-> **Státusz:** VÁZLAT — jogi/adatvédelmi szakértői jóváhagyás szükséges a produkció előtt.
-> **Verziószám:** v0.1-draft
-> **Utolsó módosítás:** 2026-06-09
+> **Engineering/Product státusz:** ✅ ACCEPTED FOR ENGINEERING (Zoltán + ChatGPT szakmai review, 2026-06-10)
+> **Legal/DPO státusz:** ⏳ FINAL SIGN-OFF PENDING BEFORE PRODUCTION ACTIVATION — not required for development phases
+> **Production aktiválás:** ⛔ NOT PRODUCTION ACTIVE — `BIOMETRIC_FACE_MATCHING_ENABLED=false`
+> **Verziószám:** v0.2-engineering-accepted
+> **Utolsó módosítás:** 2026-06-10
 > **Elkészítette:** Engineering team (technikai rész)
-> **Jóváhagyja:** [Adatvédelmi felelős / DPO neve] — PENDING
-> **Jogtanácsosi jóváhagyás:** PENDING
+> **Megjegyzés:** Ez a dokumentum engineering/product szinten elfogadott fejlesztési referencia.
+>   Külső DPO/jogtanácsosi aláírás NEM történt meg. Production aktiváláshoz külön legal/DPO
+>   final sign-off szükséges (lásd PRODUCTION_ACTIVATION_CHECKLIST.md Gate 1).
 
 ---
 

--- a/docs/biometric/PR4_PLAN.md
+++ b/docs/biometric/PR4_PLAN.md
@@ -1,10 +1,12 @@
 # PR-4 Részletes Terv — Biometric Embedding Generálás + Celery Architecture
 ## feat/biometric-pr4-embedding-celery
 
-> **Státusz:** TERV — implementáció csak jóváhagyás után.
-> **Base:** main (HEAD: 9c03a4e5 — PR-3 merged)
-> **Előfeltétel:** PR #268 merged ✓
-> **Nem KYC. Nem production-ready. DPIA/DPO jóváhagyás pending.**
+> **Engineering/Product státusz:** ✅ ACCEPTED FOR ENGINEERING (Zoltán + ChatGPT szakmai review, 2026-06-10)
+> **Legal/DPO státusz:** ⏳ LEGAL/DPO NOT REQUIRED FOR IMPLEMENTATION — pending only before production activation
+> **Production aktiválás:** ⛔ NOT PRODUCTION ACTIVE — `BIOMETRIC_FACE_MATCHING_ENABLED=false`
+> **Implementációs státusz:** ✅ IMPLEMENTED & MERGED — PR #271, merge commit c8f9d077, main HEAD c8f9d0770a
+> **Base:** main (HEAD: 9c03a4e5 — PR-3 merged → implementálva PR-4-ben)
+> **Nem KYC. Production aktiváláshoz külön legal/DPO gate szükséges.**
 
 ---
 

--- a/docs/biometric/PRODUCTION_ACTIVATION_CHECKLIST.md
+++ b/docs/biometric/PRODUCTION_ACTIVATION_CHECKLIST.md
@@ -1,10 +1,12 @@
 # Biometric Feature — Production Activation Checklist
 ## BIOMETRIC_FACE_MATCHING_ENABLED: false → true
 
-> **Jelen állapot:** `BIOMETRIC_FACE_MATCHING_ENABLED=false` (production locked)
-> **Utolsó felülvizsgálat:** 2026-06-09
+> **Engineering/Product státusz:** ✅ ACCEPTED FOR ENGINEERING (Zoltán + ChatGPT szakmai review, 2026-06-10)
+> **Legal/DPO státusz:** ⏳ FINAL APPROVAL PENDING BEFORE PRODUCTION — not required for development phases
+> **Production aktiválás:** ⛔ NOT PRODUCTION ACTIVE — `BIOMETRIC_FACE_MATCHING_ENABLED=false` locked
+> **Utolsó felülvizsgálat:** 2026-06-10
 > Ez a dokumentum az egyetlen jóváhagyott útvonal a feature production engedélyezéshez.
-> Minden sor letickelhető állapotban kell legyen, ÉS írásos approval gate szükséges.
+> Minden sor letickelhető állapotban kell legyen, ÉS írásos approval gate szükséges (Gate 1 legal/DPO).
 
 ---
 


### PR DESCRIPTION
## Summary

Updates status headers in all four biometric docs to clearly separate:
- **Engineering/Product acceptance** (Zoltán + ChatGPT review, 2026-06-10): ✅ ACCEPTED
- **Legal/DPO final sign-off**: pending before production activation only
- **Production activation**: ⛔ NOT ACTIVE — `BIOMETRIC_FACE_MATCHING_ENABLED=false`

## Changed files (4, docs only)

- `docs/biometric/DPIA_TEMPLATE.md` — v0.2-engineering-accepted
- `docs/biometric/PRODUCTION_ACTIVATION_CHECKLIST.md` — status header updated
- `docs/biometric/ARCHITECTURE_EMBEDDING_PLAN.md` — PR-4 merged status added
- `docs/biometric/PR4_PLAN.md` — IMPLEMENTED & MERGED status added

## No code changes

Zero implementation files, zero test files, zero config changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)