### PR TITLE
feat(ios): add juggling annotation edit and playback foundation

### DIFF
--- a/ios/LFAEducationCenter.xcodeproj/project.pbxproj
+++ b/ios/LFAEducationCenter.xcodeproj/project.pbxproj
@@ -109,6 +109,10 @@
 		AA100004000000000000007 /* JugglingAnnotationAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA100003000000000000007 /* JugglingAnnotationAPIClient.swift */; };
 		AA100004000000000000008 /* JugglingAnnotationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA100003000000000000008 /* JugglingAnnotationViewModel.swift */; };
 		AA100004000000000000009 /* contact_types_v1.json in Resources */ = {isa = PBXBuildFile; fileRef = AA100003000000000000009 /* contact_types_v1.json */; };
+		AA100004000000000000010 /* PlaybackController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA100003000000000000010 /* PlaybackController.swift */; };
+		CC400004000000000000010 /* EditEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC300003000000000000010 /* EditEventTests.swift */; };
+		CC400004000000000000011 /* FlushPendingEditTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC300003000000000000011 /* FlushPendingEditTests.swift */; };
+		CC400004000000000000012 /* PlaybackControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC300003000000000000012 /* PlaybackControllerTests.swift */; };
 		CC400004000000000000001 /* JugglingVideoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC300003000000000000001 /* JugglingVideoTests.swift */; };
 		CC400004000000000000005 /* ContactTaxonomyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC300003000000000000005 /* ContactTaxonomyTests.swift */; };
 		CC400004000000000000006 /* LocalAnnotationStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC300003000000000000006 /* LocalAnnotationStoreTests.swift */; };
@@ -222,6 +226,10 @@
 		AA100003000000000000007 /* JugglingAnnotationAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JugglingAnnotationAPIClient.swift; sourceTree = "<group>"; };
 		AA100003000000000000008 /* JugglingAnnotationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JugglingAnnotationViewModel.swift; sourceTree = "<group>"; };
 		AA100003000000000000009 /* contact_types_v1.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = contact_types_v1.json; sourceTree = "<group>"; };
+		AA100003000000000000010 /* PlaybackController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackController.swift; sourceTree = "<group>"; };
+		CC300003000000000000010 /* EditEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditEventTests.swift; sourceTree = "<group>"; };
+		CC300003000000000000011 /* FlushPendingEditTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlushPendingEditTests.swift; sourceTree = "<group>"; };
+		CC300003000000000000012 /* PlaybackControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackControllerTests.swift; sourceTree = "<group>"; };
 		CC300003000000000000001 /* JugglingVideoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JugglingVideoTests.swift; sourceTree = "<group>"; };
 		CC300003000000000000005 /* ContactTaxonomyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactTaxonomyTests.swift; sourceTree = "<group>"; };
 		CC300003000000000000006 /* LocalAnnotationStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalAnnotationStoreTests.swift; sourceTree = "<group>"; };
@@ -496,9 +504,18 @@
 				20CD58654D76D5278A5E5B62 /* JugglingVideoListViewModel.swift */,
 				E075CE337E219F48D39CBDFA /* JugglingPlayerView.swift */,
 				AA100002000000000000001 /* Annotation */,
+				AA100002000000000000003 /* Playback */,
 			);
 			name = Juggling;
 			path = Juggling;
+			sourceTree = "<group>";
+		};
+		AA100002000000000000003 /* Playback */ = {
+			isa = PBXGroup;
+			children = (
+				AA100003000000000000010 /* PlaybackController.swift */,
+			);
+			path = Playback;
 			sourceTree = "<group>";
 		};
 		AA100002000000000000001 /* Annotation */ = {
@@ -542,6 +559,9 @@
 				CC300003000000000000007 /* ContactEventDraftTests.swift */,
 				CC300003000000000000008 /* AnnotationSyncEngineTests.swift */,
 				CC300003000000000000009 /* JugglingAnnotationViewModelTests.swift */,
+				CC300003000000000000010 /* EditEventTests.swift */,
+				CC300003000000000000011 /* FlushPendingEditTests.swift */,
+				CC300003000000000000012 /* PlaybackControllerTests.swift */,
 			);
 			path = Juggling;
 			sourceTree = "<group>";
@@ -761,6 +781,7 @@
 				AA100004000000000000006 /* AnnotationSyncEngine.swift in Sources */,
 				AA100004000000000000007 /* JugglingAnnotationAPIClient.swift in Sources */,
 				AA100004000000000000008 /* JugglingAnnotationViewModel.swift in Sources */,
+				AA100004000000000000010 /* PlaybackController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -774,6 +795,9 @@
 				CC400004000000000000007 /* ContactEventDraftTests.swift in Sources */,
 				CC400004000000000000008 /* AnnotationSyncEngineTests.swift in Sources */,
 				CC400004000000000000009 /* JugglingAnnotationViewModelTests.swift in Sources */,
