### PR TITLE
feat(juggling): add POC video intake quality pipeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,16 @@ BIOMETRIC_FACE_MATCHING_ENABLED=false
 #   Must be stored in a secret manager in production — NEVER in plaintext.
 BIOMETRIC_EMBEDDING_KEY=
 
+# ── Juggling POC — Video Intake + Quality Pipeline ───────────────────────────
+# JUGGLING_POC_ENABLED — master switch; false = all juggling endpoints return 503.
+JUGGLING_POC_ENABLED=false
+# JUGGLING_VIDEO_MAX_SIZE_MB — upload limit (100 MB ≈ 80–130 s at 720p/60fps H.265).
+JUGGLING_VIDEO_MAX_SIZE_MB=100
+# JUGGLING_VIDEO_MAX_DURATION_SECONDS — ffprobe duration gate.
+JUGGLING_VIDEO_MAX_DURATION_SECONDS=120
+# JUGGLING_UPLOAD_DIR — storage path (NOT under app/static/).
+JUGGLING_UPLOAD_DIR=app/uploads/juggling
+
 # ── Database ────────────────────────────────────────────────────────────────
 # PostgreSQL connection string
 # Format: postgresql://user:password@host:port/database

--- a/alembic/versions/2026_06_10_1300_add_juggling_video_tables.py
+++ b/alembic/versions/2026_06_10_1300_add_juggling_video_tables.py
@@ -1,0 +1,90 @@
+"""add juggling video tables
+
+Revision ID: 2026_06_10_1300
+Revises: 2026_06_10_1200
+Create Date: 2026-06-10
+
+Tables created:
+  juggling_consents — per-user consent record (service + training + admin_review)
+  juggling_videos   — per-video upload record with status state machine
+
+Video storage:
+  Files are stored under JUGGLING_UPLOAD_DIR (outside app/static/).
+  DB stores storage_path (filesystem path), never a public URL.
+
+State machine (juggling_videos.status):
+  pending_upload → uploaded → processing → analyzed | rejected | failed
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "2026_06_10_1300"
+down_revision = "2026_06_10_1200"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # ── juggling_consents ────────────────────────────────────────────────────
+    op.create_table(
+        "juggling_consents",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("service_consent", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column("training_consent", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column("admin_review_consent", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column("consented_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.text("now()")),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.text("now()")),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("user_id", name="uq_juggling_consents_user_id"),
+    )
+    op.create_index("ix_juggling_consents_user_id", "juggling_consents", ["user_id"])
+
+    # ── juggling_videos ──────────────────────────────────────────────────────
+    op.create_table(
+        "juggling_videos",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("source_type", sa.String(30), nullable=False),
+        sa.Column("upload_source", sa.String(30), nullable=False,
+                  server_default="unknown"),
+        sa.Column("status", sa.String(30), nullable=False,
+                  server_default="pending_upload"),
+        sa.Column("storage_path", sa.String(512), nullable=True),
+        sa.Column("filename_stored", sa.String(255), nullable=True),
+        sa.Column("file_size_bytes", sa.BigInteger(), nullable=True),
+        sa.Column("checksum_sha256", sa.String(64), nullable=True),
+        sa.Column("client_reported_metadata", postgresql.JSONB(), nullable=True),
+        sa.Column("server_detected_metadata", postgresql.JSONB(), nullable=True),
+        sa.Column("quality_score", sa.String(10), nullable=True),
+        sa.Column("quality_status", sa.String(30), nullable=True,
+                  server_default="pending"),
+        sa.Column("quality_detail", postgresql.JSONB(), nullable=True),
+        sa.Column("rejection_reason", sa.String(255), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.text("now()")),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.text("now()")),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_juggling_videos_user_id", "juggling_videos", ["user_id"])
+    op.create_index("ix_juggling_videos_status", "juggling_videos", ["status"])
+    op.create_index("ix_juggling_videos_created_at", "juggling_videos", ["created_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_juggling_videos_created_at", table_name="juggling_videos")
+    op.drop_index("ix_juggling_videos_status", table_name="juggling_videos")
+    op.drop_index("ix_juggling_videos_user_id", table_name="juggling_videos")
+    op.drop_table("juggling_videos")
+
+    op.drop_index("ix_juggling_consents_user_id", table_name="juggling_consents")
+    op.drop_table("juggling_consents")

--- a/app/api/api_v1/endpoints/users/__init__.py
+++ b/app/api/api_v1/endpoints/users/__init__.py
@@ -4,7 +4,19 @@ Aggregates all user-related routers into a single router
 """
 from fastapi import APIRouter
 
-from . import crud, profile, search, credits, instructor_analytics, biometric_consent, biometric_liveness, biometric_verify, biometric_disclosure
+from . import (
+    crud,
+    profile,
+    search,
+    credits,
+    instructor_analytics,
+    biometric_consent,
+    biometric_liveness,
+    biometric_verify,
+    biometric_disclosure,
+    juggling_consent,
+    juggling_videos,
+)
 
 # Create main router
 router = APIRouter()
@@ -35,6 +47,10 @@ router.include_router(biometric_verify.router, tags=["users", "biometric"])
 
 # Biometric disclosure modal endpoints (PR-7A; BIOMETRIC_DISCLOSURE_ENABLED gated)
 router.include_router(biometric_disclosure.router, tags=["users", "biometric"])
+
+# Juggling POC — video intake + quality pipeline (JUGGLING_POC_ENABLED gated; 503 when off)
+router.include_router(juggling_consent.router, tags=["users", "juggling"])
+router.include_router(juggling_videos.router, tags=["users", "juggling"])
 
 # CRUD endpoints (should be last due to /{user_id} catch-all)
 router.include_router(crud.router, tags=["users"])

--- a/app/api/api_v1/endpoints/users/juggling_consent.py
+++ b/app/api/api_v1/endpoints/users/juggling_consent.py
@@ -1,0 +1,71 @@
+"""
+Juggling consent endpoints.
+
+POST /api/v1/users/me/juggling-consent  — create or update consent
+GET  /api/v1/users/me/juggling-consent  — get current consent state
+
+All endpoints gated by require_juggling_enabled() → 503 when flag off.
+
+Consent scope (POC):
+  service_consent      — mandatory gate before any video upload.
+  training_consent     — optional; togglable in this request.
+  admin_review_consent — optional; togglable in this request.
+
+Full revoke / GDPR data delete = V1.0 scope (not implemented here).
+Note: uploaded videos may contain audio until P2 audio stripping is active.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.dependencies import get_current_user
+from app.models.user import User
+from app.schemas.juggling import JugglingConsentGrantRequest, JugglingConsentOut
+from app.services.juggling.consent_service import get_consent, upsert_consent
+from app.services.juggling.feature_flag import require_juggling_enabled
+
+router = APIRouter()
+
+
+@router.post(
+    "/me/juggling-consent",
+    response_model=JugglingConsentOut,
+    status_code=200,
+    dependencies=[Depends(require_juggling_enabled)],
+    summary="Create or update juggling consent",
+    tags=["juggling"],
+)
+def post_juggling_consent(
+    body: JugglingConsentGrantRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> JugglingConsentOut:
+    record = upsert_consent(
+        user_id=current_user.id,
+        service_consent=body.service_consent,
+        training_consent=body.training_consent,
+        admin_review_consent=body.admin_review_consent,
+        db=db,
+    )
+    return JugglingConsentOut.model_validate(record)
+
+
+@router.get(
+    "/me/juggling-consent",
+    response_model=JugglingConsentOut,
+    dependencies=[Depends(require_juggling_enabled)],
+    summary="Get current juggling consent state",
+    tags=["juggling"],
+)
+def get_juggling_consent(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> JugglingConsentOut:
+    record = get_consent(current_user.id, db)
+    if record is None:
+        raise HTTPException(status_code=404, detail="No juggling consent record found.")
+    return JugglingConsentOut.model_validate(record)

--- a/app/api/api_v1/endpoints/users/juggling_videos.py
+++ b/app/api/api_v1/endpoints/users/juggling_videos.py
@@ -1,0 +1,246 @@
+"""
+Juggling video intake endpoints.
+
+POST /api/v1/users/me/juggling/videos/upload-init      — create pending record
+POST /api/v1/users/me/juggling/videos/{video_id}/upload  — upload file
+POST /api/v1/users/me/juggling/videos/{video_id}/complete — enqueue analysis
+GET  /api/v1/users/me/juggling/videos/{video_id}/quality  — poll result
+
+All endpoints gated by require_juggling_enabled() → 503 when flag off.
+service_consent is required before upload-init → 403 if missing.
+
+Storage: files written to JUGGLING_UPLOAD_DIR (outside app/static/).
+         DB stores storage_path only — never a public URL.
+Quality endpoint returns metadata + scores only; no video URL in response.
+
+Security pipeline (pre-save, all in upload endpoint):
+  1. Extension allowlist: .mp4 .mov .m4v
+  2. MIME allowlist: video/mp4 video/quicktime video/x-m4v
+  3. File magic bytes: ftyp box (ISO Base Media container)
+  4. Empty file reject
+  5. File size limit (JUGGLING_VIDEO_MAX_SIZE_MB from config)
+  6. Server-generated filename; client name never propagated to filesystem
+  7. checksum_sha256 stored
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, File, Request
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.dependencies import get_current_user
+from app.models.juggling import JugglingVideo, JugglingVideoStatus
+from app.models.user import User
+from app.schemas.juggling import (
+    JugglingCompleteOut,
+    JugglingQualityOut,
+    JugglingUploadFileOut,
+    JugglingUploadInitRequest,
+    JugglingUploadInitOut,
+)
+from app.services.juggling.consent_service import has_service_consent
+from app.services.juggling.feature_flag import require_juggling_enabled
+from app.services.juggling.security_service import (
+    VideoSecurityError,
+    run_all_pre_save_checks,
+)
+from app.services.juggling import video_service
+from app.tasks.juggling_tasks import analyze_video_task
+
+router = APIRouter()
+
+# Statuses from which complete() is blocked
+_COMPLETE_BLOCKED = {
+    JugglingVideoStatus.pending_upload.value,
+    JugglingVideoStatus.processing.value,
+    JugglingVideoStatus.analyzed.value,
+    JugglingVideoStatus.rejected.value,
+}
+
+
+def _get_video_or_404(video_id: str, user_id: int, db: Session) -> JugglingVideo:
+    video = (
+        db.query(JugglingVideo)
+        .filter(JugglingVideo.id == video_id, JugglingVideo.user_id == user_id)
+        .first()
+    )
+    if video is None:
+        raise HTTPException(status_code=404, detail="Video not found.")
+    return video
+
+
+@router.post(
+    "/me/juggling/videos/upload-init",
+    response_model=JugglingUploadInitOut,
+    status_code=201,
+    dependencies=[Depends(require_juggling_enabled)],
+    summary="Initialise a juggling video upload",
+    tags=["juggling"],
+)
+def upload_init(
+    body: JugglingUploadInitRequest,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> JugglingUploadInitOut:
+    if not has_service_consent(current_user.id, db):
+        raise HTTPException(
+            status_code=403,
+            detail="service_consent required before uploading juggling videos.",
+        )
+
+    video = video_service.create_pending(
+        user_id=current_user.id,
+        source_type=body.source_type,
+        upload_source=body.upload_source,
+        client_reported_metadata=body.client_reported_metadata,
+        db=db,
+    )
+
+    video_id = str(video.id)
+    base_url = str(request.base_url).rstrip("/")
+    upload_url = f"{base_url}/api/v1/users/me/juggling/videos/{video_id}/upload"
+
+    return JugglingUploadInitOut(
+        video_id=video_id,
+        status=video.status,
+        upload_url=upload_url,
+    )
+
+
+@router.post(
+    "/me/juggling/videos/{video_id}/upload",
+    response_model=JugglingUploadFileOut,
+    dependencies=[Depends(require_juggling_enabled)],
+    summary="Upload juggling video file",
+    tags=["juggling"],
+)
+async def upload_file(
+    video_id: str,
+    file: UploadFile = File(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> JugglingUploadFileOut:
+    video = _get_video_or_404(video_id, current_user.id, db)
+
+    if video.status != JugglingVideoStatus.pending_upload.value:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Cannot upload: video is in status={video.status!r}. "
+                   f"Only pending_upload videos accept file uploads.",
+        )
+
+    file_bytes = await file.read()
+    client_filename = file.filename or "upload.mp4"
+    content_type = file.content_type or "application/octet-stream"
+
+    try:
+        server_filename, checksum = run_all_pre_save_checks(
+            client_filename=client_filename,
+            content_type=content_type,
+            file_bytes=file_bytes,
+        )
+    except VideoSecurityError as exc:
+        reason = str(exc)
+        if "file_too_large" in reason:
+            raise HTTPException(status_code=413, detail=reason)
+        elif "empty_file" in reason:
+            raise HTTPException(status_code=400, detail=reason)
+        else:
+            raise HTTPException(status_code=415, detail=reason)
+
+    file_path = video_service.save_file(file_bytes, server_filename)
+
+    video_service.set_uploaded(
+        video=video,
+        storage_path=str(file_path),
+        filename_stored=server_filename,
+        file_size_bytes=len(file_bytes),
+        checksum_sha256=checksum,
+        db=db,
+    )
+
+    return JugglingUploadFileOut(
+        video_id=video_id,
+        status=JugglingVideoStatus.uploaded.value,
+        file_size_bytes=len(file_bytes),
+        checksum_sha256=checksum,
+    )
+
+
+@router.post(
+    "/me/juggling/videos/{video_id}/complete",
+    response_model=JugglingCompleteOut,
+    dependencies=[Depends(require_juggling_enabled)],
+    summary="Trigger quality analysis (Celery async)",
+    tags=["juggling"],
+)
+def complete(
+    video_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> JugglingCompleteOut:
+    video = _get_video_or_404(video_id, current_user.id, db)
+
+    if video.status in _COMPLETE_BLOCKED:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Cannot call complete from status={video.status!r}. "
+                   f"Only 'uploaded' may proceed.",
+        )
+
+    # failed is the only status not in _COMPLETE_BLOCKED — but it can only
+    # proceed after reset_processing() restores it to 'uploaded'.
+    if video.status == JugglingVideoStatus.failed.value:
+        raise HTTPException(
+            status_code=409,
+            detail="Video is in 'failed' status. Reset to 'uploaded' via admin "
+                   "reset_processing before retrying.",
+        )
+
+    # Transition to processing BEFORE enqueue (mood_photo pattern)
+    video_service.set_processing(video_id, db)
+    analyze_video_task.delay(video_id)
+
+    return JugglingCompleteOut(
+        video_id=video_id,
+        status=JugglingVideoStatus.processing.value,
+    )
+
+
+@router.get(
+    "/me/juggling/videos/{video_id}/quality",
+    response_model=JugglingQualityOut,
+    dependencies=[Depends(require_juggling_enabled)],
+    summary="Poll quality analysis result",
+    tags=["juggling"],
+)
+def get_quality(
+    video_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> JugglingQualityOut:
+    video = _get_video_or_404(video_id, current_user.id, db)
+
+    quality_score_float = None
+    if video.quality_score is not None:
+        try:
+            quality_score_float = float(video.quality_score)
+        except (ValueError, TypeError):
+            pass
+
+    warnings = []
+    detail = video.quality_detail or {}
+    if detail.get("audio_present"):
+        warnings.append("audio_present")
+
+    return JugglingQualityOut(
+        video_id=video_id,
+        status=video.status,
+        quality_status=video.quality_status,
+        quality_score=quality_score_float,
+        server_detected_metadata=video.server_detected_metadata,
+        quality_detail=detail if detail else None,
+        rejection_reason=video.rejection_reason,
+        warnings=warnings,
+    )

--- a/app/celery_app.py
+++ b/app/celery_app.py
@@ -67,6 +67,7 @@ def create_celery() -> Celery:
             "app.tasks.mood_photo_tasks.remove_background_task":                   {"queue": "mood_photos"},
             "app.tasks.biometric_tasks.biometric_generate_embedding_task":         {"queue": "biometric_embeddings"},
             "app.tasks.biometric_tasks.biometric_delete_embedding_task":           {"queue": "biometric_embeddings"},
+            "app.tasks.juggling_tasks.analyze_video_task":                         {"queue": "juggling_videos"},
         },
         # Queues
         task_default_queue="default",
@@ -75,6 +76,7 @@ def create_celery() -> Celery:
             "tournaments":          {},
             "mood_photos":          {},
             "biometric_embeddings": {},
+            "juggling_videos":      {},
         },
         # Rate limiting (protect DB under heavy load)
         task_annotations={
@@ -86,6 +88,9 @@ def create_celery() -> Celery:
             },
             "app.tasks.biometric_tasks.biometric_delete_embedding_task": {
                 "rate_limit": "60/m",
+            },
+            "app.tasks.juggling_tasks.analyze_video_task": {
+                "rate_limit": "20/m",
             },
         },
     )

--- a/app/config.py
+++ b/app/config.py
@@ -342,6 +342,24 @@ class Settings(BaseSettings):
     #   Empty string → checksum validation skipped (dev only; required in staging/prod R&D).
     BIOMETRIC_ONNX_MODEL_SHA256: str = ""
 
+    # ── Juggling POC — Video Intake + Quality Pipeline ───────────────────────
+    # JUGGLING_POC_ENABLED — master switch; false = all juggling endpoints return 503.
+    JUGGLING_POC_ENABLED: bool = False
+
+    # JUGGLING_VIDEO_MAX_SIZE_MB — upload hard limit.
+    #   100 MB ≈ 80–130 s of 720p/60fps H.265 at ~6–10 Mbps; sufficient for POC.
+    JUGGLING_VIDEO_MAX_SIZE_MB: int = 100
+
+    # JUGGLING_VIDEO_MAX_DURATION_SECONDS — ffprobe duration gate.
+    JUGGLING_VIDEO_MAX_DURATION_SECONDS: int = 120
+
+    # JUGGLING_UPLOAD_DIR — filesystem path for stored video files.
+    #   Intentionally outside app/static/ — NOT served by StaticFiles mount.
+    JUGGLING_UPLOAD_DIR: str = "app/uploads/juggling"
+
+    # JUGGLING_FFPROBE_TIMEOUT_SECONDS — subprocess timeout for ffprobe.
+    JUGGLING_FFPROBE_TIMEOUT_SECONDS: int = 30
+
     # ── Slow-query monitoring ──────────────────────────────────────────────────
     # Queries slower than SLOW_QUERY_THRESHOLD_MS are logged to app.slow_query
     # and counted in the slow_queries_total metric.  Raise this value if normal

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -68,6 +68,14 @@ from .vt_challenge import (
 )
 from .user_mood_photos import UserMoodPhoto, MOOD_PHOTO_SLOTS, MoodPhotoStatus
 from .biometric import UserBiometricConsent, UserFaceEmbedding, BiometricVerificationLog
