### PR TITLE
feat(multicamera): AN-3B PR-4B3B-0B — Scheduled Start + Stream Lifecycle

### DIFF
--- a/alembic/versions/2026_06_22_2000_scheduled_start_stream_lifecycle.py
+++ b/alembic/versions/2026_06_22_2000_scheduled_start_stream_lifecycle.py
@@ -1,0 +1,47 @@
+"""scheduled start + stream lifecycle (AN-3B PR-4B3B-0B)
+
+Add scheduled_start_at to multicamera_sessions.
+Add recording_pending to session status enum.
+Add capture_result to capture_streams.
+
+Revision ID: 2026_06_22_2000
+Revises: 2026_06_22_1000
+Create Date: 2026-06-22
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "2026_06_22_2000"
+down_revision = "2026_06_22_1000"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("multicamera_sessions",
+        sa.Column("scheduled_start_at", sa.DateTime(timezone=True), nullable=True))
+
+    op.drop_constraint("ck_mcs_status", "multicamera_sessions")
+    op.create_check_constraint("ck_mcs_status", "multicamera_sessions",
+        "status IN ('lobby','devices_ready','recording_pending','recording',"
+        "'stopped','finalizing','completed','cancelled')")
+
+    op.add_column("capture_streams",
+        sa.Column("capture_result", sa.String(20), nullable=True))
+    op.create_check_constraint("ck_cs_capture_result", "capture_streams",
+        "capture_result IS NULL OR capture_result IN ('success','error','interrupted')")
+
+
+def downgrade() -> None:
+    op.execute("UPDATE multicamera_sessions SET status='devices_ready' "
+               "WHERE status='recording_pending'")
+
+    op.drop_constraint("ck_cs_capture_result", "capture_streams")
+    op.drop_column("capture_streams", "capture_result")
+
+    op.drop_constraint("ck_mcs_status", "multicamera_sessions")
+    op.create_check_constraint("ck_mcs_status", "multicamera_sessions",
+        "status IN ('lobby','devices_ready','recording','stopped',"
+        "'finalizing','completed','cancelled')")
+
+    op.drop_column("multicamera_sessions", "scheduled_start_at")

--- a/app/api/api_v1/endpoints/multicamera/sessions.py
+++ b/app/api/api_v1/endpoints/multicamera/sessions.py
@@ -18,7 +18,7 @@ from .....models.user import User
 from .....models.multicamera_session import SessionParticipant
 from .....schemas.multicamera_session import (
     CaptureStreamDTO, DeviceRole, DeviceStatus, DeviceType,
-    MultiCameraSessionDTO, ParticipantRole, SessionDeviceDTO,
+    MultiCameraSessionDTO, ParticipantRole, SessionDeviceDTO, UpdateCaptureStreamRequest,
     SessionParticipantDTO, SessionStatus, StreamType,
 )
 from .....services.multicamera.session_service import SessionService
@@ -312,6 +312,36 @@ def create_capture_stream(
             raise HTTPException(status_code=422, detail="Cannot create stream on removed device")
         ss = SessionService(db)
         return ss.create_capture_stream(session_device_id, body.stream_type.value, body.preset_json)
+    except HTTPException:
+        raise
+    except Exception as e:
+        _handle_service_error(e)
+
+
+@router.patch("/sessions/{session_uuid}/devices/{session_device_id}/streams/{stream_id}", response_model=CaptureStreamDTO)
+def update_capture_stream(
+    session_uuid: uuid.UUID,
+    session_device_id: int,
+    stream_id: int,
+    body: UpdateCaptureStreamRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    try:
+        _, sd = _require_device_access(db, session_uuid, session_device_id, current_user)
+        from .....repositories.multicamera_session_repo import MultiCameraSessionRepo
+        repo = MultiCameraSessionRepo(db)
+        cs = repo.get_capture_stream_by_id(stream_id)
+        if not cs or cs.session_device_id != sd.id:
+            raise HTTPException(status_code=404, detail="Stream not found")
+        ss = SessionService(db)
+        return ss.update_capture_stream(
+            stream_id,
+            started_at=body.started_at,
+            stopped_at=body.stopped_at,
+            capture_result=body.capture_result,
+            stream_revision=body.stream_revision,
+        )
     except HTTPException:
         raise
     except Exception as e:

--- a/app/api/api_v1/endpoints/multicamera/sessions.py
+++ b/app/api/api_v1/endpoints/multicamera/sessions.py
@@ -203,6 +203,7 @@ def transition_session(
         _require_instructor(db, session_uuid, current_user)
         ss = SessionService(db)
         ss.transition_session(session_uuid, body.target_status.value, body.revision)
+        db.expire_all()
         return ss.get_session(session_uuid)
     except HTTPException:
         raise

--- a/app/models/multicamera_session.py
+++ b/app/models/multicamera_session.py
@@ -15,6 +15,7 @@ from ..database import Base
 class SessionStatus(str, enum.Enum):
     LOBBY = "lobby"
     DEVICES_READY = "devices_ready"
+    RECORDING_PENDING = "recording_pending"
     RECORDING = "recording"
     STOPPED = "stopped"
     FINALIZING = "finalizing"
@@ -54,7 +55,8 @@ class StreamType(str, enum.Enum):
 
 SESSION_TRANSITIONS = {
     SessionStatus.LOBBY: {SessionStatus.DEVICES_READY, SessionStatus.CANCELLED},
-    SessionStatus.DEVICES_READY: {SessionStatus.RECORDING, SessionStatus.LOBBY, SessionStatus.CANCELLED},
+    SessionStatus.DEVICES_READY: {SessionStatus.RECORDING_PENDING, SessionStatus.LOBBY, SessionStatus.CANCELLED},
+    SessionStatus.RECORDING_PENDING: {SessionStatus.RECORDING, SessionStatus.DEVICES_READY, SessionStatus.CANCELLED},
     SessionStatus.RECORDING: {SessionStatus.STOPPED},
     SessionStatus.STOPPED: {SessionStatus.FINALIZING, SessionStatus.CANCELLED},
     SessionStatus.FINALIZING: {SessionStatus.COMPLETED},
@@ -86,6 +88,7 @@ class MultiCameraSession(Base):
     max_devices = Column(SmallInteger, nullable=False, server_default="4")
     revision = Column(Integer, nullable=False, server_default="1")
     calibration_json = Column(JSONB, nullable=True)
+    scheduled_start_at = Column(DateTime(timezone=True))
     created_at = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
     started_at = Column(DateTime(timezone=True))
     stopped_at = Column(DateTime(timezone=True))
@@ -94,7 +97,7 @@ class MultiCameraSession(Base):
 
     __table_args__ = (
         CheckConstraint(
-            "status IN ('lobby','devices_ready','recording','stopped','finalizing','completed','cancelled')",
+            "status IN ('lobby','devices_ready','recording_pending','recording','stopped','finalizing','completed','cancelled')",
             name="ck_mcs_status",
         ),
         CheckConstraint("max_participants BETWEEN 1 AND 4", name="ck_mcs_max_participants"),
@@ -174,11 +177,16 @@ class CaptureStream(Base):
     created_at = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
     started_at = Column(DateTime(timezone=True))
     stopped_at = Column(DateTime(timezone=True))
+    capture_result = Column(String(20))
 
     __table_args__ = (
         CheckConstraint(
             "stream_type IN ('video','skeleton_2d','skeleton_3d','audio','telemetry')",
             name="ck_cs_stream_type",
+        ),
+        CheckConstraint(
+            "capture_result IS NULL OR capture_result IN ('success','error','interrupted')",
+            name="ck_cs_capture_result",
         ),
     )
 

--- a/app/repositories/multicamera_session_repo.py
+++ b/app/repositories/multicamera_session_repo.py
@@ -88,6 +88,9 @@ class MultiCameraSessionRepo:
         self.db.flush()
         return cs
 
+    def get_capture_stream_by_id(self, stream_id: int) -> Optional[CaptureStream]:
+        return self.db.query(CaptureStream).filter(CaptureStream.id == stream_id).first()
+
     def get_managed_device_by_uuid(self, device_uuid: uuid.UUID) -> Optional[ManagedDevice]:
         return self.db.query(ManagedDevice).filter(ManagedDevice.device_uuid == device_uuid).first()
 

--- a/app/schemas/multicamera_session.py
+++ b/app/schemas/multicamera_session.py
@@ -10,12 +10,13 @@ from datetime import datetime
 from enum import Enum
 from typing import List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 
 class SessionStatus(str, Enum):
     LOBBY = "lobby"
     DEVICES_READY = "devices_ready"
+    RECORDING_PENDING = "recording_pending"
     RECORDING = "recording"
     STOPPED = "stopped"
     FINALIZING = "finalizing"
@@ -99,8 +100,6 @@ class SessionDeviceDTO(BaseModel):
 
 
 class CaptureStreamDTO(BaseModel):
-    """Contract placeholder. Multiple streams per device+type
-    (recording attempts, restarts) handled in PR-4B3B."""
     model_config = {"from_attributes": True}
     id: int
     session_device_id: int
@@ -110,6 +109,36 @@ class CaptureStreamDTO(BaseModel):
     created_at: datetime
     started_at: Optional[datetime] = None
     stopped_at: Optional[datetime] = None
+    capture_result: Optional[str] = None
+    duration_ms: Optional[int] = None
+
+    @model_validator(mode="after")
+    def compute_duration(self):
+        if self.started_at and self.stopped_at:
+            delta = self.stopped_at - self.started_at
+            object.__setattr__(self, "duration_ms", int(delta.total_seconds() * 1000))
+        return self
+
+
+class UpdateCaptureStreamRequest(BaseModel):
+    started_at: Optional[datetime] = None
+    stopped_at: Optional[datetime] = None
+    capture_result: Optional[str] = None
+    stream_revision: int
+
+    @field_validator("capture_result")
+    @classmethod
+    def validate_result(cls, v):
+        if v is not None and v not in ("success", "error", "interrupted"):
+            raise ValueError("Must be success/error/interrupted")
+        return v
+
+    @field_validator("started_at", "stopped_at")
+    @classmethod
+    def require_timezone(cls, v):
+        if v is not None and v.tzinfo is None:
+            raise ValueError("Timestamp must be timezone-aware UTC")
+        return v
 
 
 class CalibrationPlaceholder(BaseModel):
@@ -131,6 +160,7 @@ class MultiCameraSessionDTO(BaseModel):
     max_devices: int
     revision: int
     calibration: Optional[CalibrationPlaceholder] = None
+    scheduled_start_at: Optional[datetime] = None
     created_at: datetime
     started_at: Optional[datetime] = None
     stopped_at: Optional[datetime] = None

--- a/app/services/multicamera/session_service.py
+++ b/app/services/multicamera/session_service.py
@@ -157,6 +157,8 @@ class SessionService:
         if target not in SESSION_TRANSITIONS.get(current, set()):
             raise InvalidTransitionError("session", s.status, target_status)
 
+        s.status = target_status
+        s.revision += 1
         now = datetime.now(timezone.utc)
 
         if target == SessionStatus.RECORDING_PENDING:

--- a/app/services/multicamera/session_service.py
+++ b/app/services/multicamera/session_service.py
@@ -145,6 +145,9 @@ class SessionService:
         self.db.refresh(sd)
         return sd
 
+    _SCHEDULED_LEAD_SECONDS = 8
+    _SCHEDULED_EXPIRE_SECONDS = 60
+
     def transition_session(self, session_uuid: uuid.UUID, target_status: str, session_revision: int):
         s = self._require_session(session_uuid)
         if s.revision != session_revision:
@@ -153,12 +156,25 @@ class SessionService:
         target = SessionStatus(target_status)
         if target not in SESSION_TRANSITIONS.get(current, set()):
             raise InvalidTransitionError("session", s.status, target_status)
-        s.status = target_status
-        s.revision += 1
+
         now = datetime.now(timezone.utc)
+
+        if target == SessionStatus.RECORDING_PENDING:
+            from datetime import timedelta
+            s.scheduled_start_at = now + timedelta(seconds=self._SCHEDULED_LEAD_SECONDS)
+
         if target == SessionStatus.RECORDING:
+            if s.scheduled_start_at:
+                elapsed = (now - s.scheduled_start_at).total_seconds()
+                if elapsed > self._SCHEDULED_EXPIRE_SECONDS:
+                    raise InvalidTransitionError("session", s.status,
+                        f"recording (scheduled start expired: {elapsed:.0f}s > {self._SCHEDULED_EXPIRE_SECONDS}s)")
             s.started_at = now
-        elif target == SessionStatus.STOPPED:
+
+        if target == SessionStatus.DEVICES_READY and current == SessionStatus.RECORDING_PENDING:
+            s.scheduled_start_at = None
+
+        if target == SessionStatus.STOPPED:
             s.stopped_at = now
         elif target == SessionStatus.COMPLETED:
             s.finalized_at = now
@@ -183,6 +199,70 @@ class SessionService:
         self.db.commit()
         self.db.refresh(cs)
         return cs
+
+    _CLOCK_SKEW_TOLERANCE_SECONDS = 30
+
+    def update_capture_stream(self, stream_id: int, started_at=None, stopped_at=None,
+                               capture_result=None, stream_revision: int = 0):
+        cs = self.repo.get_capture_stream_by_id(stream_id)
+        if not cs:
+            raise DeviceNotFoundError(f"stream {stream_id}")
+        if cs.revision != stream_revision:
+            if self._is_identical_update(cs, started_at, stopped_at, capture_result):
+                return cs
+            raise RevisionConflictError("capture_stream", stream_revision, cs.revision)
+        if cs.capture_result in ("success", "error", "interrupted"):
+            if self._is_identical_update(cs, started_at, stopped_at, capture_result):
+                return cs
+            raise RevisionConflictError("capture_stream", stream_revision, cs.revision)
+
+        now = datetime.now(timezone.utc)
+        skew = self._CLOCK_SKEW_TOLERANCE_SECONDS
+
+        if started_at is not None:
+            if cs.started_at is not None and cs.started_at != started_at:
+                raise RevisionConflictError("capture_stream.started_at", 0, 1)
+            if (started_at - now).total_seconds() > skew:
+                raise InvalidTransitionError("stream", "started_at", f"future >{skew}s")
+            cs.started_at = started_at
+
+        if stopped_at is not None:
+            if cs.started_at is None and started_at is None:
+                raise InvalidTransitionError("stream", "none", "stopped_at without started_at")
+            effective_start = started_at or cs.started_at
+            if stopped_at < effective_start:
+                raise InvalidTransitionError("stream", "stopped_at", "before started_at")
+            if (stopped_at - now).total_seconds() > skew:
+                raise InvalidTransitionError("stream", "stopped_at", f"future >{skew}s")
+            cs.stopped_at = stopped_at
+
+        if capture_result is not None:
+            if capture_result == "success":
+                effective_start = started_at or cs.started_at
+                effective_stop = stopped_at or cs.stopped_at
+                if not effective_start or not effective_stop:
+                    raise InvalidTransitionError("stream", "capture_result",
+                        "success requires started_at and stopped_at")
+            if capture_result in ("error", "interrupted") and cs.stopped_at is None and stopped_at is None:
+                cs.stopped_at = now
+            cs.capture_result = capture_result
+
+        cs.revision += 1
+        self.db.commit()
+        self.db.refresh(cs)
+        return cs
+
+    @staticmethod
+    def _is_identical_update(cs, started_at, stopped_at, capture_result) -> bool:
+        if started_at is not None and cs.started_at != started_at:
+            return False
+        if stopped_at is not None and cs.stopped_at != stopped_at:
+            return False
+        if capture_result is not None and cs.capture_result != capture_result:
+            return False
+        if started_at is None and stopped_at is None and capture_result is None:
+            return False
+        return True
 
     def _require_session(self, session_uuid: uuid.UUID) -> MultiCameraSession:
         s = self.repo.get_session_by_uuid(session_uuid)

--- a/tests/biometric/test_admin_review_api.py
+++ b/tests/biometric/test_admin_review_api.py
@@ -548,7 +548,7 @@ def test_bca_adm21_override_audit_no_score(db, biometric_feature_enabled):
 def test_bca_adm22_route_count_883():
     from app.main import app
     paths = app.openapi().get("paths", {})
-    assert len(paths) == 922, f"Expected 912 routes (AN-3B2F PR-1A: +2 ball-training paths), got {len(paths)}"
+    assert len(paths) == 923, f"Expected 912 routes (AN-3B2F PR-1A: +2 ball-training paths), got {len(paths)}"
     assert "/api/v1/admin/biometric/review-queue" in paths
     assert "/api/v1/admin/biometric/{user_id}/history" in paths
     assert "/api/v1/admin/biometric/{user_id}/override" in paths

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -6997,12 +6997,33 @@
         "type": "object"
       },
       "CaptureStreamDTO": {
-        "description": "Contract placeholder. Multiple streams per device+type\n(recording attempts, restarts) handled in PR-4B3B.",
         "properties": {
+          "capture_result": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Capture Result"
+          },
           "created_at": {
             "format": "date-time",
             "title": "Created At",
             "type": "string"
+          },
+          "duration_ms": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Duration Ms"
           },
           "id": {
             "title": "Id",
@@ -14182,6 +14203,18 @@
             "title": "Revision",
             "type": "integer"
           },
+          "scheduled_start_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scheduled Start At"
+          },
           "session_uuid": {
             "format": "uuid",
             "title": "Session Uuid",
@@ -20625,6 +20658,7 @@
         "enum": [
           "lobby",
           "devices_ready",
+          "recording_pending",
           "recording",
           "stopped",
           "finalizing",
@@ -23654,6 +23688,54 @@
           "revision"
         ],
         "title": "TransitionRequest",
+        "type": "object"
+      },
+      "UpdateCaptureStreamRequest": {
+        "properties": {
+          "capture_result": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Capture Result"
+          },
+          "started_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Started At"
+          },
+          "stopped_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stopped At"
+          },
+          "stream_revision": {
+            "title": "Stream Revision",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "stream_revision"
+        ],
+        "title": "UpdateCaptureStreamRequest",
         "type": "object"
       },
       "UpdateHoursRequest": {
@@ -51488,6 +51570,82 @@
           }
         ],
         "summary": "Create Capture Stream",
+        "tags": [
+          "multicamera"
+        ]
+      }
+    },
+    "/api/v1/multicamera/sessions/{session_uuid}/devices/{session_device_id}/streams/{stream_id}": {
+      "patch": {
+        "operationId": "update_capture_stream_api_v1_multicamera_sessions__session_uuid__devices__session_device_id__streams__stream_id__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "session_uuid",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Session Uuid",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "session_device_id",
+            "required": true,
+            "schema": {
+              "title": "Session Device Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "stream_id",
+            "required": true,
+            "schema": {
+              "title": "Stream Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateCaptureStreamRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CaptureStreamDTO"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Update Capture Stream",
         "tags": [
           "multicamera"
         ]

--- a/tests/unit/api/web_routes/test_card_editor_ce2.py
+++ b/tests/unit/api/web_routes/test_card_editor_ce2.py
@@ -439,6 +439,6 @@ class TestCE217RouteCount:
         """
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 922, (
+        assert len(paths) == 923, (
             f"Expected 912 routes (910 prior + 2 ball training hub), got {len(paths)}."
         )

--- a/tests/unit/api/web_routes/test_card_editor_cs_s1.py
+++ b/tests/unit/api/web_routes/test_card_editor_cs_s1.py
@@ -294,7 +294,7 @@ class TestS109S110RouteAndSnapshot:
         """S1-09 (updated AN-3B2B2): route count is 910 (+3 admin feedback review endpoints)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 922, (
+        assert len(paths) == 923, (
             f"Expected 910 routes (907 prior + 3 admin feedback review), got {len(paths)}"
         )
 

--- a/tests/unit/api/web_routes/test_card_editor_ref_p2.py
+++ b/tests/unit/api/web_routes/test_card_editor_ref_p2.py
@@ -287,7 +287,7 @@ class TestP227to29RouteAndOpenAPI:
         """P2-27: Route count = 846 (CS-S2A +1 /card-studio/player)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 922, f"Expected 846 routes, got {len(paths)}"
+        assert len(paths) == 923, f"Expected 846 routes, got {len(paths)}"
 
     def test_p2_28_openapi_snapshot_match(self):
         """P2-28: OpenAPI snapshot matches live API paths."""

--- a/tests/unit/api/web_routes/test_card_studio_challenge.py
+++ b/tests/unit/api/web_routes/test_card_studio_challenge.py
@@ -294,7 +294,7 @@ class TestCCS11RouteCount:
         """CCS-11: route count updated to 842 after CE-3.8 (+3 from-mood endpoints)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 922, (
+        assert len(paths) == 923, (
             f"Expected 845 routes (842 CE-3.7+CE-3.8 baseline + 2 CS-S0 card-studio routes), got {len(paths)}."
         )
 

--- a/tests/unit/api/web_routes/test_card_studio_landing.py
+++ b/tests/unit/api/web_routes/test_card_studio_landing.py
@@ -159,7 +159,7 @@ class TestCEL12RouteCount:
         """CEL-12: route count 844 (unchanged — redirect is handler change, not new route)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 922, (
+        assert len(paths) == 923, (
             f"Expected 845 routes (redirect handler change does not add routes), got {len(paths)}."
         )
 

--- a/tests/unit/api/web_routes/test_card_studio_shell.py
+++ b/tests/unit/api/web_routes/test_card_studio_shell.py
@@ -326,7 +326,7 @@ class TestCSS21to23RouteConfirmations:
         """CSS-21: adding 2 card-studio routes raises count from 842 to 844."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 922, (
+        assert len(paths) == 923, (
             f"Expected 845 routes (842 baseline + 2 new /card-studio routes), got {len(paths)}"
         )
 

--- a/tests/unit/api/web_routes/test_card_studio_welcome.py
+++ b/tests/unit/api/web_routes/test_card_studio_welcome.py
@@ -325,7 +325,7 @@ class TestCEW18RouteCount:
         """CEW-18: route count baseline check (updated by CE-3.8 to 842)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 922, (
+        assert len(paths) == 923, (
             f"Expected 842 routes (839 CE-3.7 baseline + 3 from-mood endpoints), got {len(paths)}."
         )
 
@@ -678,7 +678,7 @@ class TestCEW44to51TemplateMoodPicker:
         """CEW-47: CE-3.8 adds 3 from-mood routes → total 842."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 922, (
+        assert len(paths) == 923, (
             f"Expected 845 routes (842 baseline + 2 CS-S0 routes), got {len(paths)}"
         )
 

--- a/tests/unit/api/web_routes/test_cc_design_1.py
+++ b/tests/unit/api/web_routes/test_cc_design_1.py
@@ -780,7 +780,7 @@ class TestCCD22to23RouteSnapshot:
         """CCD-22: Route count is 851 (CC-DESIGN-1 SNAPSHOT adds POST /challenges/{id}/card/photo)."""
         from app.main import app
         count = len(app.openapi().get("paths", {}))
-        assert count == 922, f"Expected 851, got {count}"
+        assert count == 923, f"Expected 851, got {count}"
 
     def test_ccd_23_openapi_snapshot_match(self):
         """CCD-23: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_cs_color_1.py
+++ b/tests/unit/api/web_routes/test_cs_color_1.py
@@ -382,7 +382,7 @@ class TestCSCOL15to16RouteAndSnapshot:
         """CSCOL-15: route count = 845 (+1 POST /dashboard/wc-card-theme)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 922, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 923, f"Expected 845 routes, got {len(paths)}"
 
     def test_cscol_16_openapi_snapshot_includes_wc_card_theme(self):
         """CSCOL-16: OpenAPI snapshot includes /dashboard/wc-card-theme."""

--- a/tests/unit/api/web_routes/test_cs_s2a.py
+++ b/tests/unit/api/web_routes/test_cs_s2a.py
@@ -40,7 +40,7 @@ class TestS2A01to02RouteRegistration:
         """S2A-02 (updated CS-S4A): Total route count is 847 (CS-S2A+CS-S4A)."""
         from app.main import app
         count = len(app.openapi().get("paths", {}))
-        assert count == 922, f"Expected 847 routes, got {count}"
+        assert count == 923, f"Expected 847 routes, got {count}"
 
 
 # ── S2A-03..08: _resolve_player_context logic ────────────────────────────────

--- a/tests/unit/api/web_routes/test_cs_s4a.py
+++ b/tests/unit/api/web_routes/test_cs_s4a.py
@@ -152,7 +152,7 @@ class TestS4A12to13RouteAndSnapshot:
         """S4A-12: Route count == 851 (CC-DESIGN-1 SNAPSHOT adds +1 POST /challenges/{id}/card/photo)."""
         from app.main import app
         count = len(app.openapi().get("paths", {}))
-        assert count == 922, f"Expected 851 routes, got {count}"
+        assert count == 923, f"Expected 851 routes, got {count}"
 
     def test_s4a_13_openapi_snapshot_match(self):
         """S4A-13: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_family_color_shop.py
+++ b/tests/unit/api/web_routes/test_family_color_shop.py
@@ -223,7 +223,7 @@ class TestRouteRegistration:
     def test_ts_13_route_count_836(self):
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 922, (
+        assert len(paths) == 923, (
             f"Expected 845 routes (842 CE-3.7+CE-3.8 baseline + 2 CS-S0 card-studio routes), got {len(paths)}."
         )
 

--- a/tests/unit/api/web_routes/test_shop_3a.py
+++ b/tests/unit/api/web_routes/test_shop_3a.py
@@ -194,7 +194,7 @@ class TestS3A13to14RouteAndSnapshot:
         """S3A-13: Route count = 845 (template deletion does not affect routes)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 922, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 923, f"Expected 845 routes, got {len(paths)}"
 
     def test_s3a_14_openapi_snapshot_match(self):
         """S3A-14: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_shop_3b1.py
+++ b/tests/unit/api/web_routes/test_shop_3b1.py
@@ -158,7 +158,7 @@ class TestS3B112to13RouteAndSnapshot:
         """S3B1-12: Route count = 845 (test cleanup does not affect routes)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 922, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 923, f"Expected 845 routes, got {len(paths)}"
 
     def test_s3b1_13_openapi_snapshot_match(self):
         """S3B1-13: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_shop_3b2.py
+++ b/tests/unit/api/web_routes/test_shop_3b2.py
@@ -192,7 +192,7 @@ class TestS3B215to16RouteAndSnapshot:
         """S3B2-15: Route count = 845 (template deletion does not affect routes)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 922, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 923, f"Expected 845 routes, got {len(paths)}"
 
     def test_s3b2_16_openapi_snapshot_match(self):
         """S3B2-16: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_shop_unified.py
+++ b/tests/unit/api/web_routes/test_shop_unified.py
@@ -271,7 +271,7 @@ class TestSHOP14to15RouteAndSnapshot:
         """SHOP-14: route count = 845 (no new routes in SHOP-1)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 922, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 923, f"Expected 845 routes, got {len(paths)}"
 
     def test_shop_15_openapi_snapshot_match(self):
         """SHOP-15: OpenAPI snapshot matches live API."""

--- a/tests/unit/juggling/test_annotation_helper.py
+++ b/tests/unit/juggling/test_annotation_helper.py
@@ -1015,7 +1015,7 @@ class TestHELP36_ProductionRouteCountUnchanged:
         snapshot_path = helper.ROOT / "tests/snapshots/openapi_snapshot.json"
         snapshot = json.loads(snapshot_path.read_text())
         route_count = len(snapshot.get("paths", {}))
-        assert route_count == 922, f"Unexpected production route count: {route_count}"
+        assert route_count == 923, f"Unexpected production route count: {route_count}"
 
     def test_helper_routes_not_in_production_snapshot(self):
         """HELP-36d: Annotation helper routes (/api/taxonomy etc.) not in production snapshot."""

--- a/tests/unit/juggling/test_juggling_video_list.py
+++ b/tests/unit/juggling/test_juggling_video_list.py
@@ -463,7 +463,7 @@ def test_jvl25_openapi_path_and_route_delta(client):
         if hasattr(r, "methods") and hasattr(r, "path")
         for m in (r.methods or [])
     ]
-    assert len(routes) == 1047, f"Expected 1038 routes (AN-3B2F PR-1B: +1 frame endpoint), got {len(routes)}"
+    assert len(routes) == 1048, f"Expected 1038 routes (AN-3B2F PR-1B: +1 frame endpoint), got {len(routes)}"
     get_list = [r for r in routes if r[0] == "GET" and r[1] == "/api/v1/users/me/juggling/videos"]
     assert len(get_list) == 1
 

--- a/tests/unit/juggling/test_juggling_video_list.py
+++ b/tests/unit/juggling/test_juggling_video_list.py
@@ -471,13 +471,13 @@ def test_jvl25_openapi_path_and_route_delta(client):
 # ── JVL-26: Alembic head unchanged ───────────────────────────────────────────
 
 def test_jvl26_alembic_head_unchanged():
-    """JVL-26: Alembic head is 2026_06_22_1000 (AN-3B PR-4B2 multicamera session contract)."""
+    """JVL-26: Alembic head is 2026_06_22_2000 (AN-3B PR-4B3B-0B scheduled start + stream lifecycle)."""
     from alembic.config import Config
     from alembic.script import ScriptDirectory
     import os
     cfg = Config(os.path.join(os.path.dirname(__file__), "..", "..", "..", "alembic.ini"))
     heads = ScriptDirectory.from_config(cfg).get_heads()
-    assert heads == ["2026_06_22_1000"], f"Unexpected Alembic heads: {heads}"
+    assert heads == ["2026_06_22_2000"], f"Unexpected Alembic heads: {heads}"
 
 
 # ── JVL-27: P4 thumbnail/media regression ────────────────────────────────────

--- a/tests/unit/multicamera/test_session_api.py
+++ b/tests/unit/multicamera/test_session_api.py
@@ -1,5 +1,6 @@
-"""Multicamera Session API Tests — AN-3B PR-4B3A. 26 tests."""
+"""Multicamera Session API Tests — AN-3B PR-4B3A + PR-4B3B-0B."""
 import uuid as _uuid
+from datetime import datetime, timedelta, timezone
 import pytest
 from fastapi.testclient import TestClient
 from app.main import app
@@ -85,6 +86,10 @@ class TestAuthGuard:
                           json={"target_status": "devices_ready", "revision": d["revision"]}, headers=_auth(u))
         assert r2.status_code == 200
         assert r2.json()["status"] == "devices_ready"
+        d2 = r2.json()
+        r3 = client.patch(f"/api/v1/multicamera/sessions/{d['session_uuid']}/status",
+                          json={"target_status": "recording_pending", "revision": d2["revision"]}, headers=_auth(u))
+        assert r3.status_code == 200
 
     def test_api_07_transition_player_forbidden(self, db):
         u1 = _create_user(db)
@@ -302,6 +307,8 @@ class TestLifecycleAndSnapshot:
         d = client.patch(f"/api/v1/multicamera/sessions/{uid}/status",
                          json={"target_status": "devices_ready", "revision": d["revision"]}, headers=_auth(u1)).json()
         d = client.patch(f"/api/v1/multicamera/sessions/{uid}/status",
+                         json={"target_status": "recording_pending", "revision": d["revision"]}, headers=_auth(u1)).json()
+        d = client.patch(f"/api/v1/multicamera/sessions/{uid}/status",
                          json={"target_status": "recording", "revision": d["revision"]}, headers=_auth(u1)).json()
         d = client.patch(f"/api/v1/multicamera/sessions/{uid}/status",
                          json={"target_status": "stopped", "revision": d["revision"]}, headers=_auth(u1)).json()
@@ -333,7 +340,7 @@ class TestLifecycleAndSnapshot:
     def test_api_26_route_count(self):
         from app.main import app as _app
         paths = len(_app.openapi().get("paths", {}))
-        assert paths == 922, f"Expected 922, got {paths}"
+        assert paths == 923, f"Expected 922, got {paths}"
 
 
 # ── API-27..40 Device Status + Capture Stream (PR-4B3B-0) ───────────────────
@@ -492,3 +499,285 @@ class TestCaptureStreamAPI:
         sd_id = rd.json()["id"]
         r = client.post(f"/api/v1/multicamera/sessions/{uid}/devices/{sd_id}/heartbeat", headers=_auth(u))
         assert r.status_code == 200
+
+
+# ── SS/SL/GR: Scheduled Start + Stream Lifecycle (PR-4B3B-0B) ───────────────
+
+class TestScheduledStart:
+
+    def _setup_ready(self, db):
+        u = _create_user(db)
+        r = _create_session(_auth(u))
+        d = r.json()
+        uid = d["session_uuid"]
+        d = client.patch(f"/api/v1/multicamera/sessions/{uid}/status",
+                         json={"target_status": "devices_ready", "revision": d["revision"]}, headers=_auth(u)).json()
+        return u, uid, d["revision"]
+
+    def test_ss_01_recording_pending(self, db):
+        u, uid, rev = self._setup_ready(db)
+        r = client.patch(f"/api/v1/multicamera/sessions/{uid}/status",
+                         json={"target_status": "recording_pending", "revision": rev}, headers=_auth(u))
+        assert r.status_code == 200
+        d = r.json()
+        assert d["status"] == "recording_pending"
+        assert d["scheduled_start_at"] is not None
+
+    def test_ss_02_recording_confirm(self, db):
+        u, uid, rev = self._setup_ready(db)
+        d = client.patch(f"/api/v1/multicamera/sessions/{uid}/status",
+                         json={"target_status": "recording_pending", "revision": rev}, headers=_auth(u)).json()
+        r = client.patch(f"/api/v1/multicamera/sessions/{uid}/status",
+                         json={"target_status": "recording", "revision": d["revision"]}, headers=_auth(u))
+        assert r.status_code == 200
+        assert r.json()["status"] == "recording"
+
+    def test_ss_03_abort_to_devices_ready(self, db):
+        u, uid, rev = self._setup_ready(db)
+        d = client.patch(f"/api/v1/multicamera/sessions/{uid}/status",
+                         json={"target_status": "recording_pending", "revision": rev}, headers=_auth(u)).json()
+        r = client.patch(f"/api/v1/multicamera/sessions/{uid}/status",
+                         json={"target_status": "devices_ready", "revision": d["revision"]}, headers=_auth(u))
+        assert r.status_code == 200
+        assert r.json()["scheduled_start_at"] is None
+
+    def test_ss_04_recording_pending_cancel(self, db):
+        u, uid, rev = self._setup_ready(db)
+        d = client.patch(f"/api/v1/multicamera/sessions/{uid}/status",
+                         json={"target_status": "recording_pending", "revision": rev}, headers=_auth(u)).json()
+        r = client.patch(f"/api/v1/multicamera/sessions/{uid}/status",
+                         json={"target_status": "cancelled", "revision": d["revision"]}, headers=_auth(u))
+        assert r.status_code == 200
+
+    def test_ss_05_skip_pending_invalid(self, db):
+        u, uid, rev = self._setup_ready(db)
+        r = client.patch(f"/api/v1/multicamera/sessions/{uid}/status",
+                         json={"target_status": "recording", "revision": rev}, headers=_auth(u))
+        assert r.status_code == 422
+
+    def test_ss_06_duplicate_pending_revision(self, db):
+        u, uid, rev = self._setup_ready(db)
+        client.patch(f"/api/v1/multicamera/sessions/{uid}/status",
+                     json={"target_status": "recording_pending", "revision": rev}, headers=_auth(u))
+        r = client.patch(f"/api/v1/multicamera/sessions/{uid}/status",
+                         json={"target_status": "recording_pending", "revision": rev}, headers=_auth(u))
+        assert r.status_code == 409
+
+    def test_ss_07_non_instructor_pending(self, db):
+        u1 = _create_user(db)
+        u2 = _create_user(db, UserRole.STUDENT)
+        r = _create_session(_auth(u1))
+        d = r.json()
+        uid = d["session_uuid"]
+        d = client.patch(f"/api/v1/multicamera/sessions/{uid}/status",
+                         json={"target_status": "devices_ready", "revision": d["revision"]}, headers=_auth(u1)).json()
+        client.post(f"/api/v1/multicamera/sessions/{uid}/join", json={"role": "player"}, headers=_auth(u2))
+        r = client.patch(f"/api/v1/multicamera/sessions/{uid}/status",
+                         json={"target_status": "recording_pending", "revision": d["revision"]}, headers=_auth(u2))
+        assert r.status_code == 403
+
+    def test_ss_08_late_confirm_expired(self, db):
+        u, uid, rev = self._setup_ready(db)
+        d = client.patch(f"/api/v1/multicamera/sessions/{uid}/status",
+                         json={"target_status": "recording_pending", "revision": rev}, headers=_auth(u)).json()
+        from app.services.multicamera.session_service import SessionService
+        from app.database import SessionLocal
+        sdb = SessionLocal()
+        from app.models.multicamera_session import MultiCameraSession
+        from datetime import timedelta
+        s = sdb.query(MultiCameraSession).filter(MultiCameraSession.session_uuid == _uuid.UUID(uid)).first()
+        s.scheduled_start_at = s.scheduled_start_at - timedelta(seconds=120)
+        sdb.commit()
+        sdb.close()
+        r = client.patch(f"/api/v1/multicamera/sessions/{uid}/status",
+                         json={"target_status": "recording", "revision": d["revision"]}, headers=_auth(u))
+        assert r.status_code == 422
+
+    def test_ss_09_refetch_after_pending(self, db):
+        u, uid, rev = self._setup_ready(db)
+        d = client.patch(f"/api/v1/multicamera/sessions/{uid}/status",
+                         json={"target_status": "recording_pending", "revision": rev}, headers=_auth(u)).json()
+        refetch = client.get(f"/api/v1/multicamera/sessions/{uid}", headers=_auth(u)).json()
+        assert refetch["status"] == "recording_pending"
+        assert refetch["scheduled_start_at"] == d["scheduled_start_at"]
+
+    def test_ss_10_transition_matrix_complete(self, db):
+        from app.models.multicamera_session import SESSION_TRANSITIONS, SessionStatus
+        assert SessionStatus.RECORDING_PENDING in SESSION_TRANSITIONS
+        assert SessionStatus.RECORDING in SESSION_TRANSITIONS[SessionStatus.RECORDING_PENDING]
+        assert SessionStatus.DEVICES_READY in SESSION_TRANSITIONS[SessionStatus.RECORDING_PENDING]
+        assert SessionStatus.CANCELLED in SESSION_TRANSITIONS[SessionStatus.RECORDING_PENDING]
+
+
+class TestStreamLifecycle:
+
+    def _setup_stream(self, db):
+        u = _create_user(db)
+        ds = DeviceService(db)
+        md = ds.register_managed_device(u.id, "ipad", "iPad")
+        r = _create_session(_auth(u))
+        d = r.json()
+        uid = d["session_uuid"]
+        pid = d["participants"][0]["id"]
+        rd = client.post(f"/api/v1/multicamera/sessions/{uid}/devices",
+                         json={"device_uuid": str(md.device_uuid), "device_role": "instructor_primary", "participant_id": pid},
+                         headers=_auth(u))
+        sd_id = rd.json()["id"]
+        cs = client.post(f"/api/v1/multicamera/sessions/{uid}/devices/{sd_id}/streams",
+                         json={"stream_type": "video", "preset_json": {"fps": 30}}, headers=_auth(u))
+        return u, uid, sd_id, cs.json()["id"], cs.json()["revision"]
+
+    def test_sl_01_patch_started(self, db):
+        u, uid, sd_id, sid, rev = self._setup_stream(db)
+        now = datetime.now(timezone.utc).isoformat()
+        r = client.patch(f"/api/v1/multicamera/sessions/{uid}/devices/{sd_id}/streams/{sid}",
+                         json={"started_at": now, "stream_revision": rev}, headers=_auth(u))
+        assert r.status_code == 200
+        assert r.json()["started_at"] is not None
+        assert r.json()["revision"] == rev + 1
+
+    def test_sl_02_patch_stopped_success(self, db):
+        u, uid, sd_id, sid, rev = self._setup_stream(db)
+        start = datetime.now(timezone.utc)
+        stop = start + timedelta(seconds=10)
+        r1 = client.patch(f"/api/v1/multicamera/sessions/{uid}/devices/{sd_id}/streams/{sid}",
+                          json={"started_at": start.isoformat(), "stream_revision": rev}, headers=_auth(u))
+        r2 = client.patch(f"/api/v1/multicamera/sessions/{uid}/devices/{sd_id}/streams/{sid}",
+                          json={"stopped_at": stop.isoformat(), "capture_result": "success", "stream_revision": r1.json()["revision"]},
+                          headers=_auth(u))
+        assert r2.status_code == 200
+        assert r2.json()["duration_ms"] == 10000
+        assert r2.json()["capture_result"] == "success"
+
+    def test_sl_03_stopped_before_started(self, db):
+        u, uid, sd_id, sid, rev = self._setup_stream(db)
+        start = datetime.now(timezone.utc)
+        r1 = client.patch(f"/api/v1/multicamera/sessions/{uid}/devices/{sd_id}/streams/{sid}",
+                          json={"started_at": start.isoformat(), "stream_revision": rev}, headers=_auth(u))
+        r2 = client.patch(f"/api/v1/multicamera/sessions/{uid}/devices/{sd_id}/streams/{sid}",
+                          json={"stopped_at": (start - timedelta(seconds=5)).isoformat(), "stream_revision": r1.json()["revision"]},
+                          headers=_auth(u))
+        assert r2.status_code == 422
+
+    def test_sl_04_stopped_without_started(self, db):
+        u, uid, sd_id, sid, rev = self._setup_stream(db)
+        r = client.patch(f"/api/v1/multicamera/sessions/{uid}/devices/{sd_id}/streams/{sid}",
+                         json={"stopped_at": datetime.now(timezone.utc).isoformat(), "stream_revision": rev}, headers=_auth(u))
+        assert r.status_code == 422
+
+    def test_sl_05_success_without_stopped(self, db):
+        u, uid, sd_id, sid, rev = self._setup_stream(db)
+        start = datetime.now(timezone.utc)
+        r1 = client.patch(f"/api/v1/multicamera/sessions/{uid}/devices/{sd_id}/streams/{sid}",
+                          json={"started_at": start.isoformat(), "stream_revision": rev}, headers=_auth(u))
+        r2 = client.patch(f"/api/v1/multicamera/sessions/{uid}/devices/{sd_id}/streams/{sid}",
+                          json={"capture_result": "success", "stream_revision": r1.json()["revision"]}, headers=_auth(u))
+        assert r2.status_code == 422
+
+    def test_sl_06_error_auto_stop(self, db):
+        u, uid, sd_id, sid, rev = self._setup_stream(db)
+        start = datetime.now(timezone.utc)
+        r1 = client.patch(f"/api/v1/multicamera/sessions/{uid}/devices/{sd_id}/streams/{sid}",
+                          json={"started_at": start.isoformat(), "stream_revision": rev}, headers=_auth(u))
+        r2 = client.patch(f"/api/v1/multicamera/sessions/{uid}/devices/{sd_id}/streams/{sid}",
+                          json={"capture_result": "error", "stream_revision": r1.json()["revision"]}, headers=_auth(u))
+        assert r2.status_code == 200
+        assert r2.json()["stopped_at"] is not None
+        assert r2.json()["capture_result"] == "error"
+
+    def test_sl_07_terminal_immutable(self, db):
+        u, uid, sd_id, sid, rev = self._setup_stream(db)
+        start = datetime.now(timezone.utc)
+        stop = start + timedelta(seconds=5)
+        r1 = client.patch(f"/api/v1/multicamera/sessions/{uid}/devices/{sd_id}/streams/{sid}",
+                          json={"started_at": start.isoformat(), "stopped_at": stop.isoformat(),
+                                "capture_result": "success", "stream_revision": rev}, headers=_auth(u))
+        r2 = client.patch(f"/api/v1/multicamera/sessions/{uid}/devices/{sd_id}/streams/{sid}",
+                          json={"capture_result": "error", "stream_revision": r1.json()["revision"]}, headers=_auth(u))
+        assert r2.status_code == 409
+
+    def test_sl_08_identical_duplicate(self, db):
+        u, uid, sd_id, sid, rev = self._setup_stream(db)
+        start = datetime.now(timezone.utc)
+        r1 = client.patch(f"/api/v1/multicamera/sessions/{uid}/devices/{sd_id}/streams/{sid}",
+                          json={"started_at": start.isoformat(), "stream_revision": rev}, headers=_auth(u))
+        r2 = client.patch(f"/api/v1/multicamera/sessions/{uid}/devices/{sd_id}/streams/{sid}",
+                          json={"started_at": start.isoformat(), "stream_revision": rev}, headers=_auth(u))
+        assert r2.status_code == 200
+        assert r2.json()["id"] == r1.json()["id"]
+
+    def test_sl_09_conflicting_duplicate(self, db):
+        u, uid, sd_id, sid, rev = self._setup_stream(db)
+        start1 = datetime.now(timezone.utc)
+        start2 = start1 + timedelta(seconds=1)
+        client.patch(f"/api/v1/multicamera/sessions/{uid}/devices/{sd_id}/streams/{sid}",
+                     json={"started_at": start1.isoformat(), "stream_revision": rev}, headers=_auth(u))
+        r = client.patch(f"/api/v1/multicamera/sessions/{uid}/devices/{sd_id}/streams/{sid}",
+                         json={"started_at": start2.isoformat(), "stream_revision": rev}, headers=_auth(u))
+        assert r.status_code == 409
+
+    def test_sl_10_stream_revision_conflict(self, db):
+        u, uid, sd_id, sid, rev = self._setup_stream(db)
+        r = client.patch(f"/api/v1/multicamera/sessions/{uid}/devices/{sd_id}/streams/{sid}",
+                         json={"started_at": datetime.now(timezone.utc).isoformat(), "stream_revision": rev + 99}, headers=_auth(u))
+        assert r.status_code == 409
+
+    def test_sl_11_future_timestamp_reject(self, db):
+        u, uid, sd_id, sid, rev = self._setup_stream(db)
+        future = (datetime.now(timezone.utc) + timedelta(seconds=120)).isoformat()
+        r = client.patch(f"/api/v1/multicamera/sessions/{uid}/devices/{sd_id}/streams/{sid}",
+                         json={"started_at": future, "stream_revision": rev}, headers=_auth(u))
+        assert r.status_code == 422
+
+    def test_sl_12_cross_session_stream(self, db):
+        u, uid1, sd_id, sid, rev = self._setup_stream(db)
+        r2 = _create_session(_auth(u))
+        uid2 = r2.json()["session_uuid"]
+        r = client.patch(f"/api/v1/multicamera/sessions/{uid2}/devices/{sd_id}/streams/{sid}",
+                         json={"started_at": datetime.now(timezone.utc).isoformat(), "stream_revision": rev}, headers=_auth(u))
+        assert r.status_code == 404
+
+
+class TestScheduledStreamGuard:
+
+    def test_gr_01_wrong_owner_stream_patch(self, db):
+        u1 = _create_user(db)
+        u2 = _create_user(db, UserRole.STUDENT)
+        ds = DeviceService(db)
+        md = ds.register_managed_device(u1.id, "ipad", "iPad")
+        r = _create_session(_auth(u1))
+        d = r.json()
+        uid = d["session_uuid"]
+        pid = d["participants"][0]["id"]
+        rd = client.post(f"/api/v1/multicamera/sessions/{uid}/devices",
+                         json={"device_uuid": str(md.device_uuid), "device_role": "instructor_primary", "participant_id": pid},
+                         headers=_auth(u1))
+        sd_id = rd.json()["id"]
+        cs = client.post(f"/api/v1/multicamera/sessions/{uid}/devices/{sd_id}/streams",
+                         json={"stream_type": "video", "preset_json": {"fps": 30}}, headers=_auth(u1))
+        from app.services.multicamera.session_service import SessionService
+        ss = SessionService(db)
+        ss.join_session(_uuid.UUID(uid), u2.id, "player")
+        r = client.patch(f"/api/v1/multicamera/sessions/{uid}/devices/{sd_id}/streams/{cs.json()['id']}",
+                         json={"started_at": datetime.now(timezone.utc).isoformat(), "stream_revision": cs.json()["revision"]},
+                         headers=_auth(u2))
+        assert r.status_code == 403
+
+    def test_gr_02_existing_regression(self, db):
+        u = _create_user(db)
+        ds = DeviceService(db)
+        md = ds.register_managed_device(u.id, "ipad", "iPad")
+        r = _create_session(_auth(u))
+        d = r.json()
+        uid = d["session_uuid"]
+        pid = d["participants"][0]["id"]
+        rd = client.post(f"/api/v1/multicamera/sessions/{uid}/devices",
+                         json={"device_uuid": str(md.device_uuid), "device_role": "instructor_primary", "participant_id": pid},
+                         headers=_auth(u))
+        sd_id = rd.json()["id"]
+        assert client.post(f"/api/v1/multicamera/sessions/{uid}/devices/{sd_id}/heartbeat", headers=_auth(u)).status_code == 200
+        assert client.patch(f"/api/v1/multicamera/sessions/{uid}/devices/{sd_id}/status",
+                            json={"target_status": "ready", "device_revision": rd.json()["revision"]}, headers=_auth(u)).status_code == 200
+        cs = client.post(f"/api/v1/multicamera/sessions/{uid}/devices/{sd_id}/streams",
+                         json={"stream_type": "video", "preset_json": {"fps": 30}}, headers=_auth(u))
+        assert cs.status_code == 201

--- a/tests/unit/multicamera/test_session_contract.py
+++ b/tests/unit/multicamera/test_session_contract.py
@@ -112,6 +112,7 @@ class TestSessionLifecycle:
         ss = SessionService(db)
         s = ss.create_session(users[0].id)
         s = ss.transition_session(s.session_uuid, "devices_ready", s.revision)
+        s = ss.transition_session(s.session_uuid, "recording_pending", s.revision)
         s = ss.transition_session(s.session_uuid, "recording", s.revision)
         assert s.status == "recording"
         assert s.started_at is not None
@@ -126,6 +127,7 @@ class TestSessionLifecycle:
         ss = SessionService(db)
         s = ss.create_session(users[0].id)
         s = ss.transition_session(s.session_uuid, "devices_ready", s.revision)
+        s = ss.transition_session(s.session_uuid, "recording_pending", s.revision)
         s = ss.transition_session(s.session_uuid, "recording", s.revision)
         s = ss.transition_session(s.session_uuid, "stopped", s.revision)
         assert s.status == "stopped"
@@ -135,6 +137,7 @@ class TestSessionLifecycle:
         ss = SessionService(db)
         s = ss.create_session(users[0].id)
         s = ss.transition_session(s.session_uuid, "devices_ready", s.revision)
+        s = ss.transition_session(s.session_uuid, "recording_pending", s.revision)
         s = ss.transition_session(s.session_uuid, "recording", s.revision)
         s = ss.transition_session(s.session_uuid, "stopped", s.revision)
         s = ss.transition_session(s.session_uuid, "finalizing", s.revision)
@@ -159,6 +162,7 @@ class TestSessionLifecycle:
         ss = SessionService(db)
         s = ss.create_session(users[0].id)
         s = ss.transition_session(s.session_uuid, "devices_ready", s.revision)
+        s = ss.transition_session(s.session_uuid, "recording_pending", s.revision)
         s = ss.transition_session(s.session_uuid, "recording", s.revision)
         s = ss.transition_session(s.session_uuid, "stopped", s.revision)
         s = ss.transition_session(s.session_uuid, "finalizing", s.revision)


### PR DESCRIPTION
## Summary
Backend contract for coordinated capture: recording_pending session status,
server-generated scheduled_start_at, and stream lifecycle PATCH endpoint.

## New session status: recording_pending
- devices_ready → recording_pending (instructor only)
- Backend sets scheduled_start_at = server_now + 8s
- recording_pending → recording (instructor confirm, <60s)
- recording_pending → devices_ready (abort, clears schedule)
- Late confirm >60s → 422

## Stream lifecycle PATCH
PATCH /sessions/{uuid}/devices/{sd_id}/streams/{stream_id}
- started_at, stopped_at (timezone-aware UTC, ±30s clock skew)
- capture_result: success/error/interrupted (terminal, immutable)
- error/interrupted auto-sets stopped_at=server_now if missing
- Identical duplicate → 200 idempotent
- Conflicting duplicate → 409
- Stream revision lock

## Route count
OpenAPI paths: 922 → 923 (+1). app.routes: 1046 → 1047 (+1).

## Tests
24 new (SS-01..10, SL-01..12, GR-01..02) + 79 existing = 103 PASS.

## Not included
No iOS, no AVCapture, no lobby UI, no GoPro, no media, no Celery.