### PR TITLE
feat(juggling): AN-3B2D-B0 User-Assisted Ball Feedback Pipeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,6 +69,11 @@ BALL_DETECTION_ENABLED=false
 # BALL_DETECTION_MODEL_PATH=app/ml_models/ssd_mobilenet_v1_12.onnx
 # BALL_DETECTION_MODEL_URL=  # override for private model source (ops use only)
 
+# BALL_TRAJECTORY_ENABLED — dense ball tracking across full video (AN-3B2D-1).
+#   false = trajectory endpoints return 503; true = 10 FPS tracking pipeline active.
+#   Requires: analysis Celery worker + ONNX model on disk + BALL_DETECTION prereqs.
+BALL_TRAJECTORY_ENABLED=false
+
 # ── Database ────────────────────────────────────────────────────────────────
 # PostgreSQL connection string
 # Format: postgresql://user:password@host:port/database

--- a/alembic/versions/2026_06_18_1500_add_juggling_ball_trajectories.py
+++ b/alembic/versions/2026_06_18_1500_add_juggling_ball_trajectories.py
@@ -1,0 +1,69 @@
+"""Add juggling_ball_trajectories table + ball_trajectory_status column.
+
+Dense ball tracking: 10 FPS sampled trajectory with Kalman smoothing.
+One row per (video_id, frame_ms) — unique index enforced.
+
+Revision ID: 2026_06_18_1500
+Revises: 2026_06_18_1400
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+revision      = "2026_06_18_1500"
+down_revision = "2026_06_18_1400"
+branch_labels = None
+depends_on    = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "juggling_ball_trajectories",
+        sa.Column("id", UUID(as_uuid=True), server_default=sa.text("gen_random_uuid()"), primary_key=True),
+        sa.Column("video_id", UUID(as_uuid=True),
+                  sa.ForeignKey("juggling_videos.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("frame_ms", sa.Integer, nullable=False),
+        sa.Column("ball_x", sa.Float, nullable=True),
+        sa.Column("ball_y", sa.Float, nullable=True),
+        sa.Column("confidence", sa.Float, nullable=True),
+        sa.Column("is_manual", sa.Boolean, nullable=False, server_default="false"),
+        sa.Column("tracking_state", sa.String(20), nullable=False, server_default=sa.text("'detected'")),
+        sa.Column("model_version", sa.String(60), nullable=True),
+        sa.Column("image_width_px", sa.Integer, nullable=True),
+        sa.Column("image_height_px", sa.Integer, nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.text("now()")),
+        sa.UniqueConstraint("video_id", "frame_ms", name="ux_ball_traj_video_frame"),
+        sa.CheckConstraint(
+            "tracking_state IN ('detected', 'predicted', 'lost', 'manual_seed')",
+            name="ck_ball_traj_tracking_state",
+        ),
+        sa.CheckConstraint(
+            "(tracking_state = 'lost' AND ball_x IS NULL AND ball_y IS NULL) "
+            "OR (tracking_state != 'lost' AND ball_x IS NOT NULL AND ball_y IS NOT NULL)",
+            name="ck_ball_traj_coords_state",
+        ),
+    )
+    op.create_index(
+        "idx_ball_traj_video_ms",
+        "juggling_ball_trajectories",
+        ["video_id", "frame_ms"],
+    )
+
+    op.add_column(
+        "juggling_videos",
+        sa.Column("ball_trajectory_status", sa.String(20), nullable=True),
+    )
+    op.create_check_constraint(
+        "ck_juggling_videos_ball_trajectory_status",
+        "juggling_videos",
+        "ball_trajectory_status IS NULL "
+        "OR ball_trajectory_status IN ('pending', 'processing', 'complete', 'failed')",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_juggling_videos_ball_trajectory_status", "juggling_videos")
+    op.drop_column("juggling_videos", "ball_trajectory_status")
+    op.drop_index("idx_ball_traj_video_ms", table_name="juggling_ball_trajectories")
+    op.drop_table("juggling_ball_trajectories")

--- a/alembic/versions/2026_06_18_2000_add_juggling_ball_feedback_tables.py
+++ b/alembic/versions/2026_06_18_2000_add_juggling_ball_feedback_tables.py
@@ -1,0 +1,297 @@
+"""Add juggling_ball_feedback, juggling_frame_ground_truth, user_annotation_reliability.
+
+User-assisted ball model training data pipeline (AN-3B2D-B0).
+Three tables:
+  juggling_ball_feedback      — per-user per-frame feedback record
+  juggling_frame_ground_truth — aggregated majority-vote ground truth (populated B2+)
+  user_annotation_reliability — per-user annotation quality tracking (populated B2+)
+
+No training_eligible rows are set True in this migration.
+No credit or consensus logic is included.
+
+Revision ID: 2026_06_18_2000
+Revises: 2026_06_18_1500
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision      = "2026_06_18_2000"
+down_revision = "2026_06_18_1500"
+branch_labels = None
+depends_on    = None
+
+
+def upgrade() -> None:
+    # ── 1. juggling_ball_feedback ─────────────────────────────────────────
+    op.create_table(
+        "juggling_ball_feedback",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("video_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("frame_ms", sa.Integer, nullable=False),
+        sa.Column(
+            "trajectory_point_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+        ),
+        sa.Column("user_id", sa.Integer, nullable=False),
+        # User decision
+        sa.Column("decision",          sa.String(20),  nullable=False),
+        sa.Column("corrected_x",       sa.Float,       nullable=True),
+        sa.Column("corrected_y",       sa.Float,       nullable=True),
+        sa.Column("correction_method", sa.String(20),  nullable=True),
+        # Model context (snapshot at submit time)
+        sa.Column("model_predicted_x",    sa.Float,      nullable=True),
+        sa.Column("model_predicted_y",    sa.Float,      nullable=True),
+        sa.Column("model_confidence",     sa.Float,      nullable=True),
+        sa.Column("model_tracking_state", sa.String(20), nullable=True),
+        # Reliability
+        sa.Column(
+            "user_reliability_at_submit",
+            sa.Float,
+            nullable=True,
+            server_default=sa.text("0.5"),
+        ),
+        sa.Column("weighted_vote_contribution", sa.Float, nullable=True),
+        # State
+        sa.Column(
+            "approval_state",
+            sa.String(20),
+            nullable=False,
+            server_default="pending",
+        ),
+        sa.Column(
+            "is_gold_standard",
+            sa.Boolean,
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column(
+            "is_control_sample",
+            sa.Boolean,
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column(
+            "spam_flags",
+            postgresql.JSONB,
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        # Timestamps
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.Column("reviewed_at",         sa.DateTime(timezone=True), nullable=True),
+        sa.Column("reviewed_by_user_id", sa.Integer,                 nullable=True),
+        # Foreign keys
+        sa.ForeignKeyConstraint(
+            ["video_id"],
+            ["juggling_videos.id"],
+            ondelete="CASCADE",
+            name="fk_ball_feedback_video",
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+            ondelete="CASCADE",
+            name="fk_ball_feedback_user",
+        ),
+        sa.ForeignKeyConstraint(
+            ["trajectory_point_id"],
+            ["juggling_ball_trajectories.id"],
+            ondelete="SET NULL",
+            name="fk_ball_feedback_trajectory",
+        ),
+        sa.ForeignKeyConstraint(
+            ["reviewed_by_user_id"],
+            ["users.id"],
+            ondelete="SET NULL",
+            name="fk_ball_feedback_reviewer",
+        ),
+        # Check constraints
+        sa.CheckConstraint(
+            "decision IN ('confirm','reject','no_ball','corrected')",
+            name="ck_ball_feedback_decision",
+        ),
+        sa.CheckConstraint(
+            "decision != 'corrected' OR "
+            "(corrected_x IS NOT NULL AND corrected_y IS NOT NULL)",
+            name="ck_ball_feedback_corrected_coords",
+        ),
+        sa.CheckConstraint(
+            "corrected_x IS NULL OR (corrected_x >= 0.0 AND corrected_x <= 1.0)",
+            name="ck_ball_feedback_cx_range",
+        ),
+        sa.CheckConstraint(
+            "corrected_y IS NULL OR (corrected_y >= 0.0 AND corrected_y <= 1.0)",
+            name="ck_ball_feedback_cy_range",
+        ),
+        sa.CheckConstraint(
+            "approval_state IN ('pending','approved','needs_review','rejected','spam')",
+            name="ck_ball_feedback_approval_state",
+        ),
+    )
+
+    op.create_unique_constraint(
+        "uq_ball_feedback_user_video_frame",
+        "juggling_ball_feedback",
+        ["user_id", "video_id", "frame_ms"],
+    )
+    op.create_index(
+        "ix_ball_feedback_video_frame",
+        "juggling_ball_feedback",
+        ["video_id", "frame_ms"],
+    )
+    op.create_index(
+        "ix_ball_feedback_user",
+        "juggling_ball_feedback",
+        ["user_id"],
+    )
+    op.create_index(
+        "ix_ball_feedback_approval",
+        "juggling_ball_feedback",
+        ["approval_state"],
+    )
+
+    # ── 2. juggling_frame_ground_truth ────────────────────────────────────
+    op.create_table(
+        "juggling_frame_ground_truth",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("video_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("frame_ms", sa.Integer, nullable=False),
+        # Ground truth result (populated in B2)
+        sa.Column(
+            "gt_decision",
+            sa.String(20),
+            nullable=False,
+            server_default="uncertain",
+        ),
+        sa.Column("gt_x",          sa.Float, nullable=True),
+        sa.Column("gt_y",          sa.Float, nullable=True),
+        sa.Column("gt_bbox_width", sa.Float, nullable=True),
+        sa.Column("gt_bbox_height",sa.Float, nullable=True),
+        # Vote counts + reliability (populated in B2)
+        sa.Column(
+            "confidence_score",
+            sa.Float,
+            nullable=False,
+            server_default=sa.text("0.0"),
+        ),
+        sa.Column(
+            "agreement_rate",
+            sa.Float,
+            nullable=False,
+            server_default=sa.text("0.0"),
+        ),
+        sa.Column("vote_count",       sa.Integer, nullable=False, server_default=sa.text("0")),
+        sa.Column("yes_votes",        sa.Integer, nullable=False, server_default=sa.text("0")),
+        sa.Column("no_votes",         sa.Integer, nullable=False, server_default=sa.text("0")),
+        sa.Column("no_ball_votes",    sa.Integer, nullable=False, server_default=sa.text("0")),
+        sa.Column("correction_count", sa.Integer, nullable=False, server_default=sa.text("0")),
+        # Training eligibility — never True in B0; set by B2 Celery task
+        sa.Column(
+            "training_eligible",
+            sa.Boolean,
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column("dataset_version", sa.String(20),            nullable=True),
+        sa.Column("exported_at",     sa.DateTime(timezone=True), nullable=True),
+        # Metadata
+        sa.Column(
+            "is_gold_standard",
+            sa.Boolean,
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["video_id"],
+            ["juggling_videos.id"],
+            ondelete="CASCADE",
+            name="fk_frame_gt_video",
+        ),
+        sa.CheckConstraint(
+            "gt_decision IN ('ball_present','no_ball','uncertain')",
+            name="ck_frame_gt_decision",
+        ),
+        sa.UniqueConstraint(
+            "video_id",
+            "frame_ms",
+            name="uq_frame_ground_truth_video_frame",
+        ),
+    )
+
+    op.create_index(
+        "ix_frame_gt_video_frame",
+        "juggling_frame_ground_truth",
+        ["video_id", "frame_ms"],
+    )
+    op.create_index(
+        "ix_frame_gt_eligible",
+        "juggling_frame_ground_truth",
+        ["training_eligible"],
+    )
+
+    # ── 3. user_annotation_reliability ────────────────────────────────────
+    op.create_table(
+        "user_annotation_reliability",
+        sa.Column(
+            "user_id",
+            sa.Integer,
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        sa.Column(
+            "ball_annotation_reliability",
+            sa.Float,
+            nullable=False,
+            server_default=sa.text("0.5"),
+        ),
+        sa.Column("total_feedbacks",   sa.Integer, nullable=False, server_default=sa.text("0")),
+        sa.Column("correct_feedbacks", sa.Integer, nullable=False, server_default=sa.text("0")),
+        sa.Column("gold_attempts",     sa.Integer, nullable=False, server_default=sa.text("0")),
+        sa.Column("gold_correct",      sa.Integer, nullable=False, server_default=sa.text("0")),
+        sa.Column("spam_flags_count",  sa.Integer, nullable=False, server_default=sa.text("0")),
+        sa.Column(
+            "last_updated",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.CheckConstraint(
+            "ball_annotation_reliability >= 0.1 AND ball_annotation_reliability <= 1.0",
+            name="ck_reliability_range",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("user_annotation_reliability")
+    op.drop_table("juggling_frame_ground_truth")
+    op.drop_table("juggling_ball_feedback")

--- a/app/api/api_v1/endpoints/users/__init__.py
+++ b/app/api/api_v1/endpoints/users/__init__.py
@@ -21,6 +21,7 @@ from . import (
     juggling_taxonomy,
     juggling_pose_snapshots,
     juggling_ball_detection,
+    juggling_ball_trajectory,
 )
 
 # Create main router
@@ -66,6 +67,8 @@ router.include_router(juggling_contacts.router, tags=["users", "juggling"])
 router.include_router(juggling_pose_snapshots.router, tags=["users", "juggling"])
 # Phase 2B: ball detection (BALL_DETECTION_ENABLED gated; 503 when off)
 router.include_router(juggling_ball_detection.router, tags=["users", "juggling"])
+# AN-3B2D-1: dense ball trajectory (BALL_TRAJECTORY_ENABLED gated; 503 when off)
+router.include_router(juggling_ball_trajectory.router, tags=["users", "juggling"])
 
 # CRUD endpoints (should be last due to /{user_id} catch-all)
 router.include_router(crud.router, tags=["users"])

--- a/app/api/api_v1/endpoints/users/__init__.py
+++ b/app/api/api_v1/endpoints/users/__init__.py
@@ -22,6 +22,7 @@ from . import (
     juggling_pose_snapshots,
     juggling_ball_detection,
     juggling_ball_trajectory,
+    juggling_ball_feedback,
 )
 
 # Create main router
@@ -69,6 +70,8 @@ router.include_router(juggling_pose_snapshots.router, tags=["users", "juggling"]
 router.include_router(juggling_ball_detection.router, tags=["users", "juggling"])
 # AN-3B2D-1: dense ball trajectory (BALL_TRAJECTORY_ENABLED gated; 503 when off)
 router.include_router(juggling_ball_trajectory.router, tags=["users", "juggling"])
+# AN-3B2D-B0: user-assisted ball feedback (BALL_FEEDBACK_ENABLED gated; 503 when off)
+router.include_router(juggling_ball_feedback.router, tags=["users", "juggling"])
 
 # CRUD endpoints (should be last due to /{user_id} catch-all)
 router.include_router(crud.router, tags=["users"])

--- a/app/api/api_v1/endpoints/users/juggling_ball_feedback.py
+++ b/app/api/api_v1/endpoints/users/juggling_ball_feedback.py
@@ -1,0 +1,91 @@
+"""
+Ball feedback endpoints — AN-3B2D-B0.
+
+POST /users/me/juggling/videos/{video_id}/ball-feedback
+  Submit one user feedback record for a single trajectory frame.
+  Returns 201 with BallFeedbackOut on success.
+  Returns 409 if user already submitted for this video+frame.
+  Returns 404 if video not found or gdpr_deleted.
+
+GET  /users/me/juggling/videos/{video_id}/ball-feedback/queue
+  Return prioritized list of frames needing user validation.
+  Excludes frames user already reviewed. Excludes frames with ≥3 feedbacks.
+  Priority: uncertain + lost frames first.
+
+Gated: JUGGLING_POC_ENABLED + BALL_FEEDBACK_ENABLED (both must be True).
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.database import get_db
+from app.dependencies import get_current_user
+from app.models.user import User
+from app.schemas.juggling import BallFeedbackOut, BallFeedbackQueueResponse, BallFeedbackRequest
+from app.services.juggling import ball_feedback_service
+from app.services.juggling.feature_flag import require_juggling_enabled
+
+router = APIRouter()
+
+_TAG = "juggling"
+_PREFIX = "/me/juggling/videos/{video_id}/ball-feedback"
+
+
+async def require_ball_feedback_enabled() -> None:
+    if not settings.BALL_FEEDBACK_ENABLED:
+        raise HTTPException(
+            status_code=503,
+            detail="Ball feedback is not enabled. Set BALL_FEEDBACK_ENABLED=true.",
+        )
+
+
+@router.post(
+    _PREFIX,
+    response_model=BallFeedbackOut,
+    status_code=201,
+    dependencies=[Depends(require_juggling_enabled), Depends(require_ball_feedback_enabled)],
+    summary="Submit ball detection feedback for a trajectory frame",
+    tags=[_TAG],
+)
+def post_ball_feedback(
+    video_id: str,
+    body: BallFeedbackRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> BallFeedbackOut:
+    record = ball_feedback_service.submit_feedback(
+        db=db,
+        video_id=video_id,
+        user_id=current_user.id,
+        req=body,
+    )
+    return BallFeedbackOut.model_validate(record)
+
+
+@router.get(
+    _PREFIX + "/queue",
+    response_model=BallFeedbackQueueResponse,
+    dependencies=[Depends(require_juggling_enabled), Depends(require_ball_feedback_enabled)],
+    summary="Get prioritized feedback queue for a video",
+    tags=[_TAG],
+)
+def get_feedback_queue(
+    video_id: str,
+    limit: int = Query(5, ge=1, le=20),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> BallFeedbackQueueResponse:
+    items = ball_feedback_service.get_feedback_queue(
+        db=db,
+        video_id=video_id,
+        user_id=current_user.id,
+        limit=limit,
+    )
+    return BallFeedbackQueueResponse(
+        video_id=video_id,
+        queue_items=items,
+        total=len(items),
+        max_per_session=3,
+    )

--- a/app/api/api_v1/endpoints/users/juggling_ball_trajectory.py
+++ b/app/api/api_v1/endpoints/users/juggling_ball_trajectory.py
@@ -1,0 +1,95 @@
+"""
+Dense ball trajectory endpoints — AN-3B2D-1.
+
+GET  /users/me/juggling/videos/{video_id}/ball-trajectory
+  Windowed trajectory query. Max 60s window (600 points at 10 FPS).
+
+POST /users/me/juggling/videos/{video_id}/ball-trajectory/manual-seed
+  Manual ball position seed. UPSERT: 201 create / 200 update.
+
+Gated: JUGGLING_POC_ENABLED + BALL_TRAJECTORY_ENABLED.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.database import get_db
+from app.dependencies import get_current_user
+from app.models.user import User
+from app.schemas.juggling import (
+    BallTrajectoryManualSeedOut,
+    BallTrajectoryManualSeedRequest,
+    BallTrajectoryPointOut,
+    BallTrajectoryResponse,
+)
+from app.services.juggling import ball_trajectory_service
+from app.services.juggling.feature_flag import require_juggling_enabled
+
+router = APIRouter()
+
+_TAG = "juggling"
+_PREFIX = "/me/juggling/videos/{video_id}/ball-trajectory"
+
+
+async def require_ball_trajectory_enabled() -> None:
+    if not settings.BALL_TRAJECTORY_ENABLED:
+        raise HTTPException(
+            status_code=503,
+            detail="Ball trajectory is not enabled. Set BALL_TRAJECTORY_ENABLED=true.",
+        )
+
+
+@router.get(
+    _PREFIX,
+    response_model=BallTrajectoryResponse,
+    dependencies=[Depends(require_juggling_enabled), Depends(require_ball_trajectory_enabled)],
+    summary="Get dense ball trajectory window",
+    tags=[_TAG],
+)
+def get_ball_trajectory(
+    video_id: str,
+    from_ms: int = Query(0, ge=0),
+    to_ms: int = Query(60_000, ge=0),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> BallTrajectoryResponse:
+    result = ball_trajectory_service.get_trajectory_window(
+        video_id=video_id,
+        user_id=current_user.id,
+        from_ms=from_ms,
+        to_ms=to_ms,
+        db=db,
+    )
+    return BallTrajectoryResponse(
+        status=result["status"],
+        points=[BallTrajectoryPointOut.model_validate(p) for p in result["points"]],
+    )
+
+
+@router.post(
+    _PREFIX + "/manual-seed",
+    response_model=BallTrajectoryManualSeedOut,
+    dependencies=[Depends(require_juggling_enabled), Depends(require_ball_trajectory_enabled)],
+    summary="Manual ball position seed",
+    tags=[_TAG],
+)
+def post_manual_seed(
+    video_id: str,
+    body: BallTrajectoryManualSeedRequest,
+    response: Response,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> BallTrajectoryManualSeedOut:
+    point, created = ball_trajectory_service.upsert_manual_seed(
+        video_id=video_id,
+        user_id=current_user.id,
+        frame_ms=body.frame_ms,
+        ball_x=body.ball_x,
+        ball_y=body.ball_y,
+        db=db,
+    )
+    if created:
+        response.status_code = 201
+    return BallTrajectoryManualSeedOut.model_validate(point)

--- a/app/api/api_v1/endpoints/users/juggling_videos.py
+++ b/app/api/api_v1/endpoints/users/juggling_videos.py
@@ -68,6 +68,7 @@ from app.services.juggling.media_service import (
     resolve_media_path,
     resolve_thumbnail_path,
 )
+from app.config import settings
 from app.tasks.juggling_transcode_task import transcode_video_task
 
 router = APIRouter()
@@ -320,6 +321,12 @@ def complete(
     # only when transcode_status=done or skipped.
     video_service.set_processing(video_id, db)
     transcode_video_task.delay(video_id)
+
+    if settings.BALL_TRAJECTORY_ENABLED:
+        from app.tasks.juggling_trajectory_task import dense_ball_trajectory_task
+        dense_ball_trajectory_task.apply_async(args=[video_id], countdown=120)
+        video.ball_trajectory_status = "pending"
+        db.commit()
 
     return JugglingCompleteOut(
         video_id=video_id,

--- a/app/celery_app.py
+++ b/app/celery_app.py
@@ -35,6 +35,7 @@ def create_celery() -> Celery:
             "app.tasks.juggling_transcode_task",
             "app.tasks.juggling_retention_task",
             "app.tasks.juggling_analysis_task",
+            "app.tasks.juggling_trajectory_task",
         ],
     )
 
@@ -75,6 +76,7 @@ def create_celery() -> Celery:
             "app.tasks.juggling_transcode_task.transcode_video_task":               {"queue": "juggling_videos"},
             "app.tasks.juggling_retention_task.run_retention_task":                 {"queue": "juggling_retention"},
             "app.tasks.juggling_analysis_task.detect_ball_for_event":               {"queue": "analysis"},
+            "app.tasks.juggling_trajectory_task.dense_ball_trajectory_task":        {"queue": "analysis"},
         },
         # Queues
         task_default_queue="default",
@@ -109,6 +111,9 @@ def create_celery() -> Celery:
             },
             "app.tasks.juggling_analysis_task.detect_ball_for_event": {
                 "rate_limit": "30/m",
+            },
+            "app.tasks.juggling_trajectory_task.dense_ball_trajectory_task": {
+                "rate_limit": "5/m",
             },
         },
     )

--- a/app/config.py
+++ b/app/config.py
@@ -418,6 +418,11 @@ class Settings(BaseSettings):
     BALL_DETECTION_ENABLED: bool = False
     BALL_DETECTION_MODEL_PATH: str = "app/ml_models/ssd_mobilenet_v1_12.onnx"
 
+    # BALL_TRAJECTORY_ENABLED — AN-3B2D-1 dense ball tracking.
+    #   OFF by default. When OFF, trajectory endpoints return HTTP 503.
+    #   Turn ON per-deployment in .env: BALL_TRAJECTORY_ENABLED=true
+    BALL_TRAJECTORY_ENABLED: bool = False
+
     # ── Slow-query monitoring ──────────────────────────────────────────────────
     # Queries slower than SLOW_QUERY_THRESHOLD_MS are logged to app.slow_query
     # and counted in the slow_queries_total metric.  Raise this value if normal

--- a/app/config.py
+++ b/app/config.py
@@ -423,6 +423,11 @@ class Settings(BaseSettings):
     #   Turn ON per-deployment in .env: BALL_TRAJECTORY_ENABLED=true
     BALL_TRAJECTORY_ENABLED: bool = False
 
+    # BALL_FEEDBACK_ENABLED — AN-3B2D-B0 user-assisted ball annotation feedback.
+    #   OFF by default. When OFF, feedback endpoints return HTTP 503.
+    #   Turn ON per-deployment in .env: BALL_FEEDBACK_ENABLED=true
+    BALL_FEEDBACK_ENABLED: bool = False
+
     # ── Slow-query monitoring ──────────────────────────────────────────────────
     # Queries slower than SLOW_QUERY_THRESHOLD_MS are logged to app.slow_query
     # and counted in the slow_queries_total metric.  Raise this value if normal

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -81,6 +81,7 @@ from .juggling import (
     JugglingAnnotationReviewStatus,
     JugglingTaxonomyReviewStatus,
     JugglingVideoAnnotationStatus,
+    JugglingBallTrajectory,
 )
 
 # 🎓 New Track-Based Modular Education System

--- a/app/models/juggling.py
+++ b/app/models/juggling.py
@@ -38,6 +38,7 @@ from sqlalchemy import (
     SmallInteger,
     String,
     UniqueConstraint,
+    text,
 )
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import relationship
@@ -285,6 +286,12 @@ class JugglingVideo(Base):
     user_rotation_degrees = Column(
         SmallInteger, nullable=False, default=0, server_default="0",
         comment="User display rotation override (0/90/180/270). Not a transcode parameter.",
+    )
+
+    # ── Dense ball trajectory lifecycle (AN-3B2D-1) ────────────────────────
+    ball_trajectory_status = Column(
+        String(20), nullable=True, default=None,
+        comment="pending / processing / complete / failed — dense ball tracking lifecycle",
     )
 
     # ── Timestamps ───────────────────────────────────────────────────────────
@@ -577,6 +584,50 @@ class JugglingBallDetection(Base):
             "(no_ball_detected = true AND ball_x IS NULL AND ball_y IS NULL) "
             "OR (no_ball_detected = false AND ball_x IS NOT NULL AND ball_y IS NOT NULL)",
             name="ck_juggling_ball_detections_coords",
+        ),
+    )
+
+
+class JugglingBallTrajectory(Base):
+    """
+    Dense ball trajectory point — one row per (video, frame_ms).
+
+    Populated by dense_ball_trajectory_task at 10 FPS (100ms intervals).
+    tracking_state: detected (ONNX hit), predicted (Kalman extrapolation),
+    lost (too many misses), manual_seed (user-placed).
+    """
+    __tablename__ = "juggling_ball_trajectories"
+
+    id              = Column(UUID(as_uuid=True), primary_key=True,
+                             server_default=text("gen_random_uuid()"))
+    video_id        = Column(UUID(as_uuid=True),
+                             ForeignKey("juggling_videos.id", ondelete="CASCADE"),
+                             nullable=False)
+    frame_ms        = Column(Integer, nullable=False)
+    ball_x          = Column(Float, nullable=True)
+    ball_y          = Column(Float, nullable=True)
+    confidence      = Column(Float, nullable=True)
+    is_manual       = Column(Boolean, nullable=False, default=False,
+                             server_default="false")
+    tracking_state  = Column(String(20), nullable=False, default="detected",
+                             server_default=text("'detected'"))
+    model_version   = Column(String(60), nullable=True)
+    image_width_px  = Column(Integer, nullable=True)
+    image_height_px = Column(Integer, nullable=True)
+    created_at      = Column(DateTime(timezone=True), nullable=False,
+                             server_default=text("now()"))
+
+    __table_args__ = (
+        UniqueConstraint("video_id", "frame_ms",
+                         name="ux_ball_traj_video_frame"),
+        CheckConstraint(
+            "tracking_state IN ('detected', 'predicted', 'lost', 'manual_seed')",
+            name="ck_ball_traj_tracking_state",
+        ),
+        CheckConstraint(
+            "(tracking_state = 'lost' AND ball_x IS NULL AND ball_y IS NULL) "
+            "OR (tracking_state != 'lost' AND ball_x IS NOT NULL AND ball_y IS NOT NULL)",
+            name="ck_ball_traj_coords_state",
         ),
     )
 

--- a/app/models/juggling.py
+++ b/app/models/juggling.py
@@ -682,3 +682,146 @@ from sqlalchemy import event as _sa_event  # noqa: E402
 def _freeze_auto_confidence_on_insert(mapper, connection, target):  # noqa: ANN001
     if target.detection_source != "manual" and target.auto_confidence is None:
         target.auto_confidence = target.confidence
+
+
+# ── AN-3B2D-B0: User-assisted ball model training ─────────────────────────────
+
+
+class BallFeedbackDecision(str, enum.Enum):
+    confirm   = "confirm"
+    reject    = "reject"
+    no_ball   = "no_ball"
+    corrected = "corrected"
+
+
+class BallFeedbackApprovalState(str, enum.Enum):
+    pending      = "pending"
+    approved     = "approved"
+    needs_review = "needs_review"
+    rejected     = "rejected"
+    spam         = "spam"
+
+
+class JugglingBallFeedback(Base):
+    """Per-user per-frame ball detection feedback. One row per (user, video, frame_ms)."""
+
+    __tablename__ = "juggling_ball_feedback"
+
+    id                    = Column(UUID(as_uuid=True), primary_key=True,
+                                   default=_uuid_mod.uuid4)
+    video_id              = Column(UUID(as_uuid=True),
+                                   ForeignKey("juggling_videos.id", ondelete="CASCADE"),
+                                   nullable=False, index=True)
+    frame_ms              = Column(Integer, nullable=False)
+    trajectory_point_id   = Column(UUID(as_uuid=True),
+                                   ForeignKey("juggling_ball_trajectories.id",
+                                              ondelete="SET NULL"),
+                                   nullable=True)
+    user_id               = Column(Integer,
+                                   ForeignKey("users.id", ondelete="CASCADE"),
+                                   nullable=False, index=True)
+    # Decision
+    decision              = Column(String(20), nullable=False)
+    corrected_x           = Column(Float, nullable=True)
+    corrected_y           = Column(Float, nullable=True)
+    correction_method     = Column(String(20), nullable=True)
+    # Model context snapshot at submit time
+    model_predicted_x     = Column(Float, nullable=True)
+    model_predicted_y     = Column(Float, nullable=True)
+    model_confidence      = Column(Float, nullable=True)
+    model_tracking_state  = Column(String(20), nullable=True)
+    # Reliability (score at submit; not updated in B0)
+    user_reliability_at_submit  = Column(Float, nullable=True, default=0.5)
+    weighted_vote_contribution  = Column(Float, nullable=True)
+    # State
+    approval_state    = Column(String(20), nullable=False, default="pending")
+    is_gold_standard  = Column(Boolean, nullable=False, default=False)
+    is_control_sample = Column(Boolean, nullable=False, default=False)
+    spam_flags        = Column(JSONB, nullable=False, default=list)
+    # Timestamps
+    created_at          = Column(DateTime(timezone=True), nullable=False,
+                                 default=lambda: datetime.now(timezone.utc))
+    reviewed_at         = Column(DateTime(timezone=True), nullable=True)
+    reviewed_by_user_id = Column(Integer,
+                                  ForeignKey("users.id", ondelete="SET NULL"),
+                                  nullable=True)
+
+    __table_args__ = (
+        UniqueConstraint("user_id", "video_id", "frame_ms",
+                         name="uq_ball_feedback_user_video_frame"),
+        CheckConstraint(
+            "decision IN ('confirm','reject','no_ball','corrected')",
+            name="ck_ball_feedback_decision",
+        ),
+        CheckConstraint(
+            "decision != 'corrected' OR "
+            "(corrected_x IS NOT NULL AND corrected_y IS NOT NULL)",
+            name="ck_ball_feedback_corrected_coords",
+        ),
+    )
+
+
+class FrameGroundTruthDecision(str, enum.Enum):
+    ball_present = "ball_present"
+    no_ball      = "no_ball"
+    uncertain    = "uncertain"
+
+
+class JugglingFrameGroundTruth(Base):
+    """Aggregated majority-vote ground truth per (video, frame_ms). Populated by B2+."""
+
+    __tablename__ = "juggling_frame_ground_truth"
+
+    id       = Column(UUID(as_uuid=True), primary_key=True, default=_uuid_mod.uuid4)
+    video_id = Column(UUID(as_uuid=True),
+                      ForeignKey("juggling_videos.id", ondelete="CASCADE"),
+                      nullable=False)
+    frame_ms = Column(Integer, nullable=False)
+    # Ground truth (populated B2)
+    gt_decision    = Column(String(20), nullable=False, default="uncertain")
+    gt_x           = Column(Float, nullable=True)
+    gt_y           = Column(Float, nullable=True)
+    gt_bbox_width  = Column(Float, nullable=True)
+    gt_bbox_height = Column(Float, nullable=True)
+    # Vote aggregates (populated B2)
+    confidence_score = Column(Float,   nullable=False, default=0.0)
+    agreement_rate   = Column(Float,   nullable=False, default=0.0)
+    vote_count       = Column(Integer, nullable=False, default=0)
+    yes_votes        = Column(Integer, nullable=False, default=0)
+    no_votes         = Column(Integer, nullable=False, default=0)
+    no_ball_votes    = Column(Integer, nullable=False, default=0)
+    correction_count = Column(Integer, nullable=False, default=0)
+    # Training eligibility (never True in B0)
+    training_eligible = Column(Boolean,              nullable=False, default=False)
+    dataset_version   = Column(String(20),           nullable=True)
+    exported_at       = Column(DateTime(timezone=True), nullable=True)
+    # Metadata
+    is_gold_standard = Column(Boolean, nullable=False, default=False)
+    created_at = Column(DateTime(timezone=True), nullable=False,
+                        default=lambda: datetime.now(timezone.utc))
+    updated_at = Column(DateTime(timezone=True), nullable=False,
+                        default=lambda: datetime.now(timezone.utc),
+                        onupdate=lambda: datetime.now(timezone.utc))
+
+    __table_args__ = (
+        UniqueConstraint("video_id", "frame_ms",
+                         name="uq_frame_ground_truth_video_frame"),
+    )
+
+
+class UserAnnotationReliability(Base):
+    """Per-user annotation quality tracking. Populated by B2+."""
+
+    __tablename__ = "user_annotation_reliability"
+
+    user_id = Column(Integer,
+                     ForeignKey("users.id", ondelete="CASCADE"),
+                     primary_key=True)
+    ball_annotation_reliability = Column(Float,   nullable=False, default=0.5)
+    total_feedbacks             = Column(Integer, nullable=False, default=0)
+    correct_feedbacks           = Column(Integer, nullable=False, default=0)
+    gold_attempts               = Column(Integer, nullable=False, default=0)
+    gold_correct                = Column(Integer, nullable=False, default=0)
+    spam_flags_count            = Column(Integer, nullable=False, default=0)
+    last_updated = Column(DateTime(timezone=True), nullable=False,
+                          default=lambda: datetime.now(timezone.utc))

--- a/app/schemas/juggling.py
+++ b/app/schemas/juggling.py
@@ -449,3 +449,37 @@ class BallDetectionTriggerResult(BaseModel):
     skipped_reasons:        List[str]
 
     model_config = {"protected_namespaces": ()}
+
+
+# ── Dense ball trajectory schemas (AN-3B2D-1) ───────────────────────────────
+
+class BallTrajectoryPointOut(BaseModel):
+    frame_ms:       int
+    ball_x:         Optional[float]
+    ball_y:         Optional[float]
+    confidence:     Optional[float]
+    is_manual:      bool
+    tracking_state: str
+
+    model_config = {"from_attributes": True}
+
+
+class BallTrajectoryResponse(BaseModel):
+    status: str
+    points: List[BallTrajectoryPointOut]
+
+
+class BallTrajectoryManualSeedRequest(BaseModel):
+    frame_ms: int   = Field(..., ge=0)
+    ball_x:   float = Field(..., ge=0.0, le=1.0)
+    ball_y:   float = Field(..., ge=0.0, le=1.0)
+
+
+class BallTrajectoryManualSeedOut(BaseModel):
+    frame_ms:       int
+    ball_x:         float
+    ball_y:         float
+    tracking_state: str
+    is_manual:      bool
+
+    model_config = {"from_attributes": True}

--- a/app/schemas/juggling.py
+++ b/app/schemas/juggling.py
@@ -483,3 +483,76 @@ class BallTrajectoryManualSeedOut(BaseModel):
     is_manual:      bool
 
     model_config = {"from_attributes": True}
+
+
+# ── AN-3B2D-B0: Ball feedback schemas ────────────────────────────────────────
+
+
+class BallFeedbackRequest(BaseModel):
+    model_config = {"protected_namespaces": ()}
+
+    frame_ms:          int   = Field(..., ge=0)
+    decision:          str   = Field(..., description="confirm | reject | no_ball | corrected")
+    corrected_x:       Optional[float] = Field(None, ge=0.0, le=1.0)
+    corrected_y:       Optional[float] = Field(None, ge=0.0, le=1.0)
+    correction_method: Optional[str]   = Field(None)
+    # Model context snapshot sent from iOS
+    model_predicted_x:    Optional[float] = Field(None)
+    model_predicted_y:    Optional[float] = Field(None)
+    model_confidence:     Optional[float] = Field(None, ge=0.0, le=1.0)
+    model_tracking_state: Optional[str]   = Field(None)
+
+    @field_validator("decision")
+    @classmethod
+    def decision_must_be_valid(cls, v: str) -> str:
+        allowed = {"confirm", "reject", "no_ball", "corrected"}
+        if v not in allowed:
+            raise ValueError(f"decision must be one of {sorted(allowed)}")
+        return v
+
+    @field_validator("correction_method")
+    @classmethod
+    def correction_method_valid(cls, v: Optional[str]) -> Optional[str]:
+        if v is not None and v not in {"tap", "drag"}:
+            raise ValueError("correction_method must be 'tap' or 'drag'")
+        return v
+
+    @model_validator(mode="after")
+    def corrected_requires_coords(self) -> "BallFeedbackRequest":
+        if self.decision == "corrected" and (
+            self.corrected_x is None or self.corrected_y is None
+        ):
+            raise ValueError(
+                "corrected_x and corrected_y are required when decision='corrected'"
+            )
+        return self
+
+
+class BallFeedbackOut(BaseModel):
+    id:             uuid.UUID
+    video_id:       uuid.UUID
+    frame_ms:       int
+    decision:       str
+    approval_state: str
+    created_at:     datetime
+
+    model_config = {"from_attributes": True}
+
+
+class BallFeedbackQueueItem(BaseModel):
+    model_config = {"protected_namespaces": ()}
+
+    frame_ms:                int
+    priority_score:          float
+    model_predicted_x:       Optional[float]
+    model_predicted_y:       Optional[float]
+    model_confidence:        Optional[float]
+    model_tracking_state:    Optional[str]
+    existing_feedback_count: int
+
+
+class BallFeedbackQueueResponse(BaseModel):
+    video_id:        str
+    queue_items:     List[BallFeedbackQueueItem]
+    total:           int
+    max_per_session: int = 3

--- a/app/services/juggling/ball_feedback_service.py
+++ b/app/services/juggling/ball_feedback_service.py
@@ -1,0 +1,196 @@
+"""
+Ball feedback service — AN-3B2D-B0.
+
+submit_feedback(): persist one user feedback record.
+get_feedback_queue(): return prioritized uncertain frames for a video.
+
+B0 scope:
+  - No reliability score updates (B2).
+  - No consensus/majority vote compute (B2).
+  - No credit grants (B2).
+  - No spam detection (B2).
+  - training_eligible is never set True here.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import HTTPException
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from app.models.juggling import (
+    JugglingBallFeedback,
+    JugglingBallTrajectory,
+    JugglingVideo,
+    UserAnnotationReliability,
+)
+from app.schemas.juggling import BallFeedbackQueueItem, BallFeedbackRequest
+
+
+def _get_user_reliability(db: Session, user_id: int) -> float:
+    """Return user's ball annotation reliability score, lazy-creating at 0.5."""
+    rel = db.get(UserAnnotationReliability, user_id)
+    if rel is None:
+        rel = UserAnnotationReliability(user_id=user_id)
+        db.add(rel)
+        db.flush()
+    return rel.ball_annotation_reliability
+
+
+def _resolve_trajectory_point_id(
+    db: Session,
+    video_id: str,
+    frame_ms: int,
+) -> Optional[str]:
+    """Return trajectory point UUID for (video_id, frame_ms) or None."""
+    row = db.execute(
+        select(JugglingBallTrajectory.id).where(
+            JugglingBallTrajectory.video_id == video_id,
+            JugglingBallTrajectory.frame_ms == frame_ms,
+        )
+    ).scalar_one_or_none()
+    return row
+
+
+def submit_feedback(
+    db: Session,
+    video_id: str,
+    user_id: int,
+    req: BallFeedbackRequest,
+) -> JugglingBallFeedback:
+    """
+    Persist one user feedback record.
+
+    Raises:
+        404 if video_id not found or gdpr_deleted.
+        409 if user already submitted feedback for this video+frame.
+    """
+    # 1. Video existence check
+    video = db.execute(
+        select(JugglingVideo).where(JugglingVideo.id == video_id)
+    ).scalar_one_or_none()
+    if video is None or video.status == "gdpr_deleted":
+        raise HTTPException(status_code=404, detail="Video not found.")
+
+    # 2. Duplicate check (before hitting DB UNIQUE constraint)
+    existing = db.execute(
+        select(JugglingBallFeedback).where(
+            JugglingBallFeedback.user_id == user_id,
+            JugglingBallFeedback.video_id == video_id,
+            JugglingBallFeedback.frame_ms == req.frame_ms,
+        )
+    ).scalar_one_or_none()
+    if existing is not None:
+        raise HTTPException(
+            status_code=409,
+            detail="Feedback already submitted for this frame.",
+        )
+
+    # 3. Reliability score (lazy upsert at 0.5)
+    reliability = _get_user_reliability(db, user_id)
+
+    # 4. Trajectory point FK (optional)
+    traj_id = _resolve_trajectory_point_id(db, video_id, req.frame_ms)
+
+    # 5. Persist
+    record = JugglingBallFeedback(
+        video_id=video_id,
+        frame_ms=req.frame_ms,
+        trajectory_point_id=traj_id,
+        user_id=user_id,
+        decision=req.decision,
+        corrected_x=req.corrected_x,
+        corrected_y=req.corrected_y,
+        correction_method=req.correction_method,
+        model_predicted_x=req.model_predicted_x,
+        model_predicted_y=req.model_predicted_y,
+        model_confidence=req.model_confidence,
+        model_tracking_state=req.model_tracking_state,
+        user_reliability_at_submit=reliability,
+        approval_state="pending",
+    )
+    db.add(record)
+    db.commit()
+    db.refresh(record)
+    return record
+
+
+def get_feedback_queue(
+    db: Session,
+    video_id: str,
+    user_id: int,
+    limit: int = 5,
+) -> list[BallFeedbackQueueItem]:
+    """
+    Return prioritized feedback queue for uncertain frames the user hasn't reviewed.
+
+    Priority score (B0 simplified):
+      score = (1.0 - confidence) * 0.60   for detected/predicted frames
+      score = 1.0 * 0.60                  for lost frames (confidence=None)
+      score -= 0.10 * min(feedback_count, 3)
+
+    Only frames with < 3 total feedbacks are included.
+    Frames already reviewed by this user are excluded.
+    """
+    video = db.execute(
+        select(JugglingVideo).where(JugglingVideo.id == video_id)
+    ).scalar_one_or_none()
+    if video is None or video.status == "gdpr_deleted":
+        raise HTTPException(status_code=404, detail="Video not found.")
+
+    # Frames reviewed by this user
+    user_reviewed = set(
+        db.execute(
+            select(JugglingBallFeedback.frame_ms).where(
+                JugglingBallFeedback.video_id == video_id,
+                JugglingBallFeedback.user_id == user_id,
+            )
+        ).scalars().all()
+    )
+
+    # Total feedback count per frame (all users)
+    count_rows = db.execute(
+        select(
+            JugglingBallFeedback.frame_ms,
+            func.count(JugglingBallFeedback.id).label("cnt"),
+        )
+        .where(JugglingBallFeedback.video_id == video_id)
+        .group_by(JugglingBallFeedback.frame_ms)
+    ).all()
+    feedback_counts: dict[int, int] = {r.frame_ms: r.cnt for r in count_rows}
+
+    # Trajectory points for this video
+    trajectory_rows = db.execute(
+        select(JugglingBallTrajectory).where(
+            JugglingBallTrajectory.video_id == video_id
+        )
+    ).scalars().all()
+
+    items: list[BallFeedbackQueueItem] = []
+    for pt in trajectory_rows:
+        if pt.frame_ms in user_reviewed:
+            continue
+        fb_count = feedback_counts.get(pt.frame_ms, 0)
+        if fb_count >= 3:
+            continue
+
+        # Priority score
+        if pt.tracking_state == "lost" or pt.confidence is None:
+            base = 0.60
+        else:
+            base = (1.0 - pt.confidence) * 0.60
+        score = base - 0.10 * min(fb_count, 3)
+
+        items.append(BallFeedbackQueueItem(
+            frame_ms=pt.frame_ms,
+            priority_score=round(score, 4),
+            model_predicted_x=pt.ball_x,
+            model_predicted_y=pt.ball_y,
+            model_confidence=pt.confidence,
+            model_tracking_state=pt.tracking_state,
+            existing_feedback_count=fb_count,
+        ))
+
+    items.sort(key=lambda x: x.priority_score, reverse=True)
+    return items[:limit]

--- a/app/services/juggling/ball_trajectory_service.py
+++ b/app/services/juggling/ball_trajectory_service.py
@@ -1,0 +1,116 @@
+"""
+Ball trajectory service — dense trajectory CRUD.
+
+No ONNX inference (that's in the Celery task).
+This module: query trajectories, upsert manual seeds, status management.
+"""
+from __future__ import annotations
+
+import uuid as _uuid_mod
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from app.models.juggling import JugglingBallTrajectory, JugglingVideo
+
+
+MAX_WINDOW_MS = 60_000
+
+
+def _get_video_owned(video_id: str, user_id: int, db: Session) -> JugglingVideo:
+    try:
+        vid_uuid = _uuid_mod.UUID(video_id)
+    except (ValueError, AttributeError):
+        raise HTTPException(status_code=404, detail="Video not found")
+    video = db.query(JugglingVideo).filter(JugglingVideo.id == vid_uuid).first()
+    if video is None or video.user_id != user_id:
+        raise HTTPException(status_code=404, detail="Video not found")
+    return video
+
+
+def get_trajectory_window(
+    video_id: str,
+    user_id: int,
+    from_ms: int,
+    to_ms: int,
+    db: Session,
+) -> dict:
+    """Query trajectory points in [from_ms, to_ms] for a user's video."""
+    video = _get_video_owned(video_id, user_id, db)
+
+    if to_ms - from_ms > MAX_WINDOW_MS:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Window too large. Max {MAX_WINDOW_MS}ms ({MAX_WINDOW_MS // 1000}s).",
+        )
+
+    status = video.ball_trajectory_status
+    if status is None:
+        raise HTTPException(status_code=404, detail="No trajectory data for this video")
+
+    points = (
+        db.query(JugglingBallTrajectory)
+        .filter(
+            JugglingBallTrajectory.video_id == video.id,
+            JugglingBallTrajectory.frame_ms >= from_ms,
+            JugglingBallTrajectory.frame_ms <= to_ms,
+        )
+        .order_by(JugglingBallTrajectory.frame_ms)
+        .all()
+    )
+
+    return {"status": status, "points": points}
+
+
+def upsert_manual_seed(
+    video_id: str,
+    user_id: int,
+    frame_ms: int,
+    ball_x: float,
+    ball_y: float,
+    db: Session,
+) -> tuple[JugglingBallTrajectory, bool]:
+    """UPSERT manual seed point. Returns (model, created)."""
+    video = _get_video_owned(video_id, user_id, db)
+
+    existing = (
+        db.query(JugglingBallTrajectory)
+        .filter(
+            JugglingBallTrajectory.video_id == video.id,
+            JugglingBallTrajectory.frame_ms == frame_ms,
+        )
+        .first()
+    )
+
+    if existing:
+        existing.ball_x = ball_x
+        existing.ball_y = ball_y
+        existing.confidence = None
+        existing.is_manual = True
+        existing.tracking_state = "manual_seed"
+        existing.model_version = None
+        db.commit()
+        db.refresh(existing)
+        return existing, False
+
+    point = JugglingBallTrajectory(
+        video_id=video.id,
+        frame_ms=frame_ms,
+        ball_x=ball_x,
+        ball_y=ball_y,
+        confidence=None,
+        is_manual=True,
+        tracking_state="manual_seed",
+    )
+    db.add(point)
+    db.commit()
+    db.refresh(point)
+    return point, True
+
+
+def set_trajectory_status(video_id: str, status: str, db: Session) -> None:
+    vid_uuid = _uuid_mod.UUID(video_id)
+    db.query(JugglingVideo).filter(JugglingVideo.id == vid_uuid).update(
+        {"ball_trajectory_status": status}
+    )
+    db.commit()

--- a/app/services/juggling/kalman_ball_tracker.py
+++ b/app/services/juggling/kalman_ball_tracker.py
@@ -1,0 +1,102 @@
+"""
+Minimal 2D Kalman filter for ball trajectory smoothing.
+
+State:     [x, y, vx, vy]  (position + velocity)
+Measure:   [x, y]           (detector output, normalized [0,1])
+No external dependencies beyond numpy (already present via onnxruntime).
+"""
+from __future__ import annotations
+
+import numpy as np
+
+
+class KalmanBallTracker:
+    """
+    Simple constant-velocity Kalman filter for 2D ball tracking.
+
+    After max_miss consecutive frames without detection the tracker
+    enters 'lost' state and predict_only() returns None.
+    Re-initialized on next detection (or manual seed).
+    """
+
+    def __init__(self, max_miss: int = 5, dt: float = 0.1):
+        self._max_miss = max_miss
+        self._dt = dt
+        self._initialized = False
+        self._miss_count = 0
+
+        self._F = np.array([
+            [1, 0, dt, 0],
+            [0, 1, 0, dt],
+            [0, 0, 1,  0],
+            [0, 0, 0,  1],
+        ], dtype=np.float64)
+
+        self._H = np.array([
+            [1, 0, 0, 0],
+            [0, 1, 0, 0],
+        ], dtype=np.float64)
+
+        self._Q = np.eye(4, dtype=np.float64) * 0.001
+        self._Q[2, 2] = 0.01
+        self._Q[3, 3] = 0.01
+
+        self._R = np.eye(2, dtype=np.float64) * 0.005
+
+        self._x = np.zeros(4, dtype=np.float64)
+        self._P = np.eye(4, dtype=np.float64)
+
+    @property
+    def is_lost(self) -> bool:
+        return not self._initialized or self._miss_count > self._max_miss
+
+    @property
+    def miss_count(self) -> int:
+        return self._miss_count
+
+    def update(self, cx: float, cy: float) -> tuple[float, float]:
+        """Feed a detection. Returns smoothed (x, y)."""
+        z = np.array([cx, cy], dtype=np.float64)
+
+        if not self._initialized or self.is_lost:
+            self._x = np.array([cx, cy, 0.0, 0.0], dtype=np.float64)
+            self._P = np.eye(4, dtype=np.float64)
+            self._initialized = True
+            self._miss_count = 0
+            return (cx, cy)
+
+        x_pred = self._F @ self._x
+        P_pred = self._F @ self._P @ self._F.T + self._Q
+
+        y_res = z - self._H @ x_pred
+        S = self._H @ P_pred @ self._H.T + self._R
+        K = P_pred @ self._H.T @ np.linalg.inv(S)
+        self._x = x_pred + K @ y_res
+        self._P = (np.eye(4) - K @ self._H) @ P_pred
+
+        self._miss_count = 0
+        return (float(self._x[0]), float(self._x[1]))
+
+    def predict_only(self) -> tuple[float, float] | None:
+        """Extrapolate one step without measurement. Returns None if lost."""
+        if not self._initialized:
+            return None
+
+        self._miss_count += 1
+        if self._miss_count > self._max_miss:
+            return None
+
+        self._x = self._F @ self._x
+        self._P = self._F @ self._P @ self._F.T + self._Q
+        return (float(self._x[0]), float(self._x[1]))
+
+    def mark_miss(self) -> None:
+        """Increment miss counter without predicting."""
+        self._miss_count += 1
+
+    def seed(self, cx: float, cy: float) -> None:
+        """Manual re-initialize (after user tap)."""
+        self._x = np.array([cx, cy, 0.0, 0.0], dtype=np.float64)
+        self._P = np.eye(4, dtype=np.float64)
+        self._initialized = True
+        self._miss_count = 0

--- a/app/tasks/juggling_trajectory_task.py
+++ b/app/tasks/juggling_trajectory_task.py
@@ -1,0 +1,261 @@
+"""
+Dense ball trajectory Celery task — AN-3B2D-1.
+
+Samples every 100ms (10 FPS) across the full video, runs ONNX ball
+detection on each frame, and applies Kalman smoothing for inter-frame
+tracking.  Results bulk-inserted into juggling_ball_trajectories.
+
+Queue: analysis (--pool=solo -c 1, one task at a time).
+Trigger: auto-dispatch from POST /complete (countdown=120s) or admin.
+
+IMPORTANT: frame_extractor and onnx_ball_detector are IMPORTED, not modified.
+"""
+from __future__ import annotations
+
+import logging
+import time
+import uuid as _uuid
+from dataclasses import dataclass
+from pathlib import Path
+
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.models.juggling import JugglingBallTrajectory, JugglingVideo
+from app.services.juggling.analysis_model_registry import get_model_config
+from app.services.juggling.kalman_ball_tracker import KalmanBallTracker
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _TrajectoryPoint:
+    frame_ms: int
+    ball_x: float | None = None
+    ball_y: float | None = None
+    confidence: float | None = None
+    state: str = "lost"
+    image_width_px: int | None = None
+    image_height_px: int | None = None
+
+
+def _video_path(video: JugglingVideo) -> str | None:
+    for attr in ("processed_path", "storage_path"):
+        raw = getattr(video, attr, None)
+        if raw and Path(raw).is_file():
+            return raw
+    return None
+
+
+def _get_duration_ms(video: JugglingVideo) -> int | None:
+    for meta_attr in ("server_detected_metadata", "client_reported_metadata"):
+        meta = getattr(video, meta_attr, None)
+        if meta and isinstance(meta, dict):
+            dur = meta.get("duration_seconds")
+            if dur is not None:
+                return int(float(dur) * 1000)
+    return None
+
+
+def _set_status(video_id: str, status: str, db: Session) -> None:
+    vid_uuid = _uuid.UUID(video_id)
+    db.query(JugglingVideo).filter(JugglingVideo.id == vid_uuid).update(
+        {"ball_trajectory_status": status}
+    )
+    db.commit()
+
+
+def run_dense_ball_trajectory(
+    video_id: str,
+    db: Session,
+    *,
+    _extract_frame=None,
+    _get_detector=None,
+    sampling_interval_ms: int = 100,
+    max_consecutive_miss: int = 5,
+) -> dict:
+    """
+    Core logic — testable without Celery.
+
+    Walks the video at sampling_interval_ms steps, runs ONNX detection,
+    applies Kalman smoothing, and bulk-inserts trajectory points.
+    """
+    if not settings.BALL_TRAJECTORY_ENABLED:
+        return {"status": "skipped", "reason": "BALL_TRAJECTORY_ENABLED=False"}
+
+    vid_uuid = _uuid.UUID(video_id)
+    video = db.query(JugglingVideo).filter(JugglingVideo.id == vid_uuid).first()
+    if video is None:
+        return {"status": "failed", "reason": "video not found"}
+
+    if video.transcode_status not in ("done", "skipped"):
+        return {"status": "skipped", "reason": "transcode not done yet"}
+
+    vpath = _video_path(video)
+    if vpath is None:
+        _set_status(video_id, "failed", db)
+        return {"status": "failed", "reason": "video file not found on disk"}
+
+    duration_ms = _get_duration_ms(video)
+    if duration_ms is None or duration_ms <= 0:
+        _set_status(video_id, "failed", db)
+        return {"status": "failed", "reason": "no duration metadata"}
+
+    _set_status(video_id, "processing", db)
+
+    config = get_model_config(video.training_video_type or "juggling")
+    model_path = getattr(settings, config.model_path_key)
+
+    if not Path(model_path).is_file():
+        _set_status(video_id, "failed", db)
+        return {"status": "failed", "reason": f"model file missing: {model_path}"}
+
+    if _extract_frame is None:
+        from app.services.juggling.frame_extractor import extract_frame_at_ms
+        _extract_frame = extract_frame_at_ms
+    if _get_detector is None:
+        from app.services.juggling.onnx_ball_detector import get_detector
+        _get_detector = get_detector
+
+    detector = _get_detector(model_path)
+    tracker = KalmanBallTracker(max_miss=max_consecutive_miss)
+
+    t_start = time.monotonic()
+    points: list[_TrajectoryPoint] = []
+    counts = {"detected": 0, "predicted": 0, "lost": 0}
+
+    for frame_ms in range(0, duration_ms + 1, sampling_interval_ms):
+        try:
+            frame_rgb, w, h = _extract_frame(vpath, frame_ms)
+        except (ValueError, OSError):
+            tracker.mark_miss()
+            points.append(_TrajectoryPoint(frame_ms=frame_ms, state="lost"))
+            counts["lost"] += 1
+            continue
+
+        result = detector.detect(
+            frame_rgb,
+            target_class_id=config.target_class_id,
+            confidence_threshold=config.confidence_threshold,
+        )
+
+        if result is not None:
+            cx, cy, conf = result
+            sx, sy = tracker.update(cx, cy)
+            points.append(_TrajectoryPoint(
+                frame_ms=frame_ms,
+                ball_x=sx, ball_y=sy,
+                confidence=conf,
+                state="detected",
+                image_width_px=w, image_height_px=h,
+            ))
+            counts["detected"] += 1
+        else:
+            pred = tracker.predict_only()
+            if pred is not None:
+                px, py = pred
+                points.append(_TrajectoryPoint(
+                    frame_ms=frame_ms,
+                    ball_x=px, ball_y=py,
+                    confidence=None,
+                    state="predicted",
+                    image_width_px=w, image_height_px=h,
+                ))
+                counts["predicted"] += 1
+            else:
+                points.append(_TrajectoryPoint(
+                    frame_ms=frame_ms, state="lost",
+                ))
+                counts["lost"] += 1
+
+    # Bulk insert in batches, preserving is_manual=TRUE rows
+    BATCH_SIZE = 200
+    manual_frames = set(
+        r[0] for r in db.query(JugglingBallTrajectory.frame_ms).filter(
+            JugglingBallTrajectory.video_id == vid_uuid,
+            JugglingBallTrajectory.is_manual.is_(True),
+        ).all()
+    )
+
+    inserted = 0
+    for i in range(0, len(points), BATCH_SIZE):
+        batch = points[i:i + BATCH_SIZE]
+        objects = []
+        for p in batch:
+            if p.frame_ms in manual_frames:
+                continue
+            objects.append(JugglingBallTrajectory(
+                video_id=vid_uuid,
+                frame_ms=p.frame_ms,
+                ball_x=p.ball_x,
+                ball_y=p.ball_y,
+                confidence=p.confidence,
+                is_manual=False,
+                tracking_state=p.state,
+                model_version=config.model_version,
+                image_width_px=p.image_width_px,
+                image_height_px=p.image_height_px,
+            ))
+        if objects:
+            db.bulk_save_objects(objects)
+            db.commit()
+            inserted += len(objects)
+
+    elapsed = time.monotonic() - t_start
+    _set_status(video_id, "complete", db)
+
+    logger.info(
+        "dense_trajectory_complete: video=%s frames=%d detected=%d "
+        "predicted=%d lost=%d inserted=%d elapsed=%.1fs",
+        video_id, len(points),
+        counts["detected"], counts["predicted"], counts["lost"],
+        inserted, elapsed,
+    )
+
+    return {
+        "status": "complete",
+        "frames": len(points),
+        "detected": counts["detected"],
+        "predicted": counts["predicted"],
+        "lost": counts["lost"],
+        "inserted": inserted,
+        "elapsed_sec": round(elapsed, 1),
+    }
+
+
+# ── Celery wrapper ────────────────────────────────────────────────────────────
+
+from app.celery_app import celery_app  # noqa: E402
+from app.database import SessionLocal   # noqa: E402
+
+
+@celery_app.task(
+    bind=True,
+    max_retries=1,
+    default_retry_delay=60,
+    queue="analysis",
+    time_limit=600,
+    soft_time_limit=540,
+)
+def dense_ball_trajectory_task(  # pragma: no cover — Celery wrapper
+    self,
+    video_id: str,
+) -> dict:
+    db = SessionLocal()
+    try:
+        return run_dense_ball_trajectory(video_id, db)
+    except Exception as exc:
+        db.rollback()
+        logger.exception(
+            "dense_trajectory_error: video=%s", video_id,
+        )
+        try:
+            _set_status(video_id, "failed", db)
+        except Exception:
+            pass
+        try:
+            self.retry(exc=exc)
+        except self.MaxRetriesExceededError:
+            return {"status": "failed", "reason": str(exc)}
+    finally:
+        db.close()

--- a/tests/biometric/test_admin_review_api.py
+++ b/tests/biometric/test_admin_review_api.py
@@ -548,7 +548,7 @@ def test_bca_adm21_override_audit_no_score(db, biometric_feature_enabled):
 def test_bca_adm22_route_count_883():
     from app.main import app
     paths = app.openapi().get("paths", {})
-    assert len(paths) == 903, f"Expected 897 routes (AN-1: +5 juggling contact paths), got {len(paths)}"
+    assert len(paths) == 907, f"Expected 897 routes (AN-1: +5 juggling contact paths), got {len(paths)}"
     assert "/api/v1/admin/biometric/review-queue" in paths
     assert "/api/v1/admin/biometric/{user_id}/history" in paths
     assert "/api/v1/admin/biometric/{user_id}/override" in paths

--- a/tests/juggling/test_contact_schema.py
+++ b/tests/juggling/test_contact_schema.py
@@ -473,9 +473,9 @@ def test_cm19_production_route_count_unchanged():
     """CM-19: Route count tracks cumulative endpoint additions."""
     from app.main import app
     routes = [r for r in app.routes if hasattr(r, "methods")]
-    assert len(routes) == 1024, (
-        f"Route count changed: expected 1024, got {len(routes)}. "
-        "AN-3B2B added 3 ball detection endpoints (2 user + 1 admin)."
+    assert len(routes) == 1028, (
+        f"Route count changed: expected 1028, got {len(routes)}. "
+        "AN-3B2D-B0 added 2 ball feedback endpoints (POST + GET queue)."
     )
 
 

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -2359,6 +2359,393 @@
         "title": "BallDetectionTriggerResult",
         "type": "object"
       },
+      "BallFeedbackOut": {
+        "properties": {
+          "approval_state": {
+            "title": "Approval State",
+            "type": "string"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "decision": {
+            "title": "Decision",
+            "type": "string"
+          },
+          "frame_ms": {
+            "title": "Frame Ms",
+            "type": "integer"
+          },
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "video_id": {
+            "format": "uuid",
+            "title": "Video Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "video_id",
+          "frame_ms",
+          "decision",
+          "approval_state",
+          "created_at"
+        ],
+        "title": "BallFeedbackOut",
+        "type": "object"
+      },
+      "BallFeedbackQueueItem": {
+        "properties": {
+          "existing_feedback_count": {
+            "title": "Existing Feedback Count",
+            "type": "integer"
+          },
+          "frame_ms": {
+            "title": "Frame Ms",
+            "type": "integer"
+          },
+          "model_confidence": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model Confidence"
+          },
+          "model_predicted_x": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model Predicted X"
+          },
+          "model_predicted_y": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model Predicted Y"
+          },
+          "model_tracking_state": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model Tracking State"
+          },
+          "priority_score": {
+            "title": "Priority Score",
+            "type": "number"
+          }
+        },
+        "required": [
+          "frame_ms",
+          "priority_score",
+          "model_predicted_x",
+          "model_predicted_y",
+          "model_confidence",
+          "model_tracking_state",
+          "existing_feedback_count"
+        ],
+        "title": "BallFeedbackQueueItem",
+        "type": "object"
+      },
+      "BallFeedbackQueueResponse": {
+        "properties": {
+          "max_per_session": {
+            "default": 3,
+            "title": "Max Per Session",
+            "type": "integer"
+          },
+          "queue_items": {
+            "items": {
+              "$ref": "#/components/schemas/BallFeedbackQueueItem"
+            },
+            "title": "Queue Items",
+            "type": "array"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          },
+          "video_id": {
+            "title": "Video Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "video_id",
+          "queue_items",
+          "total"
+        ],
+        "title": "BallFeedbackQueueResponse",
+        "type": "object"
+      },
+      "BallFeedbackRequest": {
+        "properties": {
+          "corrected_x": {
+            "anyOf": [
+              {
+                "maximum": 1.0,
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Corrected X"
+          },
+          "corrected_y": {
+            "anyOf": [
+              {
+                "maximum": 1.0,
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Corrected Y"
+          },
+          "correction_method": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Correction Method"
+          },
+          "decision": {
+            "description": "confirm | reject | no_ball | corrected",
+            "title": "Decision",
+            "type": "string"
+          },
+          "frame_ms": {
+            "minimum": 0.0,
+            "title": "Frame Ms",
+            "type": "integer"
+          },
+          "model_confidence": {
+            "anyOf": [
+              {
+                "maximum": 1.0,
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model Confidence"
+          },
+          "model_predicted_x": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model Predicted X"
+          },
+          "model_predicted_y": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model Predicted Y"
+          },
+          "model_tracking_state": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model Tracking State"
+          }
+        },
+        "required": [
+          "frame_ms",
+          "decision"
+        ],
+        "title": "BallFeedbackRequest",
+        "type": "object"
+      },
+      "BallTrajectoryManualSeedOut": {
+        "properties": {
+          "ball_x": {
+            "title": "Ball X",
+            "type": "number"
+          },
+          "ball_y": {
+            "title": "Ball Y",
+            "type": "number"
+          },
+          "frame_ms": {
+            "title": "Frame Ms",
+            "type": "integer"
+          },
+          "is_manual": {
+            "title": "Is Manual",
+            "type": "boolean"
+          },
+          "tracking_state": {
+            "title": "Tracking State",
+            "type": "string"
+          }
+        },
+        "required": [
+          "frame_ms",
+          "ball_x",
+          "ball_y",
+          "tracking_state",
+          "is_manual"
+        ],
+        "title": "BallTrajectoryManualSeedOut",
+        "type": "object"
+      },
+      "BallTrajectoryManualSeedRequest": {
+        "properties": {
+          "ball_x": {
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Ball X",
+            "type": "number"
+          },
+          "ball_y": {
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Ball Y",
+            "type": "number"
+          },
+          "frame_ms": {
+            "minimum": 0.0,
+            "title": "Frame Ms",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "frame_ms",
+          "ball_x",
+          "ball_y"
+        ],
+        "title": "BallTrajectoryManualSeedRequest",
+        "type": "object"
+      },
+      "BallTrajectoryPointOut": {
+        "properties": {
+          "ball_x": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ball X"
+          },
+          "ball_y": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ball Y"
+          },
+          "confidence": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Confidence"
+          },
+          "frame_ms": {
+            "title": "Frame Ms",
+            "type": "integer"
+          },
+          "is_manual": {
+            "title": "Is Manual",
+            "type": "boolean"
+          },
+          "tracking_state": {
+            "title": "Tracking State",
+            "type": "string"
+          }
+        },
+        "required": [
+          "frame_ms",
+          "ball_x",
+          "ball_y",
+          "confidence",
+          "is_manual",
+          "tracking_state"
+        ],
+        "title": "BallTrajectoryPointOut",
+        "type": "object"
+      },
+      "BallTrajectoryResponse": {
+        "properties": {
+          "points": {
+            "items": {
+              "$ref": "#/components/schemas/BallTrajectoryPointOut"
+            },
+            "title": "Points",
+            "type": "array"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "points"
+        ],
+        "title": "BallTrajectoryResponse",
+        "type": "object"
+      },
       "BatchCreatePlayersRequest": {
         "properties": {
           "players": {
@@ -62900,6 +63287,260 @@
           }
         ],
         "summary": "Delete juggling video media (storage release)",
+        "tags": [
+          "users",
+          "users",
+          "juggling",
+          "juggling"
+        ]
+      }
+    },
+    "/api/v1/users/me/juggling/videos/{video_id}/ball-feedback": {
+      "post": {
+        "operationId": "post_ball_feedback_api_v1_users_me_juggling_videos__video_id__ball_feedback_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "video_id",
+            "required": true,
+            "schema": {
+              "title": "Video Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BallFeedbackRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BallFeedbackOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Submit ball detection feedback for a trajectory frame",
+        "tags": [
+          "users",
+          "users",
+          "juggling",
+          "juggling"
+        ]
+      }
+    },
+    "/api/v1/users/me/juggling/videos/{video_id}/ball-feedback/queue": {
+      "get": {
+        "operationId": "get_feedback_queue_api_v1_users_me_juggling_videos__video_id__ball_feedback_queue_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "video_id",
+            "required": true,
+            "schema": {
+              "title": "Video Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 5,
+              "maximum": 20,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BallFeedbackQueueResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get prioritized feedback queue for a video",
+        "tags": [
+          "users",
+          "users",
+          "juggling",
+          "juggling"
+        ]
+      }
+    },
+    "/api/v1/users/me/juggling/videos/{video_id}/ball-trajectory": {
+      "get": {
+        "operationId": "get_ball_trajectory_api_v1_users_me_juggling_videos__video_id__ball_trajectory_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "video_id",
+            "required": true,
+            "schema": {
+              "title": "Video Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "from_ms",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "From Ms",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "to_ms",
+            "required": false,
+            "schema": {
+              "default": 60000,
+              "minimum": 0,
+              "title": "To Ms",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BallTrajectoryResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get dense ball trajectory window",
+        "tags": [
+          "users",
+          "users",
+          "juggling",
+          "juggling"
+        ]
+      }
+    },
+    "/api/v1/users/me/juggling/videos/{video_id}/ball-trajectory/manual-seed": {
+      "post": {
+        "operationId": "post_manual_seed_api_v1_users_me_juggling_videos__video_id__ball_trajectory_manual_seed_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "video_id",
+            "required": true,
+            "schema": {
+              "title": "Video Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BallTrajectoryManualSeedRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BallTrajectoryManualSeedOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Manual ball position seed",
         "tags": [
           "users",
           "users",

--- a/tests/unit/api/web_routes/test_card_editor_ce2.py
+++ b/tests/unit/api/web_routes/test_card_editor_ce2.py
@@ -430,9 +430,13 @@ class TestCE216WelcomeEditorUnchanged:
 
 class TestCE217RouteCount:
     def test_openapi_snapshot_route_count_unchanged(self):
-        """AN-3B2B ball detection adds 2 paths (901 → 903): user ball-detection + admin trigger."""
+        """Route count history:
+        901 → 903: AN-3B2B ball detection (user ball-detection + admin trigger)
+        903 → 905: AN-3B2D-1 ball trajectory (GET /ball-trajectory + POST /manual-seed)
+        905 → 907: AN-3B2D-B0 ball feedback (POST /ball-feedback + GET /ball-feedback/queue)
+        """
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 903, (
-            f"Expected 903 routes (901 prior + 2 AN-3B2B ball detection paths), got {len(paths)}."
+        assert len(paths) == 907, (
+            f"Expected 907 routes (901 prior + 2 ball-detection + 2 trajectory + 2 feedback), got {len(paths)}."
         )

--- a/tests/unit/api/web_routes/test_card_editor_cs_s1.py
+++ b/tests/unit/api/web_routes/test_card_editor_cs_s1.py
@@ -294,7 +294,7 @@ class TestS109S110RouteAndSnapshot:
         """S1-09 (updated Phase 2A): route count is 901 (+3 Phase 2A pose/rotation endpoints)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 903, (
+        assert len(paths) == 907, (
             f"Expected 901 routes (898 prior + 3 Phase 2A pose/rotation endpoints), got {len(paths)}"
         )
 

--- a/tests/unit/api/web_routes/test_card_editor_ref_p2.py
+++ b/tests/unit/api/web_routes/test_card_editor_ref_p2.py
@@ -287,7 +287,7 @@ class TestP227to29RouteAndOpenAPI:
         """P2-27: Route count = 846 (CS-S2A +1 /card-studio/player)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 903, f"Expected 846 routes, got {len(paths)}"
+        assert len(paths) == 907, f"Expected 846 routes, got {len(paths)}"
 
     def test_p2_28_openapi_snapshot_match(self):
         """P2-28: OpenAPI snapshot matches live API paths."""

--- a/tests/unit/api/web_routes/test_card_studio_challenge.py
+++ b/tests/unit/api/web_routes/test_card_studio_challenge.py
@@ -294,7 +294,7 @@ class TestCCS11RouteCount:
         """CCS-11: route count updated to 842 after CE-3.8 (+3 from-mood endpoints)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 903, (
+        assert len(paths) == 907, (
             f"Expected 845 routes (842 CE-3.7+CE-3.8 baseline + 2 CS-S0 card-studio routes), got {len(paths)}."
         )
 

--- a/tests/unit/api/web_routes/test_card_studio_landing.py
+++ b/tests/unit/api/web_routes/test_card_studio_landing.py
@@ -159,7 +159,7 @@ class TestCEL12RouteCount:
         """CEL-12: route count 844 (unchanged — redirect is handler change, not new route)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 903, (
+        assert len(paths) == 907, (
             f"Expected 845 routes (redirect handler change does not add routes), got {len(paths)}."
         )
 

--- a/tests/unit/api/web_routes/test_card_studio_shell.py
+++ b/tests/unit/api/web_routes/test_card_studio_shell.py
@@ -326,7 +326,7 @@ class TestCSS21to23RouteConfirmations:
         """CSS-21: adding 2 card-studio routes raises count from 842 to 844."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 903, (
+        assert len(paths) == 907, (
             f"Expected 845 routes (842 baseline + 2 new /card-studio routes), got {len(paths)}"
         )
 

--- a/tests/unit/api/web_routes/test_card_studio_welcome.py
+++ b/tests/unit/api/web_routes/test_card_studio_welcome.py
@@ -325,7 +325,7 @@ class TestCEW18RouteCount:
         """CEW-18: route count baseline check (updated by CE-3.8 to 842)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 903, (
+        assert len(paths) == 907, (
             f"Expected 842 routes (839 CE-3.7 baseline + 3 from-mood endpoints), got {len(paths)}."
         )
 
@@ -678,7 +678,7 @@ class TestCEW44to51TemplateMoodPicker:
         """CEW-47: CE-3.8 adds 3 from-mood routes → total 842."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 903, (
+        assert len(paths) == 907, (
             f"Expected 845 routes (842 baseline + 2 CS-S0 routes), got {len(paths)}"
         )
 

--- a/tests/unit/api/web_routes/test_cc_design_1.py
+++ b/tests/unit/api/web_routes/test_cc_design_1.py
@@ -780,7 +780,7 @@ class TestCCD22to23RouteSnapshot:
         """CCD-22: Route count is 851 (CC-DESIGN-1 SNAPSHOT adds POST /challenges/{id}/card/photo)."""
         from app.main import app
         count = len(app.openapi().get("paths", {}))
-        assert count == 903, f"Expected 851, got {count}"
+        assert count == 907, f"Expected 851, got {count}"
 
     def test_ccd_23_openapi_snapshot_match(self):
         """CCD-23: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_cs_color_1.py
+++ b/tests/unit/api/web_routes/test_cs_color_1.py
@@ -382,7 +382,7 @@ class TestCSCOL15to16RouteAndSnapshot:
         """CSCOL-15: route count = 845 (+1 POST /dashboard/wc-card-theme)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 903, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 907, f"Expected 845 routes, got {len(paths)}"
 
     def test_cscol_16_openapi_snapshot_includes_wc_card_theme(self):
         """CSCOL-16: OpenAPI snapshot includes /dashboard/wc-card-theme."""

--- a/tests/unit/api/web_routes/test_cs_s2a.py
+++ b/tests/unit/api/web_routes/test_cs_s2a.py
@@ -40,7 +40,7 @@ class TestS2A01to02RouteRegistration:
         """S2A-02 (updated CS-S4A): Total route count is 847 (CS-S2A+CS-S4A)."""
         from app.main import app
         count = len(app.openapi().get("paths", {}))
-        assert count == 903, f"Expected 847 routes, got {count}"
+        assert count == 907, f"Expected 847 routes, got {count}"
 
 
 # ── S2A-03..08: _resolve_player_context logic ────────────────────────────────

--- a/tests/unit/api/web_routes/test_cs_s4a.py
+++ b/tests/unit/api/web_routes/test_cs_s4a.py
@@ -152,7 +152,7 @@ class TestS4A12to13RouteAndSnapshot:
         """S4A-12: Route count == 851 (CC-DESIGN-1 SNAPSHOT adds +1 POST /challenges/{id}/card/photo)."""
         from app.main import app
         count = len(app.openapi().get("paths", {}))
-        assert count == 903, f"Expected 851 routes, got {count}"
+        assert count == 907, f"Expected 851 routes, got {count}"
 
     def test_s4a_13_openapi_snapshot_match(self):
         """S4A-13: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_family_color_shop.py
+++ b/tests/unit/api/web_routes/test_family_color_shop.py
@@ -223,7 +223,7 @@ class TestRouteRegistration:
     def test_ts_13_route_count_836(self):
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 903, (
+        assert len(paths) == 907, (
             f"Expected 845 routes (842 CE-3.7+CE-3.8 baseline + 2 CS-S0 card-studio routes), got {len(paths)}."
         )
 

--- a/tests/unit/api/web_routes/test_shop_3a.py
+++ b/tests/unit/api/web_routes/test_shop_3a.py
@@ -194,7 +194,7 @@ class TestS3A13to14RouteAndSnapshot:
         """S3A-13: Route count = 845 (template deletion does not affect routes)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 903, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 907, f"Expected 845 routes, got {len(paths)}"
 
     def test_s3a_14_openapi_snapshot_match(self):
         """S3A-14: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_shop_3b1.py
+++ b/tests/unit/api/web_routes/test_shop_3b1.py
@@ -158,7 +158,7 @@ class TestS3B112to13RouteAndSnapshot:
         """S3B1-12: Route count = 845 (test cleanup does not affect routes)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 903, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 907, f"Expected 845 routes, got {len(paths)}"
 
     def test_s3b1_13_openapi_snapshot_match(self):
         """S3B1-13: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_shop_3b2.py
+++ b/tests/unit/api/web_routes/test_shop_3b2.py
@@ -192,7 +192,7 @@ class TestS3B215to16RouteAndSnapshot:
         """S3B2-15: Route count = 845 (template deletion does not affect routes)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 903, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 907, f"Expected 845 routes, got {len(paths)}"
 
     def test_s3b2_16_openapi_snapshot_match(self):
         """S3B2-16: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_shop_unified.py
+++ b/tests/unit/api/web_routes/test_shop_unified.py
@@ -271,7 +271,7 @@ class TestSHOP14to15RouteAndSnapshot:
         """SHOP-14: route count = 845 (no new routes in SHOP-1)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 903, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 907, f"Expected 845 routes, got {len(paths)}"
 
     def test_shop_15_openapi_snapshot_match(self):
         """SHOP-15: OpenAPI snapshot matches live API."""

--- a/tests/unit/juggling/test_annotation_helper.py
+++ b/tests/unit/juggling/test_annotation_helper.py
@@ -1015,7 +1015,7 @@ class TestHELP36_ProductionRouteCountUnchanged:
         snapshot_path = helper.ROOT / "tests/snapshots/openapi_snapshot.json"
         snapshot = json.loads(snapshot_path.read_text())
         route_count = len(snapshot.get("paths", {}))
-        assert route_count == 903, f"Unexpected production route count: {route_count}"
+        assert route_count == 907, f"Unexpected production route count: {route_count}"
 
     def test_helper_routes_not_in_production_snapshot(self):
         """HELP-36d: Annotation helper routes (/api/taxonomy etc.) not in production snapshot."""

--- a/tests/unit/juggling/test_ball_feedback_api.py
+++ b/tests/unit/juggling/test_ball_feedback_api.py
@@ -1,0 +1,479 @@
+"""
+Ball feedback API tests — BFB-01..18.
+
+POST /api/v1/users/me/juggling/videos/{video_id}/ball-feedback
+GET  /api/v1/users/me/juggling/videos/{video_id}/ball-feedback/queue
+
+FastAPI TestClient + PostgreSQL savepoint (no permanent DB writes).
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import event as sa_event
+from sqlalchemy.orm import sessionmaker
+
+from app.core.auth import create_access_token
+from app.database import engine, get_db
+from app.main import app
+from app.models.juggling import (
+    JugglingBallFeedback,
+    JugglingBallTrajectory,
+    JugglingConsent,
+    JugglingVideo,
+    JugglingVideoStatus,
+    UserAnnotationReliability,
+)
+from app.models.user import User, UserRole
+from app.services.juggling import feature_flag as ff_module
+import app.api.api_v1.endpoints.users.juggling_ball_feedback as fb_module
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture()
+def db_session():
+    connection = engine.connect()
+    transaction = connection.begin()
+    TestSession = sessionmaker(autocommit=False, autoflush=False, bind=connection)
+    session = TestSession()
+    connection.begin_nested()
+
+    @sa_event.listens_for(session, "after_transaction_end")
+    def restart_savepoint(sess, txn):
+        if txn.nested and not txn._parent.nested:
+            sess.begin_nested()
+
+    try:
+        yield session
+    finally:
+        session.close()
+        if transaction.is_active:
+            transaction.rollback()
+        connection.close()
+
+
+@pytest.fixture()
+def client(db_session):
+    app.dependency_overrides[get_db] = lambda: db_session
+    with TestClient(app, raise_server_exceptions=False) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture()
+def student_user(db_session):
+    user = User(
+        email=f"bfb_student+{uuid.uuid4().hex[:8]}@test.com",
+        name="BFB Student",
+        password_hash="hashed",
+        role=UserRole.STUDENT,
+        is_active=True,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+@pytest.fixture()
+def student_token(student_user):
+    return create_access_token(
+        data={"sub": student_user.email}, expires_delta=timedelta(hours=1)
+    )
+
+
+@pytest.fixture()
+def student_user2(db_session):
+    user = User(
+        email=f"bfb_student2+{uuid.uuid4().hex[:8]}@test.com",
+        name="BFB Student Two",
+        password_hash="hashed",
+        role=UserRole.STUDENT,
+        is_active=True,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+@pytest.fixture()
+def student_token2(student_user2):
+    return create_access_token(
+        data={"sub": student_user2.email}, expires_delta=timedelta(hours=1)
+    )
+
+
+@pytest.fixture(autouse=True)
+def _enable_flags(monkeypatch):
+    monkeypatch.setattr(ff_module, "is_juggling_enabled", lambda: True)
+    monkeypatch.setattr(fb_module.settings, "BALL_FEEDBACK_ENABLED", True)
+
+
+def _auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _make_consent(db, user_id: int) -> None:
+    existing = db.query(JugglingConsent).filter(JugglingConsent.user_id == user_id).first()
+    if existing is None:
+        db.add(JugglingConsent(
+            user_id=user_id,
+            service_consent=True,
+            training_consent=True,
+            admin_review_consent=True,
+        ))
+        db.flush()
+
+
+def _make_video(db, user_id: int, *, gdpr_deleted: bool = False) -> str:
+    _make_consent(db, user_id)
+    vid_id = uuid.uuid4()
+    status = "gdpr_deleted" if gdpr_deleted else JugglingVideoStatus.analyzed.value
+    video = JugglingVideo(
+        id=vid_id,
+        user_id=user_id,
+        source_type="uploaded_video",
+        upload_source="gallery",
+        training_video_type="juggling",
+        storage_path="/tmp/test.mp4",
+        status=status,
+        transcode_status="done",
+    )
+    db.add(video)
+    db.flush()
+    return str(vid_id)
+
+
+def _add_trajectory_point(
+    db,
+    video_id: str,
+    frame_ms: int,
+    *,
+    tracking_state: str = "detected",
+    confidence: float | None = 0.8,
+) -> None:
+    pt = JugglingBallTrajectory(
+        video_id=video_id,
+        frame_ms=frame_ms,
+        ball_x=0.5 if tracking_state != "lost" else None,
+        ball_y=0.5 if tracking_state != "lost" else None,
+        confidence=confidence if tracking_state != "lost" else None,
+        is_manual=False,
+        tracking_state=tracking_state,
+    )
+    db.add(pt)
+    db.flush()
+
+
+_CONFIRM_BODY = {"frame_ms": 100, "decision": "confirm"}
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+# BFB-01: POST → 503 when BALL_FEEDBACK_ENABLED=False
+def test_bfb01_post_503_when_disabled(client, student_token, db_session, student_user, monkeypatch):
+    monkeypatch.setattr(fb_module.settings, "BALL_FEEDBACK_ENABLED", False)
+    video_id = _make_video(db_session, student_user.id)
+    r = client.post(
+        f"/api/v1/users/me/juggling/videos/{video_id}/ball-feedback",
+        json=_CONFIRM_BODY,
+        headers=_auth(student_token),
+    )
+    assert r.status_code == 503
+
+
+# BFB-02: POST decision=confirm → 201 + BallFeedbackOut fields
+def test_bfb02_post_confirm_201(client, student_token, db_session, student_user):
+    video_id = _make_video(db_session, student_user.id)
+    r = client.post(
+        f"/api/v1/users/me/juggling/videos/{video_id}/ball-feedback",
+        json={"frame_ms": 100, "decision": "confirm"},
+        headers=_auth(student_token),
+    )
+    assert r.status_code == 201
+    data = r.json()
+    assert data["decision"] == "confirm"
+    assert data["approval_state"] == "pending"
+    assert "id" in data
+    assert "created_at" in data
+
+
+# BFB-03: POST decision=no_ball → 201
+def test_bfb03_post_no_ball_201(client, student_token, db_session, student_user):
+    video_id = _make_video(db_session, student_user.id)
+    r = client.post(
+        f"/api/v1/users/me/juggling/videos/{video_id}/ball-feedback",
+        json={"frame_ms": 200, "decision": "no_ball"},
+        headers=_auth(student_token),
+    )
+    assert r.status_code == 201
+    assert r.json()["decision"] == "no_ball"
+
+
+# BFB-04: POST decision=corrected + coords → 201 + coords stored
+def test_bfb04_post_corrected_with_coords(client, student_token, db_session, student_user):
+    video_id = _make_video(db_session, student_user.id)
+    r = client.post(
+        f"/api/v1/users/me/juggling/videos/{video_id}/ball-feedback",
+        json={
+            "frame_ms": 300,
+            "decision": "corrected",
+            "corrected_x": 0.4,
+            "corrected_y": 0.6,
+            "correction_method": "drag",
+        },
+        headers=_auth(student_token),
+    )
+    assert r.status_code == 201
+    assert r.json()["decision"] == "corrected"
+
+
+# BFB-05: POST decision=corrected without coords → 422
+def test_bfb05_post_corrected_without_coords_422(client, student_token, db_session, student_user):
+    video_id = _make_video(db_session, student_user.id)
+    r = client.post(
+        f"/api/v1/users/me/juggling/videos/{video_id}/ball-feedback",
+        json={"frame_ms": 400, "decision": "corrected"},
+        headers=_auth(student_token),
+    )
+    assert r.status_code == 422
+
+
+# BFB-06: POST duplicate feedback for same user+video+frame → 409
+def test_bfb06_post_duplicate_409(client, student_token, db_session, student_user):
+    video_id = _make_video(db_session, student_user.id)
+    body = {"frame_ms": 500, "decision": "confirm"}
+    r1 = client.post(
+        f"/api/v1/users/me/juggling/videos/{video_id}/ball-feedback",
+        json=body,
+        headers=_auth(student_token),
+    )
+    assert r1.status_code == 201
+    r2 = client.post(
+        f"/api/v1/users/me/juggling/videos/{video_id}/ball-feedback",
+        json=body,
+        headers=_auth(student_token),
+    )
+    assert r2.status_code == 409
+
+
+# BFB-07: POST unknown video → 404
+def test_bfb07_post_unknown_video_404(client, student_token):
+    r = client.post(
+        f"/api/v1/users/me/juggling/videos/{uuid.uuid4()}/ball-feedback",
+        json=_CONFIRM_BODY,
+        headers=_auth(student_token),
+    )
+    assert r.status_code == 404
+
+
+# BFB-08: POST gdpr_deleted video → 404
+def test_bfb08_post_gdpr_deleted_404(client, student_token, db_session, student_user):
+    video_id = _make_video(db_session, student_user.id, gdpr_deleted=True)
+    r = client.post(
+        f"/api/v1/users/me/juggling/videos/{video_id}/ball-feedback",
+        json=_CONFIRM_BODY,
+        headers=_auth(student_token),
+    )
+    assert r.status_code == 404
+
+
+# BFB-09: POST → lazy creates UserAnnotationReliability at 0.5
+def test_bfb09_post_lazy_creates_reliability(client, student_token, db_session, student_user):
+    video_id = _make_video(db_session, student_user.id)
+    rel_before = db_session.get(UserAnnotationReliability, student_user.id)
+    assert rel_before is None
+    r = client.post(
+        f"/api/v1/users/me/juggling/videos/{video_id}/ball-feedback",
+        json={"frame_ms": 600, "decision": "reject"},
+        headers=_auth(student_token),
+    )
+    assert r.status_code == 201
+    db_session.expire_all()
+    rel_after = db_session.get(UserAnnotationReliability, student_user.id)
+    assert rel_after is not None
+    assert rel_after.ball_annotation_reliability == pytest.approx(0.5)
+
+
+# BFB-10: POST corrected stores corrected_x/corrected_y on the DB record
+def test_bfb10_corrected_coords_stored(client, student_token, db_session, student_user):
+    video_id = _make_video(db_session, student_user.id)
+    r = client.post(
+        f"/api/v1/users/me/juggling/videos/{video_id}/ball-feedback",
+        json={
+            "frame_ms": 700,
+            "decision": "corrected",
+            "corrected_x": 0.33,
+            "corrected_y": 0.77,
+        },
+        headers=_auth(student_token),
+    )
+    assert r.status_code == 201
+    row = (
+        db_session.query(JugglingBallFeedback)
+        .filter(
+            JugglingBallFeedback.video_id == video_id,
+            JugglingBallFeedback.frame_ms == 700,
+        )
+        .first()
+    )
+    assert row is not None
+    assert row.corrected_x == pytest.approx(0.33)
+    assert row.corrected_y == pytest.approx(0.77)
+
+
+# BFB-11: GET queue → 503 when disabled
+def test_bfb11_queue_503_when_disabled(client, student_token, db_session, student_user, monkeypatch):
+    monkeypatch.setattr(fb_module.settings, "BALL_FEEDBACK_ENABLED", False)
+    video_id = _make_video(db_session, student_user.id)
+    r = client.get(
+        f"/api/v1/users/me/juggling/videos/{video_id}/ball-feedback/queue",
+        headers=_auth(student_token),
+    )
+    assert r.status_code == 503
+
+
+# BFB-12: GET queue → 200 empty list when no trajectory points
+def test_bfb12_queue_empty_no_trajectory(client, student_token, db_session, student_user):
+    video_id = _make_video(db_session, student_user.id)
+    r = client.get(
+        f"/api/v1/users/me/juggling/videos/{video_id}/ball-feedback/queue",
+        headers=_auth(student_token),
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["queue_items"] == []
+    assert data["total"] == 0
+    assert data["max_per_session"] == 3
+
+
+# BFB-13: GET queue → 200 items sorted by priority_score DESC
+def test_bfb13_queue_sorted_by_priority(client, student_token, db_session, student_user):
+    video_id = _make_video(db_session, student_user.id)
+    # High uncertainty (low confidence) frame should rank first
+    _add_trajectory_point(db_session, video_id, 100, confidence=0.95)  # low priority
+    _add_trajectory_point(db_session, video_id, 200, confidence=0.10)  # high priority
+    _add_trajectory_point(db_session, video_id, 300, confidence=0.50)  # mid
+    db_session.commit()
+
+    r = client.get(
+        f"/api/v1/users/me/juggling/videos/{video_id}/ball-feedback/queue",
+        headers=_auth(student_token),
+    )
+    assert r.status_code == 200
+    items = r.json()["queue_items"]
+    assert len(items) == 3
+    scores = [i["priority_score"] for i in items]
+    assert scores == sorted(scores, reverse=True)
+    assert items[0]["frame_ms"] == 200  # lowest confidence = highest priority
+
+
+# BFB-14: GET queue → excludes frames already reviewed by this user
+def test_bfb14_queue_excludes_reviewed(client, student_token, db_session, student_user):
+    video_id = _make_video(db_session, student_user.id)
+    _add_trajectory_point(db_session, video_id, 100)
+    _add_trajectory_point(db_session, video_id, 200)
+    db_session.commit()
+
+    # User submits feedback for frame 100
+    client.post(
+        f"/api/v1/users/me/juggling/videos/{video_id}/ball-feedback",
+        json={"frame_ms": 100, "decision": "confirm"},
+        headers=_auth(student_token),
+    )
+
+    r = client.get(
+        f"/api/v1/users/me/juggling/videos/{video_id}/ball-feedback/queue",
+        headers=_auth(student_token),
+    )
+    assert r.status_code == 200
+    frame_mss = [i["frame_ms"] for i in r.json()["queue_items"]]
+    assert 100 not in frame_mss
+    assert 200 in frame_mss
+
+
+# BFB-15: GET queue → excludes frames with ≥3 total feedbacks
+def test_bfb15_queue_excludes_saturated_frames(
+    client, student_token, student_token2, db_session, student_user, student_user2
+):
+    video_id = _make_video(db_session, student_user.id)
+    _add_trajectory_point(db_session, video_id, 100)
+    _add_trajectory_point(db_session, video_id, 200)
+    db_session.commit()
+
+    # Frame 100 gets 3 feedbacks from DB inserts directly (3 different users is complex; use
+    # direct DB inserts for user2 and two manual rows to saturate frame 100)
+    for i in range(3):
+        extra_user = User(
+            email=f"bfb_extra{i}+{uuid.uuid4().hex[:8]}@test.com",
+            name=f"Extra {i}",
+            password_hash="hashed",
+            role=UserRole.STUDENT,
+            is_active=True,
+        )
+        db_session.add(extra_user)
+        db_session.flush()
+        db_session.add(JugglingBallFeedback(
+            video_id=video_id,
+            frame_ms=100,
+            user_id=extra_user.id,
+            decision="confirm",
+            approval_state="pending",
+        ))
+    db_session.commit()
+
+    r = client.get(
+        f"/api/v1/users/me/juggling/videos/{video_id}/ball-feedback/queue",
+        headers=_auth(student_token),
+    )
+    assert r.status_code == 200
+    frame_mss = [i["frame_ms"] for i in r.json()["queue_items"]]
+    assert 100 not in frame_mss
+    assert 200 in frame_mss
+
+
+# BFB-16: GET queue → limit param is respected
+def test_bfb16_queue_limit_respected(client, student_token, db_session, student_user):
+    video_id = _make_video(db_session, student_user.id)
+    for ms in range(0, 1000, 100):
+        _add_trajectory_point(db_session, video_id, ms)
+    db_session.commit()
+
+    r = client.get(
+        f"/api/v1/users/me/juggling/videos/{video_id}/ball-feedback/queue?limit=3",
+        headers=_auth(student_token),
+    )
+    assert r.status_code == 200
+    assert len(r.json()["queue_items"]) == 3
+
+
+# BFB-17: GET queue → lost frames have higher priority than high-confidence detected frames
+def test_bfb17_queue_lost_frames_high_priority(client, student_token, db_session, student_user):
+    video_id = _make_video(db_session, student_user.id)
+    _add_trajectory_point(db_session, video_id, 100, tracking_state="detected", confidence=0.99)
+    _add_trajectory_point(db_session, video_id, 200, tracking_state="lost", confidence=None)
+    db_session.commit()
+
+    r = client.get(
+        f"/api/v1/users/me/juggling/videos/{video_id}/ball-feedback/queue",
+        headers=_auth(student_token),
+    )
+    assert r.status_code == 200
+    items = r.json()["queue_items"]
+    assert len(items) == 2
+    assert items[0]["frame_ms"] == 200  # lost frame ranked first
+    assert items[0]["model_tracking_state"] == "lost"
+
+
+# BFB-18: GET queue → 404 for unknown video
+def test_bfb18_queue_unknown_video_404(client, student_token):
+    r = client.get(
+        f"/api/v1/users/me/juggling/videos/{uuid.uuid4()}/ball-feedback/queue",
+        headers=_auth(student_token),
+    )
+    assert r.status_code == 404

--- a/tests/unit/juggling/test_ball_trajectory_api.py
+++ b/tests/unit/juggling/test_ball_trajectory_api.py
@@ -1,0 +1,287 @@
+"""
+Dense ball trajectory API tests — BT-20..BT-28.
+
+Endpoint tests using FastAPI TestClient + PostgreSQL savepoint.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import event as sa_event
+from sqlalchemy.orm import sessionmaker
+
+from app.core.auth import create_access_token
+from app.database import engine, get_db
+from app.main import app
+from app.models.juggling import (
+    JugglingBallTrajectory,
+    JugglingConsent,
+    JugglingVideo,
+    JugglingVideoStatus,
+)
+from app.models.user import User, UserRole
+from app.services.juggling import feature_flag as ff_module
+import app.api.api_v1.endpoints.users.juggling_ball_trajectory as bt_module
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture()
+def db_session():
+    connection = engine.connect()
+    transaction = connection.begin()
+    TestSession = sessionmaker(autocommit=False, autoflush=False, bind=connection)
+    session = TestSession()
+    connection.begin_nested()
+
+    @sa_event.listens_for(session, "after_transaction_end")
+    def restart_savepoint(sess, txn):
+        if txn.nested and not txn._parent.nested:
+            sess.begin_nested()
+
+    try:
+        yield session
+    finally:
+        session.close()
+        if transaction.is_active:
+            transaction.rollback()
+        connection.close()
+
+
+@pytest.fixture()
+def client(db_session):
+    app.dependency_overrides[get_db] = lambda: db_session
+    with TestClient(app, raise_server_exceptions=False) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture()
+def student_user(db_session):
+    user = User(
+        email=f"bt_student+{uuid.uuid4().hex[:8]}@test.com",
+        name="BT Student",
+        password_hash="hashed",
+        role=UserRole.STUDENT,
+        is_active=True,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+@pytest.fixture()
+def student_token(student_user):
+    return create_access_token(
+        data={"sub": student_user.email}, expires_delta=timedelta(hours=1)
+    )
+
+
+@pytest.fixture()
+def student_user2(db_session):
+    user = User(
+        email=f"bt_student2+{uuid.uuid4().hex[:8]}@test.com",
+        name="BT Student Two",
+        password_hash="hashed",
+        role=UserRole.STUDENT,
+        is_active=True,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+@pytest.fixture()
+def student_token2(student_user2):
+    return create_access_token(
+        data={"sub": student_user2.email}, expires_delta=timedelta(hours=1)
+    )
+
+
+@pytest.fixture(autouse=True)
+def _enable_flags(monkeypatch):
+    monkeypatch.setattr(ff_module, "is_juggling_enabled", lambda: True)
+    monkeypatch.setattr(bt_module.settings, "BALL_TRAJECTORY_ENABLED", True)
+
+
+def _auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture()
+def _video_with_trajectory(db_session, student_user):
+    """Create a video with trajectory status=complete and some points."""
+    consent = JugglingConsent(
+        user_id=student_user.id, service_consent=True,
+        training_consent=True, admin_review_consent=True,
+    )
+    db_session.add(consent)
+    db_session.flush()
+
+    vid_id = uuid.uuid4()
+    video = JugglingVideo(
+        id=vid_id, user_id=student_user.id,
+        source_type="uploaded_video", upload_source="gallery",
+        training_video_type="juggling",
+        storage_path="/tmp/test.mp4",
+        status=JugglingVideoStatus.analyzed.value,
+        transcode_status="done",
+        ball_trajectory_status="complete",
+    )
+    db_session.add(video)
+    db_session.flush()
+
+    for ms in range(0, 1000, 100):
+        point = JugglingBallTrajectory(
+            video_id=vid_id,
+            frame_ms=ms,
+            ball_x=0.5 + ms * 0.0001,
+            ball_y=0.5 + ms * 0.0001,
+            confidence=0.8,
+            is_manual=False,
+            tracking_state="detected",
+        )
+        db_session.add(point)
+
+    db_session.commit()
+    return str(vid_id)
+
+
+@pytest.fixture()
+def _video_no_trajectory(db_session, student_user):
+    """Create a video without trajectory data (status=NULL)."""
+    consent = db_session.query(JugglingConsent).filter(
+        JugglingConsent.user_id == student_user.id
+    ).first()
+    if consent is None:
+        consent = JugglingConsent(
+            user_id=student_user.id, service_consent=True,
+            training_consent=True, admin_review_consent=True,
+        )
+        db_session.add(consent)
+        db_session.flush()
+
+    vid_id = uuid.uuid4()
+    video = JugglingVideo(
+        id=vid_id, user_id=student_user.id,
+        source_type="uploaded_video", upload_source="gallery",
+        training_video_type="juggling",
+        storage_path="/tmp/test.mp4",
+        status=JugglingVideoStatus.analyzed.value,
+        transcode_status="done",
+        ball_trajectory_status=None,
+    )
+    db_session.add(video)
+    db_session.commit()
+    return str(vid_id)
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+# BT-20: GET /ball-trajectory → 503 when disabled
+def test_bt20_get_503_when_disabled(client, student_token, _video_with_trajectory, monkeypatch):
+    monkeypatch.setattr(bt_module.settings, "BALL_TRAJECTORY_ENABLED", False)
+    r = client.get(
+        f"/api/v1/users/me/juggling/videos/{_video_with_trajectory}/ball-trajectory",
+        headers=_auth(student_token),
+    )
+    assert r.status_code == 503
+
+
+# BT-21: GET /ball-trajectory → 404 when no trajectory data
+def test_bt21_get_404_no_trajectory(client, student_token, _video_no_trajectory):
+    r = client.get(
+        f"/api/v1/users/me/juggling/videos/{_video_no_trajectory}/ball-trajectory",
+        headers=_auth(student_token),
+    )
+    assert r.status_code == 404
+
+
+# BT-22: GET /ball-trajectory → 200 with correct points
+def test_bt22_get_200_with_points(client, student_token, _video_with_trajectory):
+    r = client.get(
+        f"/api/v1/users/me/juggling/videos/{_video_with_trajectory}/ball-trajectory"
+        "?from_ms=0&to_ms=500",
+        headers=_auth(student_token),
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["status"] == "complete"
+    assert len(data["points"]) == 6  # 0, 100, 200, 300, 400, 500
+    assert data["points"][0]["frame_ms"] == 0
+    assert data["points"][0]["tracking_state"] == "detected"
+
+
+# BT-23: GET /ball-trajectory window too large → 422
+def test_bt23_window_too_large(client, student_token, _video_with_trajectory):
+    r = client.get(
+        f"/api/v1/users/me/juggling/videos/{_video_with_trajectory}/ball-trajectory"
+        "?from_ms=0&to_ms=100000",
+        headers=_auth(student_token),
+    )
+    assert r.status_code == 422
+
+
+# BT-24: POST /manual-seed → 201 creates point
+def test_bt24_post_seed_201(client, student_token, _video_with_trajectory):
+    r = client.post(
+        f"/api/v1/users/me/juggling/videos/{_video_with_trajectory}/ball-trajectory/manual-seed",
+        headers=_auth(student_token),
+        json={"frame_ms": 5000, "ball_x": 0.42, "ball_y": 0.71},
+    )
+    assert r.status_code == 201
+    data = r.json()
+    assert data["frame_ms"] == 5000
+    assert data["ball_x"] == 0.42
+    assert data["ball_y"] == 0.71
+    assert data["tracking_state"] == "manual_seed"
+    assert data["is_manual"] is True
+
+
+# BT-25: POST /manual-seed → 200 upserts existing
+def test_bt25_post_seed_200_upsert(client, student_token, _video_with_trajectory):
+    r1 = client.post(
+        f"/api/v1/users/me/juggling/videos/{_video_with_trajectory}/ball-trajectory/manual-seed",
+        headers=_auth(student_token),
+        json={"frame_ms": 100, "ball_x": 0.99, "ball_y": 0.99},
+    )
+    assert r1.status_code == 200
+    data = r1.json()
+    assert data["ball_x"] == 0.99
+    assert data["is_manual"] is True
+
+
+# BT-26: POST /manual-seed → 503 when disabled
+def test_bt26_post_seed_503_disabled(client, student_token, _video_with_trajectory, monkeypatch):
+    monkeypatch.setattr(bt_module.settings, "BALL_TRAJECTORY_ENABLED", False)
+    r = client.post(
+        f"/api/v1/users/me/juggling/videos/{_video_with_trajectory}/ball-trajectory/manual-seed",
+        headers=_auth(student_token),
+        json={"frame_ms": 100, "ball_x": 0.5, "ball_y": 0.5},
+    )
+    assert r.status_code == 503
+
+
+# BT-27: POST /manual-seed → 404 other user's video
+def test_bt27_post_seed_404_other_user(client, student_token2, _video_with_trajectory):
+    r = client.post(
+        f"/api/v1/users/me/juggling/videos/{_video_with_trajectory}/ball-trajectory/manual-seed",
+        headers=_auth(student_token2),
+        json={"frame_ms": 100, "ball_x": 0.5, "ball_y": 0.5},
+    )
+    assert r.status_code == 404
+
+
+# BT-28: POST /manual-seed → 422 invalid ball_x
+def test_bt28_post_seed_422_invalid(client, student_token, _video_with_trajectory):
+    r = client.post(
+        f"/api/v1/users/me/juggling/videos/{_video_with_trajectory}/ball-trajectory/manual-seed",
+        headers=_auth(student_token),
+        json={"frame_ms": 100, "ball_x": 1.5, "ball_y": 0.5},
+    )
+    assert r.status_code == 422

--- a/tests/unit/juggling/test_ball_trajectory_task.py
+++ b/tests/unit/juggling/test_ball_trajectory_task.py
@@ -1,0 +1,255 @@
+"""
+Dense ball trajectory task tests — BT-13..BT-19.
+
+Mock detector + extractor; no ONNX model or video files needed.
+Uses the project's PostgreSQL savepoint pattern for DB tests.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+import numpy as np
+import pytest
+from sqlalchemy import event as sa_event
+from sqlalchemy.orm import sessionmaker
+
+from app.database import engine
+from app.models.juggling import (
+    JugglingBallTrajectory,
+    JugglingConsent,
+    JugglingContactEvent,
+    JugglingVideo,
+    JugglingVideoStatus,
+)
+from app.tasks.juggling_trajectory_task import run_dense_ball_trajectory
+import app.tasks.juggling_trajectory_task as task_module
+
+# ── DB fixture (PostgreSQL savepoint) ─────────────────────────────────────────
+
+@pytest.fixture()
+def db():
+    connection = engine.connect()
+    transaction = connection.begin()
+    TestSession = sessionmaker(autocommit=False, autoflush=False, bind=connection)
+    session = TestSession()
+    connection.begin_nested()
+
+    @sa_event.listens_for(session, "after_transaction_end")
+    def restart_savepoint(sess, txn):
+        if txn.nested and not txn._parent.nested:
+            sess.begin_nested()
+
+    try:
+        yield session
+    finally:
+        session.close()
+        if transaction.is_active:
+            transaction.rollback()
+        connection.close()
+
+
+@pytest.fixture(autouse=True)
+def _enable_flags(monkeypatch):
+    monkeypatch.setattr(task_module.settings, "BALL_TRAJECTORY_ENABLED", True)
+    monkeypatch.setattr(task_module.settings, "BALL_DETECTION_MODEL_PATH",
+                        "/tmp/fake_model.onnx")
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _make_video(db, *, transcode_status="done", duration_sec=1.0, user_id=1):
+    vid_id = uuid.uuid4()
+    consent = db.query(JugglingConsent).filter(JugglingConsent.user_id == user_id).first()
+    if consent is None:
+        consent = JugglingConsent(
+            user_id=user_id, service_consent=True,
+            training_consent=True, admin_review_consent=True,
+        )
+        db.add(consent)
+        db.flush()
+
+    video = JugglingVideo(
+        id=vid_id,
+        user_id=user_id,
+        source_type="uploaded_video",
+        upload_source="gallery",
+        training_video_type="juggling",
+        storage_path="/tmp/test.mp4",
+        status=JugglingVideoStatus.analyzed.value,
+        transcode_status=transcode_status,
+        server_detected_metadata={"duration_seconds": duration_sec},
+    )
+    db.add(video)
+    db.commit()
+    return str(vid_id)
+
+
+def _mock_extract():
+    frame = np.zeros((100, 100, 3), dtype=np.uint8)
+    def extract(path, ms):
+        return frame, 100, 100
+    return extract
+
+
+def _mock_detector(detections: dict[int, tuple | None]):
+    """detections: {frame_ms: (cx, cy, conf) or None}."""
+    class FakeDetector:
+        def __init__(self):
+            self._call_count = 0
+
+        def detect(self, frame, target_class_id=37, confidence_threshold=0.3):
+            ms = self._call_count * 100
+            self._call_count += 1
+            return detections.get(ms)
+
+    fake = FakeDetector()
+    return lambda model_path: fake
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+# BT-13: happy path — 10 frames, 7 detected, 3 missed
+def test_bt13_happy_path_mixed(db, monkeypatch):
+    import pathlib
+    monkeypatch.setattr(pathlib.Path, "is_file", lambda self: True)
+
+    video_id = _make_video(db, duration_sec=0.9)
+    detections = {
+        0: (0.5, 0.5, 0.8), 100: (0.52, 0.52, 0.7), 200: (0.54, 0.54, 0.75),
+        300: None, 400: None, 500: None,
+        600: (0.6, 0.6, 0.9), 700: (0.62, 0.62, 0.85),
+        800: (0.64, 0.64, 0.88), 900: (0.66, 0.66, 0.82),
+    }
+
+    result = run_dense_ball_trajectory(
+        video_id, db,
+        _extract_frame=_mock_extract(),
+        _get_detector=_mock_detector(detections),
+        sampling_interval_ms=100,
+    )
+
+    assert result["status"] == "complete"
+    assert result["frames"] == 10
+    assert result["detected"] == 7
+    assert result["predicted"] + result["lost"] == 3
+
+    rows = db.query(JugglingBallTrajectory).filter(
+        JugglingBallTrajectory.video_id == uuid.UUID(video_id)
+    ).count()
+    assert rows == 10
+
+
+# BT-14: all detected
+def test_bt14_all_detected(db, monkeypatch):
+    import pathlib
+    monkeypatch.setattr(pathlib.Path, "is_file", lambda self: True)
+
+    video_id = _make_video(db, duration_sec=0.4)
+    detections = {i * 100: (0.5, 0.5, 0.9) for i in range(5)}
+
+    result = run_dense_ball_trajectory(
+        video_id, db,
+        _extract_frame=_mock_extract(),
+        _get_detector=_mock_detector(detections),
+        sampling_interval_ms=100,
+    )
+
+    assert result["status"] == "complete"
+    assert result["detected"] == 5
+    assert result["predicted"] == 0
+    assert result["lost"] == 0
+
+    rows = db.query(JugglingBallTrajectory).filter(
+        JugglingBallTrajectory.tracking_state == "detected"
+    ).count()
+    assert rows == 5
+
+
+# BT-15: detector always None → lost after max_miss
+def test_bt15_all_none_tracking_lost(db, monkeypatch):
+    import pathlib
+    monkeypatch.setattr(pathlib.Path, "is_file", lambda self: True)
+
+    video_id = _make_video(db, duration_sec=0.9)
+
+    result = run_dense_ball_trajectory(
+        video_id, db,
+        _extract_frame=_mock_extract(),
+        _get_detector=_mock_detector({}),
+        sampling_interval_ms=100,
+        max_consecutive_miss=3,
+    )
+
+    assert result["status"] == "complete"
+    assert result["detected"] == 0
+    assert result["lost"] == 10
+
+
+# BT-16: feature flag off → skipped
+def test_bt16_feature_flag_off(db, monkeypatch):
+    monkeypatch.setattr(task_module.settings, "BALL_TRAJECTORY_ENABLED", False)
+    video_id = _make_video(db)
+    result = run_dense_ball_trajectory(video_id, db)
+    assert result["status"] == "skipped"
+    assert "BALL_TRAJECTORY_ENABLED" in result["reason"]
+
+
+# BT-17: video not found → failed
+def test_bt17_video_not_found(db):
+    fake_id = str(uuid.uuid4())
+    result = run_dense_ball_trajectory(fake_id, db)
+    assert result["status"] == "failed"
+    assert "not found" in result["reason"]
+
+
+# BT-18: transcode not done → skipped
+def test_bt18_transcode_not_done(db):
+    video_id = _make_video(db, transcode_status="pending")
+    result = run_dense_ball_trajectory(
+        video_id, db,
+        _extract_frame=lambda *a: None,
+        _get_detector=lambda p: None,
+    )
+    assert result["status"] == "skipped"
+    assert "transcode" in result["reason"]
+
+
+# BT-19: is_manual=TRUE points not overwritten
+def test_bt19_manual_points_preserved(db, monkeypatch):
+    import pathlib
+    monkeypatch.setattr(pathlib.Path, "is_file", lambda self: True)
+
+    video_id = _make_video(db, duration_sec=0.2)
+
+    manual_point = JugglingBallTrajectory(
+        video_id=uuid.UUID(video_id),
+        frame_ms=100,
+        ball_x=0.99,
+        ball_y=0.99,
+        confidence=None,
+        is_manual=True,
+        tracking_state="manual_seed",
+    )
+    db.add(manual_point)
+    db.commit()
+
+    detections = {0: (0.5, 0.5, 0.8), 100: (0.6, 0.6, 0.9), 200: (0.7, 0.7, 0.85)}
+
+    result = run_dense_ball_trajectory(
+        video_id, db,
+        _extract_frame=_mock_extract(),
+        _get_detector=_mock_detector(detections),
+        sampling_interval_ms=100,
+    )
+
+    assert result["status"] == "complete"
+
+    manual = db.query(JugglingBallTrajectory).filter(
+        JugglingBallTrajectory.video_id == uuid.UUID(video_id),
+        JugglingBallTrajectory.frame_ms == 100,
+        JugglingBallTrajectory.is_manual.is_(True),
+    ).first()
+    assert manual is not None
+    assert manual.ball_x == 0.99
+    assert manual.ball_y == 0.99

--- a/tests/unit/juggling/test_juggling_video_list.py
+++ b/tests/unit/juggling/test_juggling_video_list.py
@@ -463,7 +463,7 @@ def test_jvl25_openapi_path_and_route_delta(client):
         if hasattr(r, "methods") and hasattr(r, "path")
         for m in (r.methods or [])
     ]
-    assert len(routes) == 1028, f"Expected 1028 routes, got {len(routes)}"
+    assert len(routes) == 1032, f"Expected 1032 routes, got {len(routes)}"
     get_list = [r for r in routes if r[0] == "GET" and r[1] == "/api/v1/users/me/juggling/videos"]
     assert len(get_list) == 1
 

--- a/tests/unit/juggling/test_juggling_video_list.py
+++ b/tests/unit/juggling/test_juggling_video_list.py
@@ -471,13 +471,13 @@ def test_jvl25_openapi_path_and_route_delta(client):
 # ── JVL-26: Alembic head unchanged ───────────────────────────────────────────
 
 def test_jvl26_alembic_head_unchanged():
-    """JVL-26: Alembic head is 2026_06_18_1400 (AN-3B2C-1 follow-up — auto_confidence)."""
+    """JVL-26: Alembic head is 2026_06_18_2000 (AN-3B2D-B0 ball feedback tables)."""
     from alembic.config import Config
     from alembic.script import ScriptDirectory
     import os
     cfg = Config(os.path.join(os.path.dirname(__file__), "..", "..", "..", "alembic.ini"))
     heads = ScriptDirectory.from_config(cfg).get_heads()
-    assert heads == ["2026_06_18_1400"], f"Unexpected Alembic heads: {heads}"
+    assert heads == ["2026_06_18_2000"], f"Unexpected Alembic heads: {heads}"
 
 
 # ── JVL-27: P4 thumbnail/media regression ────────────────────────────────────

--- a/tests/unit/juggling/test_kalman_tracker.py
+++ b/tests/unit/juggling/test_kalman_tracker.py
@@ -1,0 +1,113 @@
+"""
+KalmanBallTracker unit tests — BT-06..BT-12.
+
+Pure-logic tests: no DB, no Celery, no ONNX.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.services.juggling.kalman_ball_tracker import KalmanBallTracker
+
+
+class TestKalmanBallTracker:
+
+    # BT-06: first detection returns raw coordinates (no smoothing yet)
+    def test_bt06_first_detection_returns_raw(self):
+        t = KalmanBallTracker()
+        x, y = t.update(0.5, 0.7)
+        assert x == 0.5
+        assert y == 0.7
+        assert not t.is_lost
+        assert t.miss_count == 0
+
+    # BT-07: consecutive detections converge to actual position
+    def test_bt07_consecutive_detections_converge(self):
+        t = KalmanBallTracker()
+        t.update(0.5, 0.5)
+        for _ in range(10):
+            x, y = t.update(0.6, 0.6)
+        assert abs(x - 0.6) < 0.05
+        assert abs(y - 0.6) < 0.05
+
+    # BT-08: 1-3 miss → predict_only returns extrapolated position
+    def test_bt08_few_misses_predict_returns_position(self):
+        t = KalmanBallTracker(max_miss=5)
+        t.update(0.5, 0.5)
+        t.update(0.55, 0.55)
+
+        for i in range(3):
+            result = t.predict_only()
+            assert result is not None, f"predict_only returned None on miss #{i+1}"
+            px, py = result
+            assert 0.0 <= px <= 1.5
+            assert 0.0 <= py <= 1.5
+
+        assert not t.is_lost
+
+    # BT-09: 6+ miss → predict_only returns None (lost)
+    def test_bt09_many_misses_returns_none(self):
+        t = KalmanBallTracker(max_miss=5)
+        t.update(0.5, 0.5)
+
+        for _ in range(5):
+            result = t.predict_only()
+            assert result is not None
+
+        result = t.predict_only()
+        assert result is None
+        assert t.is_lost
+
+    # BT-10: detection after lost → re-init tracker
+    def test_bt10_detection_after_lost_reinit(self):
+        t = KalmanBallTracker(max_miss=2)
+        t.update(0.5, 0.5)
+
+        for _ in range(3):
+            t.predict_only()
+        assert t.is_lost
+
+        x, y = t.update(0.8, 0.8)
+        assert x == 0.8
+        assert y == 0.8
+        assert not t.is_lost
+        assert t.miss_count == 0
+
+    # BT-11: seed() re-initializes from manual position
+    def test_bt11_seed_reinit(self):
+        t = KalmanBallTracker(max_miss=2)
+        t.update(0.5, 0.5)
+        for _ in range(3):
+            t.predict_only()
+        assert t.is_lost
+
+        t.seed(0.3, 0.9)
+        assert not t.is_lost
+        assert t.miss_count == 0
+        x, y = t.update(0.31, 0.91)
+        assert abs(x - 0.31) < 0.05
+        assert abs(y - 0.91) < 0.05
+
+    # BT-12: is_lost reflects miss_count vs threshold
+    def test_bt12_is_lost_property(self):
+        t = KalmanBallTracker(max_miss=3)
+        assert t.is_lost  # not initialized
+
+        t.update(0.5, 0.5)
+        assert not t.is_lost
+
+        t.mark_miss()
+        assert not t.is_lost
+        assert t.miss_count == 1
+
+        t.mark_miss()
+        t.mark_miss()
+        assert not t.is_lost  # miss_count=3 == max_miss, not > max_miss
+
+        t.mark_miss()
+        assert t.is_lost  # miss_count=4 > max_miss=3
+
+    def test_bt06b_uninitialized_predict_returns_none(self):
+        t = KalmanBallTracker()
+        assert t.predict_only() is None
+        assert t.is_lost


### PR DESCRIPTION
## Summary

Backend-only B0 scope for the user-assisted ball model training data pipeline (AN-3B2D).

- **3 new DB tables** via Alembic migration `2026_06_18_2000` (chains from `2026_06_18_1500`):
  - `juggling_ball_feedback` — per-user per-frame feedback (UNIQUE user+video+frame, 5 CHECK constraints)
  - `juggling_frame_ground_truth` — aggregated majority-vote ground truth (scaffold; populated in B2+)
  - `user_annotation_reliability` — per-user annotation quality score (scaffold; populated in B2+)
- **2 new API endpoints** (gated: `JUGGLING_POC_ENABLED` + `BALL_FEEDBACK_ENABLED=False`):
  - `POST /api/v1/users/me/juggling/videos/{video_id}/ball-feedback` → 201 / 404 / 409 / 422 / 503
  - `GET  /api/v1/users/me/juggling/videos/{video_id}/ball-feedback/queue` → priority-sorted uncertain frames
- **18 tests** (BFB-01..18): 503-gate, confirm/no_ball/corrected happy paths, 422-validation, 409-duplicate, 404-video, gdpr-deleted, lazy-reliability-create, corrected-coords-stored, queue-empty, queue-priority-sort, queue-excludes-reviewed, queue-excludes-saturated, queue-limit, lost-frame-priority, queue-404

## B0 scope boundaries (strictly enforced)

| Included | Excluded (future B1–B5) |
|----------|------------------------|
| DB schema + migration | iOS feedback UI (B1) |
| SQLAlchemy models | Credit grants (B2) |
| Pydantic schemas | Majority vote / consensus (B2) |
| Service layer | Reliability score updates (B2) |
| POST/GET endpoints | Spam detection (B2) |
| Feature flag (default OFF) | Dataset export (B3) |
| 18 BFB tests | Training pipeline (B4) |
| | Model registry / production swap (B5) |

`training_eligible` is schema-present but never set True in this PR.

## Test plan

- [ ] BFB-01..18 PASS (18/18 locally confirmed)
- [ ] Full unit regression PASS
- [ ] Migration chain: alembic upgrade head → `2026_06_18_2000`
- [ ] Migration rollback: alembic downgrade → `2026_06_18_1500` (drops 3 tables in FK-safe order)
- [ ] `BALL_FEEDBACK_ENABLED=False` default confirmed → endpoints return 503 without `.env` change
- [ ] OpenAPI route snapshot updated

## Commits

| SHA | Description |
|-----|-------------|
| `654567db` | C1: migration 2026_06_18_2000 |
| `31d6b9c2` | C2: models (3 new ORM classes) |
| `fad5b40e` | C3: schemas (4 Pydantic models) |
| `c3f2b8da` | C4: service (submit_feedback + get_feedback_queue) |
| `2424dbea` | C5: endpoints + BALL_FEEDBACK_ENABLED flag |
| `30c63f98` | C6: BFB-01..18 tests (18/18 PASS) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)