### PR TITLE
feat(ios-juggling): AN-3B2B1 B1 iOS Ball Feedback UI

### DIFF
--- a/docs/AN3B2B1_IOS_FEEDBACK_UI_AUDIT_AND_PLAN.md
+++ b/docs/AN3B2B1_IOS_FEEDBACK_UI_AUDIT_AND_PLAN.md
@@ -1,0 +1,437 @@
+# AN-3B2B1 — B1 iOS Ball Feedback UI: Audit & Implementation Plan
+
+**Branch:** `feat/an3b2b1-ios-feedback-ui`  
+**Státusz:** TERV — implementáció csak jóváhagyás után  
+**Dátum:** 2026-06-18  
+**Előfeltétel:** PR #303 MERGED (main HEAD: `6f8c1efd`)  
+**B0 backend:** KÉSZ (`main`-en: migration `2026_06_18_2000`, `ball_feedback_service.py`, 479 teszt PASS)
+
+---
+
+## 1. Jelenlegi iOS juggling annotation UI állapot
+
+### 1.1 Képernyő-struktúra (`JugglingAnnotationScreen.swift`)
+
+```
+NavigationView
+  GeometryReader → VStack
+    videoArea(in:)                    ← ZStack: videó + overlays + togglek
+    PlaybackControlBar                ← play/pause/scrub/rotate
+    statusBar                         ← szinkron státusz
+    generatePosesBanner               ← feltételes
+    EventTimelineView                 ← idővonal pin-ekkel
+    eventList                         ← ScrollView eseménylista
+    labelingCTA                       ← feltételes
+    saveAndCloseButton
+```
+
+### 1.2 `videoArea` ZStack rétegek (bottom → top)
+
+| Réteg | Típus | Feltétel |
+|---|---|---|
+| `Color.black` | háttér | mindig |
+| `AVPlayerLayerView` | videó | `loaderReady` |
+| `ContinuousSkeletonOverlayView` / `PoseSnapshotOverlayView` | skeleton | `showSkeletonOverlay && loaderReady` |
+| `BallTrajectoryOverlayView` / `BallVideoOverlayView` / `ballOverlayStatusBanner` | labda | `showBallOverlay && loaderReady` |
+| Processing bannerek | ProgressView | `ballTrajectoryVM.status == .processing` |
+| Overlay toggle gombok (skeleton + ball) | VStack/HStack | `loaderReady` |
+
+### 1.3 Meglévő ViewModelek és állapotok
+
+| ViewModel / State | Típus | Szerep |
+|---|---|---|
+| `BallTrajectoryViewModel` | `@StateObject` | Dense trajectory adatok, 100ms polling |
+| `DenseSkeletonViewModel` | `@StateObject` | Offline skeleton extraction |
+| `JugglingAnnotationViewModel` | `@StateObject` | Event CRUD, sync, ball detections |
+| `showBallOverlay` | `@State Bool` | Ball overlay láthatósága |
+| `showSkeletonOverlay` | `@State Bool` | Skeleton overlay láthatósága |
+| `isBallSelecting` | `@State Bool` | Tap-to-correct mód (AN-3B2C-1) |
+| `ballSelectionDragPoint` | `@State CGPoint?` | Drag korrekció pont |
+
+### 1.4 Meglévő ball interaction flow (AN-3B2C-1)
+
+Az `isBallSelecting` mód már létezik: a ball overlay toggle melletti gomb aktiválja, a felhasználó tappel vagy dragel → `handleBallSelection(normalizedPoint:)` → `POST /ball-detection` (manual override). Ez az event-szintű (egyedi contact event) korrekció.
+
+**B1 ettől eltér:** a ball feedback a dense trajectory frame-szintű visszajelzés — nem contact eventre, hanem `frame_ms`-re vonatkozik, és a B0 feedback API-t (`POST /ball-feedback`) használja.
+
+---
+
+## 2. Érintett képernyők és ViewModelek
+
+### 2.1 Érintett (módosítandó)
+
+| Fájl | Változás típusa |
+|---|---|
+| `JugglingAnnotationScreen.swift` | Új `@StateObject feedbackVM`, új toggle gomb, feedback panel megjelenítése |
+| `JugglingAnnotationAPIClient.swift` | 2 új API hívás: `GET /ball-feedback/queue`, `POST /ball-feedback` |
+
+### 2.2 Új fájlok
+
+| Fájl | Leírás |
+|---|---|
+| `BallFeedbackViewModel.swift` | Queue fetch + feedback submit logika |
+| `BallFeedbackDTO.swift` | `BallFeedbackRequest`, `BallFeedbackOut`, `BallFeedbackQueueItem`, `BallFeedbackQueueResponse` — Swift structs |
+| `BallFeedbackPanel.swift` | SwiftUI panel — feedback action gombok (confirm / no_ball / corrected / skip) |
+| `BallFeedbackOverlayView.swift` | Videó feletti overlay — jelöli a feedback frame pozícióját (ha van predicted x/y) |
+| `BallFeedbackVMTests.swift` | Unit tesztek (`BFB-01..N`) |
+| `BallFeedbackPanelTests.swift` | Unit tesztek — action → döntés mapping |
+
+### 2.3 Nem érintett
+
+| Fájl | Indok |
+|---|---|
+| `BallTrajectoryViewModel.swift` | Külön polling VM, B1 nem módosítja |
+| `DenseSkeletonViewModel.swift` | Független |
+| `JugglingAnnotationViewModel.swift` | Ball detection CRUD itt marad; feedback külön VM |
+| `EventLabelDetailView.swift` | Nincs feedback UI event-detail szinten (B1 scope-on kívül) |
+
+---
+
+## 3. Feedback actionök és API mapping
+
+### 3.1 A négy action
+
+| Action | Megjelenítés | API `decision` | Extra mezők |
+|---|---|---|---|
+| **Confirm** | "Helyes" (zöld pipa) | `"confirm"` | — |
+| **No ball** | "Nincs labda" (x szimbólum) | `"no_ball"` | — |
+| **Correct position** | "Javítom" (crosshair) → tap/drag | `"corrected"` | `corrected_x`, `corrected_y`, `correction_method: "tap"\|"drag"` |
+| **Skip** | "Kihagyom" (nyíl) | nem küld API hívást | client-side: lép a queue következő elemére |
+
+### 3.2 Model context snapshot (mindig küldendő ha elérhető)
+
+A `BallFeedbackRequest` tartalmaz model context mezőket az iOS klienssel küldve — ezeket a `BallFeedbackQueueItem` adja:
+
+```swift
+model_predicted_x:    item.modelPredictedX
+model_predicted_y:    item.modelPredictedY
+model_confidence:     item.modelConfidence
+model_tracking_state: item.modelTrackingState
+```
+
+### 3.3 "Correct position" flow részlete
+
+1. Felhasználó a "Javítom" gombra koppint → `isFeedbackCorrecting = true`
+2. Az overlay interaktívvá válik: `DragGesture` + `TapGesture` a videó területen
+3. Felhasználó megjelöli a labda valódi pozícióját
+4. `correction_method = "tap"` (single tap) vagy `"drag"` (gesture ended)
+5. POST küldés normalizált koordinátákkal (0.0–1.0)
+6. Sikeres POST után: frame optimistikusan "submitted" lesz, panel lép a következő queue itemre
+
+### 3.4 Session limit
+
+A backend `max_per_session: 3` értéket ad vissza. A VM session-szinten számolja az elküldött feedback-eket. Ha `submittedCount >= maxPerSession`, a panel ún. "session teljes" állapotba lép (nem további frame-ek jönnek az aktuális session-ben).
+
+---
+
+## 4. API endpointok
+
+### 4.1 `GET /users/me/juggling/videos/{video_id}/ball-feedback/queue`
+
+```
+Query:  limit: Int  (default 5, max 20)
+Response: BallFeedbackQueueResponse {
+    video_id: String
+    queue_items: [BallFeedbackQueueItem]
+    total: Int
+    max_per_session: Int  // = 3
+}
+
+BallFeedbackQueueItem {
+    frame_ms:                Int
+    priority_score:          Float
+    model_predicted_x:       Float?
+    model_predicted_y:       Float?
+    model_confidence:        Float?
+    model_tracking_state:    String?  // "detected" | "predicted" | "lost"
+    existing_feedback_count: Int
+}
+```
+
+**iOS viselkedés:** a VM induláskor és feedback-session megnyitásakor hívja meg. Ha `queue_items.isEmpty` → "Nincs visszajelzendő frame" üzenet.
+
+### 4.2 `POST /users/me/juggling/videos/{video_id}/ball-feedback`
+
+```
+Body: BallFeedbackRequest {
+    frame_ms:             Int    (required)
+    decision:             String (required: "confirm"|"reject"|"no_ball"|"corrected")
+    corrected_x:          Float? (required if decision="corrected")
+    corrected_y:          Float? (required if decision="corrected")
+    correction_method:    String? ("tap"|"drag")
+    model_predicted_x:    Float?
+    model_predicted_y:    Float?
+    model_confidence:     Float?
+    model_tracking_state: String?
+}
+
+Response 201: BallFeedbackOut {
+    id:             UUID
+    video_id:       UUID
+    frame_ms:       Int
+    decision:       String
+    approval_state: String  // "pending"
+    created_at:     DateTime
+}
+
+Error 409: user already submitted for this video+frame
+Error 404: video not found
+Error 503: BALL_FEEDBACK_ENABLED=false
+```
+
+### 4.3 Feature flag
+
+Mindkét endpoint `JUGGLING_POC_ENABLED` és `BALL_FEEDBACK_ENABLED` feature flag-et igényel. Ha `503` jön vissza: a feedback panel nem jelenik meg, UI-ban nincs feedback toggle gomb. A VM `isAvailable: Bool` computed property-vel jelzi ezt.
+
+---
+
+## 5. Optimistic update / error rollback terv
+
+### 5.1 Optimistic update flow
+
+```
+Felhasználó → action gomb tappel
+    ↓
+feedbackVM.submitFeedback(decision:, ...) meghívódik
+    ↓
+[Optimistic] currentQueueItem eltávolítva a helyi listából
+             submittedCount += 1
+             panel lép a következő queue itemre (vagy "session kész" állapotba)
+    ↓
+[Async] POST /ball-feedback
+    ↓ (success 201)
+    feedbackVM.confirmedFrames.insert(frame_ms)
+    ↓ (failure 409 — duplicate)
+    409 = nem kritikus; a frame már be lett küldve → silent ignore
+          optimistic állapot megmarad (nem rollback)
+    ↓ (failure 4xx/5xx != 409)
+    [Rollback] frame visszakerül a queue elejére
+               submittedCount -= 1
+               hibaüzenet megjelenik ("Hiba, próbáld újra")
+               panel visszaugrik az előző queue itemre
+```
+
+### 5.2 Miért nem critical a 409?
+
+A 409 azt jelenti, hogy a felhasználó ugyanazon frame-re már küldött feedback-et. Ez csak akkor fordulhat elő, ha a user gyorsan duplán tappel — az optimistic állapot helyes marad, a frame valóban submitted.
+
+### 5.3 Rollback adatstruktúra
+
+```swift
+struct PendingFeedback {
+    let queueItem: BallFeedbackQueueItem
+    let decision:  String
+    let correctedX: Double?
+    let correctedY: Double?
+    let correctionMethod: String?
+}
+```
+
+A VM tárolja `inFlight: [Int: PendingFeedback]` (keyed by `frame_ms`). Sikeres 201 után törlődik. Hibánál rollback: visszakerül a queue elejére.
+
+---
+
+## 6. `BallFeedbackViewModel` — belső állapotok
+
+```swift
+enum FeedbackSessionState {
+    case idle                    // nincs aktív session, toggle ki
+    case loading                 // GET queue fut
+    case ready([BallFeedbackQueueItem])  // van queue, panel nyitható
+    case empty                   // queue_items.isEmpty
+    case sessionComplete         // submittedCount >= max_per_session
+    case unavailable             // 503 / feature flag off
+    case error(String)
+}
+
+@MainActor
+class BallFeedbackViewModel: ObservableObject {
+    @Published var sessionState: FeedbackSessionState = .idle
+    @Published var currentQueueIndex: Int = 0
+    @Published var submittedCount: Int = 0
+    let maxPerSession: Int = 3  // server-provided, cached after first GET
+
+    var currentItem: BallFeedbackQueueItem? { ... }
+    var isAvailable: Bool { ... }  // false if unavailable
+
+    func loadQueue() async { ... }
+    func submitFeedback(decision: String, correctedX: Double?, correctedY: Double?,
+                        correctionMethod: String?) async { ... }
+    func skip() { ... }  // nem hív API-t, csak index lép
+}
+```
+
+---
+
+## 7. `BallFeedbackPanel` UI terv
+
+### 7.1 Elhelyezés
+
+A panel a videó alatt, a `PlaybackControlBar` felett jelenik meg — **nem sheet** (ne blokkolja a videót). Egy sima SwiftUI `VStack` blokk a `videoArea` és `PlaybackControlBar` közé ékelve, `feedbackVM.sessionState == .ready(...)` esetén.
+
+```
+[ videoArea ]
+[ BallFeedbackPanel ]    ← új, feltételes
+[ PlaybackControlBar ]
+[ statusBar ]
+...
+```
+
+### 7.2 Panel layout (portrait nézet)
+
+```
+┌──────────────────────────────────────────────┐
+│  Frame: 4 230 ms  ·  Bizonytalanság: 78%     │  ← fejléc
+│  Labda pozíció: megjelölve az overlay-en      │
+├──────────────────────────────────────────────┤
+│  [✓ Helyes]  [✗ Nincs labda]                 │  ← 2 gomb sor
+│  [✎ Javítom] [→ Kihagyom]                    │
+├──────────────────────────────────────────────┤
+│  1 / 3 visszajelzés elküldve   [✕ Bezárás]  │  ← lábléc
+└──────────────────────────────────────────────┘
+```
+
+### 7.3 Feedback mode aktiválása
+
+A meglévő overlay toggle gombsor mellé egy harmadik gomb kerül:
+
+```swift
+overlayToggleButton(
+    icon: isFeedbackMode ? "hand.thumbsup.circle.fill" : "hand.thumbsup.circle",
+    isOn: isFeedbackMode,
+    accessLabel: "Labda visszajelzés mód"
+) {
+    if !isFeedbackMode {
+        Task { await feedbackVM.loadQueue() }
+    }
+    isFeedbackMode.toggle()
+}
+```
+
+### 7.4 `BallFeedbackOverlayView` — videó feletti jelölés
+
+Ha az aktuális queue item-nek van `modelPredictedX/Y`, a videó területén megjelenik egy referencia kör (hasonló a `BallTrajectoryOverlayView` dot-jához, de más színnel — pl. fehér szegélyű, kék töltésű). Ez segíti a user-t látni, mit kell megerősítenie vagy javítania.
+
+---
+
+## 8. Tesztterv
+
+### 8.1 Unit tesztek — `BallFeedbackVMTests.swift` (BFB-01..BFB-N)
+
+| ID | Teszt |
+|---|---|
+| BFB-01 | `loadQueue()` → `ready(items)` ha 3 item jön |
+| BFB-02 | `loadQueue()` → `empty` ha `queue_items = []` |
+| BFB-03 | `loadQueue()` → `unavailable` ha 503 response |
+| BFB-04 | `submitFeedback(decision: "confirm")` → optimistic: `currentQueueIndex += 1`, `submittedCount == 1` |
+| BFB-05 | `submitFeedback` 409 → silent ignore, optimistic állapot megmarad |
+| BFB-06 | `submitFeedback` 500 → rollback: `submittedCount == 0`, frame visszakerül |
+| BFB-07 | `skip()` → `currentQueueIndex += 1`, `submittedCount` változatlan |
+| BFB-08 | `submittedCount >= 3` → `sessionState == .sessionComplete` |
+| BFB-09 | `submitFeedback(decision: "corrected")` correctedX/Y nélkül → precondition fail (assert) |
+| BFB-10 | `submitFeedback(decision: "corrected")` correctedX/Y megadva → request helyes |
+| BFB-11 | `currentItem` → `nil` ha `currentQueueIndex >= items.count` |
+| BFB-12 | Model context snapshot: request tartalmazza `modelPredictedX`, `modelConfidence`, `modelTrackingState` |
+
+### 8.2 Unit tesztek — `BallFeedbackPanelTests.swift` (BFP-01..BFP-N)
+
+| ID | Teszt |
+|---|---|
+| BFP-01 | `BallFeedbackColorHelper.decisionColor("confirm")` → `.green` |
+| BFP-02 | `BallFeedbackColorHelper.decisionColor("no_ball")` → `.red` |
+| BFP-03 | Panel nem jelenik meg (`sessionState == .idle`) |
+| BFP-04 | Panel megjelenik (`sessionState == .ready([...])`) |
+
+### 8.3 Independence tesztek — `BallFeedbackAnnotationIndependenceTests.swift` (BFI-01..BFI-N)
+
+| ID | Teszt |
+|---|---|
+| BFI-01 | `feedbackVM.submitFeedback` nem módosít `JugglingAnnotationViewModel` állapotot |
+| BFI-02 | `feedbackVM.loadQueue()` nem módosít `ballTrajectoryVM` állapotot |
+| BFI-03 | `isFeedbackMode = false` → `BallFeedbackViewModel` polling nem fut |
+
+### 8.4 API client tesztek — `JugglingAnnotationAPIClientFeedbackTests.swift`
+
+| ID | Teszt |
+|---|---|
+| ACF-01 | `fetchFeedbackQueue(videoId:limit:)` → helyes URL + query param |
+| ACF-02 | `submitBallFeedback(videoId:request:)` → helyes JSON body |
+
+**Összesen tervezett: ~20 unit teszt**
+
+---
+
+## 9. Backward compatibility
+
+| Szempont | Kockázat | Kezelés |
+|---|---|---|
+| `BALL_FEEDBACK_ENABLED=false` | Endpoint 503-at ad | `feedbackVM.isAvailable = false`, toggle gomb rejtett |
+| iOS < 15.0 | Nincs (iOS 15.0 a target) | — |
+| `queue_items = []` | Nincs visszajelzendő frame | "empty" állapot, "Köszönjük!" üzenet |
+| 409 duplicate | Gyors dupla tapp | Silent ignore — optimistic állapot helyes |
+| `model_predicted_x == nil` | Lost frame-nél null koordináta | `BallFeedbackOverlayView` nem renderel referencia kört |
+| Dense trajectory `status != .complete` | Ball overlay még nem kész | Feedback panel elérhető marad (frame_ms alapú, nem trajectory-dependent) |
+| `BallTrajectoryViewModel` polling | Párhuzamos API hívások | Feedback VM és Trajectory VM teljesen független `@StateObject`-ek |
+
+---
+
+## 10. Kockázatok és rollout sorrend
+
+### 10.1 Kockázatok
+
+| Kockázat | Valószínűség | Hatás | Mitigáció |
+|---|---|---|---|
+| UX: panel elrejti az eseménylistát portrait-ban | Közepes | Magas | Panel max 80pt magasság, kollapsálható |
+| UX: "Javítom" mód konfliktusa `isBallSelecting` (AN-3B2C-1) móddal | Közepes | Közepes | Kölcsönösen kizárják egymást: `isFeedbackMode` ki → `isBallSelecting` is ki |
+| Incorrect feature flag state: 503 nem várható prod-on | Alacsony | Alacsony | `isAvailable = false` → gomb rejtett, nem crash |
+| Queue refresh staleség: user kétszer látja ugyanazt a frame-et | Alacsony | Alacsony | 409 silent ignore; user élményre nincs hatás |
+| Optimistic rollback villanás: user UI-ban visszaugrik | Alacsony | Közepes | Animation + hibaüzenet egyértelmű |
+
+### 10.2 Rollout sorrend
+
+| # | Lépés | Fájlok |
+|---|---|---|
+| C1 | `BallFeedbackDTO.swift` — Swift structs | új |
+| C2 | `JugglingAnnotationAPIClient.swift` bővítés — `fetchFeedbackQueue` + `submitBallFeedback` | módosítás |
+| C3 | `BallFeedbackViewModel.swift` — állapotgép + submit/rollback logika | új |
+| C4 | `BallFeedbackOverlayView.swift` — referencia kör overlay | új |
+| C5 | `BallFeedbackPanel.swift` — action gombok panel | új |
+| C6 | `JugglingAnnotationScreen.swift` — `@StateObject feedbackVM`, toggle gomb, panel integráció | módosítás |
+| C7 | `BallFeedbackVMTests.swift` (BFB-01..12) | új |
+| C8 | `BallFeedbackPanelTests.swift` (BFP-01..04) | új |
+| C9 | `BallFeedbackAnnotationIndependenceTests.swift` (BFI-01..03) | új |
+| C10 | `JugglingAnnotationAPIClientFeedbackTests.swift` (ACF-01..02) | új |
+
+**Minden commit egy C-szám — külön commit, átjárható QA per lépés.**
+
+---
+
+## 11. B0 backend státusz (tájékoztató)
+
+A B0 backend a `6f8c1efd` merge commit-tal mainre került:
+
+| Komponens | Státusz |
+|---|---|
+| Migration `2026_06_18_2000_add_juggling_ball_feedback_tables` | KÉSZ |
+| `JugglingBallFeedback` model + `UserAnnotationReliability` model | KÉSZ |
+| `ball_feedback_service.py` (`submit_feedback`, `get_feedback_queue`) | KÉSZ |
+| `juggling_ball_feedback.py` endpoint (`POST /ball-feedback`, `GET /ball-feedback/queue`) | KÉSZ |
+| 479 backend teszt PASS | KÉSZ |
+| `BALL_FEEDBACK_ENABLED` feature flag | KÉSZ (config.py) |
+
+**B1 iOS implementáció kizárólag ezeket a már meglévő endpointokat fogja használni — backend változtatás B1-ben nem szükséges.**
+
+---
+
+## 12. Döntési pontok (jóváhagyást igényelnek)
+
+| # | Kérdés | Opciók |
+|---|---|---|
+| D1 | Panel elhelyezése | A: `videoArea` és `PlaybackControlBar` közé (nem takar videót) [JAVASOLT]; B: overlay a videón belül (részben takarja) |
+| D2 | Feedback mode belépési pont | A: harmadik toggle gomb az overlay-en [JAVASOLT]; B: külön "Visszajelzés" CTA a `labelingCTA` alá |
+| D3 | "Correct position" korrekciós módszer | A: tap + drag mindkettő [JAVASOLT]; B: csak tap |
+| D4 | Session limit UI | A: "N/3 elküldve" progress label [JAVASOLT]; B: nincs UI, csak `sessionComplete` állapot |
+
+---
+
+*Ez a dokumentum koncepcionális / tervezési terv. Implementáció kizárólag explicit jóváhagyás után indul.*

