### PR TITLE
feat(multicamera): AN-3B PR-4B3A — Session API (6 endpoints)

### DIFF
--- a/app/api/api_v1/api.py
+++ b/app/api/api_v1/api.py
@@ -213,3 +213,7 @@ api_router.include_router(
 )
 api_router.include_router(sandbox.router, prefix="/sandbox", tags=["sandbox-testing"])
 api_router.include_router(sandbox_data.router, prefix="/sandbox", tags=["sandbox-data"])
+
+# ── MULTICAMERA ──────────────────────────────────────────────────────────────
+from .endpoints.multicamera import sessions as multicamera_sessions
+api_router.include_router(multicamera_sessions.router, prefix="/multicamera", tags=["multicamera"])

--- a/app/api/api_v1/endpoints/multicamera/sessions.py
+++ b/app/api/api_v1/endpoints/multicamera/sessions.py
@@ -1,0 +1,258 @@
+"""Multicamera session API — AN-3B PR-4B3A.
+
+6 endpoints. No UI, no shutter, no recording, no media.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from .....database import get_db
+from .....dependencies import get_current_active_user
+from .....models.user import User
+from .....models.multicamera_session import SessionParticipant
+from .....schemas.multicamera_session import (
+    DeviceRole, DeviceType, MultiCameraSessionDTO, ParticipantRole,
+    SessionDeviceDTO, SessionParticipantDTO, SessionStatus,
+)
+from .....services.multicamera.session_service import SessionService
+from .....services.multicamera.device_service import DeviceService
+from .....services.multicamera.exceptions import (
+    CrossSessionReferenceError, DeviceNotFoundError, DeviceRoleViolationError,
+    InvalidTransitionError, ParticipantNotFoundError, RevisionConflictError,
+    SessionFullError, SessionNotFoundError,
+)
+
+router = APIRouter()
+
+
+# ── Request / Response schemas ───────────────────────────────────────────────
+
+class CreateSessionRequest(BaseModel):
+    max_participants: int = Field(2, ge=1, le=4)
+    max_devices: int = Field(4, ge=1, le=8)
+
+
+class JoinSessionRequest(BaseModel):
+    role: ParticipantRole
+
+
+class TransitionRequest(BaseModel):
+    target_status: SessionStatus
+    revision: int
+
+
+class RegisterDeviceRequest(BaseModel):
+    device_uuid: Optional[uuid.UUID] = None
+    device_type: Optional[DeviceType] = None
+    device_name: Optional[str] = None
+    ble_identifier: Optional[str] = None
+    device_role: DeviceRole
+    participant_id: Optional[int] = None
+    managed_by_device_id: Optional[int] = None
+
+
+class HeartbeatResponse(BaseModel):
+    session_device_id: int
+    last_heartbeat: datetime
+
+
+# ── Guards ───────────────────────────────────────────────────────────────────
+
+def _require_participant(db: Session, session_uuid: uuid.UUID, user: User) -> tuple:
+    ss = SessionService(db)
+    session = ss.get_session(session_uuid)
+    participant = db.query(SessionParticipant).filter(
+        SessionParticipant.session_id == session.id,
+        SessionParticipant.user_id == user.id,
+        SessionParticipant.left_at.is_(None),
+    ).first()
+    if not participant:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not a session participant")
+    return session, participant
+
+
+def _require_instructor(db: Session, session_uuid: uuid.UUID, user: User) -> tuple:
+    session, participant = _require_participant(db, session_uuid, user)
+    if participant.role != "instructor":
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Only instructor can transition session")
+    return session, participant
+
+
+def _handle_service_error(e: Exception):
+    if isinstance(e, SessionNotFoundError):
+        raise HTTPException(status_code=404, detail="Session not found")
+    if isinstance(e, DeviceNotFoundError):
+        raise HTTPException(status_code=404, detail="Device not found")
+    if isinstance(e, ParticipantNotFoundError):
+        raise HTTPException(status_code=404, detail="Participant not found")
+    if isinstance(e, RevisionConflictError):
+        raise HTTPException(status_code=409, detail=str(e))
+    if isinstance(e, SessionFullError):
+        raise HTTPException(status_code=409, detail=str(e))
+    if isinstance(e, InvalidTransitionError):
+        raise HTTPException(status_code=422, detail=str(e))
+    if isinstance(e, CrossSessionReferenceError):
+        raise HTTPException(status_code=422, detail=str(e))
+    if isinstance(e, DeviceRoleViolationError):
+        raise HTTPException(status_code=422, detail=str(e))
+    raise
+
+
+# ── Endpoints ────────────────────────────────────────────────────────────────
+
+@router.post("/sessions", status_code=status.HTTP_201_CREATED, response_model=MultiCameraSessionDTO)
+def create_session(
+    body: CreateSessionRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    try:
+        ss = SessionService(db)
+        session = ss.create_session(current_user.id, body.max_participants, body.max_devices)
+        ss.join_session(session.session_uuid, current_user.id, "instructor")
+        return ss.get_session(session.session_uuid)
+    except Exception as e:
+        _handle_service_error(e)
+
+
+@router.get("/sessions/{session_uuid}", response_model=MultiCameraSessionDTO)
+def get_session(
+    session_uuid: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    try:
+        session, _ = _require_participant(db, session_uuid, current_user)
+        return SessionService(db).get_session(session_uuid)
+    except HTTPException:
+        raise
+    except Exception as e:
+        _handle_service_error(e)
+
+
+@router.post("/sessions/{session_uuid}/join", response_model=SessionParticipantDTO)
+def join_session(
+    session_uuid: uuid.UUID,
+    body: JoinSessionRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    try:
+        return SessionService(db).join_session(session_uuid, current_user.id, body.role.value)
+    except Exception as e:
+        _handle_service_error(e)
+
+
+@router.patch("/sessions/{session_uuid}/status", response_model=MultiCameraSessionDTO)
+def transition_session(
+    session_uuid: uuid.UUID,
+    body: TransitionRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    try:
+        _require_instructor(db, session_uuid, current_user)
+        ss = SessionService(db)
+        ss.transition_session(session_uuid, body.target_status.value, body.revision)
+        return ss.get_session(session_uuid)
+    except HTTPException:
+        raise
+    except Exception as e:
+        _handle_service_error(e)
+
+
+@router.post("/sessions/{session_uuid}/devices", status_code=status.HTTP_201_CREATED, response_model=SessionDeviceDTO)
+def register_device(
+    session_uuid: uuid.UUID,
+    body: RegisterDeviceRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    try:
+        session, participant = _require_participant(db, session_uuid, current_user)
+        ss = SessionService(db)
+
+        if body.device_uuid:
+            from .....repositories.multicamera_session_repo import MultiCameraSessionRepo
+            repo = MultiCameraSessionRepo(db)
+            md = repo.get_managed_device_by_uuid(body.device_uuid)
+            if not md:
+                raise HTTPException(status_code=404, detail="Managed device not found")
+            if md.owner_user_id != current_user.id:
+                raise HTTPException(status_code=403, detail="Not device owner")
+            device_uuid = body.device_uuid
+        elif body.device_type:
+            ds = DeviceService(db)
+            md = ds.register_managed_device(
+                current_user.id, body.device_type.value,
+                body.device_name, body.ble_identifier,
+            )
+            device_uuid = md.device_uuid
+        else:
+            raise HTTPException(status_code=422, detail="Provide device_uuid or device_type")
+
+        if body.managed_by_device_id is not None:
+            from .....repositories.multicamera_session_repo import MultiCameraSessionRepo
+            repo = MultiCameraSessionRepo(db)
+            manager_sd = repo.get_session_device_by_id(body.managed_by_device_id)
+            if manager_sd and manager_sd.participant_id:
+                manager_participant = db.query(SessionParticipant).filter(
+                    SessionParticipant.id == manager_sd.participant_id
+                ).first()
+                if manager_participant and manager_participant.user_id != current_user.id:
+                    raise HTTPException(status_code=403, detail="Not authorized to manage this device")
+
+        return ss.register_device(
+            session_uuid, device_uuid, body.device_role.value,
+            participant_id=body.participant_id,
+            managed_by_device_id=body.managed_by_device_id,
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        _handle_service_error(e)
+
+
+@router.post("/sessions/{session_uuid}/devices/{session_device_id}/heartbeat", response_model=HeartbeatResponse)
+def heartbeat(
+    session_uuid: uuid.UUID,
+    session_device_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    try:
+        session, _ = _require_participant(db, session_uuid, current_user)
+
+        from .....repositories.multicamera_session_repo import MultiCameraSessionRepo
+        repo = MultiCameraSessionRepo(db)
+        sd = repo.get_session_device_by_id(session_device_id)
+        if not sd or sd.session_id != session.id:
+            raise HTTPException(status_code=404, detail="Session device not found")
+
+        authorized = False
+        if sd.participant_id:
+            p = db.query(SessionParticipant).filter(SessionParticipant.id == sd.participant_id).first()
+            if p and p.user_id == current_user.id:
+                authorized = True
+        if not authorized and sd.managed_by_device_id:
+            manager = repo.get_session_device_by_id(sd.managed_by_device_id)
+            if manager and manager.participant_id:
+                mp = db.query(SessionParticipant).filter(SessionParticipant.id == manager.participant_id).first()
+                if mp and mp.user_id == current_user.id:
+                    authorized = True
+        if not authorized:
+            raise HTTPException(status_code=403, detail="Not authorized for this device")
+
+        ss = SessionService(db)
+        ts = ss.heartbeat(session_device_id)
+        return HeartbeatResponse(session_device_id=session_device_id, last_heartbeat=ts)
+    except HTTPException:
+        raise
+    except Exception as e:
+        _handle_service_error(e)

--- a/tests/biometric/test_admin_review_api.py
+++ b/tests/biometric/test_admin_review_api.py
@@ -548,7 +548,7 @@ def test_bca_adm21_override_audit_no_score(db, biometric_feature_enabled):
 def test_bca_adm22_route_count_883():
     from app.main import app
     paths = app.openapi().get("paths", {})
-    assert len(paths) == 914, f"Expected 912 routes (AN-3B2F PR-1A: +2 ball-training paths), got {len(paths)}"
+    assert len(paths) == 920, f"Expected 912 routes (AN-3B2F PR-1A: +2 ball-training paths), got {len(paths)}"
     assert "/api/v1/admin/biometric/review-queue" in paths
     assert "/api/v1/admin/biometric/{user_id}/history" in paths
     assert "/api/v1/admin/biometric/{user_id}/override" in paths

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -6542,6 +6542,62 @@
         "title": "BookingWithRelations",
         "type": "object"
       },
+      "CalibrationPlaceholder": {
+        "properties": {
+          "calibration_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Calibration Id"
+          },
+          "intrinsic_cameras": {
+            "items": {},
+            "title": "Intrinsic Cameras",
+            "type": "array"
+          },
+          "schema_version": {
+            "default": 1,
+            "minimum": 1.0,
+            "title": "Schema Version",
+            "type": "integer"
+          },
+          "stereo_pairs": {
+            "items": {},
+            "title": "Stereo Pairs",
+            "type": "array"
+          },
+          "sync_metadata": {
+            "anyOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sync Metadata"
+          },
+          "world_origin_camera_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "World Origin Camera Id"
+          }
+        },
+        "title": "CalibrationPlaceholder",
+        "type": "object"
+      },
       "CampusCreate": {
         "description": "Schema for creating a new campus",
         "properties": {
@@ -6938,6 +6994,69 @@
           "enrollments_rejected"
         ],
         "title": "CancellationResponse",
+        "type": "object"
+      },
+      "CaptureStreamDTO": {
+        "description": "Contract placeholder. Multiple streams per device+type\n(recording attempts, restarts) handled in PR-4B3B.",
+        "properties": {
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "preset_json": {
+            "title": "Preset Json",
+            "type": "object"
+          },
+          "revision": {
+            "title": "Revision",
+            "type": "integer"
+          },
+          "session_device_id": {
+            "title": "Session Device Id",
+            "type": "integer"
+          },
+          "started_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Started At"
+          },
+          "stopped_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stopped At"
+          },
+          "stream_type": {
+            "$ref": "#/components/schemas/StreamType"
+          }
+        },
+        "required": [
+          "id",
+          "session_device_id",
+          "stream_type",
+          "preset_json",
+          "revision",
+          "created_at"
+        ],
+        "title": "CaptureStreamDTO",
         "type": "object"
       },
       "CategoryOverride": {
@@ -8333,6 +8452,26 @@
         "title": "CreateAssessmentResponse",
         "type": "object"
       },
+      "CreateSessionRequest": {
+        "properties": {
+          "max_devices": {
+            "default": 4,
+            "maximum": 8.0,
+            "minimum": 1.0,
+            "title": "Max Devices",
+            "type": "integer"
+          },
+          "max_participants": {
+            "default": 2,
+            "maximum": 4.0,
+            "minimum": 1.0,
+            "title": "Max Participants",
+            "type": "integer"
+          }
+        },
+        "title": "CreateSessionRequest",
+        "type": "object"
+      },
       "DeclineApplicationRequest": {
         "description": "Request schema for declining an application",
         "properties": {
@@ -8408,6 +8547,37 @@
         },
         "title": "DemoteRequest",
         "type": "object"
+      },
+      "DeviceRole": {
+        "enum": [
+          "player_primary",
+          "player_secondary",
+          "instructor_primary",
+          "auxiliary_camera"
+        ],
+        "title": "DeviceRole",
+        "type": "string"
+      },
+      "DeviceStatus": {
+        "enum": [
+          "registered",
+          "ready",
+          "recording",
+          "stopped",
+          "disconnected",
+          "error"
+        ],
+        "title": "DeviceStatus",
+        "type": "string"
+      },
+      "DeviceType": {
+        "enum": [
+          "iphone",
+          "ipad",
+          "gopro"
+        ],
+        "title": "DeviceType",
+        "type": "string"
       },
       "DirectAssignmentRequest": {
         "description": "Request schema for direct instructor assignment",
@@ -10068,6 +10238,25 @@
         "title": "HeadToHeadParticipantResult",
         "type": "object"
       },
+      "HeartbeatResponse": {
+        "properties": {
+          "last_heartbeat": {
+            "format": "date-time",
+            "title": "Last Heartbeat",
+            "type": "string"
+          },
+          "session_device_id": {
+            "title": "Session Device Id",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "session_device_id",
+          "last_heartbeat"
+        ],
+        "title": "HeartbeatResponse",
+        "type": "object"
+      },
       "HireFromApplicationRequest": {
         "description": "Schema for hiring from job application (Pathway B)",
         "properties": {
@@ -11323,6 +11512,18 @@
           "positions"
         ],
         "title": "JobBoardResponse",
+        "type": "object"
+      },
+      "JoinSessionRequest": {
+        "properties": {
+          "role": {
+            "$ref": "#/components/schemas/ParticipantRole"
+          }
+        },
+        "required": [
+          "role"
+        ],
+        "title": "JoinSessionRequest",
         "type": "object"
       },
       "JugglingCompleteOut": {
@@ -13870,6 +14071,137 @@
         "title": "MoveStudentRequest",
         "type": "object"
       },
+      "MultiCameraSessionDTO": {
+        "properties": {
+          "calibration": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/CalibrationPlaceholder"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "cancelled_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cancelled At"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "created_by_user_id": {
+            "title": "Created By User Id",
+            "type": "integer"
+          },
+          "devices": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/SessionDeviceDTO"
+            },
+            "title": "Devices",
+            "type": "array"
+          },
+          "finalized_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Finalized At"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "max_devices": {
+            "title": "Max Devices",
+            "type": "integer"
+          },
+          "max_participants": {
+            "title": "Max Participants",
+            "type": "integer"
+          },
+          "participants": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/SessionParticipantDTO"
+            },
+            "title": "Participants",
+            "type": "array"
+          },
+          "revision": {
+            "title": "Revision",
+            "type": "integer"
+          },
+          "session_uuid": {
+            "format": "uuid",
+            "title": "Session Uuid",
+            "type": "string"
+          },
+          "started_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Started At"
+          },
+          "status": {
+            "$ref": "#/components/schemas/SessionStatus"
+          },
+          "stopped_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stopped At"
+          },
+          "streams": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/CaptureStreamDTO"
+            },
+            "title": "Streams",
+            "type": "array"
+          }
+        },
+        "required": [
+          "id",
+          "session_uuid",
+          "status",
+          "created_by_user_id",
+          "max_participants",
+          "max_devices",
+          "revision",
+          "created_at"
+        ],
+        "title": "MultiCameraSessionDTO",
+        "type": "object"
+      },
       "NextLevel": {
         "properties": {
           "current_xp": {
@@ -14476,6 +14808,15 @@
         ],
         "title": "OpsScenarioResponse",
         "type": "object"
+      },
+      "ParticipantRole": {
+        "enum": [
+          "instructor",
+          "player",
+          "observer"
+        ],
+        "title": "ParticipantRole",
+        "type": "string"
       },
       "PaymentVerificationRequest": {
         "description": "Request body for payment verification",
@@ -17402,6 +17743,84 @@
         "title": "RefreshToken",
         "type": "object"
       },
+      "RegisterDeviceRequest": {
+        "properties": {
+          "ble_identifier": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ble Identifier"
+          },
+          "device_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Device Name"
+          },
+          "device_role": {
+            "$ref": "#/components/schemas/DeviceRole"
+          },
+          "device_type": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DeviceType"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "device_uuid": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Device Uuid"
+          },
+          "managed_by_device_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Managed By Device Id"
+          },
+          "participant_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Participant Id"
+          }
+        },
+        "required": [
+          "device_role"
+        ],
+        "title": "RegisterDeviceRequest",
+        "type": "object"
+      },
       "RegisterWithInvitation": {
         "description": "Registration request with invitation code",
         "properties": {
@@ -19716,6 +20135,94 @@
         "title": "SessionCreate",
         "type": "object"
       },
+      "SessionDeviceDTO": {
+        "properties": {
+          "device_id": {
+            "title": "Device Id",
+            "type": "integer"
+          },
+          "device_role": {
+            "$ref": "#/components/schemas/DeviceRole"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "last_heartbeat": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Heartbeat"
+          },
+          "managed_by_device_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Managed By Device Id"
+          },
+          "participant_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Participant Id"
+          },
+          "registered_at": {
+            "format": "date-time",
+            "title": "Registered At",
+            "type": "string"
+          },
+          "removed_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Removed At"
+          },
+          "revision": {
+            "title": "Revision",
+            "type": "integer"
+          },
+          "session_id": {
+            "title": "Session Id",
+            "type": "integer"
+          },
+          "status": {
+            "$ref": "#/components/schemas/DeviceStatus"
+          }
+        },
+        "required": [
+          "id",
+          "session_id",
+          "device_id",
+          "device_role",
+          "status",
+          "revision",
+          "registered_at"
+        ],
+        "title": "SessionDeviceDTO",
+        "type": "object"
+      },
       "SessionGenerationRequest": {
         "description": "Request body for session generation",
         "properties": {
@@ -19827,6 +20334,56 @@
           "size"
         ],
         "title": "SessionList",
+        "type": "object"
+      },
+      "SessionParticipantDTO": {
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "joined_at": {
+            "format": "date-time",
+            "title": "Joined At",
+            "type": "string"
+          },
+          "left_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Left At"
+          },
+          "revision": {
+            "title": "Revision",
+            "type": "integer"
+          },
+          "role": {
+            "$ref": "#/components/schemas/ParticipantRole"
+          },
+          "session_id": {
+            "title": "Session Id",
+            "type": "integer"
+          },
+          "user_id": {
+            "title": "User Id",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "session_id",
+          "user_id",
+          "role",
+          "revision",
+          "joined_at"
+        ],
+        "title": "SessionParticipantDTO",
         "type": "object"
       },
       "SessionSegmentCreate": {
@@ -20029,6 +20586,19 @@
         },
         "title": "SessionSegmentUpdate",
         "type": "object"
+      },
+      "SessionStatus": {
+        "enum": [
+          "lobby",
+          "devices_ready",
+          "recording",
+          "stopped",
+          "finalizing",
+          "completed",
+          "cancelled"
+        ],
+        "title": "SessionStatus",
+        "type": "string"
       },
       "SessionSummaryResponse": {
         "properties": {
@@ -21231,6 +21801,17 @@
         ],
         "title": "StatusTransitionResponse",
         "type": "object"
+      },
+      "StreamType": {
+        "enum": [
+          "video",
+          "skeleton_2d",
+          "skeleton_3d",
+          "audio",
+          "telemetry"
+        ],
+        "title": "StreamType",
+        "type": "string"
       },
       "StudentStatus": {
         "properties": {
@@ -23022,6 +23603,23 @@
           "created_at"
         ],
         "title": "TransactionHistoryItem",
+        "type": "object"
+      },
+      "TransitionRequest": {
+        "properties": {
+          "revision": {
+            "title": "Revision",
+            "type": "integer"
+          },
+          "target_status": {
+            "$ref": "#/components/schemas/SessionStatus"
+          }
+        },
+        "required": [
+          "target_status",
+          "revision"
+        ],
+        "title": "TransitionRequest",
         "type": "object"
       },
       "UpdateHoursRequest": {
@@ -50515,6 +51113,331 @@
         "summary": "Update Message",
         "tags": [
           "messages"
+        ]
+      }
+    },
+    "/api/v1/multicamera/sessions": {
+      "post": {
+        "operationId": "create_session_api_v1_multicamera_sessions_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateSessionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MultiCameraSessionDTO"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Create Session",
+        "tags": [
+          "multicamera"
+        ]
+      }
+    },
+    "/api/v1/multicamera/sessions/{session_uuid}": {
+      "get": {
+        "operationId": "get_session_api_v1_multicamera_sessions__session_uuid__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "session_uuid",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Session Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MultiCameraSessionDTO"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get Session",
+        "tags": [
+          "multicamera"
+        ]
+      }
+    },
+    "/api/v1/multicamera/sessions/{session_uuid}/devices": {
+      "post": {
+        "operationId": "register_device_api_v1_multicamera_sessions__session_uuid__devices_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "session_uuid",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Session Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegisterDeviceRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionDeviceDTO"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Register Device",
+        "tags": [
+          "multicamera"
+        ]
+      }
+    },
+    "/api/v1/multicamera/sessions/{session_uuid}/devices/{session_device_id}/heartbeat": {
+      "post": {
+        "operationId": "heartbeat_api_v1_multicamera_sessions__session_uuid__devices__session_device_id__heartbeat_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "session_uuid",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Session Uuid",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "session_device_id",
+            "required": true,
+            "schema": {
+              "title": "Session Device Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HeartbeatResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Heartbeat",
+        "tags": [
+          "multicamera"
+        ]
+      }
+    },
+    "/api/v1/multicamera/sessions/{session_uuid}/join": {
+      "post": {
+        "operationId": "join_session_api_v1_multicamera_sessions__session_uuid__join_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "session_uuid",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Session Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JoinSessionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionParticipantDTO"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Join Session",
+        "tags": [
+          "multicamera"
+        ]
+      }
+    },
+    "/api/v1/multicamera/sessions/{session_uuid}/status": {
+      "patch": {
+        "operationId": "transition_session_api_v1_multicamera_sessions__session_uuid__status_patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "session_uuid",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Session Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TransitionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MultiCameraSessionDTO"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Transition Session",
+        "tags": [
+          "multicamera"
         ]
       }
     },

--- a/tests/unit/api/web_routes/test_card_editor_ce2.py
+++ b/tests/unit/api/web_routes/test_card_editor_ce2.py
@@ -439,6 +439,6 @@ class TestCE217RouteCount:
         """
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 914, (
+        assert len(paths) == 920, (
             f"Expected 912 routes (910 prior + 2 ball training hub), got {len(paths)}."
         )

--- a/tests/unit/api/web_routes/test_card_editor_cs_s1.py
+++ b/tests/unit/api/web_routes/test_card_editor_cs_s1.py
@@ -294,7 +294,7 @@ class TestS109S110RouteAndSnapshot:
         """S1-09 (updated AN-3B2B2): route count is 910 (+3 admin feedback review endpoints)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 914, (
+        assert len(paths) == 920, (
             f"Expected 910 routes (907 prior + 3 admin feedback review), got {len(paths)}"
         )
 

--- a/tests/unit/api/web_routes/test_card_editor_ref_p2.py
+++ b/tests/unit/api/web_routes/test_card_editor_ref_p2.py
@@ -287,7 +287,7 @@ class TestP227to29RouteAndOpenAPI:
         """P2-27: Route count = 846 (CS-S2A +1 /card-studio/player)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 914, f"Expected 846 routes, got {len(paths)}"
+        assert len(paths) == 920, f"Expected 846 routes, got {len(paths)}"
 
     def test_p2_28_openapi_snapshot_match(self):
         """P2-28: OpenAPI snapshot matches live API paths."""

--- a/tests/unit/api/web_routes/test_card_studio_challenge.py
+++ b/tests/unit/api/web_routes/test_card_studio_challenge.py
@@ -294,7 +294,7 @@ class TestCCS11RouteCount:
         """CCS-11: route count updated to 842 after CE-3.8 (+3 from-mood endpoints)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 914, (
+        assert len(paths) == 920, (
             f"Expected 845 routes (842 CE-3.7+CE-3.8 baseline + 2 CS-S0 card-studio routes), got {len(paths)}."
         )
 

--- a/tests/unit/api/web_routes/test_card_studio_landing.py
+++ b/tests/unit/api/web_routes/test_card_studio_landing.py
@@ -159,7 +159,7 @@ class TestCEL12RouteCount:
         """CEL-12: route count 844 (unchanged — redirect is handler change, not new route)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 914, (
+        assert len(paths) == 920, (
             f"Expected 845 routes (redirect handler change does not add routes), got {len(paths)}."
         )
 

--- a/tests/unit/api/web_routes/test_card_studio_shell.py
+++ b/tests/unit/api/web_routes/test_card_studio_shell.py
@@ -326,7 +326,7 @@ class TestCSS21to23RouteConfirmations:
         """CSS-21: adding 2 card-studio routes raises count from 842 to 844."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 914, (
+        assert len(paths) == 920, (
             f"Expected 845 routes (842 baseline + 2 new /card-studio routes), got {len(paths)}"
         )
 

--- a/tests/unit/api/web_routes/test_card_studio_welcome.py
+++ b/tests/unit/api/web_routes/test_card_studio_welcome.py
@@ -325,7 +325,7 @@ class TestCEW18RouteCount:
         """CEW-18: route count baseline check (updated by CE-3.8 to 842)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 914, (
+        assert len(paths) == 920, (
             f"Expected 842 routes (839 CE-3.7 baseline + 3 from-mood endpoints), got {len(paths)}."
         )
 
@@ -678,7 +678,7 @@ class TestCEW44to51TemplateMoodPicker:
         """CEW-47: CE-3.8 adds 3 from-mood routes → total 842."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 914, (
+        assert len(paths) == 920, (
             f"Expected 845 routes (842 baseline + 2 CS-S0 routes), got {len(paths)}"
         )
 

--- a/tests/unit/api/web_routes/test_cc_design_1.py
+++ b/tests/unit/api/web_routes/test_cc_design_1.py
@@ -780,7 +780,7 @@ class TestCCD22to23RouteSnapshot:
         """CCD-22: Route count is 851 (CC-DESIGN-1 SNAPSHOT adds POST /challenges/{id}/card/photo)."""
         from app.main import app
         count = len(app.openapi().get("paths", {}))
-        assert count == 914, f"Expected 851, got {count}"
+        assert count == 920, f"Expected 851, got {count}"
 
     def test_ccd_23_openapi_snapshot_match(self):
         """CCD-23: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_cs_color_1.py
+++ b/tests/unit/api/web_routes/test_cs_color_1.py
@@ -382,7 +382,7 @@ class TestCSCOL15to16RouteAndSnapshot:
         """CSCOL-15: route count = 845 (+1 POST /dashboard/wc-card-theme)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 914, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 920, f"Expected 845 routes, got {len(paths)}"
 
     def test_cscol_16_openapi_snapshot_includes_wc_card_theme(self):
         """CSCOL-16: OpenAPI snapshot includes /dashboard/wc-card-theme."""

--- a/tests/unit/api/web_routes/test_cs_s2a.py
+++ b/tests/unit/api/web_routes/test_cs_s2a.py
@@ -40,7 +40,7 @@ class TestS2A01to02RouteRegistration:
         """S2A-02 (updated CS-S4A): Total route count is 847 (CS-S2A+CS-S4A)."""
         from app.main import app
         count = len(app.openapi().get("paths", {}))
-        assert count == 914, f"Expected 847 routes, got {count}"
+        assert count == 920, f"Expected 847 routes, got {count}"
 
 
 # ── S2A-03..08: _resolve_player_context logic ────────────────────────────────

--- a/tests/unit/api/web_routes/test_cs_s4a.py
+++ b/tests/unit/api/web_routes/test_cs_s4a.py
@@ -152,7 +152,7 @@ class TestS4A12to13RouteAndSnapshot:
         """S4A-12: Route count == 851 (CC-DESIGN-1 SNAPSHOT adds +1 POST /challenges/{id}/card/photo)."""
         from app.main import app
         count = len(app.openapi().get("paths", {}))
-        assert count == 914, f"Expected 851 routes, got {count}"
+        assert count == 920, f"Expected 851 routes, got {count}"
 
     def test_s4a_13_openapi_snapshot_match(self):
         """S4A-13: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_family_color_shop.py
+++ b/tests/unit/api/web_routes/test_family_color_shop.py
@@ -223,7 +223,7 @@ class TestRouteRegistration:
     def test_ts_13_route_count_836(self):
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 914, (
+        assert len(paths) == 920, (
             f"Expected 845 routes (842 CE-3.7+CE-3.8 baseline + 2 CS-S0 card-studio routes), got {len(paths)}."
         )
 

--- a/tests/unit/api/web_routes/test_shop_3a.py
+++ b/tests/unit/api/web_routes/test_shop_3a.py
@@ -194,7 +194,7 @@ class TestS3A13to14RouteAndSnapshot:
         """S3A-13: Route count = 845 (template deletion does not affect routes)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 914, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 920, f"Expected 845 routes, got {len(paths)}"
 
     def test_s3a_14_openapi_snapshot_match(self):
         """S3A-14: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_shop_3b1.py
+++ b/tests/unit/api/web_routes/test_shop_3b1.py
@@ -158,7 +158,7 @@ class TestS3B112to13RouteAndSnapshot:
         """S3B1-12: Route count = 845 (test cleanup does not affect routes)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 914, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 920, f"Expected 845 routes, got {len(paths)}"
 
     def test_s3b1_13_openapi_snapshot_match(self):
         """S3B1-13: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_shop_3b2.py
+++ b/tests/unit/api/web_routes/test_shop_3b2.py
@@ -192,7 +192,7 @@ class TestS3B215to16RouteAndSnapshot:
         """S3B2-15: Route count = 845 (template deletion does not affect routes)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 914, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 920, f"Expected 845 routes, got {len(paths)}"
 
     def test_s3b2_16_openapi_snapshot_match(self):
         """S3B2-16: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_shop_unified.py
+++ b/tests/unit/api/web_routes/test_shop_unified.py
@@ -271,7 +271,7 @@ class TestSHOP14to15RouteAndSnapshot:
         """SHOP-14: route count = 845 (no new routes in SHOP-1)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 914, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 920, f"Expected 845 routes, got {len(paths)}"
 
     def test_shop_15_openapi_snapshot_match(self):
         """SHOP-15: OpenAPI snapshot matches live API."""

--- a/tests/unit/juggling/test_annotation_helper.py
+++ b/tests/unit/juggling/test_annotation_helper.py
@@ -1015,7 +1015,7 @@ class TestHELP36_ProductionRouteCountUnchanged:
         snapshot_path = helper.ROOT / "tests/snapshots/openapi_snapshot.json"
         snapshot = json.loads(snapshot_path.read_text())
         route_count = len(snapshot.get("paths", {}))
-        assert route_count == 914, f"Unexpected production route count: {route_count}"
+        assert route_count == 920, f"Unexpected production route count: {route_count}"
 
     def test_helper_routes_not_in_production_snapshot(self):
         """HELP-36d: Annotation helper routes (/api/taxonomy etc.) not in production snapshot."""

--- a/tests/unit/juggling/test_juggling_video_list.py
+++ b/tests/unit/juggling/test_juggling_video_list.py
@@ -463,7 +463,7 @@ def test_jvl25_openapi_path_and_route_delta(client):
         if hasattr(r, "methods") and hasattr(r, "path")
         for m in (r.methods or [])
     ]
-    assert len(routes) == 1039, f"Expected 1038 routes (AN-3B2F PR-1B: +1 frame endpoint), got {len(routes)}"
+    assert len(routes) == 1045, f"Expected 1038 routes (AN-3B2F PR-1B: +1 frame endpoint), got {len(routes)}"
     get_list = [r for r in routes if r[0] == "GET" and r[1] == "/api/v1/users/me/juggling/videos"]
     assert len(get_list) == 1
 

--- a/tests/unit/multicamera/test_session_api.py
+++ b/tests/unit/multicamera/test_session_api.py
@@ -1,0 +1,336 @@
+"""Multicamera Session API Tests — AN-3B PR-4B3A. 26 tests."""
+import uuid as _uuid
+import pytest
+from fastapi.testclient import TestClient
+from app.main import app
+from app.database import SessionLocal
+from app.models.user import User, UserRole
+from app.services.multicamera.device_service import DeviceService
+
+client = TestClient(app)
+
+
+@pytest.fixture()
+def db():
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.rollback()
+        session.close()
+
+
+def _create_user(db, role=UserRole.INSTRUCTOR):
+    tag = _uuid.uuid4().hex[:8]
+    u = User(name=f"Test-{tag}", email=f"api-{tag}@mcs-test.com", password_hash="x", role=role, is_active=True)
+    db.add(u)
+    db.commit()
+    db.refresh(u)
+    return u
+
+
+def _auth(user):
+    from app.core.auth import create_access_token
+    token = create_access_token(data={"sub": user.email})
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _create_session(headers, max_p=2, max_d=4):
+    return client.post("/api/v1/multicamera/sessions", json={"max_participants": max_p, "max_devices": max_d}, headers=headers)
+
+
+# ── API-01..08 Auth + Guard ──────────────────────────────────────────────────
+
+class TestAuthGuard:
+
+    def test_api_01_create_auto_instructor(self, db):
+        u = _create_user(db)
+        r = _create_session(_auth(u))
+        assert r.status_code == 201
+        data = r.json()
+        assert data["status"] == "lobby"
+        assert len(data["participants"]) == 1
+        assert data["participants"][0]["role"] == "instructor"
+        assert data["participants"][0]["user_id"] == u.id
+
+    def test_api_02_create_no_auth(self):
+        r = client.post("/api/v1/multicamera/sessions", json={"max_participants": 2, "max_devices": 4})
+        assert r.status_code == 401
+
+    def test_api_03_get_participant(self, db):
+        u = _create_user(db)
+        r = _create_session(_auth(u))
+        uid = r.json()["session_uuid"]
+        r2 = client.get(f"/api/v1/multicamera/sessions/{uid}", headers=_auth(u))
+        assert r2.status_code == 200
+
+    def test_api_04_get_non_participant(self, db):
+        u1 = _create_user(db)
+        u2 = _create_user(db, UserRole.STUDENT)
+        r = _create_session(_auth(u1))
+        uid = r.json()["session_uuid"]
+        r2 = client.get(f"/api/v1/multicamera/sessions/{uid}", headers=_auth(u2))
+        assert r2.status_code == 403
+
+    def test_api_05_get_not_found(self, db):
+        u = _create_user(db)
+        r = client.get(f"/api/v1/multicamera/sessions/{_uuid.uuid4()}", headers=_auth(u))
+        assert r.status_code == 404
+
+    def test_api_06_transition_instructor(self, db):
+        u = _create_user(db)
+        r = _create_session(_auth(u))
+        d = r.json()
+        r2 = client.patch(f"/api/v1/multicamera/sessions/{d['session_uuid']}/status",
+                          json={"target_status": "devices_ready", "revision": d["revision"]}, headers=_auth(u))
+        assert r2.status_code == 200
+        assert r2.json()["status"] == "devices_ready"
+
+    def test_api_07_transition_player_forbidden(self, db):
+        u1 = _create_user(db)
+        u2 = _create_user(db, UserRole.STUDENT)
+        r = _create_session(_auth(u1))
+        d = r.json()
+        client.post(f"/api/v1/multicamera/sessions/{d['session_uuid']}/join",
+                    json={"role": "player"}, headers=_auth(u2))
+        r2 = client.patch(f"/api/v1/multicamera/sessions/{d['session_uuid']}/status",
+                          json={"target_status": "devices_ready", "revision": d["revision"]}, headers=_auth(u2))
+        assert r2.status_code == 403
+
+    def test_api_08_all_endpoints_no_auth(self):
+        uid = str(_uuid.uuid4())
+        assert client.post("/api/v1/multicamera/sessions", json={}).status_code == 401
+        assert client.get(f"/api/v1/multicamera/sessions/{uid}").status_code == 401
+        assert client.post(f"/api/v1/multicamera/sessions/{uid}/join", json={"role": "player"}).status_code == 401
+        assert client.patch(f"/api/v1/multicamera/sessions/{uid}/status", json={"target_status": "cancelled", "revision": 1}).status_code == 401
+        assert client.post(f"/api/v1/multicamera/sessions/{uid}/devices", json={"device_type": "iphone", "device_role": "player_primary"}).status_code == 401
+        assert client.post(f"/api/v1/multicamera/sessions/{uid}/devices/1/heartbeat").status_code == 401
+
+
+# ── API-09..11 Join ──────────────────────────────────────────────────────────
+
+class TestJoin:
+
+    def test_api_09_join(self, db):
+        u1 = _create_user(db)
+        u2 = _create_user(db, UserRole.STUDENT)
+        r = _create_session(_auth(u1))
+        uid = r.json()["session_uuid"]
+        r2 = client.post(f"/api/v1/multicamera/sessions/{uid}/join", json={"role": "player"}, headers=_auth(u2))
+        assert r2.status_code == 200
+        assert r2.json()["role"] == "player"
+
+    def test_api_10_join_duplicate_idempotent(self, db):
+        u1 = _create_user(db)
+        u2 = _create_user(db, UserRole.STUDENT)
+        r = _create_session(_auth(u1))
+        uid = r.json()["session_uuid"]
+        r2 = client.post(f"/api/v1/multicamera/sessions/{uid}/join", json={"role": "player"}, headers=_auth(u2))
+        r3 = client.post(f"/api/v1/multicamera/sessions/{uid}/join", json={"role": "player"}, headers=_auth(u2))
+        assert r2.json()["id"] == r3.json()["id"]
+
+    def test_api_11_join_full(self, db):
+        u1 = _create_user(db)
+        u2 = _create_user(db, UserRole.STUDENT)
+        r = _create_session(_auth(u1), max_p=1)
+        uid = r.json()["session_uuid"]
+        r2 = client.post(f"/api/v1/multicamera/sessions/{uid}/join", json={"role": "player"}, headers=_auth(u2))
+        assert r2.status_code == 409
+
+
+# ── API-12..14 Transition ────────────────────────────────────────────────────
+
+class TestTransition:
+
+    def test_api_12_valid_transition(self, db):
+        u = _create_user(db)
+        r = _create_session(_auth(u))
+        d = r.json()
+        r2 = client.patch(f"/api/v1/multicamera/sessions/{d['session_uuid']}/status",
+                          json={"target_status": "devices_ready", "revision": d["revision"]}, headers=_auth(u))
+        assert r2.status_code == 200
+
+    def test_api_13_invalid_transition(self, db):
+        u = _create_user(db)
+        r = _create_session(_auth(u))
+        d = r.json()
+        r2 = client.patch(f"/api/v1/multicamera/sessions/{d['session_uuid']}/status",
+                          json={"target_status": "recording", "revision": d["revision"]}, headers=_auth(u))
+        assert r2.status_code == 422
+
+    def test_api_14_revision_conflict(self, db):
+        u = _create_user(db)
+        r = _create_session(_auth(u))
+        d = r.json()
+        r2 = client.patch(f"/api/v1/multicamera/sessions/{d['session_uuid']}/status",
+                          json={"target_status": "devices_ready", "revision": d["revision"] + 99}, headers=_auth(u))
+        assert r2.status_code == 409
+
+
+# ── API-15..20 Device ────────────────────────────────────────────────────────
+
+class TestDevice:
+
+    def test_api_15_register_existing_device(self, db):
+        u = _create_user(db)
+        ds = DeviceService(db)
+        md = ds.register_managed_device(u.id, "ipad", "iPad Pro")
+        r = _create_session(_auth(u))
+        uid = r.json()["session_uuid"]
+        r2 = client.post(f"/api/v1/multicamera/sessions/{uid}/devices",
+                         json={"device_uuid": str(md.device_uuid), "device_role": "instructor_primary",
+                               "participant_id": r.json()["participants"][0]["id"]},
+                         headers=_auth(u))
+        assert r2.status_code == 201
+
+    def test_api_16_register_implicit_creation(self, db):
+        u = _create_user(db)
+        r = _create_session(_auth(u))
+        uid = r.json()["session_uuid"]
+        r2 = client.post(f"/api/v1/multicamera/sessions/{uid}/devices",
+                         json={"device_type": "iphone", "device_name": "My iPhone", "device_role": "instructor_primary"},
+                         headers=_auth(u))
+        assert r2.status_code == 201
+
+    def test_api_17_register_duplicate_idempotent(self, db):
+        u = _create_user(db)
+        ds = DeviceService(db)
+        md = ds.register_managed_device(u.id, "ipad", "iPad")
+        r = _create_session(_auth(u))
+        uid = r.json()["session_uuid"]
+        body = {"device_uuid": str(md.device_uuid), "device_role": "instructor_primary"}
+        r2 = client.post(f"/api/v1/multicamera/sessions/{uid}/devices", json=body, headers=_auth(u))
+        r3 = client.post(f"/api/v1/multicamera/sessions/{uid}/devices", json=body, headers=_auth(u))
+        assert r2.json()["id"] == r3.json()["id"]
+
+    def test_api_18_register_full(self, db):
+        u = _create_user(db)
+        r = _create_session(_auth(u), max_d=1)
+        uid = r.json()["session_uuid"]
+        client.post(f"/api/v1/multicamera/sessions/{uid}/devices",
+                    json={"device_type": "ipad", "device_role": "instructor_primary"}, headers=_auth(u))
+        r2 = client.post(f"/api/v1/multicamera/sessions/{uid}/devices",
+                         json={"device_type": "iphone", "device_role": "player_primary"}, headers=_auth(u))
+        assert r2.status_code == 409
+
+    def test_api_19_register_non_participant(self, db):
+        u1 = _create_user(db)
+        u2 = _create_user(db, UserRole.STUDENT)
+        r = _create_session(_auth(u1))
+        uid = r.json()["session_uuid"]
+        r2 = client.post(f"/api/v1/multicamera/sessions/{uid}/devices",
+                         json={"device_type": "iphone", "device_role": "player_primary"}, headers=_auth(u2))
+        assert r2.status_code == 403
+
+    def test_api_20_auxiliary_invariant_violated(self, db):
+        u = _create_user(db)
+        r = _create_session(_auth(u))
+        uid = r.json()["session_uuid"]
+        r2 = client.post(f"/api/v1/multicamera/sessions/{uid}/devices",
+                         json={"device_type": "gopro", "device_role": "auxiliary_camera"}, headers=_auth(u))
+        assert r2.status_code == 422
+
+
+# ── API-21..23 Heartbeat ─────────────────────────────────────────────────────
+
+class TestHeartbeat:
+
+    def _setup_session_with_device(self, db):
+        u = _create_user(db)
+        ds = DeviceService(db)
+        md = ds.register_managed_device(u.id, "ipad", "iPad")
+        r = _create_session(_auth(u))
+        d = r.json()
+        uid = d["session_uuid"]
+        pid = d["participants"][0]["id"]
+        rd = client.post(f"/api/v1/multicamera/sessions/{uid}/devices",
+                         json={"device_uuid": str(md.device_uuid), "device_role": "instructor_primary", "participant_id": pid},
+                         headers=_auth(u))
+        return u, uid, rd.json()["id"]
+
+    def test_api_21_heartbeat_owner(self, db):
+        u, uid, sd_id = self._setup_session_with_device(db)
+        r = client.post(f"/api/v1/multicamera/sessions/{uid}/devices/{sd_id}/heartbeat", headers=_auth(u))
+        assert r.status_code == 200
+        assert r.json()["session_device_id"] == sd_id
+
+    def test_api_22_heartbeat_wrong_user(self, db):
+        u, uid, sd_id = self._setup_session_with_device(db)
+        u2 = _create_user(db, UserRole.STUDENT)
+        from app.services.multicamera.session_service import SessionService
+        ss = SessionService(db)
+        ss.join_session(_uuid.UUID(uid), u2.id, "player")
+        r = client.post(f"/api/v1/multicamera/sessions/{uid}/devices/{sd_id}/heartbeat", headers=_auth(u2))
+        assert r.status_code == 403
+
+    def test_api_23_heartbeat_manager_auxiliary(self, db):
+        u = _create_user(db)
+        ds = DeviceService(db)
+        ipad = ds.register_managed_device(u.id, "ipad", "iPad")
+        gopro = ds.register_managed_device(u.id, "gopro", "HERO13", ble_identifier=f"BLE-{_uuid.uuid4().hex[:6]}")
+        r = _create_session(_auth(u))
+        d = r.json()
+        uid = d["session_uuid"]
+        pid = d["participants"][0]["id"]
+        rd_ipad = client.post(f"/api/v1/multicamera/sessions/{uid}/devices",
+                              json={"device_uuid": str(ipad.device_uuid), "device_role": "instructor_primary", "participant_id": pid},
+                              headers=_auth(u))
+        ipad_sd_id = rd_ipad.json()["id"]
+        rd_gopro = client.post(f"/api/v1/multicamera/sessions/{uid}/devices",
+                               json={"device_uuid": str(gopro.device_uuid), "device_role": "auxiliary_camera",
+                                     "managed_by_device_id": ipad_sd_id},
+                               headers=_auth(u))
+        gopro_sd_id = rd_gopro.json()["id"]
+        r2 = client.post(f"/api/v1/multicamera/sessions/{uid}/devices/{gopro_sd_id}/heartbeat", headers=_auth(u))
+        assert r2.status_code == 200
+
+
+# ── API-24..26 Lifecycle + Snapshot ──────────────────────────────────────────
+
+class TestLifecycleAndSnapshot:
+
+    def test_api_24_full_lifecycle(self, db):
+        u1 = _create_user(db)
+        u2 = _create_user(db, UserRole.STUDENT)
+        r = _create_session(_auth(u1))
+        d = r.json()
+        uid = d["session_uuid"]
+        client.post(f"/api/v1/multicamera/sessions/{uid}/join", json={"role": "player"}, headers=_auth(u2))
+        client.post(f"/api/v1/multicamera/sessions/{uid}/devices",
+                    json={"device_type": "ipad", "device_role": "instructor_primary"}, headers=_auth(u1))
+        d = client.get(f"/api/v1/multicamera/sessions/{uid}", headers=_auth(u1)).json()
+        d = client.patch(f"/api/v1/multicamera/sessions/{uid}/status",
+                         json={"target_status": "devices_ready", "revision": d["revision"]}, headers=_auth(u1)).json()
+        d = client.patch(f"/api/v1/multicamera/sessions/{uid}/status",
+                         json={"target_status": "recording", "revision": d["revision"]}, headers=_auth(u1)).json()
+        d = client.patch(f"/api/v1/multicamera/sessions/{uid}/status",
+                         json={"target_status": "stopped", "revision": d["revision"]}, headers=_auth(u1)).json()
+        d = client.patch(f"/api/v1/multicamera/sessions/{uid}/status",
+                         json={"target_status": "finalizing", "revision": d["revision"]}, headers=_auth(u1)).json()
+        d = client.patch(f"/api/v1/multicamera/sessions/{uid}/status",
+                         json={"target_status": "completed", "revision": d["revision"]}, headers=_auth(u1)).json()
+        assert d["status"] == "completed"
+
+    def test_api_25_heartbeat_removed_device(self, db):
+        u = _create_user(db)
+        ds = DeviceService(db)
+        md = ds.register_managed_device(u.id, "ipad", "iPad")
+        r = _create_session(_auth(u))
+        d = r.json()
+        uid = d["session_uuid"]
+        pid = d["participants"][0]["id"]
+        rd = client.post(f"/api/v1/multicamera/sessions/{uid}/devices",
+                         json={"device_uuid": str(md.device_uuid), "device_role": "instructor_primary", "participant_id": pid},
+                         headers=_auth(u))
+        sd_id = rd.json()["id"]
+        from app.services.multicamera.session_service import SessionService
+        ss = SessionService(db)
+        session = ss.get_session(_uuid.UUID(uid))
+        ss.remove_device(sd_id, session.revision)
+        r2 = client.post(f"/api/v1/multicamera/sessions/{uid}/devices/{sd_id}/heartbeat", headers=_auth(u))
+        assert r2.status_code == 404
+
+    def test_api_26_route_count(self):
+        from app.main import app as _app
+        paths = len(_app.openapi().get("paths", {}))
+        assert paths == 920, f"Expected 920, got {paths}"


### PR DESCRIPTION
## Summary
6 multicamera session API endpoints with auth, participant/instructor/device-owner guards.

## Endpoints
| Method | Path | Guard |
|---|---|---|
| POST | /multicamera/sessions | Any active user; creator auto-joins as instructor |
| GET | /multicamera/sessions/{uuid} | Participant only |
| POST | /multicamera/sessions/{uuid}/join | Self-join |
| PATCH | /multicamera/sessions/{uuid}/status | Instructor participant only |
| POST | /multicamera/sessions/{uuid}/devices | Participant + device owner |
| POST | /multicamera/sessions/{uuid}/devices/{sd_id}/heartbeat | Device owner or managing participant |

## Route count
OpenAPI paths: 914 → 920 (+6)
app.routes: 1038 → 1044 (+6)

## Tests
26 API tests (API-01..26) + 38 contract tests = 64 total PASS