### PR TITLE
security: ignore biometric uploads, profile photos, and MediaPipe task models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -204,6 +204,18 @@ local_models/cvlface_*/
 # Contains face photos of real individuals used for accuracy benchmarking.
 scripts/test_images/
 
+# Biometric uploads and profile photos — NEVER commit (GDPR: personal biometric data)
+# biometric and profile images contain personal data (face photos of real individuals).
+# none of these files may be committed.
+app/uploads/biometric/
+app/static/uploads/profile_photos/
+
+# MediaPipe task model binaries — NEVER commit (generated/downloadable binaries)
+# MediaPipe task models are generated/downloadable binaries; not source code.
+# none of these files may be committed.
+# Note: path-specific rule only — global *.task is intentionally avoided.
+app/static/mediapipe/*.task
+
 # Xcode per-developer data — editor state, breakpoints, layout (never shared)
 xcuserdata/
 


### PR DESCRIPTION
## Summary

Prevents accidental commit of GDPR-sensitive personal data and large generated binaries that were not covered by existing `.gitignore` rules.

Discovered during AN-3B2B2 post-merge repository housekeeping audit (2026-06-19).

## Changed files: 1

`.gitignore` — 12 lines added, 0 lines deleted

## Rules added (path-specific)

| Rule | Reason |
|---|---|
| `app/uploads/biometric/` | Face images = biometric personal data (GDPR); 133 user subdirs present locally |
| `app/static/uploads/profile_photos/` | User profile photos = personal data; 136 PNG files present locally |
| `app/static/mediapipe/*.task` | MediaPipe ML model binaries = generated/downloadable; not source code |

**Global `*.task` intentionally avoided** — path-specific rule only, to preserve any future version-controlled `.task` files elsewhere in the repo.

## Verification

**`git check-ignore -v` proof:**
```
.gitignore:210:app/uploads/biometric/         app/uploads/biometric/155779/biometric_155779_d3ccd4e0...jpg
.gitignore:211:app/static/uploads/profile_photos/  app/static/uploads/profile_photos/1_profile_orig_...png
.gitignore:217:app/static/mediapipe/*.task    app/static/mediapipe/face_landmarker.task
.gitignore:217:app/static/mediapipe/*.task    app/static/mediapipe/hand_landmarker.task
```

**Git history check:** none of the three paths appear in any commit across all branches — no history rewrite needed.

**Staged files after change:** none — sensitive files remain untracked and are now ignored.

## Scope

This PR only prevents accidental commit. It does **not**:
- delete any local files
- address retention, access control, or secure deletion of locally stored biometric data
- cover biometric source code, spikes, or planning docs (separate decisions pending)

## Test plan

- [ ] Verify `git check-ignore -v` output for all three path types
- [ ] Confirm `git status` shows no sensitive files in staged or modified state
- [ ] Confirm changed-files count = 1 (`.gitignore` only)
- [ ] CI passes (`.gitignore`-only change, no runtime impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)