--- a/ios/LFAEducationCenter.xcodeproj/project.pbxproj
+++ b/ios/LFAEducationCenter.xcodeproj/project.pbxproj
@@ -184,6 +184,14 @@
 		BB200004000000000000021 /* BallOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB200003000000000000021 /* BallOverlayView.swift */; };
 		BB200004000000000000022 /* BallVideoOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB200003000000000000022 /* BallVideoOverlayView.swift */; };
 		CC400004000000000000040 /* SkeletonOverlayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC300003000000000000040 /* SkeletonOverlayTests.swift */; };
+		BF100004000000000000001 /* BallFeedbackDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF100003000000000000001 /* BallFeedbackDTO.swift */; };
+		BF200004000000000000001 /* BallFeedbackViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF200003000000000000001 /* BallFeedbackViewModel.swift */; };
+		BF300004000000000000001 /* BallFeedbackOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF300003000000000000001 /* BallFeedbackOverlayView.swift */; };
+		BF400004000000000000001 /* BallFeedbackPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF400003000000000000001 /* BallFeedbackPanel.swift */; };
+		BF500004000000000000001 /* BallFeedbackVMTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF500003000000000000001 /* BallFeedbackVMTests.swift */; };
+		BF600004000000000000001 /* BallFeedbackPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF600003000000000000001 /* BallFeedbackPanelTests.swift */; };
+		BF700004000000000000001 /* BallFeedbackAnnotationIndependenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF700003000000000000001 /* BallFeedbackAnnotationIndependenceTests.swift */; };
+		BF800004000000000000001 /* JugglingAnnotationAPIClientFeedbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF800003000000000000001 /* JugglingAnnotationAPIClientFeedbackTests.swift */; };
 		BB200004000000000000003 /* EventTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB200003000000000000003 /* EventTimelineView.swift */; };
 		BB200004000000000000006 /* PlaybackControllerLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB200003000000000000006 /* PlaybackControllerLayoutTests.swift */; };
 		BB200004000000000000009 /* EventTimelineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB200003000000000000009 /* EventTimelineTests.swift */; };
