### PR TITLE
feat(ios): AN-3B2F PR-2 — Ball Training Hub (Train the AI tab)

### DIFF
--- a/ios/LFAEducationCenter.xcodeproj/project.pbxproj
+++ b/ios/LFAEducationCenter.xcodeproj/project.pbxproj
@@ -7,6 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		BT000004000000000000001 /* BallTrainingModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT000003000000000000001 /* BallTrainingModels.swift */; };
+		BT000004000000000000002 /* BallTrainingAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT000003000000000000002 /* BallTrainingAPIClient.swift */; };
+		BT000004000000000000003 /* BallTrainingHubViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT000003000000000000003 /* BallTrainingHubViewModel.swift */; };
+		BT000004000000000000004 /* BallTrainingHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT000003000000000000004 /* BallTrainingHubView.swift */; };
+		BT000004000000000000005 /* BallTrainingFrameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT000003000000000000005 /* BallTrainingFrameView.swift */; };
+		BT500004000000000000001 /* BallTrainingHubVMTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT500003000000000000001 /* BallTrainingHubVMTests.swift */; };
 		36CB92D674607508AC4335E1 /* JugglingVideoListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20CD58654D76D5278A5E5B62 /* JugglingVideoListViewModel.swift */; };
 		3A252E40BD69018C7269AAF2 /* JugglingVideoItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2FD7851919C9B8A9FC46733 /* JugglingVideoItem.swift */; };
 		7FC19EF38DE99E82AE19FBE0 /* JugglingVideoListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89E393EC38D4612DE04DD285 /* JugglingVideoListView.swift */; };
@@ -198,6 +204,12 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		BT000003000000000000001 /* BallTrainingModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BallTrainingModels.swift; sourceTree = "<group>"; };
+		BT000003000000000000002 /* BallTrainingAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BallTrainingAPIClient.swift; sourceTree = "<group>"; };
+		BT000003000000000000003 /* BallTrainingHubViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BallTrainingHubViewModel.swift; sourceTree = "<group>"; };
+		BT000003000000000000004 /* BallTrainingHubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BallTrainingHubView.swift; sourceTree = "<group>"; };
+		BT000003000000000000005 /* BallTrainingFrameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BallTrainingFrameView.swift; sourceTree = "<group>"; };
+		BT500003000000000000001 /* BallTrainingHubVMTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BallTrainingHubVMTests.swift; sourceTree = "<group>"; };
 		20CD58654D76D5278A5E5B62 /* JugglingVideoListViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = JugglingVideoListViewModel.swift; sourceTree = "<group>"; };
 		89E393EC38D4612DE04DD285 /* JugglingVideoListView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = JugglingVideoListView.swift; sourceTree = "<group>"; };
 		BB000003000000000000001 /* LFAEducationCenterApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LFAEducationCenterApp.swift; sourceTree = "<group>"; };
@@ -567,6 +579,11 @@
 		BB000002000000000000012 /* Training */ = {
 			isa = PBXGroup;
 			children = (
+				BT000003000000000000001 /* BallTrainingModels.swift */,
+				BT000003000000000000002 /* BallTrainingAPIClient.swift */,
+				BT000003000000000000003 /* BallTrainingHubViewModel.swift */,
+				BT000003000000000000004 /* BallTrainingHubView.swift */,
+				BT000003000000000000005 /* BallTrainingFrameView.swift */,
 			);
 			path = Training;
 			sourceTree = "<group>";
@@ -821,6 +838,7 @@
 				BF600003000000000000001 /* BallFeedbackPanelTests.swift */,
 				BF700003000000000000001 /* BallFeedbackAnnotationIndependenceTests.swift */,
 				BF800003000000000000001 /* JugglingAnnotationAPIClientFeedbackTests.swift */,
+				BT500003000000000000001 /* BallTrainingHubVMTests.swift */,
 				BB100003000000000000004 /* AnnotationVideoLoaderTests.swift */,
 				BB100003000000000000005 /* PlaybackBarTests.swift */,
 				BB100003000000000000006 /* AVPlayerLayerViewTests.swift */,
@@ -1082,6 +1100,11 @@
 				BB300004000000000000003 /* JugglingVideoUploadView.swift in Sources */,
 				BB300004000000000000004 /* JugglingVideoUploadCoordinator.swift in Sources */,
 				BB300004000000000000005 /* JugglingVideoExportService.swift in Sources */,
+				BT000004000000000000001 /* BallTrainingModels.swift in Sources */,
+				BT000004000000000000002 /* BallTrainingAPIClient.swift in Sources */,
+				BT000004000000000000003 /* BallTrainingHubViewModel.swift in Sources */,
+				BT000004000000000000004 /* BallTrainingHubView.swift in Sources */,
+				BT000004000000000000005 /* BallTrainingFrameView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1133,6 +1156,7 @@
 				BF600004000000000000001 /* BallFeedbackPanelTests.swift in Sources */,
 				BF700004000000000000001 /* BallFeedbackAnnotationIndependenceTests.swift in Sources */,
 				BF800004000000000000001 /* JugglingAnnotationAPIClientFeedbackTests.swift in Sources */,
+				BT500004000000000000001 /* BallTrainingHubVMTests.swift in Sources */,
 				BB100004000000000000004 /* AnnotationVideoLoaderTests.swift in Sources */,
 				BB100004000000000000005 /* PlaybackBarTests.swift in Sources */,
 				BB100004000000000000006 /* AVPlayerLayerViewTests.swift in Sources */,

--- a/ios/LFAEducationCenter/App/LFASpecTabView.swift
+++ b/ios/LFAEducationCenter/App/LFASpecTabView.swift
@@ -21,6 +21,9 @@ struct LFASpecTabView: View {
             JugglingVideoListView()
                 .tabItem { Label("Training", systemImage: "video.fill") }
 
+            BallTrainingHubView()
+                .tabItem { Label("Train AI", systemImage: "brain.head.profile") }
+
             LFAProfileTab(onReturnToHub: { presentationMode.wrappedValue.dismiss() })
                 .tabItem { Label("Profile", systemImage: "person.fill") }
         }

--- a/ios/LFAEducationCenter/Training/BallTrainingAPIClient.swift
+++ b/ios/LFAEducationCenter/Training/BallTrainingAPIClient.swift
@@ -24,7 +24,7 @@ final class BallTrainingAPIClient: BallTrainingAPIClientProtocol {
     func fetchQueue() async throws -> GlobalTrainingQueueResponse {
         do {
             return try await authManager.authenticatedGet(
-                path: "/api/v1/users/me/ball-training/queue"
+                path: "/api/v1/users/me/ball-training/queue?limit=5"
             )
         } catch APIError.httpError(503, _) {
             throw BallTrainingAPIError.unavailable

--- a/ios/LFAEducationCenter/Training/BallTrainingAPIClient.swift
+++ b/ios/LFAEducationCenter/Training/BallTrainingAPIClient.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+// MARK: — BallTrainingAPIClientProtocol
+
+@MainActor
+protocol BallTrainingAPIClientProtocol: AnyObject {
+    func fetchQueue() async throws -> GlobalTrainingQueueResponse
+    func fetchFrame(assignmentId: UUID) async throws -> Data
+    func submitFeedback(_ request: BallTrainingFeedbackRequest) async throws -> BallTrainingFeedbackResponse
+}
+
+// MARK: — BallTrainingAPIClient
+
+@MainActor
+final class BallTrainingAPIClient: BallTrainingAPIClientProtocol {
+
+    private let authManager: AuthManager
+
+    init(authManager: AuthManager) {
+        self.authManager = authManager
+    }
+
+    // GET /api/v1/users/me/ball-training/queue
+    func fetchQueue() async throws -> GlobalTrainingQueueResponse {
+        do {
+            return try await authManager.authenticatedGet(
+                path: "/api/v1/users/me/ball-training/queue"
+            )
+        } catch APIError.httpError(503, _) {
+            throw BallTrainingAPIError.unavailable
+        } catch APIError.httpError(403, _) {
+            throw BallTrainingAPIError.forbidden
+        } catch {
+            throw BallTrainingAPIError.network
+        }
+    }
+
+    // GET /api/v1/users/me/ball-training/frame/{assignment_id}
+    // Returns raw JPEG binary.  The server sets display_mode on the assignment
+    // internally; the client normalises its tap to the displayed image size and
+    // the server back-calculates full-frame coordinates.
+    func fetchFrame(assignmentId: UUID) async throws -> Data {
+        do {
+            return try await authManager.authenticatedFetchData(
+                path: "/api/v1/users/me/ball-training/frame/\(assignmentId.uuidString.lowercased())"
+            )
+        } catch APIError.httpError(410, _) {
+            throw BallTrainingAPIError.expired
+        } catch APIError.httpError(409, _) {
+            throw BallTrainingAPIError.consumed
+        } catch APIError.httpError(403, _) {
+            throw BallTrainingAPIError.forbidden
+        } catch APIError.httpError(404, _) {
+            throw BallTrainingAPIError.notFound
+        } catch APIError.httpError(503, _) {
+            throw BallTrainingAPIError.unavailable
+        } catch {
+            throw BallTrainingAPIError.network
+        }
+    }
+
+    // POST /api/v1/users/me/ball-training/feedback
+    func submitFeedback(_ request: BallTrainingFeedbackRequest) async throws -> BallTrainingFeedbackResponse {
+        do {
+            return try await authManager.authenticatedPost(
+                path: "/api/v1/users/me/ball-training/feedback",
+                body: request
+            )
+        } catch APIError.httpError(410, _) {
+            throw BallTrainingAPIError.expired
+        } catch APIError.httpError(409, _) {
+            throw BallTrainingAPIError.consumed
+        } catch APIError.httpError(403, _) {
+            throw BallTrainingAPIError.forbidden
+        } catch {
+            throw BallTrainingAPIError.network
+        }
+    }
+}

--- a/ios/LFAEducationCenter/Training/BallTrainingFrameView.swift
+++ b/ios/LFAEducationCenter/Training/BallTrainingFrameView.swift
@@ -1,0 +1,259 @@
+import SwiftUI
+import UIKit
+
+// MARK: — BallTrainingFrameView
+//
+// Displays one frame (JPEG) from the global ball-training queue,
+// overlays the model's predicted ball position, and exposes four actions:
+// Helyes (confirm) / Nincs labda (no_ball) / Javítom (corrected) / Kihagyom (skip).
+//
+// In correction mode a full-image tap detector captures the user's tap
+// and normalises it to [0, 1] relative to the displayed image.
+// The server back-calculates the true full-frame coordinate from the
+// crop metadata stored on the assignment — the client never needs to know
+// whether the image is a context_crop or full_frame.
+
+struct BallTrainingFrameView: View {
+
+    @ObservedObject var vm: BallTrainingHubViewModel
+    let item: GlobalTrainingQueueItem
+    let frameData: Data
+
+    var body: some View {
+        VStack(spacing: 0) {
+            progressHeader
+            frameArea
+            actionBar
+        }
+    }
+
+    // MARK: — Progress header
+
+    private var progressHeader: some View {
+        HStack {
+            Text("Feladat")
+                .font(.subheadline.weight(.semibold))
+                .foregroundColor(Theme.Color.muted)
+            Spacer()
+            Text(vm.progressText)
+                .font(.subheadline.weight(.bold))
+                .foregroundColor(Theme.Color.primary)
+        }
+        .padding(.horizontal, Theme.Spacing.lg)
+        .padding(.vertical, Theme.Spacing.sm)
+    }
+
+    // MARK: — Frame image + overlays
+
+    private var frameArea: some View {
+        GeometryReader { geo in
+            ZStack {
+                Color.black
+                if let uiImage = UIImage(data: frameData) {
+                    let dims = imageDims(uiImage: uiImage, in: geo.size)
+                    Image(uiImage: uiImage)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: dims.width, height: dims.height)
+                        .position(x: dims.offsetX + dims.width / 2,
+                                  y: dims.offsetY + dims.height / 2)
+
+                    ballOverlay(uiImage: uiImage, dims: dims)
+
+                    if vm.isInCorrectionMode {
+                        tapOverlay(dims: dims)
+                    }
+                }
+            }
+        }
+        .overlay(correctionModeLabel, alignment: .top)
+    }
+
+    // MARK: — Ball prediction overlay
+
+    @ViewBuilder
+    private func ballOverlay(uiImage: UIImage, dims: ImageDims) -> some View {
+        if !vm.isInCorrectionMode,
+           let bx = item.modelPredictedX,
+           let by = item.modelPredictedY {
+            let px = dims.offsetX + CGFloat(bx) * dims.width
+            let py = dims.offsetY + CGFloat(by) * dims.height
+            ZStack {
+                Circle()
+                    .strokeBorder(ballOverlayColor, lineWidth: 2.5)
+                    .background(Circle().fill(ballOverlayColor.opacity(0.18)))
+                    .frame(width: 28, height: 28)
+                    .position(x: px, y: py)
+                if let conf = item.modelConfidence {
+                    Text("\(Int(conf * 100))%")
+                        .font(.system(size: 8, weight: .semibold).monospacedDigit())
+                        .foregroundColor(.white)
+                        .padding(.horizontal, 3)
+                        .background(Color.black.opacity(0.55))
+                        .cornerRadius(3)
+                        .position(x: px + 22, y: py - 16)
+                }
+            }
+            .allowsHitTesting(false)
+        }
+    }
+
+    private var ballOverlayColor: Color {
+        guard let conf = item.modelConfidence else { return .orange }
+        if conf >= 0.80 { return .green }
+        if conf >= 0.50 { return .yellow }
+        return .orange
+    }
+
+    // MARK: — Correction mode tap layer
+
+    @ViewBuilder
+    private func tapOverlay(dims: ImageDims) -> some View {
+        Rectangle()
+            .fill(Color.blue.opacity(0.08))
+            .frame(width: dims.width, height: dims.height)
+            .position(x: dims.offsetX + dims.width / 2,
+                      y: dims.offsetY + dims.height / 2)
+            .contentShape(Rectangle())
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .onEnded { value in
+                        let raw = value.location
+                        let tx = (raw.x - dims.offsetX) / dims.width
+                        let ty = (raw.y - dims.offsetY) / dims.height
+                        let clampedX = max(0, min(1, Double(tx)))
+                        let clampedY = max(0, min(1, Double(ty)))
+                        Task { await vm.corrected(tapX: clampedX, tapY: clampedY) }
+                    }
+            )
+    }
+
+    private var correctionModeLabel: some View {
+        Group {
+            if vm.isInCorrectionMode {
+                Text("Érintsd meg a labda valódi helyzetét")
+                    .font(.caption.weight(.semibold))
+                    .foregroundColor(.white)
+                    .padding(.horizontal, Theme.Spacing.md)
+                    .padding(.vertical, Theme.Spacing.xs)
+                    .background(Color.blue.opacity(0.85))
+                    .cornerRadius(Theme.Radius.sm)
+                    .padding(.top, Theme.Spacing.sm)
+            }
+        }
+    }
+
+    // MARK: — Action bar
+
+    private var actionBar: some View {
+        VStack(spacing: Theme.Spacing.sm) {
+            if let msg = vm.lastErrorMessage {
+                Text(msg)
+                    .font(.caption)
+                    .foregroundColor(Theme.Color.error)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, Theme.Spacing.lg)
+            }
+
+            if vm.isInCorrectionMode {
+                Button("Mégse") { vm.cancelCorrectionMode() }
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundColor(Theme.Color.muted)
+            } else {
+                HStack(spacing: Theme.Spacing.sm) {
+                    actionButton(
+                        label: "Helyes",
+                        icon: "checkmark.circle.fill",
+                        color: .green,
+                        disabled: vm.isSubmitting
+                    ) { Task { await vm.confirm() } }
+
+                    actionButton(
+                        label: "Nincs labda",
+                        icon: "xmark.circle.fill",
+                        color: .red,
+                        disabled: vm.isSubmitting
+                    ) { Task { await vm.noBall() } }
+                }
+                HStack(spacing: Theme.Spacing.sm) {
+                    actionButton(
+                        label: "Javítom",
+                        icon: "pencil.circle.fill",
+                        color: .blue,
+                        disabled: vm.isSubmitting
+                    ) { vm.enterCorrectionMode() }
+
+                    actionButton(
+                        label: "Kihagyom",
+                        icon: "forward.circle.fill",
+                        color: Theme.Color.muted,
+                        disabled: vm.isSubmitting
+                    ) { vm.skip() }
+                }
+            }
+
+            if vm.isSubmitting {
+                ProgressView()
+                    .progressViewStyle(.circular)
+                    .padding(.vertical, Theme.Spacing.xs)
+            }
+        }
+        .padding(.horizontal, Theme.Spacing.lg)
+        .padding(.vertical, Theme.Spacing.md)
+        .background(Theme.Color.surface)
+    }
+
+    private func actionButton(
+        label: String,
+        icon: String,
+        color: Color,
+        disabled: Bool,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: Theme.Spacing.xs) {
+                Image(systemName: icon)
+                    .font(.system(size: 15))
+                Text(label)
+                    .font(.subheadline.weight(.semibold))
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: 44)
+            .background(color.opacity(disabled ? 0.08 : 0.14))
+            .foregroundColor(disabled ? Theme.Color.muted : color)
+            .cornerRadius(Theme.Radius.sm)
+        }
+        .disabled(disabled)
+    }
+
+    // MARK: — Image geometry helpers
+
+    private struct ImageDims {
+        let width:   CGFloat
+        let height:  CGFloat
+        let offsetX: CGFloat
+        let offsetY: CGFloat
+    }
+
+    private func imageDims(uiImage: UIImage, in containerSize: CGSize) -> ImageDims {
+        let iw = uiImage.size.width
+        let ih = uiImage.size.height
+        guard iw > 0, ih > 0 else {
+            return ImageDims(width: containerSize.width, height: containerSize.height, offsetX: 0, offsetY: 0)
+        }
+        let imageAR     = iw / ih
+        let containerAR = containerSize.width / containerSize.height
+        let displayW: CGFloat
+        let displayH: CGFloat
+        if imageAR > containerAR {
+            displayW = containerSize.width
+            displayH = containerSize.width / imageAR
+        } else {
+            displayH = containerSize.height
+            displayW = containerSize.height * imageAR
+        }
+        let offsetX = (containerSize.width  - displayW) / 2
+        let offsetY = (containerSize.height - displayH) / 2
+        return ImageDims(width: displayW, height: displayH, offsetX: offsetX, offsetY: offsetY)
+    }
+}

