### PR TITLE
feat(mc1-ios-orch2a): CaptureCycle DTOs + API client cycle endpoints

### DIFF
--- a/ios/LFAEducationCenter.xcodeproj/project.pbxproj
+++ b/ios/LFAEducationCenter.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		MC500004000000000000003 /* SessionCaptureManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = MC500003000000000000003 /* SessionCaptureManagerTests.swift */; };
 		DI500004000000000000001 /* DeviceIdentityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DI500003000000000000001 /* DeviceIdentityTests.swift */; };
 		CS500004000000000000001 /* ClockSyncServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CS500003000000000000001 /* ClockSyncServiceTests.swift */; };
+		06881AF7704345FF9DCED8DD /* CaptureCycleContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16BA790BA9964D4A9E64F6E3 /* CaptureCycleContractTests.swift */; };
 		942FE944E7544114B645BB37 /* MultiCameraSessionViewModelClockSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7923EAF385B2497998AA5258 /* MultiCameraSessionViewModelClockSyncTests.swift */; };
 		GP000004000000000000005 /* GoProConnectionDebugView.swift in Sources */ = {isa = PBXBuildFile; fileRef = GP000003000000000000005 /* GoProConnectionDebugView.swift */; };
 		GP000004000000000000006 /* CoreBluetoothBLETransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = GP000003000000000000006 /* CoreBluetoothBLETransport.swift */; };
@@ -42,6 +43,7 @@
 		GP500004000000000000001 /* GoProConnectionStateMachineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = GP500003000000000000001 /* GoProConnectionStateMachineTests.swift */; };
 		MC500004000000000000001 /* MultiCameraSessionContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = MC500003000000000000001 /* MultiCameraSessionContractTests.swift */; };
 		MC500004000000000000002 /* session_full.json in Resources */ = {isa = PBXBuildFile; fileRef = MC500003000000000000002 /* session_full.json */; };
+		CYC00004000000000000001 /* cycle_full.json in Resources */ = {isa = PBXBuildFile; fileRef = CYC00003000000000000001 /* cycle_full.json */; };
 		BT500004000000000000001 /* BallTrainingHubVMTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BT500003000000000000001 /* BallTrainingHubVMTests.swift */; };
 		SK500004000000000000001 /* CanonicalJointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = SK500003000000000000001 /* CanonicalJointTests.swift */; };
 		SK500004000000000000002 /* LegacySkeletonAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = SK500003000000000000002 /* LegacySkeletonAdapterTests.swift */; };
@@ -276,8 +278,10 @@
 		MC500003000000000000003 /* SessionCaptureManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionCaptureManagerTests.swift; sourceTree = "<group>"; };
 		DI500003000000000000001 /* DeviceIdentityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceIdentityTests.swift; sourceTree = "<group>"; };
 		CS500003000000000000001 /* ClockSyncServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClockSyncServiceTests.swift; sourceTree = "<group>"; };
+		16BA790BA9964D4A9E64F6E3 /* CaptureCycleContractTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureCycleContractTests.swift; sourceTree = "<group>"; };
 		7923EAF385B2497998AA5258 /* MultiCameraSessionViewModelClockSyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiCameraSessionViewModelClockSyncTests.swift; sourceTree = "<group>"; };
 		MC500003000000000000002 /* session_full.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; name = "session_full.json"; path = "../tests/fixtures/multicamera/session_full.json"; sourceTree = SOURCE_ROOT; };
+		CYC00003000000000000001 /* cycle_full.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; name = "cycle_full.json"; path = "../tests/fixtures/multicamera/cycle_full.json"; sourceTree = SOURCE_ROOT; };
 		BT500003000000000000001 /* BallTrainingHubVMTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BallTrainingHubVMTests.swift; sourceTree = "<group>"; };
 		SK500003000000000000001 /* CanonicalJointTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanonicalJointTests.swift; sourceTree = "<group>"; };
 		SK500003000000000000002 /* LegacySkeletonAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacySkeletonAdapterTests.swift; sourceTree = "<group>"; };
@@ -992,7 +996,9 @@
 				DI500003000000000000001 /* DeviceIdentityTests.swift */,
 				CS500003000000000000001 /* ClockSyncServiceTests.swift */,
 				7923EAF385B2497998AA5258 /* MultiCameraSessionViewModelClockSyncTests.swift */,