+				CC400004000000000000010 /* EditEventTests.swift in Sources */,
+				CC400004000000000000011 /* FlushPendingEditTests.swift in Sources */,
+				CC400004000000000000012 /* PlaybackControllerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/LFAEducationCenter/Juggling/Annotation/AnnotationSyncEngine.swift
+++ b/ios/LFAEducationCenter/Juggling/Annotation/AnnotationSyncEngine.swift
@@ -35,6 +35,8 @@ final class AnnotationSyncEngine {
     // Pushes every localOnly / retryPending draft to the server.
     // Drafts that were deleted locally before ever syncing are marked
     // .deleted without a network call (nothing exists server-side).
+    // AN-3A: also pushes .updating drafts (events that were edited after
+    // reaching .synced — see editEvent on JugglingAnnotationViewModel).
     // Mutates session.drafts in place; caller persists afterwards.
     func flushPending(session: inout AnnotationSessionFile) async {
         for index in session.drafts.indices {
@@ -55,6 +57,33 @@ final class AnnotationSyncEngine {
             let draft = session.drafts[index]
             guard draft.deletedLocally, draft.syncStatus == .synced, draft.serverEventId != nil else { continue }
             session.drafts[index] = await pushDelete(draft: draft, videoId: session.videoId)
+        }
+
+        // Edited drafts: .updating means a local edit is pending a PATCH.
+        // If the draft was also deleted before the PATCH was sent, push a
+        // DELETE instead (the user edited then immediately removed the event).
+        for index in session.drafts.indices {
+            let draft = session.drafts[index]
+            guard draft.syncStatus == .updating else { continue }
+            // pushPatch handles the serverEventId == nil defensive case internally
+            // (returns .failedPermanent with reason "patch_without_server_id").
+            if draft.deletedLocally {
+                session.drafts[index] = await pushDelete(draft: draft, videoId: session.videoId)
+            } else {
+                let request = ContactEventPatchRequest(
+                    version:              draft.version,
+                    contactType:          draft.contactType,
+                    annotationConfidence: draft.annotationConfidence,
+                    side:                 draft.side,
+                    customLabel:          draft.customLabel,
+                    customDescription:    draft.customDescription
+                )
+                session.drafts[index] = await pushPatch(
+                    draft:   draft,
+                    videoId: session.videoId,
+                    request: request
+                )
+            }
         }
     }
 
@@ -219,6 +248,19 @@ final class AnnotationSyncEngine {
         case .synced, .deleted, .failedPermanent:
             return false
         }
+    }
+
+    // MARK: — Conflict resolution (AN-3A)
+
+    // Applies authoritative server state to a .conflicted draft, transitioning
+    // it to .synced with the server's current version. Used by
+    // JugglingAnnotationViewModel.resolveConflict() which fetches the server
+    // event via listContacts before calling this.
+    func resolveConflictedDraft(
+        draft:       ContactEventDraft,
+        serverEvent: ContactEventOut
+    ) -> ContactEventDraft {
+        applyServerState(to: draft, from: serverEvent)
     }
 
     // MARK: — Private helpers

--- a/ios/LFAEducationCenter/Juggling/Annotation/JugglingAnnotationViewModel.swift
+++ b/ios/LFAEducationCenter/Juggling/Annotation/JugglingAnnotationViewModel.swift
@@ -141,6 +141,115 @@ final class JugglingAnnotationViewModel: ObservableObject {
         return draft
     }
 
+    // Edits an existing draft in-place. Permitted statuses and resulting transitions:
+    //   .localOnly     → stays .localOnly      (edit before first POST, included in pushCreate)
+    //   .retryPending  → .localOnly            (reset retry, POST the updated payload)
+    //   .synced        → .updating             (PATCH will be sent on next flushPending)
+    //   .failedPermanent (no serverEventId, not idempotency_conflict) → .localOnly  (retry POST)
+    //   .failedPermanent (serverEventId != nil, not idempotency_conflict) → .updating (retry PATCH)
+    //
+    // Blocked (no state change):
+    //   .failedPermanent with idempotency_conflict reason → caller must use resolveConflict
+    //   .conflicted, .needsReconciliation → caller must resolve / reconcile first
+    //   .syncing, .updating, .deleting    → in-flight, cannot edit
+    //   .deleted                          → unreachable from active timeline
+    //
+    // Invariants: deviceEventId (let) never changes. version is NOT mutated here —
+    // the PATCH carries the last-known-good version; applyServerState updates it on success.
+    @discardableResult
+    func editEvent(
+        deviceEventId:        UUID,
+        contactType:          String,
+        side:                 String?,
+        annotationConfidence: String,
+        customLabel:          String? = nil,
+        customDescription:    String? = nil
+    ) -> Bool {
+        guard var current = session,
+              let index = current.drafts.firstIndex(where: { $0.deviceEventId == deviceEventId })
+        else { return false }
+
+        var draft = current.drafts[index]
+
+        switch draft.syncStatus {
+        case .localOnly:
+            draft.contactType          = contactType
+            draft.side                 = side
+            draft.annotationConfidence = annotationConfidence
+            draft.customLabel          = customLabel
+            draft.customDescription    = customDescription
+
+        case .retryPending:
+            draft.contactType          = contactType
+            draft.side                 = side
+            draft.annotationConfidence = annotationConfidence
+            draft.customLabel          = customLabel
+            draft.customDescription    = customDescription
+            draft.syncStatus           = .localOnly
+            draft.retryCount           = 0
+            draft.failureReason        = nil
+
+        case .synced:
+            draft.contactType          = contactType
+            draft.side                 = side
+            draft.annotationConfidence = annotationConfidence
+            draft.customLabel          = customLabel
+            draft.customDescription    = customDescription
+            draft.syncStatus           = .updating
+
+        case .failedPermanent:
+            // idempotency_conflict cannot be fixed by editing alone — requires resolveConflict
+            if let reason = draft.failureReason, reason.hasPrefix("idempotency_conflict:") {
+                return false
+            }
+            draft.contactType          = contactType
+            draft.side                 = side
+            draft.annotationConfidence = annotationConfidence
+            draft.customLabel          = customLabel
+            draft.customDescription    = customDescription
+            draft.failureReason        = nil
+            draft.retryCount           = 0
+            draft.syncStatus           = draft.serverEventId != nil ? .updating : .localOnly
+
+        case .conflicted, .needsReconciliation, .syncing, .updating, .deleting, .deleted:
+            return false
+        }
+
+        current.drafts[index] = draft
+        try? localStore.save(session: &current)
+        session = current
+        return true
+    }
+
+    // Resolves a .conflicted draft by fetching the authoritative server state via
+    // GET /contacts and applying it locally (version + all server fields).
+    // After resolution the draft is .synced — the user can then re-edit it if desired.
+    // If the draft is absent from the server response it is treated as .deleted.
+    // On network error the draft stays .conflicted so the caller can retry.
+    func resolveConflict(deviceEventId: UUID) async {
+        guard var current = session,
+              let index = current.drafts.firstIndex(where: { $0.deviceEventId == deviceEventId }),
+              current.drafts[index].syncStatus == .conflicted
+        else { return }
+
+        do {
+            let list = try await apiClient.listContacts(videoId: videoId)
+            if let serverEvent = list.events.first(where: { $0.deviceEventId == deviceEventId }) {
+                current.drafts[index] = syncEngine.resolveConflictedDraft(
+                    draft:       current.drafts[index],
+                    serverEvent: serverEvent
+                )
+            } else {
+                current.drafts[index].syncStatus    = .deleted
+                current.drafts[index].failureReason = nil
+            }
+            try? localStore.save(session: &current)
+            session = current
+        } catch {
+            // Network error: draft remains .conflicted; UI should offer "Retry resolve".
+        }
+    }
+
     // Marks a draft for deletion. Drafts never synced are removed locally
     // immediately; synced drafts are flagged for a DELETE push on next flush.
     func markDeleted(deviceEventId: UUID) {

--- a/ios/LFAEducationCenter/Juggling/Playback/PlaybackController.swift
+++ b/ios/LFAEducationCenter/Juggling/Playback/PlaybackController.swift
@@ -22,7 +22,7 @@ enum PlaybackRate: Float, CaseIterable, Identifiable {
 // MARK: — PlayerSeekable (testability seam; AVPlayer conforms via extension below)
 
 protocol PlayerSeekable: AnyObject {
-    var currentTime: CMTime { get }
+    func currentTime() -> CMTime  // matches AVPlayer's existing method signature
     var rate: Float { get set }
     func seek(to time: CMTime, toleranceBefore: CMTime, toleranceAfter: CMTime)
     func play()
@@ -77,13 +77,14 @@ final class PlaybackController: ObservableObject {
 
     // Call once the authenticated temp-file URL is ready (after download).
     // Reads nominalFrameRate / minFrameDuration from the asset before playback starts.
-    func loadAsset(_ asset: AVAsset) async {
-        frameDuration = await Self.effectiveFrameDuration(for: asset)
+    func loadAsset(_ asset: AVAsset) {
+        frameDuration = Self.effectiveFrameDuration(for: asset)
         if let avp = player as? AVPlayer {
             let item = AVPlayerItem(asset: asset)
             avp.replaceCurrentItem(with: item)
         }
-        if let dur = try? await asset.load(.duration) {
+        let dur = asset.duration
+        if dur.isValid && dur > .zero {
             duration = dur
         }
     }
@@ -91,13 +92,14 @@ final class PlaybackController: ObservableObject {
     // MARK: — Transport controls
 
     func play() {
+        player.play()
         player.rate = selectedRate.rawValue
         isPlaying   = true
     }
 
     func pause() {
-        player.rate = 0
-        isPlaying   = false
+        player.pause()
+        isPlaying = false
     }
 
     func togglePlayPause() {
@@ -114,7 +116,7 @@ final class PlaybackController: ObservableObject {
     // Frame-accurate step — always pauses first. Clamps to [0, duration].
     func stepForward() {
         pause()
-        let stepped = player.currentTime + frameDuration
+        let stepped = player.currentTime() + frameDuration
         let clamped = duration > .zero ? min(stepped, duration) : stepped
         player.seek(to: clamped, toleranceBefore: .zero, toleranceAfter: .zero)
         currentTimestampMs = clamped.asMilliseconds
@@ -122,7 +124,7 @@ final class PlaybackController: ObservableObject {
 
     func stepBackward() {
         pause()
-        let stepped = player.currentTime - frameDuration
+        let stepped = player.currentTime() - frameDuration
         let clamped = max(.zero, stepped)
         player.seek(to: clamped, toleranceBefore: .zero, toleranceAfter: .zero)
         currentTimestampMs = clamped.asMilliseconds
@@ -155,14 +157,14 @@ final class PlaybackController: ObservableObject {
         return CMTime(value: 1, timescale: 30)
     }
 
-    // Async version used for production asset loading.
-    static func effectiveFrameDuration(for asset: AVAsset) async -> CMTime {
-        guard let track = try? await asset.loadTracks(withMediaType: .video).first else {
+    // Synchronous version used for production asset loading (iOS 14 compatible).
+    static func effectiveFrameDuration(for asset: AVAsset) -> CMTime {
+        guard let track = asset.tracks(withMediaType: .video).first else {
             return CMTime(value: 1, timescale: 30)
         }
-        let fps    = (try? await track.load(.nominalFrameRate)) ?? 0
-        let minDur = try? await track.load(.minFrameDuration)
-        return frameDuration(nominalFPS: fps, minFrameDuration: minDur)
+        let fps    = track.nominalFrameRate
+        let minDur = track.minFrameDuration
+        return frameDuration(nominalFPS: fps, minFrameDuration: minDur.isValid && minDur > .zero ? minDur : nil)
     }
 
     // MARK: — Private

--- a/ios/LFAEducationCenter/Juggling/Playback/PlaybackController.swift
+++ b/ios/LFAEducationCenter/Juggling/Playback/PlaybackController.swift
@@ -1,0 +1,192 @@
+import AVFoundation
+import Combine
+
+// MARK: — PlaybackRate
+
+enum PlaybackRate: Float, CaseIterable, Identifiable {
+    case quarter = 0.25
+    case half    = 0.5
+    case normal  = 1.0
+
+    var id: Float { rawValue }
+
+    var label: String {
+        switch self {
+        case .quarter: return "0.25×"
+        case .half:    return "0.5×"
+        case .normal:  return "1×"
+        }
+    }
+}
+
+// MARK: — PlayerSeekable (testability seam; AVPlayer conforms via extension below)
+
+protocol PlayerSeekable: AnyObject {
+    var currentTime: CMTime { get }
+    var rate: Float { get set }
+    func seek(to time: CMTime, toleranceBefore: CMTime, toleranceAfter: CMTime)
+    func play()
+    func pause()
+}
+
+extension AVPlayer: PlayerSeekable {}
+
+// MARK: — PlaybackController
+
+// Owns one AVPlayer (or mock PlayerSeekable in tests) and exposes
+// transport controls needed by the annotation screen:
+//   - play / pause / togglePlayPause
+//   - rate selection (0.25× / 0.5× / 1×)
+//   - frame-accurate step (forward / backward)
+//   - seek to a millisecond timestamp (for tap-to-seek from the event timeline)
+//   - periodic currentTimestampMs for the timestamp readout
+//
+// No rendering — pair with AVPlayerLayerView (UIViewRepresentable, added in AN-3B)
+// to display the video on screen.
+
+@MainActor
+final class PlaybackController: ObservableObject {
+
+    @Published private(set) var isPlaying:          Bool         = false
+    @Published private(set) var currentTimestampMs: Int          = 0
+    @Published private(set) var selectedRate:       PlaybackRate = .normal
+    @Published var duration: CMTime = .zero
+
+    // Set once when the asset loads; var (not private(set)) so tests can inject
+    // a specific frame duration without going through AVAsset loading.
+    var frameDuration: CMTime = CMTime(value: 1, timescale: 30)
+
+    private let player: PlayerSeekable
+    private var timeObserver: Any?
+
+    // Production init: uses a real AVPlayer.
+    init(player: PlayerSeekable = AVPlayer()) {
+        self.player = player
+        if let avp = player as? AVPlayer {
+            setupPeriodicObserver(avp)
+        }
+    }
+
+    deinit {
+        if let avp = player as? AVPlayer, let obs = timeObserver {
+            avp.removeTimeObserver(obs)
+        }
+    }
+
+    // MARK: — Asset loading
+
+    // Call once the authenticated temp-file URL is ready (after download).
+    // Reads nominalFrameRate / minFrameDuration from the asset before playback starts.
+    func loadAsset(_ asset: AVAsset) async {
+        frameDuration = await Self.effectiveFrameDuration(for: asset)
+        if let avp = player as? AVPlayer {
+            let item = AVPlayerItem(asset: asset)
+            avp.replaceCurrentItem(with: item)
+        }
+        if let dur = try? await asset.load(.duration) {
+            duration = dur
+        }
+    }
+
+    // MARK: — Transport controls
+
+    func play() {
+        player.rate = selectedRate.rawValue
+        isPlaying   = true
+    }
+
+    func pause() {
+        player.rate = 0
+        isPlaying   = false
+    }
+
+    func togglePlayPause() {
+        isPlaying ? pause() : play()
+    }
+
+    func setRate(_ rate: PlaybackRate) {
+        selectedRate = rate
+        if isPlaying {
+            player.rate = rate.rawValue
+        }
+    }
+
+    // Frame-accurate step — always pauses first. Clamps to [0, duration].
+    func stepForward() {
+        pause()
+        let stepped = player.currentTime + frameDuration
+        let clamped = duration > .zero ? min(stepped, duration) : stepped
+        player.seek(to: clamped, toleranceBefore: .zero, toleranceAfter: .zero)
+        currentTimestampMs = clamped.asMilliseconds
+    }
+
+    func stepBackward() {
+        pause()
+        let stepped = player.currentTime - frameDuration
+        let clamped = max(.zero, stepped)
+        player.seek(to: clamped, toleranceBefore: .zero, toleranceAfter: .zero)
+        currentTimestampMs = clamped.asMilliseconds
+    }
+
+    // Coarser timeline-driven seek (tap-to-seek); uses default tolerance for
+    // performance — precision is less critical than frame-step.
+    func seek(toTimestampMs ms: Int) {
+        let time = CMTime(value: CMTimeValue(ms), timescale: 1000)
+        player.seek(
+            to:              time,
+            toleranceBefore: .positiveInfinity,
+            toleranceAfter:  .positiveInfinity
+        )
+        currentTimestampMs = ms
+    }
+
+    // MARK: — Frame duration (static — directly unit-testable without AVAsset)
+
+    // Given raw track metadata values, returns the CMTime to seek per frame-step.
+    // Used by effectiveFrameDuration(for:) after the async AVAsset load, and
+    // by tests directly.
+    static func frameDuration(nominalFPS: Float, minFrameDuration: CMTime?) -> CMTime {
+        if nominalFPS > 0 {
+            return CMTime(seconds: 1.0 / Double(nominalFPS), preferredTimescale: 600)
+        }
+        if let min = minFrameDuration, min.isValid, min > .zero {
+            return min
+        }
+        return CMTime(value: 1, timescale: 30)
+    }
+
+    // Async version used for production asset loading.
+    static func effectiveFrameDuration(for asset: AVAsset) async -> CMTime {
+        guard let track = try? await asset.loadTracks(withMediaType: .video).first else {
+            return CMTime(value: 1, timescale: 30)
+        }
+        let fps    = (try? await track.load(.nominalFrameRate)) ?? 0
+        let minDur = try? await track.load(.minFrameDuration)
+        return frameDuration(nominalFPS: fps, minFrameDuration: minDur)
+    }
+
+    // MARK: — Private
+
+    private func setupPeriodicObserver(_ avPlayer: AVPlayer) {
+        let interval = CMTime(value: 1, timescale: 30)
+        timeObserver = avPlayer.addPeriodicTimeObserver(
+            forInterval: interval,
+            queue:        .main
+        ) { [weak self] time in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.currentTimestampMs = time.asMilliseconds
+                self.isPlaying          = self.player.rate != 0
+            }
+        }
+    }
+}
+
+// MARK: — CMTime helpers
+
+extension CMTime {
+    var asMilliseconds: Int {
+        guard isValid, !isIndefinite, !isNegativeInfinity, !isPositiveInfinity else { return 0 }
+        return Int(seconds * 1000)
+    }
+}

--- a/ios/LFAEducationCenterTests/Juggling/EditEventTests.swift
+++ b/ios/LFAEducationCenterTests/Juggling/EditEventTests.swift
@@ -1,0 +1,311 @@
+import XCTest
+@testable import LFAEducationCenter
+
+// MARK: — AN-3A: editEvent and resolveConflict state-machine tests (AN3-T01..T13)
+//
+// Naming follows the AN-2 convention: test_AN3_T<n>_<description>.
+// All tests are synchronous (editEvent is not async) except resolveConflict tests.
+
+@MainActor
+final class EditEventTests: XCTestCase {
+
+    // MARK: — Helpers
+
+    private func makeVM(draft: ContactEventDraft) -> (JugglingAnnotationViewModel, MockAnnotationAPIClient) {
+        let api   = MockAnnotationAPIClient()
+        let store = LocalAnnotationStore(baseDirectory: FileManager.default.temporaryDirectory
+            .appendingPathComponent("EditEventTests-\(UUID().uuidString)"))
+        let taxonomy = ContactTaxonomyStore(authManager: MockAuthManager())
+        let vm = JugglingAnnotationViewModel(
+            userId: 1, videoId: "vid-edit",
+            apiClient: api, taxonomyStore: taxonomy, localStore: store
+        )
+        var session = store.emptySession(userId: 1, videoId: "vid-edit", taxonomyVersion: "v1")
+        session.drafts = [draft]
+        try? store.save(session: &session)
+        vm.session = session
+        return (vm, api)
+    }
+
+    private func baseDraft(status: ContactEventSyncStatus, serverEventId: UUID? = nil) -> ContactEventDraft {
+        var d = ContactEventDraft.new(
+            timestampMs:          1000,
+            contactType:          "instep_right",
+            side:                 "right",
+            annotationConfidence: "certain"
+        )
+        d.syncStatus    = status
+        d.serverEventId = serverEventId
+        return d
+    }
+
+    // MARK: — editEvent transitions
+
+    // AN3-T01
+    func test_AN3_T01_editLocalOnlyStaysLocalOnly() {
+        let draft = baseDraft(status: .localOnly)
+        let (vm, _) = makeVM(draft: draft)
+
+        let result = vm.editEvent(
+            deviceEventId:        draft.deviceEventId,
+            contactType:          "toe_right",
+            side:                 "right",
+            annotationConfidence: "probable",
+            customLabel:          nil,
+            customDescription:    nil
+        )
+
+        XCTAssertTrue(result)
+        let edited = vm.activeEvents.first!
+        XCTAssertEqual(edited.syncStatus,           .localOnly)
+        XCTAssertEqual(edited.contactType,           "toe_right")
+        XCTAssertEqual(edited.annotationConfidence,  "probable")
+        XCTAssertEqual(edited.deviceEventId,         draft.deviceEventId) // immutable
+        XCTAssertEqual(edited.version,               draft.version)        // unchanged
+    }
+
+    // AN3-T02
+    func test_AN3_T02_editSyncedBecomesUpdating_deviceEventIdAndVersionUnchanged() {
+        let sid = UUID()
+        var draft = baseDraft(status: .synced, serverEventId: sid)
+        draft.version = 3
+        let (vm, _) = makeVM(draft: draft)
+
+        let result = vm.editEvent(
+            deviceEventId:        draft.deviceEventId,
+            contactType:          "heel_left",
+            side:                 "left",
+            annotationConfidence: "uncertain"
+        )
+
+        XCTAssertTrue(result)
+        let edited = vm.activeEvents.first!
+        XCTAssertEqual(edited.syncStatus,     .updating)
+        XCTAssertEqual(edited.contactType,    "heel_left")
+        XCTAssertEqual(edited.deviceEventId,  draft.deviceEventId)
+        XCTAssertEqual(edited.serverEventId,  sid)
+        XCTAssertEqual(edited.version,        3)  // MUST NOT be mutated by editEvent
+    }
+
+    // AN3-T03
+    func test_AN3_T03_editRetryPendingBecomesLocalOnlyWithRetryReset() {
+        var draft = baseDraft(status: .retryPending)
+        draft.retryCount    = 2
+        draft.failureReason = "network_error"
+        let (vm, _) = makeVM(draft: draft)
+
+        let result = vm.editEvent(
+            deviceEventId:        draft.deviceEventId,
+            contactType:          "toe_left",
+            side:                 "left",
+            annotationConfidence: "certain"
+        )
+
+        XCTAssertTrue(result)
+        let edited = vm.activeEvents.first!
+        XCTAssertEqual(edited.syncStatus,    .localOnly)
+        XCTAssertEqual(edited.contactType,   "toe_left")
+        XCTAssertEqual(edited.retryCount,    0)
+        XCTAssertNil(edited.failureReason)
+    }
+
+    // AN3-T04
+    func test_AN3_T04_editFailedPermanentNoServerIdBecomesLocalOnly() {
+        var draft = baseDraft(status: .failedPermanent, serverEventId: nil)
+        draft.failureReason = "422 validation error"
+        let (vm, _) = makeVM(draft: draft)
+
+        let result = vm.editEvent(
+            deviceEventId:        draft.deviceEventId,
+            contactType:          "knee_right",
+            side:                 "right",
+            annotationConfidence: "certain"
+        )
+
+        XCTAssertTrue(result)
+        let edited = vm.activeEvents.first!
+        XCTAssertEqual(edited.syncStatus, .localOnly)
+        XCTAssertNil(edited.failureReason)
+        XCTAssertEqual(edited.retryCount, 0)
+    }
+
+    // AN3-T05
+    func test_AN3_T05_editFailedPermanentWithServerIdBecomesUpdating() {
+        let sid = UUID()
+        var draft = baseDraft(status: .failedPermanent, serverEventId: sid)
+        draft.version       = 2
+        draft.failureReason = "422 validation error"
+        let (vm, _) = makeVM(draft: draft)
+
+        let result = vm.editEvent(
+            deviceEventId:        draft.deviceEventId,
+            contactType:          "knee_right",
+            side:                 "right",
+            annotationConfidence: "certain"
+        )
+
+        XCTAssertTrue(result)
+        let edited = vm.activeEvents.first!
+        XCTAssertEqual(edited.syncStatus,    .updating)
+        XCTAssertEqual(edited.serverEventId, sid)
+        XCTAssertEqual(edited.version,       2)   // unchanged
+        XCTAssertNil(edited.failureReason)
+        XCTAssertEqual(edited.retryCount, 0)
+    }
+
+    // AN3-T06: idempotency_conflict failedPermanent is not fixable by editing
+    func test_AN3_T06_editFailedPermanentIdempotencyConflictBlocked() {
+        var draft = baseDraft(status: .failedPermanent, serverEventId: nil)
+        draft.failureReason = "idempotency_conflict: detail"
+        let originalType = draft.contactType
+        let (vm, _) = makeVM(draft: draft)
+
+        let result = vm.editEvent(
+            deviceEventId:        draft.deviceEventId,
+            contactType:          "toe_right",
+            side:                 nil,
+            annotationConfidence: "certain"
+        )
+
+        XCTAssertFalse(result)
+        let unchanged = vm.session?.drafts.first!
+        XCTAssertEqual(unchanged?.syncStatus,  .failedPermanent)
+        XCTAssertEqual(unchanged?.contactType, originalType)   // not mutated
+    }
+
+    // AN3-T07: conflicted blocked
+    func test_AN3_T07_editConflictedBlocked() {
+        let draft = baseDraft(status: .conflicted, serverEventId: UUID())
+        let (vm, _) = makeVM(draft: draft)
+
+        let result = vm.editEvent(
+            deviceEventId: draft.deviceEventId, contactType: "toe_right",
+            side: nil, annotationConfidence: "certain"
+        )
+
+        XCTAssertFalse(result)
+        XCTAssertEqual(vm.session?.drafts.first?.syncStatus, .conflicted)
+    }
+
+    // AN3-T08: needsReconciliation blocked
+    func test_AN3_T08_editNeedsReconciliationBlocked() {
+        let draft = baseDraft(status: .needsReconciliation, serverEventId: UUID())
+        let (vm, _) = makeVM(draft: draft)
+
+        let result = vm.editEvent(
+            deviceEventId: draft.deviceEventId, contactType: "toe_right",
+            side: nil, annotationConfidence: "certain"
+        )
+
+        XCTAssertFalse(result)
+        XCTAssertEqual(vm.session?.drafts.first?.syncStatus, .needsReconciliation)
+    }
+
+    // AN3-T09: syncing (in-flight POST) blocked
+    func test_AN3_T09_editSyncingBlocked() {
+        let draft = baseDraft(status: .syncing)
+        let (vm, _) = makeVM(draft: draft)
+
+        let result = vm.editEvent(
+            deviceEventId: draft.deviceEventId, contactType: "toe_right",
+            side: nil, annotationConfidence: "certain"
+        )
+
+        XCTAssertFalse(result)
+        XCTAssertEqual(vm.session?.drafts.first?.syncStatus, .syncing)
+    }
+
+    // AN3-T10: updating (in-flight PATCH) blocked
+    func test_AN3_T10_editUpdatingBlocked() {
+        let draft = baseDraft(status: .updating, serverEventId: UUID())
+        let (vm, _) = makeVM(draft: draft)
+
+        let result = vm.editEvent(
+            deviceEventId: draft.deviceEventId, contactType: "toe_right",
+            side: nil, annotationConfidence: "certain"
+        )
+
+        XCTAssertFalse(result)
+        XCTAssertEqual(vm.session?.drafts.first?.syncStatus, .updating)
+    }
+
+    // MARK: — resolveConflict
+
+    // AN3-T11: resolveConflict for a conflicted draft that exists on the server
+    func test_AN3_T11_resolveConflictFoundOnServerBecomesSynced() async throws {
+        let serverEventId = UUID()
+        var draft = baseDraft(status: .conflicted, serverEventId: serverEventId)
+        draft.version = 1
+        let (vm, api) = makeVM(draft: draft)
+
+        let serverEvent = makeServerEvent(
+            deviceEventId: draft.deviceEventId,
+            serverEventId: serverEventId,
+            contactType:   "heel_right",
+            version:       2
+        )
+        api.listContactsResult = .success(ContactEventListOut(
+            videoId: "vid-edit", annotationStatus: "in_progress", events: [serverEvent]
+        ))
+
+        await vm.resolveConflict(deviceEventId: draft.deviceEventId)
+
+        let resolved = vm.session?.drafts.first!
+        XCTAssertEqual(resolved?.syncStatus,  .synced)
+        XCTAssertEqual(resolved?.version,     2)          // server version applied
+        XCTAssertEqual(resolved?.contactType, "heel_right") // server payload applied
+        XCTAssertNil(resolved?.failureReason)
+    }
+
+    // AN3-T12: resolveConflict — draft absent from server → .deleted
+    func test_AN3_T12_resolveConflictAbsentOnServerBecomesDeleted() async throws {
+        let draft = baseDraft(status: .conflicted, serverEventId: UUID())
+        let (vm, api) = makeVM(draft: draft)
+
+        api.listContactsResult = .success(ContactEventListOut(
+            videoId: "vid-edit", annotationStatus: "in_progress", events: []
+        ))
+
+        await vm.resolveConflict(deviceEventId: draft.deviceEventId)
+
+        XCTAssertEqual(vm.session?.drafts.first?.syncStatus, .deleted)
+    }
+
+    // AN3-T13: resolveConflict — network error → stays conflicted
+    func test_AN3_T13_resolveConflictNetworkErrorStaysConflicted() async {
+        let draft = baseDraft(status: .conflicted, serverEventId: UUID())
+        let (vm, api) = makeVM(draft: draft)
+
+        api.listContactsResult = .failure(AnnotationAPIError.retryable(code: nil))
+
+        await vm.resolveConflict(deviceEventId: draft.deviceEventId)
+
+        XCTAssertEqual(vm.session?.drafts.first?.syncStatus, .conflicted)
+    }
+
+    // MARK: — Private helpers
+
+    private func makeServerEvent(
+        deviceEventId: UUID,
+        serverEventId: UUID,
+        contactType:   String,
+        version:       Int
+    ) -> ContactEventOut {
+        ContactEventOut(
+            eventId:                serverEventId,
+            deviceEventId:          deviceEventId,
+            timestampMs:            1000,
+            contactType:            contactType,
+            side:                   "right",
+            annotationConfidence:   "certain",
+            annotationReviewStatus: "pending",
+            taxonomyReviewStatus:   "pending",
+            excludedFromTraining:   false,
+            customLabel:            nil,
+            customDescription:      nil,
+            version:                version,
+            createdAt:              Date(),
+            updatedAt:              Date()
+        )
+    }
+}

--- a/ios/LFAEducationCenterTests/Juggling/EditEventTests.swift
+++ b/ios/LFAEducationCenterTests/Juggling/EditEventTests.swift
@@ -11,19 +11,20 @@ final class EditEventTests: XCTestCase {
 
     // MARK: — Helpers
 
-    private func makeVM(draft: ContactEventDraft) -> (JugglingAnnotationViewModel, MockAnnotationAPIClient) {
+    private func makeVM(draft: ContactEventDraft) async -> (JugglingAnnotationViewModel, MockAnnotationAPIClient) {
         let api   = MockAnnotationAPIClient()
         let store = LocalAnnotationStore(baseDirectory: FileManager.default.temporaryDirectory
             .appendingPathComponent("EditEventTests-\(UUID().uuidString)"))
-        let taxonomy = ContactTaxonomyStore(authManager: MockAuthManager())
+        let taxonomy = ContactTaxonomyStore(authManager: AuthManager())
         let vm = JugglingAnnotationViewModel(
             userId: 1, videoId: "vid-edit",
             apiClient: api, taxonomyStore: taxonomy, localStore: store
         )
+        // Save the desired draft, then let onAppear() load it (session is private(set)).
         var session = store.emptySession(userId: 1, videoId: "vid-edit", taxonomyVersion: "v1")
         session.drafts = [draft]
         try? store.save(session: &session)
-        vm.session = session
+        await vm.onAppear()
         return (vm, api)
     }
 
@@ -42,9 +43,9 @@ final class EditEventTests: XCTestCase {
     // MARK: — editEvent transitions
 
     // AN3-T01
-    func test_AN3_T01_editLocalOnlyStaysLocalOnly() {
+    func test_AN3_T01_editLocalOnlyStaysLocalOnly() async {
         let draft = baseDraft(status: .localOnly)
-        let (vm, _) = makeVM(draft: draft)
+        let (vm, _) = await makeVM(draft: draft)
 
         let result = vm.editEvent(
             deviceEventId:        draft.deviceEventId,
@@ -65,11 +66,11 @@ final class EditEventTests: XCTestCase {
     }
 
     // AN3-T02
-    func test_AN3_T02_editSyncedBecomesUpdating_deviceEventIdAndVersionUnchanged() {
+    func test_AN3_T02_editSyncedBecomesUpdating_deviceEventIdAndVersionUnchanged() async {
         let sid = UUID()
         var draft = baseDraft(status: .synced, serverEventId: sid)
         draft.version = 3
-        let (vm, _) = makeVM(draft: draft)
+        let (vm, _) = await makeVM(draft: draft)
 
         let result = vm.editEvent(
             deviceEventId:        draft.deviceEventId,
@@ -88,11 +89,11 @@ final class EditEventTests: XCTestCase {
     }
 
     // AN3-T03
-    func test_AN3_T03_editRetryPendingBecomesLocalOnlyWithRetryReset() {
+    func test_AN3_T03_editRetryPendingBecomesLocalOnlyWithRetryReset() async {
         var draft = baseDraft(status: .retryPending)
         draft.retryCount    = 2
         draft.failureReason = "network_error"
-        let (vm, _) = makeVM(draft: draft)
+        let (vm, _) = await makeVM(draft: draft)
 
         let result = vm.editEvent(
             deviceEventId:        draft.deviceEventId,
@@ -110,10 +111,10 @@ final class EditEventTests: XCTestCase {
     }
 
     // AN3-T04
-    func test_AN3_T04_editFailedPermanentNoServerIdBecomesLocalOnly() {
+    func test_AN3_T04_editFailedPermanentNoServerIdBecomesLocalOnly() async {
         var draft = baseDraft(status: .failedPermanent, serverEventId: nil)
         draft.failureReason = "422 validation error"
-        let (vm, _) = makeVM(draft: draft)
+        let (vm, _) = await makeVM(draft: draft)
 
         let result = vm.editEvent(
             deviceEventId:        draft.deviceEventId,
@@ -130,12 +131,12 @@ final class EditEventTests: XCTestCase {
     }
 
     // AN3-T05
-    func test_AN3_T05_editFailedPermanentWithServerIdBecomesUpdating() {
+    func test_AN3_T05_editFailedPermanentWithServerIdBecomesUpdating() async {
         let sid = UUID()
         var draft = baseDraft(status: .failedPermanent, serverEventId: sid)
         draft.version       = 2
         draft.failureReason = "422 validation error"
-        let (vm, _) = makeVM(draft: draft)
+        let (vm, _) = await makeVM(draft: draft)
 
         let result = vm.editEvent(
             deviceEventId:        draft.deviceEventId,
@@ -154,11 +155,11 @@ final class EditEventTests: XCTestCase {
     }
 
     // AN3-T06: idempotency_conflict failedPermanent is not fixable by editing
-    func test_AN3_T06_editFailedPermanentIdempotencyConflictBlocked() {
+    func test_AN3_T06_editFailedPermanentIdempotencyConflictBlocked() async {
         var draft = baseDraft(status: .failedPermanent, serverEventId: nil)
         draft.failureReason = "idempotency_conflict: detail"
         let originalType = draft.contactType
-        let (vm, _) = makeVM(draft: draft)
+        let (vm, _) = await makeVM(draft: draft)
 
         let result = vm.editEvent(
             deviceEventId:        draft.deviceEventId,
@@ -174,9 +175,9 @@ final class EditEventTests: XCTestCase {
     }
 
     // AN3-T07: conflicted blocked
-    func test_AN3_T07_editConflictedBlocked() {
+    func test_AN3_T07_editConflictedBlocked() async {
         let draft = baseDraft(status: .conflicted, serverEventId: UUID())
-        let (vm, _) = makeVM(draft: draft)
+        let (vm, _) = await makeVM(draft: draft)
 
         let result = vm.editEvent(
             deviceEventId: draft.deviceEventId, contactType: "toe_right",
@@ -188,9 +189,9 @@ final class EditEventTests: XCTestCase {
     }
 
     // AN3-T08: needsReconciliation blocked
-    func test_AN3_T08_editNeedsReconciliationBlocked() {
+    func test_AN3_T08_editNeedsReconciliationBlocked() async {
         let draft = baseDraft(status: .needsReconciliation, serverEventId: UUID())
-        let (vm, _) = makeVM(draft: draft)
+        let (vm, _) = await makeVM(draft: draft)
 
         let result = vm.editEvent(
             deviceEventId: draft.deviceEventId, contactType: "toe_right",
@@ -202,9 +203,9 @@ final class EditEventTests: XCTestCase {
     }
 
     // AN3-T09: syncing (in-flight POST) blocked
-    func test_AN3_T09_editSyncingBlocked() {
+    func test_AN3_T09_editSyncingBlocked() async {
         let draft = baseDraft(status: .syncing)
-        let (vm, _) = makeVM(draft: draft)
+        let (vm, _) = await makeVM(draft: draft)
 
         let result = vm.editEvent(
             deviceEventId: draft.deviceEventId, contactType: "toe_right",
@@ -216,9 +217,9 @@ final class EditEventTests: XCTestCase {
     }
 
     // AN3-T10: updating (in-flight PATCH) blocked
-    func test_AN3_T10_editUpdatingBlocked() {
+    func test_AN3_T10_editUpdatingBlocked() async {
         let draft = baseDraft(status: .updating, serverEventId: UUID())
-        let (vm, _) = makeVM(draft: draft)
+        let (vm, _) = await makeVM(draft: draft)
 
         let result = vm.editEvent(
             deviceEventId: draft.deviceEventId, contactType: "toe_right",
@@ -236,7 +237,7 @@ final class EditEventTests: XCTestCase {
         let serverEventId = UUID()
         var draft = baseDraft(status: .conflicted, serverEventId: serverEventId)
         draft.version = 1
-        let (vm, api) = makeVM(draft: draft)
+        let (vm, api) = await makeVM(draft: draft)
 
         let serverEvent = makeServerEvent(
             deviceEventId: draft.deviceEventId,
@@ -260,7 +261,7 @@ final class EditEventTests: XCTestCase {
     // AN3-T12: resolveConflict — draft absent from server → .deleted
     func test_AN3_T12_resolveConflictAbsentOnServerBecomesDeleted() async throws {
         let draft = baseDraft(status: .conflicted, serverEventId: UUID())
-        let (vm, api) = makeVM(draft: draft)
+        let (vm, api) = await makeVM(draft: draft)
 
         api.listContactsResult = .success(ContactEventListOut(
             videoId: "vid-edit", annotationStatus: "in_progress", events: []
@@ -274,7 +275,7 @@ final class EditEventTests: XCTestCase {
     // AN3-T13: resolveConflict — network error → stays conflicted
     func test_AN3_T13_resolveConflictNetworkErrorStaysConflicted() async {
         let draft = baseDraft(status: .conflicted, serverEventId: UUID())
-        let (vm, api) = makeVM(draft: draft)
+        let (vm, api) = await makeVM(draft: draft)
 
         api.listContactsResult = .failure(AnnotationAPIError.retryable(code: nil))
 

--- a/ios/LFAEducationCenterTests/Juggling/FlushPendingEditTests.swift
+++ b/ios/LFAEducationCenterTests/Juggling/FlushPendingEditTests.swift
@@ -1,0 +1,123 @@
+import XCTest
+@testable import LFAEducationCenter
+
+// MARK: — AN-3A: flushPending .updating extension tests (AN3-T14..T16)
+//
+// Verifies that flushPending now also handles .updating drafts (edited events
+// that need a PATCH pushed to the server).
+
+@MainActor
+final class FlushPendingEditTests: XCTestCase {
+
+    // MARK: — Helpers
+
+    private func makeEngine(api: MockAnnotationAPIClient) -> AnnotationSyncEngine {
+        AnnotationSyncEngine(apiClient: api)
+    }
+
+    private func makeSyncedDraft(contactType: String = "instep_right") -> ContactEventDraft {
+        var d = ContactEventDraft.new(
+            timestampMs:          2000,
+            contactType:          contactType,
+            side:                 "right",
+            annotationConfidence: "certain"
+        )
+        d.syncStatus    = .synced
+        d.serverEventId = UUID()
+        d.version       = 1
+        return d
+    }
+
+    private func editedDraft(from draft: ContactEventDraft, newType: String = "heel_right") -> ContactEventDraft {
+        var d = draft
+        d.contactType = newType
+        d.syncStatus  = .updating
+        return d
+    }
+
+    private func makeSession(drafts: [ContactEventDraft]) -> AnnotationSessionFile {
+        AnnotationSessionFile(
+            schemaVersion:   1,
+            userId:          1,
+            videoId:         "vid-flush",
+            taxonomyVersion: "v1",
+            lastUpdatedAt:   Date(),
+            drafts:          drafts,
+            checksum:        ""
+        )
+    }
+
+    // AN3-T14: .updating draft with serverEventId → pushPatch called → .synced
+    func test_AN3_T14_flushPendingUpdatingDraftCallsPushPatch() async {
+        let api     = MockAnnotationAPIClient()
+        let engine  = makeEngine(api: api)
+        let synced  = makeSyncedDraft()
+        let updated = editedDraft(from: synced, newType: "heel_right")
+
+        let serverResponse = ContactEventOut(
+            eventId:                synced.serverEventId!,
+            deviceEventId:          synced.deviceEventId,
+            timestampMs:            2000,
+            contactType:            "heel_right",
+            side:                   "right",
+            annotationConfidence:   "certain",
+            annotationReviewStatus: "pending",
+            taxonomyReviewStatus:   "pending",
+            excludedFromTraining:   false,
+            customLabel:            nil,
+            customDescription:      nil,
+            version:                2,
+            createdAt:              Date(),
+            updatedAt:              Date()
+        )
+        api.patchContactResult = .success(serverResponse)
+
+        var session = makeSession(drafts: [updated])
+        await engine.flushPending(session: &session)
+
+        // Outcome: .synced with server's version and fields applied.
+        let result = session.drafts[0]
+        XCTAssertEqual(result.syncStatus,  .synced)
+        XCTAssertEqual(result.contactType, "heel_right")
+        XCTAssertEqual(result.version,     2)
+        // createContact was not invoked (draft already had serverEventId →
+        // .synced outcome proves pushPatch was taken, not pushCreate).
+        XCTAssertNotEqual(result.serverEventId, nil)
+    }
+
+    // AN3-T15: .updating + deletedLocally → DELETE path taken instead of PATCH
+    func test_AN3_T15_flushPendingUpdatingDeletedTakesDeletePath() async {
+        let api    = MockAnnotationAPIClient()
+        let engine = makeEngine(api: api)
+        let synced = makeSyncedDraft()
+        var updated = editedDraft(from: synced)
+        updated.deletedLocally = true
+
+        api.deleteContactResult = .success(.deleted)
+
+        var session = makeSession(drafts: [updated])
+        await engine.flushPending(session: &session)
+
+        // .deleted outcome proves pushDelete was called, not pushPatch.
+        XCTAssertEqual(session.drafts[0].syncStatus, .deleted)
+    }
+
+    // AN3-T16: .updating without serverEventId → failedPermanent (defensive path)
+    func test_AN3_T16_flushPendingUpdatingNoServerIdBecomesFailedPermanent() async {
+        let api    = MockAnnotationAPIClient()
+        let engine = makeEngine(api: api)
+
+        var draft = ContactEventDraft.new(
+            timestampMs: 3000, contactType: "toe_right",
+            side: "right", annotationConfidence: "certain"
+        )
+        draft.syncStatus    = .updating
+        draft.serverEventId = nil  // defensive: should not occur in normal flow
+
+        var session = makeSession(drafts: [draft])
+        await engine.flushPending(session: &session)
+
+        XCTAssertEqual(session.drafts[0].syncStatus, .failedPermanent)
+        XCTAssertEqual(session.drafts[0].failureReason, "patch_without_server_id")
+    }
+}

--- a/ios/LFAEducationCenterTests/Juggling/PlaybackControllerTests.swift
+++ b/ios/LFAEducationCenterTests/Juggling/PlaybackControllerTests.swift
@@ -11,7 +11,8 @@ import AVFoundation
 // MARK: — MockPlayer
 
 final class MockPlayer: PlayerSeekable {
-    var currentTime: CMTime = .zero
+    var _currentTime: CMTime = .zero  // backing store; set directly in tests
+    func currentTime() -> CMTime { _currentTime }
     var rate:        Float  = 0
     var seekCalled        = false
     var lastSeekTarget:  CMTime?
@@ -25,7 +26,7 @@ final class MockPlayer: PlayerSeekable {
         lastSeekTarget        = time
         lastToleranceBefore   = toleranceBefore
         lastToleranceAfter    = toleranceAfter
-        currentTime           = time  // simulate instantaneous seek for tests
+        _currentTime          = time  // simulate instantaneous seek for tests
     }
 
     func play()  { playCalled  = true; rate = 1.0 }
@@ -39,7 +40,7 @@ final class PlaybackControllerTests: XCTestCase {
 
     private func makeController(currentTime: CMTime = .zero, duration: CMTime = .zero) -> (PlaybackController, MockPlayer) {
         let player = MockPlayer()
-        player.currentTime = currentTime
+        player._currentTime = currentTime
         let controller = PlaybackController(player: player)
         if duration > .zero {
             controller.duration = duration

--- a/ios/LFAEducationCenterTests/Juggling/PlaybackControllerTests.swift
+++ b/ios/LFAEducationCenterTests/Juggling/PlaybackControllerTests.swift
@@ -1,0 +1,188 @@
+import XCTest
+import AVFoundation
+@testable import LFAEducationCenter
+
+// MARK: — AN-3A: PlaybackController unit tests (AN3-T17..T28)
+//
+// Uses MockPlayer (PlayerSeekable) to avoid real AVPlayer.
+// PlaybackController.frameDuration(nominalFPS:minFrameDuration:) is a static
+// pure function — tested directly without any AVAsset or network involvement.
+
+// MARK: — MockPlayer
+
+final class MockPlayer: PlayerSeekable {
+    var currentTime: CMTime = .zero
+    var rate:        Float  = 0
+    var seekCalled        = false
+    var lastSeekTarget:  CMTime?
+    var lastToleranceBefore: CMTime?
+    var lastToleranceAfter:  CMTime?
+    var playCalled  = false
+    var pauseCalled = false
+
+    func seek(to time: CMTime, toleranceBefore: CMTime, toleranceAfter: CMTime) {
+        seekCalled            = true
+        lastSeekTarget        = time
+        lastToleranceBefore   = toleranceBefore
+        lastToleranceAfter    = toleranceAfter
+        currentTime           = time  // simulate instantaneous seek for tests
+    }
+
+    func play()  { playCalled  = true; rate = 1.0 }
+    func pause() { pauseCalled = true; rate = 0 }
+}
+
+// MARK: — PlaybackControllerTests
+
+@MainActor
+final class PlaybackControllerTests: XCTestCase {
+
+    private func makeController(currentTime: CMTime = .zero, duration: CMTime = .zero) -> (PlaybackController, MockPlayer) {
+        let player = MockPlayer()
+        player.currentTime = currentTime
+        let controller = PlaybackController(player: player)
+        if duration > .zero {
+            controller.duration = duration
+        }
+        return (controller, player)
+    }
+
+    // MARK: — frameDuration pure-function tests (AN3-T17..T23)
+
+    // AN3-T17: 24fps
+    func test_AN3_T17_frameDuration24fps() {
+        let d = PlaybackController.frameDuration(nominalFPS: 24, minFrameDuration: nil)
+        XCTAssertEqual(d.seconds, 1.0 / 24.0, accuracy: 0.0001)
+    }
+
+    // AN3-T18: 25fps
+    func test_AN3_T18_frameDuration25fps() {
+        let d = PlaybackController.frameDuration(nominalFPS: 25, minFrameDuration: nil)
+        XCTAssertEqual(d.seconds, 1.0 / 25.0, accuracy: 0.0001)
+    }
+
+    // AN3-T19: 29.97fps
+    func test_AN3_T19_frameDuration2997fps() {
+        let d = PlaybackController.frameDuration(nominalFPS: 29.97, minFrameDuration: nil)
+        XCTAssertEqual(d.seconds, 1.0 / 29.97, accuracy: 0.0001)
+    }
+
+    // AN3-T20: 30fps
+    func test_AN3_T20_frameDuration30fps() {
+        let d = PlaybackController.frameDuration(nominalFPS: 30, minFrameDuration: nil)
+        XCTAssertEqual(d.seconds, 1.0 / 30.0, accuracy: 0.0001)
+    }
+
+    // AN3-T21: 60fps
+    func test_AN3_T21_frameDuration60fps() {
+        let d = PlaybackController.frameDuration(nominalFPS: 60, minFrameDuration: nil)
+        XCTAssertEqual(d.seconds, 1.0 / 60.0, accuracy: 0.0001)
+    }
+
+    // AN3-T22: missing metadata (nominalFPS=0, no minFrameDuration) → 30fps fallback
+    func test_AN3_T22_frameDurationMissingMetadataFallsBackTo30fps() {
+        let d = PlaybackController.frameDuration(nominalFPS: 0, minFrameDuration: nil)
+        XCTAssertEqual(d.seconds, 1.0 / 30.0, accuracy: 0.0001)
+    }
+
+    // AN3-T23: VFR — nominalFPS=0 but minFrameDuration valid → uses minFrameDuration
+    func test_AN3_T23_frameDurationVFRUsesMinFrameDuration() {
+        let minDur = CMTime(value: 1, timescale: 60)  // 1/60s
+        let d = PlaybackController.frameDuration(nominalFPS: 0, minFrameDuration: minDur)
+        XCTAssertEqual(d.seconds, minDur.seconds, accuracy: 0.0001)
+    }
+
+    // MARK: — Clamp tests (AN3-T24..T25)
+
+    // AN3-T24: stepForward clamps at duration
+    func test_AN3_T24_stepForwardClampsAtDuration() {
+        let duration   = CMTime(value: 5000, timescale: 1000)  // 5.000 s
+        let nearEnd    = CMTime(value: 4995, timescale: 1000)  // 4.995 s
+        let (ctrl, player) = makeController(currentTime: nearEnd, duration: duration)
+        ctrl.frameDuration = CMTime(value: 1, timescale: 30)   // ~33ms
+
+        ctrl.stepForward()
+
+        // 4.995 + 0.033 > 5.000 → clamped to 5.000
+        XCTAssertLessThanOrEqual(player.lastSeekTarget!.seconds, duration.seconds)
+        XCTAssertEqual(player.lastToleranceBefore, .zero)
+        XCTAssertEqual(player.lastToleranceAfter,  .zero)
+    }
+
+    // AN3-T25: stepBackward clamps at zero
+    func test_AN3_T25_stepBackwardClampsAtZero() {
+        let nearStart  = CMTime(value: 10, timescale: 1000)   // 0.010 s
+        let (ctrl, player) = makeController(currentTime: nearStart)
+        ctrl.frameDuration = CMTime(value: 1, timescale: 30)  // ~33ms
+
+        ctrl.stepBackward()
+
+        // 0.010 - 0.033 < 0 → clamped to .zero
+        XCTAssertEqual(player.lastSeekTarget?.seconds ?? -1, 0.0, accuracy: 0.0001)
+    }
+
+    // MARK: — Step-while-paused guard (AN3-T26)
+
+    // AN3-T26: stepForward pauses player before seeking
+    func test_AN3_T26_stepForwardAlwaysPausesFirst() {
+        let (ctrl, player) = makeController(currentTime: CMTime(value: 1000, timescale: 1000))
+        ctrl.frameDuration = CMTime(value: 1, timescale: 30)
+        player.rate = 1.0  // simulate playing
+
+        ctrl.stepForward()
+
+        XCTAssertTrue(player.pauseCalled, "step must pause before seeking")
+        XCTAssertTrue(player.seekCalled)
+    }
+
+    // MARK: — Rate (AN3-T27)
+
+    // AN3-T27: setRate updates selectedRate; applies to player only while playing
+    func test_AN3_T27_setRateUpdatesRateWhilePlaying() {
+        let (ctrl, player) = makeController()
+        ctrl.play()                    // starts at .normal (1×)
+        player.rate = 1.0
+
+        ctrl.setRate(.quarter)
+
+        XCTAssertEqual(ctrl.selectedRate, .quarter)
+        XCTAssertEqual(player.rate, 0.25, accuracy: 0.001)
+    }
+
+    func test_AN3_T27b_setRateDoesNotChangePlayerRateWhilePaused() {
+        let (ctrl, player) = makeController()
+        // ctrl is not playing
+
+        ctrl.setRate(.half)
+
+        XCTAssertEqual(ctrl.selectedRate, .half)
+        XCTAssertEqual(player.rate, 0.0)  // player not affected while paused
+    }
+
+    // MARK: — Timestamp conversion (AN3-T28)
+
+    // AN3-T28: seek(toTimestampMs:) converts ms → CMTime correctly
+    func test_AN3_T28_seekToTimestampMsConvertsCorrectly() {
+        let (ctrl, player) = makeController()
+
+        ctrl.seek(toTimestampMs: 1500)
+
+        XCTAssertEqual(player.lastSeekTarget?.seconds ?? 0, 1.5, accuracy: 0.001)
+        XCTAssertEqual(ctrl.currentTimestampMs, 1500)
+        // timeline seek uses loose tolerance
+        XCTAssertEqual(player.lastToleranceBefore, .positiveInfinity)
+        XCTAssertEqual(player.lastToleranceAfter,  .positiveInfinity)
+    }
+
+    // MARK: — CMTime.asMilliseconds helper
+
+    func test_cmTimeAsMilliseconds_valid() {
+        XCTAssertEqual(CMTime(value: 2500, timescale: 1000).asMilliseconds, 2500)
+        XCTAssertEqual(CMTime(value: 1,    timescale: 2).asMilliseconds,    500)
+    }
+
+    func test_cmTimeAsMilliseconds_invalid() {
+        XCTAssertEqual(CMTime.invalid.asMilliseconds, 0)
+        XCTAssertEqual(CMTime.indefinite.asMilliseconds, 0)
+    }
+}


### PR DESCRIPTION
## Summary

First PR of the AN-3 SwiftUI annotation UX series. Adds the edit state machine, conflict resolution, `flushPending` PATCH routing, and `PlaybackController` — all logic-only, no SwiftUI views.

## editEvent State Transitions

`JugglingAnnotationViewModel.editEvent(deviceEventId:contactType:side:annotationConfidence:customLabel:customDescription:) → Bool`

| Starting state | Condition | Target state | Returns |
|---|---|---|---|
| `.localOnly` | — | `.localOnly` | `true` |
| `.synced` | — | `.updating` | `true` |
| `.retryPending` | — | `.localOnly` (retryCount=0, failureReason=nil) | `true` |
| `.failedPermanent` | serverEventId==nil, reason≠idempotency | `.localOnly` (reason=nil, rc=0) | `true` |
| `.failedPermanent` | serverEventId!=nil, reason≠idempotency | `.updating` (reason=nil, rc=0) | `true` |
| `.failedPermanent` | reason.hasPrefix("idempotency_conflict") | **blocked** | `false` |
| `.conflicted` | — | **blocked** | `false` |
| `.needsReconciliation` | — | **blocked** | `false` |
| `.syncing` | — | **blocked** | `false` |
| `.updating` | — | **blocked** | `false` |

**Immutability invariants:**
- `deviceEventId` is a `let` constant — never mutated by `editEvent`.
- `version` is never mutated by `editEvent`; only `applyServerState` (called on a successful PATCH response) may update it.

### failedPermanent and idempotency_conflict rule

`failedPermanent` with `reason.hasPrefix("idempotency_conflict")` is permanently blocked from editing. This covers the case where the server rejected the create with a 409 because a matching event already exists with a different `deviceEventId` — the local record is in an inconsistent state and must be resolved via `resolveConflict`, not re-edited.

`failedPermanent` without `idempotency_conflict`:
- If `serverEventId==nil`: no confirmed server-side event exists → transition to `.localOnly` so `flushPending` re-attempts create.
- If `serverEventId!=nil`: confirmed server event exists → transition to `.updating` so `flushPending` issues a PATCH.

## resolveConflict Behaviour and Contract

`JugglingAnnotationViewModel.resolveConflict(deviceEventId:) async`

**Current implementation: server-wins.**

1. Calls `apiClient.listContacts(videoId:)` to fetch the current server state.
2. If the server event is found (matched by `deviceEventId`): calls `syncEngine.resolveConflictedDraft(draft:serverEvent:)` which is a thin wrapper around the existing `applyServerState`. The server payload completely overwrites the local conflicted fields. Draft transitions to `.synced` with the server's `version`.
3. If the server event is absent: draft transitions to `.deleted`.
4. Network error: draft remains `.conflicted` — no local state is lost.

**What this means for AN-3B UI:**
- The local conflicting edit is **not** automatically re-submitted after resolution.
- If the server-won state differs from what the user intended, the user must manually re-edit after resolve.
- AN-3B must decide: present a diff/comparison screen before resolving, or resolve silently and show the resulting server state. This contract intentionally defers that UX decision to AN-3B.

## `.updating` PATCH Routing in flushPending

`flushPending` now has three non-overlapping loops:

| Loop | Guard | Route |
|---|---|---|
| 1 | `.localOnly` ∪ `.retryPending` | `pushCreate` |
| 2 | `.synced` + `deletedLocally` | `pushDelete` |
| 3 | `.updating` | `pushPatch` (or `pushDelete` if `deletedLocally==true`) |

Loop 3 defensive path: if `.updating` draft has `serverEventId==nil` (should not occur in normal flow), `pushPatch` returns `.failedPermanent` with `failureReason="patch_without_server_id"`.

## PlaybackController

New file: `ios/LFAEducationCenter/Juggling/Playback/PlaybackController.swift`

**`PlaybackRate` enum:** `.quarter` (0.25×) / `.half` (0.5×) / `.normal` (1×) — `CaseIterable, Identifiable`.

**`PlayerSeekable` protocol** + `AVPlayer` conformance (testability seam — allows `MockPlayer` in unit tests without a real `AVPlayer` or media file).

**`@MainActor final class PlaybackController: ObservableObject`**:
- `play()` / `pause()` / `togglePlayPause()`
- `setRate(_ rate: PlaybackRate)` — applies to player only while playing (`isPlaying==true`)
- `stepForward()` / `stepBackward()` — always pauses first; `.zero` tolerance for frame-accuracy; clamped to `[.zero, duration]`
- `seek(toTimestampMs: Int)` — loose tolerance (`.positiveInfinity`) for timeline tap-to-seek performance
- `frameDuration: CMTime` — injectable `var` for tests; default 1/30s; set from asset via `loadAsset(_:)`

**No rendering.** `AVPlayerLayerView` (`UIViewRepresentable`) is AN-3B scope.

### FPS / Frame-Step Policy

`static func frameDuration(nominalFPS: Float, minFrameDuration: CMTime?) -> CMTime`:
1. `nominalFPS > 0` → `1/fps` seconds (handles 24/25/29.97/30/60fps)
2. `nominalFPS == 0` + valid `minFrameDuration` → use `minFrameDuration` (VFR content)
3. Both missing/invalid → 1/30s fallback

`static func effectiveFrameDuration(for asset: AVAsset) -> CMTime` reads `track.nominalFrameRate` and `track.minFrameDuration` synchronously (iOS 14 compatible).

### iOS 14 Compatibility

Deployment target: `IPHONEOS_DEPLOYMENT_TARGET = 14.0`. The async `AVAsset.load(_:)` / `loadTracks(withMediaType:)` API requires iOS 15. Replaced with synchronous `asset.tracks(withMediaType:)`, `track.nominalFrameRate`, `track.minFrameDuration`, `asset.duration` — all available since iOS 4.

### Actor Isolation and Observer Cleanup

- All `@Published` mutations on `@MainActor`.
- `setupPeriodicObserver` closure: `Task { @MainActor [weak self] in ... }` — `weak self` prevents retain cycle.
- `deinit`: `avPlayer.removeTimeObserver(obs)` — explicit periodic observer cleanup.

## Build and Test Proof

| Check | Result |
|---|---|
| Debug BUILD | SUCCEEDED — 0 AN-3A warnings |
| Release BUILD | SUCCEEDED — 0 AN-3A warnings |
| Full suite (87 tests) | 87/87 PASS, 0 FAIL |
| AN-3A filtered (31 tests) | 31/31 PASS (T01–T28 + T27b + CMTime helpers) |
| Taxonomy drift | OK (md5=7198de62733493537450275dadc6f445) |
| pbxproj lint | OK |

Pre-existing warnings (not AN-3A): `SpikeLivenessViewModel.swift` (Biometric Spike), `AcademyIDColorPickerView.swift` (Auth).

## Scope

**In scope:**
- `AnnotationSyncEngine`: `resolveConflictedDraft` + `flushPending` third loop
- `JugglingAnnotationViewModel`: `editEvent`, `resolveConflict`, `activeEvents`
- `PlaybackController.swift` (new): `PlaybackRate`, `PlayerSeekable`, `PlaybackController`, `CMTime.asMilliseconds`
- Test files: `EditEventTests.swift`, `FlushPendingEditTests.swift`, `PlaybackControllerTests.swift` (new)
- `project.pbxproj`: Playback group + file membership

**Not in scope (AN-3B/C):**
- No SwiftUI views (no `JugglingAnnotationScreen`, `AVPlayerLayerView`, `ContactPickerView`, event timeline)
- No `AnnotationVideoLoader` / video download lifecycle
- No `FinishView` / Finish flow
- No navigation integration
- No accessibility / VoiceOver
- No backend changes
- No Alembic migration

## Test IDs

- AN3-T01..T10: `editEvent` all 10 state transitions
- AN3-T11: `resolveConflict` found on server → `.synced`
- AN3-T12: `resolveConflict` absent on server → `.deleted`
- AN3-T13: `resolveConflict` network error → `.conflicted`
- AN3-T14: `flushPending .updating` → pushPatch → `.synced`
- AN3-T15: `flushPending .updating + deletedLocally` → pushDelete → `.deleted`
- AN3-T16: `flushPending .updating` without serverEventId → `.failedPermanent`
- AN3-T17..T23: `frameDuration()` for 24/25/29.97/30/60fps, missing metadata, VFR
- AN3-T24: `stepForward` clamps at duration
- AN3-T25: `stepBackward` clamps at zero
- AN3-T26: `stepForward` always pauses first
- AN3-T27 / T27b: `setRate` while playing / paused
- AN3-T28: `seek(toTimestampMs:)` ms→CMTime conversion + loose tolerance

🤖 Generated with [Claude Code](https://claude.com/claude-code)