### PR TITLE
feat(ios): add juggling annotation data and sync layer

### DIFF
--- a/docs/AN2_IMPLEMENTATION_REPORT.md
+++ b/docs/AN2_IMPLEMENTATION_REPORT.md
@@ -1,0 +1,183 @@
+# AN-2 — iOS Data and Synchronization Layer — Implementation Report
+
+**Branch:** `feat/ios-juggling-annotation-data-an2` (base `f1054056`, main)
+**Date:** 2026-06-13
+**Scope:** Data/sync layer only. No SwiftUI screens, no pickers, no timeline,
+no video overlay, no AN-3 UX, no backend changes. PR not opened (per
+instruction).
+
+---
+
+## 1. Commits (6, consolidated from the 7-item roadmap)
+
+| # | Commit | Files |
+|---|--------|-------|
+| 1 | `0b0e87cb` feat(ios): add deterministic bundled juggling taxonomy | `ContactTaxonomy.swift`, `ContactTaxonomyStore.swift`, `Resources/contact_types_v1.json`, `scripts/check_taxonomy_bundle_drift.py` |
+| 2 | `02e09544` feat(ios): add annotation API contracts and raw HTTP client support | `ContactEventResponse.swift`, `JugglingAnnotationAPIClient.swift`, `APIClient.swift` (+getRaw/postRaw/patchRaw), `AuthManager.swift` (+authenticatedGetRaw/PostRaw/PatchRaw) |
+| 3 | `1f261bc9` feat(ios): add versioned atomic annotation store with user isolation | `ContactEventDraft.swift`, `LocalAnnotationStore.swift` |
+| 4 | `8e96395d` feat(ios): add annotation sync and reconciliation engine | `AnnotationSyncEngine.swift` |
+| 5 | `04aa7c58` feat(ios): add annotation view model with finish guard and recovery | `JugglingAnnotationViewModel.swift`, `JugglingVideoItem.swift` (+`annotation_status`) |
+| 6 | `1c06e5bd` test(ios): add AN-2 taxonomy, persistence, sync and recovery coverage | 4 test files, 25 tests |
+
+The original roadmap's item 6 ("user isolation and recovery handling") was
+folded into commits 3 and 5 — `userId` isolation and quarantine recovery are
+load-bearing parts of `LocalAnnotationStore` and `JugglingAnnotationViewModel`
+respectively, not a separable change. Splitting them out would have produced
+an empty or purely-documentation commit.
+
+---
+
+## 2. What was built
+
+### 2.1 Taxonomy (Commit 1)
+- `ContactTaxonomy.swift`: `TaxonomyDocument` / `TaxonomyGroup` /
+  `TaxonomyContactType`, exact `Codable` mirror of
+  `datasets/juggling/contact_types_v1.json`.
+- `ContactTaxonomyStore`: `loadBundled()` (sync, always available) +
+  `refreshFromBackend()` (async, ETag/304, silent fallback to bundled/cached
+  on any error — an annotation session is never blocked by a taxonomy
+  network failure).
+- Bundled copy at
+  `ios/LFAEducationCenter/Juggling/Annotation/Resources/contact_types_v1.json`
+  — MD5 `7198de62733493537450275dadc6f445`, identical to
+  `datasets/juggling/contact_types_v1.json` and to
+  `ContactTaxonomyStore.bundledChecksum`.
+- `scripts/check_taxonomy_bundle_drift.py`: compares dataset source ↔
+  bundled copy ↔ the `bundledChecksum` Swift constant; exit 1 on any
+  mismatch. **Run now: OK.**
+
+### 2.2 API contracts + raw HTTP client (Commit 2)
+- `ContactEventResponse.swift`: exact mirror of all AN-1 schemas, verified
+  against `tests/snapshots/openapi_snapshot.json` @ `f1054056` — including
+  the nullable fields (`side`, `annotation_status`, batch `event_id`/`detail`)
+  and the `duplicate_skipped` wire key.
+- `JugglingAnnotationAPIClient` + new `JugglingAnnotationAPIClientProtocol`
+  (5 sync-relevant endpoints — taxonomy fetch stays separate, owned by
+  `ContactTaxonomyStore`). Error classification:
+  retryable / permanent / idempotencyConflict / versionConflict /
+  unauthorized / decodeFailed.
+- `APIClient`: added `getRaw` (raw `(Data, URLResponse)`, no 2xx check — lets
+  304 pass through for ETag handling), `postRaw` / `patchRaw` (raw
+  `(Data, statusCode)` for 2xx, `APIError.httpError` with parsed detail for
+  non-2xx — needed to distinguish 200 dup vs 201 created, and to surface 409
+  `idempotency_conflict` / `version_conflict` bodies).
+- `AuthManager`: added `authenticatedGetRaw` (no 401 retry — `getRaw` never
+  throws on 401, so taxonomy fallback handles it), `authenticatedPostRaw`,
+  `authenticatedPatchRaw` (both with the existing single-refresh-and-retry
+  pattern).
+
+### 2.3 Local annotation store (Commit 3)
+- `ContactEventDraft`: 10-state `ContactEventSyncStatus` (`localOnly`,
+  `syncing`, `synced`, `updating`, `deleting`, `deleted`, `failedPermanent`,
+  `retryPending`, `conflicted`, `needsReconciliation`), keyed by immutable
+  `deviceEventId`.
+- `LocalAnnotationStore`: one `AnnotationSessionFile` per `(userId, videoId)`
+  at `juggling_annotations/{userId}/{videoId}.json`. Atomic writes (temp
+  file → `replaceItemAt` with `.bak.json` backup). SHA256 checksum over the
+  drafts array, verified on load. Decode failure or checksum mismatch →
+  **quarantine** (move to `quarantine/`, never delete), with a best-effort
+  scan for `"localOnly"` markers to flag possible data loss to the caller.
+
+### 2.4 Sync / reconciliation engine (Commit 4)
+- `AnnotationSyncEngine` (max 3 retries, 2s/4s/8s base delays — caller
+  schedules with jitter):
+  - `flushPending`: pushes `localOnly`/`retryPending` creates; drafts deleted
+    locally before ever syncing → `.deleted` with no network call; drafts
+    that finished syncing but were marked deleted in the meantime get a
+    DELETE pushed.
+  - `pushCreate`: 200/201 → `.synced`; retryable → `.retryPending`
+    (`retryCount`++) until `maxRetries`, then `.failedPermanent`; 409
+    `idempotency_conflict` → `.failedPermanent` (requires user resolution,
+    not auto-retried).
+  - `pushPatch`: 409 `version_conflict` → `.conflicted`; timeout/network →
+    `.needsReconciliation` (PATCH is not idempotent — outcome unknown).
+  - `pushDelete`: 404 → `.needsReconciliation` (ownership-ambiguous, **not**
+    auto-success); timeout/network → `.needsReconciliation`.
+  - `reconcile`: GET `/contacts` is the source of truth for every
+    `.needsReconciliation` draft — present on server → `.synced` with server
+    state applied; absent → `.deleted`.
+  - `finishReadiness`: `.blocked([...])` while any active event is in-flight,
+    retryable, conflicted, or unresolved; otherwise `.readyZero` /
+    `.readyWithCount(n)`.
+
+### 2.5 View model (Commit 5)
+- `JugglingAnnotationViewModel` (`@MainActor`, `ObservableObject` — no
+  SwiftUI view consumes it yet):
+  - `onAppear()`: load bundled taxonomy → load/create local session (Hungarian
+    user-facing warning on quarantine recovery) → background taxonomy
+    refresh.
+  - `addEvent` / `markDeleted` — local-first, persisted immediately.
+  - `finish()`: flush pending → reconcile if needed → re-check readiness
+    (abort with `finishError` if still blocked) → `POST /finish` with
+    `confirm_zero_contacts = true` iff zero active events → on success,
+    delete the local session file.
+  - `clearSession()` for logout/user-switch; `userId` is immutable per
+    instance — a session is never re-targeted to a different user.
+  - Second initializer accepts `JugglingAnnotationAPIClientProtocol` +
+    stores directly for test injection.
+- `JugglingVideoItem.annotationStatus: String?` added (`annotation_status`,
+  optional — `nil` if the video-list endpoint predates AN-1; Codable
+  synthesized `decodeIfPresent` handles the missing key without a custom
+  decoder).
+
+### 2.6 Tests (Commit 6) — 25 tests, AN2-T01..T25
+
+| File | Tests | Covers |
+|------|-------|--------|
+| `ContactTaxonomyTests.swift` | T01–T04 | bundled checksum vs constant, decode counts (18/17), custom_other present + thigh forbidden, invalid `total_count` rejected |
+| `LocalAnnotationStoreTests.swift` | T05–T10 | empty load, save/load round trip, userId isolation, corrupt-file quarantine (bytes preserved), checksum-mismatch quarantine, delete |
+| `ContactEventDraftTests.swift` | T11–T16 | `.new()` defaults, immutable `deviceEventId`, `FinishReadiness` (readyZero/readyWithCount/blocked), `duplicate_skipped` wire decode |
+| `AnnotationSyncEngineTests.swift` | T17–T25 | pushCreate (success/retryable/permanent/max-retries-exhausted), pushDelete (204/404-ambiguous), reconcile (found/absent on server), flushPending (create + skip never-synced deleted draft) — via `MockAnnotationAPIClient` |
+
+---
+
+## 3. Known limitation — test execution not verified
+
+**The `LFAEducationCenter.xcodeproj` currently has no test target/scheme**
+(`xcodebuild -list` shows only the `LFAEducationCenter` app target; the
+existing `LFAEducationCenterTests/` directory, including the pre-AN-2
+`JugglingVideoTests.swift`, is not wired into `project.pbxproj`). This is a
+**pre-existing condition**, not introduced by AN-2.
+
+Consequences:
+- The 25 new tests cannot be run via `xcodebuild test` until a test target is
+  added to the project (Xcode: New Target → Unit Testing Bundle, add the 4
+  new files + the pre-existing `JugglingVideoTests.swift` + `Biometric/`
+  tests).
+- I reviewed every new/changed file for type and signature consistency
+  (struct field order, protocol conformance, `Codable` key mappings,
+  `Equatable` requirements for `XCTAssertEqual`) but **this is not a
+  substitute for a compiler run**.
+- The app target itself was not rebuilt in this session (no production code
+  outside `Annotation/` was changed except the additive `APIClient` /
+  `AuthManager` / `JugglingVideoItem` edits, which preserve all existing
+  signatures).
+
+**Recommendation:** before AN-3 begins, add a unit-test target in Xcode (one-
+time manual step) and run `xcodebuild test` to confirm the 25 AN-2 tests plus
+existing suites pass.
+
+---
+
+## 4. Drift guard
+
+```
+$ python3 scripts/check_taxonomy_bundle_drift.py
+OK — bundled taxonomy matches dataset source (md5=7198de62733493537450275dadc6f445)
+```
+
+---
+
+## 5. Explicitly NOT done (per constraints)
+
+- No SwiftUI annotation screen, picker, timeline, or video overlay.
+- No AN-3 UX.
+- No backend changes (AN-1 stays at `f1054056` on `main`, untouched).
+- No PR opened.
+- No retry-delay scheduler (timer) — `AnnotationSyncEngine.retryDelaysSeconds`
+  is exposed as a constant for the future UI/background layer to use.
+
+## 6. Suggested next step (not started)
+
+AN-3: SwiftUI annotation screen consuming `JugglingAnnotationViewModel` —
+gated on separate approval per existing constraints.

--- a/docs/AN2_PR_READINESS_REPORT.md
+++ b/docs/AN2_PR_READINESS_REPORT.md
@@ -157,36 +157,58 @@ identical to the dataset source-of-truth checksum.
 
 ---
 
-## 8. CI status (snapshot — IN PROGRESS, not yet final)
+## 8. CI status (re-checked 2026-06-13, ~20 min after first snapshot)
 
 ```
 mergeable        = MERGEABLE
-mergeStateStatus = BLOCKED   (checks still running)
+mergeStateStatus = UNSTABLE   (1 check still running)
 reviewDecision   = (none yet)
 ```
 
 | Check | Status |
 |---|---|
 | API Module Integrity (import + route count) | ✅ SUCCESS |
-| Hardcoded FK ID Guard (lint) | ✅ SUCCESS |
+| API Tests (Baseline: 0 failed, 0 errors) | ✅ SUCCESS |
+| Auth Lifecycle E2E (BLOCKING) | ✅ SUCCESS |
+| Booking Lifecycle E2E (BLOCKING) | ✅ SUCCESS |
+| Core Access & State Sanity (BLOCKING) | ✅ SUCCESS |
 | Credit Balance Audit (static AST) | ✅ SUCCESS |
+| Cypress Web E2E — admin | ✅ SUCCESS |
+| Cypress Web E2E — business-workflow | ✅ SUCCESS |
+| Cypress Web E2E — instructor | ✅ SUCCESS |
+| Cypress Web E2E — student | ✅ SUCCESS |
+| Cypress Web E2E — cross-role integration | ⏳ IN PROGRESS |
+| E2E Smoke Tests | ✅ SUCCESS |
+| Enrollment Workflow E2E (BLOCKING) | ✅ SUCCESS |
+| Hardcoded FK ID Guard (lint) | ✅ SUCCESS |
+| Instructor Assignment Lifecycle E2E (BLOCKING) | ✅ SUCCESS |
+| Instructor Lifecycle E2E (BLOCKING) | ✅ SUCCESS |
+| Load Gate — Phase 6.3 (50 VUs, 10 min) | ✅ SUCCESS |
 | Migration Chain Integrity (empty → head → base → head) | ✅ SUCCESS |
 | Migration Volume Safety (data-present roundtrip) | ✅ SUCCESS |
+| Multi-Campus Round-Robin E2E (BLOCKING) | ✅ SUCCESS |
 | Operational Smoke Test (full stack) | ✅ SUCCESS |
+| Payment Workflow E2E (BLOCKING) | ✅ SUCCESS |
+| Refund Workflow E2E (BLOCKING) | ✅ SUCCESS |
+| Security Gate (CSRF + SQL injection — 63 tests) | ✅ SUCCESS |
+| Session Management E2E (BLOCKING) | ✅ SUCCESS |
+| Skill Assessment Lifecycle E2E (BLOCKING) | ✅ SUCCESS |
 | Skill Weight Pipeline — 28 required tests | ✅ SUCCESS |
+| Student Lifecycle E2E (BLOCKING) | ✅ SUCCESS |
+| Unit Tests (Baseline: 0 failed, 0 errors) | ✅ SUCCESS |
+| User Account E2E (BLOCKING) | ✅ SUCCESS |
+| cypress-web-by-role (admin) | ✅ SUCCESS |
+| cypress-web-by-role (business-workflow) | ✅ SUCCESS |
+| cypress-web-by-role (instructor) | ✅ SUCCESS |
+| cypress-web-by-role (student) | ✅ SUCCESS |
+| cypress-web-integration | ✅ SUCCESS |
 | Preset Weight Audit (informational) | ⏭️ SKIPPED (informational, non-blocking) |
-| Unit Tests (Baseline: 0 failed, 0 errors) | ⏳ IN PROGRESS |
-| API Tests (Baseline: 0 failed, 0 errors) | ⏳ IN PROGRESS |
-| Load Gate — Phase 6.3 (50 VUs, 10 min) | ⏳ IN PROGRESS |
-| Migration Chain Integrity rerun (cypress prep) | ⏳ IN PROGRESS |
-| cypress-web-by-role (admin) | ⏳ IN PROGRESS |
-| cypress-web-by-role (instructor) | ⏳ IN PROGRESS |
-| cypress-web-by-role (student) | ⏳ IN PROGRESS |
-| cypress-web-by-role (business-workflow) | ⏳ IN PROGRESS |
 
