### PR TITLE
feat(mc1-ios-orch1b): ViewModel ClockSync integration + readiness gate

### DIFF
--- a/ios/LFAEducationCenter.xcodeproj/project.pbxproj
+++ b/ios/LFAEducationCenter.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		MC500004000000000000003 /* SessionCaptureManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = MC500003000000000000003 /* SessionCaptureManagerTests.swift */; };
 		DI500004000000000000001 /* DeviceIdentityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DI500003000000000000001 /* DeviceIdentityTests.swift */; };
 		CS500004000000000000001 /* ClockSyncServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CS500003000000000000001 /* ClockSyncServiceTests.swift */; };
+		942FE944E7544114B645BB37 /* MultiCameraSessionViewModelClockSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7923EAF385B2497998AA5258 /* MultiCameraSessionViewModelClockSyncTests.swift */; };
 		GP000004000000000000005 /* GoProConnectionDebugView.swift in Sources */ = {isa = PBXBuildFile; fileRef = GP000003000000000000005 /* GoProConnectionDebugView.swift */; };
 		GP000004000000000000006 /* CoreBluetoothBLETransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = GP000003000000000000006 /* CoreBluetoothBLETransport.swift */; };
 		GP000004000000000000007 /* GoProHTTPClientTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = GP000003000000000000007 /* GoProHTTPClientTransport.swift */; };
@@ -275,6 +276,7 @@
 		MC500003000000000000003 /* SessionCaptureManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionCaptureManagerTests.swift; sourceTree = "<group>"; };
 		DI500003000000000000001 /* DeviceIdentityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceIdentityTests.swift; sourceTree = "<group>"; };
 		CS500003000000000000001 /* ClockSyncServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClockSyncServiceTests.swift; sourceTree = "<group>"; };
+		7923EAF385B2497998AA5258 /* MultiCameraSessionViewModelClockSyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiCameraSessionViewModelClockSyncTests.swift; sourceTree = "<group>"; };
 		MC500003000000000000002 /* session_full.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; name = "session_full.json"; path = "../tests/fixtures/multicamera/session_full.json"; sourceTree = SOURCE_ROOT; };
 		BT500003000000000000001 /* BallTrainingHubVMTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BallTrainingHubVMTests.swift; sourceTree = "<group>"; };
 		SK500003000000000000001 /* CanonicalJointTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanonicalJointTests.swift; sourceTree = "<group>"; };
@@ -989,6 +991,7 @@
 				MC500003000000000000003 /* SessionCaptureManagerTests.swift */,
 				DI500003000000000000001 /* DeviceIdentityTests.swift */,
 				CS500003000000000000001 /* ClockSyncServiceTests.swift */,
+				7923EAF385B2497998AA5258 /* MultiCameraSessionViewModelClockSyncTests.swift */,
 				MC500003000000000000002 /* session_full.json */,
 			);
 			path = MultiCamera;
@@ -1341,6 +1344,7 @@
 				MC500004000000000000003 /* SessionCaptureManagerTests.swift in Sources */,
 				DI500004000000000000001 /* DeviceIdentityTests.swift in Sources */,
 				CS500004000000000000001 /* ClockSyncServiceTests.swift in Sources */,
+				942FE944E7544114B645BB37 /* MultiCameraSessionViewModelClockSyncTests.swift in Sources */,
 				BB100004000000000000004 /* AnnotationVideoLoaderTests.swift in Sources */,
 				BB100004000000000000005 /* PlaybackBarTests.swift in Sources */,
 				BB100004000000000000006 /* AVPlayerLayerViewTests.swift in Sources */,