+				16BA790BA9964D4A9E64F6E3 /* CaptureCycleContractTests.swift */,
 				MC500003000000000000002 /* session_full.json */,
+				CYC00003000000000000001 /* cycle_full.json */,
 			);
 			path = MultiCamera;
 			sourceTree = "<group>";
@@ -1105,6 +1111,7 @@
 			files = (
 				SK600004000000000000001 /* frame_v2_full.json in Resources */,
 				MC500004000000000000002 /* session_full.json in Resources */,
+				CYC00004000000000000001 /* cycle_full.json in Resources */,
 				SK600004000000000000002 /* frame_v2_2d_only.json in Resources */,
 				SK600004000000000000003 /* frame_v1_source.json in Resources */,
 				SK600004000000000000004 /* frame_v1_adapted.json in Resources */,
@@ -1345,6 +1352,7 @@
 				DI500004000000000000001 /* DeviceIdentityTests.swift in Sources */,
 				CS500004000000000000001 /* ClockSyncServiceTests.swift in Sources */,
 				942FE944E7544114B645BB37 /* MultiCameraSessionViewModelClockSyncTests.swift in Sources */,
+				06881AF7704345FF9DCED8DD /* CaptureCycleContractTests.swift in Sources */,
 				BB100004000000000000004 /* AnnotationVideoLoaderTests.swift in Sources */,
 				BB100004000000000000005 /* PlaybackBarTests.swift in Sources */,
 				BB100004000000000000006 /* AVPlayerLayerViewTests.swift in Sources */,

--- a/ios/LFAEducationCenter/MultiCamera/MultiCameraAPIClient.swift
+++ b/ios/LFAEducationCenter/MultiCamera/MultiCameraAPIClient.swift
@@ -103,3 +103,101 @@ enum MultiCameraAPIClient {
 }
 
 private struct EmptyBody: Codable {}
+
+// MARK: — Cycle request types
+
+struct CreateCycleRequest: Codable {
+    let idempotencyKey: String
+    enum CodingKeys: String, CodingKey {
+        case idempotencyKey = "idempotency_key"
+    }
+}
+
+struct ScheduleCycleRequest: Codable {
+    let revision: Int
+}
+
+struct StopCycleRequest: Codable {
+    let revision: Int
+}
+
+struct ConfirmDeviceStartRequest: Codable {
+    let startedAt: String
+    let cycleDeviceRevision: Int
+    enum CodingKeys: String, CodingKey {
+        case startedAt = "started_at"
+        case cycleDeviceRevision = "cycle_device_revision"
+    }
+}
+
+struct ConfirmDeviceStopRequest: Codable {
+    let stoppedAt: String
+    let cycleDeviceRevision: Int
+    enum CodingKeys: String, CodingKey {
+        case stoppedAt = "stopped_at"
+        case cycleDeviceRevision = "cycle_device_revision"
+    }
+}
+
+// MARK: — Cycle API Client
+
+extension MultiCameraAPIClient {
+
+    static func activateSession(token: String, uuid: String, revision: Int) async throws -> MultiCameraSessionDTO {
+        try await APIClient.post(
+            path: "\(base)/sessions/\(uuid)/activate",
+            body: ScheduleCycleRequest(revision: revision),
+            token: token
+        )
+    }
+
+    static func createCycle(token: String, uuid: String, idempotencyKey: String) async throws -> CaptureCycleDTO {
+        try await APIClient.post(
+            path: "\(base)/sessions/\(uuid)/cycles",
+            body: CreateCycleRequest(idempotencyKey: idempotencyKey),
+            token: token
+        )
+    }
+
+    static func listCycles(token: String, uuid: String) async throws -> [CaptureCycleDTO] {
+        try await APIClient.get(path: "\(base)/sessions/\(uuid)/cycles", token: token)
+    }
+
+    static func scheduleCycle(token: String, uuid: String, cycleId: Int, revision: Int) async throws -> CaptureCycleDTO {
+        try await APIClient.post(
+            path: "\(base)/sessions/\(uuid)/cycles/\(cycleId)/schedule",
+            body: ScheduleCycleRequest(revision: revision),
+            token: token
+        )
+    }
+
+    static func stopCycle(token: String, uuid: String, cycleId: Int, revision: Int) async throws -> CaptureCycleDTO {
+        try await APIClient.post(
+            path: "\(base)/sessions/\(uuid)/cycles/\(cycleId)/stop",
+            body: StopCycleRequest(revision: revision),
+            token: token
+        )
+    }
+
+    static func confirmDeviceStart(
+        token: String, uuid: String, cycleId: Int, sessionDeviceId: Int,
+        startedAt: String, cycleDeviceRevision: Int
+    ) async throws -> CaptureCycleDTO {
+        try await APIClient.post(
+            path: "\(base)/sessions/\(uuid)/cycles/\(cycleId)/devices/\(sessionDeviceId)/confirm-start",
+            body: ConfirmDeviceStartRequest(startedAt: startedAt, cycleDeviceRevision: cycleDeviceRevision),
+            token: token
+        )
+    }
+
+    static func confirmDeviceStop(
+        token: String, uuid: String, cycleId: Int, sessionDeviceId: Int,
+        stoppedAt: String, cycleDeviceRevision: Int
+    ) async throws -> CaptureCycleDTO {
+        try await APIClient.post(
+            path: "\(base)/sessions/\(uuid)/cycles/\(cycleId)/devices/\(sessionDeviceId)/confirm-stop",
+            body: ConfirmDeviceStopRequest(stoppedAt: stoppedAt, cycleDeviceRevision: cycleDeviceRevision),
+            token: token
+        )
+    }
+}

--- a/ios/LFAEducationCenter/MultiCamera/MultiCameraSessionModels.swift
+++ b/ios/LFAEducationCenter/MultiCamera/MultiCameraSessionModels.swift
@@ -3,11 +3,13 @@ import Foundation
 enum SessionStatus: String, Codable, CaseIterable {
     case lobby
     case devicesReady = "devices_ready"
+    case recordingPending = "recording_pending"
     case recording
     case stopped
     case finalizing
     case completed
     case cancelled
+    case active
 }
 
 enum ParticipantRole: String, Codable, CaseIterable {
@@ -191,5 +193,93 @@ struct AnyCodable: Codable, Equatable {
     }
     static func == (lhs: AnyCodable, rhs: AnyCodable) -> Bool {
         String(describing: lhs.value) == String(describing: rhs.value)
+    }
+}
+
+// MARK: — Capture Cycle models
+
+enum CycleStatus: String, Codable, CaseIterable {
+    case preparing
+    case recordingPending = "recording_pending"
+    case recording
+    case stopping
+    case completed
+    case failed
+    case aborted
+}
+
+enum CycleDeviceRecordingStatus: String, Codable, CaseIterable {
+    case pending
+    case confirmedStart = "confirmed_start"
+    case confirmedStop = "confirmed_stop"
+    case failed
+}
+
+enum CycleResult: String, Codable, CaseIterable {
+    case success
+    case partial
+    case failed
+}
+
+struct CaptureCycleDeviceDTO: Codable, Equatable {
+    let id: Int
+    let captureCycleId: Int
+    let sessionDeviceId: Int
+    let required: Bool
+    let recordingStatus: CycleDeviceRecordingStatus
+    let startedAt: String?
+    let stoppedAt: String?
+    let failureReason: String?
+    let revision: Int
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case captureCycleId = "capture_cycle_id"
+        case sessionDeviceId = "session_device_id"
+        case required
+        case recordingStatus = "recording_status"
+        case startedAt = "started_at"
+        case stoppedAt = "stopped_at"
+        case failureReason = "failure_reason"
+        case revision
+    }
+}
+
+struct CaptureCycleDTO: Codable, Equatable {
+    let id: Int
+    let sessionId: Int
+    let cycleIndex: Int
+    let status: CycleStatus
+    let result: CycleResult?
+    let scheduledStartAt: String?
+    let recordingStartedAt: String?
+    let stopRequestedAt: String?
+    let recordingStoppedAt: String?
+    let completedAt: String?
+    let failureReason: String?
+    let createdByParticipantId: Int
+    let idempotencyKey: String
+    let revision: Int
+    let createdAt: String
+    let updatedAt: String
+    let cycleDevices: [CaptureCycleDeviceDTO]
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case sessionId = "session_id"
+        case cycleIndex = "cycle_index"
+        case status, result
+        case scheduledStartAt = "scheduled_start_at"
+        case recordingStartedAt = "recording_started_at"
+        case stopRequestedAt = "stop_requested_at"
+        case recordingStoppedAt = "recording_stopped_at"
+        case completedAt = "completed_at"
+        case failureReason = "failure_reason"
+        case createdByParticipantId = "created_by_participant_id"
+        case idempotencyKey = "idempotency_key"
+        case revision
+        case createdAt = "created_at"
+        case updatedAt = "updated_at"
+        case cycleDevices = "cycle_devices"
     }
 }

