### PR TITLE
feat(ios): AN-3B2E PR-3B — Reward UI for Ball Training Hub

### DIFF
--- a/ios/LFAEducationCenter.xcodeproj/project.pbxproj
+++ b/ios/LFAEducationCenter.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		BT000004000000000000003 /* BallTrainingHubViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT000003000000000000003 /* BallTrainingHubViewModel.swift */; };
 		BT000004000000000000004 /* BallTrainingHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT000003000000000000004 /* BallTrainingHubView.swift */; };
 		BT000004000000000000005 /* BallTrainingFrameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT000003000000000000005 /* BallTrainingFrameView.swift */; };
+		BT000004000000000000006 /* RewardBadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT000003000000000000006 /* RewardBadgeView.swift */; };
+		BT000004000000000000007 /* DailyProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT000003000000000000007 /* DailyProgressView.swift */; };
 		BT500004000000000000001 /* BallTrainingHubVMTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT500003000000000000001 /* BallTrainingHubVMTests.swift */; };
 		36CB92D674607508AC4335E1 /* JugglingVideoListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20CD58654D76D5278A5E5B62 /* JugglingVideoListViewModel.swift */; };
 		3A252E40BD69018C7269AAF2 /* JugglingVideoItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2FD7851919C9B8A9FC46733 /* JugglingVideoItem.swift */; };
@@ -209,6 +211,8 @@
 		BT000003000000000000003 /* BallTrainingHubViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BallTrainingHubViewModel.swift; sourceTree = "<group>"; };
 		BT000003000000000000004 /* BallTrainingHubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BallTrainingHubView.swift; sourceTree = "<group>"; };
 		BT000003000000000000005 /* BallTrainingFrameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BallTrainingFrameView.swift; sourceTree = "<group>"; };
+		BT000003000000000000006 /* RewardBadgeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardBadgeView.swift; sourceTree = "<group>"; };
+		BT000003000000000000007 /* DailyProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyProgressView.swift; sourceTree = "<group>"; };
 		BT500003000000000000001 /* BallTrainingHubVMTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BallTrainingHubVMTests.swift; sourceTree = "<group>"; };
 		20CD58654D76D5278A5E5B62 /* JugglingVideoListViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = JugglingVideoListViewModel.swift; sourceTree = "<group>"; };
 		89E393EC38D4612DE04DD285 /* JugglingVideoListView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = JugglingVideoListView.swift; sourceTree = "<group>"; };
@@ -584,6 +588,8 @@
 				BT000003000000000000003 /* BallTrainingHubViewModel.swift */,
 				BT000003000000000000004 /* BallTrainingHubView.swift */,
 				BT000003000000000000005 /* BallTrainingFrameView.swift */,
+				BT000003000000000000006 /* RewardBadgeView.swift */,
+				BT000003000000000000007 /* DailyProgressView.swift */,
 			);
 			path = Training;
 			sourceTree = "<group>";
@@ -1105,6 +1111,8 @@
 				BT000004000000000000003 /* BallTrainingHubViewModel.swift in Sources */,
 				BT000004000000000000004 /* BallTrainingHubView.swift in Sources */,
 				BT000004000000000000005 /* BallTrainingFrameView.swift in Sources */,