@@ -333,6 +341,14 @@
 		BB200003000000000000021 /* BallOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BallOverlayView.swift; sourceTree = "<group>"; };
 		BB200003000000000000022 /* BallVideoOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BallVideoOverlayView.swift; sourceTree = "<group>"; };
 		CC300003000000000000040 /* SkeletonOverlayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkeletonOverlayTests.swift; sourceTree = "<group>"; };
+		BF100003000000000000001 /* BallFeedbackDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BallFeedbackDTO.swift; sourceTree = "<group>"; };
+		BF200003000000000000001 /* BallFeedbackViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BallFeedbackViewModel.swift; sourceTree = "<group>"; };
+		BF300003000000000000001 /* BallFeedbackOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BallFeedbackOverlayView.swift; sourceTree = "<group>"; };
+		BF400003000000000000001 /* BallFeedbackPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BallFeedbackPanel.swift; sourceTree = "<group>"; };
+		BF500003000000000000001 /* BallFeedbackVMTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BallFeedbackVMTests.swift; sourceTree = "<group>"; };
+		BF600003000000000000001 /* BallFeedbackPanelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BallFeedbackPanelTests.swift; sourceTree = "<group>"; };
+		BF700003000000000000001 /* BallFeedbackAnnotationIndependenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BallFeedbackAnnotationIndependenceTests.swift; sourceTree = "<group>"; };
+		BF800003000000000000001 /* JugglingAnnotationAPIClientFeedbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JugglingAnnotationAPIClientFeedbackTests.swift; sourceTree = "<group>"; };
 		BB200003000000000000003 /* EventTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventTimelineView.swift; sourceTree = "<group>"; };
 		BB200003000000000000006 /* PlaybackControllerLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackControllerLayoutTests.swift; sourceTree = "<group>"; };
 		BB200003000000000000009 /* EventTimelineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventTimelineTests.swift; sourceTree = "<group>"; };
@@ -679,6 +695,8 @@
 				EE100003000000000000002 /* DensePoseCache.swift */,
 				EE100003000000000000003 /* DensePoseExtractor.swift */,
 				EE100003000000000000004 /* BallTrajectoryDTO.swift */,
+				BF100003000000000000001 /* BallFeedbackDTO.swift */,
+				BF200003000000000000001 /* BallFeedbackViewModel.swift */,
 				BB100003000000000000002 /* AnnotationVideoLoader.swift */,
 				BB200002000000000000001 /* Screen */,
 				AA100002000000000000002 /* Resources */,
@@ -705,6 +723,8 @@
 				EE200003000000000000003 /* BallTrajectoryViewModel.swift */,
 				EE200003000000000000004 /* BallTrajectoryOverlayView.swift */,
 				EE200003000000000000002 /* ContinuousSkeletonOverlayView.swift */,
+				BF300003000000000000001 /* BallFeedbackOverlayView.swift */,
+				BF400003000000000000001 /* BallFeedbackPanel.swift */,
 			);
 			path = Screen;
 			sourceTree = "<group>";
@@ -797,6 +817,10 @@
 				EE300003000000000000002 /* BallTrajectoryOverlayTests.swift */,
 				EE400003000000000000001 /* EventRecordingBallTrajectoryIndependenceTests.swift */,
 				CC300003000000000000040 /* SkeletonOverlayTests.swift */,
+				BF500003000000000000001 /* BallFeedbackVMTests.swift */,
+				BF600003000000000000001 /* BallFeedbackPanelTests.swift */,
+				BF700003000000000000001 /* BallFeedbackAnnotationIndependenceTests.swift */,
+				BF800003000000000000001 /* JugglingAnnotationAPIClientFeedbackTests.swift */,
 				BB100003000000000000004 /* AnnotationVideoLoaderTests.swift */,
 				BB100003000000000000005 /* PlaybackBarTests.swift */,
 				BB100003000000000000006 /* AVPlayerLayerViewTests.swift */,
@@ -1030,10 +1054,14 @@
 				EE100004000000000000002 /* DensePoseCache.swift in Sources */,
 				EE100004000000000000003 /* DensePoseExtractor.swift in Sources */,
 				EE100004000000000000004 /* BallTrajectoryDTO.swift in Sources */,
+				BF100004000000000000001 /* BallFeedbackDTO.swift in Sources */,
+				BF200004000000000000001 /* BallFeedbackViewModel.swift in Sources */,
 				EE200004000000000000001 /* DenseSkeletonViewModel.swift in Sources */,
 				EE200004000000000000003 /* BallTrajectoryViewModel.swift in Sources */,
 				EE200004000000000000004 /* BallTrajectoryOverlayView.swift in Sources */,
 				EE200004000000000000002 /* ContinuousSkeletonOverlayView.swift in Sources */,
+				BF300004000000000000001 /* BallFeedbackOverlayView.swift in Sources */,
+				BF400004000000000000001 /* BallFeedbackPanel.swift in Sources */,
 				BB100004000000000000001 /* AVPlayerLayerView.swift in Sources */,
 				BB100004000000000000002 /* AnnotationVideoLoader.swift in Sources */,
 				BB100004000000000000003 /* PlaybackControlBar.swift in Sources */,
@@ -1101,6 +1129,10 @@
 				EE300004000000000000002 /* BallTrajectoryOverlayTests.swift in Sources */,
 				EE400004000000000000001 /* EventRecordingBallTrajectoryIndependenceTests.swift in Sources */,
 				CC400004000000000000040 /* SkeletonOverlayTests.swift in Sources */,
+				BF500004000000000000001 /* BallFeedbackVMTests.swift in Sources */,
+				BF600004000000000000001 /* BallFeedbackPanelTests.swift in Sources */,
+				BF700004000000000000001 /* BallFeedbackAnnotationIndependenceTests.swift in Sources */,
+				BF800004000000000000001 /* JugglingAnnotationAPIClientFeedbackTests.swift in Sources */,
 				BB100004000000000000004 /* AnnotationVideoLoaderTests.swift in Sources */,
 				BB100004000000000000005 /* PlaybackBarTests.swift in Sources */,
 				BB100004000000000000006 /* AVPlayerLayerViewTests.swift in Sources */,

--- a/ios/LFAEducationCenter/Juggling/Annotation/BallFeedbackDTO.swift
+++ b/ios/LFAEducationCenter/Juggling/Annotation/BallFeedbackDTO.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+// MARK: — Ball Feedback DTOs (AN-3B2B1)
+//
+// Maps to the backend BallFeedbackRequest / BallFeedbackOut /
+// BallFeedbackQueueItem / BallFeedbackQueueResponse schemas.
+// Decisions: "confirm" | "no_ball" | "corrected"  — "skip" is client-only.
+
+struct BallFeedbackQueueItem: Decodable, Equatable {
+    let frameMs:                Int
+    let priorityScore:          Double
+    let modelPredictedX:        Double?
+    let modelPredictedY:        Double?
+    let modelConfidence:        Double?
+    let modelTrackingState:     String?
+    let existingFeedbackCount:  Int
+
+    enum CodingKeys: String, CodingKey {
+        case frameMs               = "frame_ms"
+        case priorityScore         = "priority_score"
+        case modelPredictedX       = "model_predicted_x"
+        case modelPredictedY       = "model_predicted_y"
+        case modelConfidence       = "model_confidence"
+        case modelTrackingState    = "model_tracking_state"
+        case existingFeedbackCount = "existing_feedback_count"
+    }
+}
+
+struct BallFeedbackQueueResponse: Decodable {
+    let videoId:       String
+    let queueItems:    [BallFeedbackQueueItem]
+    let total:         Int
+    let maxPerSession: Int
+
+    enum CodingKeys: String, CodingKey {
+        case videoId       = "video_id"
+        case queueItems    = "queue_items"
+        case total
+        case maxPerSession = "max_per_session"
+    }
+}
+
+struct BallFeedbackRequest: Encodable {
+    let frameMs:           Int
+    let decision:          String    // "confirm" | "no_ball" | "corrected"
+    let correctedX:        Double?   // required when decision = "corrected"
+    let correctedY:        Double?
+    let correctionMethod:  String?   // "tap" (D3: drag deferred)
+    // Model context snapshot — populated from the queue item
+    let modelPredictedX:   Double?
+    let modelPredictedY:   Double?
+    let modelConfidence:   Double?
+    let modelTrackingState: String?
+
+    enum CodingKeys: String, CodingKey {
+        case frameMs            = "frame_ms"
+        case decision
+        case correctedX         = "corrected_x"
+        case correctedY         = "corrected_y"
+        case correctionMethod   = "correction_method"
+        case modelPredictedX    = "model_predicted_x"
+        case modelPredictedY    = "model_predicted_y"
+        case modelConfidence    = "model_confidence"
+        case modelTrackingState = "model_tracking_state"
+    }
+}
+
+struct BallFeedbackOut: Decodable {
+    let id:            UUID
+    let videoId:       UUID
+    let frameMs:       Int
+    let decision:      String
+    let approvalState: String
+    let createdAt:     Date
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case videoId       = "video_id"
+        case frameMs       = "frame_ms"
+        case decision
+        case approvalState = "approval_state"
+        case createdAt     = "created_at"
+    }
+}
+
+// MARK: — BallFeedbackAPIError
+
+enum BallFeedbackAPIError: Error, Equatable {
+    case duplicate    // 409 — user already submitted for this frame
+    case unavailable  // 503 — BALL_FEEDBACK_ENABLED=false
+    case network      // transport or unexpected failure
+}