+from .juggling import (
+    JugglingConsent,
+    JugglingVideo,
+    JugglingVideoStatus,
+    JugglingVideoQualityStatus,
+    JugglingSourceType,
+    JugglingUploadSource,
+)
 
 # 🎓 New Track-Based Modular Education System
 from .track import Track, Module, ModuleComponent

--- a/app/models/juggling.py
+++ b/app/models/juggling.py
@@ -1,0 +1,196 @@
+"""
+Juggling POC — Video Intake + Quality Pipeline models.
+
+Two tables:
+  juggling_consents  — per-user consent record (service + training + admin_review)
+  juggling_videos    — per-video upload record with status state machine
+
+State machine for juggling_videos.status:
+  pending_upload → uploaded → processing → analyzed
+                                        → rejected  (quality/codec/duration gate)
+                                        → failed    (ffprobe crash / timeout / corrupt)
+
+Definitions:
+  rejected = a deliberate quality or validation gate decision; file was readable.
+  failed   = technical error; ffprobe could not process the file.
+"""
+from __future__ import annotations
+
+import enum
+import uuid as _uuid_mod
+from datetime import datetime, timezone
+
+from sqlalchemy import (
+    BigInteger,
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    UniqueConstraint,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import relationship
+
+from app.database import Base
+
+
+class JugglingVideoStatus(str, enum.Enum):
+    pending_upload = "pending_upload"
+    uploaded       = "uploaded"
+    processing     = "processing"
+    analyzed       = "analyzed"
+    rejected       = "rejected"
+    failed         = "failed"
+
+
+class JugglingVideoQualityStatus(str, enum.Enum):
+    pending      = "pending"
+    acceptable   = "acceptable"
+    needs_review = "needs_review"
+    rejected     = "rejected"
+
+
+class JugglingSourceType(str, enum.Enum):
+    in_app_capture = "in_app_capture"
+    uploaded_video = "uploaded_video"
+
+
+class JugglingUploadSource(str, enum.Enum):
+    camera  = "camera"
+    gallery = "gallery"
+    file    = "file"
+    unknown = "unknown"
+
+
+class JugglingConsent(Base):
+    """
+    Per-user consent record for the juggling POC pipeline.
+
+    service_consent   — mandatory; gates upload-init (required=True before any upload).
+    training_consent  — optional; user may toggle after initial grant.
+    admin_review_consent — optional; user may toggle after initial grant.
+
+    Revoke scope in this POC:
+      training_consent + admin_review_consent are toggleable.
+      service_consent revoke = V1.0 GDPR flow; not implemented in POC.
+    """
+    __tablename__ = "juggling_consents"
+
+    id      = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"),
+                     nullable=False, unique=True, index=True)
+
+    service_consent      = Column(Boolean, nullable=False, default=False,
+                                  comment="Mandatory gate — required before any video upload")
+    training_consent     = Column(Boolean, nullable=False, default=False,
+                                  comment="Consent to use footage for model training")
+    admin_review_consent = Column(Boolean, nullable=False, default=False,
+                                  comment="Consent for admin/coach manual review")
+
+    consented_at  = Column(DateTime(timezone=True), nullable=True,
+                           comment="Timestamp of most recent consent update")
+    created_at    = Column(DateTime(timezone=True), nullable=False,
+                           default=lambda: datetime.now(timezone.utc))
+    updated_at    = Column(DateTime(timezone=True), nullable=False,
+                           default=lambda: datetime.now(timezone.utc),
+                           onupdate=lambda: datetime.now(timezone.utc))
+
+    user = relationship("User", back_populates="juggling_consent")
+
+
+class JugglingVideo(Base):
+    """
+    Per-video record tracking the full intake pipeline:
+      upload → ffprobe metadata detection → quality gate → result.
+
+    Storage: files live in JUGGLING_UPLOAD_DIR (outside app/static/).
+    DB stores storage_path (filesystem path), never a public URL.
+    Quality endpoint returns metadata only — no direct video URL.
+    """
+    __tablename__ = "juggling_videos"
+
+    id      = Column(UUID(as_uuid=True), primary_key=True, default=_uuid_mod.uuid4)
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"),
+                     nullable=False, index=True)
+
+    # ── Intake classification ────────────────────────────────────────────────
+    source_type   = Column(String(30), nullable=False,
+                           comment="in_app_capture | uploaded_video")
+    upload_source = Column(String(30), nullable=False, default="unknown",
+                           comment="camera | gallery | file | unknown")
+
+    # ── State machine ────────────────────────────────────────────────────────
+    status = Column(String(30), nullable=False,
+                    default=JugglingVideoStatus.pending_upload.value,
+                    index=True)
+
+    # ── File storage ─────────────────────────────────────────────────────────
+    # storage_path: filesystem path under JUGGLING_UPLOAD_DIR.
+    # NOT a public URL — the quality endpoint never returns this to clients.
+    storage_path     = Column(String(512), nullable=True,
+                              comment="Filesystem path under JUGGLING_UPLOAD_DIR; not public")
+    filename_stored  = Column(String(255), nullable=True,
+                              comment="Server-generated UUID filename; client name is discarded")
+    file_size_bytes  = Column(BigInteger, nullable=True)
+    checksum_sha256  = Column(String(64), nullable=True)
+
+    # ── Client-reported metadata (not authoritative) ─────────────────────────
+    # Allowed keys: fps, resolution, duration_seconds, codec,
+    #               device, os_version, app_version
+    client_reported_metadata = Column(
+        JSONB, nullable=True,
+        comment=(
+            "Client-supplied metadata. Not authoritative. "
+            "server_detected_metadata overrides on conflict. "
+            "Allowed: fps, resolution, duration_seconds, codec, "
+            "device, os_version, app_version."
+        ),
+    )
+
+    # ── Server-detected metadata (authoritative, ffprobe) ────────────────────
+    # Keys: fps, resolution, duration_seconds, codec, bitrate_kbps,
+    #       rotation, has_audio, file_format, container, nb_streams
+    server_detected_metadata = Column(
+        JSONB, nullable=True,
+        comment=(
+            "ffprobe-derived metadata. Authoritative. "
+            "Populated by Celery analyze task after complete endpoint."
+        ),
+    )
+
+    # ── Quality analysis results ─────────────────────────────────────────────
+    quality_score  = Column(
+        # Float, nullable until analyze task runs.
+        String(10), nullable=True,
+        comment="Stored as string to avoid float precision noise; e.g. '0.76'"
+    )
+    quality_status = Column(String(30), nullable=True,
+                            default=JugglingVideoQualityStatus.pending.value)
+    quality_detail = Column(
+        JSONB, nullable=True,
+        comment=(
+            "Per-dimension scores. Keys: blur_score, dark_frame_ratio, "
+            "fps_detected, fps_acceptable, duration_seconds, duration_acceptable, "
+            "rotation, subject_size_score (null — P2/P3), "
+            "ball_visible_score (null — P2/P3), audio_present (warning only)."
+        ),
+    )
+    rejection_reason = Column(
+        String(255), nullable=True,
+        comment=(
+            "Machine-readable reason code when status=rejected or quality_status=rejected. "
+            "E.g.: unsupported_codec, too_long, too_dark, fps_too_low, "
+            "corrupt_video, analysis_timeout."
+        ),
+    )
+
+    # ── Timestamps ───────────────────────────────────────────────────────────
+    created_at = Column(DateTime(timezone=True), nullable=False, index=True,
+                        default=lambda: datetime.now(timezone.utc))
+    updated_at = Column(DateTime(timezone=True), nullable=False,
+                        default=lambda: datetime.now(timezone.utc),
+                        onupdate=lambda: datetime.now(timezone.utc))
+
+    user = relationship("User", back_populates="juggling_videos")

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -330,6 +330,19 @@ class User(Base):
         cascade="all, delete-orphan",
         foreign_keys="UserFaceEmbedding.user_id",
     )
+    juggling_consent = relationship(
+        "JugglingConsent",
+        back_populates="user",
+        uselist=False,
+        cascade="all, delete-orphan",
+        foreign_keys="JugglingConsent.user_id",
+    )
+    juggling_videos = relationship(
+        "JugglingVideo",
+        back_populates="user",
+        cascade="all, delete-orphan",
+        foreign_keys="JugglingVideo.user_id",
+    )
 
     # 🎓 NEW: Specialization helper properties and methods
     @property

--- a/app/schemas/juggling.py
+++ b/app/schemas/juggling.py
@@ -1,0 +1,107 @@
+"""
+Juggling POC — Pydantic schemas for request/response validation.
+
+Response rules (enforced structurally):
+  - storage_path is NEVER returned in any response.
+  - filename_stored is NEVER returned in any response.
+  - quality endpoint returns metadata and scores only; no direct video URL.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field, model_validator
+
+# ── Consent schemas ──────────────────────────────────────────────────────────
+
+_CLIENT_METADATA_ALLOWED_KEYS = frozenset({
+    "fps", "resolution", "duration_seconds", "codec",
+    "device", "os_version", "app_version",
+})
+
+
+class JugglingConsentGrantRequest(BaseModel):
+    service_consent:      bool = False
+    training_consent:     bool = False
+    admin_review_consent: bool = False
+
+
+class JugglingConsentOut(BaseModel):
+    service_consent:      bool
+    training_consent:     bool
+    admin_review_consent: bool
+    consented_at:         Optional[datetime] = None
+
+    model_config = {"from_attributes": True}
+
+
+# ── Upload-init schemas ──────────────────────────────────────────────────────
+
+class JugglingUploadInitRequest(BaseModel):
+    source_type:   str = Field(..., description="in_app_capture | uploaded_video")
+    upload_source: str = Field(default="unknown",
+                               description="camera | gallery | file | unknown")
+    client_reported_metadata: Optional[Dict[str, Any]] = None
+
+    @model_validator(mode="after")
+    def _validate_enums(self) -> "JugglingUploadInitRequest":
+        valid_source_types = {"in_app_capture", "uploaded_video"}
+        if self.source_type not in valid_source_types:
+            raise ValueError(
+                f"source_type must be one of {sorted(valid_source_types)}, "
+                f"got {self.source_type!r}"
+            )
+        valid_upload_sources = {"camera", "gallery", "file", "unknown"}
+        if self.upload_source not in valid_upload_sources:
+            raise ValueError(
+                f"upload_source must be one of {sorted(valid_upload_sources)}, "
+                f"got {self.upload_source!r}"
+            )
+        if self.client_reported_metadata is not None:
+            # Strip unknown keys silently — do not raise
+            self.client_reported_metadata = {
+                k: v for k, v in self.client_reported_metadata.items()
+                if k in _CLIENT_METADATA_ALLOWED_KEYS
+            }
+        return self
+
+
+class JugglingUploadInitOut(BaseModel):
+    video_id:   str
+    status:     str
+    upload_url: str
+    message:    str = "Upload ready. POST the video file to upload_url."
+
+
+# ── File upload response ──────────────────────────────────────────────────────
+
+class JugglingUploadFileOut(BaseModel):
+    video_id:        str
+    status:          str
+    file_size_bytes: int
+    checksum_sha256: str
+
+
+# ── Complete response ─────────────────────────────────────────────────────────
+
+class JugglingCompleteOut(BaseModel):
+    video_id: str
+    status:   str
+    message:  str = "Analysis queued. Poll GET /quality for results."
+
+
+# ── Quality response ──────────────────────────────────────────────────────────
+
+class JugglingQualityOut(BaseModel):
+    video_id:                 str
+    status:                   str
+    quality_status:           Optional[str]
+    quality_score:            Optional[float]
+    server_detected_metadata: Optional[Dict[str, Any]]
+    quality_detail:           Optional[Dict[str, Any]]
+    rejection_reason:         Optional[str]
+    warnings:                 List[str] = Field(default_factory=list)
+
+    model_config = {"from_attributes": True}

--- a/app/services/juggling/__init__.py
+++ b/app/services/juggling/__init__.py
@@ -1,0 +1,1 @@
+"""Juggling POC — Video Intake + Quality Pipeline services."""

--- a/app/services/juggling/consent_service.py
+++ b/app/services/juggling/consent_service.py
@@ -1,0 +1,61 @@
+"""
+Juggling consent service — DB helpers for JugglingConsent.
+
+Consent scope:
+  service_consent      — mandatory gate for upload-init; POC: grant only.
+  training_consent     — optional; togglable.
+  admin_review_consent — optional; togglable.
+
+Full revoke / GDPR data delete = V1.0 scope (not implemented in POC).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from app.models.juggling import JugglingConsent
+
+
+def get_consent(user_id: int, db: Session) -> Optional[JugglingConsent]:
+    return db.query(JugglingConsent).filter(JugglingConsent.user_id == user_id).first()
+
+
+def upsert_consent(
+    user_id: int,
+    service_consent: bool,
+    training_consent: bool,
+    admin_review_consent: bool,
+    db: Session,
+) -> JugglingConsent:
+    """
+    Create or update the juggling consent record for user_id.
+    Returns the persisted JugglingConsent row.
+    """
+    now = datetime.now(timezone.utc)
+    record = get_consent(user_id, db)
+    if record is None:
+        record = JugglingConsent(
+            user_id=user_id,
+            service_consent=service_consent,
+            training_consent=training_consent,
+            admin_review_consent=admin_review_consent,
+            consented_at=now,
+        )
+        db.add(record)
+    else:
+        record.service_consent      = service_consent
+        record.training_consent     = training_consent
+        record.admin_review_consent = admin_review_consent
+        record.consented_at         = now
+        record.updated_at           = now
+    db.commit()
+    db.refresh(record)
+    return record
+
+
+def has_service_consent(user_id: int, db: Session) -> bool:
+    """Return True if the user has granted service_consent."""
+    record = get_consent(user_id, db)
+    return record is not None and record.service_consent

--- a/app/services/juggling/feature_flag.py
+++ b/app/services/juggling/feature_flag.py
@@ -1,0 +1,28 @@
+"""
+Juggling POC feature flag guard.
+
+All juggling endpoints depend on require_juggling_enabled().
+When JUGGLING_POC_ENABLED=False the endpoints return HTTP 503.
+There are NO exceptions — every juggling endpoint uses this guard.
+"""
+from __future__ import annotations
+
+from fastapi import HTTPException
+
+from app.config import settings
+
+
+def is_juggling_enabled() -> bool:
+    return settings.JUGGLING_POC_ENABLED
+
+
+async def require_juggling_enabled() -> None:
+    """FastAPI dependency — raises 503 when juggling POC feature is disabled."""
+    if not is_juggling_enabled():
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "Juggling POC is not enabled on this server. "
+                "Set JUGGLING_POC_ENABLED=true to activate the video intake pipeline."
+            ),
+        )

--- a/app/services/juggling/metadata_service.py
+++ b/app/services/juggling/metadata_service.py
@@ -1,0 +1,182 @@
+"""
+Juggling video metadata detection via ffprobe.
+
+Runs ffprobe as a subprocess (same pattern as card_export_service.py).
+Returns a structured dict stored in juggling_videos.server_detected_metadata.
+
+server_detected_metadata keys:
+  fps, resolution, duration_seconds, codec, bitrate_kbps,
+  rotation, has_audio, file_format, container, nb_streams
+
+This is the authoritative metadata source — client_reported_metadata is NOT trusted.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+class VideoProbeError(RuntimeError):
+    """Raised when ffprobe cannot read or parse the video file."""
+
+
+def probe_video(file_path: Path, timeout_seconds: int = 30) -> Dict[str, Any]:
+    """
+    Run ffprobe on file_path and return parsed JSON output.
+    Raises VideoProbeError on subprocess failure or JSON parse error.
+    """
+    binary = shutil.which("ffprobe") or "ffprobe"
+    try:
+        result = subprocess.run(
+            [
+                binary,
+                "-v", "quiet",
+                "-print_format", "json",
+                "-show_streams",
+                "-show_format",
+                str(file_path),
+            ],
+            capture_output=True,
+            timeout=timeout_seconds,
+        )
+    except FileNotFoundError as exc:
+        raise VideoProbeError(
+            "ffprobe binary not found — install ffmpeg (brew: ffmpeg, apt: ffmpeg)"
+        ) from exc
+    except subprocess.TimeoutExpired as exc:
+        raise VideoProbeError(
+            f"ffprobe timed out after {timeout_seconds}s"
+        ) from exc
+
+    if result.returncode != 0:
+        stderr = result.stderr.decode("utf-8", errors="replace")[:500]
+        raise VideoProbeError(
+            f"ffprobe exited with code {result.returncode}: {stderr}"
+        )
+
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise VideoProbeError(
+            f"ffprobe output could not be parsed as JSON: {exc}"
+        ) from exc
+
+
+def extract_server_metadata(probe_data: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Normalise raw ffprobe JSON into server_detected_metadata schema.
+
+    Returns a dict with keys:
+      fps, resolution, duration_seconds, codec, bitrate_kbps,
+      rotation, has_audio, file_format, container, nb_streams
+    """
+    streams: list = probe_data.get("streams", [])
+    fmt: dict = probe_data.get("format", {})
+
+    # Find the primary video stream
+    video_stream: Optional[dict] = None
+    audio_streams: list = []
+    for s in streams:
+        if s.get("codec_type") == "video" and video_stream is None:
+            video_stream = s
+        elif s.get("codec_type") == "audio":
+            audio_streams.append(s)
+
+    # FPS — prefer avg_frame_rate, fall back to r_frame_rate
+    fps: Optional[float] = None
+    if video_stream:
+        for key in ("avg_frame_rate", "r_frame_rate"):
+            raw = video_stream.get(key, "")
+            fps = _parse_fraction(raw)
+            if fps and fps > 0:
+                break
+
+    # Resolution
+    resolution: Optional[str] = None
+    if video_stream:
+        w = video_stream.get("width")
+        h = video_stream.get("height")
+        if w and h:
+            resolution = f"{w}x{h}"
+
+    # Duration
+    duration_seconds: Optional[float] = None
+    raw_duration = (
+        (video_stream or {}).get("duration")
+        or fmt.get("duration")
+    )
+    if raw_duration:
+        try:
+            duration_seconds = float(raw_duration)
+        except (ValueError, TypeError):
+            pass
+
+    # Codec
+    codec: Optional[str] = None
+    if video_stream:
+        codec = video_stream.get("codec_name")
+
+    # Bitrate (kbps)
+    bitrate_kbps: Optional[int] = None
+    raw_bitrate = fmt.get("bit_rate")
+    if raw_bitrate:
+        try:
+            bitrate_kbps = int(raw_bitrate) // 1000
+        except (ValueError, TypeError):
+            pass
+
+    # Rotation — stored in side_data or tags
+    rotation: int = 0
+    if video_stream:
+        tags = video_stream.get("tags", {})
+        raw_rot = tags.get("rotate", tags.get("rotation", "0"))
+        try:
+            rotation = int(raw_rot)
+        except (ValueError, TypeError):
+            rotation = 0
+        # Also check side_data_list
+        for sd in video_stream.get("side_data_list", []):
+            if sd.get("side_data_type") == "Display Matrix":
+                rot = sd.get("rotation")
+                if rot is not None:
+                    try:
+                        rotation = int(rot)
+                    except (ValueError, TypeError):
+                        pass
+
+    # Audio
+    has_audio: bool = len(audio_streams) > 0
+
+    # Format / container
+    file_format: Optional[str] = fmt.get("format_name")
+    container: Optional[str] = file_format.split(",")[0] if file_format else None
+
+    return {
+        "fps":              round(fps, 3) if fps else None,
+        "resolution":       resolution,
+        "duration_seconds": round(duration_seconds, 2) if duration_seconds else None,
+        "codec":            codec,
+        "bitrate_kbps":     bitrate_kbps,
+        "rotation":         rotation,
+        "has_audio":        has_audio,
+        "file_format":      file_format,
+        "container":        container,
+        "nb_streams":       len(streams),
+    }
+
+
+def _parse_fraction(value: str) -> Optional[float]:
+    """Parse '60000/1001' or '30' style FPS strings."""
+    if not value or value == "0/0":
+        return None
+    try:
+        if "/" in value:
+            num, den = value.split("/", 1)
+            d = int(den)
+            return float(int(num) / d) if d != 0 else None
+        return float(value)
+    except (ValueError, TypeError, ZeroDivisionError):
+        return None

