### PR TITLE
feat(mc1-be1): millisecond-precision system time endpoint

### DIFF
--- a/app/api/api_v1/api.py
+++ b/app/api/api_v1/api.py
@@ -101,6 +101,7 @@ from .endpoints import (
     health,
 )
 from .endpoints import system_events
+from .endpoints import system_time
 from .endpoints import admin_players
 from .endpoints import admin_biometric_review
 from .endpoints.sandbox import run_test as sandbox
@@ -159,6 +160,7 @@ api_router.include_router(health.router, prefix="/health", tags=["health-monitor
 api_router.include_router(admin.router, prefix="/admin", tags=["admin-dashboard"])
 api_router.include_router(audit.router, prefix="/audit", tags=["audit-logs"])
 api_router.include_router(system_events.router, prefix="/system-events", tags=["system-events"])
+api_router.include_router(system_time.router, prefix="/system", tags=["system"])
 api_router.include_router(semester_enrollments.router, prefix="/semester-enrollments", tags=["semester-enrollments"])
 api_router.include_router(invoices.router, prefix="/invoices", tags=["invoices"])
 api_router.include_router(coupons.router, prefix="", tags=["coupons"])

--- a/app/api/api_v1/endpoints/system_time.py
+++ b/app/api/api_v1/endpoints/system_time.py
@@ -1,0 +1,46 @@
+"""MC1-BE-1 — Millisecond-precision server time for iOS clock sync.
+
+Public endpoint (no auth). The iOS ClockSyncService uses RTT/2 offset
+calculation against server_epoch_ms. This is app-level best-effort sync,
+not NTP-grade precision. Wall-clock time may step backward on system
+clock corrections (e.g. NTP adjustment); callers must not assume
+monotonic ordering across calls.
+"""
+from __future__ import annotations
+
+import time
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Response
+from pydantic import BaseModel
+
+router = APIRouter()
+
+
+class SystemTimeResponse(BaseModel):
+    server_time_utc: str
+    server_epoch_ms: int
+    precision: str
+    source: str
+
+
+@router.get(
+    "/time",
+    response_model=SystemTimeResponse,
+    summary="Server UTC time with millisecond precision",
+    tags=["system"],
+)
+def get_system_time(response: Response) -> SystemTimeResponse:
+    epoch_ms = time.time_ns() // 1_000_000
+    utc_now = datetime.fromtimestamp(epoch_ms / 1000, tz=timezone.utc)
+    iso = utc_now.strftime("%Y-%m-%dT%H:%M:%S.") + f"{utc_now.microsecond // 1000:03d}Z"
+
+    response.headers["Cache-Control"] = "no-store, max-age=0"
+    response.headers["X-Server-Time-Ms"] = str(epoch_ms)
+
+    return SystemTimeResponse(
+        server_time_utc=iso,
+        server_epoch_ms=epoch_ms,
+        precision="milliseconds",
+        source="backend_app_clock",
+    )

--- a/app/api/api_v1/endpoints/system_time.py
+++ b/app/api/api_v1/endpoints/system_time.py
@@ -28,7 +28,6 @@ class SystemTimeResponse(BaseModel):
     "/time",
     response_model=SystemTimeResponse,
     summary="Server UTC time with millisecond precision",
-    tags=["system"],
 )
 def get_system_time(response: Response) -> SystemTimeResponse:
     epoch_ms = time.time_ns() // 1_000_000

--- a/tests/biometric/test_admin_review_api.py
+++ b/tests/biometric/test_admin_review_api.py
@@ -548,7 +548,7 @@ def test_bca_adm21_override_audit_no_score(db, biometric_feature_enabled):
 def test_bca_adm22_route_count_883():
     from app.main import app
     paths = app.openapi().get("paths", {})
-    assert len(paths) == 932, f"Expected 932 routes (PR-MC1: +9 capture-cycle paths), got {len(paths)}"
+    assert len(paths) == 933, f"Expected 932 routes (PR-MC1: +9 capture-cycle paths), got {len(paths)}"
     assert "/api/v1/admin/biometric/review-queue" in paths
     assert "/api/v1/admin/biometric/{user_id}/history" in paths
     assert "/api/v1/admin/biometric/{user_id}/override" in paths

--- a/tests/biometric/test_admin_review_api.py
+++ b/tests/biometric/test_admin_review_api.py
@@ -548,7 +548,7 @@ def test_bca_adm21_override_audit_no_score(db, biometric_feature_enabled):
 def test_bca_adm22_route_count_883():
     from app.main import app
     paths = app.openapi().get("paths", {})
-    assert len(paths) == 933, f"Expected 932 routes (PR-MC1: +9 capture-cycle paths), got {len(paths)}"
+    assert len(paths) == 933, f"Expected 933 routes, got {len(paths)}"
     assert "/api/v1/admin/biometric/review-queue" in paths
     assert "/api/v1/admin/biometric/{user_id}/history" in paths
     assert "/api/v1/admin/biometric/{user_id}/override" in paths

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -16356,6 +16356,28 @@
         }
       }
     },