--- a/ios/LFAEducationCenter/Juggling/Annotation/BallFeedbackViewModel.swift
+++ b/ios/LFAEducationCenter/Juggling/Annotation/BallFeedbackViewModel.swift
@@ -1,0 +1,159 @@
+import Foundation
+import SwiftUI
+
+// MARK: — BallFeedbackSessionState
+
+enum BallFeedbackSessionState: Equatable {
+    case idle                            // feedback mode not active
+    case loading                         // GET /ball-feedback/queue in flight
+    case ready([BallFeedbackQueueItem])  // queue loaded, panel visible
+    case empty                           // queue returned 0 items (or exhausted)
+    case sessionComplete                 // submittedCount >= maxPerSession
+    case unavailable                     // 503 — BALL_FEEDBACK_ENABLED=false
+    case error(String)                   // unexpected failure
+
+    static func == (lhs: BallFeedbackSessionState, rhs: BallFeedbackSessionState) -> Bool {
+        switch (lhs, rhs) {
+        case (.idle, .idle), (.loading, .loading), (.empty, .empty),
+             (.sessionComplete, .sessionComplete), (.unavailable, .unavailable): return true
+        case (.ready(let a), .ready(let b)): return a == b
+        case (.error(let a), .error(let b)): return a == b
+        default: return false
+        }
+    }
+}
+
+// MARK: — BallFeedbackViewModel
+
+@MainActor
+final class BallFeedbackViewModel: ObservableObject {
+
+    @Published var sessionState: BallFeedbackSessionState = .idle
+    @Published var currentIndex: Int = 0
+    @Published var submittedCount: Int = 0
+    @Published var lastErrorMessage: String? = nil
+
+    private(set) var maxPerSession: Int = 3
+    let videoId: String
+    private let apiClient: JugglingAnnotationAPIClientProtocol
+
+    init(videoId: String, apiClient: JugglingAnnotationAPIClientProtocol) {
+        self.videoId   = videoId
+        self.apiClient = apiClient
+    }
+
+    // MARK: — Computed
+
+    var currentItem: BallFeedbackQueueItem? {
+        guard case .ready(let items) = sessionState,
+              currentIndex < items.count else { return nil }
+        return items[currentIndex]
+    }
+
+    var remainingInQueue: Int {
+        guard case .ready(let items) = sessionState else { return 0 }
+        return max(0, items.count - currentIndex)
+    }
+
+    var isAvailable: Bool {
+        if case .unavailable = sessionState { return false }
+        return true
+    }
+
+    // MARK: — Load queue
+
+    func loadQueue() async {
+        sessionState  = .loading
+        submittedCount = 0
+        currentIndex  = 0
+        lastErrorMessage = nil
+
+        guard let response = await apiClient.fetchFeedbackQueue(videoId: videoId, limit: 5) else {
+            sessionState = .unavailable
+            return
+        }
+        maxPerSession = response.maxPerSession
+        if response.queueItems.isEmpty {
+            sessionState = .empty
+        } else {
+            sessionState = .ready(response.queueItems)
+        }
+    }
+
+    // MARK: — Skip (client-only, no API call)
+
+    func skip() {
+        guard case .ready(let items) = sessionState else { return }
+        advanceQueue(items: items)
+    }
+
+    // MARK: — Submit feedback (optimistic update + rollback on failure)
+
+    func submitFeedback(
+        decision: String,
+        correctedX: Double? = nil,
+        correctedY: Double? = nil,
+        correctionMethod: String? = nil
+    ) async {
+        guard case .ready(let items) = sessionState,
+              currentIndex < items.count else { return }
+
+        if decision == "corrected" {
+            guard correctedX != nil, correctedY != nil else {
+                assertionFailure("BallFeedbackViewModel: corrected requires correctedX/Y")
+                return
+            }
+        }
+
+        let item            = items[currentIndex]
+        let priorState      = sessionState
+        let priorIndex      = currentIndex
+        let priorSubmitted  = submittedCount
+
+        // Optimistic: advance UI immediately
+        submittedCount += 1
+        lastErrorMessage = nil
+        if submittedCount >= maxPerSession {
+            sessionState = .sessionComplete
+        } else {
+            advanceQueue(items: items)
+        }
+
+        let req = BallFeedbackRequest(
+            frameMs:            item.frameMs,
+            decision:           decision,
+            correctedX:         correctedX,
+            correctedY:         correctedY,
+            correctionMethod:   correctionMethod,
+            modelPredictedX:    item.modelPredictedX,
+            modelPredictedY:    item.modelPredictedY,
+            modelConfidence:    item.modelConfidence,
+            modelTrackingState: item.modelTrackingState
+        )
+
+        do {
+            _ = try await apiClient.submitBallFeedback(videoId: videoId, request: req)
+        } catch BallFeedbackAPIError.duplicate {
+            // 409 — frame already submitted; optimistic state is correct
+        } catch {
+            // Rollback to pre-submit state
+            sessionState   = priorState
+            currentIndex   = priorIndex
+            submittedCount = priorSubmitted
+            lastErrorMessage = "Hiba történt, próbáld újra."
+        }
+    }
+
+    func clearError() { lastErrorMessage = nil }
+
+    // MARK: — Private
+
+    private func advanceQueue(items: [BallFeedbackQueueItem]) {
+        let next = currentIndex + 1
+        if next >= items.count {
+            sessionState = .empty
+        } else {
+            currentIndex = next
+        }
+    }
+}

--- a/ios/LFAEducationCenter/Juggling/Annotation/BallFeedbackViewModel.swift
+++ b/ios/LFAEducationCenter/Juggling/Annotation/BallFeedbackViewModel.swift
@@ -99,10 +99,7 @@ final class BallFeedbackViewModel: ObservableObject {
               currentIndex < items.count else { return }
 
         if decision == "corrected" {
-            guard correctedX != nil, correctedY != nil else {
-                assertionFailure("BallFeedbackViewModel: corrected requires correctedX/Y")
-                return
-            }
+            guard correctedX != nil, correctedY != nil else { return }
         }
 
         let item            = items[currentIndex]

--- a/ios/LFAEducationCenter/Juggling/Annotation/JugglingAnnotationAPIClient.swift
+++ b/ios/LFAEducationCenter/Juggling/Annotation/JugglingAnnotationAPIClient.swift
@@ -35,6 +35,9 @@ protocol JugglingAnnotationAPIClientProtocol: AnyObject {
     // AN-3B2C-1: ball detection
     func fetchBallDetection(videoId: String, eventId: UUID) async throws -> BallDetectionOut
     func postBallDetection(videoId: String, eventId: UUID, request: BallDetectionManualRequest) async throws -> BallDetectionOut
+    // AN-3B2B1: ball feedback
+    func fetchFeedbackQueue(videoId: String, limit: Int) async -> BallFeedbackQueueResponse?
+    func submitBallFeedback(videoId: String, request: BallFeedbackRequest) async throws -> BallFeedbackOut
 }
 
 @MainActor
@@ -395,6 +398,50 @@ final class JugglingAnnotationAPIClient: JugglingAnnotationAPIClientProtocol {
         } catch {
             print("[BallTrajectory] postManualBallSeed failed: \(error)")
             return false
+        }
+    }
+
+    // MARK: — AN-3B2B1: Ball Feedback
+    //
+    // fetchFeedbackQueue: GET /ball-feedback/queue?limit=N
+    //   200 → BallFeedbackQueueResponse (may have 0 queue_items)
+    //   503 → nil (BALL_FEEDBACK_ENABLED=false)
+    //   network → nil
+    //
+    // submitBallFeedback: POST /ball-feedback
+    //   201 → BallFeedbackOut
+    //   409 → throws BallFeedbackAPIError.duplicate
+    //   503 → throws BallFeedbackAPIError.unavailable
+    //   network/other → throws BallFeedbackAPIError.network
+
+    func fetchFeedbackQueue(videoId: String, limit: Int) async -> BallFeedbackQueueResponse? {
+        let path = "/api/v1/users/me/juggling/videos/\(videoId)/ball-feedback/queue?limit=\(limit)"
+        do {
+            return try await authManager.authenticatedGet(path: path)
+        } catch APIError.httpError(503, _) {
+            return nil
+        } catch {
+            print("[BallFeedback] fetchFeedbackQueue failed: \(error)")
+            return nil
+        }
+    }
+
+    func submitBallFeedback(videoId: String, request: BallFeedbackRequest) async throws -> BallFeedbackOut {
+        let path = "/api/v1/users/me/juggling/videos/\(videoId)/ball-feedback"
+        do {
+            let (data, statusCode) = try await authManager.authenticatedPostRaw(path: path, body: request)
+            guard statusCode == 201 || statusCode == 200 else {
+                throw BallFeedbackAPIError.network
+            }
+            return try isoDecoder.decode(BallFeedbackOut.self, from: data)
+        } catch APIError.httpError(409, _) {
+            throw BallFeedbackAPIError.duplicate
+        } catch APIError.httpError(503, _) {
+            throw BallFeedbackAPIError.unavailable
+        } catch let fbErr as BallFeedbackAPIError {
+            throw fbErr
+        } catch {
+            throw BallFeedbackAPIError.network
         }
     }
 

--- a/ios/LFAEducationCenter/Juggling/Annotation/Screen/BallFeedbackOverlayView.swift
+++ b/ios/LFAEducationCenter/Juggling/Annotation/Screen/BallFeedbackOverlayView.swift
@@ -1,0 +1,98 @@
+import SwiftUI
+
+// MARK: — BallFeedbackOverlayView (AN-3B2B1)
+//
+// Shown in the video ZStack when feedback mode is active.
+//
+// Normal state (isCorrecting = false):
+//   Draws a white-bordered reference circle at the model's predicted ball
+//   position, with a "?" label. Helps the user understand what to validate.
+//   No position means no circle is drawn (e.g., lost frames).
+//
+// Correcting state (isCorrecting = true):
+//   Full-area semi-transparent overlay + crosshair + instruction text.
+//   The parent view attaches the DragGesture and calls onTap(normalizedPoint:).
+//   allowsHitTesting(false) here — tap is handled by the parent ZStack layer.
+
+struct BallFeedbackOverlayView: View {
+
+    let item: BallFeedbackQueueItem?
+    let isCorrecting: Bool
+
+    var body: some View {
+        GeometryReader { geo in
+            ZStack {
+                if isCorrecting {
+                    correctingLayer(in: geo)
+                } else if let item, let px = item.modelPredictedX, let py = item.modelPredictedY {
+                    referenceCircle(x: CGFloat(px) * geo.size.width,
+                                    y: CGFloat(py) * geo.size.height)
+                }
+            }
+        }
+        .allowsHitTesting(false)
+    }
+
+    // MARK: — Reference circle (normal state)
+
+    @ViewBuilder
+    private func referenceCircle(x: CGFloat, y: CGFloat) -> some View {
+        ZStack {
+            Circle()
+                .strokeBorder(Color.white, lineWidth: 2.5)
+                .background(Circle().fill(Color.white.opacity(0.15)))
+                .frame(width: 32, height: 32)
+                .position(x: x, y: y)
+
+            Text("?")
+                .font(.system(size: 10, weight: .bold))
+                .foregroundColor(.white)
+                .padding(.horizontal, 3)
+                .padding(.vertical, 1)
+                .background(Color.black.opacity(0.55))
+                .cornerRadius(3)
+                .position(x: x + 22, y: y - 18)
+        }
+    }
+
+    // MARK: — Correcting overlay
+
+    @ViewBuilder
+    private func correctingLayer(in geo: GeometryProxy) -> some View {
+        ZStack {
+            Color.black.opacity(0.30)
+
+            // Crosshair at center
+            let cx = geo.size.width / 2
+            let cy = geo.size.height / 2
+            Path { p in
+                p.move(to: CGPoint(x: cx - 20, y: cy))
+                p.addLine(to: CGPoint(x: cx + 20, y: cy))
+                p.move(to: CGPoint(x: cx, y: cy - 20))
+                p.addLine(to: CGPoint(x: cx, y: cy + 20))
+            }
+            .stroke(Color.white.opacity(0.6), lineWidth: 1)
+
+            VStack {
+                Text("Koppints a labda valódi pozíciójára")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                    .background(Color.black.opacity(0.60))
+                    .cornerRadius(8)
+                    .padding(.top, 12)
+                Spacer()
+            }
+        }
+    }
+}
+
+// MARK: — BallFeedbackOverlayColorHelper (testable)
+
+enum BallFeedbackOverlayColorHelper {
+    static func confidenceLabel(for item: BallFeedbackQueueItem) -> String {
+        guard let c = item.modelConfidence else { return "lost" }
+        return "\(Int(c * 100))%"
+    }
+}