--- a/app/services/juggling/quality_service.py
+++ b/app/services/juggling/quality_service.py
@@ -1,0 +1,140 @@
+"""
+Juggling video quality analysis.
+
+Inputs: server_detected_metadata (from ffprobe), raw file bytes for frame sampling.
+
+Scores computed in this branch:
+  blur_score         — higher = sharper  (0.0–1.0)
+  dark_frame_ratio   — fraction of frames that are too dark (0.0–1.0, lower = better)
+  fps_score          — derived from detected fps
+
+NOT computed in this branch (P2/P3 scope):
+  subject_size_score — requires MediaPipe pose inference
+  ball_visible_score — requires FootAndBall / YOLO detector
+
+overall_quality_score weighting (only scored dimensions):
+  blur_score       × 0.40
+  dark_brightness  × 0.40  (= 1.0 - dark_frame_ratio)
+  fps_score        × 0.20
+
+Reject thresholds (config-independent, hard-coded for POC):
+  dark_frame_ratio > 0.40  → too_dark
+  blur_score       < 0.30  → too_blurry
+  fps              < 24    → fps_too_low
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Tuple
+
+
+# ── Reject thresholds ────────────────────────────────────────────────────────
+_MAX_DARK_FRAME_RATIO: float = 0.40
+_MIN_BLUR_SCORE:       float = 0.30
+_MIN_FPS:              float = 24.0
+
+
+def _fps_score(fps: Optional[float]) -> float:
+    """Map detected FPS to a score in [0.0, 1.0]."""
+    if fps is None:
+        return 0.5  # unknown; neutral
+    if fps >= 60:
+        return 1.0
+    if fps >= 30:
+        return 0.7
+    if fps >= _MIN_FPS:
+        return 0.4
+    return 0.1
+
+
+def _estimate_blur_score(file_bytes: bytes) -> float:
+    """
+    Estimate sharpness from file size / duration as a POC proxy.
+
+    Real blur detection requires frame decoding (OpenCV Laplacian variance).
+    That is P2 scope.  For POC we use bitrate as a proxy: higher bitrate
+    generally means more detail, less compression artefacts.
+
+    Returns 0.0–1.0. This is a placeholder; replace with Laplacian in P2.
+    """
+    size_mb = len(file_bytes) / (1024 * 1024)
+    # Normalise: assume 5 MB minimum for reasonable quality, 80 MB = excellent
+    score = min(1.0, max(0.0, (size_mb - 2) / 78))
+    # Floor at 0.40 so the placeholder doesn't reject valid videos
+    return round(max(0.40, score), 3)
+
+
+def _estimate_dark_frame_ratio(file_bytes: bytes) -> float:
+    """
+    POC placeholder — returns a heuristic dark_frame_ratio.
+
+    Real dark frame detection requires frame decoding.  That is P2 scope.
+    We conservatively return 0.05 (5 % dark frames) as a safe default.
+    """
+    return 0.05
+
+
+def analyze(
+    file_bytes: bytes,
+    server_metadata: Optional[Dict[str, Any]],
+) -> Tuple[float, str, Dict[str, Any], Optional[str]]:
+    """
+    Run quality analysis and return:
+      (quality_score, quality_status, quality_detail, rejection_reason)
+
+    quality_status: "acceptable" | "needs_review" | "rejected"
+    rejection_reason: None or a machine-readable code string
+    """
+    meta = server_metadata or {}
+
+    fps_detected: Optional[float] = meta.get("fps")
+    duration_ok = True  # duration gate is enforced in metadata_service / task
+    rotation: int = meta.get("rotation", 0)
+
+    blur_score = _estimate_blur_score(file_bytes)
+    dark_frame_ratio = _estimate_dark_frame_ratio(file_bytes)
+    fps_sc = _fps_score(fps_detected)
+
+    fps_acceptable = fps_detected is None or fps_detected >= _MIN_FPS
+    has_audio: bool = meta.get("has_audio", False)
+
+    # ── Overall score (null dimensions excluded) ─────────────────────────────
+    dark_brightness = 1.0 - dark_frame_ratio
+    overall = round(
+        blur_score * 0.40
+        + dark_brightness * 0.40
+        + fps_sc * 0.20,
+        4,
+    )
+
+    # ── Rejection checks ─────────────────────────────────────────────────────
+    rejection_reason: Optional[str] = None
+    if dark_frame_ratio > _MAX_DARK_FRAME_RATIO:
+        rejection_reason = "too_dark"
+    elif blur_score < _MIN_BLUR_SCORE:
+        rejection_reason = "too_blurry"
+    elif fps_detected is not None and fps_detected < _MIN_FPS:
+        rejection_reason = "fps_too_low"
+
+    # ── Quality status ────────────────────────────────────────────────────────
+    if rejection_reason:
+        quality_status = "rejected"
+    elif overall >= 0.70:
+        quality_status = "acceptable"
+    else:
+        quality_status = "needs_review"
+
+    quality_detail: Dict[str, Any] = {
+        "blur_score":          blur_score,
+        "dark_frame_ratio":    dark_frame_ratio,
+        "fps_detected":        fps_detected,
+        "fps_acceptable":      fps_acceptable,
+        "duration_acceptable": duration_ok,
+        "rotation":            rotation,
+        # P2/P3 scope — always null in this branch
+        "subject_size_score":  None,
+        "ball_visible_score":  None,
+    }
+    if has_audio:
+        quality_detail["audio_present"] = True
+
+    return overall, quality_status, quality_detail, rejection_reason

--- a/app/services/juggling/security_service.py
+++ b/app/services/juggling/security_service.py
@@ -1,0 +1,144 @@
+"""
+Juggling video upload security validation.
+
+Layered pre-save checks (all run before the file touches disk):
+  1. Extension allowlist: .mp4, .mov, .m4v
+  2. MIME allowlist: video/mp4, video/quicktime, video/x-m4v
+  3. File magic bytes: ISO Base Media ftyp box (MP4/MOV container)
+  4. Empty file reject
+  5. File size limit (JUGGLING_VIDEO_MAX_SIZE_MB from config)
+
+All failures raise ValueError with a machine-readable reason code.
+The upload endpoint maps ValueError → HTTP 415 or 413 or 400.
+
+Note on magic bytes:
+  MP4 and MOV use the ISO Base Media File Format (ISOBMFF).
+  The ftyp box is always at the start (bytes 4–7 = b"ftyp").
+  Accepted ftyp brands: isom, iso2, avc1, mp41, mp42, M4V_, qt__, hvc1, hevc
+  moov/wide/mdat alone are NOT used — they appear anywhere in the file.
+"""
+from __future__ import annotations
+
+import hashlib
+import uuid
+
+from app.config import settings
+
+_ALLOWED_EXTENSIONS: frozenset[str] = frozenset({".mp4", ".mov", ".m4v"})
+_ALLOWED_MIMES: frozenset[str] = frozenset({
+    "video/mp4", "video/quicktime", "video/x-m4v",
+})
+# ftyp brands accepted for MP4/MOV container identification
+_ACCEPTED_FTYP_BRANDS: frozenset[bytes] = frozenset({
+    b"isom", b"iso2", b"avc1", b"mp41", b"mp42",
+    b"M4V ", b"qt  ", b"hvc1", b"hevc", b"iso4",
+    b"iso6", b"mmp4", b"f4v ", b"MSNV", b"NDSC",
+})
+
+
+class VideoSecurityError(ValueError):
+    """Raised when a video upload fails a pre-save security check."""
+
+
+def validate_extension(filename: str) -> str:
+    """
+    Return the lowercased extension if allowed; raise VideoSecurityError otherwise.
+    The client-supplied filename is used ONLY to extract the extension.
+    It is never propagated to the filesystem.
+    """
+    # Guard against path traversal in the extension itself
+    safe_name = filename.replace("..", "").replace("/", "").replace("\\", "")
+    dot_idx = safe_name.rfind(".")
+    if dot_idx == -1:
+        raise VideoSecurityError(
+            "unsupported_extension: no file extension found"
+        )
+    ext = safe_name[dot_idx:].lower()
+    if ext not in _ALLOWED_EXTENSIONS:
+        raise VideoSecurityError(
+            f"unsupported_extension: {ext!r} is not in {sorted(_ALLOWED_EXTENSIONS)}"
+        )
+    return ext
+
+
+def validate_mime(content_type: str) -> None:
+    """Raise VideoSecurityError if content_type is not in the allowlist."""
+    # Normalise: strip parameters (e.g. "video/mp4; codecs=avc1")
+    base_mime = content_type.split(";")[0].strip().lower()
+    if base_mime not in _ALLOWED_MIMES:
+        raise VideoSecurityError(
+            f"unsupported_mime: {content_type!r} is not in {sorted(_ALLOWED_MIMES)}"
+        )
+
+
+def validate_magic_bytes(data: bytes) -> None:
+    """
+    Verify that the file starts with a valid ISO Base Media ftyp box.
+
+    Structure: [4-byte box size][b"ftyp"][4-byte major brand][4-byte minor version]
+               [N×4-byte compatible brands]
+
+    We check bytes[4:8] == b"ftyp" and that major_brand is in _ACCEPTED_FTYP_BRANDS.
+    This is server-side, non-spoofable, and runs before the file is saved.
+    """
+    if len(data) < 12:
+        raise VideoSecurityError(
+            "magic_bytes_invalid: file too short to contain a valid ftyp box"
+        )
+    box_type = data[4:8]
+    if box_type != b"ftyp":
+        raise VideoSecurityError(
+            f"magic_bytes_invalid: expected ftyp box at offset 4, "
+            f"found {box_type!r}. Not a valid MP4/MOV container."
+        )
+    major_brand = data[8:12]
+    if major_brand not in _ACCEPTED_FTYP_BRANDS:
+        raise VideoSecurityError(
+            f"magic_bytes_invalid: unsupported ftyp major brand {major_brand!r}"
+        )
+
+
+def validate_size(file_bytes: bytes) -> None:
+    """Raise VideoSecurityError if file is empty or exceeds the configured limit."""
+    if len(file_bytes) == 0:
+        raise VideoSecurityError("empty_file: uploaded file contains no data")
+    max_bytes = settings.JUGGLING_VIDEO_MAX_SIZE_MB * 1024 * 1024
+    if len(file_bytes) > max_bytes:
+        raise VideoSecurityError(
+            f"file_too_large: {len(file_bytes):,} bytes exceeds "
+            f"limit of {settings.JUGGLING_VIDEO_MAX_SIZE_MB} MB "
+            f"({max_bytes:,} bytes)"
+        )
+
+
+def generate_server_filename(ext: str) -> str:
+    """Return a server-generated UUID filename. Client name is never used."""
+    return f"{uuid.uuid4()}{ext}"
+
+
+def compute_sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def run_all_pre_save_checks(
+    client_filename: str,
+    content_type: str,
+    file_bytes: bytes,
+) -> tuple[str, str]:
+    """
+    Run all pre-save security checks in order.
+    Returns (server_filename, checksum_sha256) on success.
+    Raises VideoSecurityError on first failure.
+    """
+    # 1. Extension
+    ext = validate_extension(client_filename)
+    # 2. MIME
+    validate_mime(content_type)
+    # 3. Empty + size — checked before magic bytes so empty file → 400, not 415
+    validate_size(file_bytes)
+    # 4. Magic bytes (server-side, non-spoofable)
+    validate_magic_bytes(file_bytes)
+    # 5. Generate server-side filename and checksum
+    server_filename = generate_server_filename(ext)
+    checksum = compute_sha256(file_bytes)
+    return server_filename, checksum

--- a/app/services/juggling/video_service.py
+++ b/app/services/juggling/video_service.py
@@ -1,0 +1,194 @@
+"""
+Juggling video service — DB state transition helpers.
+
+All DB writes go through these helpers so the Celery task and endpoints
+share consistent state logic.  Pattern mirrors mood_photo_service.py.
+
+State transitions:
+  create_pending      — upload-init creates pending_upload record
+  set_uploaded        — upload endpoint marks file received
+  set_processing      — complete endpoint sets processing (before Celery enqueue)
+  apply_analysis      — Celery task writes quality result → analyzed
+  apply_rejection     — Celery task writes gate decision → rejected
+  apply_failure       — Celery task writes technical error → failed
+  reset_processing    — admin/stuck recovery → uploaded
+"""
+from __future__ import annotations
+
+import uuid as _uuid_mod
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.models.juggling import JugglingVideo, JugglingVideoStatus, JugglingVideoQualityStatus
+
+JUGGLING_UPLOAD_DIR = Path(settings.JUGGLING_UPLOAD_DIR)
+
+# Transitions that must NOT accept a new complete() call
+_COMPLETE_BLOCKED_STATUSES = {
+    JugglingVideoStatus.pending_upload.value,
+    JugglingVideoStatus.processing.value,
+    JugglingVideoStatus.analyzed.value,
+    JugglingVideoStatus.rejected.value,
+}
+
+
+def create_pending(
+    user_id: int,
+    source_type: str,
+    upload_source: str,
+    client_reported_metadata: Optional[Dict[str, Any]],
+    db: Session,
+) -> JugglingVideo:
+    """Create a new juggling_video record in pending_upload state."""
+    video = JugglingVideo(
+        id=_uuid_mod.uuid4(),
+        user_id=user_id,
+        source_type=source_type,
+        upload_source=upload_source,
+        status=JugglingVideoStatus.pending_upload.value,
+        client_reported_metadata=client_reported_metadata,
+    )
+    db.add(video)
+    db.commit()
+    db.refresh(video)
+    return video
+
+
+def set_uploaded(
+    video: JugglingVideo,
+    storage_path: str,
+    filename_stored: str,
+    file_size_bytes: int,
+    checksum_sha256: str,
+    db: Session,
+) -> JugglingVideo:
+    """Transition pending_upload → uploaded after file is safely written to disk."""
+    video.status          = JugglingVideoStatus.uploaded.value
+    video.storage_path    = storage_path
+    video.filename_stored = filename_stored
+    video.file_size_bytes = file_size_bytes
+    video.checksum_sha256 = checksum_sha256
+    video.updated_at      = datetime.now(timezone.utc)
+    db.commit()
+    db.refresh(video)
+    return video
+
+
+def set_processing(video_id: str, db: Session) -> JugglingVideo:
+    """
+    Transition uploaded → processing.
+    Called by the complete endpoint BEFORE enqueuing the Celery task.
+    Raises ValueError if the transition is not allowed.
+    """
+    video = db.query(JugglingVideo).filter(JugglingVideo.id == video_id).first()
+    if video is None:
+        raise ValueError(f"video_not_found: {video_id}")
+    if video.status != JugglingVideoStatus.uploaded.value:
+        raise ValueError(
+            f"invalid_transition: cannot call complete from status={video.status!r}. "
+            f"Only 'uploaded' may proceed."
+        )
+    video.status     = JugglingVideoStatus.processing.value
+    video.updated_at = datetime.now(timezone.utc)
+    db.commit()
+    db.refresh(video)
+    return video
+
+
+def apply_analysis(
+    video_id: str,
+    server_detected_metadata: Dict[str, Any],
+    quality_score: float,
+    quality_status: str,
+    quality_detail: Dict[str, Any],
+    db: Session,
+) -> JugglingVideo:
+    """Transition processing → analyzed (quality result ready)."""
+    video = db.query(JugglingVideo).filter(JugglingVideo.id == video_id).first()
+    if video is None:
+        raise ValueError(f"video_not_found: {video_id}")
+    video.status                   = JugglingVideoStatus.analyzed.value
+    video.server_detected_metadata = server_detected_metadata
+    video.quality_score            = str(round(quality_score, 4))
+    video.quality_status           = quality_status
+    video.quality_detail           = quality_detail
+    video.updated_at               = datetime.now(timezone.utc)
+    db.commit()
+    db.refresh(video)
+    return video
+
+
+def apply_rejection(
+    video_id: str,
+    server_detected_metadata: Optional[Dict[str, Any]],
+    rejection_reason: str,
+    db: Session,
+) -> JugglingVideo:
+    """
+    Transition processing → rejected.
+    Used for deliberate gate decisions: unsupported_codec, too_long, quality thresholds.
+    """
+    video = db.query(JugglingVideo).filter(JugglingVideo.id == video_id).first()
+    if video is None:
+        raise ValueError(f"video_not_found: {video_id}")
+    video.status                   = JugglingVideoStatus.rejected.value
+    video.quality_status           = JugglingVideoQualityStatus.rejected.value
+    video.rejection_reason         = rejection_reason
+    video.server_detected_metadata = server_detected_metadata
+    video.updated_at               = datetime.now(timezone.utc)
+    db.commit()
+    db.refresh(video)
+    return video
+
+
+def apply_failure(
+    video_id: str,
+    reason: str,
+    db: Session,
+) -> JugglingVideo:
+    """
+    Transition processing → failed.
+    Used for technical errors: ffprobe crash, timeout, corrupt file.
+    The record is kept for debugging; storage_path remains valid.
+    """
+    video = db.query(JugglingVideo).filter(JugglingVideo.id == video_id).first()
+    if video is None:
+        raise ValueError(f"video_not_found: {video_id}")
+    video.status           = JugglingVideoStatus.failed.value
+    video.rejection_reason = reason
+    video.updated_at       = datetime.now(timezone.utc)
+    db.commit()
+    db.refresh(video)
+    return video
+
+
+def reset_processing(video_id: str, db: Session) -> Optional[JugglingVideo]:
+    """
+    Reset a stuck 'processing' record back to 'uploaded'.
+    Idempotent: no-op if status != processing.
+    Used by admin tooling to recover from worker crashes.
+    """
+    video = db.query(JugglingVideo).filter(JugglingVideo.id == video_id).first()
+    if video is None or video.status != JugglingVideoStatus.processing.value:
+        return video
+    video.status     = JugglingVideoStatus.uploaded.value
+    video.updated_at = datetime.now(timezone.utc)
+    db.commit()
+    db.refresh(video)
+    return video
+
+
+def save_file(file_bytes: bytes, filename: str) -> Path:
+    """
+    Write file_bytes to JUGGLING_UPLOAD_DIR/{filename}.
+    Creates the directory if it does not exist.
+    Returns the full Path.
+    """
+    JUGGLING_UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
+    dest = JUGGLING_UPLOAD_DIR / filename
+    dest.write_bytes(file_bytes)
+    return dest

--- a/app/tasks/juggling_tasks.py
+++ b/app/tasks/juggling_tasks.py
@@ -1,0 +1,159 @@
+"""
+Juggling video analysis Celery task.
+
+State flow (managed by video_service helpers):
+  processing → analyzed   (quality result ready)
+             → rejected   (codec / duration / quality gate decision)
+             → failed     (ffprobe crash, timeout, corrupt file — after max retries)
+
+Retry policy: max_retries=2, default_retry_delay=15s
+  → 3 total attempts before failed state is written.
+
+Accepted codecs:  h264, hevc (h265)
+Duration gate:    JUGGLING_VIDEO_MAX_DURATION_SECONDS from config
+
+Audio note:
+  has_audio is detected and stored in server_detected_metadata.
+  If has_audio=True, quality_detail includes audio_present=True (warning only).
+  Audio stripping is P2 scope.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from app.celery_app import celery_app
+from app.config import settings
+from app.database import SessionLocal
+from app.services.juggling import metadata_service, quality_service, video_service
+from app.services.juggling.metadata_service import VideoProbeError
+
+logger = logging.getLogger(__name__)
+
+_ACCEPTED_CODECS: frozenset[str] = frozenset({"h264", "hevc"})
+
+
+@celery_app.task(
+    bind=True,
+    max_retries=2,
+    default_retry_delay=15,
+    queue="juggling_videos",
+    name="app.tasks.juggling_tasks.analyze_video_task",
+    soft_time_limit=60,
+    time_limit=90,
+)
+def analyze_video_task(self, video_id: str) -> dict:
+    """
+    Load the stored video file, run ffprobe metadata detection, validate
+    codec/duration, run quality analysis, write results to DB.
+
+    video_id is the UUID string of the juggling_videos row.
+    """
+    db = SessionLocal()
+    try:
+        video = db.query(
+            __import__("app.models.juggling", fromlist=["JugglingVideo"]).JugglingVideo
+        ).filter_by(id=video_id).first()
+
+        if video is None:
+            logger.error("juggling_analyze_missing_record", extra={"video_id": video_id})
+            return {"status": "failed", "reason": "record_not_found"}
+
+        if not video.storage_path:
+            video_service.apply_failure(video_id, "missing_storage_path", db)
+            return {"status": "failed", "reason": "missing_storage_path"}
+
+        file_path = Path(video.storage_path)
+        if not file_path.exists():
+            video_service.apply_failure(video_id, "file_not_found", db)
+            return {"status": "failed", "reason": "file_not_found"}
+
+        # ── Step 1: ffprobe metadata detection ───────────────────────────────
+        try:
+            probe_data = metadata_service.probe_video(
+                file_path,
+                timeout_seconds=settings.JUGGLING_FFPROBE_TIMEOUT_SECONDS,
+            )
+        except VideoProbeError as exc:
+            logger.warning(
+                "juggling_ffprobe_error",
+                extra={"video_id": video_id, "error": str(exc)},
+            )
+            try:
+                raise self.retry(exc=exc)
+            except self.MaxRetriesExceededError:
+                video_service.apply_failure(video_id, "corrupt_video", db)
+                return {"status": "failed", "reason": "corrupt_video"}
+
+        server_metadata = metadata_service.extract_server_metadata(probe_data)
+
+        # ── Step 2: Codec validation ──────────────────────────────────────────
+        codec = (server_metadata.get("codec") or "").lower()
+        if codec not in _ACCEPTED_CODECS:
+            video_service.apply_rejection(
+                video_id, server_metadata, "unsupported_codec", db
+            )
+            logger.info(
+                "juggling_rejected_codec",
+                extra={"video_id": video_id, "codec": codec},
+            )
+            return {"status": "rejected", "reason": "unsupported_codec"}
+
+        # ── Step 3: Duration validation ───────────────────────────────────────
+        duration = server_metadata.get("duration_seconds")
+        if duration and duration > settings.JUGGLING_VIDEO_MAX_DURATION_SECONDS:
+            video_service.apply_rejection(
+                video_id, server_metadata, "too_long", db
+            )
+            logger.info(
+                "juggling_rejected_duration",
+                extra={"video_id": video_id, "duration": duration},
+            )
+            return {"status": "rejected", "reason": "too_long"}
+
+        # ── Step 4: Quality analysis ──────────────────────────────────────────
+        file_bytes = file_path.read_bytes()
+        quality_score, quality_status, quality_detail, rejection_reason = (
+            quality_service.analyze(file_bytes, server_metadata)
+        )
+
+        if rejection_reason:
+            video_service.apply_rejection(
+                video_id, server_metadata, rejection_reason, db
+            )
+            logger.info(
+                "juggling_rejected_quality",
+                extra={"video_id": video_id, "reason": rejection_reason},
+            )
+            return {"status": "rejected", "reason": rejection_reason}
+
+        # ── Step 5: Write analyzed result ─────────────────────────────────────
+        video_service.apply_analysis(
+            video_id, server_metadata, quality_score, quality_status, quality_detail, db
+        )
+        logger.info(
+            "juggling_analyzed",
+            extra={
+                "video_id": video_id,
+                "quality_score": quality_score,
+                "quality_status": quality_status,
+            },
+        )
+        return {
+            "status": "analyzed",
+            "quality_score": quality_score,
+            "quality_status": quality_status,
+        }
+
+    except Exception as exc:
+        logger.warning(
+            "juggling_task_error",
+            extra={"video_id": video_id, "error": str(exc)},
+        )
+        try:
+            raise self.retry(exc=exc)
+        except self.MaxRetriesExceededError:
+            video_service.apply_failure(video_id, "analysis_timeout", db)
+            return {"status": "failed", "reason": str(exc)}
+    finally:
+        db.close()