--- a/ios/LFAEducationCenterTests/MultiCamera/CaptureCycleContractTests.swift
+++ b/ios/LFAEducationCenterTests/MultiCamera/CaptureCycleContractTests.swift
@@ -1,0 +1,185 @@
+import XCTest
+@testable import LFAEducationCenter
+
+final class CaptureCycleContractTests: XCTestCase {
+
+    private func fixtureData() throws -> Data {
+        let url = Bundle(for: type(of: self)).url(forResource: "cycle_full", withExtension: "json")
+            ?? URL(fileURLWithPath: "../tests/fixtures/multicamera/cycle_full.json")
+        return try Data(contentsOf: url)
+    }
+
+    // CYC-01: Cycle DTO round-trip
+    func test_CYC_01_cycleRoundTrip() throws {
+        let data = try fixtureData()
+        let cycle = try JSONDecoder().decode(CaptureCycleDTO.self, from: data)
+        XCTAssertEqual(cycle.id, 1)
+        XCTAssertEqual(cycle.sessionId, 1)
+        XCTAssertEqual(cycle.cycleIndex, 0)
+        XCTAssertEqual(cycle.status, .recordingPending)
+        XCTAssertNil(cycle.result)
+        XCTAssertEqual(cycle.revision, 2)
+        XCTAssertEqual(cycle.idempotencyKey, "cycle-key-001")
+        let reEncoded = try JSONEncoder().encode(cycle)
+        let reDecoded = try JSONDecoder().decode(CaptureCycleDTO.self, from: reEncoded)
+        XCTAssertEqual(cycle, reDecoded)
+    }
+
+    // CYC-02: scheduledStartAt present
+    func test_CYC_02_scheduledStartAtPresent() throws {
+        let data = try fixtureData()
+        let cycle = try JSONDecoder().decode(CaptureCycleDTO.self, from: data)
+        XCTAssertEqual(cycle.scheduledStartAt, "2026-06-25T10:05:08+00:00")
+    }
+
+    // CYC-03: cycle devices count and roles
+    func test_CYC_03_cycleDevicesCount() throws {
+        let data = try fixtureData()
+        let cycle = try JSONDecoder().decode(CaptureCycleDTO.self, from: data)
+        XCTAssertEqual(cycle.cycleDevices.count, 3)
+        XCTAssertTrue(cycle.cycleDevices[0].required)
+        XCTAssertTrue(cycle.cycleDevices[1].required)
+        XCTAssertFalse(cycle.cycleDevices[2].required)
+    }
+
+    // CYC-04: device recording status decode
+    func test_CYC_04_deviceRecordingStatus() throws {
+        let data = try fixtureData()
+        let cycle = try JSONDecoder().decode(CaptureCycleDTO.self, from: data)
+        XCTAssertEqual(cycle.cycleDevices[0].recordingStatus, .pending)
+        XCTAssertEqual(cycle.cycleDevices[1].recordingStatus, .confirmedStart)
+        XCTAssertEqual(cycle.cycleDevices[2].recordingStatus, .pending)
+    }
+
+    // CYC-05: device startedAt present for confirmed device
+    func test_CYC_05_deviceStartedAt() throws {
+        let data = try fixtureData()
+        let cycle = try JSONDecoder().decode(CaptureCycleDTO.self, from: data)
+        XCTAssertNil(cycle.cycleDevices[0].startedAt)
+        XCTAssertEqual(cycle.cycleDevices[1].startedAt, "2026-06-25T10:05:08.123+00:00")
+    }
+
+    // CYC-06: CycleStatus enum all cases
+    func test_CYC_06_cycleStatusEnum() throws {
+        let all: [CycleStatus] = [.preparing, .recordingPending, .recording, .stopping, .completed, .failed, .aborted]
+        for s in all {
+            let json = try JSONEncoder().encode(s)
+            let decoded = try JSONDecoder().decode(CycleStatus.self, from: json)
+            XCTAssertEqual(s, decoded)
+        }
+        XCTAssertEqual(CycleStatus.allCases.count, 7)
+    }
+
+    // CYC-07: CycleDeviceRecordingStatus enum all cases
+    func test_CYC_07_deviceRecordingStatusEnum() throws {
+        let all: [CycleDeviceRecordingStatus] = [.pending, .confirmedStart, .confirmedStop, .failed]
+        for s in all {
+            let json = try JSONEncoder().encode(s)
+            let decoded = try JSONDecoder().decode(CycleDeviceRecordingStatus.self, from: json)
+            XCTAssertEqual(s, decoded)
+        }
+        XCTAssertEqual(CycleDeviceRecordingStatus.allCases.count, 4)
+    }
+
+    // CYC-08: CycleResult enum all cases
+    func test_CYC_08_cycleResultEnum() throws {
+        let all: [CycleResult] = [.success, .partial, .failed]
+        for s in all {
+            let json = try JSONEncoder().encode(s)
+            let decoded = try JSONDecoder().decode(CycleResult.self, from: json)
+            XCTAssertEqual(s, decoded)
+        }
+        XCTAssertEqual(CycleResult.allCases.count, 3)
+    }
+
+    // CYC-09: null optional fields decode
+    func test_CYC_09_nullOptionalFields() throws {
+        let data = try fixtureData()
+        let cycle = try JSONDecoder().decode(CaptureCycleDTO.self, from: data)
+        XCTAssertNil(cycle.result)
+        XCTAssertNil(cycle.recordingStartedAt)
+        XCTAssertNil(cycle.stopRequestedAt)
+        XCTAssertNil(cycle.recordingStoppedAt)
+        XCTAssertNil(cycle.completedAt)
+        XCTAssertNil(cycle.failureReason)
+    }
+
+    // CYC-10: completed cycle decode
+    func test_CYC_10_completedCycleDecode() throws {
+        let json = """
+        {
+          "id": 2, "session_id": 1, "cycle_index": 1,
+          "status": "completed", "result": "success",
+          "scheduled_start_at": "2026-06-25T10:10:00+00:00",
+          "recording_started_at": "2026-06-25T10:10:08+00:00",
+          "stop_requested_at": "2026-06-25T10:12:00+00:00",
+          "recording_stopped_at": "2026-06-25T10:12:01+00:00",
+          "completed_at": "2026-06-25T10:12:01+00:00",
+          "failure_reason": null,
+          "created_by_participant_id": 1,
+          "idempotency_key": "cycle-key-002",
+          "revision": 5,
+          "created_at": "2026-06-25T10:09:50+00:00",
+          "updated_at": "2026-06-25T10:12:01+00:00",
+          "cycle_devices": []
+        }
+        """.data(using: .utf8)!
+        let cycle = try JSONDecoder().decode(CaptureCycleDTO.self, from: json)
+        XCTAssertEqual(cycle.status, .completed)
+        XCTAssertEqual(cycle.result, .success)
+        XCTAssertNotNil(cycle.recordingStartedAt)
+        XCTAssertNotNil(cycle.recordingStoppedAt)
+        XCTAssertNotNil(cycle.completedAt)
+    }
+
+    // CYC-11: ConfirmDeviceStartRequest encode
+    func test_CYC_11_confirmStartRequestEncode() throws {
+        let req = ConfirmDeviceStartRequest(
+            startedAt: "2026-06-25T10:05:08.123Z",
+            cycleDeviceRevision: 0
+        )
+        let data = try JSONEncoder().encode(req)
+        let dict = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        XCTAssertEqual(dict["started_at"] as? String, "2026-06-25T10:05:08.123Z")
+        XCTAssertEqual(dict["cycle_device_revision"] as? Int, 0)
+    }
+
+    // CYC-12: ConfirmDeviceStopRequest encode
+    func test_CYC_12_confirmStopRequestEncode() throws {
+        let req = ConfirmDeviceStopRequest(
+            stoppedAt: "2026-06-25T10:12:01.456Z",
+            cycleDeviceRevision: 1
+        )
+        let data = try JSONEncoder().encode(req)
+        let dict = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        XCTAssertEqual(dict["stopped_at"] as? String, "2026-06-25T10:12:01.456Z")
+        XCTAssertEqual(dict["cycle_device_revision"] as? Int, 1)
+    }
+
+    // CYC-13: CreateCycleRequest encode
+    func test_CYC_13_createCycleRequestEncode() throws {
+        let req = CreateCycleRequest(idempotencyKey: "test-key-123")
+        let data = try JSONEncoder().encode(req)
+        let dict = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        XCTAssertEqual(dict["idempotency_key"] as? String, "test-key-123")
+    }
+
+    // CYC-14: SessionStatus now includes active and recordingPending
+    func test_CYC_14_sessionStatusNewCases() throws {
+        let active = try JSONDecoder().decode(SessionStatus.self, from: "\"active\"".data(using: .utf8)!)
+        XCTAssertEqual(active, .active)
+        let rp = try JSONDecoder().decode(SessionStatus.self, from: "\"recording_pending\"".data(using: .utf8)!)
+        XCTAssertEqual(rp, .recordingPending)
+        XCTAssertEqual(SessionStatus.allCases.count, 9)
+    }
+
+    // CYC-15: CaptureCycleDeviceDTO round-trip
+    func test_CYC_15_cycleDeviceRoundTrip() throws {
+        let data = try fixtureData()
+        let cycle = try JSONDecoder().decode(CaptureCycleDTO.self, from: data)
+        let device = cycle.cycleDevices[1]
+        let reEncoded = try JSONEncoder().encode(device)
+        let reDecoded = try JSONDecoder().decode(CaptureCycleDeviceDTO.self, from: reEncoded)
+        XCTAssertEqual(device, reDecoded)
+    }
+}

