### PR TITLE
feat(ios): PR-iOS-1 — biometric client integration (disclosure, liveness, verify)

### DIFF
--- a/ios/LFAEducationCenter.xcodeproj/project.pbxproj
+++ b/ios/LFAEducationCenter.xcodeproj/project.pbxproj
@@ -80,6 +80,14 @@
 		BB00000400000000000006E /* AcademyIDColorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000300000000000006E /* AcademyIDColorViewModel.swift */; };
 		BB00000400000000000006F /* AcademyIDColorPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000300000000000006F /* AcademyIDColorPickerView.swift */; };
 		BB000004000000000000071 /* AcademyIDCardPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000070 /* AcademyIDCardPreviewView.swift */; };
+		BB000004000000000000073 /* BiometricModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000073 /* BiometricModels.swift */; };
+		BB000004000000000000074 /* BiometricService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000074 /* BiometricService.swift */; };
+		BB000004000000000000075 /* BiometricDisclosureViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000075 /* BiometricDisclosureViewModel.swift */; };
+		BB000004000000000000076 /* BiometricDisclosureView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000076 /* BiometricDisclosureView.swift */; };
+		BB000004000000000000077 /* BiometricLivenessViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000077 /* BiometricLivenessViewModel.swift */; };
+		BB000004000000000000078 /* BiometricLivenessView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000078 /* BiometricLivenessView.swift */; };
+		BB000004000000000000079 /* BiometricVerifyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000079 /* BiometricVerifyViewModel.swift */; };
+		BB00000400000000000007A /* BiometricVerifyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000300000000000007A /* BiometricVerifyView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -158,6 +166,14 @@
 		BB00000300000000000006E /* AcademyIDColorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcademyIDColorViewModel.swift; sourceTree = "<group>"; };
 		BB00000300000000000006F /* AcademyIDColorPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcademyIDColorPickerView.swift; sourceTree = "<group>"; };
 		BB000003000000000000070 /* AcademyIDCardPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcademyIDCardPreviewView.swift; sourceTree = "<group>"; };
+		BB000003000000000000073 /* BiometricModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricModels.swift; sourceTree = "<group>"; };
+		BB000003000000000000074 /* BiometricService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricService.swift; sourceTree = "<group>"; };
+		BB000003000000000000075 /* BiometricDisclosureViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricDisclosureViewModel.swift; sourceTree = "<group>"; };
+		BB000003000000000000076 /* BiometricDisclosureView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricDisclosureView.swift; sourceTree = "<group>"; };
+		BB000003000000000000077 /* BiometricLivenessViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricLivenessViewModel.swift; sourceTree = "<group>"; };
+		BB000003000000000000078 /* BiometricLivenessView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricLivenessView.swift; sourceTree = "<group>"; };
+		BB000003000000000000079 /* BiometricVerifyViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricVerifyViewModel.swift; sourceTree = "<group>"; };
+		BB00000300000000000007A /* BiometricVerifyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricVerifyView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -204,6 +220,7 @@
 				BB000002000000000000015 /* Profile */,
 				BB000002000000000000016 /* Unlock */,
 				BB000002000000000000017 /* Onboarding */,
+				BB000002000000000000018 /* Biometric */,
 				BB000003000000000000004 /* Assets.xcassets */,
 			);
 			path = LFAEducationCenter;
@@ -380,6 +397,21 @@
 			path = Onboarding;
 			sourceTree = "<group>";
 		};