-**0 failed, 0 pending-forever, 6 in progress** at snapshot time. No iOS
-build/test check exists in this repository's required-checks set — see
-§9.
+**0 failed, 1 still in progress** ("Cypress Web E2E — cross-role
+integration"). `mergeStateStatus` moved from `BLOCKED` to `UNSTABLE`
+(GitHub's status for "mergeable but checks not all green yet" — the
+remaining check is in progress, not failed). No iOS build/test check
+exists in this repository's required-checks set — see §9.
 
 ---
 
@@ -259,11 +281,11 @@ PR #296's diff.
 **`BLOCKED_CI`**
 
 Rationale: the PR is `MERGEABLE` with a clean scope (§3), full local
-Xcode build/test evidence (§4-§7), and 0 failed checks so far — but
-`mergeStateStatus = BLOCKED` because 6 required CI checks (Unit Tests,
-API Tests, Load Gate, 4× Cypress) are still `IN_PROGRESS` at snapshot
-time, and `reviewDecision` is empty (no review yet). No PR merge has
-been performed. AN-3 has not been started.
+Xcode build/test evidence (§4-§7), and 0 failed checks — but
+`mergeStateStatus = UNSTABLE` because 1 check ("Cypress Web E2E —
+cross-role integration") is still `IN_PROGRESS`, and `reviewDecision`
+is empty (no review yet). No PR merge has been performed. AN-3 has not
+been started.
 
 This report will be updated once CI completes (either to
 `AN2_PR_READY_FOR_REVIEW` if all required checks pass with 0 failures,

--- a/docs/AN2_PR_READINESS_REPORT.md
+++ b/docs/AN2_PR_READINESS_REPORT.md
@@ -1,0 +1,270 @@
+# AN-2 PR Readiness Report
+
+**PR:** [#296](https://github.com/football-investment/practice-booking-system/pull/296)
+**Title:** `feat(ios): add juggling annotation data and sync layer`
+**Branch:** `feat/ios-juggling-annotation-data-an2` → **base:** `main`
+**HEAD SHA:** `f076adaa6530ba54698cbeb69c587899176d9e67`
+**Snapshot time:** 2026-06-13 (CI in progress — see §8, this report will need
+a follow-up CI-status update before merge)
+
+---
+
+## 1. Commit list (11 commits, base `f1054056`)
+
+```
+0b0e87cb feat(ios): add deterministic bundled juggling taxonomy
+02e09544 feat(ios): add annotation API contracts and raw HTTP client support
+1f261bc9 feat(ios): add versioned atomic annotation store with user isolation
+8e96395d feat(ios): add annotation sync and reconciliation engine
+04aa7c58 feat(ios): add annotation view model with finish guard and recovery
+1c06e5bd test(ios): add AN-2 taxonomy, persistence, sync and recovery coverage
+0100a944 docs(ios): add AN-2 implementation report
+5695af86 build(ios): restore LFAEducationCenter unit test target and wire AN-2 sources
+213fac4c fix(ios): resolve AN-2 compile and contract issues
+7783e95e test(ios): complete AN-2 sync, reconciliation and Finish guard coverage
+f076adaa docs(ios): add AN-2 Xcode build and validation evidence
+```
+
+---
+
+## 2. Changed files (21)
+
+```
+docs/AN2_IMPLEMENTATION_REPORT.md                                    +183
+docs/AN2_XCODE_INTEGRATION_VALIDATION_REPORT.md                      +384
+ios/LFAEducationCenter.xcodeproj/project.pbxproj                     +201
+ios/LFAEducationCenter/Auth/AuthManager.swift                        +37
+ios/LFAEducationCenter/Juggling/Annotation/AnnotationSyncEngine.swift +265
+ios/LFAEducationCenter/Juggling/Annotation/ContactEventDraft.swift   +81
+ios/LFAEducationCenter/Juggling/Annotation/ContactEventResponse.swift +163
+ios/LFAEducationCenter/Juggling/Annotation/ContactTaxonomy.swift     +101
+ios/LFAEducationCenter/Juggling/Annotation/ContactTaxonomyStore.swift +159
+ios/LFAEducationCenter/Juggling/Annotation/JugglingAnnotationAPIClient.swift +236
+ios/LFAEducationCenter/Juggling/Annotation/JugglingAnnotationViewModel.swift +238
+ios/LFAEducationCenter/Juggling/Annotation/LocalAnnotationStore.swift +168
+ios/LFAEducationCenter/Juggling/Annotation/Resources/contact_types_v1.json +507
+ios/LFAEducationCenter/Juggling/JugglingVideoItem.swift              +4
+ios/LFAEducationCenter/Networking/APIClient.swift                    +73
+ios/LFAEducationCenterTests/Juggling/AnnotationSyncEngineTests.swift +359
+ios/LFAEducationCenterTests/Juggling/ContactEventDraftTests.swift    +139
+ios/LFAEducationCenterTests/Juggling/ContactTaxonomyTests.swift      +80
+ios/LFAEducationCenterTests/Juggling/JugglingAnnotationViewModelTests.swift +69
+ios/LFAEducationCenterTests/Juggling/LocalAnnotationStoreTests.swift +128
+scripts/check_taxonomy_bundle_drift.py                               +76
+```
+All additions, 0 deletions (net-new feature on top of AN-1).
+
+---
+
+## 3. Scope proof
+
+**Present in the diff (all expected, all in-scope):**
+- AN-2 production Swift files: `ContactTaxonomy.swift`,
+  `ContactTaxonomyStore.swift`, `ContactEventDraft.swift`,
+  `ContactEventResponse.swift`, `LocalAnnotationStore.swift`,
+  `AnnotationSyncEngine.swift`, `JugglingAnnotationAPIClient.swift`,
+  `JugglingAnnotationViewModel.swift`, plus small additive edits to
+  `AuthManager.swift`, `APIClient.swift`, `JugglingVideoItem.swift`
+  (raw HTTP helpers + `annotation_status` field)
+- Taxonomy resource: `contact_types_v1.json`
+- Xcode project/test-target wiring: `project.pbxproj` (+201 lines,
+  0 deletions — new `LFAEducationCenterTests` target only)
+- AN-2 + related unit tests: 5 files under
+  `ios/LFAEducationCenterTests/Juggling/`
+- Validation/implementation docs: `AN2_IMPLEMENTATION_REPORT.md`,
+  `AN2_XCODE_INTEGRATION_VALIDATION_REPORT.md`
+- `scripts/check_taxonomy_bundle_drift.py` (drift guard used by the
+  taxonomy bundle proof)
+
+**Confirmed absent:**
+- No SwiftUI annotation screen / picker / timeline / video overlay
+- No backend route, model, schema, or migration (`app/` untouched,
+  `tests/snapshots/openapi_snapshot.json` untouched)
+- No unrelated Biometric or UI refactor (`SpikeLivenessViewModel.swift`,
+  `AcademyIDColorPickerView.swift`, `BiometricPhotoCapture.swift` etc. are
+  NOT in this diff)
+- No build artifacts, `DerivedData`, `.xcresult`, or `ios/build/` —
+  `git status` for `ios/` shows only pre-existing untracked items
+  (xcuserdata, `ios/ios/`, `ios/LFASkeleton.xcodeproj/`, an unrelated
+  `LionCrest.imageset` and `BiometricPhotoCapture.swift` from other
+  in-progress work on this machine), none staged or part of the PR
+
+**Scope verdict: clean — no drift.**
+
+---
+
+## 4. Xcode build proof (local, from validation report)
+
+- `xcodebuild -list`: 2 targets (`LFAEducationCenter` app,
+  `LFAEducationCenterTests` unit-test bundle, GUID
+  `CC100002000000000000001`, `TestTargetID` = app target),
+  `plutil -lint` → OK
+- Debug simulator build (`iPhone 16`, iOS 18.0,
+  UDID `96E63DB5-3974-445F-944B-AB1D2DBB9923`): **BUILD SUCCEEDED**,
+  4 warnings, all pre-existing/unrelated to AN-2
+- Release simulator build (same destination): **BUILD SUCCEEDED**,
+  2 warnings, both pre-existing/unrelated to AN-2
+
+---
+
+## 5. Unit test proof (local)
+
+- Full suite: **56/56 PASS**, 0 failures (`/tmp/an2_full_test.xcresult`)
+- AN-2 suite (`-only-testing` filter on AnnotationSyncEngineTests,
+  ContactEventDraftTests, ContactTaxonomyTests, LocalAnnotationStoreTests,
+  JugglingAnnotationViewModelTests): **37/37 PASS**, 0 failures
+  (`/tmp/an2_filtered.xcresult`)
+- 12 new tests (AN2-T26..T37) close all 15 items from the section-5
+  sync/reconciliation/Finish gap list
+
+---
+
+## 6. Taxonomy drift proof
+
+```
+$ python3 scripts/check_taxonomy_bundle_drift.py
+OK — bundled taxonomy matches dataset source (md5=7198de62733493537450275dadc6f445)
+```
+`contact_types_v1.json` is present at the root of both the Debug and
+Release built `.app` bundles, MD5 `7198de62733493537450275dadc6f445` —
+identical to the dataset source-of-truth checksum.
+
+---
+
+## 7. Local store / reconciliation / user-isolation / Finish-guard proof
+
+- **Local store** (`LocalAnnotationStoreTests` T05-T10, 6/6 PASS):
+  empty load, save/load round trip, per-user isolation
+  (`juggling_annotations/{userId}/{videoId}.json`), corrupt-file
+  quarantine (not deleted), checksum-mismatch quarantine, delete removes
+  file.
+- **Reconciliation** (`AnnotationSyncEngineTests` T23/T24 pre-existing,
+  T32/T33 new): server-present `needsReconciliation` draft → `.synced`
+  with server state applied; absent → `.deleted`; unrelated server-side
+  events for other device-event-ids are ignored; non-`needsReconciliation`
+  drafts are left untouched by `reconcile`.
+- **User isolation**: `LocalAnnotationStoreTests` T07 — two different
+  `userId` values never read each other's session file
+  (`juggling_annotations/{userId}/...`); `JugglingAnnotationViewModel`'s
+  `userId` is immutable per instance (set at init, cannot be re-targeted).
+- **Finish guard** (`ContactEventDraftTests` T34/T35,
+  `JugglingAnnotationViewModelTests` T36/T37): all 7 blocking sync statuses
+  (`localOnly, syncing, updating, deleting, retryPending, conflicted,
+  needsReconciliation`) individually block `finishReadiness`;
+  `failedPermanent` does not block; zero active events →
+  `confirm_zero_contacts=true` + session cleared on success; permanent API
+  error on finish → `finishError` set, session preserved for retry.
+
+---
+
+## 8. CI status (snapshot — IN PROGRESS, not yet final)
+
+```
+mergeable        = MERGEABLE
+mergeStateStatus = BLOCKED   (checks still running)
+reviewDecision   = (none yet)
+```
+
+| Check | Status |
+|---|---|
+| API Module Integrity (import + route count) | ✅ SUCCESS |
+| Hardcoded FK ID Guard (lint) | ✅ SUCCESS |
+| Credit Balance Audit (static AST) | ✅ SUCCESS |
+| Migration Chain Integrity (empty → head → base → head) | ✅ SUCCESS |
+| Migration Volume Safety (data-present roundtrip) | ✅ SUCCESS |
+| Operational Smoke Test (full stack) | ✅ SUCCESS |
+| Skill Weight Pipeline — 28 required tests | ✅ SUCCESS |
+| Preset Weight Audit (informational) | ⏭️ SKIPPED (informational, non-blocking) |
+| Unit Tests (Baseline: 0 failed, 0 errors) | ⏳ IN PROGRESS |
+| API Tests (Baseline: 0 failed, 0 errors) | ⏳ IN PROGRESS |
+| Load Gate — Phase 6.3 (50 VUs, 10 min) | ⏳ IN PROGRESS |
+| Migration Chain Integrity rerun (cypress prep) | ⏳ IN PROGRESS |
+| cypress-web-by-role (admin) | ⏳ IN PROGRESS |
+| cypress-web-by-role (instructor) | ⏳ IN PROGRESS |
+| cypress-web-by-role (student) | ⏳ IN PROGRESS |
+| cypress-web-by-role (business-workflow) | ⏳ IN PROGRESS |
+
+**0 failed, 0 pending-forever, 6 in progress** at snapshot time. No iOS
+build/test check exists in this repository's required-checks set — see
+§9.
+
+---
+
+## 9. iOS CI gap (flagged separately, per instruction)
+
+This repository's CI does **not** run an iOS build or `xcodebuild test`
+job — all required/optional checks visible on PR #296 are backend
+(API/DB/migrations), web (Cypress), and load-test jobs. There is no
+"iOS build check", "unit tests (iOS)", or "project integrity (iOS)" gate.
+
+Per instruction, **the local Xcode build/test evidence in
+`docs/AN2_XCODE_INTEGRATION_VALIDATION_REPORT.md` (Debug+Release
+BUILD SUCCEEDED, 56/56 + 37/37 unit tests PASS, taxonomy checksum proof)
+remains the required merge evidence for the iOS portion of this PR** —
+this is a pre-existing repository-CI gap, not something introduced or
+fixable by this PR.
+
+---
+
+## 10. Pre-existing excluded Biometric test files
+
+| File | Why excluded | Previously in a target? | Causes regression? | Follow-up needed? |
+|---|---|---|---|---|
+| `ios/LFAEducationCenterTests/Biometric/BiometricPhotoCaptureTests.swift` | Excluded in the prior AN-2 session for an analogous compile incompatibility with current production code | No — no test target existed in `project.pbxproj` at all before AN-2 added one | No — it has never built or run; AN-2 introduces the first working test target and these 3 files are simply not members of it, exactly as before | Yes — separate follow-up to fix/rewrite against current Biometric production code, out of AN-2 scope |
+| `ios/LFAEducationCenterTests/Biometric/SpikeLivenessViewModelPR2Tests.swift` | Assigns to `@Published private(set) var stepState`/`currentStepIndex` and reads `private let sequence` on `SpikeLivenessViewModel` from a same-module extension in a different file — `private` is file-scoped, inaccessible even with `@testable import`, under the active Swift 6 toolchain | No (see above) | No (see above) | Yes — requires either changing `SpikeLivenessViewModel`'s access levels (production-code change, Biometric feature) or rewriting the test; out of AN-2 scope |
+| `ios/LFAEducationCenterTests/Biometric/FaceGestureDetectorTests.swift` | Calls `.neutral()`/`.headLeft()`/etc. on a `FaceAnchorInput` *protocol existential* parameter; Swift resolves these against the protocol's own (empty) static members rather than the concrete `MockFaceAnchorInput` type — a Swift-toolchain/implicit-member-lookup incompatibility | No (see above) | No (see above) | Yes — requires either an explicit factory/cast at each call site (test-only rewrite) or a protocol-design change; out of AN-2 scope |
+
+**None of these three files were ever part of a working target** — the
+`LFAEducationCenterTests` target itself did not exist in `project.pbxproj`
+prior to this PR (commit `5695af86`). Their exclusion therefore changes
+nothing about what built or ran before; it is **not a regression**, and
+all 56 tests that now run (including the 25 pre-AN-2 + 12 new AN-2 tests
+and the 19 pre-existing `JugglingVideoTests`) pass. A follow-up
+issue/PR to repair these 3 Biometric test files against the current
+Swift 6 toolchain and `SpikeLivenessViewModel`/`FaceGestureDetector`
+production code is recommended, scoped to the Biometric feature track —
+**not stated as "problem-free without evidence"**, but as a documented,
+non-blocking, pre-existing gap.
+
+---
+
+## 11. Review status
+
+`reviewDecision` is empty — **no reviews yet**.
+
+---
+
+## 12. git status (local, final)
+
+```
+$ git status --porcelain=v1 -- ios/ docs/
+?? docs/AN2_XCODE_INTEGRATION_VALIDATION_PLAN.md
+?? docs/P5_PHASE2_STAGING_EXECUTION_CHECKLIST.md
+?? docs/P5_STAGING_TEST_DATA_EXECUTION_PLAN.md
+?? ios/LFAEducationCenter.xcodeproj/project.xcworkspace/xcuserdata/
+?? ios/LFAEducationCenter.xcodeproj/xcuserdata/
+?? ios/LFAEducationCenter/Assets.xcassets/LionCrest.imageset/
+?? ios/LFAEducationCenter/Biometric/Spike/BiometricPhotoCapture.swift
+?? ios/LFASkeleton.xcodeproj/
+?? ios/ios/
+```
+All untracked entries pre-date this PR and belong to other in-progress
+work on this machine (Biometric MVP, staging docs) — none are part of
+PR #296's diff.
+
+---
+
+## 13. Final verdict
+
+**`BLOCKED_CI`**
+
+Rationale: the PR is `MERGEABLE` with a clean scope (§3), full local
+Xcode build/test evidence (§4-§7), and 0 failed checks so far — but
+`mergeStateStatus = BLOCKED` because 6 required CI checks (Unit Tests,
+API Tests, Load Gate, 4× Cypress) are still `IN_PROGRESS` at snapshot
+time, and `reviewDecision` is empty (no review yet). No PR merge has
+been performed. AN-3 has not been started.
+
+This report will be updated once CI completes (either to
+`AN2_PR_READY_FOR_REVIEW` if all required checks pass with 0 failures,
+or to a more specific `BLOCKED_*` if any check fails).

--- a/docs/AN2_XCODE_INTEGRATION_VALIDATION_REPORT.md
+++ b/docs/AN2_XCODE_INTEGRATION_VALIDATION_REPORT.md
@@ -1,0 +1,384 @@
+# AN-2 — Xcode Integration and Runtime Validation Report
+
+**Status:** COMPLETE. This is the evidence report for
+`docs/AN2_XCODE_INTEGRATION_VALIDATION_PLAN.md` (approved). All builds and
+tests below were executed against the real Xcode toolchain on the iOS 18.0
+"iPhone 16" simulator (UDID `96E63DB5-3974-445F-944B-AB1D2DBB9923`).
+
+**Branch:** `feat/ios-juggling-annotation-data-an2`
+**Base SHA (merge-base with `main`):** `f1054056ed314271f3814c1046f6ea7911146dd8`
+**Pre-existing HEAD at start of this work:** `0100a94488430c879afeb88f3d5c2d641040edd3`
+**HEAD after this work:** `7783e95eb6adf5850b8010e7bdfbf6a460a30c94`
+
+---
+
+## 1. Commit list
+
+```
+5695af86 build(ios): restore LFAEducationCenter unit test target and wire AN-2 sources
+213fac4c fix(ios): resolve AN-2 compile and contract issues
+7783e95e test(ios): complete AN-2 sync, reconciliation and Finish guard coverage
+```
+
+A fourth commit adding this report follows.
+
+### Deviation from the planned 5-commit structure
+
+The plan (and the directive) called for a 5-commit split (test target /
+source wiring / compile fixes / test coverage / docs). In practice the
+`project.pbxproj` changes for the new test target, the AN-2 production
+source+resource wiring, the test-target Sources membership, and the 3
+pre-existing Biometric-test exclusions are all interleaved edits to a
+**single plist file** that must remain `plutil -lint`-valid and
+internally consistent (no dangling `PBXBuildFile`/`PBXFileReference`/group
+references) at every commit boundary. Splitting this single file into two
+"valid" intermediate plist states would have required either (a) committing
+a temporarily-inconsistent pbxproj (risking a broken project at an
+intermediate commit), or (b) hand-splitting ~200 lines of interleaved
+plist additions into two checkpoint files — both judged higher-risk than
+combining the test-target-creation and AN-2-wiring work into one commit.
+
+The Swift-side changes split cleanly along real semantic lines and were
+kept separate:
+- compile/contract fixes (`fix(ios)`) vs.
+- new test coverage (`test(ios)`)
+
+No commit is empty. Final result: **4 commits** (1 build/wiring + 1 fix +
+1 test + 1 docs) instead of 5, with the combination limited to the
+single-file pbxproj wiring step.
+
+---
+
+## 2. `.pbxproj` target list — before / after
+
+**Before** (per `docs/AN2_XCODE_INTEGRATION_VALIDATION_PLAN.md` §1.1-1.2):
+```
+Targets:  LFAEducationCenter
+Schemes:  LFAEducationCenter
+PBXNativeTarget count: 1 (productType = application)
+```
+
+**After** (`xcodebuild -list -project LFAEducationCenter.xcodeproj`):
+```
+Information about project "LFAEducationCenter":
+    Targets:
+        LFAEducationCenter
+        LFAEducationCenterTests
+
+    Build Configurations:
+        Debug
+        Release
+
+    Schemes:
+        LFAEducationCenter
+```
+`PBXNativeTarget` count: 2 — `BB000001000000000000002` (LFAEducationCenter,
+application) and `CC100002000000000000001` (LFAEducationCenterTests,
+`com.apple.product-type.bundle.unit-test`, `TEST_HOST` =
+`LFAEducationCenter.app/LFAEducationCenter`, `TestTargetID =
+BB000001000000000000002`). The new target is registered on the project's
+`targets` array and on `attributes.TargetAttributes`; the existing
+`LFAEducationCenter` scheme builds/tests both via the test-host wiring (no
+separate scheme file was needed, confirming plan §1.4/§2).
+
+`plutil -lint LFAEducationCenter.xcodeproj/project.pbxproj` → `OK` (verified
+after every edit and again on the final state).
+
+No duplicate object UUIDs were introduced; the reused GUID
+`CC100002000000000000001` had no prior collision in the file.
+
+---
+
+## 3. Changed files
+
+```
+$ git diff --stat f1054056..HEAD -- ios/
+ ios/LFAEducationCenter.xcodeproj/project.pbxproj                          | 201 +++++++++++++++++++++
+ ios/LFAEducationCenter/Juggling/Annotation/ContactTaxonomyStore.swift     |   2 +-
+ ios/LFAEducationCenterTests/Juggling/AnnotationSyncEngineTests.swift      | 143 +++++++++++++++
+ ios/LFAEducationCenterTests/Juggling/ContactEventDraftTests.swift         |  38 ++++
+ ios/LFAEducationCenterTests/Juggling/ContactTaxonomyTests.swift           |   1 +
+ ios/LFAEducationCenterTests/Juggling/JugglingAnnotationViewModelTests.swift | 69 +++++++ (new file)
+ 6 files changed, 453 insertions(+), 1 deletion(-)
+```
+
+No files outside `ios/LFAEducationCenter.xcodeproj/`,
+`ios/LFAEducationCenter/Juggling/Annotation/`, or
+`ios/LFAEducationCenterTests/Juggling/` were modified. `app/`,
+`tests/snapshots/openapi_snapshot.json`, `ios/ios/`,
+`ios/LFASkeleton.xcodeproj/` are untouched.
+
+---
+
+## 4. Test target membership (final)
+
+`LFAEducationCenterTests` Sources build phase (`CC100001000000000000001`),
+6 files:
+
+```
+JugglingVideoTests.swift
+Juggling/ContactTaxonomyTests.swift
+Juggling/LocalAnnotationStoreTests.swift
+Juggling/ContactEventDraftTests.swift
+Juggling/AnnotationSyncEngineTests.swift
+Juggling/JugglingAnnotationViewModelTests.swift
+```
+
+**Known gap — 3 pre-existing files excluded** (kept on disk, not in any
+target):
+- `ios/LFAEducationCenterTests/Biometric/BiometricPhotoCaptureTests.swift`
+- `ios/LFAEducationCenterTests/Biometric/SpikeLivenessViewModelPR2Tests.swift`
+- `ios/LFAEducationCenterTests/Biometric/FaceGestureDetectorTests.swift`
+
+All three predate AN-2 and fail to compile against the current production
+code / active Swift 6 toolchain for reasons unrelated to AN-2:
+- `SpikeLivenessViewModelPR2Tests.swift` assigns to `@Published private(set)`
+  properties (`stepState`, `currentStepIndex`) and reads a `private let
+  sequence` from a same-module extension — `private` is file-scoped, not
+  module-scoped, so this is inaccessible even with `@testable import`.
+- `FaceGestureDetectorTests.swift` calls `.neutral()`/`.headLeft()` etc. on
+  a `FaceAnchorInput` *protocol existential* parameter, which Swift resolves
+  against the protocol's own (empty) static members rather than the
+  concrete `MockFaceAnchorInput` type — a Swift-toolchain incompatibility.
+- `BiometricPhotoCaptureTests.swift` was already excluded for an analogous
+  reason in the prior AN-2 session.
+
+Fixing any of these requires changing unrelated Biometric production code or
+substantially rewriting unrelated pre-existing tests — both forbidden by the
+AN-2 scope guard ("no unrelated iOS refactor"). They are pre-existing
+conditions, not AN-2 regressions.
+
+---
+
+## 5. App build — Debug
+
+```
+$ xcodebuild clean build -project LFAEducationCenter.xcodeproj \
+    -scheme LFAEducationCenter -configuration Debug \
+    -destination 'id=96E63DB5-3974-445F-944B-AB1D2DBB9923'
+...
+** BUILD SUCCEEDED **
+EXIT=0
+```
+
+**Warnings (4, clean build), all pre-existing and outside AN-2 scope:**
+```
+LFAEducationCenter/Auth/AcademyIDColorPickerView.swift:98:13: warning: result of call to 'withAnimation' is unused
+LFAEducationCenter/Biometric/Spike/SpikeLivenessViewModel.swift:116:71: warning: main actor-isolated static property 'defaultSequence' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode
+LFAEducationCenter/Biometric/Spike/SpikeLivenessViewModel.swift:385:17: warning: initialization of immutable value 'pass' was never used
+LFAEducationCenter/Biometric/Spike/SpikeLivenessViewModel.swift:390:17: warning: initialization of immutable value 'pass2' was never used
+```
+(plus the unrelated `appintentsmetadataprocessor` informational line about
+no AppIntents.framework dependency — not a Swift warning).
+
+The single AN-2-scoped warning found in the prior build pass
+(`ContactTaxonomyStore.swift:85`, `var path` never mutated) was fixed in
+commit `213fac4c` and does not appear in this clean build.
+
+---
+
+## 6. App build — Release
+
+```
+$ xcodebuild clean build -project LFAEducationCenter.xcodeproj \
+    -scheme LFAEducationCenter -configuration Release \
+    -destination 'id=96E63DB5-3974-445F-944B-AB1D2DBB9923'
+...
+** BUILD SUCCEEDED **
+EXIT=0
+```
+
+**Warnings (2, clean build), both pre-existing and outside AN-2 scope:**
+```
+LFAEducationCenter/Auth/AcademyIDColorPickerView.swift:98:13: warning: result of call to 'withAnimation' is unused
+LFAEducationCenter/Biometric/Spike/SpikeLivenessViewModel.swift:116:71: warning: main actor-isolated static property 'defaultSequence' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode
+```
+
+---
+
+## 7. Copy Bundle Resources / runtime taxonomy bundle proof
+
+`contact_types_v1.json` is present at the root of both built `.app` bundles
+and its checksum matches the dataset source-of-truth checksum used by
+`scripts/check_taxonomy_bundle_drift.py`:
+
+```
+$ find .../Debug-iphonesimulator/LFAEducationCenter.app -iname contact_types_v1.json
+.../Debug-iphonesimulator/LFAEducationCenter.app/contact_types_v1.json
+$ md5 .../Debug-iphonesimulator/LFAEducationCenter.app/contact_types_v1.json
+MD5 (.../contact_types_v1.json) = 7198de62733493537450275dadc6f445
+
+$ find .../Release-iphonesimulator/LFAEducationCenter.app -iname contact_types_v1.json
+.../Release-iphonesimulator/LFAEducationCenter.app/contact_types_v1.json
+$ md5 .../Release-iphonesimulator/LFAEducationCenter.app/contact_types_v1.json
+MD5 (.../contact_types_v1.json) = 7198de62733493537450275dadc6f445
+```
+
+Taxonomy drift guard:
+```
+$ python3 scripts/check_taxonomy_bundle_drift.py
+OK — bundled taxonomy matches dataset source (md5=7198de62733493537450275dadc6f445)
+```
+
+All three checksums (Debug bundle, Release bundle, dataset source-of-truth)
+are identical.
+
+---
+
+## 8. Unit tests — full suite
+
+```
+$ xcodebuild test -project LFAEducationCenter.xcodeproj \
+    -scheme LFAEducationCenter -configuration Debug \
+    -destination 'id=96E63DB5-3974-445F-944B-AB1D2DBB9923' \
+    -resultBundlePath /tmp/an2_full_test.xcresult
+...
+Test Suite 'All tests' passed at 2026-06-13 14:34:08.117.
+	 Executed 56 tests, with 0 failures (0 unexpected) in 0.113 (0.336) seconds
+** TEST SUCCEEDED **
+EXIT=0
+```
+
+`.xcresult`: `/tmp/an2_full_test.xcresult`
+
+Breakdown:
+- AN-2 Juggling annotation suites: 37 tests (T01-T37, see §9)
+- Pre-existing `JugglingVideoTests` suites: 19 tests
+  (`JugglingBackendDeltaTests`=2, `JugglingVideoItemCodableTests`=3,
+  `JugglingVideoItemDisplayTests`=14)
+
+---
+
+## 9. Unit tests — AN-2 filtered run
+
+```
+$ xcodebuild test -project LFAEducationCenter.xcodeproj \
+    -scheme LFAEducationCenter -configuration Debug \
+    -destination 'id=96E63DB5-3974-445F-944B-AB1D2DBB9923' \
+    -only-testing:LFAEducationCenterTests/AnnotationSyncEngineTests \
+    -only-testing:LFAEducationCenterTests/ContactEventDraftTests \
+    -only-testing:LFAEducationCenterTests/ContactTaxonomyTests \
+    -only-testing:LFAEducationCenterTests/LocalAnnotationStoreTests \
+    -only-testing:LFAEducationCenterTests/JugglingAnnotationViewModelTests \
+    -resultBundlePath /tmp/an2_filtered.xcresult
+...
+Test Suite 'Selected tests' passed at 2026-06-13 14:23:08.727.
+	 Executed 37 tests, with 0 failures (0 unexpected) in 0.246 (0.313) seconds
+** TEST SUCCEEDED **
+```
+
+`.xcresult`: `/tmp/an2_filtered.xcresult`
+
+| Suite | Tests | Result |
+|---|---|---|
+| ContactTaxonomyTests (T01-T04) | 4 | PASS |
+| LocalAnnotationStoreTests (T05-T10) | 6 | PASS |
+| ContactEventDraftTests (T11-T16, T34-T35) | 8 | PASS |
+| AnnotationSyncEngineTests (T17-T33) | 17 | PASS |
+| JugglingAnnotationViewModelTests (T36-T37) | 2 | PASS |
+| **Total** | **37** | **0 failures** |
+
+---
+
+## 10. Section-5 missing-test gap closure (15/15)
+
+| # | Item | Test(s) |
+|---|---|---|
+| 1 | PATCH success | AN2-T26 |
+| 2 | PATCH version conflict | AN2-T27 |
+| 3 | PATCH 422 | AN2-T28 |
+| 4 | PATCH timeout reconciliation | AN2-T29 |
+| 5 | DELETE timeout reconciliation | AN2-T30 |
+| 6 | idempotency conflict | AN2-T31 |
+| 7 | server extra event (reconcile) | AN2-T32 |
+| 8 | local missing event (reconcile) | AN2-T33 (+ pre-existing T24) |
+| 9 | conflicted event blocks Finish | AN2-T34 (matrix) |
+| 10 | needsReconciliation blocks Finish | AN2-T34 (matrix) |
+| 11 | retryPending blocks Finish | AN2-T34 (matrix) |
+| 12 | full Finish-blocked matrix (all 7) | AN2-T34 |
+| 13 | failedPermanent does not block Finish | AN2-T35 |
+| 14 | zero-contact Finish | AN2-T36 |
+| 15 | post-finish error mapping | AN2-T37 |
+
+All 15 items closed. Total new tests added this session: 12
+(AN2-T26..T37), bringing the AN-2 suite from 25 to 37 tests.
+
+---
+
+## 11. Reconciliation and Finish-guard proof (selected)
+
+- **AN2-T32** — `reconcile` against a server response containing an event
+  for a device-event-id with no local draft: the unrelated server event is
+  ignored; only the matching local draft transitions to `.synced` with the
+  server's `event_id`/`version` applied. Session draft count unchanged.
+- **AN2-T33** — a `.synced` draft outside `needsReconciliation` is left
+  untouched by `reconcile` (version preserved at 5); a `.needsReconciliation`
+  draft absent from the server response transitions to `.deleted`.
+- **AN2-T34** — `finishReadiness` returns `.blocked([status])` for each of
+  the 7 blocking statuses (`localOnly, syncing, updating, deleting,
+  retryPending, conflicted, needsReconciliation`) in isolation.
+- **AN2-T35** — a lone `.failedPermanent` draft yields `.readyZero`; combined
+  with a `.synced` draft it yields `.readyWithCount(1)` — `failedPermanent`
+  never blocks Finish.
+- **AN2-T36/T37** — `JugglingAnnotationViewModel.finish()`: zero active
+  events calls `confirm_zero_contacts=true` and clears `session` on success;
+  a `permanent(403, "consent_blocked")` API error sets `finishError` to its
+  `errorDescription` and preserves `session` for retry.
+
+---
+
+## 12. Local store proof
+
+`LocalAnnotationStoreTests` (T05-T10, 6 tests, all PASS): empty-load,
+save/load round trip, per-user isolation, corrupt-file quarantine (not
+deleted), checksum-mismatch quarantine, delete removes file.
+
+---
+
+## 13. `git status` (final)
+
+```
+$ git status --porcelain=v1 -- ios/
+?? ios/LFAEducationCenter.xcodeproj/project.xcworkspace/xcuserdata/
+?? ios/LFAEducationCenter.xcodeproj/xcuserdata/
+?? ios/LFAEducationCenter/Assets.xcassets/LionCrest.imageset/
+?? ios/LFAEducationCenter/Biometric/Spike/BiometricPhotoCapture.swift
+?? ios/LFASkeleton.xcodeproj/
+?? ios/ios/
+```
+
+All remaining untracked entries pre-date this work (confirmed against the
+git status at the start of this session) and are out of scope per the
+AN-2 scope guard (`ios/ios/`, `ios/LFASkeleton.xcodeproj/`,
+xcuserdata, and unrelated Biometric/Asset additions from other
+in-progress work on this machine). Nothing in this set was created or
+modified by the AN-2 Xcode integration work.
+
+---
+
+## 14. Scope confirmation
+
+All committed changes are confined to:
+- `ios/LFAEducationCenter.xcodeproj/project.pbxproj`
+- `ios/LFAEducationCenter/Juggling/Annotation/ContactTaxonomyStore.swift` (1 line)
+- `ios/LFAEducationCenterTests/Juggling/*` (4 modified/new test files)
+- `docs/AN2_XCODE_INTEGRATION_VALIDATION_REPORT.md` (this file)
+
+No SwiftUI annotation screens, no AN-3 work, no backend/API changes
+(`app/`, `tests/snapshots/openapi_snapshot.json` untouched), no PR opened.
+
+---
+
+## 15. Final verdict
+
+**`AN2_XCODE_VALIDATED_READY_FOR_PR`**
+
+The LFAEducationCenterTests unit test target exists, builds, and runs;
+all 8 AN-2 production files + the taxonomy resource are wired into the app
+target and proven present (with correct checksum) in both Debug and Release
+built bundles; the app builds successfully in both configurations with zero
+AN-2-scoped warnings; the full test suite (56 tests) and the AN-2-filtered
+suite (37 tests) both pass with 0 failures; all 15 section-5 gap items are
+closed. The only known gap is the pre-existing exclusion of 3 unrelated
+Biometric test files, documented in §4. No PR has been opened, per
+instruction — this report is the evidence handoff for that decision.

--- a/ios/LFAEducationCenter.xcodeproj/project.pbxproj
+++ b/ios/LFAEducationCenter.xcodeproj/project.pbxproj
@@ -100,6 +100,21 @@
 		BB000004000000000000080 /* SpikeLivenessViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000080 /* SpikeLivenessViewModel.swift */; };
 		BB000004000000000000081 /* ARFaceTrackingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000081 /* ARFaceTrackingView.swift */; };
 		BB000004000000000000082 /* SpikeLivenessView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000003000000000000082 /* SpikeLivenessView.swift */; };
+		AA100004000000000000001 /* ContactTaxonomy.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA100003000000000000001 /* ContactTaxonomy.swift */; };
+		AA100004000000000000002 /* ContactTaxonomyStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA100003000000000000002 /* ContactTaxonomyStore.swift */; };
+		AA100004000000000000003 /* ContactEventDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA100003000000000000003 /* ContactEventDraft.swift */; };
+		AA100004000000000000004 /* ContactEventResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA100003000000000000004 /* ContactEventResponse.swift */; };
+		AA100004000000000000005 /* LocalAnnotationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA100003000000000000005 /* LocalAnnotationStore.swift */; };
+		AA100004000000000000006 /* AnnotationSyncEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA100003000000000000006 /* AnnotationSyncEngine.swift */; };
+		AA100004000000000000007 /* JugglingAnnotationAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA100003000000000000007 /* JugglingAnnotationAPIClient.swift */; };
+		AA100004000000000000008 /* JugglingAnnotationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA100003000000000000008 /* JugglingAnnotationViewModel.swift */; };
+		AA100004000000000000009 /* contact_types_v1.json in Resources */ = {isa = PBXBuildFile; fileRef = AA100003000000000000009 /* contact_types_v1.json */; };
+		CC400004000000000000001 /* JugglingVideoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC300003000000000000001 /* JugglingVideoTests.swift */; };
+		CC400004000000000000005 /* ContactTaxonomyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC300003000000000000005 /* ContactTaxonomyTests.swift */; };
+		CC400004000000000000006 /* LocalAnnotationStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC300003000000000000006 /* LocalAnnotationStoreTests.swift */; };
+		CC400004000000000000007 /* ContactEventDraftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC300003000000000000007 /* ContactEventDraftTests.swift */; };
+		CC400004000000000000008 /* AnnotationSyncEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC300003000000000000008 /* AnnotationSyncEngineTests.swift */; };
+		CC400004000000000000009 /* JugglingAnnotationViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC300003000000000000009 /* JugglingAnnotationViewModelTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -198,10 +213,43 @@
 		BB000003000000000000080 /* SpikeLivenessViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpikeLivenessViewModel.swift; sourceTree = "<group>"; };
 		BB000003000000000000081 /* ARFaceTrackingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ARFaceTrackingView.swift; sourceTree = "<group>"; };
 		BB000003000000000000082 /* SpikeLivenessView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpikeLivenessView.swift; sourceTree = "<group>"; };
+		AA100003000000000000001 /* ContactTaxonomy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactTaxonomy.swift; sourceTree = "<group>"; };
+		AA100003000000000000002 /* ContactTaxonomyStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactTaxonomyStore.swift; sourceTree = "<group>"; };
+		AA100003000000000000003 /* ContactEventDraft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactEventDraft.swift; sourceTree = "<group>"; };
+		AA100003000000000000004 /* ContactEventResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactEventResponse.swift; sourceTree = "<group>"; };
+		AA100003000000000000005 /* LocalAnnotationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalAnnotationStore.swift; sourceTree = "<group>"; };
+		AA100003000000000000006 /* AnnotationSyncEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationSyncEngine.swift; sourceTree = "<group>"; };
+		AA100003000000000000007 /* JugglingAnnotationAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JugglingAnnotationAPIClient.swift; sourceTree = "<group>"; };
+		AA100003000000000000008 /* JugglingAnnotationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JugglingAnnotationViewModel.swift; sourceTree = "<group>"; };
+		AA100003000000000000009 /* contact_types_v1.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = contact_types_v1.json; sourceTree = "<group>"; };
+		CC300003000000000000001 /* JugglingVideoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JugglingVideoTests.swift; sourceTree = "<group>"; };
+		CC300003000000000000005 /* ContactTaxonomyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactTaxonomyTests.swift; sourceTree = "<group>"; };
+		CC300003000000000000006 /* LocalAnnotationStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalAnnotationStoreTests.swift; sourceTree = "<group>"; };
+		CC300003000000000000007 /* ContactEventDraftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactEventDraftTests.swift; sourceTree = "<group>"; };
+		CC300003000000000000008 /* AnnotationSyncEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationSyncEngineTests.swift; sourceTree = "<group>"; };
+		CC300003000000000000009 /* JugglingAnnotationViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JugglingAnnotationViewModelTests.swift; sourceTree = "<group>"; };
+		CC100003000000000000001 /* LFAEducationCenterTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LFAEducationCenterTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
+
+/* Begin PBXContainerItemProxy section */
+		CC100001000000000000005 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BB000001000000000000001 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = BB000001000000000000002;
+			remoteInfo = LFAEducationCenter;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		BB000001000000000000005 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CC100001000000000000003 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -215,6 +263,7 @@
 			isa = PBXGroup;
 			children = (
 				BB000002000000000000003 /* LFAEducationCenter */,
+				CC200002000000000000001 /* LFAEducationCenterTests */,
 				BB000002000000000000002 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -223,6 +272,7 @@
 			isa = PBXGroup;
 			children = (
 				BB000003000000000000005 /* LFAEducationCenter.app */,
+				CC100003000000000000001 /* LFAEducationCenterTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -445,8 +495,54 @@
 				89E393EC38D4612DE04DD285 /* JugglingVideoListView.swift */,
 				20CD58654D76D5278A5E5B62 /* JugglingVideoListViewModel.swift */,
 				E075CE337E219F48D39CBDFA /* JugglingPlayerView.swift */,
+				AA100002000000000000001 /* Annotation */,
 			);
 			name = Juggling;
+			path = Juggling;
+			sourceTree = "<group>";
+		};
+		AA100002000000000000001 /* Annotation */ = {
+			isa = PBXGroup;
+			children = (
+				AA100003000000000000001 /* ContactTaxonomy.swift */,
+				AA100003000000000000002 /* ContactTaxonomyStore.swift */,
+				AA100003000000000000003 /* ContactEventDraft.swift */,
+				AA100003000000000000004 /* ContactEventResponse.swift */,
+				AA100003000000000000005 /* LocalAnnotationStore.swift */,
+				AA100003000000000000006 /* AnnotationSyncEngine.swift */,
+				AA100003000000000000007 /* JugglingAnnotationAPIClient.swift */,
+				AA100003000000000000008 /* JugglingAnnotationViewModel.swift */,
+				AA100002000000000000002 /* Resources */,
+			);
+			path = Annotation;
+			sourceTree = "<group>";
+		};
+		AA100002000000000000002 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				AA100003000000000000009 /* contact_types_v1.json */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		CC200002000000000000001 /* LFAEducationCenterTests */ = {
+			isa = PBXGroup;
+			children = (
+				CC300003000000000000001 /* JugglingVideoTests.swift */,
+				CC200002000000000000003 /* Juggling */,
+			);
+			path = LFAEducationCenterTests;
+			sourceTree = "<group>";
+		};
+		CC200002000000000000003 /* Juggling */ = {
+			isa = PBXGroup;
+			children = (
+				CC300003000000000000005 /* ContactTaxonomyTests.swift */,
+				CC300003000000000000006 /* LocalAnnotationStoreTests.swift */,
+				CC300003000000000000007 /* ContactEventDraftTests.swift */,
+				CC300003000000000000008 /* AnnotationSyncEngineTests.swift */,
+				CC300003000000000000009 /* JugglingAnnotationViewModelTests.swift */,
+			);
 			path = Juggling;
 			sourceTree = "<group>";
 		};