--- a/ios/LFAEducationCenterTests/MultiCamera/MultiCameraSessionContractTests.swift
+++ b/ios/LFAEducationCenterTests/MultiCamera/MultiCameraSessionContractTests.swift
@@ -63,15 +63,15 @@ final class MultiCameraSessionContractTests: XCTestCase {
         XCTAssertNil(session.calibration?.worldOriginCameraId)
     }
 
-    // SCP-07: SessionStatus enum values
+    // SCP-07: SessionStatus enum values (9 cases after ORCH-2A added recordingPending + active)
     func test_SCP_07_sessionStatusEnum() throws {
-        let all: [SessionStatus] = [.lobby, .devicesReady, .recording, .stopped, .finalizing, .completed, .cancelled]
+        let all: [SessionStatus] = [.lobby, .devicesReady, .recordingPending, .recording, .stopped, .finalizing, .completed, .cancelled, .active]
         for s in all {
             let json = try JSONEncoder().encode(s)
             let decoded = try JSONDecoder().decode(SessionStatus.self, from: json)
             XCTAssertEqual(s, decoded)
         }
-        XCTAssertEqual(SessionStatus.allCases.count, 7)
+        XCTAssertEqual(SessionStatus.allCases.count, 9)
     }
 
     // SCP-08: DeviceRole enum values