--- a/ios/LFAEducationCenter/Training/BallTrainingFrameView.swift
+++ b/ios/LFAEducationCenter/Training/BallTrainingFrameView.swift
@@ -7,17 +7,29 @@ import UIKit
 // overlays the model's predicted ball position, and exposes four actions:
 // Helyes (confirm) / Nincs labda (no_ball) / Javítom (corrected) / Kihagyom (skip).
 //
-// In correction mode a full-image tap detector captures the user's tap
-// and normalises it to [0, 1] relative to the displayed image.
-// The server back-calculates the true full-frame coordinate from the
-// crop metadata stored on the assignment — the client never needs to know
-// whether the image is a context_crop or full_frame.
+// Correction flow (3-step, POST only on explicit confirmation):
+//   1. User taps "Javítom" → correction mode entered, model overlay dims to 40 %.
+//   2. User taps or drags on the image → cyan crosshair marker appears; loupe
+//      magnifies the touched area during drag; out-of-bounds taps are ignored.
+//   3. User presses "Megerősítés" → corrected POST sent with the marker's
+//      normalised [0, 1] coordinate.
+//   Alternatively: "Új kijelölés" clears the marker (stays in correction mode);
+//   "Mégse" exits correction mode without any POST.
+//
+// Coordinate invariant: imageDims() is the single source of truth for the
+// displayed image rect (letterbox/pillarbox aware).  Every overlay, the loupe
+// patch crop, and the submitted tap_x/tap_y all derive from the same dims.
 
 struct BallTrainingFrameView: View {
 
     @ObservedObject var vm: BallTrainingHubViewModel
     let item: GlobalTrainingQueueItem
     let frameData: Data
+
+    @State private var loupeDragNorm: CGPoint? = nil
+
+    private let loupeSize:          CGFloat = 120
+    private let loupePatchFraction: CGFloat = 0.12   // fraction of image width shown in loupe
 
     var body: some View {
         VStack(spacing: 0) {
@@ -51,6 +63,7 @@ struct BallTrainingFrameView: View {
                 Color.black
                 if let uiImage = UIImage(data: frameData) {
                     let dims = imageDims(uiImage: uiImage, in: geo.size)
+
                     Image(uiImage: uiImage)
                         .resizable()
                         .scaledToFit()
@@ -58,23 +71,39 @@ struct BallTrainingFrameView: View {
                         .position(x: dims.offsetX + dims.width / 2,
                                   y: dims.offsetY + dims.height / 2)
 
+                    // Model overlay — always visible; dimmed during correction mode
                     ballOverlay(uiImage: uiImage, dims: dims)
 
                     if vm.isInCorrectionMode {
                         tapOverlay(dims: dims)
+                        correctionMarker(dims: dims)
+                        if let drag = loupeDragNorm {
+                            loupeView(normPoint: drag, uiImage: uiImage, dims: dims)
+                        }
                     }
                 }
             }
         }
-        .overlay(correctionModeLabel, alignment: .top)
+        .overlay(alignment: .top) {
+            // Instruction label only when in correction mode with no pending point yet
+            if vm.isInCorrectionMode && !vm.hasPendingTap {
+                Text("Érintsd meg a labda valódi helyzetét")
+                    .font(.caption.weight(.semibold))
+                    .foregroundColor(.white)
+                    .padding(.horizontal, Theme.Spacing.md)
+                    .padding(.vertical, Theme.Spacing.xs)
+                    .background(Color.blue.opacity(0.85))
+                    .cornerRadius(Theme.Radius.sm)
+                    .padding(.top, Theme.Spacing.sm)
+            }
+        }
     }
 
     // MARK: — Ball prediction overlay
 
     @ViewBuilder
     private func ballOverlay(uiImage: UIImage, dims: ImageDims) -> some View {
-        if !vm.isInCorrectionMode,
-           let bx = item.modelPredictedX,
+        if let bx = item.modelPredictedX,
            let by = item.modelPredictedY {
             let px = dims.offsetX + CGFloat(bx) * dims.width
             let py = dims.offsetY + CGFloat(by) * dims.height
@@ -94,6 +123,8 @@ struct BallTrainingFrameView: View {
                         .position(x: px + 22, y: py - 16)
                 }
             }
+            // Dimmed to 40 % in correction mode — visible as a reference point
+            .opacity(vm.isInCorrectionMode ? 0.40 : 1.0)
             .allowsHitTesting(false)
         }
     }
@@ -105,42 +136,116 @@ struct BallTrainingFrameView: View {
         return .orange
     }
 
-    // MARK: — Correction mode tap layer
+    // MARK: — Tap overlay (correction mode)
+    //
+    // onChanged: update loupe position during drag (in-bounds only).
+    // onEnded:   set pending tap (in-bounds only); out-of-bounds → silently ignored.
 
     @ViewBuilder
     private func tapOverlay(dims: ImageDims) -> some View {
         Rectangle()
-            .fill(Color.blue.opacity(0.08))
+            .fill(Color.blue.opacity(0.06))
             .frame(width: dims.width, height: dims.height)
             .position(x: dims.offsetX + dims.width / 2,
                       y: dims.offsetY + dims.height / 2)
             .contentShape(Rectangle())
             .gesture(
                 DragGesture(minimumDistance: 0)
+                    .onChanged { value in
+                        let tx = (value.location.x - dims.offsetX) / dims.width
+                        let ty = (value.location.y - dims.offsetY) / dims.height
+                        guard tx >= 0, tx <= 1, ty >= 0, ty <= 1 else {
+                            loupeDragNorm = nil
+                            return
+                        }
+                        loupeDragNorm = CGPoint(x: tx, y: ty)
+                    }
                     .onEnded { value in
-                        let raw = value.location
-                        let tx = (raw.x - dims.offsetX) / dims.width
-                        let ty = (raw.y - dims.offsetY) / dims.height
-                        let clampedX = max(0, min(1, Double(tx)))
-                        let clampedY = max(0, min(1, Double(ty)))
-                        Task { await vm.corrected(tapX: clampedX, tapY: clampedY) }
+                        loupeDragNorm = nil
+                        let tx = (value.location.x - dims.offsetX) / dims.width
+                        let ty = (value.location.y - dims.offsetY) / dims.height
+                        // Out-of-bounds tap: ignore — do NOT clamp to image edge
+                        guard tx >= 0, tx <= 1, ty >= 0, ty <= 1 else { return }
+                        vm.setPendingTap(x: Double(tx), y: Double(ty))
                     }
             )
     }
 
-    private var correctionModeLabel: some View {
-        Group {
-            if vm.isInCorrectionMode {
-                Text("Érintsd meg a labda valódi helyzetét")
-                    .font(.caption.weight(.semibold))
-                    .foregroundColor(.white)
-                    .padding(.horizontal, Theme.Spacing.md)
-                    .padding(.vertical, Theme.Spacing.xs)
-                    .background(Color.blue.opacity(0.85))
-                    .cornerRadius(Theme.Radius.sm)
-                    .padding(.top, Theme.Spacing.sm)
+    // MARK: — Correction marker (pending tap point)
+
+    @ViewBuilder
+    private func correctionMarker(dims: ImageDims) -> some View {
+        if let px = vm.pendingTapX, let py = vm.pendingTapY {
+            let sx = dims.offsetX + CGFloat(px) * dims.width
+            let sy = dims.offsetY + CGFloat(py) * dims.height
+            ZStack {
+                Circle()
+                    .strokeBorder(Color.cyan, lineWidth: 2.5)
+                    .background(Circle().fill(Color.cyan.opacity(0.20)))
+                    .frame(width: 30, height: 30)
+                Rectangle()
+                    .fill(Color.cyan)
+                    .frame(width: 20, height: 1.5)
+                Rectangle()
+                    .fill(Color.cyan)
+                    .frame(width: 1.5, height: 20)
             }
+            .position(x: sx, y: sy)
+            .allowsHitTesting(false)
         }
+    }
+
+    // MARK: — Loupe (magnifier shown during drag)
+    //
+    // Crops a patchFraction-wide square from the UIImage at the drag position
+    // and displays it in a 120 pt circle above the user's finger.
+    // The crosshair in the centre shows exactly which pixel will be recorded.
+
+    @ViewBuilder
+    private func loupeView(normPoint: CGPoint, uiImage: UIImage, dims: ImageDims) -> some View {
+        if let cgImage = uiImage.cgImage,
+           let cgCrop  = cgImage.cropping(to: loupeCropRect(cgImage: cgImage, norm: normPoint)) {
+            let screenX = dims.offsetX + normPoint.x * dims.width
+            let screenY = dims.offsetY + normPoint.y * dims.height
+            ZStack {
+                Image(uiImage: UIImage(cgImage: cgCrop))
+                    .resizable()
+                    .scaledToFill()
+                    .frame(width: loupeSize, height: loupeSize)
+                    .clipped()
+                // Crosshair
+                ZStack {
+                    Rectangle()
+                        .fill(Color.white.opacity(0.85))
+                        .frame(width: 36, height: 1.5)
+                    Rectangle()
+                        .fill(Color.white.opacity(0.85))
+                        .frame(width: 1.5, height: 36)
+                    Circle()
+                        .strokeBorder(Color.white.opacity(0.85), lineWidth: 1)
+                        .frame(width: 14, height: 14)
+                }
+            }
+            .clipShape(Circle())
+            .overlay(Circle().strokeBorder(Color.white, lineWidth: 2.5))
+            .shadow(color: .black.opacity(0.5), radius: 8, y: 3)
+            .frame(width: loupeSize, height: loupeSize)
+            .position(
+                x: screenX,
+                y: max(loupeSize / 2 + 8, screenY - loupeSize / 2 - 24)
+            )
+            .allowsHitTesting(false)
+        }
+    }
+
+    private func loupeCropRect(cgImage: CGImage, norm: CGPoint) -> CGRect {
+        let imgW    = CGFloat(cgImage.width)
+        let imgH    = CGFloat(cgImage.height)
+        let halfW   = loupePatchFraction * imgW / 2
+        let halfH   = loupePatchFraction * imgH / 2
+        let originX = max(0, min(imgW - halfW * 2, norm.x * imgW - halfW))
+        let originY = max(0, min(imgH - halfH * 2, norm.y * imgH - halfH))
+        return CGRect(x: originX, y: originY, width: halfW * 2, height: halfH * 2)
     }
 
     // MARK: — Action bar
@@ -156,40 +261,9 @@ struct BallTrainingFrameView: View {
             }
 
             if vm.isInCorrectionMode {
-                Button("Mégse") { vm.cancelCorrectionMode() }
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundColor(Theme.Color.muted)
+                correctionActionBar
             } else {
-                HStack(spacing: Theme.Spacing.sm) {
-                    actionButton(
-                        label: "Helyes",
-                        icon: "checkmark.circle.fill",
-                        color: .green,
-                        disabled: vm.isSubmitting
-                    ) { Task { await vm.confirm() } }
-
-                    actionButton(
-                        label: "Nincs labda",
-                        icon: "xmark.circle.fill",
-                        color: .red,
-                        disabled: vm.isSubmitting
-                    ) { Task { await vm.noBall() } }
-                }
-                HStack(spacing: Theme.Spacing.sm) {
-                    actionButton(
-                        label: "Javítom",
-                        icon: "pencil.circle.fill",
-                        color: .blue,
-                        disabled: vm.isSubmitting
-                    ) { vm.enterCorrectionMode() }
-
-                    actionButton(
-                        label: "Kihagyom",
-                        icon: "forward.circle.fill",
-                        color: Theme.Color.muted,
-                        disabled: vm.isSubmitting
-                    ) { vm.skip() }
-                }
+                normalActionBar
             }
 
             if vm.isSubmitting {
@@ -201,6 +275,92 @@ struct BallTrainingFrameView: View {
         .padding(.horizontal, Theme.Spacing.lg)
         .padding(.vertical, Theme.Spacing.md)
         .background(Theme.Color.surface)
+    }
+
+    // Correction mode: pending point exists → Confirm / Reselect / Cancel
+    //                  no pending point     → Cancel only
+
+    @ViewBuilder
+    private var correctionActionBar: some View {
+        if vm.hasPendingTap {
+            VStack(spacing: Theme.Spacing.sm) {
+                Button {
+                    Task { await vm.confirmCorrection() }
+                } label: {
+                    Label("Megerősítés", systemImage: "checkmark.circle.fill")
+                        .font(.body.weight(.semibold))
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 44)
+                        .background(Color.cyan.opacity(vm.isSubmitting ? 0.06 : 0.18))
+                        .foregroundColor(vm.isSubmitting ? Theme.Color.muted : .cyan)
+                        .cornerRadius(Theme.Radius.sm)
+                }
+                .disabled(vm.isSubmitting)
+
+                HStack(spacing: Theme.Spacing.sm) {
+                    Button("Új kijelölés") {
+                        vm.clearPendingTap()
+                    }
+                    .font(.subheadline.weight(.semibold))
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 44)
+                    .background(Theme.Color.primary.opacity(0.10))
+                    .foregroundColor(Theme.Color.primary)
+                    .cornerRadius(Theme.Radius.sm)
+
+                    Button("Mégse") {
+                        vm.cancelCorrectionMode()
+                    }
+                    .font(.subheadline.weight(.semibold))
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 44)
+                    .background(Color.clear)
+                    .foregroundColor(Theme.Color.muted)
+                    .cornerRadius(Theme.Radius.sm)
+                }
+            }
+        } else {
+            Button("Mégse") {
+                vm.cancelCorrectionMode()
+            }
+            .font(.subheadline.weight(.semibold))
+            .foregroundColor(Theme.Color.muted)
+        }
+    }
+
+    private var normalActionBar: some View {
+        VStack(spacing: Theme.Spacing.sm) {
+            HStack(spacing: Theme.Spacing.sm) {
+                actionButton(
+                    label: "Helyes",
+                    icon: "checkmark.circle.fill",
+                    color: .green,
+                    disabled: vm.isSubmitting
+                ) { Task { await vm.confirm() } }
+
+                actionButton(
+                    label: "Nincs labda",
+                    icon: "xmark.circle.fill",
+                    color: .red,
+                    disabled: vm.isSubmitting
+                ) { Task { await vm.noBall() } }
+            }
+            HStack(spacing: Theme.Spacing.sm) {
+                actionButton(
+                    label: "Javítom",
+                    icon: "pencil.circle.fill",
+                    color: .blue,
+                    disabled: vm.isSubmitting
+                ) { vm.enterCorrectionMode() }
+
+                actionButton(
+                    label: "Kihagyom",
+                    icon: "forward.circle.fill",
+                    color: Theme.Color.muted,
+                    disabled: vm.isSubmitting
+                ) { vm.skip() }
+            }
+        }
     }
 
     private func actionButton(

--- a/ios/LFAEducationCenter/Training/BallTrainingHubView.swift
+++ b/ios/LFAEducationCenter/Training/BallTrainingHubView.swift
@@ -1,0 +1,256 @@
+import SwiftUI
+
+// MARK: — BallTrainingHubView
+//
+// "Segíts tanítani a rendszert" — standalone tab entry point.
+// Manages the full session lifecycle: loading → frame display → session complete.
+// Navigation: 5th tab in LFASpecTabView.
+//
+// AuthManager is passed at call time (matching JugglingVideoListViewModel pattern).
+// The ViewModel lazily creates BallTrainingAPIClient on first loadQueue(authManager:).
+
+struct BallTrainingHubView: View {
+
+    @EnvironmentObject var authManager: AuthManager
+    @StateObject private var vm = BallTrainingHubViewModel()
+
+    var body: some View {
+        NavigationView {
+            content
+                .navigationTitle("Train the AI")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .navigationBarTrailing) {
+                        Button {
+                            Task { await vm.reload(authManager: authManager) }
+                        } label: {
+                            Image(systemName: "arrow.clockwise")
+                        }
+                        .disabled(vm.isSubmitting || vm.isFrameLoading)
+                        .opacity(isReloadVisible ? 1 : 0)
+                    }
+                }
+        }
+        .navigationViewStyle(.stack)
+        .task { await vm.loadQueue(authManager: authManager) }
+    }
+
+    private var isReloadVisible: Bool {
+        switch vm.sessionState {
+        case .ready, .empty, .sessionComplete, .error: return true
+        default: return false
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch vm.sessionState {
+        case .idle, .loading:
+            loadingView
+
+        case .ready:
+            readyView
+
+        case .sessionComplete:
+            sessionCompleteView
+
+        case .empty:
+            emptyView
+
+        case .unavailable:
+            unavailableView
+
+        case .forbidden:
+            forbiddenView
+
+        case .error(let msg):
+            errorView(message: msg)
+        }
+    }
+
+    // MARK: — Loading
+
+    private var loadingView: some View {
+        VStack(spacing: Theme.Spacing.lg) {
+            ProgressView()
+                .progressViewStyle(.circular)
+                .scaleEffect(1.4)
+            Text("Feladatok betöltése…")
+                .font(.subheadline)
+                .foregroundColor(Theme.Color.muted)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: — Ready (frame display)
+
+    @ViewBuilder
+    private var readyView: some View {
+        if vm.isFrameLoading {
+            VStack(spacing: Theme.Spacing.md) {
+                ProgressView()
+                    .progressViewStyle(.circular)
+                    .scaleEffect(1.2)
+                Text("Kép betöltése…")
+                    .font(.caption)
+                    .foregroundColor(Theme.Color.muted)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if let msg = vm.frameErrorMessage {
+            frameErrorView(message: msg)
+        } else if let item = vm.currentItem, let data = vm.frameData {
+            BallTrainingFrameView(vm: vm, item: item, frameData: data)
+        } else {
+            loadingView
+        }
+    }
+
+    private func frameErrorView(message: String) -> some View {
+        VStack(spacing: Theme.Spacing.lg) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 40))
+                .foregroundColor(Theme.Color.warning)
+            Text(message)
+                .font(.subheadline)
+                .multilineTextAlignment(.center)
+                .foregroundColor(Theme.Color.muted)
+                .padding(.horizontal, Theme.Spacing.xl)
+            Button("Újrapróbál") {
+                Task { await vm.fetchCurrentFrame() }
+            }
+            .font(.body.weight(.semibold))
+            .frame(maxWidth: .infinity)
+            .frame(height: 48)
+            .background(Theme.Color.primary.opacity(0.12))
+            .foregroundColor(Theme.Color.primary)
+            .cornerRadius(Theme.Radius.sm)
+            .padding(.horizontal, Theme.Spacing.xl)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: — Session complete
+
+    private var sessionCompleteView: some View {
+        VStack(spacing: Theme.Spacing.lg) {
+            Image(systemName: "checkmark.seal.fill")
+                .font(.system(size: 56))
+                .foregroundColor(Theme.Color.primary)
+
+            Text("Köszönjük!")
+                .font(.title2.weight(.bold))
+                .foregroundColor(Theme.Color.onSurface)
+
+            Text("Sikeresen segítettél a modell tanításában.\nHolnap új feladatok várnak.")
+                .font(.subheadline)
+                .multilineTextAlignment(.center)
+                .foregroundColor(Theme.Color.muted)
+                .padding(.horizontal, Theme.Spacing.xl)
+
+            Button("Újabb feladatok") {
+                Task { await vm.reload(authManager: authManager) }
+            }
+            .font(.body.weight(.semibold))
+            .frame(maxWidth: .infinity)
+            .frame(height: 48)
+            .background(Theme.Color.primary.opacity(0.12))
+            .foregroundColor(Theme.Color.primary)
+            .cornerRadius(Theme.Radius.sm)
+            .padding(.horizontal, Theme.Spacing.xl)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: — Empty queue
+
+    private var emptyView: some View {
+        VStack(spacing: Theme.Spacing.lg) {
+            Image(systemName: "tray.fill")
+                .font(.system(size: 48))
+                .foregroundColor(Theme.Color.muted)
+            Text("Jelenleg nincs elérhető feladat")
+                .font(.headline)
+                .foregroundColor(Theme.Color.onSurface)
+            Text("Nézz vissza hamarosan – a rendszer folyamatosan gyűjt új kereteket.")
+                .font(.subheadline)
+                .multilineTextAlignment(.center)
+                .foregroundColor(Theme.Color.muted)
+                .padding(.horizontal, Theme.Spacing.xl)
+            Button("Frissítés") {
+                Task { await vm.reload(authManager: authManager) }
+            }
+            .font(.body.weight(.semibold))
+            .frame(maxWidth: .infinity)
+            .frame(height: 48)
+            .background(Theme.Color.primary.opacity(0.12))
+            .foregroundColor(Theme.Color.primary)
+            .cornerRadius(Theme.Radius.sm)
+            .padding(.horizontal, Theme.Spacing.xl)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: — Unavailable (feature flag off)
+
+    private var unavailableView: some View {
+        VStack(spacing: Theme.Spacing.md) {
+            Image(systemName: "lock.fill")
+                .font(.system(size: 44))
+                .foregroundColor(Theme.Color.muted)
+            Text("A funkció jelenleg nem elérhető")
+                .font(.headline)
+                .foregroundColor(Theme.Color.onSurface)
+            Text("A labdadetektálás értékelő módja átmenetileg le van tiltva.")
+                .font(.subheadline)
+                .multilineTextAlignment(.center)
+                .foregroundColor(Theme.Color.muted)
+                .padding(.horizontal, Theme.Spacing.xl)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: — Forbidden (not in allowlist)
+
+    private var forbiddenView: some View {
+        VStack(spacing: Theme.Spacing.md) {
+            Image(systemName: "person.fill.xmark")
+                .font(.system(size: 44))
+                .foregroundColor(Theme.Color.muted)
+            Text("Hozzáférés szükséges")
+                .font(.headline)
+                .foregroundColor(Theme.Color.onSurface)
+            Text("A labdadetektálás értékelőhöz belső hozzáférés szükséges.")
+                .font(.subheadline)
+                .multilineTextAlignment(.center)
+                .foregroundColor(Theme.Color.muted)
+                .padding(.horizontal, Theme.Spacing.xl)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: — Generic error
+
+    private func errorView(message: String) -> some View {
+        VStack(spacing: Theme.Spacing.lg) {
+            Image(systemName: "wifi.exclamationmark")
+                .font(.system(size: 44))
+                .foregroundColor(Theme.Color.error)
+            Text(message)
+                .font(.subheadline)
+                .multilineTextAlignment(.center)
+                .foregroundColor(Theme.Color.muted)
+                .padding(.horizontal, Theme.Spacing.xl)
+            Button("Újrapróbál") {
+                Task { await vm.reload(authManager: authManager) }
+            }
+            .font(.body.weight(.semibold))
+            .frame(maxWidth: .infinity)
+            .frame(height: 48)
+            .background(Theme.Color.error.opacity(0.12))
+            .foregroundColor(Theme.Color.error)
+            .cornerRadius(Theme.Radius.sm)
+            .padding(.horizontal, Theme.Spacing.xl)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}

--- a/ios/LFAEducationCenter/Training/BallTrainingHubViewModel.swift
+++ b/ios/LFAEducationCenter/Training/BallTrainingHubViewModel.swift
@@ -1,0 +1,227 @@
+import Foundation
+
+// MARK: — BallTrainingSessionState
+
+enum BallTrainingSessionState: Equatable {
+    case idle
+    case loading
+    case ready([GlobalTrainingQueueItem])
+    case empty
+    case sessionComplete
+    case unavailable
+    case forbidden
+    case error(String)
+
+    static func == (lhs: BallTrainingSessionState, rhs: BallTrainingSessionState) -> Bool {
+        switch (lhs, rhs) {
+        case (.idle, .idle), (.loading, .loading), (.empty, .empty),
+             (.sessionComplete, .sessionComplete), (.unavailable, .unavailable),
+             (.forbidden, .forbidden): return true
+        case (.ready(let a), .ready(let b)): return a == b
+        case (.error(let a), .error(let b)): return a == b
+        default: return false
+        }
+    }
+}
+
+// MARK: — BallTrainingHubViewModel
+
+@MainActor
+final class BallTrainingHubViewModel: ObservableObject {
+
+    @Published var sessionState:        BallTrainingSessionState = .idle
+    @Published var currentIndex:        Int  = 0
+    @Published var submittedCount:      Int  = 0
+    @Published var frameData:           Data? = nil
+    @Published var isFrameLoading:      Bool = false
+    @Published var isSubmitting:        Bool = false
+    @Published var isInCorrectionMode:  Bool = false
+    @Published var frameErrorMessage:   String? = nil
+    @Published var lastErrorMessage:    String? = nil
+
+    private(set) var maxPerSession: Int = 5
+
+    // Lazily created in production from the passed-in AuthManager.
+    // Injected directly in tests via the test-only init.
+    private var apiClient: BallTrainingAPIClientProtocol?
+
+    // MARK: — Init
+
+    // SwiftUI @StateObject production init.
+    init() {}
+
+    // Test init — inject a mock client.
+    init(apiClient: BallTrainingAPIClientProtocol) {
+        self.apiClient = apiClient
+    }
+
+    // MARK: — Computed
+
+    var currentItem: GlobalTrainingQueueItem? {
+        guard case .ready(let items) = sessionState,
+              currentIndex < items.count else { return nil }
+        return items[currentIndex]
+    }
+
+    var progressText: String {
+        guard case .ready(let items) = sessionState else { return "" }
+        let total = min(items.count, maxPerSession)
+        return "\(min(currentIndex, total - 1) + 1)/\(total)"
+    }
+
+    // MARK: — Load queue
+
+    func loadQueue(authManager: AuthManager) async {
+        guard case .idle = sessionState else { return }
+        if apiClient == nil {
+            apiClient = BallTrainingAPIClient(authManager: authManager)
+        }
+        await _doLoadQueue()
+    }
+
+    func reload(authManager: AuthManager) async {
+        sessionState = .idle
+        frameData    = nil
+        await loadQueue(authManager: authManager)
+    }
+
+    // MARK: — Frame loading
+
+    func fetchCurrentFrame() async {
+        guard let item = currentItem else { return }
+        isFrameLoading      = true
+        frameData           = nil
+        frameErrorMessage   = nil
+
+        do {
+            frameData = try await apiClient!.fetchFrame(assignmentId: item.assignmentId)
+        } catch BallTrainingAPIError.expired {
+            frameErrorMessage = "Ez a feladat lejárt. Következő betöltése…"
+            await advanceAfterFrameError()
+        } catch BallTrainingAPIError.consumed {
+            await advanceAfterFrameError()
+        } catch BallTrainingAPIError.unavailable {
+            sessionState = .unavailable
+        } catch {
+            frameErrorMessage = "A kép betöltése nem sikerült. Érintsd meg az újrapróbálkozáshoz."
+        }
+        isFrameLoading = false
+    }
+
+    // MARK: — Actions
+
+    func confirm() async {
+        await submitDecision("confirm", tapX: nil, tapY: nil)
+    }
+
+    func noBall() async {
+        await submitDecision("no_ball", tapX: nil, tapY: nil)
+    }
+
+    func corrected(tapX: Double, tapY: Double) async {
+        isInCorrectionMode = false
+        await submitDecision("corrected", tapX: tapX, tapY: tapY)
+    }
+
+    func enterCorrectionMode() {
+        isInCorrectionMode = true
+    }
+
+    func cancelCorrectionMode() {
+        isInCorrectionMode = false
+    }
+
+    func skip() {
+        guard !isSubmitting else { return }
+        isInCorrectionMode = false
+        guard case .ready(let items) = sessionState else { return }
+        let next = currentIndex + 1
+        if next >= items.count {
+            sessionState = .empty
+        } else {
+            currentIndex = next
+            frameData    = nil
+            Task { await fetchCurrentFrame() }
+        }
+    }
+
+    // MARK: — Private
+
+    private func _doLoadQueue() async {
+        sessionState        = .loading
+        submittedCount      = 0
+        currentIndex        = 0
+        frameData           = nil
+        lastErrorMessage    = nil
+
+        do {
+            let response    = try await apiClient!.fetchQueue()
+            maxPerSession   = max(1, response.maxPerSession)
+            if response.tasks.isEmpty {
+                sessionState = .empty
+            } else {
+                sessionState = .ready(response.tasks)
+                await fetchCurrentFrame()
+            }
+        } catch BallTrainingAPIError.unavailable {
+            sessionState = .unavailable
+        } catch BallTrainingAPIError.forbidden {
+            sessionState = .forbidden
+        } catch {
+            sessionState = .error("A feladatok betöltése nem sikerült. Ellenőrizd a kapcsolatot.")
+        }
+    }
+
+    private func submitDecision(_ decision: String, tapX: Double?, tapY: Double?) async {
+        guard let item = currentItem, !isSubmitting else { return }
+        isSubmitting        = true
+        lastErrorMessage    = nil
+
+        let req = BallTrainingFeedbackRequest(
+            assignmentId: item.assignmentId,
+            decision:     decision,
+            tapX:         tapX,
+            tapY:         tapY
+        )
+
+        do {
+            _ = try await apiClient!.submitFeedback(req)
+            submittedCount += 1
+            await advanceAfterSubmit()
+        } catch BallTrainingAPIError.consumed, BallTrainingAPIError.expired {
+            submittedCount += 1
+            await advanceAfterSubmit()
+        } catch {
+            lastErrorMessage = "Hiba történt, próbáld újra."
+        }
+        isSubmitting = false
+    }
+
+    private func advanceAfterSubmit() async {
+        if submittedCount >= maxPerSession {
+            sessionState = .sessionComplete
+            return
+        }
+        guard case .ready(let items) = sessionState else { return }
+        let next = currentIndex + 1
+        if next >= items.count {
+            sessionState = .sessionComplete
+        } else {
+            currentIndex = next
+            frameData    = nil
+            await fetchCurrentFrame()
+        }
+    }
+
+    private func advanceAfterFrameError() async {
+        guard case .ready(let items) = sessionState else { return }
+        let next = currentIndex + 1
+        if next >= items.count {
+            sessionState = .empty
+        } else {
+            currentIndex = next
+            frameData    = nil
+            await fetchCurrentFrame()
+        }
+    }
+}

--- a/ios/LFAEducationCenter/Training/BallTrainingHubViewModel.swift
+++ b/ios/LFAEducationCenter/Training/BallTrainingHubViewModel.swift
@@ -38,6 +38,8 @@ final class BallTrainingHubViewModel: ObservableObject {
     @Published var isInCorrectionMode:  Bool = false
     @Published var frameErrorMessage:   String? = nil
     @Published var lastErrorMessage:    String? = nil
+    @Published var pendingTapX:         Double? = nil
+    @Published var pendingTapY:         Double? = nil
 
     private(set) var maxPerSession: Int = 5
 
@@ -62,6 +64,8 @@ final class BallTrainingHubViewModel: ObservableObject {
               currentIndex < items.count else { return nil }
         return items[currentIndex]
     }
+
+    var hasPendingTap: Bool { pendingTapX != nil }
 
     var progressText: String {
         guard case .ready(let items) = sessionState else { return "" }
@@ -125,15 +129,35 @@ final class BallTrainingHubViewModel: ObservableObject {
 
     func enterCorrectionMode() {
         isInCorrectionMode = true
+        clearPendingTap()
     }
 
     func cancelCorrectionMode() {
         isInCorrectionMode = false
+        clearPendingTap()
+    }
+
+    func setPendingTap(x: Double, y: Double) {
+        pendingTapX = x
+        pendingTapY = y
+    }
+
+    func confirmCorrection() async {
+        guard let x = pendingTapX, let y = pendingTapY, !isSubmitting else { return }
+        clearPendingTap()
+        isInCorrectionMode = false
+        await submitDecision("corrected", tapX: x, tapY: y)
+    }
+
+    func clearPendingTap() {
+        pendingTapX = nil
+        pendingTapY = nil
     }
 
     func skip() {
         guard !isSubmitting else { return }
         isInCorrectionMode = false
+        clearPendingTap()
         guard case .ready(let items) = sessionState else { return }
         let next = currentIndex + 1
         if next >= items.count {
@@ -153,6 +177,8 @@ final class BallTrainingHubViewModel: ObservableObject {
         currentIndex        = 0
         frameData           = nil
         lastErrorMessage    = nil
+        isInCorrectionMode  = false
+        clearPendingTap()
 
         do {
             let response    = try await apiClient!.fetchQueue()

--- a/ios/LFAEducationCenter/Training/BallTrainingModels.swift
+++ b/ios/LFAEducationCenter/Training/BallTrainingModels.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+// MARK: — Global Ball Training Hub — Data models (AN-3B2F PR-2)
+//
+// Privacy invariant: video_id, frame_ms, storage_path, and the video owner's
+// identity are never received from the server.  The client only handles
+// assignment_id (opaque UUID4) and model metadata needed to render the UI.
+
+// MARK: — Queue
+
+struct GlobalTrainingQueueItem: Decodable, Equatable, Identifiable {
+    let assignmentId:           UUID
+    let modelPredictedX:        Double?
+    let modelPredictedY:        Double?
+    let modelConfidence:        Double?
+    let modelTrackingState:     String?
+    let existingFeedbackCount:  Int
+    let priorityScore:          Double
+    let expiresAt:              String   // ISO-8601; expiry is enforced server-side (410)
+
+    var id: UUID { assignmentId }
+
+    enum CodingKeys: String, CodingKey {
+        case assignmentId           = "assignment_id"
+        case modelPredictedX        = "model_predicted_x"
+        case modelPredictedY        = "model_predicted_y"
+        case modelConfidence        = "model_confidence"
+        case modelTrackingState     = "model_tracking_state"
+        case existingFeedbackCount  = "existing_feedback_count"
+        case priorityScore          = "priority_score"
+        case expiresAt              = "expires_at"
+    }
+}
+
+struct GlobalTrainingQueueResponse: Decodable {
+    let tasks:          [GlobalTrainingQueueItem]
+    let maxPerSession:  Int
+    let totalInQueue:   Int
+
+    enum CodingKeys: String, CodingKey {
+        case tasks
+        case maxPerSession  = "max_per_session"
+        case totalInQueue   = "total_in_queue"
+    }
+}
+
+// MARK: — Feedback
+
+struct BallTrainingFeedbackRequest: Encodable {
+    let assignmentId:   UUID
+    let decision:       String    // "confirm" | "no_ball" | "corrected"
+    let tapX:           Double?   // required when decision == "corrected"
+    let tapY:           Double?
+
+    enum CodingKeys: String, CodingKey {
+        case assignmentId   = "assignment_id"
+        case decision
+        case tapX           = "tap_x"
+        case tapY           = "tap_y"
+    }
+}
+
+struct BallTrainingFeedbackResponse: Decodable {
+    let assignmentId:   UUID
+    let decision:       String
+    let submittedAt:    String    // ISO-8601
+    let correctedX:     Double?
+    let correctedY:     Double?
+
+    enum CodingKeys: String, CodingKey {
+        case assignmentId   = "assignment_id"
+        case decision
+        case submittedAt    = "submitted_at"
+        case correctedX     = "corrected_x"
+        case correctedY     = "corrected_y"
+    }
+}
+
+// MARK: — BallTrainingAPIError
+
+enum BallTrainingAPIError: Error, Equatable {
+    case unavailable    // 503 — BALL_TRAINING_FRAME_ENABLED=false
+    case forbidden      // 403 — user not in allowlist
+    case expired        // 410 — assignment expired (server-side TTL)
+    case consumed       // 409 — assignment already submitted
+    case notFound       // 404
+    case network        // transport or unexpected failure
+}

--- a/ios/LFAEducationCenterTests/Juggling/BallTrainingHubVMTests.swift
+++ b/ios/LFAEducationCenterTests/Juggling/BallTrainingHubVMTests.swift
@@ -397,4 +397,148 @@ final class BallTrainingHubVMTests: XCTestCase {
         await vm.corrected(tapX: 0.5, tapY: 0.5)
         XCTAssertFalse(vm.isInCorrectionMode)
     }
+
+    // BTH-VM-31: setPendingTap sets pendingTapX/Y without POST
+    func test_BTH_VM_31_setPendingTap_setsPendingWithoutPOST() async {
+        let (vm, mock) = makeVM(queueCount: 1)
+        await vm.loadQueue(authManager: AuthManager())
+        vm.setPendingTap(x: 0.42, y: 0.67)
+        XCTAssertEqual(vm.pendingTapX ?? -1, 0.42, accuracy: 0.0001)
+        XCTAssertEqual(vm.pendingTapY ?? -1, 0.67, accuracy: 0.0001)
+        XCTAssertEqual(mock.submitCallCount, 0, "setPendingTap must not call submitFeedback")
+    }
+
+    // BTH-VM-32: confirmCorrection sends exactly 1 POST with decision="corrected"
+    func test_BTH_VM_32_confirmCorrection_submitsOnce() async {
+        let (vm, mock) = makeVM(queueCount: 1)
+        await vm.loadQueue(authManager: AuthManager())
+        vm.setPendingTap(x: 0.5, y: 0.5)
+        await vm.confirmCorrection()
+        XCTAssertEqual(mock.submitCallCount, 1)
+        XCTAssertEqual(mock.lastSubmittedRequest?.decision, "corrected")
+    }
+
+    // BTH-VM-33: confirmCorrection sends pending coords as tap_x / tap_y
+    func test_BTH_VM_33_confirmCorrection_sendsPendingCoords() async {
+        let (vm, mock) = makeVM(queueCount: 1)
+        await vm.loadQueue(authManager: AuthManager())
+        vm.setPendingTap(x: 0.38, y: 0.72)
+        await vm.confirmCorrection()
+        XCTAssertEqual(mock.lastSubmittedRequest?.tapX ?? -1, 0.38, accuracy: 0.0001)
+        XCTAssertEqual(mock.lastSubmittedRequest?.tapY ?? -1, 0.72, accuracy: 0.0001)
+    }
+
+    // BTH-VM-34: confirmCorrection clears pending after submit
+    func test_BTH_VM_34_confirmCorrection_clearsPendingAfterSubmit() async {
+        let (vm, _) = makeVM(queueCount: 1)
+        await vm.loadQueue(authManager: AuthManager())
+        vm.setPendingTap(x: 0.5, y: 0.5)
+        await vm.confirmCorrection()
+        XCTAssertNil(vm.pendingTapX)
+        XCTAssertNil(vm.pendingTapY)
+    }
+
+    // BTH-VM-35: confirmCorrection exits correction mode
+    func test_BTH_VM_35_confirmCorrection_exitsCorrectionMode() async {
+        let (vm, _) = makeVM(queueCount: 2)
+        await vm.loadQueue(authManager: AuthManager())
+        vm.enterCorrectionMode()
+        vm.setPendingTap(x: 0.5, y: 0.5)
+        await vm.confirmCorrection()
+        XCTAssertFalse(vm.isInCorrectionMode)
+    }
+
+    // BTH-VM-36: confirmCorrection without pending → 0 POST
+    func test_BTH_VM_36_confirmCorrection_withoutPending_noSubmit() async {
+        let (vm, mock) = makeVM(queueCount: 1)
+        await vm.loadQueue(authManager: AuthManager())
+        vm.enterCorrectionMode()
+        // No setPendingTap called
+        await vm.confirmCorrection()
+        XCTAssertEqual(mock.submitCallCount, 0,
+                       "confirmCorrection must not submit when pendingTap is nil")
+    }
+
+    // BTH-VM-37: clearPendingTap → pending nil, 0 POST
+    func test_BTH_VM_37_clearPendingTap_noPOST() async {
+        let (vm, mock) = makeVM(queueCount: 1)
+        await vm.loadQueue(authManager: AuthManager())
+        vm.setPendingTap(x: 0.5, y: 0.5)
+        vm.clearPendingTap()
+        XCTAssertNil(vm.pendingTapX)
+        XCTAssertNil(vm.pendingTapY)
+        XCTAssertEqual(mock.submitCallCount, 0)
+    }
+
+    // BTH-VM-38: cancelCorrectionMode clears pending + exits mode, 0 POST
+    func test_BTH_VM_38_cancelCorrectionMode_clearsPendingAndMode() async {
+        let (vm, mock) = makeVM(queueCount: 1)
+        await vm.loadQueue(authManager: AuthManager())
+        vm.enterCorrectionMode()
+        vm.setPendingTap(x: 0.6, y: 0.4)
+        vm.cancelCorrectionMode()
+        XCTAssertNil(vm.pendingTapX)
+        XCTAssertNil(vm.pendingTapY)
+        XCTAssertFalse(vm.isInCorrectionMode)
+        XCTAssertEqual(mock.submitCallCount, 0)
+    }
+
+    // BTH-VM-39: setPendingTap twice → second overwrites first, still 0 POST
+    func test_BTH_VM_39_setPendingTap_overwritesPrevious() async {
+        let (vm, mock) = makeVM(queueCount: 1)
+        await vm.loadQueue(authManager: AuthManager())
+        vm.setPendingTap(x: 0.3, y: 0.3)
+        vm.setPendingTap(x: 0.7, y: 0.8)
+        XCTAssertEqual(vm.pendingTapX ?? -1, 0.7, accuracy: 0.0001)
+        XCTAssertEqual(vm.pendingTapY ?? -1, 0.8, accuracy: 0.0001)
+        XCTAssertEqual(mock.submitCallCount, 0)
+    }
+
+    // BTH-VM-40: hasPendingTap is false before any tap
+    func test_BTH_VM_40_hasPendingTap_falseInitially() {
+        let vm = BallTrainingHubViewModel(apiClient: MockBallTrainingAPIClient())
+        XCTAssertFalse(vm.hasPendingTap)
+    }
+
+    // BTH-VM-41: hasPendingTap is true after setPendingTap
+    func test_BTH_VM_41_hasPendingTap_trueAfterSet() async {
+        let (vm, _) = makeVM(queueCount: 1)
+        await vm.loadQueue(authManager: AuthManager())
+        vm.setPendingTap(x: 0.5, y: 0.5)
+        XCTAssertTrue(vm.hasPendingTap)
+    }
+
+    // BTH-VM-42: confirmCorrection blocked when isSubmitting=true (double-submit guard)
+    func test_BTH_VM_42_confirmCorrection_blockedWhileSubmitting() async {
+        let (vm, mock) = makeVM(queueCount: 2)
+        await vm.loadQueue(authManager: AuthManager())
+        vm.setPendingTap(x: 0.5, y: 0.5)
+        vm.isSubmitting = true   // simulate in-flight request
+        await vm.confirmCorrection()
+        XCTAssertEqual(mock.submitCallCount, 0,
+                       "confirmCorrection must be blocked when isSubmitting=true")
+    }
+
+    // BTH-VM-43: sessionComplete fires after 5 submits when maxPerSession=5
+    func test_BTH_VM_43_sessionComplete_after5Submits_withLimit5() async {
+        let (vm, _) = makeVM(queueCount: 5, maxPerSession: 5)
+        await vm.loadQueue(authManager: AuthManager())
+        await vm.confirm()  // 1
+        await vm.confirm()  // 2
+        await vm.confirm()  // 3
+        await vm.noBall()   // 4
+        await vm.noBall()   // 5 → sessionComplete
+        XCTAssertEqual(vm.sessionState, .sessionComplete)
+        XCTAssertEqual(vm.submittedCount, 5)
+    }
+
+    // BTH-VM-44: submittedCount resets to 0 on reload
+    func test_BTH_VM_44_submittedCount_resetsOnReload() async {
+        let (vm, _) = makeVM(queueCount: 3, maxPerSession: 5)
+        await vm.loadQueue(authManager: AuthManager())
+        await vm.confirm()
+        XCTAssertEqual(vm.submittedCount, 1)
+        await vm.reload(authManager: AuthManager())
+        XCTAssertEqual(vm.submittedCount, 0)
+    }
 }

--- a/ios/LFAEducationCenterTests/Juggling/BallTrainingHubVMTests.swift
+++ b/ios/LFAEducationCenterTests/Juggling/BallTrainingHubVMTests.swift
@@ -1,0 +1,400 @@
+import XCTest
+@testable import LFAEducationCenter
+
+// MARK: — BallTrainingHubVMTests (AN-3B2F PR-2, BTH-VM-01..30)
+//
+// All tests use MockBallTrainingAPIClient — no real networking.
+// ViewModel is always created via the test init: BallTrainingHubViewModel(apiClient: mock).
+
+// MARK: — Mock
+
+@MainActor
+final class MockBallTrainingAPIClient: BallTrainingAPIClientProtocol {
+
+    var queueResult:    Result<GlobalTrainingQueueResponse, Error>       = .success(MockBallTrainingAPIClient.emptyQueue())
+    var frameResult:    Result<Data, Error>                              = .success(MockBallTrainingAPIClient.fakeJpeg())
+    var feedbackResult: Result<BallTrainingFeedbackResponse, Error>      = .success(MockBallTrainingAPIClient.fakeFeedback())
+
+    var fetchQueueCallCount:    Int = 0
+    var fetchFrameCallCount:    Int = 0
+    var submitCallCount:        Int = 0
+    var lastSubmittedRequest:   BallTrainingFeedbackRequest?
+
+    func fetchQueue() async throws -> GlobalTrainingQueueResponse {
+        fetchQueueCallCount += 1
+        return try queueResult.get()
+    }
+
+    func fetchFrame(assignmentId: UUID) async throws -> Data {
+        fetchFrameCallCount += 1
+        return try frameResult.get()
+    }
+
+    func submitFeedback(_ request: BallTrainingFeedbackRequest) async throws -> BallTrainingFeedbackResponse {
+        submitCallCount += 1
+        lastSubmittedRequest = request
+        return try feedbackResult.get()
+    }
+
+    // MARK: — Factories
+
+    static func emptyQueue() -> GlobalTrainingQueueResponse {
+        GlobalTrainingQueueResponse(tasks: [], maxPerSession: 5, totalInQueue: 0)
+    }
+
+    static func makeQueue(count: Int, maxPerSession: Int = 5) -> GlobalTrainingQueueResponse {
+        let items = (0..<count).map { _ in makeItem() }
+        return GlobalTrainingQueueResponse(tasks: items, maxPerSession: maxPerSession, totalInQueue: count)
+    }
+
+    static func makeItem(
+        assignmentId: UUID = UUID(),
+        predictedX: Double? = 0.5,
+        predictedY: Double? = 0.4,
+        confidence: Double? = 0.85,
+        trackingState: String? = "detected"
+    ) -> GlobalTrainingQueueItem {
+        GlobalTrainingQueueItem(
+            assignmentId: assignmentId,
+            modelPredictedX: predictedX,
+            modelPredictedY: predictedY,
+            modelConfidence: confidence,
+            modelTrackingState: trackingState,
+            existingFeedbackCount: 0,
+            priorityScore: 1.0,
+            expiresAt: "2099-12-31T23:59:59Z"
+        )
+    }
+
+    static func fakeJpeg() -> Data {
+        // Minimal valid JPEG header (SOI marker)
+        Data([0xFF, 0xD8, 0xFF, 0xE0])
+    }
+
+    static func fakeFeedback(decision: String = "confirm") -> BallTrainingFeedbackResponse {
+        BallTrainingFeedbackResponse(
+            assignmentId: UUID(),
+            decision: decision,
+            submittedAt: "2026-06-19T10:00:00Z",
+            correctedX: nil,
+            correctedY: nil
+        )
+    }
+}
+
+// MARK: — Test helpers
+
+@MainActor
+private func makeVM(
+    queueCount: Int = 1,
+    maxPerSession: Int = 5,
+    queueError: Error? = nil,
+    frameError: Error? = nil,
+    feedbackError: Error? = nil
+) -> (BallTrainingHubViewModel, MockBallTrainingAPIClient) {
+    let mock = MockBallTrainingAPIClient()
+    if let err = queueError {
+        mock.queueResult = .failure(err)
+    } else {
+        mock.queueResult = .success(MockBallTrainingAPIClient.makeQueue(count: queueCount, maxPerSession: maxPerSession))
+    }
+    if let err = frameError {
+        mock.frameResult = .failure(err)
+    }
+    if let err = feedbackError {
+        mock.feedbackResult = .failure(err)
+    }
+    let vm = BallTrainingHubViewModel(apiClient: mock)
+    return (vm, mock)
+}
+
+// MARK: — Tests
+
+@MainActor
+final class BallTrainingHubVMTests: XCTestCase {
+
+    // BTH-VM-01: loadQueue transitions through loading → ready
+    func test_BTH_VM_01_loadQueue_ready() async {
+        let (vm, _) = makeVM(queueCount: 3)
+        XCTAssertEqual(vm.sessionState, .idle)
+        await vm.loadQueue(authManager: AuthManager())
+        if case .ready(let items) = vm.sessionState {
+            XCTAssertEqual(items.count, 3)
+        } else {
+            XCTFail("Expected .ready, got \(vm.sessionState)")
+        }
+    }
+
+    // BTH-VM-02: loadQueue with empty queue → empty state
+    func test_BTH_VM_02_loadQueue_empty() async {
+        let (vm, _) = makeVM(queueCount: 0)
+        await vm.loadQueue(authManager: AuthManager())
+        XCTAssertEqual(vm.sessionState, .empty)
+    }
+
+    // BTH-VM-03: loadQueue with 503 → unavailable
+    func test_BTH_VM_03_loadQueue_unavailable() async {
+        let (vm, _) = makeVM(queueError: BallTrainingAPIError.unavailable)
+        await vm.loadQueue(authManager: AuthManager())
+        XCTAssertEqual(vm.sessionState, .unavailable)
+    }
+
+    // BTH-VM-04: loadQueue with 403 → forbidden
+    func test_BTH_VM_04_loadQueue_forbidden() async {
+        let (vm, _) = makeVM(queueError: BallTrainingAPIError.forbidden)
+        await vm.loadQueue(authManager: AuthManager())
+        XCTAssertEqual(vm.sessionState, .forbidden)
+    }
+
+    // BTH-VM-05: loadQueue with network error → error state
+    func test_BTH_VM_05_loadQueue_networkError() async {
+        let (vm, _) = makeVM(queueError: BallTrainingAPIError.network)
+        await vm.loadQueue(authManager: AuthManager())
+        if case .error = vm.sessionState { } else {
+            XCTFail("Expected .error, got \(vm.sessionState)")
+        }
+    }
+
+    // BTH-VM-06: confirm calls submitFeedback with decision="confirm"
+    func test_BTH_VM_06_confirm_callsAPI() async {
+        let (vm, mock) = makeVM(queueCount: 2)
+        await vm.loadQueue(authManager: AuthManager())
+        await vm.confirm()
+        XCTAssertEqual(mock.submitCallCount, 1)
+        XCTAssertEqual(mock.lastSubmittedRequest?.decision, "confirm")
+        XCTAssertNil(mock.lastSubmittedRequest?.tapX)
+        XCTAssertNil(mock.lastSubmittedRequest?.tapY)
+    }
+
+    // BTH-VM-07: noBall calls submitFeedback with decision="no_ball"
+    func test_BTH_VM_07_noBall_callsAPI() async {
+        let (vm, mock) = makeVM(queueCount: 2)
+        await vm.loadQueue(authManager: AuthManager())
+        await vm.noBall()
+        XCTAssertEqual(mock.submitCallCount, 1)
+        XCTAssertEqual(mock.lastSubmittedRequest?.decision, "no_ball")
+    }
+
+    // BTH-VM-08: corrected sends normalised tap_x/tap_y to API
+    func test_BTH_VM_08_corrected_sendsTapCoords() async {
+        let (vm, mock) = makeVM(queueCount: 2)
+        await vm.loadQueue(authManager: AuthManager())
+        await vm.corrected(tapX: 0.35, tapY: 0.72)
+        XCTAssertEqual(mock.submitCallCount, 1)
+        XCTAssertEqual(mock.lastSubmittedRequest?.decision, "corrected")
+        XCTAssertEqual(mock.lastSubmittedRequest?.tapX ?? -1, 0.35, accuracy: 0.001)
+        XCTAssertEqual(mock.lastSubmittedRequest?.tapY ?? -1, 0.72, accuracy: 0.001)
+    }
+
+    // BTH-VM-09: skip does NOT call submitFeedback
+    func test_BTH_VM_09_skip_noNetworkCall() async {
+        let (vm, mock) = makeVM(queueCount: 2)
+        await vm.loadQueue(authManager: AuthManager())
+        vm.skip()
+        XCTAssertEqual(mock.submitCallCount, 0)
+    }
+
+    // BTH-VM-10: submittedCount increments after confirm
+    func test_BTH_VM_10_submittedCount_increments() async {
+        let (vm, _) = makeVM(queueCount: 3)
+        await vm.loadQueue(authManager: AuthManager())
+        XCTAssertEqual(vm.submittedCount, 0)
+        await vm.confirm()
+        XCTAssertEqual(vm.submittedCount, 1)
+        await vm.noBall()
+        XCTAssertEqual(vm.submittedCount, 2)
+    }
+
+    // BTH-VM-11: sessionComplete when submittedCount >= maxPerSession
+    func test_BTH_VM_11_sessionComplete_whenMaxReached() async {
+        let (vm, _) = makeVM(queueCount: 5, maxPerSession: 2)
+        await vm.loadQueue(authManager: AuthManager())
+        await vm.confirm()   // submitted=1
+        await vm.confirm()   // submitted=2 → session complete
+        XCTAssertEqual(vm.sessionState, .sessionComplete)
+    }
+
+    // BTH-VM-12: sessionComplete when all items exhausted after submits
+    func test_BTH_VM_12_sessionComplete_whenItemsExhausted() async {
+        let (vm, _) = makeVM(queueCount: 2, maxPerSession: 10)
+        await vm.loadQueue(authManager: AuthManager())
+        await vm.confirm()   // item 0 → item 1
+        await vm.confirm()   // item 1 → no more items → sessionComplete
+        XCTAssertEqual(vm.sessionState, .sessionComplete)
+    }
+
+    // BTH-VM-13: corrected tap values are passed verbatim in [0,1]
+    func test_BTH_VM_13_correctedTap_passedVerbatim() async {
+        let (vm, mock) = makeVM(queueCount: 1)
+        await vm.loadQueue(authManager: AuthManager())
+        await vm.corrected(tapX: 0.0, tapY: 1.0)
+        XCTAssertEqual(mock.lastSubmittedRequest?.tapX ?? -1, 0.0, accuracy: 0.0001)
+        XCTAssertEqual(mock.lastSubmittedRequest?.tapY ?? -1, 1.0, accuracy: 0.0001)
+    }
+
+    // BTH-VM-14: corrected tap with edge values (0.0 and 1.0) accepted
+    func test_BTH_VM_14_correctedTap_edgeBounds() async {
+        let (vm, mock) = makeVM(queueCount: 1)
+        await vm.loadQueue(authManager: AuthManager())
+        await vm.corrected(tapX: 0.001, tapY: 0.999)
+        XCTAssertEqual(mock.lastSubmittedRequest?.decision, "corrected")
+    }
+
+    // BTH-VM-15: skip does not trigger fetchFrame call for first item
+    func test_BTH_VM_15_skip_advancesIndex() async {
+        let (vm, mock) = makeVM(queueCount: 3)
+        await vm.loadQueue(authManager: AuthManager())
+        let frameCallsAfterLoad = mock.fetchFrameCallCount
+        vm.skip()
+        // fetchCurrentFrame is async-dispatched by skip(); wait a moment
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertEqual(vm.currentIndex, 1)
+        XCTAssertGreaterThan(mock.fetchFrameCallCount, frameCallsAfterLoad)
+        XCTAssertEqual(mock.submitCallCount, 0)
+    }
+
+    // BTH-VM-16: expired assignment (410) on frame fetch → advances silently
+    func test_BTH_VM_16_frameExpired_advancesSilently() async {
+        let (vm, mock) = makeVM(queueCount: 2, frameError: BallTrainingAPIError.expired)
+        await vm.loadQueue(authManager: AuthManager())
+        // After queue load, fetchCurrentFrame fails with expired; should advance
+        // (first item expired → advance to second, second also expires → empty)
+        XCTAssertEqual(vm.sessionState, .empty)
+    }
+
+    // BTH-VM-17: consumed assignment on submit → counts as success, advances
+    func test_BTH_VM_17_submitConsumed_countsAsSuccess() async {
+        let (vm, _) = makeVM(queueCount: 2, feedbackError: BallTrainingAPIError.consumed)
+        await vm.loadQueue(authManager: AuthManager())
+        await vm.confirm()
+        XCTAssertEqual(vm.submittedCount, 1)
+    }
+
+    // BTH-VM-18: isSubmitting is false after submit completes
+    func test_BTH_VM_18_isSubmitting_falseAfterSubmit() async {
+        let (vm, _) = makeVM(queueCount: 2)
+        await vm.loadQueue(authManager: AuthManager())
+        await vm.confirm()
+        XCTAssertFalse(vm.isSubmitting)
+    }
+
+    // BTH-VM-19: fetchCurrentFrame loads frameData on success
+    func test_BTH_VM_19_fetchFrame_loadsData() async {
+        let (vm, _) = makeVM(queueCount: 1)
+        await vm.loadQueue(authManager: AuthManager())
+        XCTAssertNotNil(vm.frameData)
+        XCTAssertFalse(vm.isFrameLoading)
+    }
+
+    // BTH-VM-20: fetchCurrentFrame with network error → frameErrorMessage set
+    func test_BTH_VM_20_fetchFrame_networkError_setsMessage() async {
+        let (vm, _) = makeVM(queueCount: 1, frameError: BallTrainingAPIError.network)
+        await vm.loadQueue(authManager: AuthManager())
+        XCTAssertNotNil(vm.frameErrorMessage)
+        XCTAssertNil(vm.frameData)
+    }
+
+    // BTH-VM-21: isFrameLoading is false after frame load
+    func test_BTH_VM_21_isFrameLoading_falseAfterLoad() async {
+        let (vm, _) = makeVM(queueCount: 1)
+        await vm.loadQueue(authManager: AuthManager())
+        XCTAssertFalse(vm.isFrameLoading)
+    }
+
+    // BTH-VM-22: progressText is "1/1" for single-item queue
+    func test_BTH_VM_22_progressText_singleItem() async {
+        let (vm, _) = makeVM(queueCount: 1, maxPerSession: 5)
+        await vm.loadQueue(authManager: AuthManager())
+        XCTAssertEqual(vm.progressText, "1/1")
+    }
+
+    // BTH-VM-23: progressText updates after skip
+    func test_BTH_VM_23_progressText_updatesAfterSkip() async {
+        let (vm, _) = makeVM(queueCount: 3, maxPerSession: 5)
+        await vm.loadQueue(authManager: AuthManager())
+        XCTAssertEqual(vm.progressText, "1/3")
+        vm.skip()
+        XCTAssertEqual(vm.progressText, "2/3")
+    }
+
+    // BTH-VM-24: currentItem returns the item at currentIndex
+    func test_BTH_VM_24_currentItem_correctIndex() async {
+        let id0 = UUID()
+        let id1 = UUID()
+        let mock = MockBallTrainingAPIClient()
+        mock.queueResult = .success(GlobalTrainingQueueResponse(
+            tasks: [
+                MockBallTrainingAPIClient.makeItem(assignmentId: id0),
+                MockBallTrainingAPIClient.makeItem(assignmentId: id1)
+            ],
+            maxPerSession: 5,
+            totalInQueue: 2
+        ))
+        let vm = BallTrainingHubViewModel(apiClient: mock)
+        await vm.loadQueue(authManager: AuthManager())
+        XCTAssertEqual(vm.currentItem?.assignmentId, id0)
+        vm.skip()
+        XCTAssertEqual(vm.currentItem?.assignmentId, id1)
+    }
+
+    // BTH-VM-25: skip advances currentIndex without incrementing submittedCount
+    func test_BTH_VM_25_skip_doesNotIncrementSubmitted() async {
+        let (vm, _) = makeVM(queueCount: 3)
+        await vm.loadQueue(authManager: AuthManager())
+        vm.skip()
+        XCTAssertEqual(vm.submittedCount, 0)
+        XCTAssertEqual(vm.currentIndex, 1)
+    }
+
+    // BTH-VM-26: skipping all items → empty state
+    func test_BTH_VM_26_skipAll_empty() async {
+        let (vm, _) = makeVM(queueCount: 2)
+        await vm.loadQueue(authManager: AuthManager())
+        vm.skip()   // → index 1
+        vm.skip()   // → no more items → empty
+        XCTAssertEqual(vm.sessionState, .empty)
+    }
+
+    // BTH-VM-27: reload resets state to idle → loading → ready
+    func test_BTH_VM_27_reload_resetsState() async {
+        let (vm, _) = makeVM(queueCount: 2)
+        await vm.loadQueue(authManager: AuthManager())
+        XCTAssertNotEqual(vm.sessionState, .idle)
+        await vm.reload(authManager: AuthManager())
+        if case .ready = vm.sessionState { } else {
+            XCTFail("Expected .ready after reload, got \(vm.sessionState)")
+        }
+    }
+
+    // BTH-VM-28: guard prevents double-loadQueue
+    func test_BTH_VM_28_guard_preventsDoubleLoad() async {
+        let (vm, mock) = makeVM(queueCount: 1)
+        // Call twice concurrently — guard case .idle should block the second
+        await withTaskGroup(of: Void.self) { group in
+            group.addTask { await vm.loadQueue(authManager: AuthManager()) }
+            group.addTask { await vm.loadQueue(authManager: AuthManager()) }
+        }
+        XCTAssertEqual(mock.fetchQueueCallCount, 1)
+    }
+
+    // BTH-VM-29: enterCorrectionMode / cancelCorrectionMode
+    func test_BTH_VM_29_correctionMode_toggle() async {
+        let (vm, _) = makeVM(queueCount: 1)
+        await vm.loadQueue(authManager: AuthManager())
+        XCTAssertFalse(vm.isInCorrectionMode)
+        vm.enterCorrectionMode()
+        XCTAssertTrue(vm.isInCorrectionMode)
+        vm.cancelCorrectionMode()
+        XCTAssertFalse(vm.isInCorrectionMode)
+    }
+
+    // BTH-VM-30: corrected action exits correction mode
+    func test_BTH_VM_30_corrected_exitsCorrectionMode() async {
+        let (vm, _) = makeVM(queueCount: 2)
+        await vm.loadQueue(authManager: AuthManager())
+        vm.enterCorrectionMode()
+        XCTAssertTrue(vm.isInCorrectionMode)
+        await vm.corrected(tapX: 0.5, tapY: 0.5)
+        XCTAssertFalse(vm.isInCorrectionMode)
+    }
+}


### PR DESCRIPTION
## Summary

- **New standalone tab** — \"Train AI\" (5th tab in \`LFASpecTabView\`; \`brain.head.profile\` icon) — separate from \`JugglingAnnotationScreen\`
- **Session flow**: \`GET /me/ball-training/queue?limit=5\` → 5 assignments → frame-by-frame display → sessionComplete after 5th processed task
- **Frame display**: JPEG from \`GET /me/ball-training/frame/{assignment_id}\`, model ball overlay (colour-coded by confidence, dimmed to 40 % during correction mode), portrait + landscape support
- **Four actions**: Helyes (confirm) / Nincs labda (no_ball) / Javítom (corrected — 3-step confirm flow) / Kihagyom (skip — no POST)
- **Safe correction UX**: tap/drag → cián crosshair marker (no POST); loupe magnifier during drag; model overlay stays visible at 40 % as reference; only \"Megerősítés\" sends corrected POST; \"Új kijelölés\" clears marker; \"Mégse\" exits without POST; out-of-bounds tap silently ignored (no clamp)
- **Double-submit guard**: `!isSubmitting` + `clearPendingTap()` on first confirm
- **State cleanup**: `enterCorrectionMode / cancelCorrectionMode / skip / _doLoadQueue` all call `clearPendingTap()`
- **iOS 15 min-target**, no new dependencies

## HEAD commit

`52c0a7ea5792edff6b54f4c98b47452d5c0d655b`

Commit message: `fix(ios): AN-3B2F PR-2 correction UX + queue limit`

## Test results

### Local iOS suite
- `BallTrainingHubVMTests`: **44/44 PASS** (BTH-VM-01..44)
  - BTH-VM-31..44: new pending-tap / confirm-correction / session-limit tests
- Full suite: **All tests passed — 0 FAIL, 0 regression**

### GitHub CI (commit 52c0a7ea)
| Result | Count |
|--------|-------|
| ✅ pass | **37** |
| ❌ fail | **0** |
| ⏳ pending | **0** |
| ⬜ skipping (informational) | **1** (Preset Weight Audit) |

Key checks:
- ✅ iOS Build + Unit Tests (iOS 15 min-target) — 7m44s
- ✅ Unit Tests (Baseline: 0 failed, 0 errors) — 23m55s
- ✅ All BLOCKING E2E checks (Auth / Booking / Payment / Refund / Session / Student / Instructor / Skill / Enrollment / Multi-Campus / User Account) — PASS
- ✅ Security Gate (CSRF + SQL injection — 63 tests)
- ✅ Load Gate — Phase 6.3 (50 VUs, 10 min)

## Key behaviour evidence

| Behaviour | Source | Test |
|-----------|--------|------|
| Queue uses `?limit=5` | `BallTrainingAPIClient.swift:27` | BTH-VM-43 |
| sessionComplete after 5th submit only | `BallTrainingHubViewModel.swift:227` | BTH-VM-43 |
| Tap sets marker, 0 POST | `BallTrainingHubViewModel.swift:140` | BTH-VM-31 |
| Only Megerősítés sends corrected POST | `BallTrainingHubViewModel.swift:145` | BTH-VM-32 |
| Új kijelölés → 0 POST | `BallTrainingHubViewModel.swift:152` | BTH-VM-37 |
| Mégse → 0 POST + mode=false | `BallTrainingHubViewModel.swift:136` | BTH-VM-38 |
| Double-submit blocked | `BallTrainingHubViewModel.swift:146` | BTH-VM-42 |
| Out-of-bounds tap ignored | `BallTrainingFrameView.swift:168` | (guard, no clamp) |
| reload / skip / cancel clear pending | `BallTrainingHubViewModel.swift:132,137,160,181` | BTH-VM-38,44 |

## Physical iPhone E2E — MERGE-READY ✅

Tested on `player01@lfa-seed.hu` (ID=155776), iPhone `192.168.1.72`, app HEAD `52c0a7ea`, 2026-06-20.

**Session B** (09:26–09:28 UTC, `?limit=5`, 2 × 5-task sessions, 10 × corrected):
**Session C** (09:39–09:40 UTC, `?limit=5`, targeted retest — 1 skip + 2 confirm + 2 no_ball):

| Decision type | Result | Evidence |
|---|---|---|
| ✅ confirm | **PASS** | 2× decision=confirm, corrected_x/y=NULL, HTTP 201, consumed_at immediate |
| ✅ no_ball | **PASS** | 2× decision=no_ball, HTTP 201, consumed_at immediate |
| ✅ corrected flow | **PASS** | 10× loupe during drag → cián marker on release → 0 POST before Megerősítés → Megerősítés=1 corrected POST |
| ✅ skip | **PASS** | Assignment `10e603f6`: GET frame → no POST → no feedback row → consumed_at=NULL → next frame auto-loaded +4.4s |
| ✅ session limit=5 / sessionComplete | **PASS** | Queue `?limit=5` confirmed; 5 items per queue; sessionComplete after all items processed; no 6th queue auto-fetch without user action |

- 0 non-2xx responses across all sessions
- 0 double submits detected
- corrected_x/y ∈ [0,1] confirmed (session B: cx 0.44–0.58, cy 0.31–0.70)
- Skip assignment consumed_at=NULL verified in DB; expires_at was future at skip time (not expiry sweep)

**Full E2E verdict: MERGE-READY**