--- a/app/tests/test_juggling_consent.py
+++ b/app/tests/test_juggling_consent.py
@@ -1,0 +1,116 @@
+"""
+Juggling consent endpoint tests — JC-01..JC-07.
+
+Tests run with JUGGLING_POC_ENABLED=True (monkeypatched).
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.services.juggling import feature_flag as ff_module
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture(autouse=True)
+def _enable_juggling(monkeypatch):
+    monkeypatch.setattr(ff_module, "is_juggling_enabled", lambda: True)
+
+
+def _auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+def test_jc01_post_consent_creates_record(client, student_token):
+    """JC-01: POST juggling-consent creates record and returns 200."""
+    r = client.post(
+        "/api/v1/users/me/juggling-consent",
+        json={"service_consent": True, "training_consent": True, "admin_review_consent": False},
+        headers=_auth(student_token),
+    )
+    assert r.status_code == 200, r.text
+    data = r.json()
+    assert data["service_consent"] is True
+    assert data["training_consent"] is True
+    assert data["admin_review_consent"] is False
+    assert data["consented_at"] is not None
+
+
+def test_jc02_get_consent_returns_record(client, student_token):
+    """JC-02: GET juggling-consent returns existing record."""
+    client.post(
+        "/api/v1/users/me/juggling-consent",
+        json={"service_consent": True},
+        headers=_auth(student_token),
+    )
+    r = client.get("/api/v1/users/me/juggling-consent", headers=_auth(student_token))
+    assert r.status_code == 200, r.text
+    assert r.json()["service_consent"] is True
+
+
+def test_jc03_get_consent_404_when_no_record(client, student_token):
+    """JC-03: GET juggling-consent returns 404 when user has no consent record."""
+    r = client.get("/api/v1/users/me/juggling-consent", headers=_auth(student_token))
+    assert r.status_code == 404, r.text
+
+
+def test_jc04_post_consent_is_idempotent(client, student_token):
+    """JC-04: POST juggling-consent twice updates the record (idempotent upsert)."""
+    client.post(
+        "/api/v1/users/me/juggling-consent",
+        json={"service_consent": True, "training_consent": False},
+        headers=_auth(student_token),
+    )
+    r = client.post(
+        "/api/v1/users/me/juggling-consent",
+        json={"service_consent": True, "training_consent": True},
+        headers=_auth(student_token),
+    )
+    assert r.status_code == 200
+    assert r.json()["training_consent"] is True
+
+
+def test_jc05_upload_init_403_without_service_consent(client, student_token):
+    """JC-05: upload-init returns 403 when service_consent is missing."""
+    r = client.post(
+        "/api/v1/users/me/juggling/videos/upload-init",
+        json={"source_type": "uploaded_video"},
+        headers=_auth(student_token),
+    )
+    assert r.status_code == 403, r.text
+
+
+def test_jc06_upload_init_403_when_service_consent_false(client, student_token):
+    """JC-06: upload-init returns 403 when service_consent=False."""
+    client.post(
+        "/api/v1/users/me/juggling-consent",
+        json={"service_consent": False},
+        headers=_auth(student_token),
+    )
+    r = client.post(
+        "/api/v1/users/me/juggling/videos/upload-init",
+        json={"source_type": "uploaded_video"},
+        headers=_auth(student_token),
+    )
+    assert r.status_code == 403, r.text
+
+
+def test_jc07_upload_init_201_after_service_consent(client, student_token):
+    """JC-07: upload-init returns 201 when service_consent=True."""
+    client.post(
+        "/api/v1/users/me/juggling-consent",
+        json={"service_consent": True},
+        headers=_auth(student_token),
+    )
+    r = client.post(
+        "/api/v1/users/me/juggling/videos/upload-init",
+        json={"source_type": "uploaded_video", "upload_source": "gallery"},
+        headers=_auth(student_token),
+    )
+    assert r.status_code == 201, r.text
+    data = r.json()
+    assert "video_id" in data
+    assert data["status"] == "pending_upload"
+    assert "upload_url" in data

--- a/app/tests/test_juggling_feature_flag.py
+++ b/app/tests/test_juggling_feature_flag.py
@@ -1,0 +1,77 @@
+"""
+Juggling feature flag tests — JFF-01..JFF-06.
+
+Verifies that every juggling endpoint returns HTTP 503 when
+JUGGLING_POC_ENABLED=False (default).
+"""
+from __future__ import annotations
+
+import pytest
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+def _auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+def test_jff01_consent_post_returns_503_when_disabled(client, student_token):
+    """JFF-01: POST juggling-consent → 503 when flag off."""
+    r = client.post(
+        "/api/v1/users/me/juggling-consent",
+        json={"service_consent": True},
+        headers=_auth(student_token),
+    )
+    assert r.status_code == 503, r.text
+
+
+def test_jff02_consent_get_returns_503_when_disabled(client, student_token):
+    """JFF-02: GET juggling-consent → 503 when flag off."""
+    r = client.get(
+        "/api/v1/users/me/juggling-consent",
+        headers=_auth(student_token),
+    )
+    assert r.status_code == 503, r.text
+
+
+def test_jff03_upload_init_returns_503_when_disabled(client, student_token):
+    """JFF-03: POST upload-init → 503 when flag off."""
+    r = client.post(
+        "/api/v1/users/me/juggling/videos/upload-init",
+        json={"source_type": "uploaded_video"},
+        headers=_auth(student_token),
+    )
+    assert r.status_code == 503, r.text
+
+
+def test_jff04_upload_file_returns_503_when_disabled(client, student_token):
+    """JFF-04: POST upload file → 503 when flag off."""
+    fake_id = "00000000-0000-0000-0000-000000000001"
+    r = client.post(
+        f"/api/v1/users/me/juggling/videos/{fake_id}/upload",
+        files={"file": ("test.mp4", b"\x00" * 8, "video/mp4")},
+        headers=_auth(student_token),
+    )
+    assert r.status_code == 503, r.text
+
+
+def test_jff05_complete_returns_503_when_disabled(client, student_token):
+    """JFF-05: POST complete → 503 when flag off."""
+    fake_id = "00000000-0000-0000-0000-000000000001"
+    r = client.post(
+        f"/api/v1/users/me/juggling/videos/{fake_id}/complete",
+        headers=_auth(student_token),
+    )
+    assert r.status_code == 503, r.text
+
+
+def test_jff06_quality_returns_503_when_disabled(client, student_token):
+    """JFF-06: GET quality → 503 when flag off."""
+    fake_id = "00000000-0000-0000-0000-000000000001"
+    r = client.get(
+        f"/api/v1/users/me/juggling/videos/{fake_id}/quality",
+        headers=_auth(student_token),
+    )
+    assert r.status_code == 503, r.text

--- a/app/tests/test_juggling_quality.py
+++ b/app/tests/test_juggling_quality.py
@@ -1,0 +1,228 @@
+"""
+Juggling quality service unit tests — JQ-01..JQ-14.
+
+Tests run against quality_service.py directly (no HTTP layer needed for most).
+HTTP-layer polling tests included for quality endpoint response structure.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.services.juggling import feature_flag as ff_module
+from app.services.juggling import quality_service
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+def _meta(**kwargs) -> dict:
+    base = {
+        "fps": 60.0,
+        "resolution": "1280x720",
+        "duration_seconds": 45.0,
+        "codec": "hevc",
+        "bitrate_kbps": 8000,
+        "rotation": 0,
+        "has_audio": False,
+        "file_format": "mov,mp4",
+        "container": "mov",
+        "nb_streams": 1,
+    }
+    base.update(kwargs)
+    return base
+
+
+def _file_bytes(size_mb: float = 20.0) -> bytes:
+    return b"\x00" * int(size_mb * 1024 * 1024)
+
+
+# ── Quality service unit tests ────────────────────────────────────────────────
+
+def test_jq01_acceptable_video_returns_high_score():
+    """JQ-01: Good quality video gets acceptable quality_status."""
+    score, status, detail, reason = quality_service.analyze(
+        _file_bytes(20), _meta()
+    )
+    assert status in ("acceptable", "needs_review")
+    assert reason is None
+    assert score > 0.5
+
+
+def test_jq02_subject_size_score_is_null():
+    """JQ-02: subject_size_score is always None in this branch (P2/P3 scope)."""
+    _, _, detail, _ = quality_service.analyze(_file_bytes(10), _meta())
+    assert detail["subject_size_score"] is None
+
+
+def test_jq03_ball_visible_score_is_null():
+    """JQ-03: ball_visible_score is always None in this branch (P2/P3 scope)."""
+    _, _, detail, _ = quality_service.analyze(_file_bytes(10), _meta())
+    assert detail["ball_visible_score"] is None
+
+
+def test_jq04_audio_present_warning_in_detail():
+    """JQ-04: has_audio=True → audio_present=True in quality_detail."""
+    _, _, detail, _ = quality_service.analyze(
+        _file_bytes(10), _meta(has_audio=True)
+    )
+    assert detail.get("audio_present") is True
+
+
+def test_jq05_no_audio_warning_absent():
+    """JQ-05: has_audio=False → audio_present key absent from quality_detail."""
+    _, _, detail, _ = quality_service.analyze(
+        _file_bytes(10), _meta(has_audio=False)
+    )
+    assert "audio_present" not in detail
+
+
+def test_jq06_fps_score_60fps_is_high():
+    """JQ-06: 60 fps gets fps_score=1.0."""
+    assert quality_service._fps_score(60.0) == 1.0
+
+
+def test_jq07_fps_score_30fps_is_mid():
+    """JQ-07: 30 fps gets fps_score=0.7."""
+    assert quality_service._fps_score(30.0) == 0.7
+
+
+def test_jq08_fps_score_24fps_is_low():
+    """JQ-08: 24 fps gets fps_score=0.4 (barely acceptable)."""
+    assert quality_service._fps_score(24.0) == 0.4
+
+
+def test_jq09_fps_below_min_rejected():
+    """JQ-09: fps < 24 → rejection_reason=fps_too_low."""
+    _, status, _, reason = quality_service.analyze(
+        _file_bytes(10), _meta(fps=20.0)
+    )
+    assert reason == "fps_too_low"
+    assert status == "rejected"
+
+
+def test_jq10_null_fps_neutral():
+    """JQ-10: fps=None → fps_score=0.5 (neutral, not rejected)."""
+    assert quality_service._fps_score(None) == 0.5
+    _, _, detail, reason = quality_service.analyze(
+        _file_bytes(10), _meta(fps=None)
+    )
+    assert reason != "fps_too_low"
+    assert detail["fps_acceptable"] is True
+
+
+def test_jq11_rotation_stored_in_detail():
+    """JQ-11: rotation value from server metadata appears in quality_detail."""
+    _, _, detail, _ = quality_service.analyze(
+        _file_bytes(10), _meta(rotation=90)
+    )
+    assert detail["rotation"] == 90
+
+
+def test_jq12_overall_score_excludes_null_dimensions():
+    """JQ-12: subject_size_score and ball_visible_score are null → not in score calculation."""
+    score, _, detail, _ = quality_service.analyze(
+        _file_bytes(20), _meta()
+    )
+    # Score must be computable (not None/NaN) even with null dimensions
+    assert isinstance(score, float)
+    assert 0.0 <= score <= 1.0
+    assert detail["subject_size_score"] is None
+    assert detail["ball_visible_score"] is None
+
+
+def test_jq13_duration_acceptable_true_by_default():
+    """JQ-13: duration_acceptable is True in quality_detail (duration gate is in task layer)."""
+    _, _, detail, _ = quality_service.analyze(_file_bytes(10), _meta())
+    assert detail["duration_acceptable"] is True
+
+
+# ── Quality HTTP endpoint tests ───────────────────────────────────────────────
+
+@pytest.fixture(autouse=True)
+def _enable_juggling(monkeypatch):
+    monkeypatch.setattr(ff_module, "is_juggling_enabled", lambda: True)
+
+
+def _auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_jq14_quality_endpoint_returns_correct_structure(
+    client, student_token, db_session
+):
+    """JQ-14: GET /quality returns pending status and correct schema before analysis."""
+    from app.services.juggling import consent_service, video_service
+
+    # Setup: create consent + pending_upload video
+    from app.tests.conftest import TestingSessionLocal
+    consent_service.upsert_consent(
+        user_id=_get_user_id(client, student_token),
+        service_consent=True, training_consent=False,
+        admin_review_consent=False, db=db_session,
+    )
+    r_init = client.post(
+        "/api/v1/users/me/juggling/videos/upload-init",
+        json={"source_type": "uploaded_video"},
+        headers=_auth(student_token),
+    )
+    video_id = r_init.json()["video_id"]
+
+    r = client.get(
+        f"/api/v1/users/me/juggling/videos/{video_id}/quality",
+        headers=_auth(student_token),
+    )
+    assert r.status_code == 200, r.text
+    data = r.json()
+    assert data["video_id"] == video_id
+    assert data["status"] == "pending_upload"
+    assert data["quality_status"] == "pending"
+    assert data["quality_score"] is None
+    assert data["server_detected_metadata"] is None
+    # No video URL in response
+    assert "storage_path" not in data
+    assert "filename_stored" not in data
+    assert "url" not in str(data).lower() or "upload_url" not in data
+
+
+def test_jq15_quality_endpoint_audio_warning(client, student_token, db_session):
+    """JQ-15: quality endpoint includes audio_present warning when has_audio=True."""
+    from app.services.juggling import consent_service, video_service
+
+    uid = _get_user_id(client, student_token)
+    consent_service.upsert_consent(uid, True, False, False, db_session)
+    r_init = client.post(
+        "/api/v1/users/me/juggling/videos/upload-init",
+        json={"source_type": "uploaded_video"},
+        headers=_auth(student_token),
+    )
+    video_id = r_init.json()["video_id"]
+
+    # Simulate task writing quality_detail with audio_present
+    video = db_session.query(
+        __import__("app.models.juggling", fromlist=["JugglingVideo"]).JugglingVideo
+    ).filter_by(id=video_id).first()
+
+    video_service.apply_analysis(
+        video_id,
+        {"fps": 60.0, "has_audio": True, "codec": "h264",
+         "duration_seconds": 30.0, "rotation": 0},
+        0.80, "acceptable",
+        {"blur_score": 0.75, "dark_frame_ratio": 0.05, "fps_detected": 60.0,
+         "fps_acceptable": True, "duration_acceptable": True, "rotation": 0,
+         "subject_size_score": None, "ball_visible_score": None,
+         "audio_present": True},
+        db_session,
+    )
+
+    r = client.get(
+        f"/api/v1/users/me/juggling/videos/{video_id}/quality",
+        headers=_auth(student_token),
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert "audio_present" in data["warnings"]
+
+
+def _get_user_id(client, token: str) -> int:
+    """Helper: get the user ID from /api/v1/users/me."""
+    r = client.get("/api/v1/users/me", headers={"Authorization": f"Bearer {token}"})
+    return r.json()["id"]

--- a/app/tests/test_juggling_security.py
+++ b/app/tests/test_juggling_security.py
@@ -1,0 +1,178 @@
+"""
+Juggling security service unit tests — JS-01..JS-15.
+
+Tests run against security_service.py directly (no HTTP layer needed).
+"""
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+from app.services.juggling.security_service import (
+    VideoSecurityError,
+    compute_sha256,
+    generate_server_filename,
+    run_all_pre_save_checks,
+    validate_extension,
+    validate_magic_bytes,
+    validate_mime,
+    validate_size,
+)
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+def _make_ftyp_box(brand: bytes = b"isom") -> bytes:
+    """Minimal valid ftyp box: [size=20][ftyp][brand][minor_ver=0][compat_brand]"""
+    size = 20
+    return struct.pack(">I", size) + b"ftyp" + brand + b"\x00\x00\x00\x00" + brand
+
+
+def _mp4_bytes(brand: bytes = b"isom") -> bytes:
+    """Return bytes that start with a valid ftyp box followed by zeros."""
+    return _make_ftyp_box(brand) + b"\x00" * 100
+
+
+# ── Extension tests ───────────────────────────────────────────────────────────
+
+def test_js01_valid_extensions_accepted():
+    """JS-01: .mp4, .mov, .m4v are accepted."""
+    assert validate_extension("video.mp4") == ".mp4"
+    assert validate_extension("clip.MOV") == ".mov"
+    assert validate_extension("session.m4v") == ".m4v"
+
+
+def test_js02_invalid_extension_raises():
+    """JS-02: .avi, .mkv, .webm, .mp3 are rejected."""
+    for name in ("video.avi", "video.mkv", "video.webm", "audio.mp3"):
+        with pytest.raises(VideoSecurityError, match="unsupported_extension"):
+            validate_extension(name)
+
+
+def test_js03_path_traversal_in_filename_safe():
+    """JS-03: path traversal characters in client filename do not raise on extension extraction."""
+    # The .. and / are stripped before extension extraction — no crash, just normal rejection
+    with pytest.raises(VideoSecurityError):
+        validate_extension("../../etc/passwd")
+
+
+def test_js04_no_extension_raises():
+    """JS-04: filename with no extension raises."""
+    with pytest.raises(VideoSecurityError, match="unsupported_extension"):
+        validate_extension("videofile")
+
+
+# ── MIME tests ────────────────────────────────────────────────────────────────
+
+def test_js05_valid_mimes_accepted():
+    """JS-05: video/mp4, video/quicktime, video/x-m4v are accepted."""
+    validate_mime("video/mp4")
+    validate_mime("video/quicktime")
+    validate_mime("video/x-m4v")
+    validate_mime("video/mp4; codecs=avc1")  # with parameters
+
+
+def test_js06_invalid_mime_raises():
+    """JS-06: image/jpeg, application/octet-stream are rejected."""
+    for mime in ("image/jpeg", "application/octet-stream", "video/avi"):
+        with pytest.raises(VideoSecurityError, match="unsupported_mime"):
+            validate_mime(mime)
+
+
+# ── Magic bytes tests ─────────────────────────────────────────────────────────
+
+def test_js07_valid_ftyp_isom_accepted():
+    """JS-07: ftyp box with isom brand is accepted."""
+    validate_magic_bytes(_mp4_bytes(b"isom"))
+
+
+def test_js08_valid_ftyp_brands_accepted():
+    """JS-08: All accepted ftyp brands pass."""
+    for brand in (b"iso2", b"avc1", b"mp41", b"mp42", b"qt  ", b"hvc1"):
+        validate_magic_bytes(_mp4_bytes(brand))
+
+
+def test_js09_jpeg_magic_rejected():
+    """JS-09: JPEG magic bytes (FF D8 FF) with .mp4 extension — magic check fails."""
+    jpeg_bytes = b"\xff\xd8\xff\xe0" + b"\x00" * 20
+    with pytest.raises(VideoSecurityError, match="magic_bytes_invalid"):
+        validate_magic_bytes(jpeg_bytes)
+
+
+def test_js10_too_short_bytes_rejected():
+    """JS-10: File shorter than 12 bytes fails magic check."""
+    with pytest.raises(VideoSecurityError, match="magic_bytes_invalid"):
+        validate_magic_bytes(b"\x00" * 8)
+
+
+def test_js11_moov_only_rejected():
+    """JS-11: File starting with moov (no ftyp) is rejected — moov alone is insufficient."""
+    moov_bytes = b"\x00\x00\x00\x08" + b"moov" + b"\x00" * 100
+    with pytest.raises(VideoSecurityError, match="magic_bytes_invalid"):
+        validate_magic_bytes(moov_bytes)
+
+
+# ── Size tests ────────────────────────────────────────────────────────────────
+
+def test_js12_empty_file_raises():
+    """JS-12: Empty file (0 bytes) raises with empty_file code."""
+    with pytest.raises(VideoSecurityError, match="empty_file"):
+        validate_size(b"")
+
+
+def test_js13_oversized_file_raises(monkeypatch):
+    """JS-13: File exceeding JUGGLING_VIDEO_MAX_SIZE_MB raises file_too_large."""
+    from app.services.juggling import security_service as ss
+    monkeypatch.setattr(ss.settings, "JUGGLING_VIDEO_MAX_SIZE_MB", 1)
+    big = b"\x00" * (2 * 1024 * 1024)  # 2 MB > 1 MB limit
+    with pytest.raises(VideoSecurityError, match="file_too_large"):
+        validate_size(big)
+
+
+# ── Filename / checksum tests ─────────────────────────────────────────────────
+
+def test_js14_server_filename_is_uuid_not_client_name():
+    """JS-14: server-generated filename is UUID-based, never client name."""
+    fname = generate_server_filename(".mp4")
+    assert fname.endswith(".mp4")
+    assert "client" not in fname
+    assert "/" not in fname
+    assert ".." not in fname
+    # Should be UUID4 format: 8-4-4-4-12 hex chars
+    stem = fname[:-4]
+    assert len(stem) == 36  # UUID string length
+
+
+def test_js15_checksum_sha256_is_hex_64():
+    """JS-15: compute_sha256 returns 64-char hex string."""
+    digest = compute_sha256(b"hello world")
+    assert len(digest) == 64
+    assert all(c in "0123456789abcdef" for c in digest)
+
+
+def test_js16_run_all_checks_pass_returns_filename_and_checksum():
+    """JS-16: run_all_pre_save_checks returns (server_filename, checksum) on valid input."""
+    data = _mp4_bytes()
+    server_fname, checksum = run_all_pre_save_checks(
+        client_filename="myvideo.mp4",
+        content_type="video/mp4",
+        file_bytes=data,
+    )
+    assert server_fname.endswith(".mp4")
+    assert len(checksum) == 64
+    # Client filename is NOT used in server filename
+    assert "myvideo" not in server_fname
+
+
+def test_js17_run_all_checks_order_extension_first():
+    """JS-17: Extension check runs first — .avi rejected before MIME or magic checked."""
+    data = _mp4_bytes()  # valid bytes but wrong extension
+    with pytest.raises(VideoSecurityError, match="unsupported_extension"):
+        run_all_pre_save_checks("video.avi", "video/mp4", data)
+
+
+def test_js18_empty_file_returns_400_error_not_415():
+    """JS-18: Empty file raises empty_file (not magic_bytes_invalid) so endpoint returns 400."""
+    with pytest.raises(VideoSecurityError, match="empty_file"):
+        run_all_pre_save_checks("video.mp4", "video/mp4", b"")

--- a/app/tests/test_juggling_upload.py
+++ b/app/tests/test_juggling_upload.py
@@ -1,0 +1,363 @@
+"""
+Juggling upload endpoint tests — JU-01..JU-18.
+
+Tests run with JUGGLING_POC_ENABLED=True (monkeypatched).
+analyze_video_task.delay is mocked so no Celery worker is needed.
+"""
+from __future__ import annotations
+
+import struct
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.juggling import feature_flag as ff_module
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture(autouse=True)
+def _enable_juggling(monkeypatch):
+    monkeypatch.setattr(ff_module, "is_juggling_enabled", lambda: True)
+
+
+def _auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _make_ftyp_box(brand: bytes = b"isom") -> bytes:
+    size = 20
+    return struct.pack(">I", size) + b"ftyp" + brand + b"\x00\x00\x00\x00" + brand
+
+
+def _valid_mp4() -> bytes:
+    return _make_ftyp_box() + b"\x00" * 200
+
+
+def _grant_consent(client, token):
+    client.post(
+        "/api/v1/users/me/juggling-consent",
+        json={"service_consent": True},
+        headers=_auth(token),
+    )
+
+
+def _init_upload(client, token, source_type="uploaded_video"):
+    return client.post(
+        "/api/v1/users/me/juggling/videos/upload-init",
+        json={"source_type": source_type, "upload_source": "gallery"},
+        headers=_auth(token),
+    )
+
+
+def _upload_file(client, token, video_id, data=None, filename="video.mp4", ct="video/mp4"):
+    if data is None:
+        data = _valid_mp4()
+    return client.post(
+        f"/api/v1/users/me/juggling/videos/{video_id}/upload",
+        files={"file": (filename, data, ct)},
+        headers=_auth(token),
+    )
+
+
+# ── upload-init tests ─────────────────────────────────────────────────────────
+
+def test_ju01_upload_init_in_app_capture_201(client, student_token):
+    """JU-01: upload-init source_type=in_app_capture returns 201."""
+    _grant_consent(client, student_token)
+    r = _init_upload(client, student_token, "in_app_capture")
+    assert r.status_code == 201, r.text
+    data = r.json()
+    assert data["status"] == "pending_upload"
+    assert "video_id" in data
+
+
+def test_ju02_upload_init_uploaded_video_201(client, student_token):
+    """JU-02: upload-init source_type=uploaded_video returns 201."""
+    _grant_consent(client, student_token)
+    r = _init_upload(client, student_token, "uploaded_video")
+    assert r.status_code == 201, r.text
+
+
+def test_ju03_upload_init_invalid_source_type_422(client, student_token):
+    """JU-03: invalid source_type returns 422."""
+    _grant_consent(client, student_token)
+    r = client.post(
+        "/api/v1/users/me/juggling/videos/upload-init",
+        json={"source_type": "webcam_recording"},
+        headers=_auth(student_token),
+    )
+    assert r.status_code == 422, r.text
+
+
+def test_ju04_upload_init_client_metadata_optional(client, student_token):
+    """JU-04: client_reported_metadata is optional."""
+    _grant_consent(client, student_token)
+    r = client.post(
+        "/api/v1/users/me/juggling/videos/upload-init",
+        json={"source_type": "uploaded_video"},
+        headers=_auth(student_token),
+    )
+    assert r.status_code == 201
+
+
+def test_ju05_upload_init_extra_metadata_keys_ignored(client, student_token):
+    """JU-05: Unknown keys in client_reported_metadata are silently dropped."""
+    _grant_consent(client, student_token)
+    r = client.post(
+        "/api/v1/users/me/juggling/videos/upload-init",
+        json={
+            "source_type": "uploaded_video",
+            "client_reported_metadata": {
+                "fps": 60.0,
+                "resolution": "1280x720",
+                "SECRET_KEY": "should_be_dropped",
+                "malicious_key": "also_dropped",
+            },
+        },
+        headers=_auth(student_token),
+    )
+    assert r.status_code == 201
+
+
+# ── file upload tests ─────────────────────────────────────────────────────────
+
+def test_ju06_upload_mp4_ok(client, student_token, tmp_path):
+    """JU-06: Upload valid .mp4 returns 200 with checksum."""
+    _grant_consent(client, student_token)
+    init = _init_upload(client, student_token)
+    video_id = init.json()["video_id"]
+
+    with patch("app.services.juggling.video_service.save_file") as mock_save:
+        mock_save.return_value = tmp_path / "test.mp4"
+        (tmp_path / "test.mp4").write_bytes(_valid_mp4())
+        r = _upload_file(client, student_token, video_id)
+
+    assert r.status_code == 200, r.text
+    data = r.json()
+    assert data["status"] == "uploaded"
+    assert "checksum_sha256" in data
+    assert len(data["checksum_sha256"]) == 64
+
+
+def test_ju07_upload_mov_ok(client, student_token, tmp_path):
+    """JU-07: Upload valid .mov returns 200."""
+    _grant_consent(client, student_token)
+    init = _init_upload(client, student_token)
+    video_id = init.json()["video_id"]
+
+    with patch("app.services.juggling.video_service.save_file") as mock_save:
+        mock_save.return_value = tmp_path / "test.mov"
+        (tmp_path / "test.mov").write_bytes(_valid_mp4())
+        r = _upload_file(client, student_token, video_id,
+                         filename="clip.mov", ct="video/quicktime")
+
+    assert r.status_code == 200
+
+
+def test_ju08_upload_too_large_413(client, student_token, monkeypatch):
+    """JU-08: File exceeding size limit returns 413."""
+    from app.services.juggling import security_service as ss
+    monkeypatch.setattr(ss.settings, "JUGGLING_VIDEO_MAX_SIZE_MB", 0)  # 0 MB → everything too large
+
+    _grant_consent(client, student_token)
+    init = _init_upload(client, student_token)
+    video_id = init.json()["video_id"]
+
+    r = _upload_file(client, student_token, video_id, data=_valid_mp4())
+    assert r.status_code == 413, r.text
+
+
+def test_ju09_upload_empty_file_400(client, student_token):
+    """JU-09: Empty file returns 400."""
+    _grant_consent(client, student_token)
+    init = _init_upload(client, student_token)
+    video_id = init.json()["video_id"]
+    r = _upload_file(client, student_token, video_id, data=b"")
+    assert r.status_code == 400, r.text
+
+
+def test_ju10_upload_unsupported_extension_415(client, student_token):
+    """JU-10: .avi extension returns 415."""
+    _grant_consent(client, student_token)
+    init = _init_upload(client, student_token)
+    video_id = init.json()["video_id"]
+    r = _upload_file(client, student_token, video_id,
+                     filename="video.avi", ct="video/x-msvideo",
+                     data=_valid_mp4())
+    assert r.status_code == 415, r.text
+
+
+def test_ju11_upload_unsupported_mime_415(client, student_token):
+    """JU-11: image/jpeg MIME returns 415."""
+    _grant_consent(client, student_token)
+    init = _init_upload(client, student_token)
+    video_id = init.json()["video_id"]
+    r = _upload_file(client, student_token, video_id,
+                     filename="video.mp4", ct="image/jpeg",
+                     data=_valid_mp4())
+    assert r.status_code == 415, r.text
+
+
+def test_ju12_upload_magic_bytes_mismatch_415(client, student_token):
+    """JU-12: .mp4 extension + video/mp4 MIME but JPEG magic bytes → 415."""
+    jpeg_magic = b"\xff\xd8\xff\xe0" + b"\x00" * 200
+    _grant_consent(client, student_token)
+    init = _init_upload(client, student_token)
+    video_id = init.json()["video_id"]
+    r = _upload_file(client, student_token, video_id,
+                     filename="fake.mp4", ct="video/mp4",
+                     data=jpeg_magic)
+    assert r.status_code == 415, r.text
+
+
+def test_ju13_server_generated_filename_not_client_name(client, student_token, tmp_path):
+    """JU-13: Stored filename is server-generated UUID, never the client filename."""
+    _grant_consent(client, student_token)
+    init = _init_upload(client, student_token)
+    video_id = init.json()["video_id"]
+
+    saved_path = tmp_path / "uuid-generated.mp4"
+    with patch("app.services.juggling.video_service.save_file") as mock_save:
+        mock_save.return_value = saved_path
+        saved_path.write_bytes(_valid_mp4())
+        r = _upload_file(client, student_token, video_id,
+                         filename="my_personal_video.mp4")
+
+    assert r.status_code == 200
+    # The saved filename should NOT contain the client's filename
+    call_args = mock_save.call_args
+    stored_fname = call_args[0][1]  # second positional arg = filename
+    assert "my_personal_video" not in stored_fname
+    assert ".." not in stored_fname
+
+
+def test_ju14_checksum_sha256_stored(client, student_token, tmp_path, db_session):
+    """JU-14: checksum_sha256 is stored in DB after upload."""
+    from app.models.juggling import JugglingVideo
+    from app.services.juggling.security_service import compute_sha256
+
+    _grant_consent(client, student_token)
+    init = _init_upload(client, student_token)
+    video_id = init.json()["video_id"]
+    mp4_data = _valid_mp4()
+    expected_checksum = compute_sha256(mp4_data)
+
+    with patch("app.services.juggling.video_service.save_file") as mock_save:
+        mock_save.return_value = tmp_path / "test.mp4"
+        (tmp_path / "test.mp4").write_bytes(mp4_data)
+        _upload_file(client, student_token, video_id, data=mp4_data)
+
+    record = db_session.query(JugglingVideo).filter_by(id=video_id).first()
+    assert record is not None
+    assert record.checksum_sha256 == expected_checksum
+
+
+# ── complete endpoint tests ───────────────────────────────────────────────────
+
+def test_ju15_complete_returns_processing(client, student_token, tmp_path):
+    """JU-15: complete endpoint transitions to processing and returns 200."""
+    _grant_consent(client, student_token)
+    init = _init_upload(client, student_token)
+    video_id = init.json()["video_id"]
+
+    with patch("app.services.juggling.video_service.save_file") as mock_save:
+        mock_save.return_value = tmp_path / "t.mp4"
+        (tmp_path / "t.mp4").write_bytes(_valid_mp4())
+        _upload_file(client, student_token, video_id)
+
+    with patch(
+        "app.api.api_v1.endpoints.users.juggling_videos.analyze_video_task"
+    ) as mock_task:
+        mock_task.delay = MagicMock()
+        r = client.post(
+            f"/api/v1/users/me/juggling/videos/{video_id}/complete",
+            headers=_auth(student_token),
+        )
+
+    assert r.status_code == 200, r.text
+    assert r.json()["status"] == "processing"
+    mock_task.delay.assert_called_once_with(video_id)
+
+
+def test_ju16_complete_409_from_pending_upload(client, student_token):
+    """JU-16: complete returns 409 if video is in pending_upload status."""
+    _grant_consent(client, student_token)
+    init = _init_upload(client, student_token)
+    video_id = init.json()["video_id"]
+    r = client.post(
+        f"/api/v1/users/me/juggling/videos/{video_id}/complete",
+        headers=_auth(student_token),
+    )
+    assert r.status_code == 409, r.text
+
+
+def test_ju17_complete_409_double_submit(client, student_token, tmp_path):
+    """JU-17: calling complete twice returns 409 on second call."""
+    _grant_consent(client, student_token)
+    init = _init_upload(client, student_token)
+    video_id = init.json()["video_id"]
+
+    with patch("app.services.juggling.video_service.save_file") as mock_save:
+        mock_save.return_value = tmp_path / "t.mp4"
+        (tmp_path / "t.mp4").write_bytes(_valid_mp4())
+        _upload_file(client, student_token, video_id)
+
+    with patch("app.api.api_v1.endpoints.users.juggling_videos.analyze_video_task") as mock_task:
+        mock_task.delay = MagicMock()
+        client.post(
+            f"/api/v1/users/me/juggling/videos/{video_id}/complete",
+            headers=_auth(student_token),
+        )
+        r = client.post(
+            f"/api/v1/users/me/juggling/videos/{video_id}/complete",
+            headers=_auth(student_token),
+        )
+    assert r.status_code == 409, r.text
+
+
+def test_ju18_server_metadata_overrides_client_metadata(
+    client, student_token, tmp_path, db_session
+):
+    """JU-18: server_detected_metadata is written by task; client metadata is not authoritative."""
+    from app.models.juggling import JugglingVideo
+    from app.services.juggling import video_service
+
+    _grant_consent(client, student_token)
+    # Init with client metadata claiming fps=24
+    r_init = client.post(
+        "/api/v1/users/me/juggling/videos/upload-init",
+        json={
+            "source_type": "in_app_capture",
+            "client_reported_metadata": {"fps": 24.0, "resolution": "640x480"},
+        },
+        headers=_auth(student_token),
+    )
+    video_id = r_init.json()["video_id"]
+
+    with patch("app.services.juggling.video_service.save_file") as mock_save:
+        mock_save.return_value = tmp_path / "t.mp4"
+        (tmp_path / "t.mp4").write_bytes(_valid_mp4())
+        _upload_file(client, student_token, video_id)
+
+    # Simulate task writing server metadata with different fps
+    server_meta = {"fps": 59.94, "resolution": "1280x720", "codec": "h264",
+                   "has_audio": False, "duration_seconds": 30.0}
+    video_service.apply_analysis(
+        video_id, server_meta, 0.85, "acceptable",
+        {"blur_score": 0.8, "dark_frame_ratio": 0.05, "fps_detected": 59.94,
+         "fps_acceptable": True, "duration_acceptable": True, "rotation": 0,
+         "subject_size_score": None, "ball_visible_score": None},
+        db_session,
+    )
+
+    r_q = client.get(
+        f"/api/v1/users/me/juggling/videos/{video_id}/quality",
+        headers=_auth(student_token),
+    )
+    assert r_q.status_code == 200
+    server = r_q.json()["server_detected_metadata"]
+    assert server["fps"] == 59.94       # server wins
+    assert server["resolution"] == "1280x720"  # server wins
+    assert "SECRET_KEY" not in server

--- a/tests/biometric/test_admin_review_api.py
+++ b/tests/biometric/test_admin_review_api.py
@@ -542,7 +542,7 @@ def test_bca_adm21_override_audit_no_score(db, biometric_feature_enabled):
 def test_bca_adm22_route_count_883():
     from app.main import app
     paths = app.openapi().get("paths", {})
-    assert len(paths) == 883, f"Expected 883 routes, got {len(paths)}"
+    assert len(paths) == 888, f"Expected 883 routes, got {len(paths)}"
     assert "/api/v1/admin/biometric/review-queue" in paths
     assert "/api/v1/admin/biometric/{user_id}/history" in paths
     assert "/api/v1/admin/biometric/{user_id}/override" in paths

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -5111,6 +5111,20 @@
         "title": "Body_team_invite_teams__team_id__invite_post",
         "type": "object"
       },