+		BB000002000000000000018 /* Biometric */ = {
+			isa = PBXGroup;
+			children = (
+				BB000003000000000000073 /* BiometricModels.swift */,
+				BB000003000000000000074 /* BiometricService.swift */,
+				BB000003000000000000075 /* BiometricDisclosureViewModel.swift */,
+				BB000003000000000000076 /* BiometricDisclosureView.swift */,
+				BB000003000000000000077 /* BiometricLivenessViewModel.swift */,
+				BB000003000000000000078 /* BiometricLivenessView.swift */,
+				BB000003000000000000079 /* BiometricVerifyViewModel.swift */,
+				BB00000300000000000007A /* BiometricVerifyView.swift */,
+			);
+			path = Biometric;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -521,6 +553,14 @@
 				BB00000400000000000006E /* AcademyIDColorViewModel.swift in Sources */,
 				BB00000400000000000006F /* AcademyIDColorPickerView.swift in Sources */,
 				BB000004000000000000071 /* AcademyIDCardPreviewView.swift in Sources */,
+				BB000004000000000000073 /* BiometricModels.swift in Sources */,
+				BB000004000000000000074 /* BiometricService.swift in Sources */,
+				BB000004000000000000075 /* BiometricDisclosureViewModel.swift in Sources */,
+				BB000004000000000000076 /* BiometricDisclosureView.swift in Sources */,
+				BB000004000000000000077 /* BiometricLivenessViewModel.swift in Sources */,
+				BB000004000000000000078 /* BiometricLivenessView.swift in Sources */,
+				BB000004000000000000079 /* BiometricVerifyViewModel.swift in Sources */,
+				BB00000400000000000007A /* BiometricVerifyView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/LFAEducationCenter/Biometric/BiometricDisclosureView.swift
+++ b/ios/LFAEducationCenter/Biometric/BiometricDisclosureView.swift
@@ -43,9 +43,9 @@ struct BiometricDisclosureView: View {
                 .environmentObject(authManager)
             }
         }
-        .task { await vm.load() }
         .onAppear {
             vm.onReadyForLiveness = { showLiveness = true }
+            Task { await vm.load() }
         }
     }
 

--- a/ios/LFAEducationCenter/Biometric/BiometricDisclosureView.swift
+++ b/ios/LFAEducationCenter/Biometric/BiometricDisclosureView.swift
@@ -1,0 +1,264 @@
+import SwiftUI
+
+// Disclosure + consent flow — two sequential steps gated by backend flags.
+//
+// Disclosure text is a dev/test placeholder (v1.0).
+// Legal review of the final Hungarian disclosure text is required before production use.
+// The disclosureVersion sent to the backend is "v1.0" (kBiometricDisclosureVersion).
+struct BiometricDisclosureView: View {
+
+    @EnvironmentObject private var authManager: AuthManager
+    @StateObject private var vm: BiometricDisclosureViewModel
+
+    @State private var showLiveness = false
+    private let onDismiss: () -> Void
+
+    init(service: BiometricService, onDismiss: @escaping () -> Void) {
+        _vm = StateObject(wrappedValue: BiometricDisclosureViewModel(service: service))
+        self.onDismiss = onDismiss
+    }
+
+    var body: some View {
+        NavigationView {
+            ZStack {
+                Color(UIColor.systemBackground).ignoresSafeArea()
+                content
+                if vm.isLoading { loadingOverlay }
+            }
+            .navigationTitle(navigationTitle)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar { closeButton }
+            .alert(item: $vm.error) { err in
+                Alert(
+                    title: Text("Hiba"),
+                    message: Text(err.userFacingMessage),
+                    dismissButton: .default(Text("OK"))
+                )
+            }
+            .fullScreenCover(isPresented: $showLiveness) {
+                BiometricLivenessView(
+                    service: makeService(),
+                    onDismiss: { showLiveness = false }
+                )
+                .environmentObject(authManager)
+            }
+        }
+        .task { await vm.load() }
+        .onAppear {
+            vm.onReadyForLiveness = { showLiveness = true }
+        }
+    }
+
+    // MARK: — Phase rendering
+
+    @ViewBuilder
+    private var content: some View {
+        switch vm.phase {
+        case .loading:
+            ProgressView()
+        case .unavailable(let message):
+            unavailableView(message: message)
+        case .disclosure:
+            disclosureStep
+        case .consent:
+            consentStep
+        case .done:
+            doneView
+        }
+    }
+
+    // MARK: — Disclosure step
+
+    private var disclosureStep: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Theme.Spacing.lg) {
+                Text("Biometrikus Tájékoztató")
+                    .font(.system(size: Theme.FontSize.title3, weight: .bold))
+                    .foregroundColor(Theme.Color.onSurface)
+
+                // DEV/TEST PLACEHOLDER — not legally approved production text.
+                // Legal review of the Hungarian disclosure is required before production.
+                Text(disclosureBodyText)
+                    .font(.system(size: Theme.FontSize.body))
+                    .foregroundColor(Theme.Color.onSurface)
+                    .lineSpacing(4)
+
+                Text("Verzió: \(kBiometricDisclosureVersion)")
+                    .font(.system(size: Theme.FontSize.caption))
+                    .foregroundColor(Theme.Color.muted)
+
+                actionButton(
+                    label: "Elfogadom",
+                    color: Theme.Color.primary
+                ) { await vm.acceptDisclosure() }
+
+                Button(action: onDismiss) {
+                    Text("Elutasítom / Később")
+                        .font(.system(size: Theme.FontSize.body))
+                        .foregroundColor(Theme.Color.muted)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, Theme.Spacing.sm)
+                }
+            }
+            .padding(Theme.Spacing.md)
+        }
+    }
+
+    // DEV/TEST placeholder disclosure text.
+    // This is NOT the legally reviewed final text.
+    // Legal sign-off is required before this text can be used in production.
+    private var disclosureBodyText: String {
+        """
+        Az LFA Football Academy biometrikus arcfelismerési rendszert alkalmaz az \
+        edzéslátogatás és az Academy ID azonosítás ellenőrzéséhez.
+
+        Az arcfelismerési adatokat (arc-embedding vektort) titkosítva tároljuk. \
+        Ezek az adatok kizárólag belső azonosítási célra kerülnek felhasználásra, \
+        és a GDPR 9. cikke szerinti különleges kategóriájú személyes adatnak minősülnek.
+
+        A hozzájárulás bármikor visszavonható a Profil → Biometrikus beállítások menüben. \
+        Visszavonás esetén az arc-embedding adatot 30 napon belül töröljük.
+
+        Ez a tájékoztató fejlesztői/tesztkörnyezetre vonatkozik. \
+        A végleges jogi szöveg külön jóváhagyás tárgyát képezi.
+        """
+    }
+
+    // MARK: — Consent step
+
+    private var consentStep: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Theme.Spacing.lg) {
+                Text("Biometrikus Hozzájárulás")
+                    .font(.system(size: Theme.FontSize.title3, weight: .bold))
+                    .foregroundColor(Theme.Color.onSurface)
+
+                Text(
+                    "A tájékoztatót elfogadtad. A biometrikus ellenőrzés aktiválásához " +
+                    "szükséges az explicit GDPR Art. 9(2)(a) szerinti hozzájárulás megadása is."
+                )
+                .font(.system(size: Theme.FontSize.body))
+                .foregroundColor(Theme.Color.onSurface)
+                .lineSpacing(4)
+
+                Text("Hozzájárulás verziója: \(kBiometricConsentVersion)")
+                    .font(.system(size: Theme.FontSize.caption))
+                    .foregroundColor(Theme.Color.muted)
+
+                actionButton(
+                    label: "Hozzájárulok",
+                    color: Theme.Color.primary
+                ) { await vm.grantConsent() }
+
+                Button(action: onDismiss) {
+                    Text("Mégsem")
+                        .font(.system(size: Theme.FontSize.body))
+                        .foregroundColor(Theme.Color.muted)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, Theme.Spacing.sm)
+                }
+            }
+            .padding(Theme.Spacing.md)
+        }
+    }
+
+    // MARK: — Done
+
+    private var doneView: some View {
+        VStack(spacing: Theme.Spacing.lg) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 64))
+                .foregroundColor(Theme.Color.primary)
+            Text("Tájékoztató és hozzájárulás elfogadva.")
+                .font(.system(size: Theme.FontSize.title3, weight: .semibold))
+                .foregroundColor(Theme.Color.onSurface)
+                .multilineTextAlignment(.center)
+
+            actionButton(label: "Folytatás a liveness teszthez", color: Theme.Color.primary) {
+                showLiveness = true
+            }
+            Button(action: onDismiss) {
+                Text("Bezárás")
+                    .font(.system(size: Theme.FontSize.body))
+                    .foregroundColor(Theme.Color.muted)
+            }
+        }
+        .padding(Theme.Spacing.md)
+    }
+
+    // MARK: — Unavailable
+
+    private func unavailableView(message: String) -> some View {
+        VStack(spacing: Theme.Spacing.lg) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 48))
+                .foregroundColor(Theme.Color.warning)
+            Text(message)
+                .font(.system(size: Theme.FontSize.body))
+                .foregroundColor(Theme.Color.onSurface)
+                .multilineTextAlignment(.center)
+            Button(action: onDismiss) {
+                Text("Bezárás")
+                    .font(.system(size: Theme.FontSize.body))
+                    .foregroundColor(Theme.Color.muted)
+            }
+        }
+        .padding(Theme.Spacing.md)
+    }
+
+    // MARK: — Helpers
+
+    private var navigationTitle: String {
+        switch vm.phase {
+        case .loading, .unavailable: return "Biometrikus"
+        case .disclosure:            return "Tájékoztató"
+        case .consent:               return "Hozzájárulás"
+        case .done:                  return "Kész"
+        }
+    }
+
+    private var closeButton: some ToolbarContent {
+        ToolbarItem(placement: .navigationBarLeading) {
+            Button(action: onDismiss) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(Theme.Color.onSurface)
+            }
+        }
+    }
+
+    private var loadingOverlay: some View {
+        Color.black.opacity(0.15)
+            .ignoresSafeArea()
+            .overlay(ProgressView())
+    }
+
+    @ViewBuilder
+    private func actionButton(
+        label: String,
+        color: Color,
+        action: @escaping () async -> Void
+    ) -> some View {
+        Button {
+            Task { await action() }
+        } label: {
+            Text(label)
+                .font(.system(size: Theme.FontSize.body, weight: .semibold))
+                .foregroundColor(.white)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, Theme.Spacing.sm)
+                .background(color)
+                .cornerRadius(Theme.Radius.sm)
+        }
+        .disabled(vm.isLoading)
+    }
+
+    private func makeService() -> BiometricService {
+        BiometricService(auth: authManager)
+    }
+}
+
+// BiometricClientError conformance for .alert(item:)
+extension BiometricClientError: Identifiable {
+    var id: String { userFacingMessage }
+}

--- a/ios/LFAEducationCenter/Biometric/BiometricDisclosureViewModel.swift
+++ b/ios/LFAEducationCenter/Biometric/BiometricDisclosureViewModel.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+@MainActor
+final class BiometricDisclosureViewModel: ObservableObject {
+
+    enum Phase {
+        case loading
+        case unavailable(String)   // feature flag off or blocking error
+        case disclosure            // user must accept tájékoztató
+        case consent               // disclosure done, consent still needed
+        case done                  // both active — ready for liveness
+    }
+
+    @Published private(set) var phase:             Phase = .loading
+    @Published private(set) var isLoading:         Bool  = false
+    @Published              var error:             BiometricClientError?
+
+    // Fired when the user completes both steps — parent view advances to liveness.
+    var onReadyForLiveness: (() -> Void)?
+
+    private let service: BiometricService
+
+    init(service: BiometricService) {
+        self.service = service
+    }
+
+    // MARK: — Load
+
+    func load() async {
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            let disclosure = try await service.getDisclosureStatus()
+            if disclosure.isActive {
+                let consent = try await service.getConsentStatus()
+                phase = consent.isActive ? .done : .consent
+            } else {
+                phase = .disclosure
+            }
+        } catch BiometricClientError.featureDisabled,
+                BiometricClientError.rateLimiterUnavailable {
+            phase = .unavailable("A biometrikus ellenőrzés jelenleg nem elérhető.")
+        } catch BiometricClientError.parentalConsentRequired {
+            phase = .unavailable("A biometrikus ellenőrzés 18 éves kor felett érhető el.")
+        } catch let e as BiometricClientError {
+            error = e
+        } catch {
+            self.error = .networkError(error)
+        }
+    }
+
+    // MARK: — Disclosure
+
+    func acceptDisclosure() async {
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            _ = try await service.acceptDisclosure()
+            let consent = try await service.getConsentStatus()
+            phase = consent.isActive ? .done : .consent
+        } catch BiometricClientError.disclosureAlreadyAccepted {
+            // Already accepted — advance to consent step.
+            phase = .consent
+        } catch BiometricClientError.parentalConsentRequired {
+            phase = .unavailable("A biometrikus ellenőrzés 18 éves kor felett érhető el.")
+        } catch let e as BiometricClientError {
+            error = e
+        } catch {
+            self.error = .networkError(error)
+        }
+    }
+
+    // MARK: — Consent
+
+    func grantConsent() async {
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            _ = try await service.grantConsent()
+            phase = .done
+            onReadyForLiveness?()
+        } catch BiometricClientError.consentAlreadyActive {
+            phase = .done
+            onReadyForLiveness?()
+        } catch let e as BiometricClientError {
+            error = e
+        } catch {
+            self.error = .networkError(error)
+        }
+    }
+}

--- a/ios/LFAEducationCenter/Biometric/BiometricLivenessView.swift
+++ b/ios/LFAEducationCenter/Biometric/BiometricLivenessView.swift
@@ -1,0 +1,211 @@
+import SwiftUI
+import AVFoundation
+
+// Liveness challenge UI.
+//
+// DEV/TEST MVP — manual step advancement, no automatic head-position detection.
+// The user manually taps through CENTER→LEFT→CENTER→RIGHT→CENTER steps,
+// then CameraImagePicker captures a still photo for the CAPTURE step.
+//
+// Anti-spoofing note: manual step advancement provides NO liveness guarantee.
+// Automatic Vision/MediaPipe-based head-turn detection is a separate future PR.
+// This view is suitable only for dev/test environments.
+//
+// CameraManager reuse: CameraPreview (AVCaptureSession) is reused from Skeleton module.
+// detector is set to nil — no BodyPoseDetector is attached in liveness flow.
+struct BiometricLivenessView: View {
+
+    @EnvironmentObject private var authManager: AuthManager
+    @StateObject private var cameraManager = CameraManager()
+    @StateObject private var vm: BiometricLivenessViewModel
+
+    @State private var showCapturePicker = false
+    @State private var navigateToVerify  = false
+    @State private var photoFilenameForVerify: String?
+
+    private let onDismiss: () -> Void
+
+    init(service: BiometricService, onDismiss: @escaping () -> Void) {
+        _vm = StateObject(wrappedValue: BiometricLivenessViewModel(service: service))
+        self.onDismiss = onDismiss
+    }
+
+    var body: some View {
+        NavigationView {
+            ZStack(alignment: .bottom) {
+                cameraLayer
+                overlayLayer
+                if vm.isLoading { loadingOverlay }
+            }
+            .ignoresSafeArea(edges: .bottom)
+            .navigationTitle("Liveness Teszt")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar { closeButton }
+            .alert(item: $vm.error) { err in
+                Alert(
+                    title: Text("Hiba"),
+                    message: Text(err.userFacingMessage),
+                    primaryButton: .default(Text("Újra")) { vm.retry() },
+                    secondaryButton: .cancel(Text("Mégse"), action: onDismiss)
+                )
+            }
+            .sheet(isPresented: $showCapturePicker) {
+                CameraImagePicker { image in
+                    showCapturePicker = false
+                    if let image = image { vm.onPhotoCaptured(image) }
+                }
+            }
+            .background(
+                NavigationLink(
+                    destination: BiometricVerifyView(
+                        service: BiometricService(auth: authManager),
+                        photoFilename: photoFilenameForVerify,
+                        onDismiss: onDismiss
+                    )
+                    .environmentObject(authManager),
+                    isActive: $navigateToVerify
+                ) { EmptyView() }
+                .hidden()
+            )
+        }
+        .onAppear {
+            cameraManager.requestPermissionAndStart()
+            vm.start()
+            vm.onLivenessComplete = { filename in
+                photoFilenameForVerify = filename
+                navigateToVerify = true
+            }
+        }
+        .onDisappear { cameraManager.stop() }
+    }
+
+    // MARK: — Camera
+
+    @ViewBuilder
+    private var cameraLayer: some View {
+        if cameraManager.authDenied {
+            cameraPermissionDeniedView
+        } else {
+            CameraPreview(session: cameraManager.session)
+                .ignoresSafeArea()
+        }
+    }
+
+    private var cameraPermissionDeniedView: some View {
+        VStack(spacing: Theme.Spacing.lg) {
+            Image(systemName: "camera.slash.fill")
+                .font(.system(size: 48))
+                .foregroundColor(Theme.Color.warning)
+            Text("Kamera hozzáférés szükséges.")
+                .font(.system(size: Theme.FontSize.body, weight: .semibold))
+                .foregroundColor(Theme.Color.onSurface)
+                .multilineTextAlignment(.center)
+            Text("Engedélyezd a kamera hozzáférést a Beállításokban.")
+                .font(.system(size: Theme.FontSize.body))
+                .foregroundColor(Theme.Color.muted)
+                .multilineTextAlignment(.center)
+            Button("Beállítások megnyitása") {
+                if let url = URL(string: UIApplication.openSettingsURLString) {
+                    UIApplication.shared.open(url)
+                }
+            }
+            .foregroundColor(Theme.Color.primary)
+        }
+        .padding(Theme.Spacing.md)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Theme.Color.background)
+    }
+
+    // MARK: — Overlay
+
+    private var overlayLayer: some View {
+        VStack(spacing: Theme.Spacing.md) {
+            progressBar
+            instructionCard
+            actionButton
+        }
+        .padding(Theme.Spacing.md)
+        .padding(.bottom, Theme.Spacing.xl)
+    }
+
+    private var progressBar: some View {
+        VStack(spacing: Theme.Spacing.xs) {
+            Text("\(vm.currentStepIndex + 1) / \(vm.totalSteps)")
+                .font(.system(size: Theme.FontSize.caption, weight: .semibold))
+                .foregroundColor(.white)
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(Color.white.opacity(0.3))
+                        .frame(height: 6)
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(Color.white)
+                        .frame(
+                            width: geo.size.width * CGFloat(vm.currentStepIndex + 1) / CGFloat(vm.totalSteps),
+                            height: 6
+                        )
+                        .animation(.easeInOut(duration: 0.25), value: vm.currentStepIndex)
+                }
+            }
+            .frame(height: 6)
+        }
+    }
+
+    private var instructionCard: some View {
+        Text(vm.currentStep.instruction)
+            .font(.system(size: Theme.FontSize.title3, weight: .bold))
+            .foregroundColor(.white)
+            .multilineTextAlignment(.center)
+            .padding(Theme.Spacing.md)
+            .frame(maxWidth: .infinity)
+            .background(Color.black.opacity(0.55))
+            .cornerRadius(Theme.Radius.md)
+    }
+
+    @ViewBuilder
+    private var actionButton: some View {
+        if vm.currentStep.isCapture {
+            Button {
+                showCapturePicker = true
+            } label: {
+                Label("Kép rögzítése", systemImage: "camera.fill")
+                    .font(.system(size: Theme.FontSize.body, weight: .semibold))
+                    .foregroundColor(.black)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, Theme.Spacing.sm)
+                    .background(Color.white)
+                    .cornerRadius(Theme.Radius.sm)
+            }
+            .disabled(vm.isLoading)
+        } else {
+            Button {
+                vm.advanceStep()
+            } label: {
+                Text("Tovább →")
+                    .font(.system(size: Theme.FontSize.body, weight: .semibold))
+                    .foregroundColor(.black)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, Theme.Spacing.sm)
+                    .background(Color.white)
+                    .cornerRadius(Theme.Radius.sm)
+            }
+            .disabled(vm.isLoading)
+        }
+    }
+
+    private var loadingOverlay: some View {
+        Color.black.opacity(0.4)
+            .ignoresSafeArea()
+            .overlay(ProgressView().tint(.white))
+    }
+
+    private var closeButton: some ToolbarContent {
+        ToolbarItem(placement: .navigationBarLeading) {
+            Button(action: onDismiss) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(Theme.Color.onSurface)
+            }
+        }
+    }
+}

--- a/ios/LFAEducationCenter/Biometric/BiometricLivenessView.swift
+++ b/ios/LFAEducationCenter/Biometric/BiometricLivenessView.swift
@@ -196,7 +196,7 @@ struct BiometricLivenessView: View {
     private var loadingOverlay: some View {
         Color.black.opacity(0.4)
             .ignoresSafeArea()
-            .overlay(ProgressView().tint(.white))
+            .overlay(ProgressView().accentColor(.white))
     }
 
     private var closeButton: some ToolbarContent {

--- a/ios/LFAEducationCenter/Biometric/BiometricLivenessViewModel.swift
+++ b/ios/LFAEducationCenter/Biometric/BiometricLivenessViewModel.swift
@@ -1,0 +1,140 @@
+import Foundation
+import UIKit
+
+// Liveness challenge state machine.
+//
+// Challenge spec: CENTER → LEFT → CENTER → RIGHT → CENTER → CAPTURE (6 steps).
+// challenge_version: "v1.0" (kBiometricChallengeVersion).
+//
+// DEV/TEST MVP — manual step advancement only.
+// The user taps "Tovább" to progress through each step.
+// No automatic head-position detection is implemented in PR-iOS-1.
+// Automatic Vision/MediaPipe-based detection is out of scope and requires a separate PR.
+//
+// photo_filename: UUID-based safe basename. No JPEG bytes are transmitted.
+// The backend POST /me/biometric-liveness accepts JSON only — no multipart endpoint exists.
+// Image upload support is out of scope for PR-iOS-1.
+@MainActor
+final class BiometricLivenessViewModel: ObservableObject {
+
+    enum Step: Int, CaseIterable {
+        case center1, left, center2, right, center3, capture
+
+        var displayName: String {
+            switch self {
+            case .center1, .center2, .center3: return "CENTER"
+            case .left:                        return "LEFT"
+            case .right:                       return "RIGHT"
+            case .capture:                     return "CAPTURE"
+            }
+        }
+
+        var instruction: String {
+            switch self {
+            case .center1: return "Nézz egyenesen a kamerába"
+            case .left:    return "Fordítsd lassan a fejed BALRA"
+            case .center2: return "Fordítsd vissza a fejed EGYENESEN"
+            case .right:   return "Fordítsd lassan a fejed JOBBRA"
+            case .center3: return "Fordítsd vissza a fejed EGYENESEN"
+            case .capture: return "Maradj egyenesen — kép rögzítése"
+            }
+        }
+
+        var isCapture: Bool { self == .capture }
+    }
+
+    @Published private(set) var currentStepIndex: Int = 0
+    @Published private(set) var isLoading:         Bool = false
+    @Published private(set) var livenessResult:    BiometricVerificationStatus?
+    @Published              var error:             BiometricClientError?
+
+    // Fired on successful liveness submit — parent shows BiometricVerifyView.
+    var onLivenessComplete: ((String?) -> Void)?
+
+    private let service:     BiometricService
+    private var startedAt:   Date = Date()
+    private var retryCount:  Int  = 0
+    private var capturedFilename: String?
+
+    var currentStep: Step { Step(rawValue: currentStepIndex) ?? .center1 }
+    var totalSteps:  Int  { Step.allCases.count }
+
+    init(service: BiometricService) {
+        self.service = service
+    }
+
+    // MARK: — Step control
+
+    func start() {
+        startedAt = Date()
+        currentStepIndex = 0
+        capturedFilename = nil
+        error = nil
+    }
+
+    // Called by the "Tovább" button for non-capture steps.
+    func advanceStep() {
+        guard currentStepIndex < Step.allCases.count - 1 else { return }
+        currentStepIndex += 1
+    }
+
+    // Called by CameraImagePicker on successful photo capture.
+    // image: captured UIImage — NOT stored, NOT logged, NOT transmitted.
+    // Only a UUID-based basename is derived for the photo_filename field.
+    // No JPEG bytes are sent in PR-iOS-1.
+    func onPhotoCaptured(_ image: UIImage) {
+        // Derive safe basename — no path separators, no PII.
+        let uuid = UUID().uuidString.lowercased()
+        capturedFilename = "liveness_\(uuid).jpg"
+        // image is intentionally discarded — no storage, no log, no upload in PR-iOS-1.
+        _ = image
+        Task { await submitLiveness() }
+    }
+
+    func retry() {
+        retryCount += 1
+        currentStepIndex = 0
+        capturedFilename  = nil
+        error             = nil
+        startedAt         = Date()
+    }
+
+    // MARK: — Submit
+
+    private func submitLiveness() async {
+        isLoading = true
+        defer { isLoading = false }
+        let metadata = buildMetadata()
+        do {
+            let result = try await service.submitLiveness(
+                metadata:      metadata,
+                photoFilename: capturedFilename
+            )
+            livenessResult = result
+            onLivenessComplete?(capturedFilename)
+        } catch BiometricClientError.livenessAlreadySubmitted {
+            // Treat as success — reference already captured in a previous session.
+            onLivenessComplete?(capturedFilename)
+        } catch let e as BiometricClientError {
+            error = e
+        } catch {
+            self.error = .networkError(error)
+        }
+    }
+
+    private func buildMetadata() -> BiometricLivenessMetadata {
+        let completedSteps = Step.allCases
+            .prefix(currentStepIndex + 1)
+            .map { $0.displayName }
+        let durationMs = Int(Date().timeIntervalSince(startedAt) * 1000)
+        return BiometricLivenessMetadata(
+            challengeVersion: kBiometricChallengeVersion,
+            stepsCompleted:   completedSteps,
+            totalDurationMs:  max(0, durationMs),
+            retryCount:       retryCount,
+            failureReason:    nil
+        )
+        // Structural guarantee: yaw, roll, device_model, ios_version, landmarks, frames
+        // are absent — not collected, not included. Backend extra="forbid" enforces this.
+    }
+}

--- a/ios/LFAEducationCenter/Biometric/BiometricModels.swift
+++ b/ios/LFAEducationCenter/Biometric/BiometricModels.swift
@@ -1,0 +1,209 @@
+import Foundation
+
+// MARK: — Version constants
+
+// Must match CURRENT_BIOMETRIC_DISCLOSURE_VERSION in backend app/config.py.
+let kBiometricDisclosureVersion = "v1.0"
+let kBiometricConsentVersion    = "v1.0"
+let kBiometricChallengeVersion  = "v1.0"
+// Only accepted source value for POST /me/biometric-liveness.
+let kBiometricLivenessSource    = "onboarding_liveness"
+
+// MARK: — Request models
+
+struct BiometricDisclosureAcceptRequest: Encodable {
+    let disclosureVersion: String
+    enum CodingKeys: String, CodingKey {
+        case disclosureVersion = "disclosure_version"
+    }
+}
+
+struct BiometricConsentGrantRequest: Encodable {
+    let consentVersion: String
+    enum CodingKeys: String, CodingKey {
+        case consentVersion = "consent_version"
+    }
+}
+
+struct BiometricConsentRevokeRequest: Encodable {
+    let reason: String?
+}
+
+// Exactly 5 allowed metadata fields — backend extra="forbid" rejects anything else.
+// face_match_score, yaw, roll, device_model, ios_version, landmarks, frames: ABSENT by design.
+struct BiometricLivenessMetadata: Encodable {
+    let challengeVersion: String
+    let stepsCompleted:   [String]
+    let totalDurationMs:  Int
+    let retryCount:       Int
+    let failureReason:    String?
+
+    enum CodingKeys: String, CodingKey {
+        case challengeVersion = "challenge_version"
+        case stepsCompleted   = "steps_completed"
+        case totalDurationMs  = "total_duration_ms"
+        case retryCount       = "retry_count"
+        case failureReason    = "failure_reason"
+    }
+}
+
+// POST /me/biometric-liveness — JSON body only.
+// Backend has no image upload endpoint; photo_filename is a string basename placeholder.
+// DEV/TEST MVP: no JPEG bytes are transmitted. Image upload is out of scope for PR-iOS-1.
+struct BiometricLivenessSubmitRequest: Encodable {
+    let source:           String
+    let livenessMetadata: BiometricLivenessMetadata
+    let photoFilename:    String?
+
+    enum CodingKeys: String, CodingKey {
+        case source
+        case livenessMetadata = "liveness_metadata"
+        case photoFilename    = "photo_filename"
+    }
+}
+
+// POST /me/biometric-verify — JSON body only.
+// Backend has no image upload endpoint; photo_filename is a string basename placeholder.
+// DEV/TEST MVP: no JPEG bytes are transmitted. Image upload is out of scope for PR-iOS-1.
+struct BiometricVerifyRequestBody: Encodable {
+    let photoFilename: String?
+    enum CodingKeys: String, CodingKey {
+        case photoFilename = "photo_filename"
+    }
+}
+
+// MARK: — Response models
+
+// GET / POST / DELETE /me/biometric-disclosure
+// face_match_score: ABSENT — mirrors backend BiometricDisclosureStatusOut structural enforcement.
+struct BiometricDisclosureStatus: Decodable {
+    let hasDisclosure:   Bool
+    let isActive:        Bool
+    let acceptedVersion: String?
+    let acceptedAt:      String?
+    let revokedAt:       String?
+
+    enum CodingKeys: String, CodingKey {
+        case hasDisclosure   = "has_disclosure"
+        case isActive        = "is_active"
+        case acceptedVersion = "accepted_version"
+        case acceptedAt      = "accepted_at"
+        case revokedAt       = "revoked_at"
+    }
+}
+
+// GET / POST / DELETE /me/biometric-consent
+// face_match_score: ABSENT — mirrors backend BiometricConsentStatusOut structural enforcement.
+struct BiometricConsentStatus: Decodable {
+    let hasConsent: Bool
+    let grantedAt:  String?
+    let version:    String?
+    let revokedAt:  String?
+    let isActive:   Bool
+
+    enum CodingKeys: String, CodingKey {
+        case hasConsent = "has_consent"
+        case grantedAt  = "granted_at"
+        case version
+        case revokedAt  = "revoked_at"
+        case isActive   = "is_active"
+    }
+}
+
+// POST /me/biometric-liveness response
+// face_match_score: ABSENT — mirrors backend BiometricVerificationStatusOut.
+struct BiometricVerificationStatus: Decodable {
+    let faceMatchStatus:          String?
+    let faceReferencePhotoStatus: String?
+    let hasBiometricConsent:      Bool
+    let manualReviewRequired:     Bool
+
+    enum CodingKeys: String, CodingKey {
+        case faceMatchStatus          = "face_match_status"
+        case faceReferencePhotoStatus = "face_reference_photo_status"
+        case hasBiometricConsent      = "has_biometric_consent"
+        case manualReviewRequired     = "manual_review_required"
+    }
+}
+
+// POST /me/biometric-verify response
+// result: "verified" | "manual_review_required" | "rejected"
+// face_match_score: ABSENT — mirrors backend BiometricVerifyResponse structural enforcement.
+// face_match_score must never appear in this struct, any view, or any log — not even in debug.
+struct BiometricVerifyResult: Decodable {
+    let result: String
+    // face_match_score intentionally absent — backend Pydantic enforces this; iOS mirrors it.
+}
+
+// MARK: — Typed error
+
+// Error detail strings sourced from backend app/services/biometric/*.py and endpoints.
+// Only known backend detail values are mapped — unknown detail falls through to .unknown.
+enum BiometricClientError: Error {
+    case featureDisabled               // 503 — BIOMETRIC_*_ENABLED=false (long string detail)
+    case rateLimiterUnavailable        // 503 "biometric_rate_limiter_unavailable"
+    case rateLimited                   // 429 "rate_limited"
+    case parentalConsentRequired       // 403 "parental_consent_required"
+    case disclosureRequired            // 403 "biometric_disclosure_required"
+    case disclosureUpdateRequired      // 403 "biometric_disclosure_update_required"
+    case consentRequired               // 403 "biometric_consent_required"
+    case disclosureAlreadyAccepted     // 409 "disclosure_already_accepted"
+    case consentAlreadyActive          // 409 (consent service returns a sentence, not a key)
+    case livenessAlreadySubmitted      // 409 "onboarding_liveness_already_submitted"
+    case disclosureNotFound            // 404 "biometric_disclosure_not_found"
+    case referenceNotFound             // 404 "biometric_reference_not_found"
+    case pathTraversalRejected         // 400 "photo_filename_path_traversal"
+    case unauthorized                  // 401
+    case networkError(Error)
+    case unknown(Int, String?)
+
+    var userFacingMessage: String {
+        switch self {
+        case .featureDisabled:           return "A biometrikus ellenőrzés jelenleg nem elérhető."
+        case .rateLimiterUnavailable:    return "A biometrikus rendszer átmenetileg nem elérhető."
+        case .rateLimited:               return "Túl sok kísérlet. Kérjük, várj egy percet."
+        case .parentalConsentRequired:   return "A biometrikus ellenőrzés 18 éves kor felett érhető el."
+        case .disclosureRequired:        return "A tájékoztató elfogadása szükséges."
+        case .disclosureUpdateRequired:  return "A tájékoztató megváltozott. Kérjük, fogadd el újra."
+        case .consentRequired:           return "A hozzájárulás megadása szükséges."
+        case .disclosureAlreadyAccepted: return "A tájékoztató már el lett fogadva."
+        case .consentAlreadyActive:      return "A hozzájárulás már megadásra került."
+        case .livenessAlreadySubmitted:  return "A liveness teszt már elvégzésre került."
+        case .disclosureNotFound:        return "Nincs aktív tájékoztató visszavonni."
+        case .referenceNotFound:         return "Nincs tárolt referencia kép. Végezd el a liveness tesztet."
+        case .pathTraversalRejected:     return "Érvénytelen fájlnév."
+        case .unauthorized:              return "A munkamenet lejárt. Kérjük, jelentkezz be újra."
+        case .networkError:              return "Hálózati hiba. Ellenőrizd a kapcsolatot."
+        case .unknown(let code, let d):  return d ?? "Ismeretlen hiba (\(code))."
+        }
+    }
+
+    static func from(_ error: Error) -> BiometricClientError {
+        switch error {
+        case APIError.unauthorized:
+            return .unauthorized
+        case APIError.networkError(let e):
+            return .networkError(e)
+        case APIError.httpError(let code, let detail):
+            switch (code, detail) {
+            case (503, "biometric_rate_limiter_unavailable"): return .rateLimiterUnavailable
+            case (503, _):                                    return .featureDisabled
+            case (429, _):                                    return .rateLimited
+            case (403, "parental_consent_required"):          return .parentalConsentRequired
+            case (403, "biometric_disclosure_required"):      return .disclosureRequired
+            case (403, "biometric_disclosure_update_required"): return .disclosureUpdateRequired
+            case (403, "biometric_consent_required"):         return .consentRequired
+            case (409, "disclosure_already_accepted"):        return .disclosureAlreadyAccepted
+            case (409, "onboarding_liveness_already_submitted"): return .livenessAlreadySubmitted
+            case (409, _):                                    return .consentAlreadyActive
+            case (404, "biometric_disclosure_not_found"):     return .disclosureNotFound
+            case (404, "biometric_reference_not_found"):      return .referenceNotFound
+            case (400, "photo_filename_path_traversal"):      return .pathTraversalRejected
+            case (401, _):                                    return .unauthorized
+            default:                                          return .unknown(code, detail)
+            }
+        default:
+            return .networkError(error)
+        }
+    }
+}

--- a/ios/LFAEducationCenter/Biometric/BiometricService.swift
+++ b/ios/LFAEducationCenter/Biometric/BiometricService.swift
@@ -169,8 +169,7 @@ final class BiometricService: ObservableObject {
             throw APIError.networkError(URLError(.badServerResponse))
         }
         guard (200...299).contains(http.statusCode) else {
-            struct D: Decodable { let detail: String? }
-            let d = try? JSONDecoder().decode(D.self, from: data)
+            let d = try? JSONDecoder().decode(_BiometricDeleteErrorBody.self, from: data)
             throw APIError.httpError(statusCode: http.statusCode, detail: d?.detail)
         }
         do {
@@ -182,3 +181,7 @@ final class BiometricService: ObservableObject {
 }
 
 private struct EmptyBody: Encodable {}
+
+private struct _BiometricDeleteErrorBody: Decodable {
+    let detail: String?
+}

--- a/ios/LFAEducationCenter/Biometric/BiometricService.swift
+++ b/ios/LFAEducationCenter/Biometric/BiometricService.swift
@@ -1,0 +1,184 @@
+import Foundation
+
+// Service layer for all biometric backend endpoints.
+// All calls use AuthManager's authenticated wrappers for Bearer inject and 401 refresh retry.
+//
+// Backend contract (PR-iOS-1):
+//   POST /me/biometric-liveness: JSON body only — no image bytes, no multipart.
+//   POST /me/biometric-verify:   JSON body only — no image bytes, no multipart.
+//   photo_filename is a UUID-based string basename (dev/test placeholder only).
+//   Image upload requires a future backend multipart endpoint — out of scope here.
+//
+// Privacy rules (enforced structurally):
+//   face_match_score: no model field, no return value, no log — ever.
+//   Bearer token: not logged.
+//   user_id: not logged.
+//   Raw error body: not logged — only typed BiometricClientError is propagated.
+//
+// DELETE endpoints for disclosure and consent return 200 + JSON body (not 204).
+// AuthManager.authenticatedDeleteNoContent handles 204 only — a local wrapper handles
+// these two endpoints without modifying AuthManager.
+@MainActor
+final class BiometricService: ObservableObject {
+
+    private let auth: AuthManager
+
+    init(auth: AuthManager) {
+        self.auth = auth
+    }
+
+    // MARK: — Disclosure
+
+    func getDisclosureStatus() async throws -> BiometricDisclosureStatus {
+        do {
+            return try await auth.authenticatedGet(path: "/api/v1/users/me/biometric-disclosure")
+        } catch {
+            throw BiometricClientError.from(error)
+        }
+    }
+
+    func acceptDisclosure() async throws -> BiometricDisclosureStatus {
+        let body = BiometricDisclosureAcceptRequest(disclosureVersion: kBiometricDisclosureVersion)
+        do {
+            return try await auth.authenticatedPost(path: "/api/v1/users/me/biometric-disclosure", body: body)
+        } catch {
+            throw BiometricClientError.from(error)
+        }
+    }
+
+    func revokeDisclosure() async throws -> BiometricDisclosureStatus {
+        do {
+            return try await deleteWithBody(path: "/api/v1/users/me/biometric-disclosure")
+        } catch {
+            throw BiometricClientError.from(error)
+        }
+    }
+
+    // MARK: — Consent
+
+    func getConsentStatus() async throws -> BiometricConsentStatus {
+        do {
+            return try await auth.authenticatedGet(path: "/api/v1/users/me/biometric-consent")
+        } catch {
+            throw BiometricClientError.from(error)
+        }
+    }
+
+    func grantConsent() async throws -> BiometricConsentStatus {
+        let body = BiometricConsentGrantRequest(consentVersion: kBiometricConsentVersion)
+        do {
+            return try await auth.authenticatedPost(path: "/api/v1/users/me/biometric-consent", body: body)
+        } catch {
+            throw BiometricClientError.from(error)
+        }
+    }
+
+    func revokeConsent(reason: String? = nil) async throws -> BiometricConsentStatus {
+        let body = BiometricConsentRevokeRequest(reason: reason)
+        do {
+            return try await deleteWithBody(path: "/api/v1/users/me/biometric-consent", body: body)
+        } catch {
+            throw BiometricClientError.from(error)
+        }
+    }
+
+    // MARK: — Liveness
+
+    // Submits completed liveness challenge result.
+    // photo_filename: safe UUID basename, e.g. "liveness_<uuid>.jpg".
+    // No image bytes are sent — JSON body only. Image upload is out of scope for PR-iOS-1.
+    func submitLiveness(
+        metadata: BiometricLivenessMetadata,
+        photoFilename: String?
+    ) async throws -> BiometricVerificationStatus {
+        let body = BiometricLivenessSubmitRequest(
+            source:           kBiometricLivenessSource,
+            livenessMetadata: metadata,
+            photoFilename:    photoFilename
+        )
+        do {
+            return try await auth.authenticatedPost(
+                path: "/api/v1/users/me/biometric-liveness",
+                body: body
+            )
+        } catch {
+            throw BiometricClientError.from(error)
+        }
+    }
+
+    // MARK: — Verify
+
+    // Submits face verify request.
+    // photo_filename: safe UUID basename, e.g. "verify_<uuid>.jpg".
+    // No image bytes are sent — JSON body only. Image upload is out of scope for PR-iOS-1.
+    func verify(photoFilename: String?) async throws -> BiometricVerifyResult {
+        let body = BiometricVerifyRequestBody(photoFilename: photoFilename)
+        do {
+            return try await auth.authenticatedPost(
+                path: "/api/v1/users/me/biometric-verify",
+                body: body
+            )
+        } catch {
+            throw BiometricClientError.from(error)
+        }
+    }
+
+    // MARK: — Private: DELETE + JSON response
+
+    // The disclosure and consent DELETE endpoints return 200 + JSON body.
+    // AuthManager.authenticatedDeleteNoContent expects 204 only, so we use a local
+    // single-attempt DELETE wrapper. On 401 the caller gets .unauthorized — acceptable
+    // for dev/test MVP without modifying AuthManager.
+    private func deleteWithBody<T: Decodable>(path: String) async throws -> T {
+        guard let token = auth.accessToken else { throw APIError.unauthorized }
+        return try await performDelete(path: path, body: Optional<EmptyBody>.none, token: token)
+    }
+
+    private func deleteWithBody<B: Encodable, T: Decodable>(
+        path: String, body: B
+    ) async throws -> T {
+        guard let token = auth.accessToken else { throw APIError.unauthorized }
+        return try await performDelete(path: path, body: body, token: token)
+    }
+
+    private func performDelete<B: Encodable, T: Decodable>(
+        path: String, body: B?, token: String
+    ) async throws -> T {
+        guard let url = URL(string: APIConfig.baseURL + path) else {
+            throw APIError.invalidURL
+        }
+        var req = URLRequest(url: url)
+        req.httpMethod = "DELETE"
+        req.setValue("application/json", forHTTPHeaderField: "Accept")
+        req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        if let body = body {
+            req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            req.httpBody = try JSONEncoder().encode(body)
+        }
+        let (data, response) = try await withCheckedThrowingContinuation {
+            (cont: CheckedContinuation<(Data, URLResponse), Error>) in
+            URLSession.shared.dataTask(with: req) { d, r, e in
+                if let e = e { cont.resume(throwing: APIError.networkError(e)); return }
+                guard let d = d, let r = r else {
+                    cont.resume(throwing: APIError.networkError(URLError(.unknown))); return
+                }
+                cont.resume(returning: (d, r))
+            }.resume()
+        }
+        guard let http = response as? HTTPURLResponse else {
+            throw APIError.networkError(URLError(.badServerResponse))
+        }
+        guard (200...299).contains(http.statusCode) else {
+            struct D: Decodable { let detail: String? }
+            let d = try? JSONDecoder().decode(D.self, from: data)
+            throw APIError.httpError(statusCode: http.statusCode, detail: d?.detail)
+        }
+        do {
+            return try JSONDecoder().decode(T.self, from: data)
+        } catch {
+            throw APIError.decodingError
+        }
+    }
+}
+
+private struct EmptyBody: Encodable {}

--- a/ios/LFAEducationCenter/Biometric/BiometricVerifyView.swift
+++ b/ios/LFAEducationCenter/Biometric/BiometricVerifyView.swift
@@ -1,0 +1,146 @@
+import SwiftUI
+
+// Verify result screen.
+//
+// Displays one of three outcomes: verified / manual_review_required / rejected.
+// face_match_score is never requested, stored, displayed, or logged — not even in debug.
+// Only result.result (a classified string) is shown.
+struct BiometricVerifyView: View {
+
+    @EnvironmentObject private var authManager: AuthManager
+    @StateObject private var vm: BiometricVerifyViewModel
+
+    private let photoFilename: String?
+    private let onDismiss:     () -> Void
+
+    init(service: BiometricService, photoFilename: String?, onDismiss: @escaping () -> Void) {
+        _vm = StateObject(wrappedValue: BiometricVerifyViewModel(service: service))
+        self.photoFilename = photoFilename
+        self.onDismiss     = onDismiss
+    }
+
+    var body: some View {
+        ZStack {
+            Color(UIColor.systemBackground).ignoresSafeArea()
+            content
+            if vm.isLoading { loadingOverlay }
+        }
+        .navigationTitle("Ellenőrzés")
+        .navigationBarTitleDisplayMode(.inline)
+        .alert(item: $vm.error) { err in
+            Alert(
+                title: Text("Hiba"),
+                message: Text(err.userFacingMessage),
+                dismissButton: .default(Text("OK"), action: onDismiss)
+            )
+        }
+        .task { await vm.verify(photoFilename: photoFilename) }
+    }
+
+    // MARK: — Content
+
+    @ViewBuilder
+    private var content: some View {
+        if let result = vm.result {
+            resultView(for: result.result)
+        } else if !vm.isLoading {
+            // verify() returned nil without error — treat as loading.
+            ProgressView()
+        }
+    }
+
+    @ViewBuilder
+    private func resultView(for outcome: String) -> some View {
+        switch outcome {
+        case "verified":
+            outcomeView(
+                icon: "checkmark.circle.fill",
+                color: Theme.Color.primary,
+                title: "Biometrikus ellenőrzés sikeres.",
+                subtitle: nil,
+                showRetry: false
+            )
+        case "manual_review_required":
+            outcomeView(
+                icon: "clock.fill",
+                color: Theme.Color.warning,
+                title: "Ellenőrzés kézi felülvizsgálatra vár.",
+                subtitle: "Az adminisztrátor hamarosan felülvizsgálja a kérelmet.",
+                showRetry: false
+            )
+        case "rejected":
+            outcomeView(
+                icon: "xmark.circle.fill",
+                color: Theme.Color.error,
+                title: "Az ellenőrzés nem sikerült.",
+                subtitle: "Kérjük, próbáld meg újra a liveness folyamatot.",
+                showRetry: true
+            )
+        default:
+            outcomeView(
+                icon: "questionmark.circle.fill",
+                color: Theme.Color.muted,
+                title: "Ismeretlen eredmény.",
+                subtitle: nil,
+                showRetry: false
+            )
+        }
+        // face_match_score: not requested, not stored, not displayed — structural guarantee.
+    }
+
+    private func outcomeView(
+        icon: String,
+        color: Color,
+        title: String,
+        subtitle: String?,
+        showRetry: Bool
+    ) -> some View {
+        VStack(spacing: Theme.Spacing.lg) {
+            Image(systemName: icon)
+                .font(.system(size: 72))
+                .foregroundColor(color)
+
+            Text(title)
+                .font(.system(size: Theme.FontSize.title3, weight: .semibold))
+                .foregroundColor(Theme.Color.onSurface)
+                .multilineTextAlignment(.center)
+
+            if let subtitle = subtitle {
+                Text(subtitle)
+                    .font(.system(size: Theme.FontSize.body))
+                    .foregroundColor(Theme.Color.muted)
+                    .multilineTextAlignment(.center)
+            }
+
+            if showRetry {
+                Button {
+                    onDismiss()   // pop back to liveness entry point
+                } label: {
+                    Text("Újra")
+                        .font(.system(size: Theme.FontSize.body, weight: .semibold))
+                        .foregroundColor(.white)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, Theme.Spacing.sm)
+                        .background(Theme.Color.primary)
+                        .cornerRadius(Theme.Radius.sm)
+                }
+                .padding(.horizontal, Theme.Spacing.md)
+            }
+
+            Button(action: onDismiss) {
+                Text("Bezárás")
+                    .font(.system(size: Theme.FontSize.body))
+                    .foregroundColor(Theme.Color.muted)
+            }
+        }
+        .padding(Theme.Spacing.lg)
+    }
+
+    // MARK: — Helpers
+
+    private var loadingOverlay: some View {
+        Color.black.opacity(0.15)
+            .ignoresSafeArea()
+            .overlay(ProgressView())
+    }
+}

--- a/ios/LFAEducationCenter/Biometric/BiometricVerifyViewModel.swift
+++ b/ios/LFAEducationCenter/Biometric/BiometricVerifyViewModel.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+@MainActor
+final class BiometricVerifyViewModel: ObservableObject {
+
+    @Published private(set) var result:    BiometricVerifyResult?
+    @Published private(set) var isLoading: Bool = false
+    @Published              var error:    BiometricClientError?
+
+    private let service: BiometricService
+
+    init(service: BiometricService) {
+        self.service = service
+    }
+
+    func verify(photoFilename: String?) async {
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            result = try await service.verify(photoFilename: photoFilename)
+        } catch let e as BiometricClientError {
+            error = e
+        } catch {
+            self.error = .networkError(error)
+        }
+    }
+}

--- a/ios/LFAEducationCenter/Profile/ProfileView.swift
+++ b/ios/LFAEducationCenter/Profile/ProfileView.swift
@@ -12,10 +12,11 @@ struct ProfileView: View {
 
     @Environment(\.presentationMode) private var presentationMode
 
-    @State private var isShowingAcademyID       = false
-    @State private var isShowingPhotoUpload     = false
+    @State private var isShowingAcademyID          = false
+    @State private var isShowingPhotoUpload        = false
     @State private var isShowingBaselineSelfRating = false
     @State private var isShowingMoodPhotos         = false
+    @State private var isShowingBiometric          = false
 
     var body: some View {
         NavigationView {
@@ -25,6 +26,7 @@ struct ProfileView: View {
                     identitySection
                     academyIDSection
                     completionSection
+                    biometricSection
                     Spacer(minLength: Theme.Spacing.xl)
                 }
                 .padding(.horizontal, Theme.Spacing.md)
@@ -69,6 +71,13 @@ struct ProfileView: View {
                 }
                 .environmentObject(authManager)
                 .environmentObject(dashboardVM)
+            }
+            .fullScreenCover(isPresented: $isShowingBiometric) {
+                BiometricDisclosureView(
+                    service: BiometricService(auth: authManager),
+                    onDismiss: { isShowingBiometric = false }
+                )
+                .environmentObject(authManager)
             }
         }
         .navigationViewStyle(.stack)
@@ -169,6 +178,42 @@ struct ProfileView: View {
             )
                 .padding(.top, Theme.Spacing.lg)
         }
+    }
+
+    // MARK: — Biometric (dev/test — gated by BIOMETRIC_DISCLOSURE_ENABLED on backend)
+
+    private var biometricSection: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            Text("BIOMETRIKUS AZONOSÍTÁS")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(Theme.Color.muted)
+                .kerning(0.8)
+
+            Button { isShowingBiometric = true } label: {
+                HStack {
+                    Image(systemName: "faceid")
+                        .font(.system(size: 15))
+                        .foregroundColor(Theme.Color.primary)
+                        .frame(width: 28)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Biometrikus regisztráció")
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundColor(Theme.Color.onSurface)
+                        Text("Tájékoztató és liveness teszt")
+                            .font(.system(size: 11))
+                            .foregroundColor(Theme.Color.muted)
+                    }
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundColor(Theme.Color.muted)
+                }
+                .padding(Theme.Spacing.md)
+                .background(Theme.Color.surface)
+                .cornerRadius(Theme.Radius.md)
+            }
+        }
+        .padding(.top, Theme.Spacing.lg)
     }
 
     // MARK: — Academy ID entry


### PR DESCRIPTION
## Summary

- iOS biometric client flow connecting to backend PR-1..PR-8 endpoints
- 8 new Swift files in `ios/LFAEducationCenter/Biometric/` + ProfileView CTA + pbxproj update
- DEV/TEST scope only — production activation remains blocked

## Backend contract (verified pre-implementation)

| Endpoint | Method | Body type | Image upload? |
|---|---|---|---|
| `/me/biometric-disclosure` | GET/POST/DELETE | JSON | **No** |
| `/me/biometric-consent` | GET/POST/DELETE | JSON | **No** |
| `/me/biometric-liveness` | POST | JSON (`source`, `liveness_metadata`, `photo_filename`) | **No** |
| `/me/biometric-verify` | POST | JSON (`photo_filename`) | **No** |

`photo_filename` is a UUID-based string basename placeholder. No multipart endpoint exists. Image upload is out of scope for this PR.

## Liveness MVP limitation (DEV/TEST only)

Manual CENTER→LEFT→CENTER→RIGHT→CENTER→CAPTURE step advancement. **No automatic head-position detection.** Vision/MediaPipe-based detection is a separate future PR. This is documented in `BiometricLivenessViewModel.swift` and `BiometricLivenessView.swift`.

## Privacy (structural enforcement)

- `face_match_score`: absent from every model, view, and log — not even in debug
- Bearer token: not logged
- `user_id`: not logged
- Raw image bytes: not transmitted, not stored, not logged
- `liveness_metadata`: exactly 5 allowed fields; yaw/roll/device_model/ios_version/landmarks absent by design

## Error mapping

| HTTP | Detail | `BiometricClientError` |
|---|---|---|
| 503 | `biometric_rate_limiter_unavailable` | `.rateLimiterUnavailable` |
| 503 | (feature flag string) | `.featureDisabled` |
| 429 | `rate_limited` | `.rateLimited` |
| 403 | `parental_consent_required` | `.parentalConsentRequired` |
| 403 | `biometric_disclosure_required` | `.disclosureRequired` |
| 403 | `biometric_disclosure_update_required` | `.disclosureUpdateRequired` |
| 403 | `biometric_consent_required` | `.consentRequired` |
| 409 | `disclosure_already_accepted` | `.disclosureAlreadyAccepted` |
| 409 | `onboarding_liveness_already_submitted` | `.livenessAlreadySubmitted` |
| 409 | (consent string) | `.consentAlreadyActive` |
| 404 | `biometric_disclosure_not_found` | `.disclosureNotFound` |
| 404 | `biometric_reference_not_found` | `.referenceNotFound` |
| 400 | `photo_filename_path_traversal` | `.pathTraversalRejected` |
| 401 | any | `.unauthorized` |

## Out of scope (this PR)

- Production activation
- App Store release
- Automatic head-position detection
- Image upload (no backend endpoint)
- Admin review UI
- New backend endpoints
- Parental consent flow
- face_match_score in any context
- ONNX/face embedding on iOS

## Production blockers (unchanged)

- `BIOMETRIC_FACE_MATCHING_ENABLED=True` — TILOS pending DPIA/DPO/legal sign-off
- `BIOMETRIC_DISCLOSURE_ENABLED=True` — TILOS pending legal approval
- Bias/fairness audit PENDING
- Disclosure v1.0 legal review PENDING
- Parental consent flow PENDING

## iOS build

Requires Xcode build verification on physical device or simulator. pbxproj updated with `BB000002000000000000018` Biometric group and 8 file references/build phases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)