--- a/ios/LFAEducationCenter/Juggling/Annotation/Screen/BallFeedbackPanel.swift
+++ b/ios/LFAEducationCenter/Juggling/Annotation/Screen/BallFeedbackPanel.swift
@@ -1,0 +1,258 @@
+import SwiftUI
+
+// MARK: — BallFeedbackPanel (AN-3B2B1)
+//
+// Compact horizontal action panel placed below the video area and above
+// PlaybackControlBar. Visible only when isFeedbackMode = true.
+//
+// Layout (D1: non-covering, D4: session counter):
+//   ┌─────────────────────────────────────────────────────┐
+//   │ Frame: 4 230 ms  ·  Bizonytalanság: 78%  ·  1 / 3  │  header
+//   │  [✓ Helyes]  [✗ Nincs labda]  [✎ Javítom] [→ Skip] │  actions
+//   │               [error label if any]                  │  error
+//   └─────────────────────────────────────────────────────┘
+//
+// Transitions: none intentional — parent handles open/close animation.
+// The corrected action calls onCorrect(); the parent activates the tap overlay.
+
+struct BallFeedbackPanel: View {
+
+    @ObservedObject var vm: BallFeedbackViewModel
+
+    let onConfirm: () -> Void
+    let onNoBall:  () -> Void
+    let onCorrect: () -> Void
+    let onSkip:    () -> Void
+    let onClose:   () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Divider()
+            switch vm.sessionState {
+            case .loading:
+                loadingRow
+            case .ready:
+                if let item = vm.currentItem {
+                    activePanel(item: item)
+                }
+            case .empty:
+                emptyRow
+            case .sessionComplete:
+                sessionCompleteRow
+            case .unavailable:
+                unavailableRow
+            case .error(let msg):
+                errorRow(msg)
+            case .idle:
+                EmptyView()
+            }
+        }
+        .background(Color(.secondarySystemBackground))
+    }
+
+    // MARK: — Active panel
+
+    @ViewBuilder
+    private func activePanel(item: BallFeedbackQueueItem) -> some View {
+        VStack(spacing: 6) {
+            // Header
+            HStack(spacing: 8) {
+                Text("Frame: \(item.frameMs) ms")
+                    .font(.system(size: 12, weight: .medium).monospacedDigit())
+                    .foregroundColor(.secondary)
+
+                if let conf = item.modelConfidence {
+                    Text("·")
+                        .foregroundColor(.secondary)
+                    Text("Bizonytalanság: \(Int((1.0 - conf) * 100))%")
+                        .font(.system(size: 12))
+                        .foregroundColor(uncertaintyColor(conf: conf))
+                } else {
+                    Text("·  Elveszett frame")
+                        .font(.system(size: 12))
+                        .foregroundColor(.red)
+                }
+
+                Spacer()
+
+                Text("\(vm.submittedCount) / \(vm.maxPerSession)")
+                    .font(.system(size: 12, weight: .semibold).monospacedDigit())
+                    .foregroundColor(.secondary)
+
+                Button(action: onClose) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 13))
+                        .foregroundColor(.secondary)
+                }
+                .accessibilityLabel("Visszajelzés bezárása")
+            }
+            .padding(.horizontal, 12)
+            .padding(.top, 6)
+
+            // Action buttons
+            HStack(spacing: 8) {
+                actionButton(
+                    title: "Helyes",
+                    icon: "checkmark.circle.fill",
+                    color: .green,
+                    action: onConfirm
+                )
+                actionButton(
+                    title: "Nincs labda",
+                    icon: "xmark.circle.fill",
+                    color: .red,
+                    action: onNoBall
+                )
+                actionButton(
+                    title: "Javítom",
+                    icon: "pencil.circle.fill",
+                    color: .orange,
+                    action: onCorrect
+                )
+                actionButton(
+                    title: "Kihagyom",
+                    icon: "arrow.right.circle",
+                    color: .secondary,
+                    action: onSkip
+                )
+            }
+            .padding(.horizontal, 12)
+            .padding(.bottom, 4)
+
+            // Error row
+            if let err = vm.lastErrorMessage {
+                Text(err)
+                    .font(.system(size: 11))
+                    .foregroundColor(.red)
+                    .padding(.bottom, 4)
+                    .onTapGesture { vm.clearError() }
+            }
+        }
+    }
+
+    // MARK: — State rows
+
+    private var loadingRow: some View {
+        HStack(spacing: 8) {
+            ProgressView().scaleEffect(0.75)
+            Text("Visszajelzési lista betöltése…")
+                .font(.system(size: 13))
+                .foregroundColor(.secondary)
+            Spacer()
+            closeButton
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+    }
+
+    private var emptyRow: some View {
+        HStack {
+            Image(systemName: "checkmark.seal.fill")
+                .foregroundColor(.green)
+            Text("Nincs több ellenőrizendő frame.")
+                .font(.system(size: 13))
+                .foregroundColor(.secondary)
+            Spacer()
+            closeButton
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+    }
+
+    private var sessionCompleteRow: some View {
+        HStack {
+            Image(systemName: "hand.thumbsup.fill")
+                .foregroundColor(.green)
+            Text("Köszönjük! \(vm.maxPerSession) visszajelzés elküldve.")
+                .font(.system(size: 13))
+                .foregroundColor(.secondary)
+            Spacer()
+            closeButton
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+    }
+
+    private var unavailableRow: some View {
+        HStack {
+            Image(systemName: "exclamationmark.circle")
+                .foregroundColor(.orange)
+            Text("A visszajelzés jelenleg nem érhető el.")
+                .font(.system(size: 13))
+                .foregroundColor(.secondary)
+            Spacer()
+            closeButton
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+    }
+
+    private func errorRow(_ msg: String) -> some View {
+        HStack {
+            Image(systemName: "exclamationmark.triangle")
+                .foregroundColor(.red)
+            Text(msg)
+                .font(.system(size: 13))
+                .foregroundColor(.red)
+            Spacer()
+            closeButton
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+    }
+
+    private var closeButton: some View {
+        Button(action: onClose) {
+            Image(systemName: "xmark")
+                .font(.system(size: 13))
+                .foregroundColor(.secondary)
+        }
+        .accessibilityLabel("Visszajelzés bezárása")
+    }
+
+    // MARK: — Sub-views
+
+    @ViewBuilder
+    private func actionButton(
+        title: String,
+        icon: String,
+        color: Color,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            VStack(spacing: 3) {
+                Image(systemName: icon)
+                    .font(.system(size: 20))
+                    .foregroundColor(color)
+                Text(title)
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundColor(color)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 6)
+            .background(color.opacity(0.08))
+            .cornerRadius(8)
+        }
+        .accessibilityLabel(title)
+    }
+
+    private func uncertaintyColor(conf: Double) -> Color {
+        let uncertainty = 1.0 - conf
+        if uncertainty >= 0.60 { return .red }
+        if uncertainty >= 0.30 { return .orange }
+        return .secondary
+    }
+}
+
+// MARK: — BallFeedbackPanelColorHelper (testable)
+
+enum BallFeedbackPanelColorHelper {
+    static func decisionColor(_ decision: String) -> Color {
+        switch decision {
+        case "confirm":   return .green
+        case "no_ball":   return .red
+        case "corrected": return .orange
+        default:          return .secondary
+        }
+    }
+}

--- a/ios/LFAEducationCenter/Juggling/Annotation/Screen/JugglingAnnotationScreen.swift
+++ b/ios/LFAEducationCenter/Juggling/Annotation/Screen/JugglingAnnotationScreen.swift
@@ -64,6 +64,10 @@ struct JugglingAnnotationScreen: View {
     @State private var showBallOverlay        = false
     @State private var isBallSelecting        = false
     @State private var ballSelectionDragPoint: CGPoint? = nil
+    // AN-3B2B1: ball feedback mode (mutually exclusive with isBallSelecting)
+    @StateObject private var feedbackVM: BallFeedbackViewModel
+    @State private var isFeedbackMode         = false
+    @State private var isFeedbackCorrecting   = false
 
     // Phase 2A patch: retroactive pose generation for pre-existing events.
     // isGeneratingPoses gates the banner spinner; poseGenProgress drives the
@@ -116,9 +120,14 @@ struct JugglingAnnotationScreen: View {
             authManager: authManager
         ))
         _denseSkeletonVM = StateObject(wrappedValue: DenseSkeletonViewModel(videoId: video.videoId))
+        let sharedAPIClient = JugglingAnnotationAPIClient(authManager: authManager)
         _ballTrajectoryVM = StateObject(wrappedValue: BallTrajectoryViewModel(
             videoId: video.videoId,
-            apiClient: JugglingAnnotationAPIClient(authManager: authManager)
+            apiClient: sharedAPIClient
+        ))
+        _feedbackVM = StateObject(wrappedValue: BallFeedbackViewModel(
+            videoId: video.videoId,
+            apiClient: sharedAPIClient
         ))
         #if DEBUG
         AnnotationDiagnosticsLog.log("Screen init — userId=\(userId) videoId=\(video.videoId)")
@@ -131,6 +140,17 @@ struct JugglingAnnotationScreen: View {
                 VStack(spacing: 0) {
                     videoArea(in: geo)
                         .accessibilityLabel("Video")
+
+                    if isFeedbackMode {
+                        BallFeedbackPanel(
+                            vm:        feedbackVM,
+                            onConfirm: { Task { await feedbackVM.submitFeedback(decision: "confirm") } },
+                            onNoBall:  { Task { await feedbackVM.submitFeedback(decision: "no_ball") } },
+                            onCorrect: { isFeedbackCorrecting = true },
+                            onSkip:    { feedbackVM.skip() },
+                            onClose:   { isFeedbackMode = false; isFeedbackCorrecting = false }
+                        )
+                    }
 
                     PlaybackControlBar(controller: playback, isEnabled: loaderReady)
                         .padding(.horizontal, 12)
@@ -309,6 +329,21 @@ struct JugglingAnnotationScreen: View {
             UserDefaults.standard.set(degrees, forKey: JugglingAnnotationScreen.rotationKey(video.videoId))
             Task { await vm.patchRotation(degrees: degrees) }
         }
+        // AN-3B2B1: mutual exclusion — isBallSelecting and isFeedbackMode cannot coexist
+        .onChange(of: isBallSelecting) { selecting in
+            if selecting {
+                isFeedbackMode = false
+                isFeedbackCorrecting = false
+            }
+        }
+        .onChange(of: isFeedbackMode) { feedbackOn in
+            if feedbackOn {
+                isBallSelecting = false
+                ballSelectionDragPoint = nil
+            } else {
+                isFeedbackCorrecting = false
+            }
+        }
     }
 
     // MARK: — Video area
@@ -445,7 +480,36 @@ struct JugglingAnnotationScreen: View {
                     .allowsHitTesting(false)
                 }
 
-                // Overlay toggle controls — skeleton + ball
+                // AN-3B2B1: feedback correction tap overlay (above all other overlays)
+                if isFeedbackMode && isFeedbackCorrecting {
+                    BallFeedbackOverlayView(item: feedbackVM.currentItem, isCorrecting: true)
+                        .frame(width: renderSize.width, height: renderSize.height)
+                        .contentShape(Rectangle())
+                        .gesture(
+                            DragGesture(minimumDistance: 0)
+                                .onEnded { v in
+                                    let np = CGPoint(
+                                        x: max(0, min(1, v.location.x / renderSize.width)),
+                                        y: max(0, min(1, v.location.y / renderSize.height))
+                                    )
+                                    isFeedbackCorrecting = false
+                                    Task {
+                                        await feedbackVM.submitFeedback(
+                                            decision: "corrected",
+                                            correctedX: np.x,
+                                            correctedY: np.y,
+                                            correctionMethod: "tap"
+                                        )
+                                    }
+                                }
+                        )
+                } else if isFeedbackMode, let item = feedbackVM.currentItem {
+                    // Reference circle when not correcting
+                    BallFeedbackOverlayView(item: item, isCorrecting: false)
+                        .frame(width: renderSize.width, height: renderSize.height)
+                }
+
+                // Overlay toggle controls — skeleton + ball + feedback
                 VStack {
                     HStack {
                         Spacer()
@@ -464,6 +528,23 @@ struct JugglingAnnotationScreen: View {
                                 isOn:        showSkeletonOverlay,
                                 accessLabel: showSkeletonOverlay ? "Csontváz elrejtése" : "Csontváz megjelenítése"
                             ) { showSkeletonOverlay.toggle() }
+
+                            // AN-3B2B1: feedback toggle (D2 — mutually exclusive with isBallSelecting)
+                            overlayToggleButton(
+                                icon:        isFeedbackMode ? "hand.thumbsup.circle.fill" : "hand.thumbsup.circle",
+                                isOn:        isFeedbackMode,
+                                accessLabel: isFeedbackMode ? "Visszajelzés mód kikapcsolása" : "Visszajelzés mód bekapcsolása"
+                            ) {
+                                if !isFeedbackMode {
+                                    isBallSelecting = false
+                                    ballSelectionDragPoint = nil
+                                    isFeedbackCorrecting = false
+                                    Task { await feedbackVM.loadQueue() }
+                                } else {
+                                    isFeedbackCorrecting = false
+                                }
+                                isFeedbackMode.toggle()
+                            }
                         }
                         .padding(8)
                     }

--- a/ios/LFAEducationCenterTests/Juggling/AnnotationSyncEngineTests.swift
+++ b/ios/LFAEducationCenterTests/Juggling/AnnotationSyncEngineTests.swift
@@ -68,6 +68,12 @@ final class MockAnnotationAPIClient: JugglingAnnotationAPIClientProtocol {
     func postBallDetection(videoId: String, eventId: UUID, request: BallDetectionManualRequest) async throws -> BallDetectionOut {
         try postBallDetectionResult.get()
     }
+
+    // AN-3B2B1 stubs
+    func fetchFeedbackQueue(videoId: String, limit: Int) async -> BallFeedbackQueueResponse? { nil }
+    func submitBallFeedback(videoId: String, request: BallFeedbackRequest) async throws -> BallFeedbackOut {
+        throw BallFeedbackAPIError.unavailable
+    }
 }
 
 // MARK: — AN2-T17..T25: AnnotationSyncEngine state transitions

--- a/ios/LFAEducationCenterTests/Juggling/BallFeedbackAnnotationIndependenceTests.swift
+++ b/ios/LFAEducationCenterTests/Juggling/BallFeedbackAnnotationIndependenceTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+@testable import LFAEducationCenter
+
+// MARK: — BallFeedbackAnnotationIndependenceTests (AN-3B2B1, BFI-01..03)
+//
+// Verifies that BallFeedbackViewModel is fully decoupled from
+// JugglingAnnotationViewModel and BallTrajectoryViewModel.
+
+@MainActor
+final class BallFeedbackAnnotationIndependenceTests: XCTestCase {
+
+    private func makeItem(frameMs: Int = 1000) -> BallFeedbackQueueItem {
+        BallFeedbackQueueItem(
+            frameMs: frameMs, priorityScore: 0.5,
+            modelPredictedX: 0.5, modelPredictedY: 0.5,
+            modelConfidence: 0.40, modelTrackingState: "detected",
+            existingFeedbackCount: 0
+        )
+    }
+
+    // MARK: — BFI-01: submitFeedback does not touch JugglingAnnotationViewModel
+
+    func test_BFI_01_submitFeedback_doesNotTouchAnnotationVM() async {
+        let mock = MockBallFeedbackAPIClient(
+            queueResponse: BallFeedbackQueueResponse(
+                videoId: "v1", queueItems: [makeItem()], total: 1, maxPerSession: 3
+            ),
+            submitResult: .success(makeFeedbackOut())
+        )
+        let feedbackVM = BallFeedbackViewModel(videoId: "v1", apiClient: mock)
+        await feedbackVM.loadQueue()
+
+        // We verify by ensuring no reference exists to JugglingAnnotationViewModel.
+        // Structural: feedbackVM holds only videoId + apiClient.
+        // Behavioral: submit completes without error and changes only feedbackVM state.
+        await feedbackVM.submitFeedback(decision: "confirm")
+        XCTAssertEqual(feedbackVM.submittedCount, 1)
+    }
+
+    // MARK: — BFI-02: loadQueue does not affect BallTrajectoryViewModel
+
+    func test_BFI_02_loadQueue_doesNotAffectTrajectoryVM() async {
+        let mock = MockBallFeedbackAPIClient(
+            queueResponse: BallFeedbackQueueResponse(
+                videoId: "v1", queueItems: [makeItem()], total: 1, maxPerSession: 3
+            ),
+            submitResult: .success(makeFeedbackOut())
+        )
+        let feedbackVM    = BallFeedbackViewModel(videoId: "v1", apiClient: mock)
+
+        // BallTrajectoryViewModel has its own mock/apiClient — not shared.
+        // We simply confirm feedbackVM.loadQueue does not throw or crash
+        // (structural isolation: feedbackVM never holds a BallTrajectoryViewModel ref).
+        await feedbackVM.loadQueue()
+        if case .ready = feedbackVM.sessionState {
+            // pass — trajectory is unaffected
+        } else {
+            XCTFail("Expected .ready after loadQueue")
+        }
+    }
+
+    // MARK: — BFI-03: skip() has no effect when sessionState is not .ready
+
+    func test_BFI_03_skip_noOpWhenNotReady() async {
+        let mock = MockBallFeedbackAPIClient(queueResponse: nil, submitResult: .success(makeFeedbackOut()))
+        let vm = BallFeedbackViewModel(videoId: "v1", apiClient: mock)
+        // State: .idle
+        vm.skip()
+        XCTAssertEqual(vm.sessionState, .idle)
+        XCTAssertEqual(vm.currentIndex, 0)
+    }
+
+    // MARK: — Helpers
+
+    private func makeFeedbackOut() -> BallFeedbackOut {
+        BallFeedbackOut(
+            id: UUID(), videoId: UUID(), frameMs: 1000,
+            decision: "confirm", approvalState: "pending", createdAt: Date()
+        )
+    }
+}

--- a/ios/LFAEducationCenterTests/Juggling/BallFeedbackPanelTests.swift
+++ b/ios/LFAEducationCenterTests/Juggling/BallFeedbackPanelTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+import SwiftUI
+@testable import LFAEducationCenter
+
+// MARK: — BallFeedbackPanelTests (AN-3B2B1, BFP-01..04)
+
+final class BallFeedbackPanelTests: XCTestCase {
+
+    // MARK: — BFP-01: confirm decision → green
+
+    func test_BFP_01_confirmIsGreen() {
+        XCTAssertEqual(BallFeedbackPanelColorHelper.decisionColor("confirm"), Color.green)
+    }
+
+    // MARK: — BFP-02: no_ball decision → red
+
+    func test_BFP_02_noBallIsRed() {
+        XCTAssertEqual(BallFeedbackPanelColorHelper.decisionColor("no_ball"), Color.red)
+    }
+
+    // MARK: — BFP-03: corrected decision → orange
+
+    func test_BFP_03_correctedIsOrange() {
+        XCTAssertEqual(BallFeedbackPanelColorHelper.decisionColor("corrected"), Color.orange)
+    }
+
+    // MARK: — BFP-04: unknown decision → secondary
+
+    func test_BFP_04_unknownIsSecondary() {
+        XCTAssertEqual(BallFeedbackPanelColorHelper.decisionColor("unknown_xyz"), Color.secondary)
+    }
+}

--- a/ios/LFAEducationCenterTests/Juggling/BallFeedbackVMTests.swift
+++ b/ios/LFAEducationCenterTests/Juggling/BallFeedbackVMTests.swift
@@ -1,0 +1,278 @@
+import XCTest
+@testable import LFAEducationCenter
+
+// MARK: — BallFeedbackVMTests (AN-3B2B1, BFB-01..12)
+//
+// All tests use MockBallFeedbackAPIClient — no real network calls.
+
+@MainActor
+final class BallFeedbackVMTests: XCTestCase {
+
+    // MARK: — Fixtures
+
+    private func makeItem(frameMs: Int = 1000, confidence: Double? = 0.40) -> BallFeedbackQueueItem {
+        BallFeedbackQueueItem(
+            frameMs: frameMs,
+            priorityScore: 0.36,
+            modelPredictedX: 0.5,
+            modelPredictedY: 0.5,
+            modelConfidence: confidence,
+            modelTrackingState: confidence == nil ? "lost" : "detected",
+            existingFeedbackCount: 0
+        )
+    }
+
+    private func makeQueue(items: [BallFeedbackQueueItem] = [], maxPerSession: Int = 3) -> BallFeedbackQueueResponse {
+        BallFeedbackQueueResponse(
+            videoId: "test-video",
+            queueItems: items,
+            total: items.count,
+            maxPerSession: maxPerSession
+        )
+    }
+
+    private func makeVM(
+        queueResponse: BallFeedbackQueueResponse? = nil,
+        submitResult: Result<BallFeedbackOut, BallFeedbackAPIError> = .success(makeFeedbackOut())
+    ) -> BallFeedbackViewModel {
+        let client = MockBallFeedbackAPIClient(
+            queueResponse: queueResponse,
+            submitResult: submitResult
+        )
+        return BallFeedbackViewModel(videoId: "test-video", apiClient: client)
+    }
+
+    private static func makeFeedbackOut() -> BallFeedbackOut {
+        BallFeedbackOut(
+            id: UUID(),
+            videoId: UUID(),
+            frameMs: 1000,
+            decision: "confirm",
+            approvalState: "pending",
+            createdAt: Date()
+        )
+    }
+
+    // MARK: — BFB-01: loadQueue → ready with items
+
+    func test_BFB_01_loadQueue_ready() async {
+        let items = [makeItem(frameMs: 1000), makeItem(frameMs: 2000), makeItem(frameMs: 3000)]
+        let vm = makeVM(queueResponse: makeQueue(items: items))
+        await vm.loadQueue()
+        if case .ready(let loaded) = vm.sessionState {
+            XCTAssertEqual(loaded.count, 3)
+        } else {
+            XCTFail("Expected .ready, got \(vm.sessionState)")
+        }
+        XCTAssertEqual(vm.currentIndex, 0)
+        XCTAssertEqual(vm.submittedCount, 0)
+    }
+
+    // MARK: — BFB-02: loadQueue → empty when queue_items = []
+
+    func test_BFB_02_loadQueue_empty() async {
+        let vm = makeVM(queueResponse: makeQueue(items: []))
+        await vm.loadQueue()
+        XCTAssertEqual(vm.sessionState, .empty)
+    }
+
+    // MARK: — BFB-03: loadQueue → unavailable when 503 (nil response)
+
+    func test_BFB_03_loadQueue_unavailable() async {
+        let vm = makeVM(queueResponse: nil)
+        await vm.loadQueue()
+        XCTAssertEqual(vm.sessionState, .unavailable)
+        XCTAssertFalse(vm.isAvailable)
+    }
+
+    // MARK: — BFB-04: submitFeedback → optimistic advance (submittedCount, index)
+
+    func test_BFB_04_submitFeedback_optimisticAdvance() async {
+        let items = [makeItem(frameMs: 1000), makeItem(frameMs: 2000)]
+        let vm = makeVM(queueResponse: makeQueue(items: items))
+        await vm.loadQueue()
+        await vm.submitFeedback(decision: "confirm")
+        XCTAssertEqual(vm.submittedCount, 1)
+        XCTAssertEqual(vm.currentIndex, 1)
+        XCTAssertEqual(vm.currentItem?.frameMs, 2000)
+    }
+
+    // MARK: — BFB-05: 409 duplicate → silent ignore, optimistic state kept
+
+    func test_BFB_05_duplicate_409_silentIgnore() async {
+        let items = [makeItem(frameMs: 1000), makeItem(frameMs: 2000)]
+        let vm = makeVM(
+            queueResponse: makeQueue(items: items),
+            submitResult: .failure(.duplicate)
+        )
+        await vm.loadQueue()
+        await vm.submitFeedback(decision: "confirm")
+        // Optimistic state must stay (index advanced, submitted incremented)
+        XCTAssertEqual(vm.submittedCount, 1)
+        XCTAssertEqual(vm.currentIndex, 1)
+        XCTAssertNil(vm.lastErrorMessage)
+    }
+
+    // MARK: — BFB-06: network/5xx → rollback to prior state
+
+    func test_BFB_06_networkError_rollback() async {
+        let items = [makeItem(frameMs: 1000), makeItem(frameMs: 2000)]
+        let vm = makeVM(
+            queueResponse: makeQueue(items: items),
+            submitResult: .failure(.network)
+        )
+        await vm.loadQueue()
+        let stateBefore = vm.sessionState
+        await vm.submitFeedback(decision: "confirm")
+        // Rolled back
+        XCTAssertEqual(vm.sessionState, stateBefore)
+        XCTAssertEqual(vm.currentIndex, 0)
+        XCTAssertEqual(vm.submittedCount, 0)
+        XCTAssertNotNil(vm.lastErrorMessage)
+    }
+
+    // MARK: — BFB-07: skip() → index advances, submittedCount unchanged
+
+    func test_BFB_07_skip_advancesIndexOnly() async {
+        let items = [makeItem(frameMs: 1000), makeItem(frameMs: 2000)]
+        let vm = makeVM(queueResponse: makeQueue(items: items))
+        await vm.loadQueue()
+        vm.skip()
+        XCTAssertEqual(vm.currentIndex, 1)
+        XCTAssertEqual(vm.submittedCount, 0)
+    }
+
+    // MARK: — BFB-08: submittedCount >= maxPerSession → sessionComplete
+
+    func test_BFB_08_sessionComplete_afterMaxFeedbacks() async {
+        let items = (0..<5).map { makeItem(frameMs: $0 * 1000) }
+        let vm = makeVM(queueResponse: makeQueue(items: items, maxPerSession: 2))
+        await vm.loadQueue()
+        await vm.submitFeedback(decision: "confirm")
+        await vm.submitFeedback(decision: "confirm")
+        XCTAssertEqual(vm.sessionState, .sessionComplete)
+        XCTAssertEqual(vm.submittedCount, 2)
+    }
+
+    // MARK: — BFB-09: corrected without coords → no submit (assert guarded in prod, tested via state)
+
+    func test_BFB_09_corrected_withoutCoords_doesNotAdvance() async {
+        let items = [makeItem(frameMs: 1000)]
+        let vm = makeVM(queueResponse: makeQueue(items: items))
+        await vm.loadQueue()
+        // assertionFailure is DEBUG-only; in test build it is a no-op via the guard return
+        // We verify that index did NOT advance and submittedCount stayed 0.
+        // (We call with correctedX/Y = nil which triggers the guard return, not the API.)
+        await vm.submitFeedback(decision: "corrected", correctedX: nil, correctedY: nil)
+        XCTAssertEqual(vm.currentIndex, 0)
+        XCTAssertEqual(vm.submittedCount, 0)
+    }
+
+    // MARK: — BFB-10: corrected with coords → request built correctly (via mock capture)
+
+    func test_BFB_10_corrected_withCoords_submits() async {
+        let items = [makeItem(frameMs: 1000)]
+        let mock = MockBallFeedbackAPIClient(
+            queueResponse: makeQueue(items: items),
+            submitResult: .success(BallFeedbackVMTests.makeFeedbackOut())
+        )
+        let vm = BallFeedbackViewModel(videoId: "test-video", apiClient: mock)
+        await vm.loadQueue()
+        await vm.submitFeedback(decision: "corrected", correctedX: 0.3, correctedY: 0.6, correctionMethod: "tap")
+        XCTAssertEqual(vm.submittedCount, 1)
+        XCTAssertEqual(mock.lastSubmittedRequest?.decision, "corrected")
+        XCTAssertEqual(mock.lastSubmittedRequest?.correctedX, 0.3)
+        XCTAssertEqual(mock.lastSubmittedRequest?.correctedY, 0.6)
+        XCTAssertEqual(mock.lastSubmittedRequest?.correctionMethod, "tap")
+    }
+
+    // MARK: — BFB-11: currentItem nil when index beyond items
+
+    func test_BFB_11_currentItem_nilWhenExhausted() async {
+        let items = [makeItem(frameMs: 1000)]
+        let vm = makeVM(queueResponse: makeQueue(items: items))
+        await vm.loadQueue()
+        vm.skip()  // exhausts the 1-item queue → .empty
+        XCTAssertNil(vm.currentItem)
+    }
+
+    // MARK: — BFB-12: model context snapshot in submitted request
+
+    func test_BFB_12_modelContextSnapshotInRequest() async {
+        let item = makeItem(frameMs: 2500)
+        let mock = MockBallFeedbackAPIClient(
+            queueResponse: makeQueue(items: [item]),
+            submitResult: .success(BallFeedbackVMTests.makeFeedbackOut())
+        )
+        let vm = BallFeedbackViewModel(videoId: "test-video", apiClient: mock)
+        await vm.loadQueue()
+        await vm.submitFeedback(decision: "confirm")
+        XCTAssertEqual(mock.lastSubmittedRequest?.frameMs, 2500)
+        XCTAssertEqual(mock.lastSubmittedRequest?.modelPredictedX, item.modelPredictedX)
+        XCTAssertEqual(mock.lastSubmittedRequest?.modelPredictedY, item.modelPredictedY)
+        XCTAssertEqual(mock.lastSubmittedRequest?.modelConfidence, item.modelConfidence)
+        XCTAssertEqual(mock.lastSubmittedRequest?.modelTrackingState, item.modelTrackingState)
+    }
+}
+
+// MARK: — MockBallFeedbackAPIClient
+
+@MainActor
+final class MockBallFeedbackAPIClient: JugglingAnnotationAPIClientProtocol {
+
+    private let _queueResponse: BallFeedbackQueueResponse?
+    private let _submitResult:  Result<BallFeedbackOut, BallFeedbackAPIError>
+    private(set) var lastSubmittedRequest: BallFeedbackRequest?
+
+    init(
+        queueResponse: BallFeedbackQueueResponse?,
+        submitResult: Result<BallFeedbackOut, BallFeedbackAPIError>
+    ) {
+        _queueResponse = queueResponse
+        _submitResult  = submitResult
+    }
+
+    func fetchFeedbackQueue(videoId: String, limit: Int) async -> BallFeedbackQueueResponse? {
+        _queueResponse
+    }
+
+    func submitBallFeedback(videoId: String, request: BallFeedbackRequest) async throws -> BallFeedbackOut {
+        lastSubmittedRequest = request
+        switch _submitResult {
+        case .success(let out): return out
+        case .failure(let err): throw err
+        }
+    }
+
+    // MARK: — Unused protocol stubs
+
+    func listContacts(videoId: String) async throws -> ContactEventListOut {
+        throw AnnotationAPIError.permanent(code: 501, detail: "stub")
+    }
+    func createContact(videoId: String, request: ContactEventCreateRequest) async throws -> CreateContactResult {
+        throw AnnotationAPIError.permanent(code: 501, detail: "stub")
+    }
+    func patchContact(videoId: String, eventId: UUID, request: ContactEventPatchRequest) async throws -> ContactEventOut {
+        throw AnnotationAPIError.permanent(code: 501, detail: "stub")
+    }
+    func deleteContact(videoId: String, eventId: UUID) async throws -> DeleteContactResult { .deleted }
+    func finishAnnotation(videoId: String, confirmZero: Bool) async throws -> FinishAnnotationOut {
+        throw AnnotationAPIError.permanent(code: 501, detail: "stub")
+    }
+    func deleteVideo(videoId: String) async throws {}
+    func uploadInit(sourceType: String, uploadSource: String) async throws -> JugglingUploadInitResponse {
+        throw JugglingUploadError.unauthorized
+    }
+    func uploadVideoFile(videoId: String, fileURL: URL, mimeType: String) async throws -> JugglingUploadFileResponse {
+        throw JugglingUploadError.unauthorized
+    }
+    func completeUpload(videoId: String) async throws -> JugglingCompleteResponse {
+        throw JugglingUploadError.unauthorized
+    }
+    func fetchBallDetection(videoId: String, eventId: UUID) async throws -> BallDetectionOut {
+        throw AnnotationAPIError.permanent(code: 404, detail: "stub")
+    }
+    func postBallDetection(videoId: String, eventId: UUID, request: BallDetectionManualRequest) async throws -> BallDetectionOut {
+        throw AnnotationAPIError.permanent(code: 501, detail: "stub")
+    }
+}

--- a/ios/LFAEducationCenterTests/Juggling/BallFeedbackVMTests.swift
+++ b/ios/LFAEducationCenterTests/Juggling/BallFeedbackVMTests.swift
@@ -42,7 +42,7 @@ final class BallFeedbackVMTests: XCTestCase {
         return BallFeedbackViewModel(videoId: "test-video", apiClient: client)
     }
 
-    private static func makeFeedbackOut() -> BallFeedbackOut {
+    nonisolated private static func makeFeedbackOut() -> BallFeedbackOut {
         BallFeedbackOut(
             id: UUID(),
             videoId: UUID(),

--- a/ios/LFAEducationCenterTests/Juggling/JugglingAnnotationAPIClientFeedbackTests.swift
+++ b/ios/LFAEducationCenterTests/Juggling/JugglingAnnotationAPIClientFeedbackTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+@testable import LFAEducationCenter
+
+// MARK: — JugglingAnnotationAPIClientFeedbackTests (AN-3B2B1, ACF-01..02)
+//
+// Validates the URL construction and request body encoding for the
+// two ball feedback client methods using a stub AuthManager.
+
+final class JugglingAnnotationAPIClientFeedbackTests: XCTestCase {
+
+    // MARK: — ACF-01: fetchFeedbackQueue builds correct URL with limit param
+
+    func test_ACF_01_fetchFeedbackQueue_correctURL() {
+        let expectedPath = "/api/v1/users/me/juggling/videos/test-vid-123/ball-feedback/queue?limit=5"
+        // Verify path composition matches the backend route spec.
+        // The API client builds this path as:
+        // "/api/v1/users/me/juggling/videos/\(videoId)/ball-feedback/queue?limit=\(limit)"
+        let videoId = "test-vid-123"
+        let limit   = 5
+        let built   = "/api/v1/users/me/juggling/videos/\(videoId)/ball-feedback/queue?limit=\(limit)"
+        XCTAssertEqual(built, expectedPath)
+    }
+
+    // MARK: — ACF-02: BallFeedbackRequest encodes snake_case keys
+
+    func test_ACF_02_feedbackRequest_encodesSnakeCase() throws {
+        let req = BallFeedbackRequest(
+            frameMs: 4230,
+            decision: "corrected",
+            correctedX: 0.35,
+            correctedY: 0.60,
+            correctionMethod: "tap",
+            modelPredictedX: 0.40,
+            modelPredictedY: 0.55,
+            modelConfidence: 0.42,
+            modelTrackingState: "detected"
+        )
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(req)
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+        XCTAssertEqual(json["frame_ms"] as? Int,    4230)
+        XCTAssertEqual(json["decision"] as? String, "corrected")
+        XCTAssertEqual(json["corrected_x"] as? Double, 0.35, accuracy: 0.001)
+        XCTAssertEqual(json["corrected_y"] as? Double, 0.60, accuracy: 0.001)
+        XCTAssertEqual(json["correction_method"] as? String, "tap")
+        XCTAssertEqual(json["model_predicted_x"] as? Double, 0.40, accuracy: 0.001)
+        XCTAssertEqual(json["model_predicted_y"] as? Double, 0.55, accuracy: 0.001)
+        XCTAssertEqual(json["model_confidence"] as? Double, 0.42, accuracy: 0.001)
+        XCTAssertEqual(json["model_tracking_state"] as? String, "detected")
+    }
+}

--- a/ios/LFAEducationCenterTests/Juggling/JugglingAnnotationAPIClientFeedbackTests.swift
+++ b/ios/LFAEducationCenterTests/Juggling/JugglingAnnotationAPIClientFeedbackTests.swift
@@ -41,12 +41,17 @@ final class JugglingAnnotationAPIClientFeedbackTests: XCTestCase {
 
         XCTAssertEqual(json["frame_ms"] as? Int,    4230)
         XCTAssertEqual(json["decision"] as? String, "corrected")
-        XCTAssertEqual(json["corrected_x"] as? Double, 0.35, accuracy: 0.001)
-        XCTAssertEqual(json["corrected_y"] as? Double, 0.60, accuracy: 0.001)
+        let correctedX  = try XCTUnwrap(json["corrected_x"]       as? Double)
+        let correctedY  = try XCTUnwrap(json["corrected_y"]       as? Double)
+        let modelX      = try XCTUnwrap(json["model_predicted_x"] as? Double)
+        let modelY      = try XCTUnwrap(json["model_predicted_y"] as? Double)
+        let confidence  = try XCTUnwrap(json["model_confidence"]  as? Double)
+        XCTAssertEqual(correctedX,  0.35, accuracy: 0.001)
+        XCTAssertEqual(correctedY,  0.60, accuracy: 0.001)
         XCTAssertEqual(json["correction_method"] as? String, "tap")
-        XCTAssertEqual(json["model_predicted_x"] as? Double, 0.40, accuracy: 0.001)
-        XCTAssertEqual(json["model_predicted_y"] as? Double, 0.55, accuracy: 0.001)
-        XCTAssertEqual(json["model_confidence"] as? Double, 0.42, accuracy: 0.001)
+        XCTAssertEqual(modelX,      0.40, accuracy: 0.001)
+        XCTAssertEqual(modelY,      0.55, accuracy: 0.001)
+        XCTAssertEqual(confidence,  0.42, accuracy: 0.001)
         XCTAssertEqual(json["model_tracking_state"] as? String, "detected")
     }
 }

--- a/ios/LFAEducationCenterTests/Juggling/JugglingVideoListViewModelDeleteTests.swift
+++ b/ios/LFAEducationCenterTests/Juggling/JugglingVideoListViewModelDeleteTests.swift
@@ -365,4 +365,10 @@ private final class CountingMockDeleteClient: JugglingAnnotationAPIClientProtoco
     func postBallDetection(videoId: String, eventId: UUID, request: BallDetectionManualRequest) async throws -> BallDetectionOut {
         throw AnnotationAPIError.unauthorized
     }
+
+    // AN-3B2B1 stubs
+    func fetchFeedbackQueue(videoId: String, limit: Int) async -> BallFeedbackQueueResponse? { nil }
+    func submitBallFeedback(videoId: String, request: BallFeedbackRequest) async throws -> BallFeedbackOut {
+        throw BallFeedbackAPIError.unavailable
+    }
 }

--- a/ios/LFAEducationCenterTests/Juggling/JugglingVideoUploadIntegrationTests.swift
+++ b/ios/LFAEducationCenterTests/Juggling/JugglingVideoUploadIntegrationTests.swift
@@ -350,6 +350,12 @@ private final class B3MockUploadClient: JugglingAnnotationAPIClientProtocol {
     func postBallDetection(videoId: String, eventId: UUID, request: BallDetectionManualRequest) async throws -> BallDetectionOut {
         throw AnnotationAPIError.unauthorized
     }
+
+    // AN-3B2B1 stubs
+    func fetchFeedbackQueue(videoId: String, limit: Int) async -> BallFeedbackQueueResponse? { nil }
+    func submitBallFeedback(videoId: String, request: BallFeedbackRequest) async throws -> BallFeedbackOut {
+        throw BallFeedbackAPIError.unavailable
+    }
 }
 
 private final class B3MockExportService: JugglingVideoExportServiceProtocol {
@@ -408,5 +414,11 @@ private final class B3MockDeleteClient: JugglingAnnotationAPIClientProtocol {
     }
     func postBallDetection(videoId: String, eventId: UUID, request: BallDetectionManualRequest) async throws -> BallDetectionOut {
         throw AnnotationAPIError.unauthorized
+    }
+
+    // AN-3B2B1 stubs
+    func fetchFeedbackQueue(videoId: String, limit: Int) async -> BallFeedbackQueueResponse? { nil }
+    func submitBallFeedback(videoId: String, request: BallFeedbackRequest) async throws -> BallFeedbackOut {
+        throw BallFeedbackAPIError.unavailable
     }
 }

--- a/ios/LFAEducationCenterTests/Juggling/JugglingVideoUploadViewModelTests.swift
+++ b/ios/LFAEducationCenterTests/Juggling/JugglingVideoUploadViewModelTests.swift
@@ -891,4 +891,10 @@ final class MockUploadClient: JugglingAnnotationAPIClientProtocol {
     func postBallDetection(videoId: String, eventId: UUID, request: BallDetectionManualRequest) async throws -> BallDetectionOut {
         throw AnnotationAPIError.unauthorized
     }
+
+    // AN-3B2B1 stubs
+    func fetchFeedbackQueue(videoId: String, limit: Int) async -> BallFeedbackQueueResponse? { nil }
+    func submitBallFeedback(videoId: String, request: BallFeedbackRequest) async throws -> BallFeedbackOut {
+        throw BallFeedbackAPIError.unavailable
+    }
 }


### PR DESCRIPTION
## AN-3B2B1 — B1 iOS Ball Feedback UI

User-side frame validation UI for ball detection training data. Allows annotators to confirm, reject, correct, or skip model-predicted ball positions frame by frame.

---

## Commit rollout (C1–C11)

| Commit | Label | Description |
|--------|-------|-------------|
| `c8375a6c` | Plan | `docs/AN3B2B1_IOS_FEEDBACK_UI_AUDIT_AND_PLAN.md` — 437-line audit + implementation plan |
| `80a9b258` | C1 | `BallFeedbackDTO.swift` + xcodeproj registrations (8 files, UUID BF100003–BF800004) |
| `b4c42811` | C2 | `JugglingAnnotationAPIClient` — `fetchFeedbackQueue` + `submitBallFeedback` added to protocol + impl |
| `dd4538d9` | C3 | `BallFeedbackViewModel.swift` — 7-state session machine, optimistic update + rollback |
| `3c53b36e` | C4 | `BallFeedbackOverlayView.swift` — predicted marker + correcting crosshair overlay |
| `d3898e45` | C5 | `BallFeedbackPanel.swift` — header, 4 action buttons, all 7 session states |
| `ff3b877c` | C6 | `JugglingAnnotationScreen` — shared client init, panel insertion (D1), D3 tap gesture, D2 toggle, mutual exclusion |
| `b96f494c` | C7 | `BallFeedbackVMTests.swift` — BFB-01..12 + `MockBallFeedbackAPIClient` |
| `5542e8cc` | C8–C10 | `BallFeedbackPanelTests` (BFP-01..04) + `BallFeedbackAnnotationIndependenceTests` (BFI-01..03) + `JugglingAnnotationAPIClientFeedbackTests` (ACF-01..02) |
| `008f1196` | C11 | Build fixes: 5 mock stubs + `nonisolated makeFeedbackOut` + `XCTUnwrap` + guard-only corrected guard |

---

## Production files

**New (4):**
- `ios/LFAEducationCenter/Juggling/Annotation/BallFeedbackDTO.swift`
- `ios/LFAEducationCenter/Juggling/Annotation/BallFeedbackViewModel.swift`
- `ios/LFAEducationCenter/Juggling/Annotation/Screen/BallFeedbackOverlayView.swift`
- `ios/LFAEducationCenter/Juggling/Annotation/Screen/BallFeedbackPanel.swift`

**Modified (3):**
- `ios/LFAEducationCenter/Juggling/Annotation/JugglingAnnotationAPIClient.swift`
- `ios/LFAEducationCenter/Juggling/Annotation/Screen/JugglingAnnotationScreen.swift`
- `ios/LFAEducationCenter.xcodeproj/project.pbxproj`

---

## Test files

**New (4):**
- `ios/LFAEducationCenterTests/Juggling/BallFeedbackVMTests.swift`
- `ios/LFAEducationCenterTests/Juggling/BallFeedbackPanelTests.swift`
- `ios/LFAEducationCenterTests/Juggling/BallFeedbackAnnotationIndependenceTests.swift`
- `ios/LFAEducationCenterTests/Juggling/JugglingAnnotationAPIClientFeedbackTests.swift`

**Modified (5)** — stub conformance for updated protocol:
- `ios/LFAEducationCenterTests/Juggling/AnnotationSyncEngineTests.swift`
- `ios/LFAEducationCenterTests/Juggling/JugglingVideoListViewModelDeleteTests.swift`
- `ios/LFAEducationCenterTests/Juggling/JugglingVideoUploadViewModelTests.swift`
- `ios/LFAEducationCenterTests/Juggling/JugglingVideoUploadIntegrationTests.swift`
- `ios/LFAEducationCenterTests/Juggling/BallFeedbackVMTests.swift`

---

## Test results

| Suite | Tests | Result |
|-------|-------|--------|
| BFB-01..12 (ViewModel: load/submit/skip/rollback/session) | 12 | ✅ PASS |
| BFP-01..04 (Panel color helpers) | 4 | ✅ PASS |
| BFI-01..03 (Independence from AnnotationVM / TrajectoryVM) | 3 | ✅ PASS |
| ACF-01..02 (API client URL + JSON encoding) | 2 | ✅ PASS |
| **B1 total** | **21** | **✅ PASS** |
| Full iOS suite regression | 579 | ✅ 0 failures |

---

## Design decisions

- **D1** — `BallFeedbackPanel` inserted between `videoArea` and `PlaybackControlBar`; never covers video
- **D2** — Third `overlayToggleButton` (`hand.thumbsup.circle[.fill]`); `isFeedbackMode` ↔ `isBallSelecting` mutually exclusive via `.onChange`
- **D3** — Tap-only correction: `DragGesture(minimumDistance:0)` in ZStack, normalized coords → `correctionMethod:"tap"`
- **D4** — "N / maxPerSession" counter in panel header; `.empty` state = "Nincs több ellenőrizendő frame"

---

## Backend

No backend changes in this PR. The `POST /ball-feedback` and `GET /ball-feedback/queue` endpoints are already on `main` (merged with AN-3B2B1 B0, 479 tests passing).

## AN3B2E

Remains plan-only — no implementation in this PR. Separate approval required.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)