### PR TITLE
feat(mc1-ios-orch1a): add scheduledStartAt to MultiCameraSessionDTO

### DIFF
--- a/ios/LFAEducationCenter/MultiCamera/MultiCameraSessionModels.swift
+++ b/ios/LFAEducationCenter/MultiCamera/MultiCameraSessionModels.swift
@@ -141,6 +141,7 @@ struct MultiCameraSessionDTO: Codable, Equatable {
     let maxDevices: Int
     let revision: Int
     let calibration: CalibrationPlaceholderDTO?
+    let scheduledStartAt: String?
     let createdAt: String
     let startedAt: String?
     let stoppedAt: String?
@@ -158,6 +159,7 @@ struct MultiCameraSessionDTO: Codable, Equatable {
         case maxParticipants = "max_participants"
         case maxDevices = "max_devices"
         case revision, calibration
+        case scheduledStartAt = "scheduled_start_at"
         case createdAt = "created_at"
         case startedAt = "started_at"
         case stoppedAt = "stopped_at"

--- a/ios/LFAEducationCenterTests/MultiCamera/MultiCameraSessionContractTests.swift
+++ b/ios/LFAEducationCenterTests/MultiCamera/MultiCameraSessionContractTests.swift
@@ -116,4 +116,37 @@ final class MultiCameraSessionContractTests: XCTestCase {
         XCTAssertNotNil(gopro.managedByDeviceId)
         XCTAssertEqual(gopro.managedByDeviceId, 2)
     }
+
+    // SCP-11: scheduledStartAt present in fixture
+    func test_SCP_11_scheduledStartAtPresent() throws {
+        let data = try fixtureData()
+        let session = try JSONDecoder().decode(MultiCameraSessionDTO.self, from: data)
+        XCTAssertEqual(session.scheduledStartAt, "2026-06-22T10:04:52+00:00")
+    }
+
+    // SCP-12: scheduledStartAt null decode
+    func test_SCP_12_scheduledStartAtNull() throws {
+        let json = """
+        {
+          "id": 99, "session_uuid": "00000000-0000-0000-0000-000000000099",
+          "status": "lobby", "created_by_user_id": 1,
+          "max_participants": 2, "max_devices": 4, "revision": 1,
+          "calibration": null, "scheduled_start_at": null,
+          "created_at": "2026-06-22T10:00:00+00:00",
+          "started_at": null, "stopped_at": null, "finalized_at": null, "cancelled_at": null,
+          "participants": [], "devices": [], "streams": []
+        }
+        """.data(using: .utf8)!
+        let session = try JSONDecoder().decode(MultiCameraSessionDTO.self, from: json)
+        XCTAssertNil(session.scheduledStartAt)
+    }
+
+    // SCP-13: scheduledStartAt round-trip
+    func test_SCP_13_scheduledStartAtRoundTrip() throws {
+        let data = try fixtureData()
+        let session = try JSONDecoder().decode(MultiCameraSessionDTO.self, from: data)
+        let reEncoded = try JSONEncoder().encode(session)
+        let reDecoded = try JSONDecoder().decode(MultiCameraSessionDTO.self, from: reEncoded)
+        XCTAssertEqual(session.scheduledStartAt, reDecoded.scheduledStartAt)
+    }
 }

--- a/tests/fixtures/multicamera/session_full.json
+++ b/tests/fixtures/multicamera/session_full.json
@@ -6,6 +6,7 @@
   "max_participants": 2,
   "max_devices": 4,
   "revision": 5,
+  "scheduled_start_at": "2026-06-22T10:04:52+00:00",
   "calibration": {
     "schema_version": 1,
     "calibration_id": null,


### PR DESCRIPTION
## Summary
- Adds `scheduledStartAt: String?` to iOS `MultiCameraSessionDTO`, mirroring the backend `scheduled_start_at` field already present in the API response
- Updates `session_full.json` fixture with `scheduled_start_at` value
- Adds 3 contract tests: SCP-11 (presence), SCP-12 (null decode), SCP-13 (round-trip)

## Scope
- **iOS only** — no backend, no ViewModel, no ClockSyncService changes
- **Non-behavioral** — existing functionality unchanged, new field is read-only
- Prerequisite for MC1-iOS-ORCH-1B (ViewModel ClockSync integration)

## Changed files
- `ios/LFAEducationCenter/MultiCamera/MultiCameraSessionModels.swift` — DTO field + CodingKey
- `ios/LFAEducationCenterTests/MultiCamera/MultiCameraSessionContractTests.swift` — SCP-11/12/13
- `tests/fixtures/multicamera/session_full.json` — `scheduled_start_at` field added

## Test plan
- [x] SCP-01..SCP-10 existing contract tests PASS (13/13)
- [x] SCP-11 scheduledStartAt present in fixture
- [x] SCP-12 scheduledStartAt null decode
- [x] SCP-13 scheduledStartAt round-trip
- [x] CS-01..CS-14 ClockSyncService regression PASS (14/14)
- [x] iOS BUILD SUCCEEDED (0 warnings in changed files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)