### PR TITLE
fix(ios): APIClient — parse backend error.message format

### DIFF
--- a/ios/LFAEducationCenter/Networking/APIClient.swift
+++ b/ios/LFAEducationCenter/Networking/APIClient.swift
@@ -180,9 +180,10 @@ enum APIError: Error {
     case unauthorized   // no token available or refresh failed
 }
 
-// Handles both string and object `detail` shapes from FastAPI:
-//   {"detail": "some message"}
-//   {"detail": {"error": "...", "message": "human readable"}}
+// Handles all backend error shapes:
+//   {"detail": "some message"}                           — standard FastAPI HTTPException
+//   {"detail": {"error": "...", "message": "..."}}       — FastAPI detail object
+//   {"error": {"code": "http_NNN", "message": "..."}}    — ProductionExceptionHandler JSON format
 private struct ErrorBody: Decodable {
     let detail: String?
 
@@ -192,12 +193,14 @@ private struct ErrorBody: Decodable {
             detail = s
         } else if let obj = try? container.decode(ErrorDetailObject.self, forKey: .detail) {
             detail = obj.message
+        } else if let wrapper = try? container.decode(ErrorDetailObject.self, forKey: .error) {
+            detail = wrapper.message
         } else {
             detail = nil
         }
     }
 
-    enum CodingKeys: String, CodingKey { case detail }
+    enum CodingKeys: String, CodingKey { case detail, error }
 }
 
 private struct ErrorDetailObject: Decodable {


### PR DESCRIPTION
## Summary

Fixes iOS biometric error message mapping broken by backend error format mismatch. Detected during Physical iPhone Smoke QA of PR-iOS-1.

## Root cause

Backend `ProductionExceptionHandler` returns HTTP errors as:
```json
{"error": {"code": "http_NNN", "message": "<detail_string>", "timestamp": "...", "request_id": "..."}}
```
Not the bare FastAPI format: `{"detail": "some_string"}`.

`APIClient.swift` `ErrorBody` only decoded the `"detail"` key, so all biometric error detail strings (disclosure_required, consent_required, reference_not_found, etc.) arrived as `nil`. Every error alert showed `"Ismeretlen hiba (NNN)"`.

## Fix

Added `"error"` as a third `CodingKey` fallback in `ErrorBody`. Tries `error.message` when `"detail"` is absent. Existing two-path parsing preserved.

## Scope

- 1 file: `ios/LFAEducationCenter/Networking/APIClient.swift`
- No backend changes, no new endpoints
- Applies to ALL API error responses (not just biometric)
- Build: `BUILD SUCCEEDED`, `INSTALL SUCCEEDED` on device

🤖 Generated with [Claude Code](https://claude.com/claude-code)