@@ -485,6 +581,24 @@
 			productReference = BB000003000000000000005 /* LFAEducationCenter.app */;
 			productType = "com.apple.product-type.application";
 		};
+		CC100002000000000000001 /* LFAEducationCenterTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CC100006000000000000001 /* Build configuration list for PBXNativeTarget "LFAEducationCenterTests" */;
+			buildPhases = (
+				CC100001000000000000001 /* Sources */,
+				CC100001000000000000002 /* Resources */,
+				CC100001000000000000003 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				CC100001000000000000004 /* PBXTargetDependency */,
+			);
+			name = LFAEducationCenterTests;
+			productName = LFAEducationCenterTests;
+			productReference = CC100003000000000000001 /* LFAEducationCenterTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -497,6 +611,10 @@
 				TargetAttributes = {
 					BB000001000000000000002 = {
 						CreatedOnToolsVersion = 15.0;
+					};
+					CC100002000000000000001 = {
+						CreatedOnToolsVersion = 15.0;
+						TestTargetID = BB000001000000000000002;
 					};
 				};
 			};
@@ -514,6 +632,7 @@
 			projectRoot = "";
 			targets = (
 				BB000001000000000000002 /* LFAEducationCenter */,
+				CC100002000000000000001 /* LFAEducationCenterTests */,
 			);
 		};
 /* End PBXProject section */
@@ -525,6 +644,14 @@
 			files = (
 				BB000004000000000000003 /* Assets.xcassets in Resources */,
 				BB000004000000000000010 /* skeleton_receiver.html in Resources */,
+				AA100004000000000000009 /* contact_types_v1.json in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CC100001000000000000002 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -626,10 +753,39 @@
 				BB000004000000000000080 /* SpikeLivenessViewModel.swift in Sources */,
 				BB000004000000000000081 /* ARFaceTrackingView.swift in Sources */,
 				BB000004000000000000082 /* SpikeLivenessView.swift in Sources */,
+				AA100004000000000000001 /* ContactTaxonomy.swift in Sources */,
+				AA100004000000000000002 /* ContactTaxonomyStore.swift in Sources */,
+				AA100004000000000000003 /* ContactEventDraft.swift in Sources */,
+				AA100004000000000000004 /* ContactEventResponse.swift in Sources */,
+				AA100004000000000000005 /* LocalAnnotationStore.swift in Sources */,
+				AA100004000000000000006 /* AnnotationSyncEngine.swift in Sources */,
+				AA100004000000000000007 /* JugglingAnnotationAPIClient.swift in Sources */,
+				AA100004000000000000008 /* JugglingAnnotationViewModel.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CC100001000000000000001 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CC400004000000000000001 /* JugglingVideoTests.swift in Sources */,
+				CC400004000000000000005 /* ContactTaxonomyTests.swift in Sources */,
+				CC400004000000000000006 /* LocalAnnotationStoreTests.swift in Sources */,
+				CC400004000000000000007 /* ContactEventDraftTests.swift in Sources */,
+				CC400004000000000000008 /* AnnotationSyncEngineTests.swift in Sources */,
+				CC400004000000000000009 /* JugglingAnnotationViewModelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		CC100001000000000000004 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = BB000001000000000000002 /* LFAEducationCenter */;
+			targetProxy = CC100001000000000000005 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		BB000005000000000000001 /* Debug */ = {
@@ -799,6 +955,42 @@
 			};
 			name = Release;
 		};
+		CC100005000000000000001 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 4D7V9ZWVHY;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.lovas-zoltan.lfa-education-center.LFAEducationCenterTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/LFAEducationCenter.app/LFAEducationCenter";
+				TEST_TARGET_NAME = LFAEducationCenter;
+			};
+			name = Debug;
+		};
+		CC100005000000000000002 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 4D7V9ZWVHY;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.lovas-zoltan.lfa-education-center.LFAEducationCenterTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/LFAEducationCenter.app/LFAEducationCenter";
+				TEST_TARGET_NAME = LFAEducationCenter;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -816,6 +1008,15 @@
 			buildConfigurations = (
 				BB000005000000000000003 /* Debug */,
 				BB000005000000000000004 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CC100006000000000000001 /* Build configuration list for PBXNativeTarget "LFAEducationCenterTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CC100005000000000000001 /* Debug */,
+				CC100005000000000000002 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/ios/LFAEducationCenter/Auth/AuthManager.swift
+++ b/ios/LFAEducationCenter/Auth/AuthManager.swift
@@ -272,6 +272,43 @@ final class AuthManager: ObservableObject {
         }
     }
 