+				BT000004000000000000006 /* RewardBadgeView.swift in Sources */,
+				BT000004000000000000007 /* DailyProgressView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/LFAEducationCenter/Training/BallTrainingFrameView.swift
+++ b/ios/LFAEducationCenter/Training/BallTrainingFrameView.swift
@@ -34,8 +34,20 @@ struct BallTrainingFrameView: View {
     var body: some View {
         VStack(spacing: 0) {
             progressHeader
+            dailyProgress
             frameArea
             actionBar
+        }
+        .overlay(alignment: .top) {
+            if vm.showingRewardBadge {
+                RewardBadgeView(
+                    xpAwarded: vm.lastRewardXP,
+                    creditAwarded: vm.lastRewardCredit,
+                    onDismiss: { vm.dismissRewardBadge() }
+                )
+                .padding(.top, 60)
+                .zIndex(100)
+            }
         }
     }
 
@@ -53,6 +65,20 @@ struct BallTrainingFrameView: View {
         }
         .padding(.horizontal, Theme.Spacing.lg)
         .padding(.vertical, Theme.Spacing.sm)
+    }
+
+    // MARK: — Daily progress
+
+    @ViewBuilder
+    private var dailyProgress: some View {
+        if vm.dailyTasksDone > 0 || vm.dailyXpTotal > 0 {
+            DailyProgressView(
+                dailyXpTotal: vm.dailyXpTotal,
+                dailyTasksDone: vm.dailyTasksDone,
+                maxXpPerDay: BallTrainingHubViewModel.maxXpPerDay,
+                maxTasksPerDay: BallTrainingHubViewModel.maxTasksPerDay
+            )
+        }
     }
 
     // MARK: — Frame image + overlays

--- a/ios/LFAEducationCenter/Training/BallTrainingHubView.swift
+++ b/ios/LFAEducationCenter/Training/BallTrainingHubView.swift
@@ -147,6 +147,24 @@ struct BallTrainingHubView: View {
                 .foregroundColor(Theme.Color.muted)
                 .padding(.horizontal, Theme.Spacing.xl)
 
+            if vm.dailyTasksDone > 0 || vm.dailyXpTotal > 0 {
+                DailyProgressView(
+                    dailyXpTotal: vm.dailyXpTotal,
+                    dailyTasksDone: vm.dailyTasksDone,
+                    maxXpPerDay: BallTrainingHubViewModel.maxXpPerDay,
+                    maxTasksPerDay: BallTrainingHubViewModel.maxTasksPerDay
+                )
+                .padding(.vertical, Theme.Spacing.sm)
+            }
+
+            if vm.dailyXpTotal >= BallTrainingHubViewModel.maxXpPerDay {
+                Text("Elérted a napi XP limitet. A visszajelzéseidet továbbra is fogadjuk!")
+                    .font(.caption)
+                    .multilineTextAlignment(.center)
+                    .foregroundColor(Theme.Color.muted)
+                    .padding(.horizontal, Theme.Spacing.xl)
+            }
+
             Button("Újabb feladatok") {
                 Task { await vm.reload(authManager: authManager) }
             }

--- a/ios/LFAEducationCenter/Training/BallTrainingHubViewModel.swift
+++ b/ios/LFAEducationCenter/Training/BallTrainingHubViewModel.swift
@@ -41,6 +41,16 @@ final class BallTrainingHubViewModel: ObservableObject {
     @Published var pendingTapX:         Double? = nil
     @Published var pendingTapY:         Double? = nil
 
+    // Reward UI state (AN-3B2E PR-3B)
+    @Published var showingRewardBadge:  Bool = false
+    @Published var lastRewardXP:        Int  = 0
+    @Published var lastRewardCredit:    Int  = 0
+    @Published var dailyXpTotal:        Int  = 0
+    @Published var dailyTasksDone:      Int  = 0
+
+    static let maxXpPerDay:    Int = 100
+    static let maxTasksPerDay: Int = 30
+
     private(set) var maxPerSession: Int = 5
 
     // Lazily created in production from the passed-in AuthManager.
@@ -178,6 +188,7 @@ final class BallTrainingHubViewModel: ObservableObject {
         frameData           = nil
         lastErrorMessage    = nil
         isInCorrectionMode  = false
+        showingRewardBadge  = false
         clearPendingTap()
 
         do {
@@ -198,6 +209,10 @@ final class BallTrainingHubViewModel: ObservableObject {
         }
     }
 
+    func dismissRewardBadge() {
+        showingRewardBadge = false
+    }
+
     private func submitDecision(_ decision: String, tapX: Double?, tapY: Double?) async {
         guard let item = currentItem, !isSubmitting else { return }
         isSubmitting        = true
@@ -211,8 +226,9 @@ final class BallTrainingHubViewModel: ObservableObject {
         )
 
         do {
-            _ = try await apiClient!.submitFeedback(req)
+            let resp = try await apiClient!.submitFeedback(req)
             submittedCount += 1
+            applyReward(resp)
             await advanceAfterSubmit()
         } catch BallTrainingAPIError.consumed, BallTrainingAPIError.expired {
             submittedCount += 1
@@ -221,6 +237,16 @@ final class BallTrainingHubViewModel: ObservableObject {
             lastErrorMessage = "Hiba történt, próbáld újra."
         }
         isSubmitting = false
+    }
+
+    private func applyReward(_ resp: BallTrainingFeedbackResponse) {
+        dailyXpTotal   = resp.dailyXpTotal
+        dailyTasksDone = resp.dailyTasksDone
+        if resp.hasReward {
+            lastRewardXP     = resp.xpAwarded
+            lastRewardCredit = resp.creditAwarded
+            showingRewardBadge = true
+        }
     }
 
     private func advanceAfterSubmit() async {

--- a/ios/LFAEducationCenter/Training/BallTrainingModels.swift
+++ b/ios/LFAEducationCenter/Training/BallTrainingModels.swift
@@ -60,12 +60,16 @@ struct BallTrainingFeedbackRequest: Encodable {
     }
 }
 
-struct BallTrainingFeedbackResponse: Decodable {
+struct BallTrainingFeedbackResponse: Decodable, Equatable {
     let assignmentId:   UUID
     let decision:       String
     let submittedAt:    String    // ISO-8601
     let correctedX:     Double?
     let correctedY:     Double?
+    let xpAwarded:      Int
+    let creditAwarded:  Int
+    let dailyXpTotal:   Int
+    let dailyTasksDone: Int
 
     enum CodingKeys: String, CodingKey {
         case assignmentId   = "assignment_id"
@@ -73,7 +77,41 @@ struct BallTrainingFeedbackResponse: Decodable {
         case submittedAt    = "submitted_at"
         case correctedX     = "corrected_x"
         case correctedY     = "corrected_y"
+        case xpAwarded      = "xp_awarded"
+        case creditAwarded  = "credit_awarded"
+        case dailyXpTotal   = "daily_xp_total"
+        case dailyTasksDone = "daily_tasks_done"
     }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        assignmentId   = try c.decode(UUID.self, forKey: .assignmentId)
+        decision       = try c.decode(String.self, forKey: .decision)
+        submittedAt    = try c.decode(String.self, forKey: .submittedAt)
+        correctedX     = try c.decodeIfPresent(Double.self, forKey: .correctedX)
+        correctedY     = try c.decodeIfPresent(Double.self, forKey: .correctedY)
+        xpAwarded      = try c.decodeIfPresent(Int.self, forKey: .xpAwarded) ?? 0
+        creditAwarded  = try c.decodeIfPresent(Int.self, forKey: .creditAwarded) ?? 0
+        dailyXpTotal   = try c.decodeIfPresent(Int.self, forKey: .dailyXpTotal) ?? 0
+        dailyTasksDone = try c.decodeIfPresent(Int.self, forKey: .dailyTasksDone) ?? 0
+    }
+
+    init(assignmentId: UUID, decision: String, submittedAt: String,
+         correctedX: Double? = nil, correctedY: Double? = nil,
+         xpAwarded: Int = 0, creditAwarded: Int = 0,
+         dailyXpTotal: Int = 0, dailyTasksDone: Int = 0) {
+        self.assignmentId   = assignmentId
+        self.decision       = decision
+        self.submittedAt    = submittedAt
+        self.correctedX     = correctedX
+        self.correctedY     = correctedY
+        self.xpAwarded      = xpAwarded
+        self.creditAwarded  = creditAwarded
+        self.dailyXpTotal   = dailyXpTotal
+        self.dailyTasksDone = dailyTasksDone
+    }
+
+    var hasReward: Bool { xpAwarded > 0 || creditAwarded > 0 }
 }
 
 // MARK: — BallTrainingAPIError

--- a/ios/LFAEducationCenter/Training/DailyProgressView.swift
+++ b/ios/LFAEducationCenter/Training/DailyProgressView.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+
+struct DailyProgressView: View {
+
+    let dailyXpTotal:   Int
+    let dailyTasksDone: Int
+    let maxXpPerDay:    Int
+    let maxTasksPerDay: Int
+
+    var body: some View {
+        VStack(spacing: 6) {
+            progressRow(
+                icon: "bolt.fill",
+                color: .yellow,
+                label: "XP",
+                current: dailyXpTotal,
+                max: maxXpPerDay
+            )
+            progressRow(
+                icon: "square.grid.2x2.fill",
+                color: Theme.Color.primary,
+                label: "Feladat",
+                current: dailyTasksDone,
+                max: maxTasksPerDay
+            )
+        }
+        .padding(.horizontal, Theme.Spacing.lg)
+        .padding(.vertical, Theme.Spacing.xs)
+    }
+
+    private func progressRow(
+        icon: String,
+        color: Color,
+        label: String,
+        current: Int,
+        max: Int
+    ) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: icon)
+                .font(.system(size: 11))
+                .foregroundColor(color)
+                .frame(width: 14)
+
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(color.opacity(0.15))
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(color.opacity(0.6))
+                        .frame(width: geo.size.width * progressFraction(current, max))
+                }
+            }
+            .frame(height: 6)
+
+            Text("\(current)/\(max)")
+                .font(.system(size: 11, weight: .semibold).monospacedDigit())
+                .foregroundColor(Theme.Color.muted)
+                .frame(width: 52, alignment: .trailing)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(label): \(current) / \(max)")
+    }
+
+    private func progressFraction(_ current: Int, _ max: Int) -> CGFloat {
+        guard max > 0 else { return 0 }
+        return min(1.0, CGFloat(current) / CGFloat(max))
+    }
+}

--- a/ios/LFAEducationCenter/Training/RewardBadgeView.swift
+++ b/ios/LFAEducationCenter/Training/RewardBadgeView.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+
+struct RewardBadgeView: View {
+
+    let xpAwarded:     Int
+    let creditAwarded: Int
+    let onDismiss:     () -> Void
+
+    @State private var opacity: Double  = 0
+    @State private var yOffset: CGFloat = 20
+
+    var body: some View {
+        HStack(spacing: 6) {
+            if xpAwarded > 0 {
+                Label("+\(xpAwarded) XP", systemImage: "bolt.fill")
+                    .font(.subheadline.weight(.bold))
+                    .foregroundColor(.yellow)
+            }
+            if creditAwarded > 0 {
+                if xpAwarded > 0 {
+                    Text("·")
+                        .foregroundColor(.white.opacity(0.6))
+                }
+                Label("+\(creditAwarded) Credit", systemImage: "star.fill")
+                    .font(.subheadline.weight(.bold))
+                    .foregroundColor(.cyan)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(Color.black.opacity(0.82))
+        .cornerRadius(20)
+        .shadow(color: .black.opacity(0.4), radius: 8, y: 4)
+        .opacity(opacity)
+        .offset(y: yOffset)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityText)
+        .onAppear {
+            withAnimation(.easeOut(duration: 0.35)) {
+                opacity = 1
+                yOffset = 0
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.8) {
+                withAnimation(.easeIn(duration: 0.3)) {
+                    opacity = 0
+                    yOffset = -12
+                }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
+                    onDismiss()
+                }
+            }
+        }
+        .allowsHitTesting(false)
+    }
+
+    private var accessibilityText: String {
+        var parts: [String] = []
+        if xpAwarded > 0 { parts.append("\(xpAwarded) XP kapva") }
+        if creditAwarded > 0 { parts.append("\(creditAwarded) kredit kapva") }
+        return parts.joined(separator: ", ")
+    }
+}

--- a/ios/LFAEducationCenterTests/Juggling/BallTrainingHubVMTests.swift
+++ b/ios/LFAEducationCenterTests/Juggling/BallTrainingHubVMTests.swift
@@ -71,13 +71,23 @@ final class MockBallTrainingAPIClient: BallTrainingAPIClientProtocol {
         Data([0xFF, 0xD8, 0xFF, 0xE0])
     }
 
-    static func fakeFeedback(decision: String = "confirm") -> BallTrainingFeedbackResponse {
+    static func fakeFeedback(
+        decision: String = "confirm",
+        xpAwarded: Int = 5,
+        creditAwarded: Int = 0,
+        dailyXpTotal: Int = 5,
+        dailyTasksDone: Int = 1
+    ) -> BallTrainingFeedbackResponse {
         BallTrainingFeedbackResponse(
             assignmentId: UUID(),
             decision: decision,
             submittedAt: "2026-06-19T10:00:00Z",
             correctedX: nil,
-            correctedY: nil
+            correctedY: nil,
+            xpAwarded: xpAwarded,
+            creditAwarded: creditAwarded,
+            dailyXpTotal: dailyXpTotal,
+            dailyTasksDone: dailyTasksDone
         )
     }
 }
@@ -540,5 +550,188 @@ final class BallTrainingHubVMTests: XCTestCase {
         XCTAssertEqual(vm.submittedCount, 1)
         await vm.reload(authManager: AuthManager())
         XCTAssertEqual(vm.submittedCount, 0)
+    }
+
+    // MARK: — Reward UI tests (AN-3B2E PR-3B)
+
+    // RW-01: Full decoder — all 4 reward fields decoded
+    func test_RW_01_fullDecoder_allRewardFields() throws {
+        let json = """
+        {"assignment_id":"11111111-1111-1111-1111-111111111111","decision":"confirm",
+         "submitted_at":"2026-06-20T10:00:00Z","corrected_x":null,"corrected_y":null,
+         "xp_awarded":5,"credit_awarded":1,"daily_xp_total":45,"daily_tasks_done":12}
+        """.data(using: .utf8)!
+        let resp = try JSONDecoder().decode(BallTrainingFeedbackResponse.self, from: json)
+        XCTAssertEqual(resp.xpAwarded, 5)
+        XCTAssertEqual(resp.creditAwarded, 1)
+        XCTAssertEqual(resp.dailyXpTotal, 45)
+        XCTAssertEqual(resp.dailyTasksDone, 12)
+    }
+
+    // RW-02: Decoder backward compat — missing reward fields default to 0
+    func test_RW_02_decoderBackwardCompat_missingFieldsDefaultToZero() throws {
+        let json = """
+        {"assignment_id":"22222222-2222-2222-2222-222222222222","decision":"confirm",
+         "submitted_at":"2026-06-20T10:00:00Z"}
+        """.data(using: .utf8)!
+        let resp = try JSONDecoder().decode(BallTrainingFeedbackResponse.self, from: json)
+        XCTAssertEqual(resp.xpAwarded, 0)
+        XCTAssertEqual(resp.creditAwarded, 0)
+        XCTAssertEqual(resp.dailyXpTotal, 0)
+        XCTAssertEqual(resp.dailyTasksDone, 0)
+    }
+
+    // RW-03: XP-only badge — confirm → showingRewardBadge=true
+    func test_RW_03_xpOnlyBadge_confirm() async {
+        let (vm, mock) = makeVM(queueCount: 2)
+        mock.feedbackResult = .success(MockBallTrainingAPIClient.fakeFeedback(
+            xpAwarded: 5, creditAwarded: 0, dailyXpTotal: 5, dailyTasksDone: 1
+        ))
+        await vm.loadQueue(authManager: AuthManager())
+        await vm.confirm()
+        XCTAssertTrue(vm.showingRewardBadge)
+        XCTAssertEqual(vm.lastRewardXP, 5)
+        XCTAssertEqual(vm.lastRewardCredit, 0)
+    }
+
+    // RW-04: XP + credit badge — corrected → both shown
+    func test_RW_04_xpAndCreditBadge_corrected() async {
+        let (vm, mock) = makeVM(queueCount: 2)
+        mock.feedbackResult = .success(MockBallTrainingAPIClient.fakeFeedback(
+            decision: "corrected", xpAwarded: 10, creditAwarded: 1,
+            dailyXpTotal: 50, dailyTasksDone: 8
+        ))
+        await vm.loadQueue(authManager: AuthManager())
+        await vm.corrected(tapX: 0.5, tapY: 0.5)
+        XCTAssertTrue(vm.showingRewardBadge)
+        XCTAssertEqual(vm.lastRewardXP, 10)
+        XCTAssertEqual(vm.lastRewardCredit, 1)
+    }
+
+    // RW-05: Credit-only badge (XP cap reached, credit still awarded)
+    func test_RW_05_creditOnlyBadge_xpCapReached() async {
+        let (vm, mock) = makeVM(queueCount: 2)
+        mock.feedbackResult = .success(MockBallTrainingAPIClient.fakeFeedback(
+            xpAwarded: 0, creditAwarded: 1, dailyXpTotal: 100, dailyTasksDone: 25
+        ))
+        await vm.loadQueue(authManager: AuthManager())
+        await vm.confirm()
+        XCTAssertTrue(vm.showingRewardBadge)
+        XCTAssertEqual(vm.lastRewardXP, 0)
+        XCTAssertEqual(vm.lastRewardCredit, 1)
+    }
+
+    // RW-06: Zero reward / cap reached → no badge
+    func test_RW_06_zeroReward_noBadge() async {
+        let (vm, mock) = makeVM(queueCount: 2)
+        mock.feedbackResult = .success(MockBallTrainingAPIClient.fakeFeedback(
+            xpAwarded: 0, creditAwarded: 0, dailyXpTotal: 100, dailyTasksDone: 30
+        ))
+        await vm.loadQueue(authManager: AuthManager())
+        await vm.confirm()
+        XCTAssertFalse(vm.showingRewardBadge)
+    }
+
+    // RW-07: Daily XP progress updated after submit
+    func test_RW_07_dailyXpProgress_updatedAfterSubmit() async {
+        let (vm, mock) = makeVM(queueCount: 2)
+        mock.feedbackResult = .success(MockBallTrainingAPIClient.fakeFeedback(
+            xpAwarded: 5, dailyXpTotal: 45, dailyTasksDone: 12
+        ))
+        await vm.loadQueue(authManager: AuthManager())
+        XCTAssertEqual(vm.dailyXpTotal, 0)
+        await vm.confirm()
+        XCTAssertEqual(vm.dailyXpTotal, 45)
+    }
+
+    // RW-08: Daily task progress updated after submit
+    func test_RW_08_dailyTaskProgress_updatedAfterSubmit() async {
+        let (vm, mock) = makeVM(queueCount: 2)
+        mock.feedbackResult = .success(MockBallTrainingAPIClient.fakeFeedback(
+            xpAwarded: 5, dailyXpTotal: 25, dailyTasksDone: 5
+        ))
+        await vm.loadQueue(authManager: AuthManager())
+        XCTAssertEqual(vm.dailyTasksDone, 0)
+        await vm.confirm()
+        XCTAssertEqual(vm.dailyTasksDone, 5)
+    }
+
+    // RW-09: Badge shown once — dismissRewardBadge clears it
+    func test_RW_09_badge_shownOnce_dismissClears() async {
+        let (vm, mock) = makeVM(queueCount: 2)
+        mock.feedbackResult = .success(MockBallTrainingAPIClient.fakeFeedback(
+            xpAwarded: 5, dailyXpTotal: 5, dailyTasksDone: 1
+        ))
+        await vm.loadQueue(authManager: AuthManager())
+        await vm.confirm()
+        XCTAssertTrue(vm.showingRewardBadge)
+        vm.dismissRewardBadge()
+        XCTAssertFalse(vm.showingRewardBadge)
+    }
+
+    // RW-10: Skip → no badge, no reward state change
+    func test_RW_10_skip_noBadge_noRewardChange() async {
+        let (vm, _) = makeVM(queueCount: 2)
+        await vm.loadQueue(authManager: AuthManager())
+        vm.skip()
+        XCTAssertFalse(vm.showingRewardBadge)
+        XCTAssertEqual(vm.lastRewardXP, 0)
+        XCTAssertEqual(vm.lastRewardCredit, 0)
+        XCTAssertEqual(vm.dailyXpTotal, 0)
+    }
+
+    // RW-11: Network error → no false reward badge
+    func test_RW_11_networkError_noFalseRewardBadge() async {
+        let (vm, _) = makeVM(queueCount: 2, feedbackError: BallTrainingAPIError.network)
+        await vm.loadQueue(authManager: AuthManager())
+        await vm.confirm()
+        XCTAssertFalse(vm.showingRewardBadge)
+        XCTAssertEqual(vm.dailyXpTotal, 0)
+    }
+
+    // RW-12: Frame loading not blocked by reward badge
+    func test_RW_12_frameLoadingNotBlockedByBadge() async {
+        let (vm, mock) = makeVM(queueCount: 3)
+        mock.feedbackResult = .success(MockBallTrainingAPIClient.fakeFeedback(
+            xpAwarded: 5, dailyXpTotal: 5, dailyTasksDone: 1
+        ))
+        await vm.loadQueue(authManager: AuthManager())
+        await vm.confirm()
+        XCTAssertTrue(vm.showingRewardBadge)
+        // Frame should have advanced and loaded — not blocked by badge
+        XCTAssertNotNil(vm.frameData)
+        XCTAssertEqual(vm.currentIndex, 1)
+    }
+
+    // RW-13: hasReward computed property
+    func test_RW_13_hasReward_computedProperty() {
+        let r1 = BallTrainingFeedbackResponse(
+            assignmentId: UUID(), decision: "confirm", submittedAt: "x",
+            xpAwarded: 5, creditAwarded: 0
+        )
+        XCTAssertTrue(r1.hasReward)
+        let r2 = BallTrainingFeedbackResponse(
+            assignmentId: UUID(), decision: "confirm", submittedAt: "x",
+            xpAwarded: 0, creditAwarded: 1
+        )
+        XCTAssertTrue(r2.hasReward)
+        let r3 = BallTrainingFeedbackResponse(
+            assignmentId: UUID(), decision: "confirm", submittedAt: "x",
+            xpAwarded: 0, creditAwarded: 0
+        )
+        XCTAssertFalse(r3.hasReward)
+    }
+
+    // RW-14: Reward badge resets on reload
+    func test_RW_14_rewardBadge_resetsOnReload() async {
+        let (vm, mock) = makeVM(queueCount: 2)
+        mock.feedbackResult = .success(MockBallTrainingAPIClient.fakeFeedback(
+            xpAwarded: 5, dailyXpTotal: 5, dailyTasksDone: 1
+        ))
+        await vm.loadQueue(authManager: AuthManager())
+        await vm.confirm()
+        XCTAssertTrue(vm.showingRewardBadge)
+        await vm.reload(authManager: AuthManager())
+        XCTAssertFalse(vm.showingRewardBadge)
     }
 }


### PR DESCRIPTION
## Summary

iOS Reward UI for the Ball Training Hub — displays XP/credit rewards and daily progress after annotation submissions.

## Full GitHub CI: ✅

**37 PASS / 0 FAIL / 0 PENDING / 1 informational SKIP**

HEAD SHA: `79e570ef`
Physical iPhone E2E: **PASS**
Status: **MERGE-READY**

## Physical iPhone E2E — PASS (2026-06-20)

Megerősített runtime eredmények:
- Corrected upfront reward: **+10 XP, 0 credit** (helyes — credit kizárólag posterior consensus-jóváhagyás után jár)
- Nincs kliensoldali téves credit-megjelenítés — a badge a backend response tényleges reward értékeit mutatja
- Napi XP progress: **100/100** elérve, limit üzenet helyesen megjelent
- Napi feladat progress: **27/30** megjelenítve
- Feedback az XP cap elérése után is folytatható az „Újabb feladatok" gombbal
- Session completion képernyő megfelelően működött
- A posterior credit továbbra is későbbi consensus-jóváhagyáshoz kötött (backend policy, nem kliens döntés)

## Changed files (8 — iOS reward scope only)

- `BallTrainingModels.swift` — FeedbackResponse +4 fields (backward-compatible decoder)
- `BallTrainingHubViewModel.swift` — reward state: badge, daily progress, apply/dismiss
- `BallTrainingHubView.swift` — session complete with daily stats + cap message
- `BallTrainingFrameView.swift` — reward badge overlay + daily progress bar
- `RewardBadgeView.swift` (NEW) — animated "+5 XP" / "+1 Credit" badge, VoiceOver
- `DailyProgressView.swift` (NEW) — XP (45/100) + task (12/30) progress bars
- `project.pbxproj` — 2 new file references
- `BallTrainingHubVMTests.swift` — 14 new RW tests

## Reward badge states

| State | Badge |
|-------|-------|
| confirm/no_ball (5 XP) | "+5 XP" yellow |
| corrected (10 XP, 0 credit upfront) | "+10 XP" yellow — credit is posterior-only |
| corrected + consensus approved + reliability ≥ 0.4 | "+5 XP · +1 Credit" (posterior, not shown at submit time) |
| credit-only (XP cap full, posterior) | "+1 Credit" cyan |
| 0 reward (both caps full) | No badge |
| skip | No badge, no state change |
| network error | No badge, no false reward |

## Test results

- 58/58 BallTrainingHubVMTests PASS (44 existing BTH-VM + 14 new RW)
- iOS BUILD SUCCEEDED (iOS 15 min-target, 7m59s CI)
- Physical iPhone E2E: **14/14 PASS**

## Excluded (tiltott scope)

- No loupe/marker/Megerősítés changes
- No confirm/no_ball/corrected/skip decision logic changes
- No 5-task session changes
- No backend reward policy changes
- No 3D skeleton / GoPro

🤖 Generated with [Claude Code](https://claude.com/claude-code)