+    "/api/v1/system/time": {
+      "get": {
+        "tags": [
+          "system",
+          "system"
+        ],
+        "summary": "Server UTC time with millisecond precision",
+        "operationId": "get_system_time_api_v1_system_time_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SystemTimeResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/semester-enrollments/semesters/{semester_id}/enrollments": {
       "get": {
         "tags": [
@@ -71104,6 +71126,34 @@
           "resolved"
         ],
         "title": "SystemEventResponse"
+      },
+      "SystemTimeResponse": {
+        "properties": {
+          "server_time_utc": {
+            "type": "string",
+            "title": "Server Time Utc"
+          },
+          "server_epoch_ms": {
+            "type": "integer",
+            "title": "Server Epoch Ms"
+          },
+          "precision": {
+            "type": "string",
+            "title": "Precision"
+          },
+          "source": {
+            "type": "string",
+            "title": "Source"
+          }
+        },
+        "type": "object",
+        "required": [
+          "server_time_utc",
+          "server_epoch_ms",
+          "precision",
+          "source"
+        ],
+        "title": "SystemTimeResponse"
       },
       "TeachingHoursRecord": {
         "properties": {

--- a/tests/snapshots/openapi_snapshot.json
+++ b/tests/snapshots/openapi_snapshot.json
@@ -16359,7 +16359,6 @@
     "/api/v1/system/time": {
       "get": {
         "tags": [
-          "system",
           "system"
         ],
         "summary": "Server UTC time with millisecond precision",

--- a/tests/unit/api/web_routes/test_card_editor_ce2.py
+++ b/tests/unit/api/web_routes/test_card_editor_ce2.py
@@ -439,6 +439,6 @@ class TestCE217RouteCount:
         """
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 932, (
+        assert len(paths) == 933, (
             f"Expected 932 routes (923 prior + 9 multicamera cycle endpoints), got {len(paths)}."
         )

--- a/tests/unit/api/web_routes/test_card_editor_ce2.py
+++ b/tests/unit/api/web_routes/test_card_editor_ce2.py
@@ -440,5 +440,5 @@ class TestCE217RouteCount:
         from app.main import app
         paths = app.openapi().get("paths", {})
         assert len(paths) == 933, (
-            f"Expected 932 routes (923 prior + 9 multicamera cycle endpoints), got {len(paths)}."
+            f"Expected 933 routes, got {len(paths)}"
         )

--- a/tests/unit/api/web_routes/test_card_editor_cs_s1.py
+++ b/tests/unit/api/web_routes/test_card_editor_cs_s1.py
@@ -294,7 +294,7 @@ class TestS109S110RouteAndSnapshot:
         """S1-09 (updated AN-3B2B2): route count is 910 (+3 admin feedback review endpoints)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 932, (
+        assert len(paths) == 933, (
             f"Expected 910 routes (907 prior + 3 admin feedback review), got {len(paths)}"
         )
 

--- a/tests/unit/api/web_routes/test_card_editor_cs_s1.py
+++ b/tests/unit/api/web_routes/test_card_editor_cs_s1.py
@@ -290,12 +290,12 @@ class TestS1bCTAAndNaming:
 
 class TestS109S110RouteAndSnapshot:
 
-    def test_s1_09_route_count_846(self):
+    def test_s1_09_route_count_933(self):
         """S1-09 (updated AN-3B2B2): route count is 910 (+3 admin feedback review endpoints)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
         assert len(paths) == 933, (
-            f"Expected 910 routes (907 prior + 3 admin feedback review), got {len(paths)}"
+            f"Expected 933 routes, got {len(paths)}"
         )
 
     def test_s1_10_openapi_snapshot_still_matches(self):

--- a/tests/unit/api/web_routes/test_card_editor_ref_p2.py
+++ b/tests/unit/api/web_routes/test_card_editor_ref_p2.py
@@ -287,7 +287,7 @@ class TestP227to29RouteAndOpenAPI:
         """P2-27: Route count = 846 (CS-S2A +1 /card-studio/player)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 932, f"Expected 846 routes, got {len(paths)}"
+        assert len(paths) == 933, f"Expected 846 routes, got {len(paths)}"
 
     def test_p2_28_openapi_snapshot_match(self):
         """P2-28: OpenAPI snapshot matches live API paths."""

--- a/tests/unit/api/web_routes/test_card_editor_ref_p2.py
+++ b/tests/unit/api/web_routes/test_card_editor_ref_p2.py
@@ -31,7 +31,7 @@ P2-23  #btn-export-video present in expanded source
 P2-24  all 11 Jinja2-rendered values present in scripts.html
 P2-25  no unexpected Jinja2 {{ }} patterns in scripts.html
 P2-26  scripts.html starts with <script>, ends with </script>
-P2-27  route count = 845 (no new routes)
+P2-27  route count = 933
 P2-28  OpenAPI snapshot match
 P2-29  /card-editor/player route still registered
 """
@@ -283,11 +283,11 @@ class TestP226ScriptsBoundaries:
 
 class TestP227to29RouteAndOpenAPI:
 
-    def test_p2_27_route_count_844(self):
+    def test_p2_27_route_count_933(self):
         """P2-27: Route count = 846 (CS-S2A +1 /card-studio/player)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 933, f"Expected 846 routes, got {len(paths)}"
+        assert len(paths) == 933, f"Expected 933 routes, got {len(paths)}"
 
     def test_p2_28_openapi_snapshot_match(self):
         """P2-28: OpenAPI snapshot matches live API paths."""

--- a/tests/unit/api/web_routes/test_card_studio_challenge.py
+++ b/tests/unit/api/web_routes/test_card_studio_challenge.py
@@ -294,7 +294,7 @@ class TestCCS11RouteCount:
         """CCS-11: route count updated to 842 after CE-3.8 (+3 from-mood endpoints)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 932, (
+        assert len(paths) == 933, (
             f"Expected 845 routes (842 CE-3.7+CE-3.8 baseline + 2 CS-S0 card-studio routes), got {len(paths)}."
         )
 

--- a/tests/unit/api/web_routes/test_card_studio_challenge.py
+++ b/tests/unit/api/web_routes/test_card_studio_challenge.py
@@ -13,7 +13,7 @@ CCS-07  owned format rows follow CHALLENGE_CARD_FORMATS order
 CCS-08  owned format row fields: design_id, label, style_tag, dims
 CCS-09  legacy "challenge" CDO shim → both valid formats owned
 CCS-10  CardDraftService is never called
-CCS-11  route count = 839 (838 + GET /card-editor/challenge)
+CCS-11  route count = 933
 CCS-12  template contains /my-cards/challenge link
 CCS-13  template contains /challenges/results link
 CCS-14  template contains /challenges link
@@ -291,11 +291,11 @@ class TestCCS10NoDraftService:
 class TestCCS11RouteCount:
 
     def test_ccs_11_route_count_839(self):
-        """CCS-11: route count updated to 842 after CE-3.8 (+3 from-mood endpoints)."""
+        """CCS-11: route count = 933."""
         from app.main import app
         paths = app.openapi().get("paths", {})
         assert len(paths) == 933, (
-            f"Expected 845 routes (842 CE-3.7+CE-3.8 baseline + 2 CS-S0 card-studio routes), got {len(paths)}."
+            f"Expected 933 routes, got {len(paths)}"
         )
 
     def test_ccs_11b_card_editor_challenge_route_registered(self):

--- a/tests/unit/api/web_routes/test_card_studio_landing.py
+++ b/tests/unit/api/web_routes/test_card_studio_landing.py
@@ -159,7 +159,7 @@ class TestCEL12RouteCount:
         """CEL-12: route count 844 (unchanged — redirect is handler change, not new route)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 932, (
+        assert len(paths) == 933, (
             f"Expected 845 routes (redirect handler change does not add routes), got {len(paths)}."
         )
 

--- a/tests/unit/api/web_routes/test_card_studio_landing.py
+++ b/tests/unit/api/web_routes/test_card_studio_landing.py
@@ -11,7 +11,7 @@ CEL-08b empty state block in template
 CEL-09  Player CTA links to /card-editor/player, text "Open Studio"
 CEL-10  Welcome CTA links to /card-studio/welcome (CS-S1b)
 CEL-11  Challenge CTA links to /card-editor/challenge
-CEL-12  route count = 844
+CEL-12  route count = 933
 CEL-13  OpenAPI snapshot is up to date
 CEL-14  /card-editor/player regression — lfa_player_card_editor still callable
 """
@@ -151,16 +151,16 @@ class TestCEL091011CTALinks:
         assert 'href="/card-studio/player"' not in src
 
 
-# ── CEL-12: route count = 844 ────────────────────────────────────────────────
+# ── CEL-12: route count = 933 ────────────────────────────────────────────────
 
 class TestCEL12RouteCount:
 
-    def test_cel_12_route_count_844(self):
-        """CEL-12: route count 844 (unchanged — redirect is handler change, not new route)."""
+    def test_cel_12_route_count_933(self):
+        """CEL-12: route count = 933."""
         from app.main import app
         paths = app.openapi().get("paths", {})
         assert len(paths) == 933, (
-            f"Expected 845 routes (redirect handler change does not add routes), got {len(paths)}."
+            f"Expected 933 routes, got {len(paths)}"
         )
 
     def test_cel_12b_card_editor_route_registered(self):

--- a/tests/unit/api/web_routes/test_card_studio_shell.py
+++ b/tests/unit/api/web_routes/test_card_studio_shell.py
@@ -326,7 +326,7 @@ class TestCSS21to23RouteConfirmations:
         """CSS-21: adding 2 card-studio routes raises count from 842 to 844."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 932, (
+        assert len(paths) == 933, (
             f"Expected 845 routes (842 baseline + 2 new /card-studio routes), got {len(paths)}"
         )
 

--- a/tests/unit/api/web_routes/test_card_studio_shell.py
+++ b/tests/unit/api/web_routes/test_card_studio_shell.py
@@ -21,7 +21,7 @@ CSS-17  mobile markup: cs-mood-section before cs-preview-panel
 CSS-18  template contains cs-preview-iframe
 CSS-19  template contains X-CSRF-Token in assign JS
 CSS-20  template contains !csrf guard
-CSS-21  route count == 845 (842 + 2 new card-studio routes)
+CSS-21  route count = 933
 CSS-22  GET /card-studio route registered
 CSS-23  GET /card-studio/welcome route registered
 """
@@ -322,12 +322,12 @@ class TestCSS13to20TemplateConfirmations:
 
 class TestCSS21to23RouteConfirmations:
 
-    def test_css_21_route_count_844(self):
+    def test_css_21_route_count_933(self):
         """CSS-21: adding 2 card-studio routes raises count from 842 to 844."""
         from app.main import app
         paths = app.openapi().get("paths", {})
         assert len(paths) == 933, (
-            f"Expected 845 routes (842 baseline + 2 new /card-studio routes), got {len(paths)}"
+            f"Expected 933 routes, got {len(paths)}"
         )
 
     def test_css_22_card_studio_route_registered(self):

--- a/tests/unit/api/web_routes/test_card_studio_welcome.py
+++ b/tests/unit/api/web_routes/test_card_studio_welcome.py
@@ -325,7 +325,7 @@ class TestCEW18RouteCount:
         """CEW-18: route count baseline check (updated by CE-3.8 to 842)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 932, (
+        assert len(paths) == 933, (
             f"Expected 842 routes (839 CE-3.7 baseline + 3 from-mood endpoints), got {len(paths)}."
         )
 
@@ -678,7 +678,7 @@ class TestCEW44to51TemplateMoodPicker:
         """CEW-47: CE-3.8 adds 3 from-mood routes → total 842."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 932, (
+        assert len(paths) == 933, (
             f"Expected 845 routes (842 baseline + 2 CS-S0 routes), got {len(paths)}"
         )
 

--- a/tests/unit/api/web_routes/test_card_studio_welcome.py
+++ b/tests/unit/api/web_routes/test_card_studio_welcome.py
@@ -55,7 +55,7 @@ CEW-38c card_studio_welcome context contains mood_slot_meta key (CE-3.8 correcte
 CEW-38d mood_slot_meta has 6 entries with slot/emoji/label (CE-3.8 corrected)
 CEW-45  template references all three /from-mood routes (CE-3.8)
 CEW-46  template contains link to /profile/my-mood-photos (CE-3.8)
-CEW-47  route count = 842 (CE-3.8 +3 routes)
+CEW-47  route count = 933
 CEW-48  assign JS fetch carries X-CSRF-Token header (CE-3.8)
 CEW-49  assign JS missing CSRF guard present (CE-3.8)
 CEW-50  template does NOT contain BG removal reference (CE-3.8 scope guard)
@@ -322,11 +322,11 @@ class TestCEW17WCE1Unchanged:
 class TestCEW18RouteCount:
 
     def test_cew_18_route_count_838(self):
-        """CEW-18: route count baseline check (updated by CE-3.8 to 842)."""
+        """CEW-18: route count = 933."""
         from app.main import app
         paths = app.openapi().get("paths", {})
         assert len(paths) == 933, (
-            f"Expected 842 routes (839 CE-3.7 baseline + 3 from-mood endpoints), got {len(paths)}."
+            f"Expected 933 routes, got {len(paths)}"
         )
 
     def test_cew_18b_card_editor_welcome_route_registered(self):
@@ -674,12 +674,12 @@ class TestCEW44to51TemplateMoodPicker:
         """CEW-46: template contains link to /profile/my-mood-photos."""
         assert "/profile/my-mood-photos" in self._src()
 
-    def test_cew_47_route_count_842(self):
+    def test_cew_47_route_count_933(self):
         """CEW-47: CE-3.8 adds 3 from-mood routes → total 842."""
         from app.main import app
         paths = app.openapi().get("paths", {})
         assert len(paths) == 933, (
-            f"Expected 845 routes (842 baseline + 2 CS-S0 routes), got {len(paths)}"
+            f"Expected 933 routes, got {len(paths)}"
         )
 
     def test_cew_48_assign_js_has_csrf_header(self):

--- a/tests/unit/api/web_routes/test_cc_design_1.py
+++ b/tests/unit/api/web_routes/test_cc_design_1.py
@@ -780,7 +780,7 @@ class TestCCD22to23RouteSnapshot:
         """CCD-22: Route count is 851 (CC-DESIGN-1 SNAPSHOT adds POST /challenges/{id}/card/photo)."""
         from app.main import app
         count = len(app.openapi().get("paths", {}))
-        assert count == 932, f"Expected 851, got {count}"
+        assert count == 933, f"Expected 851, got {count}"
 
     def test_ccd_23_openapi_snapshot_match(self):
         """CCD-23: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_cc_design_1.py
+++ b/tests/unit/api/web_routes/test_cc_design_1.py
@@ -29,7 +29,7 @@ CCD-20  challenge media panel (cs-cc-mood-section) in cs_challenge_panel.html pr
 CCD-21  _setChallengePhoto JS function present in shell (challenge preview mode)
 
 Route/snapshot:
-CCD-22  route count still 850 (BG-REMOVAL-1 added 3 routes; no new routes in CC-DESIGN-1)
+CCD-22  route count = 933
 CCD-23  OpenAPI snapshot match true
 
 Naming:
@@ -776,11 +776,11 @@ class TestCCExportDirect:
 
 class TestCCD22to23RouteSnapshot:
 
-    def test_ccd_22_route_count_851(self):
+    def test_ccd_22_route_count_933(self):
         """CCD-22: Route count is 851 (CC-DESIGN-1 SNAPSHOT adds POST /challenges/{id}/card/photo)."""
         from app.main import app
         count = len(app.openapi().get("paths", {}))
-        assert count == 933, f"Expected 851, got {count}"
+        assert count == 933, f"Expected 933 routes, got {count}"
 
     def test_ccd_23_openapi_snapshot_match(self):
         """CCD-23: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_cs_color_1.py
+++ b/tests/unit/api/web_routes/test_cs_color_1.py
@@ -382,7 +382,7 @@ class TestCSCOL15to16RouteAndSnapshot:
         """CSCOL-15: route count = 845 (+1 POST /dashboard/wc-card-theme)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 932, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 933, f"Expected 845 routes, got {len(paths)}"
 
     def test_cscol_16_openapi_snapshot_includes_wc_card_theme(self):
         """CSCOL-16: OpenAPI snapshot includes /dashboard/wc-card-theme."""

--- a/tests/unit/api/web_routes/test_cs_color_1.py
+++ b/tests/unit/api/web_routes/test_cs_color_1.py
@@ -19,7 +19,7 @@ CSCOL-11  export_url contains theme={active_theme}
 CSCOL-12  card_studio_shell.html contains cs-color-chip swatch UI
 CSCOL-13  setWelcomeTheme JS present, POST /dashboard/wc-card-theme with X-CSRF-Token
 CSCOL-14  format change URL preserves theme via CardDraft (server-side persistence)
-CSCOL-15  route count == 845
+CSCOL-15  route count == 933
 CSCOL-16  OpenAPI snapshot includes /dashboard/wc-card-theme
 """
 from __future__ import annotations
@@ -378,11 +378,11 @@ class TestCSCOL14FormatThemePersistence:
 
 class TestCSCOL15to16RouteAndSnapshot:
 
-    def test_cscol_15_route_count_845(self):
-        """CSCOL-15: route count = 845 (+1 POST /dashboard/wc-card-theme)."""
+    def test_cscol_15_route_count_933(self):
+        """CSCOL-15: route count = 933."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 933, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 933, f"Expected 933 routes, got {len(paths)}"
 
     def test_cscol_16_openapi_snapshot_includes_wc_card_theme(self):
         """CSCOL-16: OpenAPI snapshot includes /dashboard/wc-card-theme."""

--- a/tests/unit/api/web_routes/test_cs_s2a.py
+++ b/tests/unit/api/web_routes/test_cs_s2a.py
@@ -40,7 +40,7 @@ class TestS2A01to02RouteRegistration:
         """S2A-02 (updated CS-S4A): Total route count is 847 (CS-S2A+CS-S4A)."""
         from app.main import app
         count = len(app.openapi().get("paths", {}))
-        assert count == 932, f"Expected 847 routes, got {count}"
+        assert count == 933, f"Expected 847 routes, got {count}"
 
 
 # ── S2A-03..08: _resolve_player_context logic ────────────────────────────────

--- a/tests/unit/api/web_routes/test_cs_s2a.py
+++ b/tests/unit/api/web_routes/test_cs_s2a.py
@@ -36,11 +36,11 @@ class TestS2A01to02RouteRegistration:
         paths = [getattr(r, "path", "") for r in app.routes]
         assert "/card-studio/player" in paths
 
-    def test_s2a_02_route_count_846(self):
-        """S2A-02 (updated CS-S4A): Total route count is 847 (CS-S2A+CS-S4A)."""
+    def test_s2a_02_route_count_933(self):
+        """S2A-02 (updated CS-S4A): Total route count is 933."""
         from app.main import app
         count = len(app.openapi().get("paths", {}))
-        assert count == 933, f"Expected 847 routes, got {count}"
+        assert count == 933, f"Expected 933 routes, got {count}"
 
 
 # ── S2A-03..08: _resolve_player_context logic ────────────────────────────────

--- a/tests/unit/api/web_routes/test_cs_s4a.py
+++ b/tests/unit/api/web_routes/test_cs_s4a.py
@@ -152,7 +152,7 @@ class TestS4A12to13RouteAndSnapshot:
         """S4A-12: Route count == 851 (CC-DESIGN-1 SNAPSHOT adds +1 POST /challenges/{id}/card/photo)."""
         from app.main import app
         count = len(app.openapi().get("paths", {}))
-        assert count == 932, f"Expected 851 routes, got {count}"
+        assert count == 933, f"Expected 851 routes, got {count}"
 
     def test_s4a_13_openapi_snapshot_match(self):
         """S4A-13: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_cs_s4a.py
+++ b/tests/unit/api/web_routes/test_cs_s4a.py
@@ -12,7 +12,7 @@ S4A-08  Shell has challenge preview placeholder (not live iframe)
 S4A-09  legacy editor CTA /card-editor/challenge present in panel
 S4A-10  cs_challenge_panel.html has no Challenge write form
 S4A-11  cs_challenge_panel.html has no Challenge export link
-S4A-12  route count == 850
+S4A-12  route count == 933
 S4A-13  OpenAPI snapshot match true
 """
 from __future__ import annotations
@@ -148,11 +148,11 @@ class TestS4A10to11NoWriteNoExport:
 
 class TestS4A12to13RouteAndSnapshot:
 
-    def test_s4a_12_route_count_851(self):
+    def test_s4a_12_route_count_933(self):
         """S4A-12: Route count == 851 (CC-DESIGN-1 SNAPSHOT adds +1 POST /challenges/{id}/card/photo)."""
         from app.main import app
         count = len(app.openapi().get("paths", {}))
-        assert count == 933, f"Expected 851 routes, got {count}"
+        assert count == 933, f"Expected 933 routes, got {count}"
 
     def test_s4a_13_openapi_snapshot_match(self):
         """S4A-13: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_family_color_shop.py
+++ b/tests/unit/api/web_routes/test_family_color_shop.py
@@ -223,7 +223,7 @@ class TestRouteRegistration:
     def test_ts_13_route_count_836(self):
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 932, (
+        assert len(paths) == 933, (
             f"Expected 845 routes (842 CE-3.7+CE-3.8 baseline + 2 CS-S0 card-studio routes), got {len(paths)}."
         )
 

--- a/tests/unit/api/web_routes/test_family_color_shop.py
+++ b/tests/unit/api/web_routes/test_family_color_shop.py
@@ -224,7 +224,7 @@ class TestRouteRegistration:
         from app.main import app
         paths = app.openapi().get("paths", {})
         assert len(paths) == 933, (
-            f"Expected 845 routes (842 CE-3.7+CE-3.8 baseline + 2 CS-S0 card-studio routes), got {len(paths)}."
+            f"Expected 933 routes, got {len(paths)}"
         )
 
     def test_ts_14_unlock_theme_still_registered(self):

--- a/tests/unit/api/web_routes/test_shop_3a.py
+++ b/tests/unit/api/web_routes/test_shop_3a.py
@@ -194,7 +194,7 @@ class TestS3A13to14RouteAndSnapshot:
         """S3A-13: Route count = 845 (template deletion does not affect routes)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 932, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 933, f"Expected 845 routes, got {len(paths)}"
 
     def test_s3a_14_openapi_snapshot_match(self):
         """S3A-14: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_shop_3a.py
+++ b/tests/unit/api/web_routes/test_shop_3a.py
@@ -190,11 +190,11 @@ class TestS3A10to12UnchangedRoutes:
 
 class TestS3A13to14RouteAndSnapshot:
 
-    def test_s3a_13_route_count_845(self):
+    def test_s3a_13_route_count_933(self):
         """S3A-13: Route count = 845 (template deletion does not affect routes)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 933, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 933, f"Expected 933 routes, got {len(paths)}"
 
     def test_s3a_14_openapi_snapshot_match(self):
         """S3A-14: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_shop_3b1.py
+++ b/tests/unit/api/web_routes/test_shop_3b1.py
@@ -158,7 +158,7 @@ class TestS3B112to13RouteAndSnapshot:
         """S3B1-12: Route count = 845 (test cleanup does not affect routes)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 932, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 933, f"Expected 845 routes, got {len(paths)}"
 
     def test_s3b1_13_openapi_snapshot_match(self):
         """S3B1-13: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_shop_3b1.py
+++ b/tests/unit/api/web_routes/test_shop_3b1.py
@@ -154,11 +154,11 @@ class TestS3B108to11RouteBehavior:
 
 class TestS3B112to13RouteAndSnapshot:
 
-    def test_s3b1_12_route_count_845(self):
+    def test_s3b1_12_route_count_933(self):
         """S3B1-12: Route count = 845 (test cleanup does not affect routes)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 933, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 933, f"Expected 933 routes, got {len(paths)}"
 
     def test_s3b1_13_openapi_snapshot_match(self):
         """S3B1-13: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_shop_3b2.py
+++ b/tests/unit/api/web_routes/test_shop_3b2.py
@@ -192,7 +192,7 @@ class TestS3B215to16RouteAndSnapshot:
         """S3B2-15: Route count = 845 (template deletion does not affect routes)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 932, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 933, f"Expected 845 routes, got {len(paths)}"
 
     def test_s3b2_16_openapi_snapshot_match(self):
         """S3B2-16: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_shop_3b2.py
+++ b/tests/unit/api/web_routes/test_shop_3b2.py
@@ -188,11 +188,11 @@ class TestS3B212to14UnchangedRoutes:
 
 class TestS3B215to16RouteAndSnapshot:
 
-    def test_s3b2_15_route_count_845(self):
+    def test_s3b2_15_route_count_933(self):
         """S3B2-15: Route count = 845 (template deletion does not affect routes)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 933, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 933, f"Expected 933 routes, got {len(paths)}"
 
     def test_s3b2_16_openapi_snapshot_match(self):
         """S3B2-16: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_shop_unified.py
+++ b/tests/unit/api/web_routes/test_shop_unified.py
@@ -271,7 +271,7 @@ class TestSHOP14to15RouteAndSnapshot:
         """SHOP-14: route count = 845 (no new routes in SHOP-1)."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 932, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 933, f"Expected 845 routes, got {len(paths)}"
 
     def test_shop_15_openapi_snapshot_match(self):
         """SHOP-15: OpenAPI snapshot matches live API."""

--- a/tests/unit/api/web_routes/test_shop_unified.py
+++ b/tests/unit/api/web_routes/test_shop_unified.py
@@ -267,11 +267,11 @@ class TestSHOP11to13LegacyRoutes:
 
 class TestSHOP14to15RouteAndSnapshot:
 
-    def test_shop_14_route_count_845(self):
-        """SHOP-14: route count = 845 (no new routes in SHOP-1)."""
+    def test_shop_14_route_count_933(self):
+        """SHOP-14: route count = 933."""
         from app.main import app
         paths = app.openapi().get("paths", {})
-        assert len(paths) == 933, f"Expected 845 routes, got {len(paths)}"
+        assert len(paths) == 933, f"Expected 933 routes, got {len(paths)}"
 
     def test_shop_15_openapi_snapshot_match(self):
         """SHOP-15: OpenAPI snapshot matches live API."""

--- a/tests/unit/juggling/test_annotation_helper.py
+++ b/tests/unit/juggling/test_annotation_helper.py
@@ -1015,7 +1015,7 @@ class TestHELP36_ProductionRouteCountUnchanged:
         snapshot_path = helper.ROOT / "tests/snapshots/openapi_snapshot.json"
         snapshot = json.loads(snapshot_path.read_text())
         route_count = len(snapshot.get("paths", {}))
-        assert route_count == 932, f"Unexpected production route count: {route_count}"
+        assert route_count == 933, f"Unexpected production route count: {route_count}"
 
     def test_helper_routes_not_in_production_snapshot(self):
         """HELP-36d: Annotation helper routes (/api/taxonomy etc.) not in production snapshot."""

--- a/tests/unit/juggling/test_juggling_video_list.py
+++ b/tests/unit/juggling/test_juggling_video_list.py
@@ -453,7 +453,7 @@ def test_jvl24_server_detected_metadata_not_in_response(client, student_token, s
 # ── JVL-25: OpenAPI path delta +1, route delta +1 ────────────────────────────
 
 def test_jvl25_openapi_path_and_route_delta(client):
-    """JVL-25: GET /api/v1/users/me/juggling/videos in OpenAPI; route count = 1013."""
+    """JVL-25: GET /api/v1/users/me/juggling/videos in OpenAPI; route count = 1059."""
     from app.main import app as fastapi_app
     schema = fastapi_app.openapi()
     assert "/api/v1/users/me/juggling/videos" in schema["paths"], "List path missing from OpenAPI"
@@ -463,7 +463,7 @@ def test_jvl25_openapi_path_and_route_delta(client):
         if hasattr(r, "methods") and hasattr(r, "path")
         for m in (r.methods or [])
     ]
-    assert len(routes) == 1058, f"Expected 1058 routes (PR-MC1: +10 capture cycle routes), got {len(routes)}"
+    assert len(routes) == 1059, f"Expected 1059 routes, got {len(routes)}"
     get_list = [r for r in routes if r[0] == "GET" and r[1] == "/api/v1/users/me/juggling/videos"]
     assert len(get_list) == 1
 

--- a/tests/unit/multicamera/test_session_api.py
+++ b/tests/unit/multicamera/test_session_api.py
@@ -340,7 +340,7 @@ class TestLifecycleAndSnapshot:
     def test_api_26_route_count(self):
         from app.main import app as _app
         paths = len(_app.openapi().get("paths", {}))
-        assert paths == 932, f"Expected 932, got {paths}"
+        assert paths == 933, f"Expected 932, got {paths}"
 
 
 # ── API-27..40 Device Status + Capture Stream (PR-4B3B-0) ───────────────────

--- a/tests/unit/multicamera/test_session_api.py
+++ b/tests/unit/multicamera/test_session_api.py
@@ -340,7 +340,7 @@ class TestLifecycleAndSnapshot:
     def test_api_26_route_count(self):
         from app.main import app as _app
         paths = len(_app.openapi().get("paths", {}))
-        assert paths == 933, f"Expected 932, got {paths}"
+        assert paths == 933, f"Expected 933 routes, got {paths}"
 
 
 # ── API-27..40 Device Status + Capture Stream (PR-4B3B-0) ───────────────────

--- a/tests/unit/multicamera/test_system_time.py
+++ b/tests/unit/multicamera/test_system_time.py
@@ -1,0 +1,109 @@
+"""
+MC1-BE-1 — System Time Endpoint tests.
+
+ST-01  Response has all 4 required fields
+ST-02  server_time_utc is ISO 8601 with millisecond precision and Z suffix
+ST-03  server_epoch_ms matches parsed server_time_utc within 10ms
+ST-04  Cache-Control header contains no-store
+ST-05  X-Server-Time-Ms header matches body server_epoch_ms
+ST-06  No auth required (200 without token)
+ST-07  precision field == "milliseconds"
+ST-08  source field == "backend_app_clock"
+ST-09  Route count == 933 (932 + 1 new)
+ST-10  /api/v1/system/time present in OpenAPI schema
+ST-11  Two sequential calls return non-negative epoch_ms values
+"""
+import re
+from datetime import datetime, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+@pytest.fixture()
+def client():
+    with TestClient(app, raise_server_exceptions=False) as c:
+        yield c
+
+
+class TestSystemTimeResponse:
+
+    def test_st_01_response_has_all_fields(self, client):
+        """ST-01: Response contains server_time_utc, server_epoch_ms, precision, source."""
+        r = client.get("/api/v1/system/time")
+        assert r.status_code == 200
+        data = r.json()
+        assert "server_time_utc" in data
+        assert "server_epoch_ms" in data
+        assert "precision" in data
+        assert "source" in data
+
+    def test_st_02_iso_format_with_millis(self, client):
+        """ST-02: server_time_utc matches YYYY-MM-DDTHH:MM:SS.mmmZ."""
+        r = client.get("/api/v1/system/time")
+        ts = r.json()["server_time_utc"]
+        pattern = r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$"
+        assert re.match(pattern, ts), f"Timestamp {ts!r} does not match ISO 8601 millis"
+
+    def test_st_03_epoch_ms_matches_iso(self, client):
+        """ST-03: server_epoch_ms and server_time_utc represent the same instant (±10ms)."""
+        r = client.get("/api/v1/system/time")
+        data = r.json()
+        epoch_ms = data["server_epoch_ms"]
+        parsed = datetime.strptime(data["server_time_utc"], "%Y-%m-%dT%H:%M:%S.%fZ")
+        parsed = parsed.replace(tzinfo=timezone.utc)
+        parsed_ms = int(parsed.timestamp() * 1000)
+        assert abs(epoch_ms - parsed_ms) <= 10, (
+            f"epoch_ms={epoch_ms} vs parsed={parsed_ms}, diff={abs(epoch_ms - parsed_ms)}ms"
+        )
+
+    def test_st_04_cache_control_no_store(self, client):
+        """ST-04: Cache-Control header contains no-store."""
+        r = client.get("/api/v1/system/time")
+        cc = r.headers.get("cache-control", "")
+        assert "no-store" in cc, f"Cache-Control={cc!r}, expected no-store"
+
+    def test_st_05_header_matches_body(self, client):
+        """ST-05: X-Server-Time-Ms header equals body server_epoch_ms."""
+        r = client.get("/api/v1/system/time")
+        header_ms = r.headers.get("x-server-time-ms")
+        assert header_ms is not None, "X-Server-Time-Ms header missing"
+        body_ms = r.json()["server_epoch_ms"]
+        assert int(header_ms) == body_ms
+
+    def test_st_06_no_auth_required(self, client):
+        """ST-06: Endpoint returns 200 without Authorization header."""
+        r = client.get("/api/v1/system/time")
+        assert r.status_code == 200
+
+    def test_st_07_precision_field(self, client):
+        """ST-07: precision == 'milliseconds'."""
+        r = client.get("/api/v1/system/time")
+        assert r.json()["precision"] == "milliseconds"
+
+    def test_st_08_source_field(self, client):
+        """ST-08: source == 'backend_app_clock'."""
+        r = client.get("/api/v1/system/time")
+        assert r.json()["source"] == "backend_app_clock"
+
+    def test_st_09_route_count(self, client):
+        """ST-09: OpenAPI route count == 933 (932 baseline + 1 new)."""
+        schema = client.app.openapi()
+        paths = len(schema.get("paths", {}))
+        assert paths == 933, f"Expected 933 routes, got {paths}"
+
+    def test_st_10_openapi_presence(self, client):
+        """ST-10: /api/v1/system/time in OpenAPI schema."""
+        schema = client.app.openapi()
+        assert "/api/v1/system/time" in schema["paths"]
+
+    def test_st_11_sequential_calls_positive(self, client):
+        """ST-11: Two sequential calls return positive epoch_ms values."""
+        r1 = client.get("/api/v1/system/time")
+        r2 = client.get("/api/v1/system/time")
+        ms1 = r1.json()["server_epoch_ms"]
+        ms2 = r2.json()["server_epoch_ms"]
+        assert ms1 > 0
+        assert ms2 > 0


### PR DESCRIPTION
## Summary

- **New endpoint**: `GET /api/v1/system/time` — public, no auth, no DB dependency
- Returns `server_epoch_ms` (integer) + `server_time_utc` (ISO 8601 with ms precision) from a single `time.time_ns()` sample
- `Cache-Control: no-store, max-age=0` + `X-Server-Time-Ms` response header
- Pydantic `response_model` validated via `Response` parameter (not raw `JSONResponse`)
- Route count 932→933, OpenAPI snapshot updated, 19 route count assertions updated

### Design decisions

- **Public (no auth)**: mirrors `/health/ready`, `/health/live` pattern — server time is not sensitive; iOS needs sync before session auth
- **Wall-clock warning**: `time.time_ns()` is not monotonic — NTP corrections can cause backward steps; documented in module docstring
- **Single sample**: both ISO string and epoch_ms derive from the same `time.time_ns()` call — body and `X-Server-Time-Ms` header are identical
- **Rate limiting**: `RateLimitMiddleware` is active in production (`ENABLE_RATE_LIMITING=True`, 100 calls/60s/IP) — no additional rate limiting needed
- **No proxy cache override found**: no Caddyfile/nginx/vercel.json with cache rules exist in the repo; `no-store` header is the sole cache prevention

### Prepares

iOS `ClockSyncService` (MC1-iOS-CLOCK): RTT/2 offset calculation using `server_epoch_ms` and `CACurrentMediaTime()`

## Test plan

- [x] ST-01: Response has all 4 required fields
- [x] ST-02: ISO 8601 format `YYYY-MM-DDTHH:MM:SS.mmmZ`
- [x] ST-03: `server_epoch_ms` matches parsed `server_time_utc` (±10ms)
- [x] ST-04: `Cache-Control` contains `no-store`
- [x] ST-05: `X-Server-Time-Ms` header matches body `server_epoch_ms`
- [x] ST-06: 200 OK without auth token
- [x] ST-07: `precision == "milliseconds"`
- [x] ST-08: `source == "backend_app_clock"`
- [x] ST-09: Route count == 933
- [x] ST-10: `/api/v1/system/time` in OpenAPI schema
- [x] ST-11: Sequential calls return positive epoch_ms values
- [x] 19 existing route count assertions updated 932→933
- [x] OpenAPI snapshot regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)