+    // GET (raw) — inject Bearer, returns (Data, URLResponse) without a 2xx check.
+    // No 401 refresh: getRaw never throws on non-2xx, so a 401 body passes through
+    // for the caller to inspect (e.g. ContactTaxonomyStore falls back to bundled data).
+    func authenticatedGetRaw(
+        path:         String,
+        extraHeaders: [String: String] = [:]
+    ) async throws -> (Data, URLResponse) {
+        guard let token = accessToken else { logout(); throw APIError.unauthorized }
+        return try await APIClient.getRaw(path: path, token: token, extraHeaders: extraHeaders)
+    }
+
+    // POST (raw) — inject Bearer, single 401 refresh + retry, returns (Data, statusCode).
+    // Used by annotation create/batch endpoints to distinguish 200 (duplicate) from 201 (created)
+    // and to surface 409 conflict bodies to the caller via APIError.httpError.
+    func authenticatedPostRaw<B: Encodable>(path: String, body: B) async throws -> (Data, Int) {
+        guard let token = accessToken else { logout(); throw APIError.unauthorized }
+        do {
+            return try await APIClient.postRaw(path: path, body: body, token: token)
+        } catch APIError.httpError(401, _) {
+            let refreshed = await performRefresh()
+            guard refreshed, let newToken = accessToken else { throw APIError.unauthorized }
+            return try await APIClient.postRaw(path: path, body: body, token: newToken)
+        }
+    }
+
+    // PATCH (raw) — inject Bearer, single 401 refresh + retry, returns (Data, statusCode).
+    func authenticatedPatchRaw<B: Encodable>(path: String, body: B) async throws -> (Data, Int) {
+        guard let token = accessToken else { logout(); throw APIError.unauthorized }
+        do {
+            return try await APIClient.patchRaw(path: path, body: body, token: token)
+        } catch APIError.httpError(401, _) {
+            let refreshed = await performRefresh()
+            guard refreshed, let newToken = accessToken else { throw APIError.unauthorized }
+            return try await APIClient.patchRaw(path: path, body: body, token: newToken)
+        }
+    }
+
     // MARK: — Token accessors
 
     var accessToken: String? {

--- a/ios/LFAEducationCenter/Juggling/Annotation/AnnotationSyncEngine.swift
+++ b/ios/LFAEducationCenter/Juggling/Annotation/AnnotationSyncEngine.swift
@@ -1,0 +1,265 @@
+import Foundation
+
+// MARK: — AnnotationSyncEngine
+//
+// Implements the 10-state ContactEventSyncStatus machine for one annotation
+// session. All methods operate on a single ContactEventDraft (or the whole
+// session for flush/reconcile) and return updated values — the caller
+// (JugglingAnnotationViewModel) owns persistence via LocalAnnotationStore.
+//
+// Retry policy: max 3 attempts. Delay schedule (2s / 4s / 8s, ± jitter) is
+// the caller's responsibility — this engine only tracks retryCount and
+// reports whether the cap has been reached.
+//
+// Ambiguity handling:
+//   - POST timeout: idempotent via device_event_id → retryPending (safe to retry)
+//   - PATCH timeout: optimistic-lock side effect unknown → needsReconciliation
+//   - DELETE timeout or 404: outcome unknown → needsReconciliation
+//   - reconcile(): GET /contacts is the only source of truth for needsReconciliation
+
+@MainActor
+final class AnnotationSyncEngine {
+
+    static let maxRetries = 3
+    // Base retry delays in seconds; caller applies ± jitter before scheduling.
+    static let retryDelaysSeconds: [Double] = [2.0, 4.0, 8.0]
+
+    private let apiClient: JugglingAnnotationAPIClientProtocol
+
+    init(apiClient: JugglingAnnotationAPIClientProtocol) {
+        self.apiClient = apiClient
+    }
+
+    // MARK: — Flush pending
+
+    // Pushes every localOnly / retryPending draft to the server.
+    // Drafts that were deleted locally before ever syncing are marked
+    // .deleted without a network call (nothing exists server-side).
+    // Mutates session.drafts in place; caller persists afterwards.
+    func flushPending(session: inout AnnotationSessionFile) async {
+        for index in session.drafts.indices {
+            let draft = session.drafts[index]
+            guard draft.syncStatus == .localOnly || draft.syncStatus == .retryPending else { continue }
+
+            if draft.deletedLocally {
+                session.drafts[index].syncStatus = .deleted
+                continue
+            }
+
+            session.drafts[index] = await pushCreate(draft: draft, videoId: session.videoId)
+        }
+
+        // Drafts that finished syncing but were marked for deletion in the
+        // meantime now need a DELETE pushed to the server.
+        for index in session.drafts.indices {
+            let draft = session.drafts[index]
+            guard draft.deletedLocally, draft.syncStatus == .synced, draft.serverEventId != nil else { continue }
+            session.drafts[index] = await pushDelete(draft: draft, videoId: session.videoId)
+        }
+    }
+
+    // MARK: — Reconciliation (GET /contacts → align local state with server)
+
+    // Resolves every draft in .needsReconciliation by comparing against the
+    // authoritative server list. A draft absent from the server response is
+    // treated as deleted (covers both confirmed DELETE and 404-ambiguous DELETE).
+    func reconcile(session: inout AnnotationSessionFile) async throws {
+        let list = try await apiClient.listContacts(videoId: session.videoId)
+        let serverByDeviceId = Dictionary(
+            uniqueKeysWithValues: list.events.map { ($0.deviceEventId, $0) }
+        )
+
+        for index in session.drafts.indices {
+            let draft = session.drafts[index]
+            guard draft.syncStatus == .needsReconciliation else { continue }
+
+            if let serverEvent = serverByDeviceId[draft.deviceEventId] {
+                session.drafts[index] = applyServerState(to: draft, from: serverEvent)
+            } else {
+                session.drafts[index].syncStatus     = .deleted
+                session.drafts[index].failureReason  = nil
+            }
+        }
+    }
+
+    // MARK: — Single-draft operations
+
+    // POST /contacts. 201 → new, 200 → exact duplicate — both are .synced.
+    func pushCreate(draft: ContactEventDraft, videoId: String) async -> ContactEventDraft {
+        var updated = draft
+        updated.syncStatus = .syncing
+
+        let request = ContactEventCreateRequest(
+            deviceEventId:        draft.deviceEventId,
+            timestampMs:          draft.timestampMs,
+            contactType:          draft.contactType,
+            annotationConfidence: draft.annotationConfidence,
+            side:                 draft.side,
+            customLabel:          draft.customLabel,
+            customDescription:    draft.customDescription
+        )
+
+        do {
+            let result = try await apiClient.createContact(videoId: videoId, request: request)
+            updated = applyServerState(to: updated, from: result.event)
+        } catch let error as AnnotationAPIError {
+            updated = applyCreateFailure(to: updated, error: error)
+        } catch {
+            updated = applyCreateFailure(to: updated, error: .retryable(code: nil))
+        }
+        return updated
+    }
+
+    // PATCH /contacts/{id}. Optimistic-lock conflict → .conflicted.
+    // Network/timeout → .needsReconciliation (PATCH is not idempotent: the
+    // server may have applied it before the response was lost).
+    func pushPatch(
+        draft:   ContactEventDraft,
+        videoId: String,
+        request: ContactEventPatchRequest
+    ) async -> ContactEventDraft {
+        guard let serverEventId = draft.serverEventId else {
+            var updated = draft
+            updated.syncStatus    = .failedPermanent
+            updated.failureReason = "patch_without_server_id"
+            return updated
+        }
+
+        var updated = draft
+        updated.syncStatus = .updating
+
+        do {
+            let event = try await apiClient.patchContact(
+                videoId: videoId, eventId: serverEventId, request: request
+            )
+            updated = applyServerState(to: updated, from: event)
+        } catch let error as AnnotationAPIError {
+            switch error {
+            case .versionConflict(let detail):
+                updated.syncStatus    = .conflicted
+                updated.failureReason = detail
+            case .retryable:
+                updated.syncStatus    = .needsReconciliation
+                updated.failureReason = "patch_timeout_or_unavailable"
+            default:
+                updated.syncStatus    = .failedPermanent
+                updated.failureReason = error.errorDescription
+            }
+        } catch {
+            updated.syncStatus    = .needsReconciliation
+            updated.failureReason = "patch_network_error"
+        }
+        return updated
+    }
+
+    // DELETE /contacts/{id} (soft-delete). 404 is ownership-ambiguous and
+    // network/timeout outcomes are unknown — both route to .needsReconciliation
+    // rather than being assumed successful.
+    func pushDelete(draft: ContactEventDraft, videoId: String) async -> ContactEventDraft {
+        guard let serverEventId = draft.serverEventId else {
+            // Never reached the server — nothing to delete remotely.
+            var updated = draft
+            updated.syncStatus = .deleted
+            return updated
+        }
+
+        var updated = draft
+        updated.syncStatus = .deleting
+
+        do {
+            switch try await apiClient.deleteContact(videoId: videoId, eventId: serverEventId) {
+            case .deleted:
+                updated.syncStatus    = .deleted
+                updated.failureReason = nil
+            case .notFoundAmbiguous:
+                updated.syncStatus    = .needsReconciliation
+                updated.failureReason = "delete_404_ambiguous"
+            }
+        } catch let error as AnnotationAPIError {
+            switch error {
+            case .retryable:
+                updated.syncStatus    = .needsReconciliation
+                updated.failureReason = "delete_timeout_or_unavailable"
+            default:
+                updated.syncStatus    = .failedPermanent
+                updated.failureReason = error.errorDescription
+            }
+        } catch {
+            updated.syncStatus    = .needsReconciliation
+            updated.failureReason = "delete_network_error"
+        }
+        return updated
+    }
+
+    // MARK: — Finish readiness
+
+    // An active event is one neither deleted locally nor confirmed deleted
+    // on the server. Finish is blocked while any active event is in an
+    // in-flight, retryable, conflicted, or unresolved state.
+    func finishReadiness(for session: AnnotationSessionFile) -> FinishReadiness {
+        let activeEvents = session.drafts.filter { !$0.deletedLocally && $0.syncStatus != .deleted }
+
+        let blockingStatuses = activeEvents
+            .map { $0.syncStatus }
+            .filter(Self.isBlocking)
+
+        if !blockingStatuses.isEmpty {
+            return .blocked(blockingStatuses)
+        }
+
+        let syncedCount = activeEvents.filter { $0.syncStatus == .synced }.count
+        return syncedCount > 0 ? .readyWithCount(syncedCount) : .readyZero
+    }
+
+    static func isBlocking(_ status: ContactEventSyncStatus) -> Bool {
+        switch status {
+        case .localOnly, .syncing, .updating, .deleting,
+             .retryPending, .conflicted, .needsReconciliation:
+            return true
+        case .synced, .deleted, .failedPermanent:
+            return false
+        }
+    }
+
+    // MARK: — Private helpers
+
+    private func applyServerState(to draft: ContactEventDraft, from server: ContactEventOut) -> ContactEventDraft {
+        var updated = draft
+        updated.serverEventId      = server.eventId
+        updated.version             = server.version
+        updated.contactType         = server.contactType
+        updated.side                = server.side
+        updated.annotationConfidence = server.annotationConfidence
+        updated.customLabel         = server.customLabel
+        updated.customDescription   = server.customDescription
+        updated.serverCreatedAt     = server.createdAt
+        updated.serverUpdatedAt     = server.updatedAt
+        updated.syncStatus          = .synced
+        updated.retryCount          = 0
+        updated.failureReason       = nil
+        return updated
+    }
+
+    private func applyCreateFailure(to draft: ContactEventDraft, error: AnnotationAPIError) -> ContactEventDraft {
+        var updated = draft
+        switch error {
+        case .retryable:
+            if updated.retryCount < Self.maxRetries {
+                updated.retryCount += 1
+                updated.syncStatus  = .retryPending
+            } else {
+                updated.syncStatus  = .failedPermanent
+            }
+            updated.failureReason = error.errorDescription
+        case .idempotencyConflict(let detail):
+            // Same device_event_id with a different payload — not retryable
+            // automatically; requires the user to resolve the conflict.
+            updated.syncStatus    = .failedPermanent
+            updated.failureReason = "idempotency_conflict: \(detail)"
+        default:
+            updated.syncStatus    = .failedPermanent
+            updated.failureReason = error.errorDescription
+        }
+        return updated
+    }
+}

--- a/ios/LFAEducationCenter/Juggling/Annotation/ContactEventDraft.swift
+++ b/ios/LFAEducationCenter/Juggling/Annotation/ContactEventDraft.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+// MARK: — ContactEventSyncStatus
+
+// 10-state sync machine.
+// Transitions are documented in the sync engine.
+// "failed" is split into failedPermanent and retryPending for clear retry routing.
+enum ContactEventSyncStatus: String, Codable, Equatable {
+    case localOnly            // draft created locally, never sent
+    case syncing              // POST /contacts in-flight
+    case synced               // server confirmed 201 or 200 (exact dup)
+    case updating             // PATCH in-flight
+    case deleting             // DELETE in-flight
+    case deleted              // server confirmed 204 (or reconciled as absent)
+    case failedPermanent      // non-retryable: 403, 404, 409 idempotency, 422
+    case retryPending         // retryable: network, timeout, 502, 503, 504 (retryCount < max)
+    case conflicted           // PATCH 409 version_conflict — needs re-fetch + user decision
+    case needsReconciliation  // timeout/network on PATCH or DELETE — outcome unknown
+}
+
+// MARK: — ContactEventDraft
+
+// Persistent local representation of one annotation event.
+// device_event_id is immutable after creation — it is the idempotency key.
+// All fields that can change are var; identity fields are let.
+struct ContactEventDraft: Codable, Identifiable, Equatable {
+    let deviceEventId:        UUID        // immutable; idempotency key; never changes
+    var serverEventId:        UUID?       // set after server 201/200 response
+    var syncStatus:           ContactEventSyncStatus
+    var version:              Int         // mirrors server version for optimistic locking
+    var timestampMs:          Int
+    var contactType:          String      // validated taxonomy key
+    var side:                 String?
+    var annotationConfidence: String      // "certain"|"probable"|"uncertain"
+    var customLabel:          String?
+    var customDescription:    String?
+    var deletedLocally:       Bool
+    var failureReason:        String?     // error detail for failedPermanent / conflicted
+    var retryCount:           Int
+    var createdAtLocal:       Date
+    var serverCreatedAt:      Date?
+    var serverUpdatedAt:      Date?
+
+    var id: UUID { deviceEventId }
+
+    static func new(
+        timestampMs:          Int,
+        contactType:          String,
+        side:                 String?,
+        annotationConfidence: String,
+        customLabel:          String? = nil,
+        customDescription:    String? = nil
+    ) -> ContactEventDraft {
+        ContactEventDraft(
+            deviceEventId:        UUID(),
+            serverEventId:        nil,
+            syncStatus:           .localOnly,
+            version:              1,
+            timestampMs:          timestampMs,
+            contactType:          contactType,
+            side:                 side,
+            annotationConfidence: annotationConfidence,
+            customLabel:          customLabel,
+            customDescription:    customDescription,
+            deletedLocally:       false,
+            failureReason:        nil,
+            retryCount:           0,
+            createdAtLocal:       Date(),
+            serverCreatedAt:      nil,
+            serverUpdatedAt:      nil
+        )
+    }
+}
+
+// MARK: — FinishReadiness
+
+enum FinishReadiness: Equatable {
+    case readyWithCount(Int)          // >0 synced active events
+    case readyZero                    // 0 active events; confirmZeroContacts must be true
+    case blocked([ContactEventSyncStatus]) // at least one event in a blocking state
+}

--- a/ios/LFAEducationCenter/Juggling/Annotation/ContactEventResponse.swift
+++ b/ios/LFAEducationCenter/Juggling/Annotation/ContactEventResponse.swift
@@ -1,0 +1,163 @@
+import Foundation
+
+// MARK: — ContactEventOut
+// Exact mirror of AN-1 OpenAPI schema ContactEventOut.
+// All fields verified against tests/snapshots/openapi_snapshot.json @ f1054056.
+
+struct ContactEventOut: Codable, Identifiable {
+    let eventId:                UUID     // required, uuid string
+    let deviceEventId:          UUID     // required, uuid string
+    let timestampMs:            Int      // required
+    let contactType:            String   // required
+    let side:                   String?  // required but NULLABLE
+    let annotationConfidence:   String   // required
+    let annotationReviewStatus: String   // required
+    let taxonomyReviewStatus:   String   // required
+    let excludedFromTraining:   Bool     // required
+    let customLabel:            String?  // required but NULLABLE
+    let customDescription:      String?  // required but NULLABLE
+    let version:                Int      // required
+    let createdAt:              Date     // required, date-time
+    let updatedAt:              Date     // required, date-time
+
+    var id: UUID { eventId }
+
+    enum CodingKeys: String, CodingKey {
+        case eventId                = "event_id"
+        case deviceEventId          = "device_event_id"
+        case timestampMs            = "timestamp_ms"
+        case contactType            = "contact_type"
+        case side
+        case annotationConfidence   = "annotation_confidence"
+        case annotationReviewStatus = "annotation_review_status"
+        case taxonomyReviewStatus   = "taxonomy_review_status"
+        case excludedFromTraining   = "excluded_from_training"
+        case customLabel            = "custom_label"
+        case customDescription      = "custom_description"
+        case version
+        case createdAt              = "created_at"
+        case updatedAt              = "updated_at"
+    }
+}
+
+// MARK: — ContactEventListOut
+// GET /contacts response envelope. annotation_status is NULLABLE.
+
+struct ContactEventListOut: Codable {
+    let videoId:          String    // required
+    let annotationStatus: String?   // required but NULLABLE
+    let events:           [ContactEventOut] // required
+
+    enum CodingKeys: String, CodingKey {
+        case videoId          = "video_id"
+        case annotationStatus = "annotation_status"
+        case events
+    }
+}
+
+// MARK: — ContactEventBatchItemResult
+// Per-item result inside batch response.
+// event_id and detail are both optional AND nullable per OpenAPI spec.
+
+struct ContactEventBatchItemResult: Codable {
+    let deviceEventId: UUID      // required
+    let status:        String    // required: "created"|"duplicate"|"conflict"
+    let eventId:       UUID?     // optional + NULLABLE
+    let detail:        String?   // optional + NULLABLE
+
+    enum CodingKeys: String, CodingKey {
+        case deviceEventId = "device_event_id"
+        case status
+        case eventId       = "event_id"
+        case detail
+    }
+}
+
+// MARK: — ContactEventBatchResult
+// POST /contacts/batch response.
+// HTTP status: 201 all-new / 200 all-dup / 207 mixed.
+
+struct ContactEventBatchResult: Codable {
+    let created:          Int    // required
+    let duplicateSkipped: Int    // required; JSON key: "duplicate_skipped"
+    let conflict:         Int    // required
+    let results:          [ContactEventBatchItemResult] // required
+
+    enum CodingKeys: String, CodingKey {
+        case created
+        case duplicateSkipped = "duplicate_skipped"
+        case conflict
+        case results
+    }
+}
+
+// MARK: — FinishAnnotationOut
+// POST /contacts/finish response.
+
+struct FinishAnnotationOut: Codable {
+    let videoId:              String  // required
+    let annotationStatus:     String  // required
+    let totalJugglingCount:   Int     // required
+    let contactEventCount:    Int     // required
+    let annotationFinishedAt: Date    // required, date-time
+
+    enum CodingKeys: String, CodingKey {
+        case videoId              = "video_id"
+        case annotationStatus     = "annotation_status"
+        case totalJugglingCount   = "total_juggling_count"
+        case contactEventCount    = "contact_event_count"
+        case annotationFinishedAt = "annotation_finished_at"
+    }
+}
+
+// MARK: — Request bodies
+
+struct ContactEventCreateRequest: Encodable {
+    let deviceEventId:       UUID
+    let timestampMs:         Int
+    let contactType:         String
+    let annotationConfidence:String
+    let side:                String?
+    let customLabel:         String?
+    let customDescription:   String?
+
+    enum CodingKeys: String, CodingKey {
+        case deviceEventId       = "device_event_id"
+        case timestampMs         = "timestamp_ms"
+        case contactType         = "contact_type"
+        case annotationConfidence = "annotation_confidence"
+        case side
+        case customLabel         = "custom_label"
+        case customDescription   = "custom_description"
+    }
+}
+
+struct ContactEventPatchRequest: Encodable {
+    let version:              Int     // required for optimistic lock
+    let contactType:          String?
+    let annotationConfidence: String?
+    let side:                 String?
+    let customLabel:          String?
+    let customDescription:    String?
+
+    enum CodingKeys: String, CodingKey {
+        case version
+        case contactType          = "contact_type"
+        case annotationConfidence = "annotation_confidence"
+        case side
+        case customLabel          = "custom_label"
+        case customDescription    = "custom_description"
+    }
+}
+
+struct ContactEventBatchRequest: Encodable {
+    let events: [ContactEventCreateRequest]
+}
+
+struct FinishAnnotationRequest: Encodable {
+    let confirmZeroContacts: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case confirmZeroContacts = "confirm_zero_contacts"
+    }
+}

--- a/ios/LFAEducationCenter/Juggling/Annotation/ContactTaxonomy.swift
+++ b/ios/LFAEducationCenter/Juggling/Annotation/ContactTaxonomy.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+// MARK: — TaxonomyDocument
+
+// Codable mirror of datasets/juggling/contact_types_v1.json.
+// Source-of-truth: the dataset JSON file.
+// Bundled copy: LFAEducationCenter/Juggling/Annotation/Resources/contact_types_v1.json
+// Do NOT add Swift enum keys by hand — the JSON is the authoritative key list.
+
+struct TaxonomyDocument: Codable {
+    let taxonomyVersion: String       // "v1"
+    let stableCount:     Int          // 17
+    let totalCount:      Int          // 18
+    let groups:          [TaxonomyGroup]
+    let stableKeys:      [String]
+    let allKeys:         [String]
+
+    enum CodingKeys: String, CodingKey {
+        case taxonomyVersion = "taxonomy_version"
+        case stableCount     = "stable_count"
+        case totalCount      = "total_count"
+        case groups
+        case stableKeys      = "stable_keys"
+        case allKeys         = "all_keys"
+    }
+}
+
+struct TaxonomyGroup: Codable, Identifiable {
+    let groupId:        String
+    let groupLabelHu:   String
+    let groupLabelEn:   String
+    let groupSortOrder: Int
+    let iosIcon:        String?
+    let contactTypes:   [TaxonomyContactType]
+
+    var id: String { groupId }
+
+    enum CodingKeys: String, CodingKey {
+        case groupId        = "group_id"
+        case groupLabelHu   = "group_label_hu"
+        case groupLabelEn   = "group_label_en"
+        case groupSortOrder = "group_sort_order"
+        case iosIcon        = "ios_section_icon"
+        case contactTypes   = "contact_types"
+    }
+}
+
+struct TaxonomyContactType: Codable, Identifiable {
+    let key:                      String   // taxonomy key — never hardcode in Swift
+    let labelHu:                  String
+    let labelEn:                  String
+    let side:                     String?  // nil for custom_other
+    let sidePolicy:               String   // "fixed" | "center" | "explicit_required"
+    let isStable:                 Bool
+    let sortOrder:                Int
+    let iosIcon:                  String?
+    let excludedFromTrainingAuto: Bool
+    let requiresCustomLabel:      Bool?
+    let requiresCustomDescription:Bool?
+    let requiresExplicitSide:     Bool?
+
+    var id: String { key }
+
+    enum CodingKeys: String, CodingKey {
+        case key, side
+        case labelHu                  = "label_hu"
+        case labelEn                  = "label_en"
+        case sidePolicy               = "side_policy"
+        case isStable                 = "is_stable"
+        case sortOrder                = "sort_order"
+        case iosIcon                  = "ios_icon"
+        case excludedFromTrainingAuto = "excluded_from_training_auto"
+        case requiresCustomLabel      = "requires_custom_label"
+        case requiresCustomDescription = "requires_custom_description"
+        case requiresExplicitSide     = "requires_explicit_side"
+    }
+}
+
+// MARK: — TaxonomyError
+
+enum TaxonomyError: Error, LocalizedError {
+    case invalidTotalCount(Int)
+    case invalidStableCount(Int)
+    case missingCustomOther
+    case forbiddenThighKey
+    case wrongVersion(String)
+    case decodeFailed(Error)
+    case bundleFileMissing
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidTotalCount(let n):  return "Taxonomy total_count must be 18, got \(n)"
+        case .invalidStableCount(let n): return "Taxonomy stable_count must be 17, got \(n)"
+        case .missingCustomOther:        return "Taxonomy missing required key: custom_other"
+        case .forbiddenThighKey:         return "Taxonomy contains forbidden key: thigh"
+        case .wrongVersion(let v):       return "Taxonomy version must be v1, got \(v)"
+        case .decodeFailed(let e):       return "Taxonomy decode failed: \(e)"
+        case .bundleFileMissing:         return "Bundled contact_types_v1.json not found in app bundle"
+        }
+    }
+}