--- a/ios/LFAEducationCenter/MultiCamera/ClockSyncService.swift
+++ b/ios/LFAEducationCenter/MultiCamera/ClockSyncService.swift
@@ -57,7 +57,7 @@ struct LiveSystemTimeAPIClient: SystemTimeAPIClient {
 
 // MARK: — Result types
 
-struct ClockSyncResult: Sendable {
+struct ClockSyncResult: Sendable, Equatable {
     let estimatedServerAtSampleMs: Double
     let clockOffsetMs: Double
     let rttMs: Double

--- a/ios/LFAEducationCenter/MultiCamera/MultiCameraSessionViewModel.swift
+++ b/ios/LFAEducationCenter/MultiCamera/MultiCameraSessionViewModel.swift
@@ -2,6 +2,13 @@ import Foundation
 import Combine
 import UIKit
 
+enum ClockSyncState: Equatable {
+    case notSynced
+    case syncing
+    case synced(ClockSyncResult)
+    case failed(retryCount: Int, message: String?)
+}
+
 enum LobbyState: Equatable {
     case idle
     case creating
@@ -24,21 +31,27 @@ final class MultiCameraSessionViewModel: ObservableObject {
 
     @Published private(set) var state: LobbyState = .idle
     @Published private(set) var sessionDeviceId: Int?
+    @Published private(set) var clockSyncState: ClockSyncState = .notSynced
 
     private var pollingTask: Task<Void, Never>?
     private var heartbeatTask: Task<Void, Never>?
+    private var clockSyncTask: Task<Void, Never>?
     private var isCreateInProgress = false
 
     private let authManager: AuthManager
+    private let clockSyncService: ClockSyncService
     private let pollingInterval: UInt64
     private let heartbeatInterval: UInt64
+    private static let maxRetries = 3
 
     init(
         authManager: AuthManager,
+        clockSyncService: ClockSyncService = ClockSyncService(),
         pollingIntervalSeconds: Double = 3.0,
         heartbeatIntervalSeconds: Double = 5.0
     ) {
         self.authManager = authManager
+        self.clockSyncService = clockSyncService
         self.pollingInterval = UInt64(pollingIntervalSeconds * 1_000_000_000)
         self.heartbeatInterval = UInt64(heartbeatIntervalSeconds * 1_000_000_000)
     }
@@ -46,6 +59,7 @@ final class MultiCameraSessionViewModel: ObservableObject {
     deinit {
         pollingTask?.cancel()
         heartbeatTask?.cancel()
+        clockSyncTask?.cancel()
     }
 
     // MARK: — Public actions
@@ -64,6 +78,7 @@ final class MultiCameraSessionViewModel: ObservableObject {
                 await autoRegisterDevice(sessionUuid: session.sessionUuid)
                 startPolling(uuid: session.sessionUuid)
                 startHeartbeat(uuid: session.sessionUuid)
+                startClockSync()
             } catch {
                 state = .error(mapError(error))
             }
@@ -82,6 +97,7 @@ final class MultiCameraSessionViewModel: ObservableObject {
                 await autoRegisterDevice(sessionUuid: session.sessionUuid)
                 startPolling(uuid: session.sessionUuid)
                 startHeartbeat(uuid: session.sessionUuid)
+                startClockSync()
             } catch {
                 state = .error(mapError(error))
             }
@@ -123,10 +139,13 @@ final class MultiCameraSessionViewModel: ObservableObject {
     func reset() {
         pollingTask?.cancel()
         heartbeatTask?.cancel()
+        clockSyncTask?.cancel()
         pollingTask = nil
         heartbeatTask = nil
+        clockSyncTask = nil
         sessionDeviceId = nil
         isCreateInProgress = false
+        clockSyncState = .notSynced
         state = .idle
     }
 
@@ -188,6 +207,52 @@ final class MultiCameraSessionViewModel: ObservableObject {
                 _ = try? await MultiCameraAPIClient.heartbeat(token: token, uuid: uuid, sessionDeviceId: sdId)
             }
         }
+    }
+
+    // MARK: — Clock sync
+
+    func startClockSync() {
+        clockSyncTask?.cancel()
+        clockSyncTask = Task { [weak self] in
+            guard let self else { return }
+            self.clockSyncState = .syncing
+            for attempt in 0...Self.maxRetries {
+                guard !Task.isCancelled else { return }
+                if attempt > 0 {
+                    let delayNs = UInt64(pow(2.0, Double(attempt - 1))) * 1_000_000_000
+                    try? await Task.sleep(nanoseconds: delayNs)
+                    guard !Task.isCancelled else { return }
+                }
+                do {
+                    let result = try await self.clockSyncService.sync()
+                    guard !Task.isCancelled else { return }
+                    self.clockSyncState = .synced(result)
+                    return
+                } catch {
+                    if attempt == Self.maxRetries {
+                        self.clockSyncState = .failed(
+                            retryCount: Self.maxRetries,
+                            message: error.localizedDescription
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    func retryClockSync() {
+        startClockSync()
+    }
+
+    var isClockSynced: Bool {
+        if case .synced = clockSyncState { return true }
+        return false
+    }
+
+    var canStartCapture: Bool {
+        guard case .inLobby = state else { return false }
+        guard isClockSynced else { return false }
+        return true
     }
 
     // MARK: — Helpers

--- a/ios/LFAEducationCenterTests/MultiCamera/MultiCameraSessionViewModelClockSyncTests.swift
+++ b/ios/LFAEducationCenterTests/MultiCamera/MultiCameraSessionViewModelClockSyncTests.swift
@@ -1,0 +1,284 @@
+import XCTest
+@testable import LFAEducationCenter
+
+// MARK: — Helpers
+
+private func makeSuccessClient(epochMs: Int = 1_700_000_000_000) -> FakeSystemTimeAPIClient {
+    let dto = ServerTimeDTO(
+        serverTimeUtc: "2023-11-15T10:00:00.000Z",
+        serverEpochMs: epochMs,
+        precision: "milliseconds",
+        source: "backend_app_clock"
+    )
+    return FakeSystemTimeAPIClient(responses: Array(repeating: .success(dto), count: 12))
+}
+
+private func makeFailClient() -> FakeSystemTimeAPIClient {
+    let err = NSError(domain: "test", code: -1, userInfo: [NSLocalizedDescriptionKey: "network down"])
+    return FakeSystemTimeAPIClient(responses: Array(repeating: .failure(err), count: 20))
+}
+
+private func makeMixedClient(failCount: Int, epochMs: Int = 1_700_000_000_000) -> FakeSystemTimeAPIClient {
+    let err = NSError(domain: "test", code: -1, userInfo: [NSLocalizedDescriptionKey: "transient"])
+    let dto = ServerTimeDTO(
+        serverTimeUtc: "2023-11-15T10:00:00.000Z",
+        serverEpochMs: epochMs,
+        precision: "milliseconds",
+        source: "backend_app_clock"
+    )
+    var responses: [Result<ServerTimeDTO, Error>] = Array(repeating: .failure(err), count: failCount)
+    responses.append(contentsOf: Array(repeating: .success(dto), count: 12))
+    return FakeSystemTimeAPIClient(responses: responses)
+}
+
+@MainActor
+private func makeViewModel(apiClient: FakeSystemTimeAPIClient, sampleCount: Int = 1) -> MultiCameraSessionViewModel {
+    let clock = FakeClock(wallMs: 1_700_000_000_000.0, mono: 100.0)
+    let service = ClockSyncService(
+        apiClient: apiClient,
+        wallClockMs: clock.asWallClock,
+        monotonicClock: clock.asMonotonic,
+        sampleCount: sampleCount
+    )
+    return MultiCameraSessionViewModel(
+        authManager: AuthManager(),
+        clockSyncService: service
+    )
+}
+
+private let fixtureSession = MultiCameraSessionDTO(
+    id: 1,
+    sessionUuid: "test-uuid-1234",
+    status: .lobby,
+    createdByUserId: 10,
+    maxParticipants: 2,
+    maxDevices: 4,
+    revision: 1,
+    calibration: nil,
+    scheduledStartAt: nil,
+    createdAt: "2026-06-25T10:00:00+00:00",
+    startedAt: nil,
+    stoppedAt: nil,
+    finalizedAt: nil,
+    cancelledAt: nil,
+    participants: [],
+    devices: [],
+    streams: []
+)
+
+@MainActor
+private func yieldToTasks() async {
+    for _ in 0..<20 {
+        await Task.yield()
+        try? await Task.sleep(nanoseconds: 10_000_000)
+    }
+}
+
+@MainActor
+private func waitForState(
+    _ vm: MultiCameraSessionViewModel,
+    timeout: TimeInterval = 2.0,
+    check: () -> Bool
+) async {
+    let deadline = Date().addingTimeInterval(timeout)
+    while !check() && Date() < deadline {
+        await Task.yield()
+        try? await Task.sleep(nanoseconds: 10_000_000)
+    }
+}
+
+// MARK: — Tests
+
+@MainActor
+final class MultiCameraSessionViewModelClockSyncTests: XCTestCase {
+
+    // ORCH-01: startClockSync transitions to .synced
+    func test_ORCH_01_startClockSyncTransitionsToSynced() async throws {
+        let vm = makeViewModel(apiClient: makeSuccessClient())
+        XCTAssertEqual(vm.clockSyncState, .notSynced)
+
+        vm.startClockSync()
+
+        await waitForState(vm) { vm.isClockSynced }
+
+        if case .synced(let result) = vm.clockSyncState {
+            XCTAssertGreaterThan(result.estimatedServerAtSampleMs, 0)
+        } else {
+            XCTFail("Expected .synced, got \(vm.clockSyncState)")
+        }
+    }
+
+    // ORCH-02: startClockSync cancels previous and restarts
+    func test_ORCH_02_startClockSyncCancelsPreviousTask() async throws {
+        let vm = makeViewModel(apiClient: makeSuccessClient())
+
+        vm.startClockSync()
+        vm.startClockSync()
+
+        await waitForState(vm) { vm.isClockSynced }
+
+        if case .synced = vm.clockSyncState {
+            // second call replaced first, final state is synced
+        } else {
+            XCTFail("Expected .synced after restart, got \(vm.clockSyncState)")
+        }
+    }
+
+    // ORCH-03: all retries fail → .failed(retryCount: 3)
+    func test_ORCH_03_syncFailureAfterAllRetries() async throws {
+        let vm = makeViewModel(apiClient: makeFailClient())
+
+        vm.startClockSync()
+
+        await waitForState(vm, timeout: 15.0) {
+            if case .failed = vm.clockSyncState { return true }
+            return false
+        }
+
+        if case .failed(let count, let msg) = vm.clockSyncState {
+            XCTAssertEqual(count, 3)
+            XCTAssertNotNil(msg)
+        } else {
+            XCTFail("Expected .failed, got \(vm.clockSyncState)")
+        }
+    }
+
+    // ORCH-04: reset cancels clock sync and restores .notSynced
+    func test_ORCH_04_resetCancelsClockSync() async throws {
+        let vm = makeViewModel(apiClient: makeSuccessClient())
+
+        vm.startClockSync()
+        await Task.yield()
+        vm.reset()
+
+        XCTAssertEqual(vm.clockSyncState, .notSynced)
+        XCTAssertEqual(vm.state, .idle)
+
+        await yieldToTasks()
+        XCTAssertEqual(vm.clockSyncState, .notSynced)
+    }
+
+    // ORCH-05: synced result accessible via isClockSynced
+    func test_ORCH_05_syncedResultAccessible() async throws {
+        let clock = FakeClock(wallMs: 1_700_000_000_000.0, mono: 100.0)
+        let dto = ServerTimeDTO(
+            serverTimeUtc: "2023-11-15T10:00:00.000Z",
+            serverEpochMs: 1_700_000_050_000,
+            precision: "milliseconds",
+            source: "backend_app_clock"
+        )
+        let client = FakeSystemTimeAPIClient(responses: [.success(dto)])
+        let service = ClockSyncService(
+            apiClient: client,
+            wallClockMs: clock.asWallClock,
+            monotonicClock: clock.asMonotonic,
+            sampleCount: 1
+        )
+        let vm = MultiCameraSessionViewModel(
+            authManager: AuthManager(),
+            clockSyncService: service
+        )
+
+        XCTAssertFalse(vm.isClockSynced)
+
+        vm.startClockSync()
+        await waitForState(vm) { vm.isClockSynced }
+
+        XCTAssertTrue(vm.isClockSynced)
+        if case .synced(let result) = vm.clockSyncState {
+            XCTAssertGreaterThan(result.estimatedServerAtSampleMs, 0)
+        }
+    }
+
+    // ORCH-06: canStartCapture false without sync
+    func test_ORCH_06_canStartCaptureFalseWithoutSync() {
+        let vm = makeViewModel(apiClient: makeSuccessClient())
+        XCTAssertFalse(vm.canStartCapture)
+    }
+
+    // ORCH-07: canStartCapture false when synced but not inLobby
+    func test_ORCH_07_canStartCaptureRequiresBothSyncAndLobby() async throws {
+        let vm = makeViewModel(apiClient: makeSuccessClient())
+
+        vm.startClockSync()
+        await waitForState(vm) { vm.isClockSynced }
+
+        XCTAssertTrue(vm.isClockSynced)
+        XCTAssertEqual(vm.state, .idle)
+        XCTAssertFalse(vm.canStartCapture)
+    }
+
+    // ORCH-08: retryClockSync restarts after failure
+    func test_ORCH_08_retryAfterFailure() async throws {
+        let err = NSError(domain: "test", code: -1, userInfo: [NSLocalizedDescriptionKey: "fail"])
+        let dto = ServerTimeDTO(
+            serverTimeUtc: "2023-11-15T10:00:00.000Z",
+            serverEpochMs: 1_700_000_000_000,
+            precision: "milliseconds",
+            source: "backend_app_clock"
+        )
+        var responses: [Result<ServerTimeDTO, Error>] = Array(repeating: .failure(err), count: 4)
+        responses.append(contentsOf: Array(repeating: .success(dto), count: 4))
+        let client = FakeSystemTimeAPIClient(responses: responses)
+        let clock = FakeClock()
+        let service = ClockSyncService(
+            apiClient: client,
+            wallClockMs: clock.asWallClock,
+            monotonicClock: clock.asMonotonic,
+            sampleCount: 1
+        )
+        let vm = MultiCameraSessionViewModel(
+            authManager: AuthManager(),
+            clockSyncService: service
+        )
+
+        vm.startClockSync()
+        await waitForState(vm, timeout: 15.0) {
+            if case .failed = vm.clockSyncState { return true }
+            return false
+        }
+
+        vm.retryClockSync()
+        await waitForState(vm, timeout: 2.0) { vm.isClockSynced }
+
+        XCTAssertTrue(vm.isClockSynced)
+    }
+
+    // ORCH-09: partial failure then success (2 sync() calls fail, 3rd succeeds)
+    func test_ORCH_09_partialFailureRetrySucceeds() async throws {
+        let client = makeMixedClient(failCount: 2, epochMs: 1_700_000_050_000)
+        let clock = FakeClock()
+        let service = ClockSyncService(
+            apiClient: client,
+            wallClockMs: clock.asWallClock,
+            monotonicClock: clock.asMonotonic,
+            sampleCount: 1
+        )
+        let vm = MultiCameraSessionViewModel(
+            authManager: AuthManager(),
+            clockSyncService: service
+        )
+
+        vm.startClockSync()
+
+        await waitForState(vm, timeout: 10.0) { vm.isClockSynced }
+
+        if case .synced(let result) = vm.clockSyncState {
+            XCTAssertGreaterThan(result.estimatedServerAtSampleMs, 0)
+        } else {
+            XCTFail("Expected .synced after partial failure, got \(vm.clockSyncState)")
+        }
+    }
+
+    // ORCH-10: canStartCapture requires lobby state
+    func test_ORCH_10_canStartCaptureRequiresLobby() async throws {
+        let vm = makeViewModel(apiClient: makeSuccessClient())
+
+        vm.startClockSync()
+        await waitForState(vm) { vm.isClockSynced }
+
+        XCTAssertTrue(vm.isClockSynced)
+        XCTAssertEqual(vm.state, .idle)
+        XCTAssertFalse(vm.canStartCapture)
+    }
+}


### PR DESCRIPTION
## Summary
- Integrates `ClockSyncService` into `MultiCameraSessionViewModel` with automatic sync on lobby entry
- Adds `ClockSyncState` enum (`.notSynced` / `.syncing` / `.synced` / `.failed`)
- Exponential backoff retry (1s, 2s, 4s — max 3 retries)
- Strict mode: `canStartCapture` gate requires successful clock sync
- Proper cleanup in `reset()` and `deinit`
- 10 unit tests (ORCH-01..ORCH-10)

## Scope boundaries — NOT in this PR
- No `SessionCaptureManager` changes
- No backend changes
- No UI / `MultiCameraLobbyView` changes
- No `confirm-start` / `confirm-stop` API calls
- No capture orchestration / scheduled timer
- No `MultiCameraAPIClient` refactor

## Changed files
- `ClockSyncService.swift` — `ClockSyncResult: Equatable` conformance (+1 word)
- `MultiCameraSessionViewModel.swift` — `ClockSyncState` enum, injection, retry, gate, cleanup
- `MultiCameraSessionViewModelClockSyncTests.swift` — ORCH-01..ORCH-10 (NEW)
- `project.pbxproj` — test file reference

## Test plan
- [x] ORCH-01 startClockSyncTransitionsToSynced
- [x] ORCH-02 startClockSyncCancelsPreviousTask
- [x] ORCH-03 syncFailureAfterAllRetries → .failed(retryCount: 3)
- [x] ORCH-04 resetCancelsClockSync → .notSynced
- [x] ORCH-05 syncedResultAccessible
- [x] ORCH-06 canStartCaptureFalseWithoutSync
- [x] ORCH-07 canStartCaptureRequiresBothSyncAndLobby
- [x] ORCH-08 retryAfterFailure
- [x] ORCH-09 partialFailureRetrySucceeds
- [x] ORCH-10 canStartCaptureRequiresLobby
- [x] CS-01..CS-14 regression PASS (14/14)
- [x] SCP-01..SCP-13 regression PASS (13/13)
- [x] iOS BUILD SUCCEEDED

🤖 Generated with [Claude Code](https://claude.com/claude-code)