### PR TITLE
feat(multicamera): AN-3B PR-4B3B-0 — Device Status + Capture Stream API

### DIFF
--- a/app/api/api_v1/endpoints/multicamera/sessions.py
+++ b/app/api/api_v1/endpoints/multicamera/sessions.py
@@ -1,6 +1,6 @@
-"""Multicamera session API — AN-3B PR-4B3A.
+"""Multicamera session API — AN-3B PR-4B3A + PR-4B3B-0.
 
-6 endpoints. No UI, no shutter, no recording, no media.
+8 endpoints. No UI, no shutter, no recording, no media.
 """
 from __future__ import annotations
 
@@ -9,7 +9,7 @@ from datetime import datetime
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from sqlalchemy.orm import Session
 
 from .....database import get_db
@@ -17,8 +17,9 @@ from .....dependencies import get_current_active_user
 from .....models.user import User
 from .....models.multicamera_session import SessionParticipant
 from .....schemas.multicamera_session import (
-    DeviceRole, DeviceType, MultiCameraSessionDTO, ParticipantRole,
-    SessionDeviceDTO, SessionParticipantDTO, SessionStatus,
+    CaptureStreamDTO, DeviceRole, DeviceStatus, DeviceType,
+    MultiCameraSessionDTO, ParticipantRole, SessionDeviceDTO,
+    SessionParticipantDTO, SessionStatus, StreamType,
 )
 from .....services.multicamera.session_service import SessionService
 from .....services.multicamera.device_service import DeviceService
@@ -62,6 +63,25 @@ class HeartbeatResponse(BaseModel):
     last_heartbeat: datetime
 
 
+class DeviceStatusUpdateRequest(BaseModel):
+    target_status: DeviceStatus
+    device_revision: int
+
+
+class CreateCaptureStreamRequest(BaseModel):
+    stream_type: StreamType
+    preset_json: dict
+
+    @field_validator("preset_json")
+    @classmethod
+    def validate_preset(cls, v):
+        import json
+        raw = json.dumps(v)
+        if len(raw) > 4096:
+            raise ValueError("preset_json exceeds 4KB limit")
+        return v
+
+
 # ── Guards ───────────────────────────────────────────────────────────────────
 
 def _require_participant(db: Session, session_uuid: uuid.UUID, user: User) -> tuple:
@@ -82,6 +102,29 @@ def _require_instructor(db: Session, session_uuid: uuid.UUID, user: User) -> tup
     if participant.role != "instructor":
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Only instructor can transition session")
     return session, participant
+
+
+def _require_device_access(db: Session, session_uuid: uuid.UUID, session_device_id: int, user: User):
+    from .....repositories.multicamera_session_repo import MultiCameraSessionRepo
+    session, _ = _require_participant(db, session_uuid, user)
+    repo = MultiCameraSessionRepo(db)
+    sd = repo.get_session_device_by_id(session_device_id)
+    if not sd or sd.session_id != session.id:
+        raise HTTPException(status_code=404, detail="Session device not found")
+    authorized = False
+    if sd.participant_id:
+        p = db.query(SessionParticipant).filter(SessionParticipant.id == sd.participant_id).first()
+        if p and p.user_id == user.id:
+            authorized = True
+    if not authorized and sd.managed_by_device_id:
+        manager = repo.get_session_device_by_id(sd.managed_by_device_id)
+        if manager and manager.participant_id:
+            mp = db.query(SessionParticipant).filter(SessionParticipant.id == manager.participant_id).first()
+            if mp and mp.user_id == user.id:
+                authorized = True
+    if not authorized:
+        raise HTTPException(status_code=403, detail="Not authorized for this device")
+    return session, sd
 
 
 def _handle_service_error(e: Exception):
@@ -227,31 +270,48 @@ def heartbeat(
     current_user: User = Depends(get_current_active_user),
 ):
     try:
-        session, _ = _require_participant(db, session_uuid, current_user)
-
-        from .....repositories.multicamera_session_repo import MultiCameraSessionRepo
-        repo = MultiCameraSessionRepo(db)
-        sd = repo.get_session_device_by_id(session_device_id)
-        if not sd or sd.session_id != session.id:
-            raise HTTPException(status_code=404, detail="Session device not found")
-
-        authorized = False
-        if sd.participant_id:
-            p = db.query(SessionParticipant).filter(SessionParticipant.id == sd.participant_id).first()
-            if p and p.user_id == current_user.id:
-                authorized = True
-        if not authorized and sd.managed_by_device_id:
-            manager = repo.get_session_device_by_id(sd.managed_by_device_id)
-            if manager and manager.participant_id:
-                mp = db.query(SessionParticipant).filter(SessionParticipant.id == manager.participant_id).first()
-                if mp and mp.user_id == current_user.id:
-                    authorized = True
-        if not authorized:
-            raise HTTPException(status_code=403, detail="Not authorized for this device")
-
+        _require_device_access(db, session_uuid, session_device_id, current_user)
         ss = SessionService(db)
         ts = ss.heartbeat(session_device_id)
         return HeartbeatResponse(session_device_id=session_device_id, last_heartbeat=ts)
+    except HTTPException:
+        raise
+    except Exception as e:
+        _handle_service_error(e)
+
+
+@router.patch("/sessions/{session_uuid}/devices/{session_device_id}/status", response_model=SessionDeviceDTO)
+def update_device_status(
+    session_uuid: uuid.UUID,
+    session_device_id: int,
+    body: DeviceStatusUpdateRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    try:
+        _require_device_access(db, session_uuid, session_device_id, current_user)
+        ss = SessionService(db)
+        return ss.update_device_status(session_device_id, body.target_status.value, body.device_revision)
+    except HTTPException:
+        raise
+    except Exception as e:
+        _handle_service_error(e)
+
+
+@router.post("/sessions/{session_uuid}/devices/{session_device_id}/streams", status_code=status.HTTP_201_CREATED, response_model=CaptureStreamDTO)
+def create_capture_stream(
+    session_uuid: uuid.UUID,
+    session_device_id: int,
+    body: CreateCaptureStreamRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    try:
+        _, sd = _require_device_access(db, session_uuid, session_device_id, current_user)
+        if sd.removed_at is not None:
+            raise HTTPException(status_code=422, detail="Cannot create stream on removed device")
+        ss = SessionService(db)
+        return ss.create_capture_stream(session_device_id, body.stream_type.value, body.preset_json)
     except HTTPException:
         raise
     except Exception as e:

--- a/tests/biometric/test_admin_review_api.py
+++ b/tests/biometric/test_admin_review_api.py
@@ -548,7 +548,7 @@ def test_bca_adm21_override_audit_no_score(db, biometric_feature_enabled):
 def test_bca_adm22_route_count_883():
     from app.main import app
     paths = app.openapi().get("paths", {})
-    assert len(paths) == 920, f"Expected 912 routes (AN-3B2F PR-1A: +2 ball-training paths), got {len(paths)}"
+    assert len(paths) == 922, f"Expected 912 routes (AN-3B2F PR-1A: +2 ball-training paths), got {len(paths)}"
     assert "/api/v1/admin/biometric/review-queue" in paths
     assert "/api/v1/admin/biometric/{user_id}/history" in paths
     assert "/api/v1/admin/biometric/{user_id}/override" in paths

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -8452,6 +8452,23 @@
         "title": "CreateAssessmentResponse",
         "type": "object"
       },
+      "CreateCaptureStreamRequest": {
+        "properties": {
+          "preset_json": {
+            "title": "Preset Json",
+            "type": "object"
+          },
+          "stream_type": {
+            "$ref": "#/components/schemas/StreamType"
+          }
+        },
+        "required": [
+          "stream_type",
+          "preset_json"
+        ],
+        "title": "CreateCaptureStreamRequest",
+        "type": "object"
+      },
       "CreateSessionRequest": {
         "properties": {
           "max_devices": {
@@ -8569,6 +8586,23 @@
         ],
         "title": "DeviceStatus",
         "type": "string"
+      },
+      "DeviceStatusUpdateRequest": {
+        "properties": {
+          "device_revision": {
+            "title": "Device Revision",
+            "type": "integer"
+          },
+          "target_status": {
+            "$ref": "#/components/schemas/DeviceStatus"
+          }
+        },
+        "required": [
+          "target_status",
+          "device_revision"
+        ],
+        "title": "DeviceStatusUpdateRequest",
+        "type": "object"
       },
       "DeviceType": {
         "enum": [
@@ -51320,6 +51354,140 @@
           }
         ],
         "summary": "Heartbeat",
+        "tags": [
+          "multicamera"
+        ]
+      }
+    },
+    "/api/v1/multicamera/sessions/{session_uuid}/devices/{session_device_id}/status": {
+      "patch": {
+        "operationId": "update_device_status_api_v1_multicamera_sessions__session_uuid__devices__session_device_id__status_patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "session_uuid",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Session Uuid",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "session_device_id",
+            "required": true,
+            "schema": {
+              "title": "Session Device Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeviceStatusUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionDeviceDTO"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Update Device Status",
+        "tags": [
+          "multicamera"
+        ]
+      }
+    },
+    "/api/v1/multicamera/sessions/{session_uuid}/devices/{session_device_id}/streams": {
+      "post": {
+        "operationId": "create_capture_stream_api_v1_multicamera_sessions__session_uuid__devices__session_device_id__streams_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "session_uuid",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Session Uuid",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "session_device_id",
+            "required": true,
+            "schema": {
+              "title": "Session Device Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateCaptureStreamRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CaptureStreamDTO"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Create Capture Stream",
         "tags": [
           "multicamera"
         ]

--- a/tests/unit/api/web_routes/test_card_editor_ce2.py
+++ b/tests/unit/api/web_routes/test_card_editor_ce2.py
@@ -439,6 +439,6 @@ class TestCE217RouteCount:
         """
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 920, (
+        assert len(paths) == 922, (
             f"Expected 912 routes (910 prior + 2 ball training hub), got {len(paths)}."
         )

--- a/tests/unit/api/web_routes/test_card_editor_cs_s1.py
+++ b/tests/unit/api/web_routes/test_card_editor_cs_s1.py
@@ -294,7 +294,7 @@ class TestS109S110RouteAndSnapshot:
         """S1-09 (updated AN-3B2B2): route count is 910 (+3 admin feedback review endpoints)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 920, (
+        assert len(paths) == 922, (
             f"Expected 910 routes (907 prior + 3 admin feedback review), got {len(paths)}"
         )
 

--- a/tests/unit/api/web_routes/test_card_editor_ref_p2.py
+++ b/tests/unit/api/web_routes/test_card_editor_ref_p2.py
@@ -287,7 +287,7 @@ class TestP227to29RouteAndOpenAPI:
         """P2-27: Route count = 846 (CS-S2A +1 /card-studio/player)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 920, f"Expected 846 routes, got {len(paths)}"
+        assert len(paths) == 922, f"Expected 846 routes, got {len(paths)}"
 
     def test_p2_28_openapi_snapshot_match(self):
         """P2-28: OpenAPI snapshot matches live API paths."""

--- a/tests/unit/api/web_routes/test_card_studio_challenge.py
+++ b/tests/unit/api/web_routes/test_card_studio_challenge.py
@@ -294,7 +294,7 @@ class TestCCS11RouteCount:
         """CCS-11: route count updated to 842 after CE-3.8 (+3 from-mood endpoints)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 920, (
+        assert len(paths) == 922, (
             f"Expected 845 routes (842 CE-3.7+CE-3.8 baseline + 2 CS-S0 card-studio routes), got {len(paths)}."
         )
 

--- a/tests/unit/api/web_routes/test_card_studio_landing.py
+++ b/tests/unit/api/web_routes/test_card_studio_landing.py
@@ -159,7 +159,7 @@ class TestCEL12RouteCount:
         """CEL-12: route count 844 (unchanged — redirect is handler change, not new route)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 920, (
+        assert len(paths) == 922, (
             f"Expected 845 routes (redirect handler change does not add routes), got {len(paths)}."
         )
 

--- a/tests/unit/api/web_routes/test_card_studio_shell.py
+++ b/tests/unit/api/web_routes/test_card_studio_shell.py
@@ -326,7 +326,7 @@ class TestCSS21to23RouteConfirmations:
         """CSS-21: adding 2 card-studio routes raises count from 842 to 844."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 920, (
+        assert len(paths) == 922, (
             f"Expected 845 routes (842 baseline + 2 new /card-studio routes), got {len(paths)}"
         )
 

--- a/tests/unit/api/web_routes/test_card_studio_welcome.py
+++ b/tests/unit/api/web_routes/test_card_studio_welcome.py
@@ -325,7 +325,7 @@ class TestCEW18RouteCount:
         """CEW-18: route count baseline check (updated by CE-3.8 to 842)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 920, (
+        assert len(paths) == 922, (
             f"Expected 842 routes (839 CE-3.7 baseline + 3 from-mood endpoints), got {len(paths)}."
         )
 
@@ -678,7 +678,7 @@ class TestCEW44to51TemplateMoodPicker:
         """CEW-47: CE-3.8 adds 3 from-mood routes → total 842."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 920, (
+        assert len(paths) == 922, (
             f"Expected 845 routes (842 baseline + 2 CS-S0 routes), got {len(paths)}"
         )
 

--- a/tests/unit/api/web_routes/test_cc_design_1.py
+++ b/tests/unit/api/web_routes/test_cc_design_1.py
@@ -780,7 +780,7 @@ class TestCCD22to23RouteSnapshot:
         """CCD-22: Route count is 851 (CC-DESIGN-1 SNAPSHOT adds POST /challenges/{id}/card/photo)."""
         from app.main import app
         count = len(app.openapi().get("paths", {}))
-        assert count == 920, f"Expected 851, got {count}"
+        assert count == 922, f"Expected 851, got {count}"
 
     def test_ccd_23_openapi_snapshot_match(self):
         """CCD-23: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_cs_color_1.py
+++ b/tests/unit/api/web_routes/test_cs_color_1.py
@@ -382,7 +382,7 @@ class TestCSCOL15to16RouteAndSnapshot:
         """CSCOL-15: route count = 845 (+1 POST /dashboard/wc-card-theme)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 920, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 922, f"Expected 845 routes, got {len(paths)}"
 
     def test_cscol_16_openapi_snapshot_includes_wc_card_theme(self):
         """CSCOL-16: OpenAPI snapshot includes /dashboard/wc-card-theme."""

--- a/tests/unit/api/web_routes/test_cs_s2a.py
+++ b/tests/unit/api/web_routes/test_cs_s2a.py
@@ -40,7 +40,7 @@ class TestS2A01to02RouteRegistration:
         """S2A-02 (updated CS-S4A): Total route count is 847 (CS-S2A+CS-S4A)."""
         from app.main import app
         count = len(app.openapi().get("paths", {}))
-        assert count == 920, f"Expected 847 routes, got {count}"
+        assert count == 922, f"Expected 847 routes, got {count}"
 
 
 # ── S2A-03..08: _resolve_player_context logic ────────────────────────────────

--- a/tests/unit/api/web_routes/test_cs_s4a.py
+++ b/tests/unit/api/web_routes/test_cs_s4a.py
@@ -152,7 +152,7 @@ class TestS4A12to13RouteAndSnapshot:
         """S4A-12: Route count == 851 (CC-DESIGN-1 SNAPSHOT adds +1 POST /challenges/{id}/card/photo)."""
         from app.main import app
         count = len(app.openapi().get("paths", {}))
-        assert count == 920, f"Expected 851 routes, got {count}"
+        assert count == 922, f"Expected 851 routes, got {count}"
 
     def test_s4a_13_openapi_snapshot_match(self):
         """S4A-13: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_family_color_shop.py
+++ b/tests/unit/api/web_routes/test_family_color_shop.py
@@ -223,7 +223,7 @@ class TestRouteRegistration:
     def test_ts_13_route_count_836(self):
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 920, (
+        assert len(paths) == 922, (
             f"Expected 845 routes (842 CE-3.7+CE-3.8 baseline + 2 CS-S0 card-studio routes), got {len(paths)}."
         )
 

--- a/tests/unit/api/web_routes/test_shop_3a.py
+++ b/tests/unit/api/web_routes/test_shop_3a.py
@@ -194,7 +194,7 @@ class TestS3A13to14RouteAndSnapshot:
         """S3A-13: Route count = 845 (template deletion does not affect routes)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 920, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 922, f"Expected 845 routes, got {len(paths)}"
 
     def test_s3a_14_openapi_snapshot_match(self):
         """S3A-14: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_shop_3b1.py
+++ b/tests/unit/api/web_routes/test_shop_3b1.py
@@ -158,7 +158,7 @@ class TestS3B112to13RouteAndSnapshot:
         """S3B1-12: Route count = 845 (test cleanup does not affect routes)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 920, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 922, f"Expected 845 routes, got {len(paths)}"
 
     def test_s3b1_13_openapi_snapshot_match(self):
         """S3B1-13: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_shop_3b2.py
+++ b/tests/unit/api/web_routes/test_shop_3b2.py
@@ -192,7 +192,7 @@ class TestS3B215to16RouteAndSnapshot:
         """S3B2-15: Route count = 845 (template deletion does not affect routes)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 920, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 922, f"Expected 845 routes, got {len(paths)}"
 
     def test_s3b2_16_openapi_snapshot_match(self):
         """S3B2-16: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_shop_unified.py
+++ b/tests/unit/api/web_routes/test_shop_unified.py
@@ -271,7 +271,7 @@ class TestSHOP14to15RouteAndSnapshot:
         """SHOP-14: route count = 845 (no new routes in SHOP-1)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 920, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 922, f"Expected 845 routes, got {len(paths)}"
 
     def test_shop_15_openapi_snapshot_match(self):
         """SHOP-15: OpenAPI snapshot matches live API."""

--- a/tests/unit/juggling/test_annotation_helper.py
+++ b/tests/unit/juggling/test_annotation_helper.py
@@ -1015,7 +1015,7 @@ class TestHELP36_ProductionRouteCountUnchanged:
         snapshot_path = helper.ROOT / "tests/snapshots/openapi_snapshot.json"
         snapshot = json.loads(snapshot_path.read_text())
         route_count = len(snapshot.get("paths", {}))
-        assert route_count == 920, f"Unexpected production route count: {route_count}"
+        assert route_count == 922, f"Unexpected production route count: {route_count}"
 
     def test_helper_routes_not_in_production_snapshot(self):
         """HELP-36d: Annotation helper routes (/api/taxonomy etc.) not in production snapshot."""

--- a/tests/unit/juggling/test_juggling_video_list.py
+++ b/tests/unit/juggling/test_juggling_video_list.py
@@ -463,7 +463,7 @@ def test_jvl25_openapi_path_and_route_delta(client):
         if hasattr(r, "methods") and hasattr(r, "path")
         for m in (r.methods or [])
     ]
-    assert len(routes) == 1045, f"Expected 1038 routes (AN-3B2F PR-1B: +1 frame endpoint), got {len(routes)}"
+    assert len(routes) == 1047, f"Expected 1038 routes (AN-3B2F PR-1B: +1 frame endpoint), got {len(routes)}"
     get_list = [r for r in routes if r[0] == "GET" and r[1] == "/api/v1/users/me/juggling/videos"]
     assert len(get_list) == 1
 

--- a/tests/unit/multicamera/test_session_api.py
+++ b/tests/unit/multicamera/test_session_api.py
@@ -333,4 +333,162 @@ class TestLifecycleAndSnapshot:
     def test_api_26_route_count(self):
         from app.main import app as _app
         paths = len(_app.openapi().get("paths", {}))
-        assert paths == 920, f"Expected 920, got {paths}"
+        assert paths == 922, f"Expected 922, got {paths}"
+
+
+# ── API-27..40 Device Status + Capture Stream (PR-4B3B-0) ───────────────────
+
+class TestDeviceStatusAPI:
+
+    def _setup(self, db):
+        u = _create_user(db)
+        ds = DeviceService(db)
+        md = ds.register_managed_device(u.id, "ipad", "iPad")
+        r = _create_session(_auth(u))
+        d = r.json()
+        uid = d["session_uuid"]
+        pid = d["participants"][0]["id"]
+        rd = client.post(f"/api/v1/multicamera/sessions/{uid}/devices",
+                         json={"device_uuid": str(md.device_uuid), "device_role": "instructor_primary", "participant_id": pid},
+                         headers=_auth(u))
+        return u, uid, rd.json()["id"], rd.json()["revision"]
+
+    def test_api_27_device_status_valid(self, db):
+        u, uid, sd_id, rev = self._setup(db)
+        r = client.patch(f"/api/v1/multicamera/sessions/{uid}/devices/{sd_id}/status",
+                         json={"target_status": "ready", "device_revision": rev}, headers=_auth(u))
+        assert r.status_code == 200
+        assert r.json()["status"] == "ready"
+        assert r.json()["revision"] == rev + 1
+
+    def test_api_28_device_status_invalid_transition(self, db):
+        u, uid, sd_id, rev = self._setup(db)
+        r = client.patch(f"/api/v1/multicamera/sessions/{uid}/devices/{sd_id}/status",
+                         json={"target_status": "stopped", "device_revision": rev}, headers=_auth(u))
+        assert r.status_code == 422
+
+    def test_api_29_device_status_revision_conflict(self, db):
+        u, uid, sd_id, rev = self._setup(db)
+        r = client.patch(f"/api/v1/multicamera/sessions/{uid}/devices/{sd_id}/status",
+                         json={"target_status": "ready", "device_revision": rev + 99}, headers=_auth(u))
+        assert r.status_code == 409
+
+    def test_api_30_device_status_wrong_owner(self, db):
+        u, uid, sd_id, rev = self._setup(db)
+        u2 = _create_user(db, UserRole.STUDENT)
+        from app.services.multicamera.session_service import SessionService
+        ss = SessionService(db)
+        ss.join_session(_uuid.UUID(uid), u2.id, "player")
+        r = client.patch(f"/api/v1/multicamera/sessions/{uid}/devices/{sd_id}/status",
+                         json={"target_status": "ready", "device_revision": rev}, headers=_auth(u2))
+        assert r.status_code == 403
+
+    def test_api_31_device_status_cross_session(self, db):
+        u, uid1, sd_id, rev = self._setup(db)
+        r2 = _create_session(_auth(u))
+        uid2 = r2.json()["session_uuid"]
+        r = client.patch(f"/api/v1/multicamera/sessions/{uid2}/devices/{sd_id}/status",
+                         json={"target_status": "ready", "device_revision": rev}, headers=_auth(u))
+        assert r.status_code == 404
+
+    def test_api_32_device_status_removed(self, db):
+        u, uid, sd_id, rev = self._setup(db)
+        from app.services.multicamera.session_service import SessionService
+        ss = SessionService(db)
+        session = ss.get_session(_uuid.UUID(uid))
+        ss.remove_device(sd_id, session.revision)
+        r = client.patch(f"/api/v1/multicamera/sessions/{uid}/devices/{sd_id}/status",
+                         json={"target_status": "ready", "device_revision": rev}, headers=_auth(u))
+        assert r.status_code in (404, 422)
+
+    def test_api_33_device_status_no_auth(self):
+        r = client.patch(f"/api/v1/multicamera/sessions/{_uuid.uuid4()}/devices/1/status",
+                         json={"target_status": "ready", "device_revision": 1})
+        assert r.status_code == 401
+
+
+class TestCaptureStreamAPI:
+
+    def _setup(self, db):
+        u = _create_user(db)
+        ds = DeviceService(db)
+        md = ds.register_managed_device(u.id, "ipad", "iPad")
+        r = _create_session(_auth(u))
+        d = r.json()
+        uid = d["session_uuid"]
+        pid = d["participants"][0]["id"]
+        rd = client.post(f"/api/v1/multicamera/sessions/{uid}/devices",
+                         json={"device_uuid": str(md.device_uuid), "device_role": "instructor_primary", "participant_id": pid},
+                         headers=_auth(u))
+        return u, uid, rd.json()["id"]
+
+    def test_api_34_create_stream(self, db):
+        u, uid, sd_id = self._setup(db)
+        r = client.post(f"/api/v1/multicamera/sessions/{uid}/devices/{sd_id}/streams",
+                        json={"stream_type": "video", "preset_json": {"resolution": "1920x1080", "fps": 30}},
+                        headers=_auth(u))
+        assert r.status_code == 201
+        assert r.json()["stream_type"] == "video"
+
+    def test_api_35_create_stream_duplicate_idempotent(self, db):
+        u, uid, sd_id = self._setup(db)
+        body = {"stream_type": "video", "preset_json": {"resolution": "1920x1080", "fps": 30}}
+        r1 = client.post(f"/api/v1/multicamera/sessions/{uid}/devices/{sd_id}/streams", json=body, headers=_auth(u))
+        r2 = client.post(f"/api/v1/multicamera/sessions/{uid}/devices/{sd_id}/streams", json=body, headers=_auth(u))
+        assert r1.json()["id"] == r2.json()["id"]
+
+    def test_api_36_create_stream_wrong_owner(self, db):
+        u, uid, sd_id = self._setup(db)
+        u2 = _create_user(db, UserRole.STUDENT)
+        from app.services.multicamera.session_service import SessionService
+        ss = SessionService(db)
+        ss.join_session(_uuid.UUID(uid), u2.id, "player")
+        r = client.post(f"/api/v1/multicamera/sessions/{uid}/devices/{sd_id}/streams",
+                        json={"stream_type": "video", "preset_json": {"fps": 30}}, headers=_auth(u2))
+        assert r.status_code == 403
+
+    def test_api_37_create_stream_cross_session(self, db):
+        u, uid1, sd_id = self._setup(db)
+        r2 = _create_session(_auth(u))
+        uid2 = r2.json()["session_uuid"]
+        r = client.post(f"/api/v1/multicamera/sessions/{uid2}/devices/{sd_id}/streams",
+                        json={"stream_type": "video", "preset_json": {"fps": 30}}, headers=_auth(u))
+        assert r.status_code == 404
+
+    def test_api_38_create_stream_removed_device(self, db):
+        u, uid, sd_id = self._setup(db)
+        from app.services.multicamera.session_service import SessionService
+        ss = SessionService(db)
+        session = ss.get_session(_uuid.UUID(uid))
+        ss.remove_device(sd_id, session.revision)
+        r = client.post(f"/api/v1/multicamera/sessions/{uid}/devices/{sd_id}/streams",
+                        json={"stream_type": "video", "preset_json": {"fps": 30}}, headers=_auth(u))
+        assert r.status_code == 422
+
+    def test_api_39_create_stream_oversized_preset(self, db):
+        u, uid, sd_id = self._setup(db)
+        big = {"key": "x" * 5000}
+        r = client.post(f"/api/v1/multicamera/sessions/{uid}/devices/{sd_id}/streams",
+                        json={"stream_type": "video", "preset_json": big}, headers=_auth(u))
+        assert r.status_code == 422
+
+    def test_api_40_create_stream_no_auth(self):
+        r = client.post(f"/api/v1/multicamera/sessions/{_uuid.uuid4()}/devices/1/streams",
+                        json={"stream_type": "video", "preset_json": {"fps": 30}})
+        assert r.status_code == 401
+
+    def test_api_41_heartbeat_regression(self, db):
+        """Heartbeat still works after _require_device_access refactor."""
+        u = _create_user(db)
+        ds = DeviceService(db)
+        md = ds.register_managed_device(u.id, "ipad", "iPad")
+        r = _create_session(_auth(u))
+        d = r.json()
+        uid = d["session_uuid"]
+        pid = d["participants"][0]["id"]
+        rd = client.post(f"/api/v1/multicamera/sessions/{uid}/devices",
+                         json={"device_uuid": str(md.device_uuid), "device_role": "instructor_primary", "participant_id": pid},
+                         headers=_auth(u))
+        sd_id = rd.json()["id"]
+        r = client.post(f"/api/v1/multicamera/sessions/{uid}/devices/{sd_id}/heartbeat", headers=_auth(u))
+        assert r.status_code == 200


### PR DESCRIPTION
## Summary
2 new endpoints for device-level state management and capture stream metadata.

## Endpoints
| Method | Path | Guard |
|---|---|---|
| PATCH | /sessions/{uuid}/devices/{sd_id}/status | Device owner/manager |
| POST | /sessions/{uuid}/devices/{sd_id}/streams | Device owner/manager |

Shared `_require_device_access` guard (also refactored heartbeat).

## Route count
OpenAPI paths: 920 → 922 (+2). app.routes: 1044 → 1046 (+2).

## Tests
15 new (API-27..41) + 26 existing = 41 API tests PASS.
Heartbeat regression test (API-41) PASS.

## Not included
No iOS, no AVCapture, no local video, no lobby UI, no shutter, no media.