--- a/ios/LFAEducationCenter/Juggling/Annotation/ContactTaxonomyStore.swift
+++ b/ios/LFAEducationCenter/Juggling/Annotation/ContactTaxonomyStore.swift
@@ -1,0 +1,159 @@
+import Foundation
+
+// MARK: — ContactTaxonomyStore
+//
+// Source-of-truth hierarchy (AN-2):
+//   1. Backend GET /api/v1/users/me/juggling/taxonomy  (primary, ETag cached)
+//   2. Bundled contact_types_v1.json                    (offline fallback)
+//
+// The bundled JSON is a deterministic copy of datasets/juggling/contact_types_v1.json.
+// A test (AN2-T01) verifies the bundled copy matches the dataset source by checksum.
+// CI must fail if they diverge (scripts/check_taxonomy_bundle_drift.py).
+//
+// taxonomy() is always available synchronously from the bundled fallback;
+// refreshFromBackend() updates it without blocking annotation sessions.
+
+@MainActor
+final class ContactTaxonomyStore: ObservableObject {
+
+    @Published private(set) var document: TaxonomyDocument?
+    @Published private(set) var loadError: TaxonomyError?
+
+    private var cachedETag: String?
+    private let cacheFileURL: URL
+    private let authManager: AuthManager
+
+    // Checksum of the bundled file as shipped. Updated by the drift-guard script.
+    // If bundled content changes, this constant must be updated in the same commit.
+    static let bundledChecksum = "7198de62733493537450275dadc6f445"  // MD5 of contact_types_v1.json
+
+    init(authManager: AuthManager, cacheDirectory: URL? = nil) {
+        self.authManager = authManager
+        let dir = cacheDirectory ?? FileManager.default
+            .urls(for: .documentDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("juggling_taxonomy", isDirectory: true)
+        self.cacheFileURL = dir.appendingPathComponent("taxonomy_cache.json")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    }
+
+    // MARK: — Public API
+
+    // Load bundled taxonomy synchronously. Call on app launch before any annotation session.
+    func loadBundled() {
+        do {
+            let doc = try Self.decodeBundled()
+            try validate(doc)
+            self.document = doc
+            self.loadError = nil
+        } catch let e as TaxonomyError {
+            self.loadError = e
+        } catch {
+            self.loadError = .decodeFailed(error)
+        }
+    }
+
+    // Try to update from backend. Falls back silently on any error.
+    // Sets document to updated version only if decode + validation pass.
+    func refreshFromBackend() async {
+        do {
+            let updated = try await fetchFromBackend()
+            self.document = updated
+            self.loadError = nil
+        } catch {
+            // Backend unavailable or invalid — existing document (bundled or cached) remains.
+        }
+    }
+
+    // Returns all contact type keys. Returns empty if not loaded (callers must loadBundled first).
+    var allKeys: [String] { document?.allKeys ?? [] }
+    var stableKeys: [String] { document?.stableKeys ?? [] }
+    var groups: [TaxonomyGroup] { document?.groups ?? [] }
+
+    // MARK: — Bundled decode (static — usable in tests)
+
+    static func decodeBundled() throws -> TaxonomyDocument {
+        guard let url = Bundle.main.url(forResource: "contact_types_v1", withExtension: "json") else {
+            throw TaxonomyError.bundleFileMissing
+        }
+        let data = try Data(contentsOf: url)
+        return try decodeAndValidate(data)
+    }
+
+    // MARK: — Private
+
+    private func fetchFromBackend() async throws -> TaxonomyDocument {
+        var path = "/api/v1/users/me/juggling/taxonomy"
+        let headers: [String: String]? = cachedETag.map { ["If-None-Match": $0] }
+
+        // Use raw token inject rather than authenticated* wrapper so we can inspect status code.
+        // 304 is not an error — it means our ETag is still valid.
+        guard let token = authManager.accessToken else { throw APIError.unauthorized }
+
+        let (data, response) = try await APIClient.getRaw(path: path, token: token, extraHeaders: headers ?? [:])
+
+        guard let http = response as? HTTPURLResponse else { throw APIError.networkError(URLError(.badServerResponse)) }
+
+        switch http.statusCode {
+        case 304:
+            // ETag still valid — decode from cache file if present, else use current in-memory doc
+            if let cached = try? loadFromCacheFile() { return cached }
+            if let doc = document { return doc }
+            throw TaxonomyError.decodeFailed(URLError(.cannotDecodeContentData))
+
+        case 200:
+            let doc = try Self.decodeAndValidate(data)
+            // Persist to cache file
+            try? saveToCacheFile(data: data)
+            // Save ETag for next request
+            cachedETag = http.allHeaderFields["Etag"] as? String
+                      ?? http.allHeaderFields["etag"] as? String
+            return doc
+
+        case 401:
+            // Let AuthManager refresh and retry once via caller
+            throw APIError.httpError(statusCode: 401, detail: nil)
+
+        default:
+            throw APIError.httpError(statusCode: http.statusCode, detail: nil)
+        }
+    }
+
+    // Internal (not private) so AN2-T04 can exercise validation with malformed fixtures.
+    static func decodeAndValidate(_ data: Data) throws -> TaxonomyDocument {
+        let decoder = JSONDecoder()
+        let doc: TaxonomyDocument
+        do {
+            doc = try decoder.decode(TaxonomyDocument.self, from: data)
+        } catch {
+            throw TaxonomyError.decodeFailed(error)
+        }
+        try validate(doc)
+        return doc
+    }
+
+    static func validate(_ doc: TaxonomyDocument) throws {
+        guard doc.taxonomyVersion == "v1"     else { throw TaxonomyError.wrongVersion(doc.taxonomyVersion) }
+        guard doc.totalCount == 18            else { throw TaxonomyError.invalidTotalCount(doc.totalCount) }
+        guard doc.stableCount == 17           else { throw TaxonomyError.invalidStableCount(doc.stableCount) }
+        guard doc.allKeys.contains("custom_other") else { throw TaxonomyError.missingCustomOther }
+        guard !doc.allKeys.contains("thigh")  else { throw TaxonomyError.forbiddenThighKey }
+    }
+
+    // Non-static wrapper for instance calls
+    private func validate(_ doc: TaxonomyDocument) throws {
+        try Self.validate(doc)
+    }
+
+    private func loadFromCacheFile() throws -> TaxonomyDocument {
+        let data = try Data(contentsOf: cacheFileURL)
+        return try Self.decodeAndValidate(data)
+    }
+
+    private func saveToCacheFile(data: Data) throws {
+        // Atomic write via temp file + replace
+        let tmp = cacheFileURL.deletingLastPathComponent()
+            .appendingPathComponent("taxonomy_cache_tmp.json")
+        try data.write(to: tmp, options: .atomic)
+        _ = try FileManager.default.replaceItemAt(cacheFileURL, withItemAt: tmp)
+    }
+}

--- a/ios/LFAEducationCenter/Juggling/Annotation/ContactTaxonomyStore.swift
+++ b/ios/LFAEducationCenter/Juggling/Annotation/ContactTaxonomyStore.swift
@@ -82,7 +82,7 @@ final class ContactTaxonomyStore: ObservableObject {
     // MARK: — Private
 
     private func fetchFromBackend() async throws -> TaxonomyDocument {
-        var path = "/api/v1/users/me/juggling/taxonomy"
+        let path = "/api/v1/users/me/juggling/taxonomy"
         let headers: [String: String]? = cachedETag.map { ["If-None-Match": $0] }
 
         // Use raw token inject rather than authenticated* wrapper so we can inspect status code.

--- a/ios/LFAEducationCenter/Juggling/Annotation/JugglingAnnotationAPIClient.swift
+++ b/ios/LFAEducationCenter/Juggling/Annotation/JugglingAnnotationAPIClient.swift
@@ -1,0 +1,236 @@
+import Foundation
+
+// MARK: — JugglingAnnotationAPIClient
+//
+// All 7 AN-1 annotation endpoints.
+// Never stores a raw access token — all calls go through AuthManager wrappers.
+// AuthManager handles 401 → refresh → retry internally (single refresh barrier).
+//
+// Error classification (caller uses this to set SyncStatus):
+//   retryable:  AnnotationAPIError.retryable   (network, 502, 503, 504)
+//   permanent:  AnnotationAPIError.permanent    (403, 404, 409 idempotency, 422)
+//   conflict:   AnnotationAPIError.versionConflict  (409 version_conflict on PATCH)
+//   idempotencyConflict: (409 idempotency_conflict on POST)
+//   unauthorized: APIError.unauthorized (session expired beyond recovery)
+
+// MARK: — JugglingAnnotationAPIClientProtocol
+//
+// Abstraction over the 5 sync-relevant endpoints (taxonomy fetch is handled
+// separately by ContactTaxonomyStore). AnnotationSyncEngine depends on this
+// protocol so tests can inject a mock without any networking.
+
+@MainActor
+protocol JugglingAnnotationAPIClientProtocol: AnyObject {
+    func listContacts(videoId: String) async throws -> ContactEventListOut
+    func createContact(videoId: String, request: ContactEventCreateRequest) async throws -> CreateContactResult
+    func patchContact(videoId: String, eventId: UUID, request: ContactEventPatchRequest) async throws -> ContactEventOut
+    func deleteContact(videoId: String, eventId: UUID) async throws -> DeleteContactResult
+    func finishAnnotation(videoId: String, confirmZero: Bool) async throws -> FinishAnnotationOut
+}
+
+@MainActor
+final class JugglingAnnotationAPIClient: JugglingAnnotationAPIClientProtocol {
+
+    private let authManager: AuthManager
+    private let isoDecoder: JSONDecoder
+
+    init(authManager: AuthManager) {
+        self.authManager = authManager
+        isoDecoder = JSONDecoder()
+        isoDecoder.dateDecodingStrategy = .custom { decoder in
+            let container = try decoder.singleValueContainer()
+            let str = try container.decode(String.self)
+            // Try with fractional seconds first (FastAPI default), then without
+            let fmtFrac = ISO8601DateFormatter()
+            fmtFrac.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            if let d = fmtFrac.date(from: str) { return d }
+            let fmt = ISO8601DateFormatter()
+            fmt.formatOptions = [.withInternetDateTime]
+            if let d = fmt.date(from: str) { return d }
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Cannot decode date: \(str)")
+        }
+    }
+
+    // MARK: — Taxonomy
+
+    // Returns raw (Data, HTTPURLResponse) so ContactTaxonomyStore can inspect ETag + 304.
+    func fetchTaxonomyRaw(eTag: String?) async throws -> (Data, HTTPURLResponse) {
+        var extraHeaders: [String: String] = [:]
+        if let e = eTag { extraHeaders["If-None-Match"] = e }
+        let (data, response) = try await authManager.authenticatedGetRaw(
+            path: "/api/v1/users/me/juggling/taxonomy",
+            extraHeaders: extraHeaders
+        )
+        guard let http = response as? HTTPURLResponse else {
+            throw APIError.networkError(URLError(.badServerResponse))
+        }
+        return (data, http)
+    }
+
+    // MARK: — Contact list
+
+    func listContacts(videoId: String) async throws -> ContactEventListOut {
+        let response: ContactEventListOut = try await authManager.authenticatedGet(
+            path: "/api/v1/users/me/juggling/videos/\(videoId)/contacts"
+        )
+        return response
+    }
+
+    // MARK: — Single create
+    //
+    // HTTP 201 → ContactEventOut, isNew = true
+    // HTTP 200 → ContactEventOut, isNew = false (exact duplicate)
+    // HTTP 409 + "idempotency_conflict" → throws AnnotationAPIError.idempotencyConflict
+    // HTTP 409 (other) → throws AnnotationAPIError.permanent
+    // HTTP 403 / 404 / 422 → throws AnnotationAPIError.permanent
+    // HTTP 502/503/504 / network → throws AnnotationAPIError.retryable
+
+    func createContact(videoId: String, request: ContactEventCreateRequest) async throws -> CreateContactResult {
+        let path = "/api/v1/users/me/juggling/videos/\(videoId)/contacts"
+        do {
+            let (data, statusCode) = try await authManager.authenticatedPostRaw(path: path, body: request)
+            let event = try decodeEvent(data)
+            return CreateContactResult(event: event, isNew: statusCode == 201)
+        } catch let apiErr as APIError {
+            throw classifyAPIError(apiErr, path: "createContact")
+        }
+    }
+
+    // MARK: — Batch submit
+    //
+    // HTTP 201 → all new; HTTP 200 → all dup; HTTP 207 → mixed/conflict
+    // All three are success responses — caller processes ContactEventBatchResult.results.
+
+    func batchSubmit(videoId: String, request: ContactEventBatchRequest) async throws -> ContactEventBatchResult {
+        let path = "/api/v1/users/me/juggling/videos/\(videoId)/contacts/batch"
+        do {
+            let (data, _) = try await authManager.authenticatedPostRaw(path: path, body: request)
+            return try isoDecoder.decode(ContactEventBatchResult.self, from: data)
+        } catch let apiErr as APIError {
+            throw classifyAPIError(apiErr, path: "batchSubmit")
+        }
+    }
+
+    // MARK: — PATCH
+    //
+    // HTTP 200 → ContactEventOut (updated)
+    // HTTP 409 + "version_conflict" → throws AnnotationAPIError.versionConflict
+    // HTTP 409 (other) → permanent
+    // Network timeout: caller must set needsReconciliation
+
+    func patchContact(videoId: String, eventId: UUID, request: ContactEventPatchRequest) async throws -> ContactEventOut {
+        let path = "/api/v1/users/me/juggling/videos/\(videoId)/contacts/\(eventId.uuidString.lowercased())"
+        do {
+            let (data, _) = try await authManager.authenticatedPatchRaw(path: path, body: request)
+            return try decodeEvent(data)
+        } catch let apiErr as APIError {
+            throw classifyAPIError(apiErr, path: "patchContact")
+        }
+    }
+
+    // MARK: — DELETE (soft-delete)
+    //
+    // HTTP 204 → success (.deleted)
+    // HTTP 404 → ownership ambiguous — caller must reconcile (GET /contacts)
+    // Network timeout → caller sets .needsReconciliation
+
+    func deleteContact(videoId: String, eventId: UUID) async throws -> DeleteContactResult {
+        let path = "/api/v1/users/me/juggling/videos/\(videoId)/contacts/\(eventId.uuidString.lowercased())"
+        do {
+            try await authManager.authenticatedDeleteNoContent(path: path)
+            return .deleted
+        } catch APIError.httpError(let code, _) where code == 404 {
+            return .notFoundAmbiguous   // caller must reconcile, not auto-treat as success
+        } catch let apiErr as APIError {
+            throw classifyAPIError(apiErr, path: "deleteContact")
+        }
+    }
+
+    // MARK: — Finish
+
+    func finishAnnotation(videoId: String, confirmZero: Bool) async throws -> FinishAnnotationOut {
+        let path = "/api/v1/users/me/juggling/videos/\(videoId)/contacts/finish"
+        let body = FinishAnnotationRequest(confirmZeroContacts: confirmZero)
+        do {
+            let result: FinishAnnotationOut = try await authManager.authenticatedPost(path: path, body: body)
+            return result
+        } catch let apiErr as APIError {
+            throw classifyAPIError(apiErr, path: "finishAnnotation")
+        }
+    }
+
+    // MARK: — Private helpers
+
+    private func decodeEvent(_ data: Data) throws -> ContactEventOut {
+        do {
+            return try isoDecoder.decode(ContactEventOut.self, from: data)
+        } catch {
+            throw AnnotationAPIError.decodeFailed(error)
+        }
+    }
+
+    private func classifyAPIError(_ error: APIError, path: String) -> AnnotationAPIError {
+        switch error {
+        case .httpError(let code, let detail):
+            switch code {
+            case 401: return .unauthorized
+            case 403: return .permanent(code: code, detail: detail ?? "consent_blocked")
+            case 404: return .permanent(code: code, detail: detail ?? "not_found")
+            case 409:
+                let d = detail ?? ""
+                if d.contains("idempotency_conflict") {
+                    return .idempotencyConflict(detail: d)
+                } else if d.contains("version_conflict") {
+                    return .versionConflict(detail: d)
+                }
+                return .permanent(code: code, detail: d)
+            case 422: return .permanent(code: code, detail: detail ?? "validation_error")
+            case 502, 503, 504: return .retryable(code: code)
+            default:  return .permanent(code: code, detail: detail ?? "http_\(code)")
+            }
+        case .networkError: return .retryable(code: nil)
+        case .unauthorized: return .unauthorized
+        case .decodingError: return .decodeFailed(URLError(.cannotDecodeContentData))
+        case .invalidURL:    return .permanent(code: nil, detail: "invalid_url")
+        }
+    }
+}
+
+// MARK: — Result types
+
+struct CreateContactResult {
+    let event: ContactEventOut
+    let isNew:  Bool   // true = 201, false = 200 dup
+}
+
+enum DeleteContactResult {
+    case deleted           // 204 — server confirmed soft-delete
+    case notFoundAmbiguous // 404 — unclear: already deleted vs. ownership error → reconcile
+}
+
+// MARK: — AnnotationAPIError
+
+enum AnnotationAPIError: Error, LocalizedError {
+    case retryable(code: Int?)             // network, 502, 503, 504
+    case permanent(code: Int?, detail: String) // 403, 404, 409 idempotency, 422
+    case idempotencyConflict(detail: String)   // 409 same device_event_id, different payload
+    case versionConflict(detail: String)       // 409 PATCH version mismatch
+    case unauthorized                          // 401 after refresh — session expired
+    case decodeFailed(Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .retryable(let code):           return "Retryable error (HTTP \(code.map(String.init) ?? "network"))"
+        case .permanent(let code, let d):    return "Permanent error (HTTP \(code.map(String.init) ?? "?")): \(d)"
+        case .idempotencyConflict(let d):    return "Idempotency conflict: \(d)"
+        case .versionConflict(let d):        return "Version conflict: \(d)"
+        case .unauthorized:                  return "Session expired. Please log in again."
+        case .decodeFailed(let e):           return "Decode failed: \(e)"
+        }
+    }
+
+    var isRetryable: Bool {
+        if case .retryable = self { return true }
+        return false
+    }
+}

--- a/ios/LFAEducationCenter/Juggling/Annotation/JugglingAnnotationViewModel.swift
+++ b/ios/LFAEducationCenter/Juggling/Annotation/JugglingAnnotationViewModel.swift
@@ -1,0 +1,238 @@
+import Foundation
+
+// MARK: — JugglingAnnotationViewModel
+//
+// Orchestrates taxonomy loading, local draft persistence, and server sync
+// for one (userId, videoId) annotation session. No SwiftUI screen exists yet
+// (AN-3) — this view model exposes @Published state so a future screen can
+// bind directly.
+//
+// User isolation: userId is fixed at init and threaded through every store
+// call. clearSession() must be called on logout/user switch so a new
+// instance is created for the next user — this view model never re-targets
+// an existing session to a different userId.
+
+@MainActor
+final class JugglingAnnotationViewModel: ObservableObject {
+
+    @Published private(set) var session:      AnnotationSessionFile?
+    @Published private(set) var taxonomy:      TaxonomyDocument?
+    @Published private(set) var loadWarning:   String?
+    @Published private(set) var isFinishing:   Bool = false
+    @Published private(set) var finishResult:  FinishAnnotationOut?
+    @Published private(set) var finishError:   String?
+
+    let userId:  Int
+    let videoId: String
+
+    private let taxonomyStore: ContactTaxonomyStore
+    private let localStore:    LocalAnnotationStore
+    private let syncEngine:    AnnotationSyncEngine
+    private let apiClient:     JugglingAnnotationAPIClientProtocol
+
+    init(
+        userId:      Int,
+        videoId:     String,
+        authManager: AuthManager
+    ) {
+        self.userId  = userId
+        self.videoId = videoId
+
+        let api = JugglingAnnotationAPIClient(authManager: authManager)
+        self.apiClient    = api
+        self.taxonomyStore = ContactTaxonomyStore(authManager: authManager)
+        self.localStore    = LocalAnnotationStore()
+        self.syncEngine    = AnnotationSyncEngine(apiClient: api)
+    }
+
+    // Test/DI entry point — bypasses AuthManager/JugglingAnnotationAPIClient construction.
+    init(
+        userId:        Int,
+        videoId:       String,
+        apiClient:     JugglingAnnotationAPIClientProtocol,
+        taxonomyStore: ContactTaxonomyStore,
+        localStore:    LocalAnnotationStore
+    ) {
+        self.userId        = userId
+        self.videoId       = videoId
+        self.apiClient     = apiClient
+        self.taxonomyStore = taxonomyStore
+        self.localStore    = localStore
+        self.syncEngine    = AnnotationSyncEngine(apiClient: apiClient)
+    }
+
+    // MARK: — Lifecycle
+
+    // Call once when the annotation screen appears. Loads bundled taxonomy
+    // synchronously (always available), loads/creates the local session,
+    // then attempts a background taxonomy refresh.
+    func onAppear() async {
+        taxonomyStore.loadBundled()
+        taxonomy = taxonomyStore.document
+
+        switch localStore.load(userId: userId, videoId: videoId) {
+        case .empty:
+            var fresh = localStore.emptySession(
+                userId: userId, videoId: videoId,
+                taxonomyVersion: taxonomyStore.document?.taxonomyVersion ?? "v1"
+            )
+            try? localStore.save(session: &fresh)
+            session = fresh
+
+        case .loaded(let loaded):
+            session = loaded
+
+        case .quarantined(_, let hasLocalOnlyEvents):
+            loadWarning = hasLocalOnlyEvents
+                ? "A korábbi annotációs adatok megsérültek és karanténba kerültek. Néhány nem-szinkronizált esemény elveszhetett."
+                : "A korábbi annotációs adatok megsérültek és karanténba kerültek. Új session indul."
+            var fresh = localStore.emptySession(
+                userId: userId, videoId: videoId,
+                taxonomyVersion: taxonomyStore.document?.taxonomyVersion ?? "v1"
+            )
+            try? localStore.save(session: &fresh)
+            session = fresh
+        }
+
+        await taxonomyStore.refreshFromBackend()
+        taxonomy = taxonomyStore.document
+    }
+
+    // Call when the annotation screen disappears — persists any in-memory changes.
+    func onDisappear() {
+        guard var current = session else { return }
+        try? localStore.save(session: &current)
+    }
+
+    // Call on logout / user switch. Drops in-memory state for this instance;
+    // the caller must construct a new view model for the next user (userId
+    // is immutable here by design).
+    func clearSession() {
+        session     = nil
+        loadWarning  = nil
+        finishResult = nil
+        finishError  = nil
+    }
+
+    // MARK: — Draft management
+
+    @discardableResult
+    func addEvent(
+        timestampMs:          Int,
+        contactType:          String,
+        side:                 String?,
+        annotationConfidence: String,
+        customLabel:          String? = nil,
+        customDescription:    String? = nil
+    ) -> ContactEventDraft? {
+        guard var current = session else { return nil }
+
+        let draft = ContactEventDraft.new(
+            timestampMs:          timestampMs,
+            contactType:          contactType,
+            side:                 side,
+            annotationConfidence: annotationConfidence,
+            customLabel:          customLabel,
+            customDescription:    customDescription
+        )
+        current.drafts.append(draft)
+        try? localStore.save(session: &current)
+        session = current
+        return draft
+    }
+
+    // Marks a draft for deletion. Drafts never synced are removed locally
+    // immediately; synced drafts are flagged for a DELETE push on next flush.
+    func markDeleted(deviceEventId: UUID) {
+        guard var current = session else { return }
+        guard let index = current.drafts.firstIndex(where: { $0.deviceEventId == deviceEventId }) else { return }
+
+        current.drafts[index].deletedLocally = true
+        if current.drafts[index].syncStatus == .localOnly {
+            current.drafts[index].syncStatus = .deleted
+        }
+
+        try? localStore.save(session: &current)
+        session = current
+    }
+
+    var activeEvents: [ContactEventDraft] {
+        session?.drafts.filter { !$0.deletedLocally && $0.syncStatus != .deleted } ?? []
+    }
+
+    var finishReadiness: FinishReadiness {
+        guard let current = session else { return .readyZero }
+        return syncEngine.finishReadiness(for: current)
+    }
+
+    // MARK: — Background sync
+
+    // Pushes all localOnly / retryPending drafts. Safe to call repeatedly
+    // (e.g. from a periodic retry timer in the future UI layer).
+    func flushPending() async {
+        guard var current = session else { return }
+        await syncEngine.flushPending(session: &current)
+        try? localStore.save(session: &current)
+        session = current
+    }
+
+    // MARK: — Finish flow
+    //
+    // 1. Flush localOnly / retryPending drafts.
+    // 2. Reconcile needsReconciliation drafts via GET /contacts.
+    // 3. Re-check readiness — abort with finishError if still blocked.
+    // 4. Call POST /finish (confirm_zero_contacts = true iff zero active events).
+    // 5. On success, delete the local session file (server is now authoritative).
+    func finish() async {
+        guard var current = session else { return }
+
+        isFinishing  = true
+        finishError  = nil
+        finishResult = nil
+        defer { isFinishing = false }
+
+        await syncEngine.flushPending(session: &current)
+        try? localStore.save(session: &current)
+
+        if current.drafts.contains(where: { $0.syncStatus == .needsReconciliation }) {
+            do {
+                try await syncEngine.reconcile(session: &current)
+                try? localStore.save(session: &current)
+            } catch {
+                session = current
+                finishError = "A befejezés sikertelen: nem sikerült egyeztetni a szerverrel. Ellenőrizd a kapcsolatot, és próbáld újra."
+                return
+            }
+        }
+
+        let readiness = syncEngine.finishReadiness(for: current)
+        session = current
+
+        switch readiness {
+        case .blocked:
+            finishError = "A befejezés sikertelen: néhány esemény még nincs szinkronizálva. Próbáld újra később."
+            return
+
+        case .readyZero:
+            await callFinish(confirmZero: true)
+
+        case .readyWithCount:
+            await callFinish(confirmZero: false)
+        }
+    }
+
+    // MARK: — Private
+
+    private func callFinish(confirmZero: Bool) async {
+        do {
+            let result = try await apiClient.finishAnnotation(videoId: videoId, confirmZero: confirmZero)
+            localStore.delete(userId: userId, videoId: videoId)
+            session      = nil
+            finishResult = result
+        } catch let error as AnnotationAPIError {
+            finishError = error.errorDescription
+        } catch {
+            finishError = "A befejezés sikertelen: \(error.localizedDescription)"
+        }
+    }
+}

--- a/ios/LFAEducationCenter/Juggling/Annotation/LocalAnnotationStore.swift
+++ b/ios/LFAEducationCenter/Juggling/Annotation/LocalAnnotationStore.swift
@@ -1,0 +1,168 @@
+import Foundation
+import CryptoKit
+
+// MARK: — AnnotationSessionFile
+//
+// On-disk format for one video's annotation session.
+// schemaVersion allows future migration without discarding data.
+// checksum covers drafts array only (for integrity validation on load).
+
+struct AnnotationSessionFile: Codable {
+    var schemaVersion:   Int              // current: 1
+    var userId:          Int              // isolation key — drafts are user-scoped
+    var videoId:         String
+    var taxonomyVersion: String           // "v1"
+    var lastUpdatedAt:   Date
+    var drafts:          [ContactEventDraft]
+    var checksum:        String           // SHA256 hex of drafts JSON bytes (integrity check)
+}
+
+// MARK: — LocalAnnotationStore
+//
+// File-based Codable store. One JSON file per (userId, videoId) pair.
+// File path: {documents}/juggling_annotations/{userId}/{videoId}.json
+//
+// Write strategy: atomic via temp-file + FileManager.replaceItemAt.
+// On corruption: quarantine original → new empty store → attempt server re-sync signal.
+// The draft is NEVER silently discarded — quarantine preserves bytes for recovery.
+//
+// User isolation: file path includes userId so user A never reads user B's drafts.
+// On logout or user switch: caller is responsible for not opening sessions with wrong userId.
+
+@MainActor
+final class LocalAnnotationStore {
+
+    private let baseDirectory: URL
+    private let decoder: JSONDecoder
+    private let encoder: JSONEncoder
+
+    init(baseDirectory: URL? = nil) {
+        let dir = baseDirectory ?? FileManager.default
+            .urls(for: .documentDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("juggling_annotations", isDirectory: true)
+        self.baseDirectory = dir
+        self.decoder = JSONDecoder()
+        self.decoder.dateDecodingStrategy = .iso8601
+        self.encoder = JSONEncoder()
+        self.encoder.dateEncodingStrategy = .iso8601
+        self.encoder.outputFormatting = .sortedKeys
+    }
+
+    // MARK: — Public interface
+
+    // Load session. On corruption: quarantine + return empty + emit recovery event.
+    func load(userId: Int, videoId: String) -> AnnotationLoadResult {
+        let url = fileURL(userId: userId, videoId: videoId)
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            return .empty
+        }
+        do {
+            let data = try Data(contentsOf: url)
+            let session = try decoder.decode(AnnotationSessionFile.self, from: data)
+            // Integrity check
+            let expectedChecksum = try checksumOf(drafts: session.drafts)
+            guard session.checksum == expectedChecksum else {
+                let qURL = try quarantine(fileAt: url, reason: "checksum_mismatch")
+                return .quarantined(quarantineURL: qURL, hasLocalOnlyEvents: false)
+            }
+            return .loaded(session)
+        } catch {
+            // Corrupt / undecodable
+            let qURL = (try? quarantine(fileAt: url, reason: "decode_failure")) ?? url
+            let hasLocalOnly = hasLocalOnlyEventsInRawBytes(
+                at: url.deletingLastPathComponent()
+                    .appendingPathComponent("quarantine")
+                    .appendingPathComponent(url.lastPathComponent + "_quarantine")
+            )
+            return .quarantined(quarantineURL: qURL, hasLocalOnlyEvents: hasLocalOnly)
+        }
+    }
+
+    // Save session atomically. Throws on write failure (caller decides how to handle).
+    func save(session: inout AnnotationSessionFile) throws {
+        session.lastUpdatedAt = Date()
+        session.checksum = try checksumOf(drafts: session.drafts)
+
+        let url = fileURL(userId: session.userId, videoId: session.videoId)
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+
+        let data = try encoder.encode(session)
+
+        // Write to temp file first
+        let tmpURL = url.deletingLastPathComponent()
+            .appendingPathComponent(".\(session.videoId)_tmp.json")
+        try data.write(to: tmpURL, options: [.atomic])
+
+        // Atomic replace (preserves previous-good as backup via replaceItemAt's built-in backup)
+        _ = try FileManager.default.replaceItemAt(url, withItemAt: tmpURL,
+                                                   backupItemName: "\(session.videoId).bak.json",
+                                                   options: [])
+    }
+
+    // Delete session file (e.g. after successful finish + server confirm).
+    func delete(userId: Int, videoId: String) {
+        let url = fileURL(userId: userId, videoId: videoId)
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    // MARK: — Session factory
+
+    func emptySession(userId: Int, videoId: String, taxonomyVersion: String = "v1") -> AnnotationSessionFile {
+        AnnotationSessionFile(
+            schemaVersion:   1,
+            userId:          userId,
+            videoId:         videoId,
+            taxonomyVersion: taxonomyVersion,
+            lastUpdatedAt:   Date(),
+            drafts:          [],
+            checksum:        ""
+        )
+    }
+
+    // MARK: — Private helpers
+
+    private func fileURL(userId: Int, videoId: String) -> URL {
+        baseDirectory
+            .appendingPathComponent("\(userId)", isDirectory: true)
+            .appendingPathComponent("\(videoId).json")
+    }
+
+    private func checksumOf(drafts: [ContactEventDraft]) throws -> String {
+        let data = try encoder.encode(drafts)
+        let digest = SHA256.hash(data: data)
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    // Move file to quarantine subdirectory preserving original bytes.
+    // Returns the quarantine URL.
+    @discardableResult
+    private func quarantine(fileAt url: URL, reason: String) throws -> URL {
+        let quarantineDir = url.deletingLastPathComponent()
+            .appendingPathComponent("quarantine", isDirectory: true)
+        try FileManager.default.createDirectory(at: quarantineDir, withIntermediateDirectories: true)
+        let timestamp = Int(Date().timeIntervalSince1970)
+        let qName = "\(url.lastPathComponent)_\(reason)_\(timestamp)"
+        let qURL  = quarantineDir.appendingPathComponent(qName)
+        try FileManager.default.moveItem(at: url, to: qURL)
+        return qURL
+    }
+
+    // Best-effort check: scan quarantined bytes for "localOnly" status marker.
+    // Used only to determine if the blocking recovery signal should fire.
+    private func hasLocalOnlyEventsInRawBytes(at url: URL) -> Bool {
+        guard let data = try? Data(contentsOf: url),
+              let raw = String(data: data, encoding: .utf8) else { return false }
+        return raw.contains("\"localOnly\"")
+    }
+}
+
+// MARK: — AnnotationLoadResult
+
+enum AnnotationLoadResult {
+    case empty
+    case loaded(AnnotationSessionFile)
+    case quarantined(quarantineURL: URL, hasLocalOnlyEvents: Bool)
+}

--- a/ios/LFAEducationCenter/Juggling/Annotation/Resources/contact_types_v1.json
+++ b/ios/LFAEducationCenter/Juggling/Annotation/Resources/contact_types_v1.json
@@ -1,0 +1,507 @@
+{
+  "_comment": "Source-of-truth for juggling contact type taxonomy. This file is the single canonical definition used by: browser helper, annotation_schema_v2.json, iOS Swift enum, and the training pipeline. Do NOT modify enum keys without a taxonomy review. See contact_taxonomy_v1.md for the full governance process.",
+  "taxonomy_version": "v1",
+  "created_at": "2026-06-13",
+  "policy": "no_paid_model",
+  "stable_count": 17,
+  "total_count": 18,
+
+  "_invariants": {
+    "right_stable_keys_count": 7,
+    "left_stable_keys_count": 7,
+    "center_stable_keys_count": 3,
+    "custom_keys_count": 1,
+    "no_duplicate_keys": true,
+    "no_duplicate_sort_orders": true,
+    "custom_other_excluded_from_training_auto": true,
+    "thigh_to_hip_auto_migration": "FORBIDDEN",
+    "thigh_to_hip_auto_migration_reason": "Anatomically distinct contact zones. If a non-null v1 body_part=thigh contact_event exists, manual_review_required must be set. No automatic reclassification."
+  },
+
+  "side_policy": {
+    "description": "For stable contact types the side is derived from the enum key and must never be set independently by the user. Validators must enforce consistency. Only custom_other requires explicit user-supplied side.",
+    "right_prefix_keys": ["right_instep","right_inside_foot","right_outside_foot","right_heel","right_knee","right_hip","right_shoulder"],
+    "left_prefix_keys":  ["left_instep","left_inside_foot","left_outside_foot","left_heel","left_knee","left_hip","left_shoulder"],
+    "center_keys":       ["chest","head","back"],
+    "custom_explicit":   ["custom_other"],
+    "allowed_side_values": ["left","right","center","unknown"]
+  },
+
+  "review_status_enum": {
+    "_comment": "Single unified enum for all contact events regardless of source. Annotator and user-facing statuses use the same values to avoid divergence.",
+    "values": {
+      "pending":                  "Created but not yet reviewed by anyone.",
+      "confirmed":                "Reviewer confirmed the contact type and side are correct.",
+      "corrected":                "Contact type or side was changed by a reviewer or user from a previous value.",
+      "rejected":                 "Event is invalid (false detection, double-counted, non-contact frame). Excluded from counts and training.",
+      "pending_taxonomy_review":  "custom_other only — awaiting taxonomy review to determine classification path.",
+      "reclassified":             "custom_other — reviewer determined it matches an existing stable key; contact_type updated to that stable key.",
+      "promotion_candidate":      "custom_other — same custom_label seen in ≥3 videos; under evaluation for new stable type.",
+      "promoted":                 "custom_other — new stable enum key created and approved; contact_type updated; legacy custom fields preserved for audit.",
+      "approved_unclassified":    "custom_other — reviewed, does not match any stable type and will not be promoted. Permanently excluded from training."
+    },
+    "stable_type_allowed": ["pending","confirmed","corrected","rejected"],
+    "custom_other_allowed": ["pending_taxonomy_review","reclassified","promotion_candidate","promoted","approved_unclassified"],
+    "excluded_from_training_states": ["pending","rejected","pending_taxonomy_review","promotion_candidate","approved_unclassified"]
+  },
+
+  "annotation_source_enum": {
+    "values": {
+      "manual_annotator": "Entered via the browser annotation helper or CLI by an internal annotator producing ground truth.",
+      "manual_user":      "Entered by an athlete/student via the iOS app (manual fallback mode).",
+      "model_prediction": "Automatically detected by the trained model (Phase D+). Not yet reviewed.",
+      "user_corrected":   "Originally a model_prediction that was changed by a user or reviewer."
+    }
+  },
+
+  "groups": [
+    {
+      "group_id": "foot",
+      "group_label_hu": "Lábfej",
+      "group_label_en": "Foot",
+      "group_sort_order": 1,
+      "ios_section_icon": "shoe.fill",
+      "contact_types": [
+        {
+          "key": "right_instep",
+          "label_hu": "Jobb rüszt",
+          "label_en": "Right instep",
+          "body_region": "foot",
+          "side": "right",
+          "side_policy": "fixed",
+          "sort_order": 1,
+          "ios_icon": "shoe.2",
+          "is_stable": true,
+          "auto_detectable": true,
+          "auto_detectable_phase": "D",
+          "annotation_difficulty": "medium",
+          "definition_hu": "A jobb lábfej háti (dorsal) felszíne, a lábujjtő és a bokaszár között. Klasszikus rüsztérintés.",
+          "definition_en": "Dorsal surface of the right foot between the toe knuckles and the ankle. Classic instep touch.",
+          "excluded_from_training_auto": false,
+          "taxonomy_version_added": "v1"
+        },
+        {
+          "key": "left_instep",
+          "label_hu": "Bal rüszt",
+          "label_en": "Left instep",
+          "body_region": "foot",
+          "side": "left",
+          "side_policy": "fixed",
+          "sort_order": 2,
+          "ios_icon": "shoe.2",
+          "is_stable": true,
+          "auto_detectable": true,
+          "auto_detectable_phase": "D",
+          "annotation_difficulty": "medium",
+          "definition_hu": "A bal lábfej háti felszíne. Klasszikus rüsztérintés.",
+          "definition_en": "Dorsal surface of the left foot. Classic instep touch.",
+          "excluded_from_training_auto": false,
+          "taxonomy_version_added": "v1"
+        },
+        {
+          "key": "right_inside_foot",
+          "label_hu": "Jobb belső",
+          "label_en": "Right inside foot",
+          "body_region": "foot",
+          "side": "right",
+          "side_policy": "fixed",
+          "sort_order": 3,
+          "ios_icon": "shoe.fill",
+          "is_stable": true,
+          "auto_detectable": false,
+          "auto_detectable_phase": null,
+          "annotation_difficulty": "hard",
+          "definition_hu": "A jobb láb mediális (belső) felszíne a sarokcsonttól a nagy lábujj tövéig.",
+          "definition_en": "Medial surface of the right foot from the heel to the base of the big toe.",
+          "excluded_from_training_auto": false,
+          "taxonomy_version_added": "v1"
+        },
+        {
+          "key": "left_inside_foot",
+          "label_hu": "Bal belső",
+          "label_en": "Left inside foot",
+          "body_region": "foot",
+          "side": "left",
+          "side_policy": "fixed",
+          "sort_order": 4,
+          "ios_icon": "shoe.fill",
+          "is_stable": true,
+          "auto_detectable": false,
+          "auto_detectable_phase": null,
+          "annotation_difficulty": "hard",
+          "definition_hu": "A bal láb mediális felszíne a saroktól a nagy lábujj tövéig.",
+          "definition_en": "Medial surface of the left foot from heel to base of big toe.",
+          "excluded_from_training_auto": false,
+          "taxonomy_version_added": "v1"
+        },
+        {
+          "key": "right_outside_foot",
+          "label_hu": "Jobb külső",
+          "label_en": "Right outside foot",
+          "body_region": "foot",
+          "side": "right",
+          "side_policy": "fixed",
+          "sort_order": 5,
+          "ios_icon": "shoe.fill",
+          "is_stable": true,
+          "auto_detectable": false,
+          "auto_detectable_phase": null,
+          "annotation_difficulty": "very_hard",
+          "definition_hu": "A jobb láb laterális (külső) felszíne a kis ujjak mentén.",
+          "definition_en": "Lateral surface of the right foot along the little toe side.",
+          "excluded_from_training_auto": false,
+          "taxonomy_version_added": "v1"
+        },
+        {
+          "key": "left_outside_foot",
+          "label_hu": "Bal külső",
+          "label_en": "Left outside foot",
+          "body_region": "foot",
+          "side": "left",
+          "side_policy": "fixed",
+          "sort_order": 6,
+          "ios_icon": "shoe.fill",
+          "is_stable": true,
+          "auto_detectable": false,
+          "auto_detectable_phase": null,
+          "annotation_difficulty": "very_hard",
+          "definition_hu": "A bal láb laterális felszíne.",
+          "definition_en": "Lateral surface of the left foot.",
+          "excluded_from_training_auto": false,
+          "taxonomy_version_added": "v1"
+        },
+        {
+          "key": "right_heel",
+          "label_hu": "Jobb sarok",
+          "label_en": "Right heel",
+          "body_region": "foot",
+          "side": "right",
+          "side_policy": "fixed",
+          "sort_order": 7,
+          "ios_icon": "shoe.fill",
+          "is_stable": true,
+          "auto_detectable": false,
+          "auto_detectable_phase": null,
+          "annotation_difficulty": "very_hard",
+          "definition_hu": "A jobb láb sarokcsonti (calcaneus) felszíne.",
+          "definition_en": "Calcaneal (heel bone) surface of the right foot.",
+          "excluded_from_training_auto": false,
+          "taxonomy_version_added": "v1"
+        },
+        {
+          "key": "left_heel",
+          "label_hu": "Bal sarok",
+          "label_en": "Left heel",
+          "body_region": "foot",
+          "side": "left",
+          "side_policy": "fixed",
+          "sort_order": 8,
+          "ios_icon": "shoe.fill",
+          "is_stable": true,
+          "auto_detectable": false,
+          "auto_detectable_phase": null,
+          "annotation_difficulty": "very_hard",
+          "definition_hu": "A bal láb sarokcsonti felszíne.",
+          "definition_en": "Calcaneal surface of the left foot.",
+          "excluded_from_training_auto": false,
+          "taxonomy_version_added": "v1"
+        }
+      ]
+    },
+    {
+      "group_id": "knee",
+      "group_label_hu": "Térd",
+      "group_label_en": "Knee",
+      "group_sort_order": 2,
+      "ios_section_icon": "figure.stand",
+      "contact_types": [
+        {
+          "key": "right_knee",
+          "label_hu": "Jobb térd",
+          "label_en": "Right knee",
+          "body_region": "knee",
+          "side": "right",
+          "side_policy": "fixed",
+          "sort_order": 9,
+          "ios_icon": "figure.stand",
+          "is_stable": true,
+          "auto_detectable": true,
+          "auto_detectable_phase": "D",
+          "annotation_difficulty": "medium",
+          "definition_hu": "A jobb térdkalács és a közvetlenül körülötte lévő felszín.",
+          "definition_en": "The right patella and immediately surrounding surface.",
+          "excluded_from_training_auto": false,
+          "taxonomy_version_added": "v1"
+        },
+        {
+          "key": "left_knee",
+          "label_hu": "Bal térd",
+          "label_en": "Left knee",
+          "body_region": "knee",
+          "side": "left",
+          "side_policy": "fixed",
+          "sort_order": 10,
+          "ios_icon": "figure.stand",
+          "is_stable": true,
+          "auto_detectable": true,
+          "auto_detectable_phase": "D",
+          "annotation_difficulty": "medium",
+          "definition_hu": "A bal térdkalács és körülötte lévő felszín.",
+          "definition_en": "The left patella and immediately surrounding surface.",
+          "excluded_from_training_auto": false,
+          "taxonomy_version_added": "v1"
+        }
+      ]
+    },
+    {
+      "group_id": "hip",
+      "group_label_hu": "Csípő",
+      "group_label_en": "Hip",
+      "group_sort_order": 3,
+      "ios_section_icon": "figure.stand",
+      "_backward_compat_note": "v1 schema had 'thigh' as a body_part. 'thigh' and 'hip' are anatomically distinct. Auto-migration from thigh→hip is FORBIDDEN. If a non-null v1 contact_event with body_part='thigh' exists, it must be flagged for manual_review_required.",
+      "contact_types": [
+        {
+          "key": "right_hip",
+          "label_hu": "Jobb csípő",
+          "label_en": "Right hip",
+          "body_region": "hip",
+          "side": "right",
+          "side_policy": "fixed",
+          "sort_order": 11,
+          "ios_icon": "figure.stand",
+          "is_stable": true,
+          "auto_detectable": false,
+          "auto_detectable_phase": null,
+          "annotation_difficulty": "hard",
+          "definition_hu": "A jobb csípőcsont laterális felszíne és a nagyobb trochanter környéke. NEM azonos a combbal (thigh).",
+          "definition_en": "Lateral surface of the right iliac crest and greater trochanter area. NOT the same as thigh.",
+          "excluded_from_training_auto": false,
+          "taxonomy_version_added": "v1"
+        },
+        {
+          "key": "left_hip",
+          "label_hu": "Bal csípő",
+          "label_en": "Left hip",
+          "body_region": "hip",
+          "side": "left",
+          "side_policy": "fixed",
+          "sort_order": 12,
+          "ios_icon": "figure.stand",
+          "is_stable": true,
+          "auto_detectable": false,
+          "auto_detectable_phase": null,
+          "annotation_difficulty": "hard",
+          "definition_hu": "A bal csípőcsont laterális felszíne. NEM azonos a combbal.",
+          "definition_en": "Lateral surface of the left iliac crest. NOT the same as thigh.",
+          "excluded_from_training_auto": false,
+          "taxonomy_version_added": "v1"
+        }
+      ]
+    },
+    {
+      "group_id": "upper_body",
+      "group_label_hu": "Felsőtest",
+      "group_label_en": "Upper Body",
+      "group_sort_order": 4,
+      "ios_section_icon": "figure.arms.open",
+      "contact_types": [
+        {
+          "key": "chest",
+          "label_hu": "Mellkas",
+          "label_en": "Chest",
+          "body_region": "chest",
+          "side": "center",
+          "side_policy": "center",
+          "sort_order": 13,
+          "ios_icon": "heart.fill",
+          "is_stable": true,
+          "auto_detectable": true,
+          "auto_detectable_phase": "D",
+          "annotation_difficulty": "easy",
+          "definition_hu": "A mellcsont és a mellkasi elülső felszín (pectoralis zona). Nincs lateralitás — side=center.",
+          "definition_en": "Sternum and anterior thoracic surface (pectoral zone). No laterality — side=center.",
+          "excluded_from_training_auto": false,
+          "taxonomy_version_added": "v1"
+        },
+        {
+          "key": "right_shoulder",
+          "label_hu": "Jobb váll",
+          "label_en": "Right shoulder",
+          "body_region": "shoulder",
+          "side": "right",
+          "side_policy": "fixed",
+          "sort_order": 14,
+          "ios_icon": "figure.arms.open",
+          "is_stable": true,
+          "auto_detectable": true,
+          "auto_detectable_phase": "D",
+          "annotation_difficulty": "medium",
+          "definition_hu": "A jobb deltoid felszín és a felső karfej (acromion környéke).",
+          "definition_en": "Right deltoid surface and upper arm head (acromion region).",
+          "excluded_from_training_auto": false,
+          "taxonomy_version_added": "v1"
+        },
+        {
+          "key": "left_shoulder",
+          "label_hu": "Bal váll",
+          "label_en": "Left shoulder",
+          "body_region": "shoulder",
+          "side": "left",
+          "side_policy": "fixed",
+          "sort_order": 15,
+          "ios_icon": "figure.arms.open",
+          "is_stable": true,
+          "auto_detectable": true,
+          "auto_detectable_phase": "D",
+          "annotation_difficulty": "medium",
+          "definition_hu": "A bal deltoid felszín és felső karfej.",
+          "definition_en": "Left deltoid surface and upper arm head.",
+          "excluded_from_training_auto": false,
+          "taxonomy_version_added": "v1"
+        },
+        {
+          "key": "head",
+          "label_hu": "Fej",
+          "label_en": "Head",
+          "body_region": "head",
+          "side": "center",
+          "side_policy": "center",
+          "sort_order": 16,
+          "ios_icon": "person.fill",
+          "is_stable": true,
+          "auto_detectable": true,
+          "auto_detectable_phase": "D",
+          "annotation_difficulty": "easy",
+          "definition_hu": "A koponya bármely felszíne. Nincs lateralitás — side=center.",
+          "definition_en": "Any surface of the skull. No laterality — side=center.",
+          "excluded_from_training_auto": false,
+          "taxonomy_version_added": "v1"
+        },
+        {
+          "key": "back",
+          "label_hu": "Hát",
+          "label_en": "Back",
+          "body_region": "back",
+          "side": "center",
+          "side_policy": "center",
+          "sort_order": 17,
+          "ios_icon": "figure.walk.motion",
+          "is_stable": true,
+          "auto_detectable": false,
+          "auto_detectable_phase": null,
+          "annotation_difficulty": "very_hard",
+          "definition_hu": "A hát spinális oldala (thoracalis és lumbalis zona). Nincs lateralitás — side=center.",
+          "definition_en": "Spinal side of the back (thoracic and lumbar zone). No laterality — side=center.",
+          "excluded_from_training_auto": false,
+          "taxonomy_version_added": "v1"
+        }
+      ]
+    },
+    {
+      "group_id": "custom",
+      "group_label_hu": "Egyéb / Egyedi",
+      "group_label_en": "Other / Custom",
+      "group_sort_order": 5,
+      "ios_section_icon": "plus.circle",
+      "contact_types": [
+        {
+          "key": "custom_other",
+          "label_hu": "Egyedi érintés",
+          "label_en": "Custom / Other",
+          "body_region": "unclassified",
+          "side": null,
+          "side_policy": "explicit_required",
+          "side_allowed_values": ["left","right","center","unknown"],
+          "sort_order": 18,
+          "ios_icon": "plus.circle",
+          "is_stable": false,
+          "auto_detectable": false,
+          "auto_detectable_phase": null,
+          "annotation_difficulty": "variable",
+          "definition_hu": "Olyan érintési mód, amely nem illeszthető a 17 stabil kategóriába. Kötelező custom_label és custom_description. Taxonomy review szükséges.",
+          "definition_en": "A contact type that does not fit any of the 17 stable categories. Requires custom_label and custom_description. Taxonomy review required.",
+          "excluded_from_training_auto": true,
+          "excluded_from_training_policy": "ALWAYS — in every review_status. No unclassified_custom training class exists. Training inclusion only possible after promotion to a new stable key.",
+          "requires_custom_label": true,
+          "requires_custom_description": true,
+          "requires_explicit_side": true,
+          "custom_label_constraints": {
+            "pattern": "^[a-z][a-z0-9_]{0,38}[a-z0-9]$",
+            "max_length": 40,
+            "must_not_match_existing_key": true,
+            "normalization": "lowercase_underscore",
+            "deduplication_check_required": true
+          },
+          "custom_description_constraints": {
+            "max_length": 200,
+            "must_not_be_empty": true
+          },
+          "review_flow": {
+            "initial_review_status": "pending_taxonomy_review",
+            "allowed_transitions": {
+              "pending_taxonomy_review": ["reclassified","promotion_candidate","approved_unclassified"],
+              "promotion_candidate": ["promoted","approved_unclassified"],
+              "reclassified": [],
+              "promoted": [],
+              "approved_unclassified": []
+            },
+            "promotion_threshold_videos": 3,
+            "promotion_requires_manual_approval": true,
+            "auto_enum_key_from_custom_label": "FORBIDDEN"
+          },
+          "taxonomy_version_added": "v1"
+        }
+      ]
+    }
+  ],
+
+  "stable_keys": [
+    "right_instep","left_instep",
+    "right_inside_foot","left_inside_foot",
+    "right_outside_foot","left_outside_foot",
+    "right_heel","left_heel",
+    "right_knee","left_knee",
+    "right_hip","left_hip",
+    "chest","right_shoulder","left_shoulder",
+    "head","back"
+  ],
+
+  "right_stable_keys": [
+    "right_instep","right_inside_foot","right_outside_foot","right_heel",
+    "right_knee","right_hip","right_shoulder"
+  ],
+
+  "left_stable_keys": [
+    "left_instep","left_inside_foot","left_outside_foot","left_heel",
+    "left_knee","left_hip","left_shoulder"
+  ],
+
+  "center_stable_keys": ["chest","head","back"],
+
+  "all_keys": [
+    "right_instep","left_instep",
+    "right_inside_foot","left_inside_foot",
+    "right_outside_foot","left_outside_foot",
+    "right_heel","left_heel",
+    "right_knee","left_knee",
+    "right_hip","left_hip",
+    "chest","right_shoulder","left_shoulder",
+    "head","back",
+    "custom_other"
+  ],
+
+  "backward_compatibility": {
+    "v1_body_part_to_v2_contact_type": {
+      "foot":     ["right_instep","left_instep","right_inside_foot","left_inside_foot","right_outside_foot","left_outside_foot","right_heel","left_heel"],
+      "knee":     ["right_knee","left_knee"],
+      "thigh":    "MANUAL_REVIEW_REQUIRED — thigh and hip are anatomically distinct. Auto-migration FORBIDDEN.",
+      "shoulder": ["right_shoulder","left_shoulder"],
+      "head":     ["head"],
+      "chest":    ["chest"]
+    },
+    "v2_new_keys_not_in_v1": ["right_hip","left_hip","back"],
+    "v1_deprecated_keys": ["thigh"],
+    "thigh_migration_policy": "If a non-null contact_event with body_part='thigh' is found in a v1 annotation, set manual_review_required=true on that event. Do not reclassify automatically."
+  }
+}

--- a/ios/LFAEducationCenter/Juggling/JugglingVideoItem.swift
+++ b/ios/LFAEducationCenter/Juggling/JugglingVideoItem.swift
@@ -26,6 +26,9 @@ struct JugglingVideoItem: Codable, Identifiable {
     let hasMedia:                 Bool
     let uploadSource:             String
     let sourceType:               String
+    // AN-1 contact annotation state. Nil if the backend response predates AN-1
+    // or annotation was never started for this video.
+    let annotationStatus:         String?
 
     var id: String { videoId }
 
@@ -45,6 +48,7 @@ struct JugglingVideoItem: Codable, Identifiable {
         case hasMedia                 = "has_media"
         case uploadSource             = "upload_source"
         case sourceType               = "source_type"
+        case annotationStatus         = "annotation_status"
     }
 
     // MARK: — Display helpers

--- a/ios/LFAEducationCenter/Networking/APIClient.swift
+++ b/ios/LFAEducationCenter/Networking/APIClient.swift
@@ -54,6 +54,62 @@ enum APIClient {
         return try await execute(request)
     }
 
+    // MARK: — PATCH (JSON)
+
+    static func patch<B: Encodable, T: Decodable>(
+        path:  String,
+        body:  B,
+        token: String? = nil
+    ) async throws -> T {
+        var request = try buildRequest(path: path, method: "PATCH", token: token)
+        request.httpBody = try JSONEncoder().encode(body)
+        return try await execute(request)
+    }
+
+    // MARK: — GET (raw — no 2xx check, no decode)
+    // Caller receives (Data, URLResponse) and inspects the status code directly.
+    // Used for ETag-based endpoints where 304 is a valid non-error response.
+
+    static func getRaw(
+        path:         String,
+        token:        String? = nil,
+        extraHeaders: [String: String] = [:]
+    ) async throws -> (Data, URLResponse) {
+        var request = try buildRequest(path: path, method: "GET", token: token)
+        for (key, value) in extraHeaders {
+            request.setValue(value, forHTTPHeaderField: key)
+        }
+        return try await perform(request)
+    }
+
+    // MARK: — POST (raw status code)
+    // Returns (Data, statusCode) for 2xx. Throws APIError.httpError for non-2xx
+    // (with parsed detail, so callers can distinguish e.g. 409 idempotency vs version conflicts).
+    // Used by annotation endpoints that need to distinguish 200 (duplicate) from 201 (created).
+
+    static func postRaw<B: Encodable>(
+        path:  String,
+        body:  B,
+        token: String? = nil
+    ) async throws -> (Data, Int) {
+        var request = try buildRequest(path: path, method: "POST", token: token)
+        request.httpBody = try JSONEncoder().encode(body)
+        return try await executeRaw(request)
+    }
+
+    // MARK: — PATCH (raw status code)
+    // See postRaw — same semantics, PATCH method.
+
+    static func patchRaw<B: Encodable>(
+        path:  String,
+        body:  B,
+        token: String? = nil
+    ) async throws -> (Data, Int) {
+        var request = try buildRequest(path: path, method: "PATCH", token: token)
+        request.httpBody = try JSONEncoder().encode(body)
+        return try await executeRaw(request)
+    }
+
     // MARK: — DELETE (No Content — 204)
 
     static func deleteNoContent(path: String, token: String? = nil) async throws {
@@ -169,6 +225,23 @@ enum APIClient {
         } catch {
             throw APIError.decodingError
         }
+    }
+
+    // Returns (Data, statusCode) for 2xx; throws APIError.httpError with parsed
+    // detail for non-2xx so callers can branch on status code + body together.
+    private static func executeRaw(_ request: URLRequest) async throws -> (Data, Int) {
+        let (data, response) = try await perform(request)
+
+        guard let http = response as? HTTPURLResponse else {
+            throw APIError.networkError(URLError(.badServerResponse))
+        }
+
+        guard (200...299).contains(http.statusCode) else {
+            let detail = try? JSONDecoder().decode(ErrorBody.self, from: data)
+            throw APIError.httpError(statusCode: http.statusCode, detail: detail?.detail)
+        }
+
+        return (data, http.statusCode)
     }
 
     // URLSession.data(for:) async is iOS 15+.

--- a/ios/LFAEducationCenterTests/Juggling/AnnotationSyncEngineTests.swift
+++ b/ios/LFAEducationCenterTests/Juggling/AnnotationSyncEngineTests.swift
@@ -1,0 +1,216 @@
+import XCTest
+@testable import LFAEducationCenter
+
+// MARK: — MockAnnotationAPIClient
+//
+// Configurable stand-in for JugglingAnnotationAPIClient. Each endpoint has a
+// Result<_, Error> slot set by the test before calling the engine.
+
+@MainActor
+final class MockAnnotationAPIClient: JugglingAnnotationAPIClientProtocol {
+
+    var listContactsResult:    Result<ContactEventListOut, Error> = .success(ContactEventListOut(videoId: "vid-1", annotationStatus: nil, events: []))
+    var createContactResult:   Result<CreateContactResult, Error> = .failure(AnnotationAPIError.unauthorized)
+    var patchContactResult:    Result<ContactEventOut, Error> = .failure(AnnotationAPIError.unauthorized)
+    var deleteContactResult:   Result<DeleteContactResult, Error> = .failure(AnnotationAPIError.unauthorized)
+    var finishAnnotationResult: Result<FinishAnnotationOut, Error> = .failure(AnnotationAPIError.unauthorized)
+
+    func listContacts(videoId: String) async throws -> ContactEventListOut {
+        try listContactsResult.get()
+    }
+
+    func createContact(videoId: String, request: ContactEventCreateRequest) async throws -> CreateContactResult {
+        try createContactResult.get()
+    }
+
+    func patchContact(videoId: String, eventId: UUID, request: ContactEventPatchRequest) async throws -> ContactEventOut {
+        try patchContactResult.get()
+    }
+
+    func deleteContact(videoId: String, eventId: UUID) async throws -> DeleteContactResult {
+        try deleteContactResult.get()
+    }
+
+    func finishAnnotation(videoId: String, confirmZero: Bool) async throws -> FinishAnnotationOut {
+        try finishAnnotationResult.get()
+    }
+}
+
+// MARK: — AN2-T17..T25: AnnotationSyncEngine state transitions
+
+@MainActor
+final class AnnotationSyncEngineTests: XCTestCase {
+
+    // AN2-T17: successful create (201) → synced, server identity captured.
+    func test_AN2_T17_pushCreateSuccessBecomesSynced() async {
+        let mock = MockAnnotationAPIClient()
+        let draft = ContactEventDraft.new(timestampMs: 100, contactType: "right_instep", side: "right", annotationConfidence: "certain")
+        let serverEvent = makeServerEvent(deviceEventId: draft.deviceEventId, contactType: "right_instep", side: "right", version: 1)
+        mock.createContactResult = .success(CreateContactResult(event: serverEvent, isNew: true))
+
+        let engine = AnnotationSyncEngine(apiClient: mock)
+        let result = await engine.pushCreate(draft: draft, videoId: "vid-1")
+
+        XCTAssertEqual(result.syncStatus, .synced)
+        XCTAssertEqual(result.serverEventId, serverEvent.eventId)
+        XCTAssertEqual(result.version, 1)
+        XCTAssertEqual(result.retryCount, 0)
+    }
+
+    // AN2-T18: network error → retryPending, retryCount incremented.
+    func test_AN2_T18_pushCreateNetworkErrorBecomesRetryPending() async {
+        let mock = MockAnnotationAPIClient()
+        mock.createContactResult = .failure(AnnotationAPIError.retryable(code: nil))
+        let draft = ContactEventDraft.new(timestampMs: 1, contactType: "head", side: "center", annotationConfidence: "certain")
+
+        let engine = AnnotationSyncEngine(apiClient: mock)
+        let result = await engine.pushCreate(draft: draft, videoId: "vid-1")
+
+        XCTAssertEqual(result.syncStatus, .retryPending)
+        XCTAssertEqual(result.retryCount, 1)
+    }
+
+    // AN2-T19: permanent error (403 consent blocked) → failedPermanent, no retry.
+    func test_AN2_T19_pushCreatePermanentErrorBecomesFailedPermanent() async {
+        let mock = MockAnnotationAPIClient()
+        mock.createContactResult = .failure(AnnotationAPIError.permanent(code: 403, detail: "consent_blocked"))
+        let draft = ContactEventDraft.new(timestampMs: 1, contactType: "head", side: "center", annotationConfidence: "certain")
+
+        let engine = AnnotationSyncEngine(apiClient: mock)
+        let result = await engine.pushCreate(draft: draft, videoId: "vid-1")
+
+        XCTAssertEqual(result.syncStatus, .failedPermanent)
+        XCTAssertEqual(result.retryCount, 0)
+    }
+
+    // AN2-T20: retryable error once retryCount has hit maxRetries → failedPermanent.
+    func test_AN2_T20_pushCreateRetryableAtMaxRetriesBecomesFailedPermanent() async {
+        let mock = MockAnnotationAPIClient()
+        mock.createContactResult = .failure(AnnotationAPIError.retryable(code: 503))
+        var draft = ContactEventDraft.new(timestampMs: 1, contactType: "head", side: "center", annotationConfidence: "certain")
+        draft.retryCount = AnnotationSyncEngine.maxRetries
+
+        let engine = AnnotationSyncEngine(apiClient: mock)
+        let result = await engine.pushCreate(draft: draft, videoId: "vid-1")
+
+        XCTAssertEqual(result.syncStatus, .failedPermanent)
+        XCTAssertEqual(result.retryCount, AnnotationSyncEngine.maxRetries)
+    }
+
+    // AN2-T21: DELETE 204 → deleted.
+    func test_AN2_T21_pushDeleteConfirmedBecomesDeleted() async {
+        let mock = MockAnnotationAPIClient()
+        mock.deleteContactResult = .success(.deleted)
+        var draft = ContactEventDraft.new(timestampMs: 1, contactType: "head", side: "center", annotationConfidence: "certain")
+        draft.serverEventId = UUID()
+        draft.syncStatus = .synced
+
+        let engine = AnnotationSyncEngine(apiClient: mock)
+        let result = await engine.pushDelete(draft: draft, videoId: "vid-1")
+
+        XCTAssertEqual(result.syncStatus, .deleted)
+    }
+
+    // AN2-T22: DELETE 404 is ownership-ambiguous → needsReconciliation, not auto-success.
+    func test_AN2_T22_pushDeleteNotFoundBecomesNeedsReconciliation() async {
+        let mock = MockAnnotationAPIClient()
+        mock.deleteContactResult = .success(.notFoundAmbiguous)
+        var draft = ContactEventDraft.new(timestampMs: 1, contactType: "head", side: "center", annotationConfidence: "certain")
+        draft.serverEventId = UUID()
+        draft.syncStatus = .synced
+
+        let engine = AnnotationSyncEngine(apiClient: mock)
+        let result = await engine.pushDelete(draft: draft, videoId: "vid-1")
+
+        XCTAssertEqual(result.syncStatus, .needsReconciliation)
+        XCTAssertEqual(result.failureReason, "delete_404_ambiguous")
+    }
+
+    // AN2-T23: reconcile finds the event on the server → synced with server state applied.
+    func test_AN2_T23_reconcileFindsEventOnServerBecomesSynced() async throws {
+        let mock = MockAnnotationAPIClient()
+        var draft = ContactEventDraft.new(timestampMs: 1, contactType: "head", side: "center", annotationConfidence: "certain")
+        draft.syncStatus = .needsReconciliation
+
+        let serverEvent = makeServerEvent(deviceEventId: draft.deviceEventId, contactType: "head", side: "center", version: 2)
+        mock.listContactsResult = .success(ContactEventListOut(videoId: "vid-1", annotationStatus: "in_progress", events: [serverEvent]))
+
+        let engine = AnnotationSyncEngine(apiClient: mock)
+        var session = makeSession(drafts: [draft])
+        try await engine.reconcile(session: &session)
+
+        XCTAssertEqual(session.drafts[0].syncStatus, .synced)
+        XCTAssertEqual(session.drafts[0].serverEventId, serverEvent.eventId)
+        XCTAssertEqual(session.drafts[0].version, 2)
+    }
+
+    // AN2-T24: reconcile finds the event absent from the server → deleted.
+    func test_AN2_T24_reconcileEventAbsentFromServerBecomesDeleted() async throws {
+        let mock = MockAnnotationAPIClient()
+        var draft = ContactEventDraft.new(timestampMs: 1, contactType: "head", side: "center", annotationConfidence: "certain")
+        draft.syncStatus = .needsReconciliation
+        draft.serverEventId = UUID()
+
+        mock.listContactsResult = .success(ContactEventListOut(videoId: "vid-1", annotationStatus: "in_progress", events: []))
+
+        let engine = AnnotationSyncEngine(apiClient: mock)
+        var session = makeSession(drafts: [draft])
+        try await engine.reconcile(session: &session)
+
+        XCTAssertEqual(session.drafts[0].syncStatus, .deleted)
+    }
+
+    // AN2-T25: flushPending pushes localOnly creates and skips never-synced
+    // drafts that were deleted locally before ever reaching the server.
+    func test_AN2_T25_flushPendingSyncsCreatesAndSkipsLocallyDeletedNeverSynced() async {
+        let mock = MockAnnotationAPIClient()
+        let toCreate = ContactEventDraft.new(timestampMs: 1, contactType: "head", side: "center", annotationConfidence: "certain")
+        var toSkip = ContactEventDraft.new(timestampMs: 2, contactType: "chest", side: "center", annotationConfidence: "certain")
+        toSkip.deletedLocally = true
+
+        let serverEvent = makeServerEvent(deviceEventId: toCreate.deviceEventId, contactType: "head", side: "center", version: 1)
+        mock.createContactResult = .success(CreateContactResult(event: serverEvent, isNew: true))
+
+        let engine = AnnotationSyncEngine(apiClient: mock)
+        var session = makeSession(drafts: [toCreate, toSkip])
+        await engine.flushPending(session: &session)
+
+        let created = session.drafts.first { $0.deviceEventId == toCreate.deviceEventId }!
+        let skipped = session.drafts.first { $0.deviceEventId == toSkip.deviceEventId }!
+
+        XCTAssertEqual(created.syncStatus, .synced)
+        XCTAssertEqual(created.serverEventId, serverEvent.eventId)
+        XCTAssertEqual(skipped.syncStatus, .deleted)
+    }
+
+    // MARK: — Helpers
+
+    private func makeSession(drafts: [ContactEventDraft]) -> AnnotationSessionFile {
+        AnnotationSessionFile(
+            schemaVersion: 1, userId: 1, videoId: "vid-1",
+            taxonomyVersion: "v1", lastUpdatedAt: Date(),
+            drafts: drafts, checksum: ""
+        )
+    }
+
+    private func makeServerEvent(
+        deviceEventId: UUID, contactType: String, side: String?, version: Int
+    ) -> ContactEventOut {
+        ContactEventOut(
+            eventId: UUID(),
+            deviceEventId: deviceEventId,
+            timestampMs: 1,
+            contactType: contactType,
+            side: side,
+            annotationConfidence: "certain",
+            annotationReviewStatus: "pending",
+            taxonomyReviewStatus: "not_applicable",
+            excludedFromTraining: true,
+            customLabel: nil,
+            customDescription: nil,
+            version: version,
+            createdAt: Date(),
+            updatedAt: Date()
+        )
+    }
+}

--- a/ios/LFAEducationCenterTests/Juggling/AnnotationSyncEngineTests.swift
+++ b/ios/LFAEducationCenterTests/Juggling/AnnotationSyncEngineTests.swift
@@ -183,6 +183,149 @@ final class AnnotationSyncEngineTests: XCTestCase {
         XCTAssertEqual(skipped.syncStatus, .deleted)
     }
 
+    // AN2-T26: PATCH 200 → synced, server state (incl. bumped version) applied.
+    func test_AN2_T26_pushPatchSuccessBecomesSynced() async {
+        let mock = MockAnnotationAPIClient()
+        var draft = ContactEventDraft.new(timestampMs: 1, contactType: "head", side: "center", annotationConfidence: "certain")
+        draft.serverEventId = UUID()
+        draft.syncStatus = .synced
+        draft.version = 1
+
+        let serverEvent = makeServerEvent(deviceEventId: draft.deviceEventId, contactType: "chest", side: "center", version: 2)
+        mock.patchContactResult = .success(serverEvent)
+
+        let engine = AnnotationSyncEngine(apiClient: mock)
+        let request = ContactEventPatchRequest(version: 1, contactType: "chest", annotationConfidence: nil, side: nil, customLabel: nil, customDescription: nil)
+        let result = await engine.pushPatch(draft: draft, videoId: "vid-1", request: request)
+
+        XCTAssertEqual(result.syncStatus, .synced)
+        XCTAssertEqual(result.contactType, "chest")
+        XCTAssertEqual(result.version, 2)
+        XCTAssertNil(result.failureReason)
+    }
+
+    // AN2-T27: PATCH 409 version_conflict → conflicted, failureReason carries detail.
+    func test_AN2_T27_pushPatchVersionConflictBecomesConflicted() async {
+        let mock = MockAnnotationAPIClient()
+        var draft = ContactEventDraft.new(timestampMs: 1, contactType: "head", side: "center", annotationConfidence: "certain")
+        draft.serverEventId = UUID()
+        draft.syncStatus = .synced
+        mock.patchContactResult = .failure(AnnotationAPIError.versionConflict(detail: "version_conflict: expected 1, got 2"))
+
+        let engine = AnnotationSyncEngine(apiClient: mock)
+        let request = ContactEventPatchRequest(version: 1, contactType: nil, annotationConfidence: nil, side: nil, customLabel: nil, customDescription: nil)
+        let result = await engine.pushPatch(draft: draft, videoId: "vid-1", request: request)
+
+        XCTAssertEqual(result.syncStatus, .conflicted)
+        XCTAssertEqual(result.failureReason, "version_conflict: expected 1, got 2")
+    }
+
+    // AN2-T28: PATCH 422 validation error → failedPermanent, not retried.
+    func test_AN2_T28_pushPatchValidationErrorBecomesFailedPermanent() async {
+        let mock = MockAnnotationAPIClient()
+        var draft = ContactEventDraft.new(timestampMs: 1, contactType: "head", side: "center", annotationConfidence: "certain")
+        draft.serverEventId = UUID()
+        draft.syncStatus = .synced
+        mock.patchContactResult = .failure(AnnotationAPIError.permanent(code: 422, detail: "validation_error"))
+
+        let engine = AnnotationSyncEngine(apiClient: mock)
+        let request = ContactEventPatchRequest(version: 1, contactType: nil, annotationConfidence: nil, side: nil, customLabel: nil, customDescription: nil)
+        let result = await engine.pushPatch(draft: draft, videoId: "vid-1", request: request)
+
+        XCTAssertEqual(result.syncStatus, .failedPermanent)
+        XCTAssertEqual(result.retryCount, 0)
+    }
+
+    // AN2-T29: PATCH timeout/network error → needsReconciliation (outcome unknown, not idempotent).
+    func test_AN2_T29_pushPatchTimeoutBecomesNeedsReconciliation() async {
+        let mock = MockAnnotationAPIClient()
+        var draft = ContactEventDraft.new(timestampMs: 1, contactType: "head", side: "center", annotationConfidence: "certain")
+        draft.serverEventId = UUID()
+        draft.syncStatus = .synced
+        mock.patchContactResult = .failure(AnnotationAPIError.retryable(code: nil))
+
+        let engine = AnnotationSyncEngine(apiClient: mock)
+        let request = ContactEventPatchRequest(version: 1, contactType: nil, annotationConfidence: nil, side: nil, customLabel: nil, customDescription: nil)
+        let result = await engine.pushPatch(draft: draft, videoId: "vid-1", request: request)
+
+        XCTAssertEqual(result.syncStatus, .needsReconciliation)
+        XCTAssertEqual(result.failureReason, "patch_timeout_or_unavailable")
+    }
+
+    // AN2-T30: DELETE timeout/network error → needsReconciliation (outcome unknown).
+    func test_AN2_T30_pushDeleteTimeoutBecomesNeedsReconciliation() async {
+        let mock = MockAnnotationAPIClient()
+        var draft = ContactEventDraft.new(timestampMs: 1, contactType: "head", side: "center", annotationConfidence: "certain")
+        draft.serverEventId = UUID()
+        draft.syncStatus = .synced
+        mock.deleteContactResult = .failure(AnnotationAPIError.retryable(code: nil))
+
+        let engine = AnnotationSyncEngine(apiClient: mock)
+        let result = await engine.pushDelete(draft: draft, videoId: "vid-1")
+
+        XCTAssertEqual(result.syncStatus, .needsReconciliation)
+        XCTAssertEqual(result.failureReason, "delete_timeout_or_unavailable")
+    }
+
+    // AN2-T31: POST 409 idempotency_conflict → failedPermanent, requires user resolution (no auto-retry).
+    func test_AN2_T31_pushCreateIdempotencyConflictBecomesFailedPermanent() async {
+        let mock = MockAnnotationAPIClient()
+        mock.createContactResult = .failure(AnnotationAPIError.idempotencyConflict(detail: "idempotency_conflict: payload mismatch"))
+        let draft = ContactEventDraft.new(timestampMs: 1, contactType: "head", side: "center", annotationConfidence: "certain")
+
+        let engine = AnnotationSyncEngine(apiClient: mock)
+        let result = await engine.pushCreate(draft: draft, videoId: "vid-1")
+
+        XCTAssertEqual(result.syncStatus, .failedPermanent)
+        XCTAssertEqual(result.retryCount, 0)
+        XCTAssertEqual(result.failureReason, "idempotency_conflict: idempotency_conflict: payload mismatch")
+    }
+
+    // AN2-T32: reconcile — server list contains an event for an unrelated
+    // device (not present locally) alongside the one this draft needs.
+    // The extra server-side event must be ignored; only the matching draft
+    // is updated.
+    func test_AN2_T32_reconcileIgnoresUnrelatedServerEvent() async throws {
+        let mock = MockAnnotationAPIClient()
+        var draft = ContactEventDraft.new(timestampMs: 1, contactType: "head", side: "center", annotationConfidence: "certain")
+        draft.syncStatus = .needsReconciliation
+
+        let matchingServerEvent = makeServerEvent(deviceEventId: draft.deviceEventId, contactType: "head", side: "center", version: 1)
+        let unrelatedServerEvent = makeServerEvent(deviceEventId: UUID(), contactType: "chest", side: "center", version: 1)
+        mock.listContactsResult = .success(ContactEventListOut(videoId: "vid-1", annotationStatus: "in_progress", events: [matchingServerEvent, unrelatedServerEvent]))
+
+        let engine = AnnotationSyncEngine(apiClient: mock)
+        var session = makeSession(drafts: [draft])
+        try await engine.reconcile(session: &session)
+
+        XCTAssertEqual(session.drafts.count, 1, "reconcile must not add drafts for server events with no local match")
+        XCTAssertEqual(session.drafts[0].syncStatus, .synced)
+        XCTAssertEqual(session.drafts[0].serverEventId, matchingServerEvent.eventId)
+    }
+
+    // AN2-T33: reconcile — drafts not in needsReconciliation are left untouched.
+    func test_AN2_T33_reconcileLeavesNonReconciliationDraftsUntouched() async throws {
+        let mock = MockAnnotationAPIClient()
+        var needsRecon = ContactEventDraft.new(timestampMs: 1, contactType: "head", side: "center", annotationConfidence: "certain")
+        needsRecon.syncStatus = .needsReconciliation
+        needsRecon.serverEventId = UUID()
+
+        var alreadySynced = ContactEventDraft.new(timestampMs: 2, contactType: "chest", side: "center", annotationConfidence: "certain")
+        alreadySynced.syncStatus = .synced
+        alreadySynced.serverEventId = UUID()
+        alreadySynced.version = 5
+
+        mock.listContactsResult = .success(ContactEventListOut(videoId: "vid-1", annotationStatus: "in_progress", events: []))
+
+        let engine = AnnotationSyncEngine(apiClient: mock)
+        var session = makeSession(drafts: [needsRecon, alreadySynced])
+        try await engine.reconcile(session: &session)
+
+        XCTAssertEqual(session.drafts[0].syncStatus, .deleted, "absent needsReconciliation draft must become deleted")
+        XCTAssertEqual(session.drafts[1].syncStatus, .synced, "drafts outside needsReconciliation must be left untouched")
+        XCTAssertEqual(session.drafts[1].version, 5)
+    }
+
     // MARK: — Helpers
 
     private func makeSession(drafts: [ContactEventDraft]) -> AnnotationSessionFile {

--- a/ios/LFAEducationCenterTests/Juggling/ContactEventDraftTests.swift
+++ b/ios/LFAEducationCenterTests/Juggling/ContactEventDraftTests.swift
@@ -1,0 +1,101 @@
+import XCTest
+@testable import LFAEducationCenter
+
+// MARK: — AN2-T11..T16: ContactEventDraft model + FinishReadiness + wire decode
+
+final class ContactEventDraftTests: XCTestCase {
+
+    // AN2-T11: .new() produces a localOnly draft with sane defaults.
+    func test_AN2_T11_newDraftDefaults() {
+        let draft = ContactEventDraft.new(
+            timestampMs: 5000, contactType: "left_knee",
+            side: "left", annotationConfidence: "probable"
+        )
+        XCTAssertEqual(draft.syncStatus, .localOnly)
+        XCTAssertEqual(draft.version, 1)
+        XCTAssertEqual(draft.retryCount, 0)
+        XCTAssertFalse(draft.deletedLocally)
+        XCTAssertNil(draft.serverEventId)
+        XCTAssertNil(draft.failureReason)
+    }
+
+    // AN2-T12: deviceEventId is the identity and is immutable across mutation.
+    func test_AN2_T12_deviceEventIdIsStableIdentity() {
+        var draft = ContactEventDraft.new(
+            timestampMs: 1, contactType: "chest",
+            side: "center", annotationConfidence: "certain"
+        )
+        let originalId = draft.deviceEventId
+        draft.syncStatus = .synced
+        draft.version = 2
+        draft.serverEventId = UUID()
+
+        XCTAssertEqual(draft.deviceEventId, originalId)
+        XCTAssertEqual(draft.id, originalId)
+    }
+
+    // AN2-T13: zero drafts → readyZero.
+    func test_AN2_T13_finishReadinessReadyZeroWhenEmpty() {
+        let engine = AnnotationSyncEngine(apiClient: MockAnnotationAPIClient())
+        let session = makeSession(drafts: [])
+        XCTAssertEqual(engine.finishReadiness(for: session), .readyZero)
+    }
+
+    // AN2-T14: synced drafts → readyWithCount(N).
+    func test_AN2_T14_finishReadinessReadyWithCount() {
+        let engine = AnnotationSyncEngine(apiClient: MockAnnotationAPIClient())
+        var d1 = ContactEventDraft.new(timestampMs: 1, contactType: "head", side: "center", annotationConfidence: "certain")
+        d1.syncStatus = .synced
+        var d2 = ContactEventDraft.new(timestampMs: 2, contactType: "chest", side: "center", annotationConfidence: "certain")
+        d2.syncStatus = .synced
+        let session = makeSession(drafts: [d1, d2])
+
+        XCTAssertEqual(engine.finishReadiness(for: session), .readyWithCount(2))
+    }
+
+    // AN2-T15: any in-flight/unresolved active draft blocks finish.
+    func test_AN2_T15_finishReadinessBlockedByLocalOnly() {
+        let engine = AnnotationSyncEngine(apiClient: MockAnnotationAPIClient())
+        var synced = ContactEventDraft.new(timestampMs: 1, contactType: "head", side: "center", annotationConfidence: "certain")
+        synced.syncStatus = .synced
+        let pending = ContactEventDraft.new(timestampMs: 2, contactType: "chest", side: "center", annotationConfidence: "certain")
+        // pending.syncStatus == .localOnly by default
+        let session = makeSession(drafts: [synced, pending])
+
+        XCTAssertEqual(engine.finishReadiness(for: session), .blocked([.localOnly]))
+    }
+
+    // AN2-T16: ContactEventBatchResult decodes "duplicate_skipped" wire key correctly.
+    func test_AN2_T16_batchResultDecodesDuplicateSkippedKey() throws {
+        let json = """
+        {
+          "created": 2,
+          "duplicate_skipped": 1,
+          "conflict": 0,
+          "results": [
+            {"device_event_id": "11111111-1111-1111-1111-111111111111", "status": "created", "event_id": "22222222-2222-2222-2222-222222222222", "detail": null},
+            {"device_event_id": "33333333-3333-3333-3333-333333333333", "status": "duplicate", "event_id": null, "detail": "exact_duplicate"}
+          ]
+        }
+        """.data(using: .utf8)!
+
+        let result = try JSONDecoder().decode(ContactEventBatchResult.self, from: json)
+
+        XCTAssertEqual(result.created, 2)
+        XCTAssertEqual(result.duplicateSkipped, 1)
+        XCTAssertEqual(result.conflict, 0)
+        XCTAssertEqual(result.results.count, 2)
+        XCTAssertEqual(result.results[1].status, "duplicate")
+        XCTAssertNil(result.results[1].eventId)
+    }
+
+    // MARK: — Helper
+
+    private func makeSession(drafts: [ContactEventDraft]) -> AnnotationSessionFile {
+        AnnotationSessionFile(
+            schemaVersion: 1, userId: 1, videoId: "vid-1",
+            taxonomyVersion: "v1", lastUpdatedAt: Date(),
+            drafts: drafts, checksum: ""
+        )
+    }
+}

--- a/ios/LFAEducationCenterTests/Juggling/ContactEventDraftTests.swift
+++ b/ios/LFAEducationCenterTests/Juggling/ContactEventDraftTests.swift
@@ -3,6 +3,7 @@ import XCTest
 
 // MARK: — AN2-T11..T16: ContactEventDraft model + FinishReadiness + wire decode
 
+@MainActor
 final class ContactEventDraftTests: XCTestCase {
 
     // AN2-T11: .new() produces a localOnly draft with sane defaults.

--- a/ios/LFAEducationCenterTests/Juggling/ContactEventDraftTests.swift
+++ b/ios/LFAEducationCenterTests/Juggling/ContactEventDraftTests.swift
@@ -90,6 +90,43 @@ final class ContactEventDraftTests: XCTestCase {
         XCTAssertNil(result.results[1].eventId)
     }
 
+    // AN2-T34: full Finish-blocked matrix — every blocking status, in isolation,
+    // blocks finish with exactly that status reported.
+    func test_AN2_T34_finishReadinessBlockedMatrix() {
+        let engine = AnnotationSyncEngine(apiClient: MockAnnotationAPIClient())
+        let blockingStatuses: [ContactEventSyncStatus] = [
+            .localOnly, .syncing, .updating, .deleting,
+            .retryPending, .conflicted, .needsReconciliation,
+        ]
+
+        for status in blockingStatuses {
+            var draft = ContactEventDraft.new(timestampMs: 1, contactType: "head", side: "center", annotationConfidence: "certain")
+            draft.syncStatus = status
+            let session = makeSession(drafts: [draft])
+
+            XCTAssertEqual(
+                engine.finishReadiness(for: session), .blocked([status]),
+                "status \(status) must block finish"
+            )
+        }
+    }
+
+    // AN2-T35: a failedPermanent active event does NOT block finish — it
+    // requires user resolution but finish proceeds with the remaining events.
+    func test_AN2_T35_finishReadinessNotBlockedByFailedPermanent() {
+        let engine = AnnotationSyncEngine(apiClient: MockAnnotationAPIClient())
+        var failed = ContactEventDraft.new(timestampMs: 1, contactType: "head", side: "center", annotationConfidence: "certain")
+        failed.syncStatus = .failedPermanent
+
+        let zeroSession = makeSession(drafts: [failed])
+        XCTAssertEqual(engine.finishReadiness(for: zeroSession), .readyZero)
+
+        var synced = ContactEventDraft.new(timestampMs: 2, contactType: "chest", side: "center", annotationConfidence: "certain")
+        synced.syncStatus = .synced
+        let withSyncedSession = makeSession(drafts: [failed, synced])
+        XCTAssertEqual(engine.finishReadiness(for: withSyncedSession), .readyWithCount(1))
+    }
+
     // MARK: — Helper
 
     private func makeSession(drafts: [ContactEventDraft]) -> AnnotationSessionFile {

--- a/ios/LFAEducationCenterTests/Juggling/ContactTaxonomyTests.swift
+++ b/ios/LFAEducationCenterTests/Juggling/ContactTaxonomyTests.swift
@@ -1,0 +1,79 @@
+import XCTest
+import CryptoKit
+@testable import LFAEducationCenter
+
+// MARK: — AN2-T01..T04: Taxonomy bundling, decode, and validation
+//
+// Files are located relative to #filePath rather than via Bundle.main —
+// the unit test target does not register the iOS Resources bundle, and the
+// authoritative drift check (bundled copy == dataset source) is owned by
+// scripts/check_taxonomy_bundle_drift.py in CI. These tests verify the
+// bundled JSON decodes and validates correctly, plus the checksum constant
+// is consistent with the file actually shipped.
+
+final class ContactTaxonomyTests: XCTestCase {
+
+    // ios/LFAEducationCenterTests/Juggling/ContactTaxonomyTests.swift
+    //   → ../../LFAEducationCenter/Juggling/Annotation/Resources/contact_types_v1.json
+    private static var bundledJSONURL: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()                  // .../Juggling
+            .deletingLastPathComponent()                  // .../LFAEducationCenterTests
+            .deletingLastPathComponent()                  // .../ios
+            .appendingPathComponent("LFAEducationCenter/Juggling/Annotation/Resources/contact_types_v1.json")
+    }
+
+    // AN2-T01: bundled checksum constant matches the bundled file on disk.
+    func test_AN2_T01_bundledChecksumMatchesShippedFile() throws {
+        let data = try Data(contentsOf: Self.bundledJSONURL)
+        let digest = Insecure.MD5.hash(data: data)
+        let hex = digest.map { String(format: "%02x", $0) }.joined()
+
+        XCTAssertEqual(hex, ContactTaxonomyStore.bundledChecksum,
+                        "Bundled contact_types_v1.json drifted from ContactTaxonomyStore.bundledChecksum — run scripts/check_taxonomy_bundle_drift.py")
+    }
+
+    // AN2-T02: bundled JSON decodes with correct version / counts.
+    func test_AN2_T02_decodeBundledHasCorrectCounts() throws {
+        let data = try Data(contentsOf: Self.bundledJSONURL)
+        let doc = try ContactTaxonomyStore.decodeAndValidate(data)
+
+        XCTAssertEqual(doc.taxonomyVersion, "v1")
+        XCTAssertEqual(doc.totalCount, 18)
+        XCTAssertEqual(doc.stableCount, 17)
+        XCTAssertEqual(doc.allKeys.count, 18)
+        XCTAssertEqual(doc.stableKeys.count, 17)
+    }
+
+    // AN2-T03: custom_other present, thigh forbidden.
+    func test_AN2_T03_customOtherPresentThighForbidden() throws {
+        let data = try Data(contentsOf: Self.bundledJSONURL)
+        let doc = try ContactTaxonomyStore.decodeAndValidate(data)
+
+        XCTAssertTrue(doc.allKeys.contains("custom_other"))
+        XCTAssertFalse(doc.allKeys.contains("thigh"))
+
+        let customOther = doc.groups
+            .flatMap(\.contactTypes)
+            .first { $0.key == "custom_other" }
+        XCTAssertNotNil(customOther)
+        XCTAssertNil(customOther?.side)
+        XCTAssertEqual(customOther?.sidePolicy, "explicit_required")
+        XCTAssertFalse(customOther?.isStable ?? true)
+    }
+
+    // AN2-T04: validation rejects a taxonomy with the wrong total_count.
+    func test_AN2_T04_invalidTotalCountThrows() throws {
+        let validData = try Data(contentsOf: Self.bundledJSONURL)
+        var json = try JSONSerialization.jsonObject(with: validData) as! [String: Any]
+        json["total_count"] = 99
+        let invalidData = try JSONSerialization.data(withJSONObject: json)
+
+        XCTAssertThrowsError(try ContactTaxonomyStore.decodeAndValidate(invalidData)) { error in
+            guard case TaxonomyError.invalidTotalCount(let n) = error else {
+                return XCTFail("Expected invalidTotalCount, got \(error)")
+            }
+            XCTAssertEqual(n, 99)
+        }
+    }
+}

--- a/ios/LFAEducationCenterTests/Juggling/ContactTaxonomyTests.swift
+++ b/ios/LFAEducationCenterTests/Juggling/ContactTaxonomyTests.swift
@@ -11,6 +11,7 @@ import CryptoKit
 // bundled JSON decodes and validates correctly, plus the checksum constant
 // is consistent with the file actually shipped.
 
+@MainActor
 final class ContactTaxonomyTests: XCTestCase {
 
     // ios/LFAEducationCenterTests/Juggling/ContactTaxonomyTests.swift

--- a/ios/LFAEducationCenterTests/Juggling/JugglingAnnotationViewModelTests.swift
+++ b/ios/LFAEducationCenterTests/Juggling/JugglingAnnotationViewModelTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+@testable import LFAEducationCenter
+
+// MARK: — AN2-T36..T37: JugglingAnnotationViewModel finish() flow
+
+@MainActor
+final class JugglingAnnotationViewModelTests: XCTestCase {
+
+    private var tempDir: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("an2_viewmodel_tests_\(UUID().uuidString)", isDirectory: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempDir)
+        tempDir = nil
+        super.tearDown()
+    }
+
+    private func makeViewModel(apiClient: MockAnnotationAPIClient) -> JugglingAnnotationViewModel {
+        JugglingAnnotationViewModel(
+            userId: 1,
+            videoId: "vid-1",
+            apiClient: apiClient,
+            taxonomyStore: ContactTaxonomyStore(authManager: AuthManager(), cacheDirectory: tempDir),
+            localStore: LocalAnnotationStore(baseDirectory: tempDir)
+        )
+    }
+
+    // AN2-T36: zero active events → finish() calls confirm_zero_contacts=true
+    // and clears the local session on success.
+    func test_AN2_T36_finishWithZeroContactsCallsConfirmZeroAndClearsSession() async {
+        let mock = MockAnnotationAPIClient()
+        mock.finishAnnotationResult = .success(FinishAnnotationOut(
+            videoId: "vid-1", annotationStatus: "human_review_pending",
+            totalJugglingCount: 0, contactEventCount: 0, annotationFinishedAt: Date()
+        ))
+
+        let vm = makeViewModel(apiClient: mock)
+        await vm.onAppear()
+        XCTAssertNotNil(vm.session)
+
+        await vm.finish()
+
+        XCTAssertNil(vm.finishError)
+        XCTAssertEqual(vm.finishResult?.contactEventCount, 0)
+        XCTAssertNil(vm.session, "session must be cleared after a successful finish")
+    }
+
+    // AN2-T37: finishAnnotation throws a permanent API error → finishError
+    // is set to its description; session is preserved so the user can retry.
+    func test_AN2_T37_finishMapsPermanentApiErrorToFinishError() async {
+        let mock = MockAnnotationAPIClient()
+        mock.finishAnnotationResult = .failure(AnnotationAPIError.permanent(code: 403, detail: "consent_blocked"))
+
+        let vm = makeViewModel(apiClient: mock)
+        await vm.onAppear()
+
+        await vm.finish()
+
+        XCTAssertNotNil(vm.finishError)
+        XCTAssertEqual(vm.finishError, AnnotationAPIError.permanent(code: 403, detail: "consent_blocked").errorDescription)
+        XCTAssertNotNil(vm.session, "session must be preserved when finish fails so the user can retry")
+        XCTAssertNil(vm.finishResult)
+    }
+}

--- a/ios/LFAEducationCenterTests/Juggling/LocalAnnotationStoreTests.swift
+++ b/ios/LFAEducationCenterTests/Juggling/LocalAnnotationStoreTests.swift
@@ -1,0 +1,128 @@
+import XCTest
+@testable import LFAEducationCenter
+
+// MARK: — AN2-T05..T10: LocalAnnotationStore persistence, isolation, recovery
+
+@MainActor
+final class LocalAnnotationStoreTests: XCTestCase {
+
+    private var tempDir: URL!
+    private var store: LocalAnnotationStore!
+
+    override func setUp() {
+        super.setUp()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("an2_local_store_tests_\(UUID().uuidString)", isDirectory: true)
+        store = LocalAnnotationStore(baseDirectory: tempDir)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempDir)
+        store = nil
+        tempDir = nil
+        super.tearDown()
+    }
+
+    // AN2-T05: no file on disk → .empty
+    func test_AN2_T05_loadWithNoFileReturnsEmpty() {
+        switch store.load(userId: 1, videoId: "vid-1") {
+        case .empty: break
+        default: XCTFail("Expected .empty")
+        }
+    }
+
+    // AN2-T06: save then load round-trips drafts including computed checksum.
+    func test_AN2_T06_saveAndLoadRoundTrip() throws {
+        var session = store.emptySession(userId: 1, videoId: "vid-1")
+        let draft = ContactEventDraft.new(
+            timestampMs: 1234, contactType: "right_instep",
+            side: "right", annotationConfidence: "certain"
+        )
+        session.drafts.append(draft)
+        try store.save(session: &session)
+        XCTAssertFalse(session.checksum.isEmpty)
+
+        switch store.load(userId: 1, videoId: "vid-1") {
+        case .loaded(let loaded):
+            XCTAssertEqual(loaded.drafts.count, 1)
+            XCTAssertEqual(loaded.drafts[0].deviceEventId, draft.deviceEventId)
+            XCTAssertEqual(loaded.drafts[0].contactType, "right_instep")
+            XCTAssertEqual(loaded.checksum, session.checksum)
+        default:
+            XCTFail("Expected .loaded")
+        }
+    }
+
+    // AN2-T07: userId is part of the storage key — user A never sees user B's drafts.
+    func test_AN2_T07_userIsolation() throws {
+        var sessionUser1 = store.emptySession(userId: 1, videoId: "vid-shared")
+        sessionUser1.drafts.append(.new(timestampMs: 1, contactType: "head", side: "center", annotationConfidence: "certain"))
+        try store.save(session: &sessionUser1)
+
+        // User 2 with the same videoId sees no session.
+        switch store.load(userId: 2, videoId: "vid-shared") {
+        case .empty: break
+        default: XCTFail("Expected .empty for a different userId with the same videoId")
+        }
+
+        // User 1's session is unaffected.
+        switch store.load(userId: 1, videoId: "vid-shared") {
+        case .loaded(let loaded): XCTAssertEqual(loaded.drafts.count, 1)
+        default: XCTFail("Expected .loaded for user 1")
+        }
+    }
+
+    // AN2-T08: undecodable file → quarantined, original bytes preserved.
+    func test_AN2_T08_corruptFileIsQuarantinedNotDeleted() throws {
+        let fileURL = tempDir
+            .appendingPathComponent("3", isDirectory: true)
+            .appendingPathComponent("vid-corrupt.json")
+        try FileManager.default.createDirectory(at: fileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let garbage = Data("{ not valid json".utf8)
+        try garbage.write(to: fileURL)
+
+        switch store.load(userId: 3, videoId: "vid-corrupt") {
+        case .quarantined(let quarantineURL, _):
+            XCTAssertFalse(FileManager.default.fileExists(atPath: fileURL.path), "original path should be vacated")
+            XCTAssertTrue(FileManager.default.fileExists(atPath: quarantineURL.path), "quarantine copy must exist")
+            let preserved = try Data(contentsOf: quarantineURL)
+            XCTAssertEqual(preserved, garbage, "quarantine must preserve original bytes")
+        default:
+            XCTFail("Expected .quarantined")
+        }
+    }
+
+    // AN2-T09: checksum mismatch (tampered drafts) → quarantined.
+    func test_AN2_T09_checksumMismatchIsQuarantined() throws {
+        var session = store.emptySession(userId: 4, videoId: "vid-tamper")
+        session.drafts.append(.new(timestampMs: 1, contactType: "head", side: "center", annotationConfidence: "certain"))
+        try store.save(session: &session)
+
+        // Tamper with the on-disk file: corrupt the checksum field only.
+        let fileURL = tempDir
+            .appendingPathComponent("4", isDirectory: true)
+            .appendingPathComponent("vid-tamper.json")
+        var raw = try JSONSerialization.jsonObject(with: try Data(contentsOf: fileURL)) as! [String: Any]
+        raw["checksum"] = "0000000000000000000000000000000000000000000000000000000000000000"
+        try JSONSerialization.data(withJSONObject: raw).write(to: fileURL)
+
+        switch store.load(userId: 4, videoId: "vid-tamper") {
+        case .quarantined: break
+        default: XCTFail("Expected .quarantined on checksum mismatch")
+        }
+    }
+
+    // AN2-T10: delete removes the session file; subsequent load is .empty.
+    func test_AN2_T10_deleteRemovesFile() throws {
+        var session = store.emptySession(userId: 5, videoId: "vid-finish")
+        session.drafts.append(.new(timestampMs: 1, contactType: "head", side: "center", annotationConfidence: "certain"))
+        try store.save(session: &session)
+
+        store.delete(userId: 5, videoId: "vid-finish")
+
+        switch store.load(userId: 5, videoId: "vid-finish") {
+        case .empty: break
+        default: XCTFail("Expected .empty after delete")
+        }
+    }
+}

--- a/scripts/check_taxonomy_bundle_drift.py
+++ b/scripts/check_taxonomy_bundle_drift.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Fail if the iOS-bundled juggling taxonomy diverges from the dataset source.
+
+AN-2: ContactTaxonomyStore.bundledChecksum (Swift) and the bundled copy of
+contact_types_v1.json must stay byte-identical to
+datasets/juggling/contact_types_v1.json. CI runs this script; any taxonomy
+edit must update the bundled copy AND bundledChecksum in the same commit.
+
+Usage: python scripts/check_taxonomy_bundle_drift.py
+Exit codes: 0 = in sync, 1 = drift detected, 2 = file missing.
+"""
+import hashlib
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SOURCE_PATH = REPO_ROOT / "datasets" / "juggling" / "contact_types_v1.json"
+BUNDLED_PATH = (
+    REPO_ROOT / "ios" / "LFAEducationCenter" / "Juggling" / "Annotation"
+    / "Resources" / "contact_types_v1.json"
+)
+STORE_SWIFT_PATH = (
+    REPO_ROOT / "ios" / "LFAEducationCenter" / "Juggling" / "Annotation"
+    / "ContactTaxonomyStore.swift"
+)
+
+
+def md5_of(path: Path) -> str:
+    return hashlib.md5(path.read_bytes()).hexdigest()
+
+
+def extract_bundled_checksum_constant(swift_source: str) -> str:
+    match = re.search(
+        r'bundledChecksum\s*=\s*"([0-9a-f]{32})"', swift_source
+    )
+    if not match:
+        raise ValueError("bundledChecksum constant not found in ContactTaxonomyStore.swift")
+    return match.group(1)
+
+
+def main() -> int:
+    for path in (SOURCE_PATH, BUNDLED_PATH, STORE_SWIFT_PATH):
+        if not path.exists():
+            print(f"MISSING: {path}")
+            return 2
+
+    source_md5 = md5_of(SOURCE_PATH)
+    bundled_md5 = md5_of(BUNDLED_PATH)
+    constant_md5 = extract_bundled_checksum_constant(STORE_SWIFT_PATH.read_text())
+
+    errors = []
+    if source_md5 != bundled_md5:
+        errors.append(
+            f"Bundled copy differs from dataset source:\n"
+            f"  source : {source_md5}  {SOURCE_PATH.relative_to(REPO_ROOT)}\n"
+            f"  bundled: {bundled_md5}  {BUNDLED_PATH.relative_to(REPO_ROOT)}"
+        )
+    if source_md5 != constant_md5:
+        errors.append(
+            f"ContactTaxonomyStore.bundledChecksum is stale:\n"
+            f"  source  : {source_md5}\n"
+            f"  constant: {constant_md5}  ({STORE_SWIFT_PATH.relative_to(REPO_ROOT)})"
+        )
+
+    if errors:
+        print("TAXONOMY BUNDLE DRIFT DETECTED:\n")
+        print("\n\n".join(errors))
+        return 1
+
+    print(f"OK — bundled taxonomy matches dataset source (md5={source_md5})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

AN-2: the iOS data and synchronization layer for the juggling contact-event
annotation feature (AN-1 backend, PR #295, merged to main). No SwiftUI
annotation UI — that is AN-3, gated on separate approval.

- **Taxonomy bundle + ETag cache**: `ContactTaxonomy.swift` +
  `ContactTaxonomyStore` ship a bundled `contact_types_v1.json`
  (MD5 `7198de62733493537450275dadc6f445`), refresh via ETag against
  `GET /api/v1/users/me/juggling/taxonomy`, with silent fallback to the
  bundled copy on network failure. `scripts/check_taxonomy_bundle_drift.py`
  guards the bundle against drift from the dataset source of truth.
- **API client**: `ContactEventResponse.swift` + `JugglingAnnotationAPIClient`
  (+ `JugglingAnnotationAPIClientProtocol`) cover all 5 AN-1 endpoints
  (taxonomy, contacts CRUD, batch, finish). `APIClient`/`AuthManager` gained
  raw `get/post/patch` HTTP helpers needed for the contact-event wire format.
- **Local atomic store**: `ContactEventDraft` (10-state sync machine:
  `localOnly, syncing, synced, updating, deleting, deleted, failedPermanent,
  retryPending, conflicted, needsReconciliation`) + `LocalAnnotationStore`
  — atomic writes, SHA-256 checksum, per-user + per-video isolation.
- **Quarantine/recovery**: corrupt or checksum-mismatched session files are
  quarantined (renamed aside), never silently deleted.
- **Sync state machine + reconciliation**: `AnnotationSyncEngine` —
  `pushCreate`/`pushPatch`/`pushDelete`/`reconcile`/`finishReadiness`.
- **Retry policy**: retryable errors get up to 3 retries at 2s/4s/8s before
  `failedPermanent`; 422/idempotency-conflict are permanent (no retry);
  PATCH/DELETE timeouts go to `needsReconciliation` (outcome unknown, not
  idempotent) and are resolved by `reconcile`.
- **Finish guard**: `JugglingAnnotationViewModel.finish()` is blocked while
  any of the 7 blocking sync statuses are present; `failedPermanent` does
  not block; zero active events triggers `confirm_zero_contacts=true` and
  clears the local session on success; a permanent API error on finish is
  surfaced via `finishError` with the session preserved for retry.
- **Xcode test target restoration**: `LFAEducationCenterTests` unit-test
  bundle target re-added to `project.pbxproj` (was missing entirely), with
  all 8 AN-2 production sources + the taxonomy resource wired into the app
  target, and 6 test files wired into the new test target.

## Build / test evidence

- Debug simulator build: **BUILD SUCCEEDED** (0 AN-2-scoped warnings)
- Release simulator build: **BUILD SUCCEEDED** (0 AN-2-scoped warnings)
- Full iOS unit suite: **56/56 PASS**
- AN-2 suite (taxonomy, local store, drafts, sync engine, view model):
  **37/37 PASS** (25 original + 12 new closing all 15 sync/reconciliation/
  Finish-guard gaps from the integration plan)
- Taxonomy resource present in both built `.app` bundles, checksum matches
  dataset source of truth (`7198de62733493537450275dadc6f445`)

Full evidence: `docs/AN2_XCODE_INTEGRATION_VALIDATION_REPORT.md` and
`docs/AN2_IMPLEMENTATION_REPORT.md`.

## Explicitly out of scope

- No SwiftUI annotation screen / picker / timeline / video overlay (AN-3,
  separate approval required)
- No backend or API changes (`app/`, `tests/snapshots/openapi_snapshot.json`
  untouched)
- AN-3 development has not started

## Known gap

3 pre-existing Biometric test files
(`BiometricPhotoCaptureTests.swift`, `SpikeLivenessViewModelPR2Tests.swift`,
`FaceGestureDetectorTests.swift`) are excluded from the new test target —
they predate AN-2 and fail to compile against current production code /
the active Swift 6 toolchain for reasons unrelated to AN-2. See
`docs/AN2_XCODE_INTEGRATION_VALIDATION_REPORT.md` §4 for detail.

## Test plan

- [x] Debug simulator build SUCCEEDED
- [x] Release simulator build SUCCEEDED
- [x] Full unit suite 56/56 PASS
- [x] AN-2 unit suite 37/37 PASS
- [x] Taxonomy bundle drift guard OK
- [x] Taxonomy resource present + checksum-correct in built app bundles

🤖 Generated with [Claude Code](https://claude.com/claude-code)