+      "Body_upload_file_api_v1_users_me_juggling_videos__video_id__upload_post": {
+        "properties": {
+          "file": {
+            "format": "binary",
+            "title": "File",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file"
+        ],
+        "title": "Body_upload_file_api_v1_users_me_juggling_videos__video_id__upload_post",
+        "type": "object"
+      },
       "Body_upload_mood_photo_api_v1_lfa_player_mood_photos__slot__upload_post": {
         "properties": {
           "photo": {
@@ -9827,6 +9841,257 @@
           "positions"
         ],
         "title": "JobBoardResponse",
+        "type": "object"
+      },
+      "JugglingCompleteOut": {
+        "properties": {
+          "message": {
+            "default": "Analysis queued. Poll GET /quality for results.",
+            "title": "Message",
+            "type": "string"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "video_id": {
+            "title": "Video Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "video_id",
+          "status"
+        ],
+        "title": "JugglingCompleteOut",
+        "type": "object"
+      },
+      "JugglingConsentGrantRequest": {
+        "properties": {
+          "admin_review_consent": {
+            "default": false,
+            "title": "Admin Review Consent",
+            "type": "boolean"
+          },
+          "service_consent": {
+            "default": false,
+            "title": "Service Consent",
+            "type": "boolean"
+          },
+          "training_consent": {
+            "default": false,
+            "title": "Training Consent",
+            "type": "boolean"
+          }
+        },
+        "title": "JugglingConsentGrantRequest",
+        "type": "object"
+      },
+      "JugglingConsentOut": {
+        "properties": {
+          "admin_review_consent": {
+            "title": "Admin Review Consent",
+            "type": "boolean"
+          },
+          "consented_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Consented At"
+          },
+          "service_consent": {
+            "title": "Service Consent",
+            "type": "boolean"
+          },
+          "training_consent": {
+            "title": "Training Consent",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "service_consent",
+          "training_consent",
+          "admin_review_consent"
+        ],
+        "title": "JugglingConsentOut",
+        "type": "object"
+      },
+      "JugglingQualityOut": {
+        "properties": {
+          "quality_detail": {
+            "anyOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Quality Detail"
+          },
+          "quality_score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Quality Score"
+          },
+          "quality_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Quality Status"
+          },
+          "rejection_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rejection Reason"
+          },
+          "server_detected_metadata": {
+            "anyOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Server Detected Metadata"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "video_id": {
+            "title": "Video Id",
+            "type": "string"
+          },
+          "warnings": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Warnings",
+            "type": "array"
+          }
+        },
+        "required": [
+          "video_id",
+          "status",
+          "quality_status",
+          "quality_score",
+          "server_detected_metadata",
+          "quality_detail",
+          "rejection_reason"
+        ],
+        "title": "JugglingQualityOut",
+        "type": "object"
+      },
+      "JugglingUploadFileOut": {
+        "properties": {
+          "checksum_sha256": {
+            "title": "Checksum Sha256",
+            "type": "string"
+          },
+          "file_size_bytes": {
+            "title": "File Size Bytes",
+            "type": "integer"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "video_id": {
+            "title": "Video Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "video_id",
+          "status",
+          "file_size_bytes",
+          "checksum_sha256"
+        ],
+        "title": "JugglingUploadFileOut",
+        "type": "object"
+      },
+      "JugglingUploadInitOut": {
+        "properties": {
+          "message": {
+            "default": "Upload ready. POST the video file to upload_url.",
+            "title": "Message",
+            "type": "string"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "upload_url": {
+            "title": "Upload Url",
+            "type": "string"
+          },
+          "video_id": {
+            "title": "Video Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "video_id",
+          "status",
+          "upload_url"
+        ],
+        "title": "JugglingUploadInitOut",
+        "type": "object"
+      },
+      "JugglingUploadInitRequest": {
+        "properties": {
+          "client_reported_metadata": {
+            "anyOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Client Reported Metadata"
+          },
+          "source_type": {
+            "description": "in_app_capture | uploaded_video",
+            "title": "Source Type",
+            "type": "string"
+          },
+          "upload_source": {
+            "default": "unknown",
+            "description": "camera | gallery | file | unknown",
+            "title": "Upload Source",
+            "type": "string"
+          }
+        },
+        "required": [
+          "source_type"
+        ],
+        "title": "JugglingUploadInitRequest",
         "type": "object"
       },
       "LFAPlayerAmateurRequest": {
@@ -61043,6 +61308,291 @@
         "tags": [
           "users",
           "users"
+        ]
+      }
+    },
+    "/api/v1/users/me/juggling-consent": {
+      "get": {
+        "operationId": "get_juggling_consent_api_v1_users_me_juggling_consent_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JugglingConsentOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get current juggling consent state",
+        "tags": [
+          "users",
+          "users",
+          "juggling",
+          "juggling"
+        ]
+      },
+      "post": {
+        "operationId": "post_juggling_consent_api_v1_users_me_juggling_consent_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JugglingConsentGrantRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JugglingConsentOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Create or update juggling consent",
+        "tags": [
+          "users",
+          "users",
+          "juggling",
+          "juggling"
+        ]
+      }
+    },
+    "/api/v1/users/me/juggling/videos/upload-init": {
+      "post": {
+        "operationId": "upload_init_api_v1_users_me_juggling_videos_upload_init_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JugglingUploadInitRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JugglingUploadInitOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Initialise a juggling video upload",
+        "tags": [
+          "users",
+          "users",
+          "juggling",
+          "juggling"
+        ]
+      }
+    },
+    "/api/v1/users/me/juggling/videos/{video_id}/complete": {
+      "post": {
+        "operationId": "complete_api_v1_users_me_juggling_videos__video_id__complete_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "video_id",
+            "required": true,
+            "schema": {
+              "title": "Video Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JugglingCompleteOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Trigger quality analysis (Celery async)",
+        "tags": [
+          "users",
+          "users",
+          "juggling",
+          "juggling"
+        ]
+      }
+    },
+    "/api/v1/users/me/juggling/videos/{video_id}/quality": {
+      "get": {
+        "operationId": "get_quality_api_v1_users_me_juggling_videos__video_id__quality_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "video_id",
+            "required": true,
+            "schema": {
+              "title": "Video Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JugglingQualityOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Poll quality analysis result",
+        "tags": [
+          "users",
+          "users",
+          "juggling",
+          "juggling"
+        ]
+      }
+    },
+    "/api/v1/users/me/juggling/videos/{video_id}/upload": {
+      "post": {
+        "operationId": "upload_file_api_v1_users_me_juggling_videos__video_id__upload_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "video_id",
+            "required": true,
+            "schema": {
+              "title": "Video Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_upload_file_api_v1_users_me_juggling_videos__video_id__upload_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JugglingUploadFileOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Upload juggling video file",
+        "tags": [
+          "users",
+          "users",
+          "juggling",
+          "juggling"
         ]
       }
     },

--- a/tests/unit/api/web_routes/test_card_editor_ce2.py
+++ b/tests/unit/api/web_routes/test_card_editor_ce2.py
@@ -430,9 +430,9 @@ class TestCE216WelcomeEditorUnchanged:
 
 class TestCE217RouteCount:
     def test_openapi_snapshot_route_count_unchanged(self):
-        """PR-6 biometric verify adds 1 new path — snapshot path count must equal 879."""
+        """PR-JUG-1 juggling intake adds 5 new paths (883 prior → 888)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 883, (
-            f"Expected 879 routes (878 prior + 1 biometric-verify path), got {len(paths)}."
+        assert len(paths) == 888, (
+            f"Expected 888 routes (883 prior + 5 juggling-intake paths), got {len(paths)}."
         )

--- a/tests/unit/api/web_routes/test_card_editor_cs_s1.py
+++ b/tests/unit/api/web_routes/test_card_editor_cs_s1.py
@@ -291,11 +291,11 @@ class TestS1bCTAAndNaming:
 class TestS109S110RouteAndSnapshot:
 
     def test_s1_09_route_count_846(self):
-        """S1-09 (updated PR-6): route count is 879 (+1 biometric-verify endpoint)."""
+        """S1-09 (updated PR-JUG-1): route count is 888 (+5 juggling-intake paths)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 883, (
-            f"Expected 879 routes (878 prior + 1 biometric-verify), got {len(paths)}"
+        assert len(paths) == 888, (
+            f"Expected 888 routes (883 prior + 5 juggling-intake paths), got {len(paths)}"
         )
 
     def test_s1_10_openapi_snapshot_still_matches(self):

--- a/tests/unit/api/web_routes/test_card_editor_ref_p2.py
+++ b/tests/unit/api/web_routes/test_card_editor_ref_p2.py
@@ -287,7 +287,7 @@ class TestP227to29RouteAndOpenAPI:
         """P2-27: Route count = 846 (CS-S2A +1 /card-studio/player)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 883, f"Expected 846 routes, got {len(paths)}"
+        assert len(paths) == 888, f"Expected 846 routes, got {len(paths)}"
 
     def test_p2_28_openapi_snapshot_match(self):
         """P2-28: OpenAPI snapshot matches live API paths."""

--- a/tests/unit/api/web_routes/test_card_studio_challenge.py
+++ b/tests/unit/api/web_routes/test_card_studio_challenge.py
@@ -294,7 +294,7 @@ class TestCCS11RouteCount:
         """CCS-11: route count updated to 842 after CE-3.8 (+3 from-mood endpoints)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 883, (
+        assert len(paths) == 888, (
             f"Expected 845 routes (842 CE-3.7+CE-3.8 baseline + 2 CS-S0 card-studio routes), got {len(paths)}."
         )
 

--- a/tests/unit/api/web_routes/test_card_studio_landing.py
+++ b/tests/unit/api/web_routes/test_card_studio_landing.py
@@ -159,7 +159,7 @@ class TestCEL12RouteCount:
         """CEL-12: route count 844 (unchanged — redirect is handler change, not new route)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 883, (
+        assert len(paths) == 888, (
             f"Expected 845 routes (redirect handler change does not add routes), got {len(paths)}."
         )
 

--- a/tests/unit/api/web_routes/test_card_studio_shell.py
+++ b/tests/unit/api/web_routes/test_card_studio_shell.py
@@ -326,7 +326,7 @@ class TestCSS21to23RouteConfirmations:
         """CSS-21: adding 2 card-studio routes raises count from 842 to 844."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 883, (
+        assert len(paths) == 888, (
             f"Expected 845 routes (842 baseline + 2 new /card-studio routes), got {len(paths)}"
         )
 

--- a/tests/unit/api/web_routes/test_card_studio_welcome.py
+++ b/tests/unit/api/web_routes/test_card_studio_welcome.py
@@ -325,7 +325,7 @@ class TestCEW18RouteCount:
         """CEW-18: route count baseline check (updated by CE-3.8 to 842)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 883, (
+        assert len(paths) == 888, (
             f"Expected 842 routes (839 CE-3.7 baseline + 3 from-mood endpoints), got {len(paths)}."
         )
 
@@ -678,7 +678,7 @@ class TestCEW44to51TemplateMoodPicker:
         """CEW-47: CE-3.8 adds 3 from-mood routes → total 842."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 883, (
+        assert len(paths) == 888, (
             f"Expected 845 routes (842 baseline + 2 CS-S0 routes), got {len(paths)}"
         )
 

--- a/tests/unit/api/web_routes/test_cc_design_1.py
+++ b/tests/unit/api/web_routes/test_cc_design_1.py
@@ -780,7 +780,7 @@ class TestCCD22to23RouteSnapshot:
         """CCD-22: Route count is 851 (CC-DESIGN-1 SNAPSHOT adds POST /challenges/{id}/card/photo)."""
         from app.main import app
         count = len(app.openapi().get("paths", {}))
-        assert count == 883, f"Expected 851, got {count}"
+        assert count == 888, f"Expected 851, got {count}"
 
     def test_ccd_23_openapi_snapshot_match(self):
         """CCD-23: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_cs_color_1.py
+++ b/tests/unit/api/web_routes/test_cs_color_1.py
@@ -382,7 +382,7 @@ class TestCSCOL15to16RouteAndSnapshot:
         """CSCOL-15: route count = 845 (+1 POST /dashboard/wc-card-theme)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 883, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 888, f"Expected 845 routes, got {len(paths)}"
 
     def test_cscol_16_openapi_snapshot_includes_wc_card_theme(self):
         """CSCOL-16: OpenAPI snapshot includes /dashboard/wc-card-theme."""

--- a/tests/unit/api/web_routes/test_cs_s2a.py
+++ b/tests/unit/api/web_routes/test_cs_s2a.py
@@ -40,7 +40,7 @@ class TestS2A01to02RouteRegistration:
         """S2A-02 (updated CS-S4A): Total route count is 847 (CS-S2A+CS-S4A)."""
         from app.main import app
         count = len(app.openapi().get("paths", {}))
-        assert count == 883, f"Expected 847 routes, got {count}"
+        assert count == 888, f"Expected 847 routes, got {count}"
 
 
 # ── S2A-03..08: _resolve_player_context logic ────────────────────────────────

--- a/tests/unit/api/web_routes/test_cs_s4a.py
+++ b/tests/unit/api/web_routes/test_cs_s4a.py
@@ -152,7 +152,7 @@ class TestS4A12to13RouteAndSnapshot:
         """S4A-12: Route count == 851 (CC-DESIGN-1 SNAPSHOT adds +1 POST /challenges/{id}/card/photo)."""
         from app.main import app
         count = len(app.openapi().get("paths", {}))
-        assert count == 883, f"Expected 851 routes, got {count}"
+        assert count == 888, f"Expected 851 routes, got {count}"
 
     def test_s4a_13_openapi_snapshot_match(self):
         """S4A-13: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_family_color_shop.py
+++ b/tests/unit/api/web_routes/test_family_color_shop.py
@@ -223,7 +223,7 @@ class TestRouteRegistration:
     def test_ts_13_route_count_836(self):
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 883, (
+        assert len(paths) == 888, (
             f"Expected 845 routes (842 CE-3.7+CE-3.8 baseline + 2 CS-S0 card-studio routes), got {len(paths)}."
         )
 

--- a/tests/unit/api/web_routes/test_shop_3a.py
+++ b/tests/unit/api/web_routes/test_shop_3a.py
@@ -194,7 +194,7 @@ class TestS3A13to14RouteAndSnapshot:
         """S3A-13: Route count = 845 (template deletion does not affect routes)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 883, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 888, f"Expected 845 routes, got {len(paths)}"
 
     def test_s3a_14_openapi_snapshot_match(self):
         """S3A-14: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_shop_3b1.py
+++ b/tests/unit/api/web_routes/test_shop_3b1.py
@@ -158,7 +158,7 @@ class TestS3B112to13RouteAndSnapshot:
         """S3B1-12: Route count = 845 (test cleanup does not affect routes)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 883, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 888, f"Expected 845 routes, got {len(paths)}"
 
     def test_s3b1_13_openapi_snapshot_match(self):
         """S3B1-13: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_shop_3b2.py
+++ b/tests/unit/api/web_routes/test_shop_3b2.py
@@ -192,7 +192,7 @@ class TestS3B215to16RouteAndSnapshot:
         """S3B2-15: Route count = 845 (template deletion does not affect routes)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 883, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 888, f"Expected 845 routes, got {len(paths)}"
 
     def test_s3b2_16_openapi_snapshot_match(self):
         """S3B2-16: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_shop_unified.py
+++ b/tests/unit/api/web_routes/test_shop_unified.py
@@ -271,7 +271,7 @@ class TestSHOP14to15RouteAndSnapshot:
         """SHOP-14: route count = 845 (no new routes in SHOP-1)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 883, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 888, f"Expected 845 routes, got {len(paths)}"
 
     def test_shop_15_openapi_snapshot_match(self):
         """SHOP-15: OpenAPI snapshot matches live API."""

--- a/tests/unit/juggling/test_juggling_services.py
+++ b/tests/unit/juggling/test_juggling_services.py
@@ -1,0 +1,335 @@
+"""
+Juggling service unit tests — CI coverage suite.
+
+Pure function tests for security_service, quality_service, feature_flag.
+No DB, no HTTP, no Celery. Fast and isolated.
+
+These complement app/tests/test_juggling_*.py which cover the full
+HTTP layer but are not included in the CI coverage run.
+"""
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+
+# ── security_service ─────────────────────────────────────────────────────────
+
+from app.services.juggling.security_service import (
+    VideoSecurityError,
+    compute_sha256,
+    generate_server_filename,
+    run_all_pre_save_checks,
+    validate_extension,
+    validate_magic_bytes,
+    validate_mime,
+    validate_size,
+)
+
+
+def _ftyp_mp4(size_bytes: int = 200) -> bytes:
+    box = struct.pack(">I", 20) + b"ftyp" + b"isom" + b"\x00\x00\x00\x00" + b"isom"
+    return box + b"\x00" * size_bytes
+
+
+class TestSecurityServiceExtension:
+    def test_mp4_accepted(self):
+        assert validate_extension("clip.mp4") == ".mp4"
+
+    def test_mov_accepted(self):
+        assert validate_extension("clip.MOV") == ".mov"
+
+    def test_m4v_accepted(self):
+        assert validate_extension("session.m4v") == ".m4v"
+
+    def test_avi_rejected(self):
+        with pytest.raises(VideoSecurityError, match="unsupported_extension"):
+            validate_extension("clip.avi")
+
+    def test_mkv_rejected(self):
+        with pytest.raises(VideoSecurityError, match="unsupported_extension"):
+            validate_extension("clip.mkv")
+
+    def test_no_extension_rejected(self):
+        with pytest.raises(VideoSecurityError, match="unsupported_extension"):
+            validate_extension("noextension")
+
+    def test_path_traversal_stripped(self):
+        with pytest.raises(VideoSecurityError):
+            validate_extension("../../etc/passwd")
+
+
+class TestSecurityServiceMime:
+    def test_video_mp4_accepted(self):
+        validate_mime("video/mp4")
+
+    def test_video_quicktime_accepted(self):
+        validate_mime("video/quicktime")
+
+    def test_video_x_m4v_accepted(self):
+        validate_mime("video/x-m4v")
+
+    def test_mime_with_params_accepted(self):
+        validate_mime("video/mp4; codecs=avc1")
+
+    def test_image_jpeg_rejected(self):
+        with pytest.raises(VideoSecurityError, match="unsupported_mime"):
+            validate_mime("image/jpeg")
+
+    def test_octet_stream_rejected(self):
+        with pytest.raises(VideoSecurityError, match="unsupported_mime"):
+            validate_mime("application/octet-stream")
+
+
+class TestSecurityServiceMagicBytes:
+    def test_isom_ftyp_accepted(self):
+        validate_magic_bytes(_ftyp_mp4())
+
+    def test_avc1_brand_accepted(self):
+        box = struct.pack(">I", 20) + b"ftyp" + b"avc1" + b"\x00\x00\x00\x00" + b"avc1"
+        validate_magic_bytes(box + b"\x00" * 100)
+
+    def test_qt_brand_accepted(self):
+        box = struct.pack(">I", 20) + b"ftyp" + b"qt  " + b"\x00\x00\x00\x00" + b"qt  "
+        validate_magic_bytes(box + b"\x00" * 100)
+
+    def test_hvc1_brand_accepted(self):
+        box = struct.pack(">I", 20) + b"ftyp" + b"hvc1" + b"\x00\x00\x00\x00" + b"hvc1"
+        validate_magic_bytes(box + b"\x00" * 100)
+
+    def test_jpeg_magic_rejected(self):
+        with pytest.raises(VideoSecurityError, match="magic_bytes_invalid"):
+            validate_magic_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 100)
+
+    def test_too_short_rejected(self):
+        with pytest.raises(VideoSecurityError, match="magic_bytes_invalid"):
+            validate_magic_bytes(b"\x00" * 8)
+
+    def test_moov_alone_rejected(self):
+        moov = b"\x00\x00\x00\x08" + b"moov" + b"\x00" * 100
+        with pytest.raises(VideoSecurityError, match="magic_bytes_invalid"):
+            validate_magic_bytes(moov)
+
+    def test_unknown_brand_rejected(self):
+        box = struct.pack(">I", 20) + b"ftyp" + b"UNKN" + b"\x00\x00\x00\x00" + b"UNKN"
+        with pytest.raises(VideoSecurityError, match="magic_bytes_invalid"):
+            validate_magic_bytes(box + b"\x00" * 100)
+
+
+class TestSecurityServiceSize:
+    def test_empty_file_rejected(self):
+        with pytest.raises(VideoSecurityError, match="empty_file"):
+            validate_size(b"")
+
+    def test_oversized_rejected(self, monkeypatch):
+        from app.services.juggling import security_service as ss
+        monkeypatch.setattr(ss.settings, "JUGGLING_VIDEO_MAX_SIZE_MB", 1)
+        with pytest.raises(VideoSecurityError, match="file_too_large"):
+            validate_size(b"\x00" * (2 * 1024 * 1024))
+
+    def test_within_limit_accepted(self, monkeypatch):
+        from app.services.juggling import security_service as ss
+        monkeypatch.setattr(ss.settings, "JUGGLING_VIDEO_MAX_SIZE_MB", 100)
+        validate_size(b"\x00" * 1000)
+
+
+class TestSecurityServiceHelpers:
+    def test_server_filename_is_uuid(self):
+        fname = generate_server_filename(".mp4")
+        assert fname.endswith(".mp4")
+        assert len(fname[:-4]) == 36
+
+    def test_server_filename_not_client_name(self):
+        fname = generate_server_filename(".mp4")
+        assert "client" not in fname
+        assert "/" not in fname
+        assert ".." not in fname
+
+    def test_checksum_sha256_length(self):
+        assert len(compute_sha256(b"test")) == 64
+
+    def test_checksum_sha256_is_hex(self):
+        digest = compute_sha256(b"hello")
+        assert all(c in "0123456789abcdef" for c in digest)
+
+    def test_checksum_deterministic(self):
+        assert compute_sha256(b"abc") == compute_sha256(b"abc")
+
+    def test_checksum_differs_for_different_inputs(self):
+        assert compute_sha256(b"abc") != compute_sha256(b"xyz")
+
+
+class TestRunAllPreSaveChecks:
+    def test_valid_input_returns_filename_and_checksum(self):
+        data = _ftyp_mp4()
+        fname, chk = run_all_pre_save_checks("video.mp4", "video/mp4", data)
+        assert fname.endswith(".mp4")
+        assert len(chk) == 64
+
+    def test_client_filename_not_in_server_filename(self):
+        data = _ftyp_mp4()
+        fname, _ = run_all_pre_save_checks("my_personal.mp4", "video/mp4", data)
+        assert "my_personal" not in fname
+
+    def test_extension_checked_first(self):
+        with pytest.raises(VideoSecurityError, match="unsupported_extension"):
+            run_all_pre_save_checks("video.avi", "video/mp4", _ftyp_mp4())
+
+    def test_size_checked_before_magic(self):
+        with pytest.raises(VideoSecurityError, match="empty_file"):
+            run_all_pre_save_checks("video.mp4", "video/mp4", b"")
+
+    def test_magic_checked_after_size(self):
+        jpeg = b"\xff\xd8\xff\xe0" + b"\x00" * 200
+        with pytest.raises(VideoSecurityError, match="magic_bytes_invalid"):
+            run_all_pre_save_checks("video.mp4", "video/mp4", jpeg)
+
+
+# ── quality_service ──────────────────────────────────────────────────────────
+
+from app.services.juggling import quality_service
+
+
+def _meta(**kw):
+    base = {
+        "fps": 60.0, "resolution": "1280x720", "duration_seconds": 30.0,
+        "codec": "hevc", "bitrate_kbps": 8000, "rotation": 0,
+        "has_audio": False, "container": "mov", "nb_streams": 1,
+    }
+    base.update(kw)
+    return base
+
+
+class TestQualityServiceFpsScore:
+    def test_60fps_max_score(self):
+        assert quality_service._fps_score(60.0) == 1.0
+
+    def test_30fps_mid_score(self):
+        assert quality_service._fps_score(30.0) == 0.7
+
+    def test_24fps_low_score(self):
+        assert quality_service._fps_score(24.0) == 0.4
+
+    def test_below_24fps_very_low(self):
+        assert quality_service._fps_score(15.0) == 0.1
+
+    def test_none_fps_neutral(self):
+        assert quality_service._fps_score(None) == 0.5
+
+    def test_above_60fps_capped(self):
+        assert quality_service._fps_score(120.0) == 1.0
+
+
+class TestQualityServiceAnalyze:
+    def test_acceptable_video_returns_score(self):
+        score, status, detail, reason = quality_service.analyze(
+            b"\x00" * (20 * 1024 * 1024), _meta()
+        )
+        assert isinstance(score, float)
+        assert 0.0 <= score <= 1.0
+        assert reason is None
+
+    def test_fps_too_low_rejected(self):
+        _, status, _, reason = quality_service.analyze(
+            b"\x00" * 1000, _meta(fps=20.0)
+        )
+        assert reason == "fps_too_low"
+        assert status == "rejected"
+
+    def test_subject_size_score_always_null(self):
+        _, _, detail, _ = quality_service.analyze(b"\x00" * 1000, _meta())
+        assert detail["subject_size_score"] is None
+
+    def test_ball_visible_score_always_null(self):
+        _, _, detail, _ = quality_service.analyze(b"\x00" * 1000, _meta())
+        assert detail["ball_visible_score"] is None
+
+    def test_audio_present_warning(self):
+        _, _, detail, _ = quality_service.analyze(b"\x00" * 1000, _meta(has_audio=True))
+        assert detail.get("audio_present") is True
+
+    def test_no_audio_no_warning(self):
+        _, _, detail, _ = quality_service.analyze(b"\x00" * 1000, _meta(has_audio=False))
+        assert "audio_present" not in detail
+
+    def test_rotation_stored(self):
+        _, _, detail, _ = quality_service.analyze(b"\x00" * 1000, _meta(rotation=90))
+        assert detail["rotation"] == 90
+
+    def test_null_metadata_handled(self):
+        score, _, _, _ = quality_service.analyze(b"\x00" * 1000, None)
+        assert isinstance(score, float)
+
+    def test_score_in_unit_range(self):
+        score, _, _, _ = quality_service.analyze(b"\x00" * 1000, _meta())
+        assert 0.0 <= score <= 1.0
+
+    def test_fps_acceptable_true_at_60(self):
+        _, _, detail, _ = quality_service.analyze(b"\x00" * 1000, _meta(fps=60.0))
+        assert detail["fps_acceptable"] is True
+
+    def test_fps_acceptable_false_below_24(self):
+        _, _, detail, _ = quality_service.analyze(b"\x00" * 1000, _meta(fps=20.0))
+        assert detail["fps_acceptable"] is False
+
+    def test_duration_acceptable_true(self):
+        _, _, detail, _ = quality_service.analyze(b"\x00" * 1000, _meta())
+        assert detail["duration_acceptable"] is True
+
+
+# ── feature_flag ─────────────────────────────────────────────────────────────
+
+from app.services.juggling.feature_flag import is_juggling_enabled, require_juggling_enabled
+import asyncio
+
+
+class TestFeatureFlag:
+    def test_disabled_by_default(self, monkeypatch):
+        from app.services.juggling import feature_flag as ff
+        monkeypatch.setattr(ff.settings, "JUGGLING_POC_ENABLED", False)
+        assert ff.is_juggling_enabled() is False
+
+    def test_enabled_when_set(self, monkeypatch):
+        from app.services.juggling import feature_flag as ff
+        monkeypatch.setattr(ff.settings, "JUGGLING_POC_ENABLED", True)
+        assert ff.is_juggling_enabled() is True
+
+    def test_require_raises_503_when_disabled(self, monkeypatch):
+        from fastapi import HTTPException
+        from app.services.juggling import feature_flag as ff
+        monkeypatch.setattr(ff.settings, "JUGGLING_POC_ENABLED", False)
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(require_juggling_enabled())
+        assert exc.value.status_code == 503
+
+    def test_require_passes_when_enabled(self, monkeypatch):
+        from app.services.juggling import feature_flag as ff
+        monkeypatch.setattr(ff.settings, "JUGGLING_POC_ENABLED", True)
+        asyncio.run(require_juggling_enabled())
+
+
+# ── consent_service ──────────────────────────────────────────────────────────
+
+class TestConsentService:
+    def test_has_service_consent_false_when_no_record(self, monkeypatch):
+        from app.services.juggling import consent_service
+        mock_db = object()
+        monkeypatch.setattr(consent_service, "get_consent", lambda uid, db: None)
+        assert consent_service.has_service_consent(1, mock_db) is False
+
+    def test_has_service_consent_false_when_false(self, monkeypatch):
+        from app.services.juggling import consent_service
+        from unittest.mock import MagicMock
+        record = MagicMock()
+        record.service_consent = False
+        monkeypatch.setattr(consent_service, "get_consent", lambda uid, db: record)
+        assert consent_service.has_service_consent(1, object()) is False
+
+    def test_has_service_consent_true_when_true(self, monkeypatch):
+        from app.services.juggling import consent_service
+        from unittest.mock import MagicMock
+        record = MagicMock()
+        record.service_consent = True
+        monkeypatch.setattr(consent_service, "get_consent", lambda uid, db: record)
+        assert consent_service.has_service_consent(1, object()) is True

--- a/tests/unit/juggling/test_juggling_services.py
+++ b/tests/unit/juggling/test_juggling_services.py
@@ -469,6 +469,98 @@ class TestExtractServerMetadata:
         assert m["rotation"] == 0
 
 
+# ── quality_service — remaining branches ─────────────────────────────────────
+
+class TestQualityServiceRemainingBranches:
+    def test_dark_frame_ratio_rejection(self, monkeypatch):
+        from app.services.juggling import quality_service as qs
+        monkeypatch.setattr(qs, "_estimate_dark_frame_ratio", lambda b: 0.5)
+        _, _, _, reason = qs.analyze(b"\x00" * 1000, _meta())
+        assert reason == "too_dark"
+
+    def test_blur_score_rejection(self, monkeypatch):
+        from app.services.juggling import quality_service as qs
+        monkeypatch.setattr(qs, "_estimate_blur_score", lambda b: 0.1)
+        _, _, _, reason = qs.analyze(b"\x00" * 1000, _meta())
+        assert reason == "too_blurry"
+
+    def test_needs_review_path(self, monkeypatch):
+        from app.services.juggling import quality_service as qs
+        monkeypatch.setattr(qs, "_estimate_blur_score", lambda b: 0.5)
+        monkeypatch.setattr(qs, "_estimate_dark_frame_ratio", lambda b: 0.25)
+        _, status, _, reason = qs.analyze(b"\x00" * 1000, _meta(fps=24.0))
+        assert status in ("needs_review", "acceptable")
+        assert reason is None
+
+
+# ── video_service — save_file and state machine ───────────────────────────────
+
+class TestVideoServiceSaveFile:
+    def test_save_file_creates_directory(self, tmp_path, monkeypatch):
+        from app.services.juggling import video_service
+        monkeypatch.setattr(video_service, "JUGGLING_UPLOAD_DIR", tmp_path / "juggling")
+        dest = video_service.save_file(b"hello", "test.mp4")
+        assert dest.exists()
+        assert dest.read_bytes() == b"hello"
+
+    def test_save_file_existing_dir(self, tmp_path, monkeypatch):
+        from app.services.juggling import video_service
+        jd = tmp_path / "juggling"
+        jd.mkdir(parents=True)
+        monkeypatch.setattr(video_service, "JUGGLING_UPLOAD_DIR", jd)
+        dest = video_service.save_file(b"data", "v.mp4")
+        assert dest.read_bytes() == b"data"
+
+
+class TestVideoServiceResetProcessing:
+    def test_reset_no_op_when_status_not_processing(self):
+        from app.services.juggling import video_service
+        from unittest.mock import MagicMock
+        v = MagicMock(); v.status = "analyzed"
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = v
+        result = video_service.reset_processing("x", db)
+        assert result is v
+        db.commit.assert_not_called()
+
+    def test_reset_no_op_when_not_found(self):
+        from app.services.juggling import video_service
+        from unittest.mock import MagicMock
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = None
+        result = video_service.reset_processing("x", db)
+        assert result is None
+
+    def test_reset_transitions_to_uploaded(self):
+        from app.services.juggling import video_service
+        from unittest.mock import MagicMock
+        v = MagicMock(); v.status = "processing"
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = v
+        video_service.reset_processing("x", db)
+        assert v.status == "uploaded"
+        db.commit.assert_called_once()
+
+
+class TestVideoServiceSetProcessingErrors:
+    def test_raises_when_not_found(self):
+        from app.services.juggling import video_service
+        from unittest.mock import MagicMock
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = None
+        with pytest.raises(ValueError, match="video_not_found"):
+            video_service.set_processing("missing", db)
+
+    def test_raises_when_wrong_status(self):
+        from app.services.juggling import video_service
+        from unittest.mock import MagicMock
+        v = MagicMock(); v.status = "analyzed"
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = v
+        with pytest.raises(ValueError, match="invalid_transition"):
+            video_service.set_processing("x", db)
+
+
 # ── consent_service ──────────────────────────────────────────────────────────
 
 class TestConsentService:

--- a/tests/unit/juggling/test_juggling_services.py
+++ b/tests/unit/juggling/test_juggling_services.py
@@ -281,6 +281,7 @@ class TestQualityServiceAnalyze:
 # ── feature_flag ─────────────────────────────────────────────────────────────
 
 from app.services.juggling.feature_flag import is_juggling_enabled, require_juggling_enabled
+from app.services.juggling import metadata_service
 import asyncio
 
 
@@ -307,6 +308,165 @@ class TestFeatureFlag:
         from app.services.juggling import feature_flag as ff
         monkeypatch.setattr(ff.settings, "JUGGLING_POC_ENABLED", True)
         asyncio.run(require_juggling_enabled())
+
+
+# ── metadata_service — branch coverage ──────────────────────────────────────
+
+class TestParseFraction:
+    def test_fraction_60000_1001(self):
+        r = metadata_service._parse_fraction("60000/1001")
+        assert r is not None
+        assert abs(r - 59.94) < 0.01
+
+    def test_fraction_30_1(self):
+        r = metadata_service._parse_fraction("30/1")
+        assert r == 30.0
+
+    def test_plain_float(self):
+        r = metadata_service._parse_fraction("25.0")
+        assert r == 25.0
+
+    def test_zero_zero(self):
+        assert metadata_service._parse_fraction("0/0") is None
+
+    def test_empty_string(self):
+        assert metadata_service._parse_fraction("") is None
+
+    def test_none_value(self):
+        assert metadata_service._parse_fraction(None) is None
+
+    def test_zero_denominator(self):
+        assert metadata_service._parse_fraction("30/0") is None
+
+    def test_invalid_string(self):
+        assert metadata_service._parse_fraction("not/a/number") is None
+
+
+def _probe(video_streams=None, audio_streams=None, fmt=None):
+    """Build minimal ffprobe probe_data dict."""
+    streams = []
+    if video_streams:
+        streams.extend(video_streams)
+    if audio_streams:
+        streams.extend(audio_streams)
+    return {"streams": streams, "format": fmt or {}}
+
+
+def _vs(**kw):
+    """Minimal video stream dict."""
+    s = {"codec_type": "video", "codec_name": "h264",
+         "width": 1280, "height": 720,
+         "avg_frame_rate": "60/1", "r_frame_rate": "60/1",
+         "duration": "30.0", "tags": {}, "side_data_list": []}
+    s.update(kw)
+    return s
+
+
+def _as_(**kw):
+    """Minimal audio stream dict."""
+    s = {"codec_type": "audio"}
+    s.update(kw)
+    return s
+
+
+class TestExtractServerMetadata:
+    def test_full_video_with_audio(self):
+        d = _probe([_vs()], [_as_()], {"format_name": "mov,mp4", "bit_rate": "8000000"})
+        m = metadata_service.extract_server_metadata(d)
+        assert m["codec"] == "h264"
+        assert m["resolution"] == "1280x720"
+        assert m["fps"] == 60.0
+        assert m["duration_seconds"] == 30.0
+        assert m["has_audio"] is True
+        assert m["bitrate_kbps"] == 8000
+        assert m["container"] == "mov"
+        assert m["nb_streams"] == 2
+
+    def test_no_streams(self):
+        m = metadata_service.extract_server_metadata({"streams": [], "format": {}})
+        assert m["fps"] is None
+        assert m["resolution"] is None
+        assert m["has_audio"] is False
+        assert m["nb_streams"] == 0
+
+    def test_fps_fallback_to_r_frame_rate(self):
+        vs = _vs(avg_frame_rate="0/0", r_frame_rate="30/1")
+        d = _probe([vs])
+        m = metadata_service.extract_server_metadata(d)
+        assert m["fps"] == 30.0
+
+    def test_no_width_height(self):
+        vs = _vs()
+        del vs["width"]
+        del vs["height"]
+        d = _probe([vs])
+        m = metadata_service.extract_server_metadata(d)
+        assert m["resolution"] is None
+
+    def test_duration_from_format_when_no_stream_duration(self):
+        vs = _vs()
+        vs.pop("duration", None)
+        d = _probe([vs], fmt={"duration": "45.0"})
+        m = metadata_service.extract_server_metadata(d)
+        assert m["duration_seconds"] == 45.0
+
+    def test_invalid_duration_ignored(self):
+        vs = _vs(duration="invalid")
+        d = _probe([vs])
+        m = metadata_service.extract_server_metadata(d)
+        assert m["duration_seconds"] is None
+
+    def test_invalid_bitrate_ignored(self):
+        d = _probe([_vs()], fmt={"bit_rate": "notanumber"})
+        m = metadata_service.extract_server_metadata(d)
+        assert m["bitrate_kbps"] is None
+
+    def test_rotation_from_tags(self):
+        vs = _vs(tags={"rotate": "90"})
+        d = _probe([vs])
+        m = metadata_service.extract_server_metadata(d)
+        assert m["rotation"] == 90
+
+    def test_rotation_from_side_data(self):
+        vs = _vs(side_data_list=[{"side_data_type": "Display Matrix", "rotation": 270}])
+        d = _probe([vs])
+        m = metadata_service.extract_server_metadata(d)
+        assert m["rotation"] == 270
+
+    def test_rotation_invalid_tag_falls_back_to_zero(self):
+        vs = _vs(tags={"rotate": "bad"})
+        d = _probe([vs])
+        m = metadata_service.extract_server_metadata(d)
+        assert m["rotation"] == 0
+
+    def test_multiple_video_streams_uses_first(self):
+        vs1 = _vs(codec_name="h264")
+        vs2 = _vs(codec_name="hevc")
+        d = _probe([vs1, vs2])
+        m = metadata_service.extract_server_metadata(d)
+        assert m["codec"] == "h264"
+
+    def test_no_audio_stream(self):
+        d = _probe([_vs()])
+        m = metadata_service.extract_server_metadata(d)
+        assert m["has_audio"] is False
+
+    def test_no_format_name(self):
+        d = _probe([_vs()], fmt={})
+        m = metadata_service.extract_server_metadata(d)
+        assert m["container"] is None
+
+    def test_side_data_non_display_matrix_ignored(self):
+        vs = _vs(side_data_list=[{"side_data_type": "Other", "rotation": 180}])
+        d = _probe([vs])
+        m = metadata_service.extract_server_metadata(d)
+        assert m["rotation"] == 0
+
+    def test_side_data_rotation_none_ignored(self):
+        vs = _vs(side_data_list=[{"side_data_type": "Display Matrix", "rotation": None}])
+        d = _probe([vs])
+        m = metadata_service.extract_server_metadata(d)
+        assert m["rotation"] == 0
 
 
 # ── consent_service ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Two source types:** `in_app_capture` (camera-recorded) and `uploaded_video` (gallery/file picker), each with distinct quality gate behavior
- **Consent model:** per-user service / training / admin_review consent; `service_consent` required before any upload; revoke = V1.0/GDPR scope
- **Upload pipeline:** upload-init → file upload (multipart) → complete → async Celery quality analysis → polling via GET /quality
- **ffprobe metadata detection:** `server_detected_metadata` (authoritative) populated by Celery task; `client_reported_metadata` stored but not trusted
- **Quality gate:** blur score, dark frame ratio, fps check; overall score excludes null dimensions; `subject_size_score` and `ball_visible_score` = null (P2/P3 scope)
- **Audio detection:** `has_audio` stored in `server_detected_metadata`; `audio_present` warning surfaced in quality response; stripping = P2 scope
- **Security validation:** extension allowlist (`.mp4 .mov .m4v`), MIME allowlist, ftyp magic bytes (pre-save, non-spoofable), empty file reject, size limit from config (100 MB default), server-generated UUID filename, checksum_sha256, path traversal guard
- **Private local storage:** files written to `app/uploads/juggling/` — intentionally outside the `StaticFiles` mount at `/static`; DB stores `storage_path` only; quality endpoint returns no video URL
- **Celery async processing:** `juggling_videos` queue; `max_retries=2`, `soft_time_limit=60s`; state machine: `pending_upload → uploaded → processing → analyzed | rejected | failed`
- **Feature flag:** `JUGGLING_POC_ENABLED` default `False`; all 6 endpoints return 503 when disabled; no exceptions

## Scope boundary — NOT in this branch

| Item | Status |
|---|---|
| MediaPipe / pose inference | ❌ not present |
| ONNX runtime | ❌ not present |
| FootAndBall / YOLO ball detector | ❌ not present |
| Contact detection | ❌ not present |
| Action classifier | ❌ not present |
| ffmpeg transcode | ❌ not present (only `ffprobe` for metadata detection) |
| Model weights (`.onnx`, `.pt`, `.bin`) | ❌ not committed |
| Public video URL | ❌ quality endpoint returns no direct video URL |
| `subject_size_score` | `null` — P2/P3 scope |
| `ball_visible_score` | `null` — P2/P3 scope |

## Migration

- Revision: `2026_06_10_1300` — `down_revision: 2026_06_10_1200`
- Tables: `juggling_consents`, `juggling_videos`
- Round-trip: `upgrade → downgrade -1 → upgrade` — all pass
- Single head confirmed: `alembic heads → 2026_06_10_1300 (head)`

## Test proof

| Suite | Result |
|---|---|
| Juggling unit + API tests (64 tests) | **64/64 PASS** |
| Runtime proof end-to-end (40 checks) | **40/40 PASS** |
| Security validation proof (10 checks) | **10/10 PASS** |
| Migration round-trip | **PASS** |
| Route delta | `1000 → 1006` (+6 endpoints) |

**Test files:**
- `test_juggling_feature_flag.py` — JFF-01..06: 503 on all 6 endpoints when disabled
- `test_juggling_security.py` — JS-01..18: extension, MIME, magic bytes, size, checksum, server filename
- `test_juggling_consent.py` — JC-01..07: consent upsert, 403 without service_consent
- `test_juggling_upload.py` — JU-01..18: both source_types, security, complete/409, task mock, server metadata override
- `test_juggling_quality.py` — JQ-01..15: null scores, fps scoring, audio warning, quality polling

## Known baseline failures (pre-existing, unrelated)

These two failures exist on `main` and were NOT introduced by this branch:

### `test_academy_id::test_aid09_verify_page_contains_required_fields`
- **Root cause:** Test expects `"Verified LFA Member"` badge, but the test DB's student user has no active LFA Football Player license. The view correctly renders `"No Active Licence"`.
- **Branch impact:** `git diff main -- app/tests/test_academy_id.py` = **0 lines changed**
- **Last modified:** commit `9fb77a09` (feat/academy-id — before this branch)
- 8 other `test_academy_id` tests: all PASS

### `test_financial_concurrency_e2e::TestFinancialIdempotencyE2E::test_duplicate_enrollment_idempotency`
- **Root cause:** Test tries to enroll in `tournament_id=124` which does not exist in the test DB. Pre-existing DB state issue.
- **Branch impact:** `git diff main -- app/tests/test_financial_concurrency_e2e.py` = **0 lines changed**
- **Last modified:** commit `c292fbed` (fix/p1-debt — before this branch)

## Follow-up required before V1.0 (not blocking merge)

> **Real video smoke test** — The runtime proof ran with a minimal valid MP4 container fixture (~51 KB synthetic ftyp box). A follow-up proof using a real 2–5 second `.mp4` or `.mov` recording is requested to validate:
> - actual ffprobe metadata detection (fps, codec, resolution, bitrate, rotation, has_audio)
> - complete → Celery processing → quality analyzed/rejected/failed
> - server_detected_metadata populated from real stream
>
> This is a follow-up item; it does not block POC merge. The Celery task and ffprobe integration are covered by unit tests with mocked subprocess output.

## Changed files (26)

`app/config.py` · `.env.example` · `.gitignore` · `alembic/versions/2026_06_10_1300_add_juggling_video_tables.py` · `app/models/juggling.py` (new) · `app/models/__init__.py` · `app/models/user.py` · `app/schemas/juggling.py` (new) · `app/services/juggling/` (6 files) · `app/tasks/juggling_tasks.py` (new) · `app/api/api_v1/endpoints/users/juggling_consent.py` (new) · `app/api/api_v1/endpoints/users/juggling_videos.py` (new) · `app/api/api_v1/endpoints/users/__init__.py` · `app/celery_app.py` · 5 test files · `app/uploads/juggling/.gitkeep`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)