### PR TITLE
feat(juggling): add P5 video list endpoint

### DIFF
--- a/app/api/api_v1/endpoints/users/juggling_videos.py
+++ b/app/api/api_v1/endpoints/users/juggling_videos.py
@@ -1,6 +1,7 @@
 """
 Juggling video intake endpoints.
 
+GET  /api/v1/users/me/juggling/videos                    — list own videos (P5)
 POST /api/v1/users/me/juggling/videos/upload-init      — create pending record
 POST /api/v1/users/me/juggling/videos/{video_id}/upload  — upload file
 POST /api/v1/users/me/juggling/videos/{video_id}/complete — enqueue analysis
@@ -27,13 +28,13 @@ Security pipeline (pre-save, all in upload endpoint):
 """
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException, UploadFile, File, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, UploadFile, File, Request
 from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session
 
 from app.database import get_db
 from app.dependencies import get_current_user, get_current_user_media
-from app.models.juggling import JugglingVideo, JugglingVideoStatus
+from app.models.juggling import JugglingVideo, JugglingVideoStatus, JugglingTranscodeStatus
 from app.models.user import User
 from app.schemas.juggling import (
     JugglingCompleteOut,
@@ -41,6 +42,8 @@ from app.schemas.juggling import (
     JugglingUploadFileOut,
     JugglingUploadInitRequest,
     JugglingUploadInitOut,
+    JugglingVideoItemOut,
+    JugglingVideoListOut,
 )
 from app.services.juggling.consent_service import has_service_consent
 from app.services.juggling.feature_flag import require_juggling_enabled
@@ -62,7 +65,41 @@ from app.tasks.juggling_transcode_task import transcode_video_task
 
 router = APIRouter()
 
-# Statuses from which complete() is blocked (gdpr_deleted is also caught by _get_video_or_404 → 410)
+# ── P5 list helpers ───────────────────────────────────────────────────────────
+
+# Statuses where a thumbnail cannot exist yet — mirrors media_service._THUMBNAIL_NOT_READY_STATUSES
+_THUMBNAIL_NOT_READY = frozenset({
+    JugglingVideoStatus.pending_upload.value,
+    JugglingVideoStatus.uploaded.value,
+    JugglingVideoStatus.processing.value,
+})
+
+
+def _has_thumbnail(video: JugglingVideo) -> bool:
+    return video.thumbnail_path is not None and video.status not in _THUMBNAIL_NOT_READY
+
+
+def _has_media(video: JugglingVideo) -> bool:
+    return (
+        video.status == JugglingVideoStatus.analyzed.value
+        and video.transcode_status == JugglingTranscodeStatus.done.value
+        and video.processed_path is not None
+    )
+
+
+def _duration_seconds(video: JugglingVideo) -> float | None:
+    detail = video.quality_detail or {}
+    val = detail.get("duration_seconds")
+    if val is None:
+        return None
+    try:
+        return float(val)
+    except (TypeError, ValueError):
+        return None
+
+
+# ── Statuses from which complete() is blocked ─────────────────────────────────
+# (gdpr_deleted is also caught by _get_video_or_404 → 410)
 _COMPLETE_BLOCKED = {
     JugglingVideoStatus.pending_upload.value,
     JugglingVideoStatus.processing.value,
@@ -83,6 +120,58 @@ def _get_video_or_404(video_id: str, user_id: int, db: Session) -> JugglingVideo
     if video.status == JugglingVideoStatus.gdpr_deleted.value:
         raise HTTPException(status_code=410, detail="Video has been permanently deleted.")
     return video
+
+
+@router.get(
+    "/me/juggling/videos",
+    response_model=JugglingVideoListOut,
+    dependencies=[Depends(require_juggling_enabled)],
+    summary="List own juggling videos",
+    tags=["juggling"],
+)
+def list_videos(
+    limit:  int = Query(default=50, ge=1, le=100, description="Max items to return (1–100)"),
+    offset: int = Query(default=0,  ge=0,          description="Number of items to skip"),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> JugglingVideoListOut:
+    base_q = (
+        db.query(JugglingVideo)
+        .filter(
+            JugglingVideo.user_id == current_user.id,
+            JugglingVideo.status != JugglingVideoStatus.gdpr_deleted.value,
+        )
+    )
+    total = base_q.count()
+    rows = (
+        base_q
+        .order_by(JugglingVideo.created_at.desc())
+        .limit(limit)
+        .offset(offset)
+        .all()
+    )
+
+    items = [
+        JugglingVideoItemOut(
+            video_id=str(v.id),
+            status=v.status,
+            transcode_status=v.transcode_status,
+            quality_status=v.quality_status,
+            quality_score=float(v.quality_score) if v.quality_score is not None else None,
+            created_at=v.created_at,
+            updated_at=v.updated_at,
+            duration_seconds=_duration_seconds(v),
+            processed_resolution=v.processed_resolution,
+            processed_fps=v.processed_fps,
+            processed_file_size_bytes=v.processed_file_size_bytes,
+            has_thumbnail=_has_thumbnail(v),
+            has_media=_has_media(v),
+            upload_source=v.upload_source,
+            source_type=v.source_type,
+        )
+        for v in rows
+    ]
+    return JugglingVideoListOut(videos=items, total=total, limit=limit, offset=offset)
 
 
 @router.post(

--- a/app/schemas/juggling.py
+++ b/app/schemas/juggling.py
@@ -111,3 +111,36 @@ class JugglingQualityOut(BaseModel):
     processed_file_size_bytes:  Optional[int] = None
 
     model_config = {"from_attributes": True}
+
+
+# ── Video list schemas (P5) ───────────────────────────────────────────────────
+
+class JugglingVideoItemOut(BaseModel):
+    """One video row in the list response.
+
+    Privacy invariant: no raw path, no filesystem path, no URL is ever included.
+    has_thumbnail / has_media signal expected availability; the media endpoints
+    perform the authoritative disk check and return 404 if the file is absent.
+    """
+    video_id:                   str
+    status:                     str
+    transcode_status:           Optional[str]
+    quality_status:             Optional[str]
+    quality_score:              Optional[float]
+    created_at:                 datetime
+    updated_at:                 datetime
+    duration_seconds:           Optional[float]
+    processed_resolution:       Optional[str]
+    processed_fps:              Optional[float]
+    processed_file_size_bytes:  Optional[int]
+    has_thumbnail:              bool
+    has_media:                  bool
+    upload_source:              str
+    source_type:                str
+
+
+class JugglingVideoListOut(BaseModel):
+    videos: List[JugglingVideoItemOut]
+    total:  int
+    limit:  int
+    offset: int

--- a/tests/biometric/test_admin_review_api.py
+++ b/tests/biometric/test_admin_review_api.py
@@ -542,7 +542,7 @@ def test_bca_adm21_override_audit_no_score(db, biometric_feature_enabled):
 def test_bca_adm22_route_count_883():
     from app.main import app
     paths = app.openapi().get("paths", {})
-    assert len(paths) == 890, f"Expected 890 routes (P4 private media +2), got {len(paths)}"
+    assert len(paths) == 891, f"Expected 890 routes (P4 private media +2), got {len(paths)}"
     assert "/api/v1/admin/biometric/review-queue" in paths
     assert "/api/v1/admin/biometric/{user_id}/history" in paths
     assert "/api/v1/admin/biometric/{user_id}/override" in paths

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -1462,6 +1462,74 @@
         ]
       }
     },
+    "/api/v1/users/me/juggling/videos": {
+      "get": {
+        "tags": [
+          "users",
+          "users",
+          "juggling",
+          "juggling"
+        ],
+        "summary": "List own juggling videos",
+        "operationId": "list_videos_api_v1_users_me_juggling_videos_get",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "description": "Max items to return (1\u2013100)",
+              "default": 50,
+              "title": "Limit"
+            },
+            "description": "Max items to return (1\u2013100)"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Number of items to skip",
+              "default": 0,
+              "title": "Offset"
+            },
+            "description": "Number of items to skip"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JugglingVideoListOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/users/me/juggling/videos/upload-init": {
       "post": {
         "tags": [
@@ -55950,6 +56018,172 @@
           "source_type"
         ],
         "title": "JugglingUploadInitRequest"
+      },
+      "JugglingVideoItemOut": {
+        "properties": {
+          "video_id": {
+            "type": "string",
+            "title": "Video Id"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "transcode_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Transcode Status"
+          },
+          "quality_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Quality Status"
+          },
+          "quality_score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Quality Score"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          },
+          "duration_seconds": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Duration Seconds"
+          },
+          "processed_resolution": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Processed Resolution"
+          },
+          "processed_fps": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Processed Fps"
+          },
+          "processed_file_size_bytes": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Processed File Size Bytes"
+          },
+          "has_thumbnail": {
+            "type": "boolean",
+            "title": "Has Thumbnail"
+          },
+          "has_media": {
+            "type": "boolean",
+            "title": "Has Media"
+          },
+          "upload_source": {
+            "type": "string",
+            "title": "Upload Source"
+          },
+          "source_type": {
+            "type": "string",
+            "title": "Source Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "video_id",
+          "status",
+          "transcode_status",
+          "quality_status",
+          "quality_score",
+          "created_at",
+          "updated_at",
+          "duration_seconds",
+          "processed_resolution",
+          "processed_fps",
+          "processed_file_size_bytes",
+          "has_thumbnail",
+          "has_media",
+          "upload_source",
+          "source_type"
+        ],
+        "title": "JugglingVideoItemOut",
+        "description": "One video row in the list response.\n\nPrivacy invariant: no raw path, no filesystem path, no URL is ever included.\nhas_thumbnail / has_media signal expected availability; the media endpoints\nperform the authoritative disk check and return 404 if the file is absent."
+      },
+      "JugglingVideoListOut": {
+        "properties": {
+          "videos": {
+            "items": {
+              "$ref": "#/components/schemas/JugglingVideoItemOut"
+            },
+            "type": "array",
+            "title": "Videos"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit"
+          },
+          "offset": {
+            "type": "integer",
+            "title": "Offset"
+          }
+        },
+        "type": "object",
+        "required": [
+          "videos",
+          "total",
+          "limit",
+          "offset"
+        ],
+        "title": "JugglingVideoListOut"
       },
       "LFAPlayerAmateurRequest": {
         "properties": {

--- a/tests/unit/api/web_routes/test_card_editor_ce2.py
+++ b/tests/unit/api/web_routes/test_card_editor_ce2.py
@@ -433,6 +433,6 @@ class TestCE217RouteCount:
         """PR-JUG-1 juggling intake adds 5 new paths (883 prior → 888); P4 private media adds 2 (888 → 890)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 890, (
+        assert len(paths) == 891, (
             f"Expected 890 routes (888 prior (now 890 with P4 private media +2) + 2 P4 private-media paths), got {len(paths)}."
         )

--- a/tests/unit/api/web_routes/test_card_editor_cs_s1.py
+++ b/tests/unit/api/web_routes/test_card_editor_cs_s1.py
@@ -294,7 +294,7 @@ class TestS109S110RouteAndSnapshot:
         """S1-09 (updated PR-JUG-1): route count is 888 (+5 juggling-intake paths)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 890, (
+        assert len(paths) == 891, (
             f"Expected 890 routes (883 prior + 5 juggling-intake paths), got {len(paths)}"
         )
 

--- a/tests/unit/api/web_routes/test_card_editor_ref_p2.py
+++ b/tests/unit/api/web_routes/test_card_editor_ref_p2.py
@@ -287,7 +287,7 @@ class TestP227to29RouteAndOpenAPI:
         """P2-27: Route count = 846 (CS-S2A +1 /card-studio/player)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 890, f"Expected 846 routes, got {len(paths)}"
+        assert len(paths) == 891, f"Expected 846 routes, got {len(paths)}"
 
     def test_p2_28_openapi_snapshot_match(self):
         """P2-28: OpenAPI snapshot matches live API paths."""

--- a/tests/unit/api/web_routes/test_card_studio_challenge.py
+++ b/tests/unit/api/web_routes/test_card_studio_challenge.py
@@ -294,7 +294,7 @@ class TestCCS11RouteCount:
         """CCS-11: route count updated to 842 after CE-3.8 (+3 from-mood endpoints)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 890, (
+        assert len(paths) == 891, (
             f"Expected 845 routes (842 CE-3.7+CE-3.8 baseline + 2 CS-S0 card-studio routes), got {len(paths)}."
         )
 

--- a/tests/unit/api/web_routes/test_card_studio_landing.py
+++ b/tests/unit/api/web_routes/test_card_studio_landing.py
@@ -159,7 +159,7 @@ class TestCEL12RouteCount:
         """CEL-12: route count 844 (unchanged — redirect is handler change, not new route)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 890, (
+        assert len(paths) == 891, (
             f"Expected 845 routes (redirect handler change does not add routes), got {len(paths)}."
         )
 

--- a/tests/unit/api/web_routes/test_card_studio_shell.py
+++ b/tests/unit/api/web_routes/test_card_studio_shell.py
@@ -326,7 +326,7 @@ class TestCSS21to23RouteConfirmations:
         """CSS-21: adding 2 card-studio routes raises count from 842 to 844."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 890, (
+        assert len(paths) == 891, (
             f"Expected 845 routes (842 baseline + 2 new /card-studio routes), got {len(paths)}"
         )
 

--- a/tests/unit/api/web_routes/test_card_studio_welcome.py
+++ b/tests/unit/api/web_routes/test_card_studio_welcome.py
@@ -325,7 +325,7 @@ class TestCEW18RouteCount:
         """CEW-18: route count baseline check (updated by CE-3.8 to 842)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 890, (
+        assert len(paths) == 891, (
             f"Expected 842 routes (839 CE-3.7 baseline + 3 from-mood endpoints), got {len(paths)}."
         )
 
@@ -678,7 +678,7 @@ class TestCEW44to51TemplateMoodPicker:
         """CEW-47: CE-3.8 adds 3 from-mood routes → total 842."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 890, (
+        assert len(paths) == 891, (
             f"Expected 845 routes (842 baseline + 2 CS-S0 routes), got {len(paths)}"
         )
 

--- a/tests/unit/api/web_routes/test_cc_design_1.py
+++ b/tests/unit/api/web_routes/test_cc_design_1.py
@@ -780,7 +780,7 @@ class TestCCD22to23RouteSnapshot:
         """CCD-22: Route count is 851 (CC-DESIGN-1 SNAPSHOT adds POST /challenges/{id}/card/photo)."""
         from app.main import app
         count = len(app.openapi().get("paths", {}))
-        assert count == 890, f"Expected 851, got {count}"
+        assert count == 891, f"Expected 851, got {count}"
 
     def test_ccd_23_openapi_snapshot_match(self):
         """CCD-23: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_cs_color_1.py
+++ b/tests/unit/api/web_routes/test_cs_color_1.py
@@ -382,7 +382,7 @@ class TestCSCOL15to16RouteAndSnapshot:
         """CSCOL-15: route count = 845 (+1 POST /dashboard/wc-card-theme)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 890, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 891, f"Expected 845 routes, got {len(paths)}"
 
     def test_cscol_16_openapi_snapshot_includes_wc_card_theme(self):
         """CSCOL-16: OpenAPI snapshot includes /dashboard/wc-card-theme."""

--- a/tests/unit/api/web_routes/test_cs_s2a.py
+++ b/tests/unit/api/web_routes/test_cs_s2a.py
@@ -40,7 +40,7 @@ class TestS2A01to02RouteRegistration:
         """S2A-02 (updated CS-S4A): Total route count is 847 (CS-S2A+CS-S4A)."""
         from app.main import app
         count = len(app.openapi().get("paths", {}))
-        assert count == 890, f"Expected 847 routes, got {count}"
+        assert count == 891, f"Expected 847 routes, got {count}"
 
 
 # ── S2A-03..08: _resolve_player_context logic ────────────────────────────────

--- a/tests/unit/api/web_routes/test_cs_s4a.py
+++ b/tests/unit/api/web_routes/test_cs_s4a.py
@@ -152,7 +152,7 @@ class TestS4A12to13RouteAndSnapshot:
         """S4A-12: Route count == 851 (CC-DESIGN-1 SNAPSHOT adds +1 POST /challenges/{id}/card/photo)."""
         from app.main import app
         count = len(app.openapi().get("paths", {}))
-        assert count == 890, f"Expected 851 routes, got {count}"
+        assert count == 891, f"Expected 851 routes, got {count}"
 
     def test_s4a_13_openapi_snapshot_match(self):
         """S4A-13: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_family_color_shop.py
+++ b/tests/unit/api/web_routes/test_family_color_shop.py
@@ -223,7 +223,7 @@ class TestRouteRegistration:
     def test_ts_13_route_count_836(self):
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 890, (
+        assert len(paths) == 891, (
             f"Expected 845 routes (842 CE-3.7+CE-3.8 baseline + 2 CS-S0 card-studio routes), got {len(paths)}."
         )
 

--- a/tests/unit/api/web_routes/test_shop_3a.py
+++ b/tests/unit/api/web_routes/test_shop_3a.py
@@ -194,7 +194,7 @@ class TestS3A13to14RouteAndSnapshot:
         """S3A-13: Route count = 845 (template deletion does not affect routes)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 890, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 891, f"Expected 845 routes, got {len(paths)}"
 
     def test_s3a_14_openapi_snapshot_match(self):
         """S3A-14: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_shop_3b1.py
+++ b/tests/unit/api/web_routes/test_shop_3b1.py
@@ -158,7 +158,7 @@ class TestS3B112to13RouteAndSnapshot:
         """S3B1-12: Route count = 845 (test cleanup does not affect routes)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 890, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 891, f"Expected 845 routes, got {len(paths)}"
 
     def test_s3b1_13_openapi_snapshot_match(self):
         """S3B1-13: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_shop_3b2.py
+++ b/tests/unit/api/web_routes/test_shop_3b2.py
@@ -192,7 +192,7 @@ class TestS3B215to16RouteAndSnapshot:
         """S3B2-15: Route count = 845 (template deletion does not affect routes)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 890, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 891, f"Expected 845 routes, got {len(paths)}"
 
     def test_s3b2_16_openapi_snapshot_match(self):
         """S3B2-16: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_shop_unified.py
+++ b/tests/unit/api/web_routes/test_shop_unified.py
@@ -271,7 +271,7 @@ class TestSHOP14to15RouteAndSnapshot:
         """SHOP-14: route count = 845 (no new routes in SHOP-1)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 890, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 891, f"Expected 845 routes, got {len(paths)}"
 
     def test_shop_15_openapi_snapshot_match(self):
         """SHOP-15: OpenAPI snapshot matches live API."""

--- a/tests/unit/juggling/test_juggling_video_list.py
+++ b/tests/unit/juggling/test_juggling_video_list.py
@@ -1,0 +1,538 @@
+"""
+Juggling P5 — Video list endpoint unit tests (JVL-01..JVL-30).
+
+GET /api/v1/users/me/juggling/videos
+
+Privacy invariants verified:
+  - No raw path in response (JVL-18)
+  - No public URL in response (JVL-19)
+  - No quality_detail / client_reported_metadata / server_detected_metadata (JVL-22..24)
+  - gdpr_deleted excluded (JVL-05)
+  - Other user videos excluded (JVL-04)
+
+Run: pytest tests/unit/juggling/test_juggling_video_list.py -v
+"""
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import event
+from sqlalchemy.orm import Session, sessionmaker
+
+from app.core.auth import create_access_token
+from app.database import engine, get_db
+from app.main import app
+from app.models.juggling import JugglingVideo, JugglingVideoStatus, JugglingTranscodeStatus
+from app.models.user import User, UserRole
+from app.services.juggling import feature_flag as ff_module
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture()
+def db_session():
+    connection = engine.connect()
+    transaction = connection.begin()
+    TestSession = sessionmaker(autocommit=False, autoflush=False, bind=connection)
+    session = TestSession()
+    connection.begin_nested()
+
+    @event.listens_for(session, "after_transaction_end")
+    def restart_savepoint(session, txn):
+        if txn.nested and not txn._parent.nested:
+            session.begin_nested()
+
+    try:
+        yield session
+    finally:
+        session.close()
+        if transaction.is_active:
+            transaction.rollback()
+        connection.close()
+
+
+@pytest.fixture()
+def client(db_session):
+    app.dependency_overrides[get_db] = lambda: db_session
+    with TestClient(app, raise_server_exceptions=False) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture()
+def student_user(db_session):
+    user = User(
+        email=f"jvl+{uuid.uuid4().hex[:8]}@test.com",
+        name="JVL Test Student",
+        password_hash="hashed",
+        role=UserRole.STUDENT,
+        is_active=True,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+@pytest.fixture()
+def other_user(db_session):
+    user = User(
+        email=f"other+{uuid.uuid4().hex[:8]}@test.com",
+        name="Other User",
+        password_hash="hashed",
+        role=UserRole.STUDENT,
+        is_active=True,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+@pytest.fixture()
+def student_token(student_user):
+    return create_access_token(
+        data={"sub": student_user.email},
+        expires_delta=timedelta(hours=1),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _enable_juggling(monkeypatch):
+    monkeypatch.setattr(ff_module, "is_juggling_enabled", lambda: True)
+
+
+_LIST_URL = "/api/v1/users/me/juggling/videos"
+
+
+def _auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _make_video(
+    db_session,
+    user_id: int,
+    status: str = JugglingVideoStatus.analyzed.value,
+    transcode_status: str | None = JugglingTranscodeStatus.done.value,
+    thumbnail_path: str | None = "/tmp/uploads/thumb.jpg",
+    processed_path: str | None = "/tmp/uploads/proc.mp4",
+    quality_status: str | None = "pass",
+    quality_score: float | None = 87.5,
+    quality_detail: dict | None = None,
+    created_at: datetime | None = None,
+    source_type: str = "uploaded_video",
+    upload_source: str = "gallery",
+    processed_resolution: str | None = "1920x1080",
+    processed_fps: float | None = 30.0,
+    processed_file_size_bytes: int | None = 14_800_000,
+) -> JugglingVideo:
+    v = JugglingVideo(
+        id=uuid.uuid4(),
+        user_id=user_id,
+        source_type=source_type,
+        upload_source=upload_source,
+        status=status,
+        transcode_status=transcode_status,
+        thumbnail_path=thumbnail_path,
+        processed_path=processed_path,
+        quality_status=quality_status,
+        quality_score=quality_score,
+        quality_detail=quality_detail,
+        processed_resolution=processed_resolution,
+        processed_fps=processed_fps,
+        processed_file_size_bytes=processed_file_size_bytes,
+    )
+    if created_at is not None:
+        v.created_at = created_at
+    db_session.add(v)
+    db_session.commit()
+    db_session.refresh(v)
+    return v
+
+
+# ── JVL-01: Authenticated user gets own videos ────────────────────────────────
+
+def test_jvl01_authenticated_user_gets_own_videos(client, student_token, student_user, db_session):
+    """JVL-01: Authenticated user with 3 videos → 200, total=3, len(videos)=3."""
+    for _ in range(3):
+        _make_video(db_session, student_user.id)
+    r = client.get(_LIST_URL, headers=_auth(student_token))
+    assert r.status_code == 200, r.text
+    data = r.json()
+    assert data["total"] == 3
+    assert len(data["videos"]) == 3
+
+
+# ── JVL-02: Unauthenticated 401 ───────────────────────────────────────────────
+
+def test_jvl02_unauthenticated_401(client):
+    """JVL-02: No token → 401."""
+    r = client.get(_LIST_URL)
+    assert r.status_code == 401, r.text
+
+
+# ── JVL-03: Feature flag off → 503 ───────────────────────────────────────────
+
+def test_jvl03_feature_flag_off_503(client, student_token, monkeypatch):
+    """JVL-03: JUGGLING_POC_ENABLED=false → 503."""
+    monkeypatch.setattr(ff_module, "is_juggling_enabled", lambda: False)
+    r = client.get(_LIST_URL, headers=_auth(student_token))
+    assert r.status_code == 503, r.text
+
+
+# ── JVL-04: Only own videos returned ─────────────────────────────────────────
+
+def test_jvl04_only_own_videos(client, student_token, student_user, other_user, db_session):
+    """JVL-04: Other user's video is not returned."""
+    own = _make_video(db_session, student_user.id)
+    other = _make_video(db_session, other_user.id)
+    r = client.get(_LIST_URL, headers=_auth(student_token))
+    assert r.status_code == 200
+    ids = [v["video_id"] for v in r.json()["videos"]]
+    assert str(own.id) in ids
+    assert str(other.id) not in ids
+
+
+# ── JVL-05: gdpr_deleted excluded ────────────────────────────────────────────
+
+def test_jvl05_gdpr_deleted_excluded(client, student_token, student_user, db_session):
+    """JVL-05: gdpr_deleted video does not appear in list."""
+    good = _make_video(db_session, student_user.id)
+    deleted = _make_video(
+        db_session, student_user.id,
+        status=JugglingVideoStatus.gdpr_deleted.value,
+        transcode_status=None, thumbnail_path=None, processed_path=None,
+    )
+    r = client.get(_LIST_URL, headers=_auth(student_token))
+    assert r.status_code == 200
+    ids = [v["video_id"] for v in r.json()["videos"]]
+    assert str(good.id) in ids
+    assert str(deleted.id) not in ids
+
+
+# ── JVL-06: Ordering created_at DESC ─────────────────────────────────────────
+
+def test_jvl06_ordering_created_at_desc(client, student_token, student_user, db_session):
+    """JVL-06: Videos ordered by created_at descending — newest first."""
+    now = datetime.now(timezone.utc)
+    old = _make_video(db_session, student_user.id, created_at=now - timedelta(hours=2))
+    mid = _make_video(db_session, student_user.id, created_at=now - timedelta(hours=1))
+    new = _make_video(db_session, student_user.id, created_at=now)
+    r = client.get(_LIST_URL, headers=_auth(student_token))
+    assert r.status_code == 200
+    ids = [v["video_id"] for v in r.json()["videos"]]
+    assert ids[0] == str(new.id)
+    assert ids[1] == str(mid.id)
+    assert ids[2] == str(old.id)
+
+
+# ── JVL-07: Pagination first page ────────────────────────────────────────────
+
+def test_jvl07_pagination_first_page(client, student_token, student_user, db_session):
+    """JVL-07: limit=2&offset=0 → 2 items, total=4."""
+    for _ in range(4):
+        _make_video(db_session, student_user.id)
+    r = client.get(_LIST_URL + "?limit=2&offset=0", headers=_auth(student_token))
+    assert r.status_code == 200
+    data = r.json()
+    assert len(data["videos"]) == 2
+    assert data["total"] == 4
+    assert data["limit"] == 2
+    assert data["offset"] == 0
+
+
+# ── JVL-08: Pagination second page ───────────────────────────────────────────
+
+def test_jvl08_pagination_second_page(client, student_token, student_user, db_session):
+    """JVL-08: limit=2&offset=2 returns next 2 items."""
+    now = datetime.now(timezone.utc)
+    videos = [
+        _make_video(db_session, student_user.id, created_at=now - timedelta(seconds=i))
+        for i in range(4)
+    ]
+    r1 = client.get(_LIST_URL + "?limit=2&offset=0", headers=_auth(student_token))
+    r2 = client.get(_LIST_URL + "?limit=2&offset=2", headers=_auth(student_token))
+    ids1 = {v["video_id"] for v in r1.json()["videos"]}
+    ids2 = {v["video_id"] for v in r2.json()["videos"]}
+    assert len(ids1) == 2
+    assert len(ids2) == 2
+    assert ids1.isdisjoint(ids2)  # no overlap between pages
+
+
+# ── JVL-09: Max limit enforced ───────────────────────────────────────────────
+
+def test_jvl09_max_limit_enforced(client, student_token):
+    """JVL-09: limit=101 → 422 Unprocessable Entity."""
+    r = client.get(_LIST_URL + "?limit=101", headers=_auth(student_token))
+    assert r.status_code == 422, r.text
+
+
+# ── JVL-10: Negative limit → 422 ─────────────────────────────────────────────
+
+def test_jvl10_negative_limit_422(client, student_token):
+    """JVL-10: limit=-1 → 422."""
+    r = client.get(_LIST_URL + "?limit=-1", headers=_auth(student_token))
+    assert r.status_code == 422, r.text
+
+
+# ── JVL-11: Negative offset → 422 ────────────────────────────────────────────
+
+def test_jvl11_negative_offset_422(client, student_token):
+    """JVL-11: offset=-1 → 422."""
+    r = client.get(_LIST_URL + "?offset=-1", headers=_auth(student_token))
+    assert r.status_code == 422, r.text
+
+
+# ── JVL-12: has_thumbnail = true (analyzed + thumbnail_path set) ──────────────
+
+def test_jvl12_has_thumbnail_true(client, student_token, student_user, db_session):
+    """JVL-12: analyzed + thumbnail_path set → has_thumbnail=True."""
+    _make_video(db_session, student_user.id, thumbnail_path="/tmp/uploads/t.jpg")
+    r = client.get(_LIST_URL, headers=_auth(student_token))
+    assert r.json()["videos"][0]["has_thumbnail"] is True
+
+
+# ── JVL-13: has_thumbnail = false (processing status) ────────────────────────
+
+def test_jvl13_has_thumbnail_false_processing(client, student_token, student_user, db_session):
+    """JVL-13: processing status → has_thumbnail=False regardless of path."""
+    _make_video(
+        db_session, student_user.id,
+        status=JugglingVideoStatus.processing.value,
+        transcode_status=None,
+        thumbnail_path="/tmp/uploads/t.jpg",
+        processed_path=None,
+    )
+    r = client.get(_LIST_URL, headers=_auth(student_token))
+    assert r.json()["videos"][0]["has_thumbnail"] is False
+
+
+# ── JVL-14: has_thumbnail = false (thumbnail_path is null) ───────────────────
+
+def test_jvl14_has_thumbnail_false_no_path(client, student_token, student_user, db_session):
+    """JVL-14: analyzed + thumbnail_path=None → has_thumbnail=False."""
+    _make_video(db_session, student_user.id, thumbnail_path=None)
+    r = client.get(_LIST_URL, headers=_auth(student_token))
+    assert r.json()["videos"][0]["has_thumbnail"] is False
+
+
+# ── JVL-15: has_media = true ──────────────────────────────────────────────────
+
+def test_jvl15_has_media_true(client, student_token, student_user, db_session):
+    """JVL-15: analyzed + transcode_done + processed_path set → has_media=True."""
+    _make_video(
+        db_session, student_user.id,
+        status=JugglingVideoStatus.analyzed.value,
+        transcode_status=JugglingTranscodeStatus.done.value,
+        processed_path="/tmp/uploads/p.mp4",
+    )
+    r = client.get(_LIST_URL, headers=_auth(student_token))
+    assert r.json()["videos"][0]["has_media"] is True
+
+
+# ── JVL-16: has_media = false (processing) ───────────────────────────────────
+
+def test_jvl16_has_media_false_processing(client, student_token, student_user, db_session):
+    """JVL-16: processing status → has_media=False."""
+    _make_video(
+        db_session, student_user.id,
+        status=JugglingVideoStatus.processing.value,
+        transcode_status=JugglingTranscodeStatus.processing.value,
+        thumbnail_path=None, processed_path=None,
+    )
+    r = client.get(_LIST_URL, headers=_auth(student_token))
+    assert r.json()["videos"][0]["has_media"] is False
+
+
+# ── JVL-17: has_media = false (transcode_failed) ─────────────────────────────
+
+def test_jvl17_has_media_false_transcode_failed(client, student_token, student_user, db_session):
+    """JVL-17: analyzed + transcode_failed → has_media=False."""
+    _make_video(
+        db_session, student_user.id,
+        status=JugglingVideoStatus.analyzed.value,
+        transcode_status=JugglingTranscodeStatus.failed.value,
+        processed_path=None,
+    )
+    r = client.get(_LIST_URL, headers=_auth(student_token))
+    assert r.json()["videos"][0]["has_media"] is False
+
+
+# ── JVL-18: No raw path in response ──────────────────────────────────────────
+
+def test_jvl18_no_raw_path_in_response(client, student_token, student_user, db_session):
+    """JVL-18: Response must not contain any filesystem path strings."""
+    _make_video(
+        db_session, student_user.id,
+        thumbnail_path="/tmp/juggling_uploads/secret_thumb.jpg",
+        processed_path="/tmp/juggling_uploads/secret_video.mp4",
+    )
+    r = client.get(_LIST_URL, headers=_auth(student_token))
+    assert r.status_code == 200
+    raw = r.text
+    forbidden = [
+        "storage_path", "original_path", "processed_path", "thumbnail_path",
+        "filename_stored", "checksum_sha256", "checksum_processed",
+        "transcode_error", "deletion_reason", "deleted_at",
+        "retention_expires_at",
+        "/tmp/juggling_uploads", "secret_thumb", "secret_video",
+    ]
+    for field in forbidden:
+        assert field not in raw, f"Forbidden field/value found in response: {field!r}"
+
+
+# ── JVL-19: No public URL in response ────────────────────────────────────────
+
+def test_jvl19_no_public_url_in_response(client, student_token, student_user, db_session):
+    """JVL-19: Response must not contain public URLs."""
+    _make_video(db_session, student_user.id)
+    r = client.get(_LIST_URL, headers=_auth(student_token))
+    raw = r.text
+    for pattern in ["http://", "https://", "/uploads/", "/media/", "signed", "public_url"]:
+        assert pattern not in raw, f"Forbidden URL pattern in response: {pattern!r}"
+
+
+# ── JVL-20: Empty list ────────────────────────────────────────────────────────
+
+def test_jvl20_empty_list(client, student_token):
+    """JVL-20: No videos → 200, videos=[], total=0."""
+    r = client.get(_LIST_URL, headers=_auth(student_token))
+    assert r.status_code == 200
+    data = r.json()
+    assert data["videos"] == []
+    assert data["total"] == 0
+
+
+# ── JVL-21: duration_seconds extracted from quality_detail ───────────────────
+
+def test_jvl21_duration_seconds_from_quality_detail(client, student_token, student_user, db_session):
+    """JVL-21: duration_seconds extracted from quality_detail JSONB."""
+    _make_video(
+        db_session, student_user.id,
+        quality_detail={"duration_seconds": 15.3, "fps_detected": 30.0},
+    )
+    r = client.get(_LIST_URL, headers=_auth(student_token))
+    assert r.json()["videos"][0]["duration_seconds"] == pytest.approx(15.3)
+
+
+# ── JVL-22: quality_detail raw JSONB not in response ─────────────────────────
+
+def test_jvl22_quality_detail_not_in_response(client, student_token, student_user, db_session):
+    """JVL-22: Raw quality_detail JSONB must not appear in response."""
+    _make_video(
+        db_session, student_user.id,
+        quality_detail={"duration_seconds": 15.3, "fps_detected": 30.0},
+    )
+    r = client.get(_LIST_URL, headers=_auth(student_token))
+    assert "quality_detail" not in r.text
+    assert "fps_detected" not in r.text
+
+
+# ── JVL-23: client_reported_metadata not in response ─────────────────────────
+
+def test_jvl23_client_reported_metadata_not_in_response(client, student_token, student_user, db_session):
+    """JVL-23: client_reported_metadata must not appear in response."""
+    _make_video(db_session, student_user.id)
+    r = client.get(_LIST_URL, headers=_auth(student_token))
+    assert "client_reported_metadata" not in r.text
+
+
+# ── JVL-24: server_detected_metadata not in response ─────────────────────────
+
+def test_jvl24_server_detected_metadata_not_in_response(client, student_token, student_user, db_session):
+    """JVL-24: server_detected_metadata must not appear in response."""
+    _make_video(db_session, student_user.id)
+    r = client.get(_LIST_URL, headers=_auth(student_token))
+    assert "server_detected_metadata" not in r.text
+
+
+# ── JVL-25: OpenAPI path delta +1, route delta +1 ────────────────────────────
+
+def test_jvl25_openapi_path_and_route_delta(client):
+    """JVL-25: GET /api/v1/users/me/juggling/videos in OpenAPI; route count = 1013."""
+    from app.main import app as fastapi_app
+    schema = fastapi_app.openapi()
+    assert "/api/v1/users/me/juggling/videos" in schema["paths"], "List path missing from OpenAPI"
+    routes = [
+        (m, r.path)
+        for r in fastapi_app.routes
+        if hasattr(r, "methods") and hasattr(r, "path")
+        for m in (r.methods or [])
+    ]
+    assert len(routes) == 1013, f"Expected 1013 routes, got {len(routes)}"
+    get_list = [r for r in routes if r[0] == "GET" and r[1] == "/api/v1/users/me/juggling/videos"]
+    assert len(get_list) == 1
+
+
+# ── JVL-26: Alembic head unchanged ───────────────────────────────────────────
+
+def test_jvl26_alembic_head_unchanged():
+    """JVL-26: No DB migration added."""
+    from alembic.config import Config
+    from alembic.script import ScriptDirectory
+    import os
+    cfg = Config(os.path.join(os.path.dirname(__file__), "..", "..", "..", "alembic.ini"))
+    heads = ScriptDirectory.from_config(cfg).get_heads()
+    assert heads == ["2026_06_11_1100"], f"Unexpected Alembic heads: {heads}"
+
+
+# ── JVL-27: P4 thumbnail/media regression ────────────────────────────────────
+
+def test_jvl27_p4_thumbnail_endpoint_unchanged(client, student_token):
+    """JVL-27a: P4 thumbnail endpoint still returns 404 for unknown video (not 500)."""
+    r = client.get(
+        f"/api/v1/users/me/juggling/videos/{uuid.uuid4()}/thumbnail",
+        headers=_auth(student_token),
+    )
+    assert r.status_code == 404, r.text
+
+
+def test_jvl27_p4_media_endpoint_unchanged(client, student_token):
+    """JVL-27b: P4 media endpoint still returns 404 for unknown video (not 500)."""
+    r = client.get(
+        f"/api/v1/users/me/juggling/videos/{uuid.uuid4()}/media",
+        headers=_auth(student_token),
+    )
+    assert r.status_code == 404, r.text
+
+
+# ── JVL-28: rejected status in list ──────────────────────────────────────────
+
+def test_jvl28_rejected_in_list(client, student_token, student_user, db_session):
+    """JVL-28: rejected video IS included in list (only gdpr_deleted is excluded)."""
+    v = _make_video(
+        db_session, student_user.id,
+        status=JugglingVideoStatus.rejected.value,
+        transcode_status=None, processed_path=None,
+    )
+    r = client.get(_LIST_URL, headers=_auth(student_token))
+    ids = [x["video_id"] for x in r.json()["videos"]]
+    assert str(v.id) in ids
+
+
+# ── JVL-29: failed status in list ────────────────────────────────────────────
+
+def test_jvl29_failed_in_list(client, student_token, student_user, db_session):
+    """JVL-29: failed video IS included in list."""
+    v = _make_video(
+        db_session, student_user.id,
+        status=JugglingVideoStatus.failed.value,
+        transcode_status=JugglingTranscodeStatus.failed.value,
+        thumbnail_path=None, processed_path=None,
+    )
+    r = client.get(_LIST_URL, headers=_auth(student_token))
+    ids = [x["video_id"] for x in r.json()["videos"]]
+    assert str(v.id) in ids
+
+
+# ── JVL-30: Default limit = 50 ───────────────────────────────────────────────
+
+def test_jvl30_default_limit_50(client, student_token):
+    """JVL-30: No ?limit param → limit=50 in response envelope."""
+    r = client.get(_LIST_URL, headers=_auth(student_token))
+    assert r.status_code == 200
+    assert r.json()["limit"] == 50


### PR DESCRIPTION
## Scope summary

Adds `GET /api/v1/users/me/juggling/videos` — the P5 video list endpoint.
Returns the authenticated user's own juggling videos with no raw path, public URL, or filesystem path in the response.
No production code changed except `juggling_videos.py` and `juggling.py` schema.

## Changed files

| File | Change |
|---|---|
| `app/api/api_v1/endpoints/users/juggling_videos.py` | New `list_videos` route + `_has_thumbnail` / `_has_media` / `_duration_seconds` helpers |
| `app/schemas/juggling.py` | New `JugglingVideoItemOut` + `JugglingVideoListOut` schemas |
| `tests/unit/juggling/test_juggling_video_list.py` | New — 31 JVL tests |
| `tests/snapshots/openapi_snapshot.json` | Regenerated (891 paths) |
| 17× `tests/unit/api/web_routes/` + `tests/biometric/` | Route count snapshots: 890 → 891 |

## Route delta

**+1** — 1012 → 1013

```
GET /api/v1/users/me/juggling/videos
```

## OpenAPI delta

**+1** — 890 → 891

## Alembic head

`2026_06_11_1100` — unchanged. No DB migration.

## No raw path proof

`JugglingVideoItemOut` schema contains no `storage_path`, `processed_path`, `thumbnail_path`, `original_path`, `filename_stored`, `checksum_*`, `transcode_error`, `deletion_reason`, or any URL field. Verified by JVL-18 and JVL-19.

## No public URL proof

No URL generation in the list endpoint. Clients assemble `/{video_id}/thumbnail` and `/{video_id}/media` API paths themselves. Verified by JVL-19.

## P4 regression proof

JVL-27a/27b: `GET .../{id}/thumbnail` and `GET .../{id}/media` return 404 (not 500) for unknown video — P4 endpoints unchanged.

## Test summary

31 JVL tests — all PASS:
- JVL-01: own videos returned
- JVL-02: unauthenticated → 401
- JVL-03: feature flag off → 503
- JVL-04: other user excluded
- JVL-05: gdpr_deleted excluded
- JVL-06: ordering created_at DESC
- JVL-07/08: pagination limit/offset
- JVL-09: max limit 100 enforced
- JVL-10/11: negative limit/offset → 422
- JVL-12/13/14: has_thumbnail logic
- JVL-15/16/17: has_media logic
- JVL-18: no raw path in response
- JVL-19: no public URL in response
- JVL-20: empty list works
- JVL-21: duration_seconds extracted from quality_detail
- JVL-22/23/24: quality_detail / client_metadata / server_metadata excluded
- JVL-25: route + OpenAPI delta verified
- JVL-26: Alembic head unchanged
- JVL-27a/27b: P4 regression
- JVL-28/29: rejected/failed in list
- JVL-30: default limit=50

## Final verdict

READY — all invariants verified locally. CI pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)