--- a/tests/fixtures/multicamera/cycle_full.json
+++ b/tests/fixtures/multicamera/cycle_full.json
@@ -1,0 +1,53 @@
+{
+  "id": 1,
+  "session_id": 1,
+  "cycle_index": 0,
+  "status": "recording_pending",
+  "result": null,
+  "scheduled_start_at": "2026-06-25T10:05:08+00:00",
+  "recording_started_at": null,
+  "stop_requested_at": null,
+  "recording_stopped_at": null,
+  "completed_at": null,
+  "failure_reason": null,
+  "created_by_participant_id": 1,
+  "idempotency_key": "cycle-key-001",
+  "revision": 2,
+  "created_at": "2026-06-25T10:04:50+00:00",
+  "updated_at": "2026-06-25T10:05:00+00:00",
+  "cycle_devices": [
+    {
+      "id": 1,
+      "capture_cycle_id": 1,
+      "session_device_id": 1,
+      "required": true,
+      "recording_status": "pending",
+      "started_at": null,
+      "stopped_at": null,
+      "failure_reason": null,
+      "revision": 0
+    },
+    {
+      "id": 2,
+      "capture_cycle_id": 1,
+      "session_device_id": 2,
+      "required": true,
+      "recording_status": "confirmed_start",
+      "started_at": "2026-06-25T10:05:08.123+00:00",
+      "stopped_at": null,
+      "failure_reason": null,
+      "revision": 1
+    },
+    {
+      "id": 3,
+      "capture_cycle_id": 1,
+      "session_device_id": 3,
+      "required": false,
+      "recording_status": "pending",
+      "started_at": null,
+      "stopped_at": null,
+      "failure_reason": null,
+      "revision": 0
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- **ORCH-2A scope only** — pure API/DTO layer, no ViewModel, timer, or SessionCaptureManager changes
- `CaptureCycleDTO` + `CaptureCycleDeviceDTO` with full `Codable`/`Equatable` conformance
- `CycleStatus` (7 cases), `CycleDeviceRecordingStatus` (4 cases), `CycleResult` (3 cases) enums
- `ConfirmDeviceStartRequest`, `ConfirmDeviceStopRequest`, `CreateCycleRequest`, `ScheduleCycleRequest`, `StopCycleRequest` request structs
- 6 new `MultiCameraAPIClient` cycle methods: `createCycle`, `listCycles`, `scheduleCycle`, `stopCycle`, `confirmDeviceStart`, `confirmDeviceStop`
- `CaptureCycleContractTests` — 15 tests (CYC-01..15): round-trip decode, optional nulls, enum exhaustiveness, request encoding
- `tests/fixtures/multicamera/cycle_full.json` — fixture with 3 cycle devices in mixed recording states

## Test plan

- [x] CYC-01..15 all pass (15/15) — iPhone 16 iOS 18.1 simulator
- [x] iOS build SUCCEEDED
- [x] No ViewModel, timer, SessionCaptureManager, or backend changes
- [x] `project.pbxproj` updated with test file reference

## Scope exclusions (ORCH-2B — separate audit required)

- No `SessionCaptureManager` start/stop calls
- No scheduled timer or `Task.sleep` auto-start
- No ViewModel orchestration changes
- No `captureStartServerMs` / `captureStopServerMs` properties
- No UI changes
- No backend changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)