### PR TITLE
feat(mc1-ios-orch2b): CycleCaptureOrchestrator + strict-mode timer + CaptureController protocol

### DIFF
--- a/ios/LFAEducationCenter.xcodeproj/project.pbxproj
+++ b/ios/LFAEducationCenter.xcodeproj/project.pbxproj
@@ -31,6 +31,12 @@
 		MC000004000000000000007 /* SessionCaptureDebugView.swift in Sources */ = {isa = PBXBuildFile; fileRef = MC000003000000000000007 /* SessionCaptureDebugView.swift */; };
 		DI000004000000000000001 /* DeviceIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = DI000003000000000000001 /* DeviceIdentity.swift */; };
 		CS000004000000000000001 /* ClockSyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CS000003000000000000001 /* ClockSyncService.swift */; };
+		OR000004000000000000001 /* CaptureController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OR000003000000000000001 /* CaptureController.swift */; };
+		OR000004000000000000002 /* CycleIdempotencyKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = OR000003000000000000002 /* CycleIdempotencyKey.swift */; };
+		OR000004000000000000003 /* CycleCaptureOrchestrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OR000003000000000000003 /* CycleCaptureOrchestrator.swift */; };
+		OR500004000000000000001 /* FakeCaptureController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OR500003000000000000001 /* FakeCaptureController.swift */; };
+		OR500004000000000000002 /* CycleIdempotencyKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OR500003000000000000002 /* CycleIdempotencyKeyTests.swift */; };
+		OR500004000000000000003 /* CycleCaptureOrchestratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OR500003000000000000003 /* CycleCaptureOrchestratorTests.swift */; };
 		MC500004000000000000003 /* SessionCaptureManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = MC500003000000000000003 /* SessionCaptureManagerTests.swift */; };
 		DI500004000000000000001 /* DeviceIdentityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DI500003000000000000001 /* DeviceIdentityTests.swift */; };
 		CS500004000000000000001 /* ClockSyncServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CS500003000000000000001 /* ClockSyncServiceTests.swift */; };
@@ -269,6 +275,12 @@
 		MC000003000000000000007 /* SessionCaptureDebugView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionCaptureDebugView.swift; sourceTree = "<group>"; };
 		DI000003000000000000001 /* DeviceIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceIdentity.swift; sourceTree = "<group>"; };
 		CS000003000000000000001 /* ClockSyncService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClockSyncService.swift; sourceTree = "<group>"; };
+		OR000003000000000000001 /* CaptureController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureController.swift; sourceTree = "<group>"; };
+		OR000003000000000000002 /* CycleIdempotencyKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CycleIdempotencyKey.swift; sourceTree = "<group>"; };
+		OR000003000000000000003 /* CycleCaptureOrchestrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CycleCaptureOrchestrator.swift; sourceTree = "<group>"; };
+		OR500003000000000000001 /* FakeCaptureController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeCaptureController.swift; sourceTree = "<group>"; };
+		OR500003000000000000002 /* CycleIdempotencyKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CycleIdempotencyKeyTests.swift; sourceTree = "<group>"; };
+		OR500003000000000000003 /* CycleCaptureOrchestratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CycleCaptureOrchestratorTests.swift; sourceTree = "<group>"; };
 		GP000003000000000000005 /* GoProConnectionDebugView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoProConnectionDebugView.swift; sourceTree = "<group>"; };
 		GP000003000000000000006 /* CoreBluetoothBLETransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreBluetoothBLETransport.swift; sourceTree = "<group>"; };
 		GP000003000000000000007 /* GoProHTTPClientTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoProHTTPClientTransport.swift; sourceTree = "<group>"; };
@@ -710,6 +722,9 @@
 				MC000003000000000000007 /* SessionCaptureDebugView.swift */,
 				DI000003000000000000001 /* DeviceIdentity.swift */,
 				CS000003000000000000001 /* ClockSyncService.swift */,
+				OR000003000000000000001 /* CaptureController.swift */,
+				OR000003000000000000002 /* CycleIdempotencyKey.swift */,
+				OR000003000000000000003 /* CycleCaptureOrchestrator.swift */,
 				GP000003000000000000005 /* GoProConnectionDebugView.swift */,
 				GP000003000000000000006 /* CoreBluetoothBLETransport.swift */,
 				GP000003000000000000007 /* GoProHTTPClientTransport.swift */,
@@ -997,6 +1012,9 @@
 				CS500003000000000000001 /* ClockSyncServiceTests.swift */,
 				7923EAF385B2497998AA5258 /* MultiCameraSessionViewModelClockSyncTests.swift */,
 				16BA790BA9964D4A9E64F6E3 /* CaptureCycleContractTests.swift */,
+				OR500003000000000000001 /* FakeCaptureController.swift */,
+				OR500003000000000000002 /* CycleIdempotencyKeyTests.swift */,
+				OR500003000000000000003 /* CycleCaptureOrchestratorTests.swift */,
 				MC500003000000000000002 /* session_full.json */,
 				CYC00003000000000000001 /* cycle_full.json */,
 			);
@@ -1288,6 +1306,9 @@
 				MC000004000000000000007 /* SessionCaptureDebugView.swift in Sources */,
 				DI000004000000000000001 /* DeviceIdentity.swift in Sources */,
 				CS000004000000000000001 /* ClockSyncService.swift in Sources */,
+				OR000004000000000000001 /* CaptureController.swift in Sources */,
+				OR000004000000000000002 /* CycleIdempotencyKey.swift in Sources */,
+				OR000004000000000000003 /* CycleCaptureOrchestrator.swift in Sources */,
 				GP000004000000000000005 /* GoProConnectionDebugView.swift in Sources */,
 				GP000004000000000000006 /* CoreBluetoothBLETransport.swift in Sources */,
 				GP000004000000000000007 /* GoProHTTPClientTransport.swift in Sources */,
@@ -1353,6 +1374,9 @@
 				CS500004000000000000001 /* ClockSyncServiceTests.swift in Sources */,
 				942FE944E7544114B645BB37 /* MultiCameraSessionViewModelClockSyncTests.swift in Sources */,
 				06881AF7704345FF9DCED8DD /* CaptureCycleContractTests.swift in Sources */,
+				OR500004000000000000001 /* FakeCaptureController.swift in Sources */,
+				OR500004000000000000002 /* CycleIdempotencyKeyTests.swift in Sources */,
+				OR500004000000000000003 /* CycleCaptureOrchestratorTests.swift in Sources */,
 				BB100004000000000000004 /* AnnotationVideoLoaderTests.swift in Sources */,
 				BB100004000000000000005 /* PlaybackBarTests.swift in Sources */,
 				BB100004000000000000006 /* AVPlayerLayerViewTests.swift in Sources */,

--- a/ios/LFAEducationCenter/MultiCamera/CaptureController.swift
+++ b/ios/LFAEducationCenter/MultiCamera/CaptureController.swift
@@ -1,0 +1,9 @@
+import Foundation
+import Combine
+
+@MainActor
+protocol CaptureController: AnyObject {
+    var captureStatePublisher: AnyPublisher<CaptureState, Never> { get }
+    func startCapture()
+    func stopCapture()
+}

--- a/ios/LFAEducationCenter/MultiCamera/CycleCaptureOrchestrator.swift
+++ b/ios/LFAEducationCenter/MultiCamera/CycleCaptureOrchestrator.swift
@@ -1,0 +1,466 @@
+import Foundation
+import Combine
+
+// MARK: — OrchestratorFailure
+
+enum OrchestratorFailure: Error, Equatable {
+    case noAuth
+    case clockSyncRequired
+    case scheduledStartAtMissing
+    case scheduledStartAtInvalid
+    case cycleExpired(lagMs: Double)
+    case timerError(String)
+    case apiError(statusCode: Int, detail: String)
+    case confirmStartRejected(detail: String)
+    case confirmStopRejected(detail: String)
+}
+
+// MARK: — OrchestratorState
+
+enum OrchestratorState: Equatable {
+    case idle
+    case creating
+    case scheduling
+    case waitingForStart
+    case capturing(cycleId: Int)
+    case stopping(cycleId: Int)
+    case completed(cycleId: Int)
+    case failed(OrchestratorFailure)
+}
+
+// MARK: — AccessTokenProvider
+
+protocol AccessTokenProvider {
+    var accessToken: String? { get }
+}
+
+extension AuthManager: AccessTokenProvider {}
+
+// MARK: — CycleAPIClient
+
+protocol CycleAPIClient {
+    func createCycle(token: String, uuid: String, idempotencyKey: String) async throws -> CaptureCycleDTO
+    func scheduleCycle(token: String, uuid: String, cycleId: Int, revision: Int) async throws -> CaptureCycleDTO
+    func stopCycle(token: String, uuid: String, cycleId: Int, revision: Int) async throws -> CaptureCycleDTO
+    func confirmDeviceStart(token: String, uuid: String, cycleId: Int, sessionDeviceId: Int, startedAt: String, cycleDeviceRevision: Int) async throws -> CaptureCycleDTO
+    func confirmDeviceStop(token: String, uuid: String, cycleId: Int, sessionDeviceId: Int, stoppedAt: String, cycleDeviceRevision: Int) async throws -> CaptureCycleDTO
+}
+
+// MARK: — LiveCycleAPIClient
+
+struct LiveCycleAPIClient: CycleAPIClient {
+    func createCycle(token: String, uuid: String, idempotencyKey: String) async throws -> CaptureCycleDTO {
+        try await MultiCameraAPIClient.createCycle(token: token, uuid: uuid, idempotencyKey: idempotencyKey)
+    }
+
+    func scheduleCycle(token: String, uuid: String, cycleId: Int, revision: Int) async throws -> CaptureCycleDTO {
+        try await MultiCameraAPIClient.scheduleCycle(token: token, uuid: uuid, cycleId: cycleId, revision: revision)
+    }
+
+    func stopCycle(token: String, uuid: String, cycleId: Int, revision: Int) async throws -> CaptureCycleDTO {
+        try await MultiCameraAPIClient.stopCycle(token: token, uuid: uuid, cycleId: cycleId, revision: revision)
+    }
+
+    func confirmDeviceStart(token: String, uuid: String, cycleId: Int, sessionDeviceId: Int, startedAt: String, cycleDeviceRevision: Int) async throws -> CaptureCycleDTO {
+        try await MultiCameraAPIClient.confirmDeviceStart(
+            token: token, uuid: uuid, cycleId: cycleId,
+            sessionDeviceId: sessionDeviceId, startedAt: startedAt,
+            cycleDeviceRevision: cycleDeviceRevision
+        )
+    }
+
+    func confirmDeviceStop(token: String, uuid: String, cycleId: Int, sessionDeviceId: Int, stoppedAt: String, cycleDeviceRevision: Int) async throws -> CaptureCycleDTO {
+        try await MultiCameraAPIClient.confirmDeviceStop(
+            token: token, uuid: uuid, cycleId: cycleId,
+            sessionDeviceId: sessionDeviceId, stoppedAt: stoppedAt,
+            cycleDeviceRevision: cycleDeviceRevision
+        )
+    }
+}
+
+// MARK: — CycleCaptureOrchestrator
+
+@MainActor
+final class CycleCaptureOrchestrator: ObservableObject {
+
+    // MARK: — Constants
+    private static let scheduledStartToleranceMs: Double = 2_000
+
+    // MARK: — Published state
+    @Published private(set) var state: OrchestratorState = .idle
+
+    // MARK: — Dependencies
+    private let authManager: any AccessTokenProvider
+    private let clockSyncService: ClockSyncService
+    private let captureController: CaptureController
+    private let cycleAPIClient: CycleAPIClient
+    private let sleepProvider: (UInt64) async throws -> Void
+
+    // MARK: — Internal tracking
+    private var currentCycle: CaptureCycleDTO?
+    private var startTask: Task<Void, Never>?
+    private var captureSubscription: AnyCancellable?
+
+    // MARK: — Init
+
+    init(
+        authManager: any AccessTokenProvider,
+        clockSyncService: ClockSyncService,
+        captureController: CaptureController,
+        cycleAPIClient: CycleAPIClient = LiveCycleAPIClient(),
+        sleepProvider: @escaping (UInt64) async throws -> Void = { ns in try await Task.sleep(nanoseconds: ns) }
+    ) {
+        self.authManager       = authManager
+        self.clockSyncService  = clockSyncService
+        self.captureController = captureController
+        self.cycleAPIClient    = cycleAPIClient
+        self.sleepProvider     = sleepProvider
+    }
+
+    // MARK: — Public API
+
+    func startCycle(sessionUuid: String, sessionDeviceId: Int) {
+        startTask?.cancel()
+        startTask = Task { [weak self] in
+            await self?.performStartCycle(sessionUuid: sessionUuid, sessionDeviceId: sessionDeviceId)
+        }
+    }
+
+    func stopCycle() async {
+        guard case .capturing(let cycleId) = state else { return }
+        guard let token = authManager.accessToken else {
+            state = .failed(.noAuth)
+            return
+        }
+        guard let cycle = currentCycle else { return }
+        state = .stopping(cycleId: cycleId)
+        do {
+            _ = try await cycleAPIClient.stopCycle(
+                token: token,
+                uuid: currentCycleSessionUuid ?? "",
+                cycleId: cycleId,
+                revision: cycle.revision
+            )
+            captureController.stopCapture()
+        } catch {
+            let nsErr = error as NSError
+            state = .failed(.apiError(statusCode: nsErr.code, detail: nsErr.localizedDescription))
+        }
+    }
+
+    func reset() {
+        startTask?.cancel()
+        startTask = nil
+        captureSubscription?.cancel()
+        captureSubscription = nil
+        currentCycle = nil
+        currentCycleSessionUuid = nil
+        currentSessionDeviceId  = nil
+        state = .idle
+    }
+
+    // MARK: — Private state for stop
+    private var currentCycleSessionUuid: String?
+    private var currentSessionDeviceId: Int?
+
+    // MARK: — Core orchestration
+
+    private func performStartCycle(sessionUuid: String, sessionDeviceId: Int) async {
+        // Store for later use
+        currentCycleSessionUuid = sessionUuid
+        currentSessionDeviceId  = sessionDeviceId
+
+        // 1. Auth check
+        guard let token = authManager.accessToken else {
+            state = .failed(.noAuth)
+            return
+        }
+
+        // 2. Create cycle
+        state = .creating
+        let cycle: CaptureCycleDTO
+        do {
+            let cycleIndex = 0 // first cycle in session
+            let idempotencyKey = CycleIdempotencyKey.make(sessionUuid: sessionUuid, cycleIndex: cycleIndex)
+            cycle = try await cycleAPIClient.createCycle(
+                token: token,
+                uuid: sessionUuid,
+                idempotencyKey: idempotencyKey
+            )
+        } catch {
+            if Task.isCancelled { return }
+            let nsErr = error as NSError
+            state = .failed(.apiError(statusCode: nsErr.code, detail: nsErr.localizedDescription))
+            return
+        }
+
+        if Task.isCancelled { return }
+
+        // 3. Schedule cycle
+        state = .scheduling
+        let scheduledCycle: CaptureCycleDTO
+        do {
+            scheduledCycle = try await cycleAPIClient.scheduleCycle(
+                token: token,
+                uuid: sessionUuid,
+                cycleId: cycle.id,
+                revision: cycle.revision
+            )
+        } catch {
+            if Task.isCancelled { return }
+            let nsErr = error as NSError
+            state = .failed(.apiError(statusCode: nsErr.code, detail: nsErr.localizedDescription))
+            return
+        }
+
+        if Task.isCancelled { return }
+        currentCycle = scheduledCycle
+
+        // 4. Wait for scheduled start
+        state = .waitingForStart
+        do {
+            try await waitForScheduledStart(cycle: scheduledCycle)
+        } catch is CancellationError {
+            return
+        } catch let failure as OrchestratorFailure {
+            state = .failed(failure)
+            return
+        } catch {
+            state = .failed(.timerError(error.localizedDescription))
+            return
+        }
+
+        if Task.isCancelled { return }
+
+        // 5. Subscribe to capture state BEFORE starting capture
+        subscribeToCaptureState(
+            token: token,
+            sessionUuid: sessionUuid,
+            cycleId: scheduledCycle.id,
+            sessionDeviceId: sessionDeviceId,
+            cycleDeviceRevision: 0
+        )
+
+        // 6. Start capture
+        captureController.startCapture()
+    }
+
+    // MARK: — Wait for scheduled start (STRICT MODE)
+
+    private func waitForScheduledStart(cycle: CaptureCycleDTO) async throws {
+        // nil scheduledStartAt → throw .scheduledStartAtMissing
+        guard let scheduledStartAtStr = cycle.scheduledStartAt else {
+            throw OrchestratorFailure.scheduledStartAtMissing
+        }
+
+        // Parse ISO8601 with fractional seconds
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        guard let scheduledDate = formatter.date(from: scheduledStartAtStr) else {
+            throw OrchestratorFailure.scheduledStartAtInvalid
+        }
+
+        // clockSyncService.adjustedServerTimeMs == nil → throw .clockSyncRequired
+        guard let serverTimeMs = await clockSyncService.adjustedServerTimeMs else {
+            throw OrchestratorFailure.clockSyncRequired
+        }
+
+        let scheduledMs = scheduledDate.timeIntervalSince1970 * 1000.0
+        let waitMs = scheduledMs - serverTimeMs
+
+        if waitMs < 0 {
+            let lagMs = -waitMs
+            // lag > 2000ms → expired
+            if lagMs > Self.scheduledStartToleranceMs {
+                throw OrchestratorFailure.cycleExpired(lagMs: lagMs)
+            }
+            // lag <= 2000ms → tolerance window, start immediately
+            return
+        }
+
+        // waitMs >= 0 → sleep
+        let waitNs = UInt64(waitMs * 1_000_000)
+        do {
+            try await sleepProvider(waitNs)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            throw OrchestratorFailure.timerError(error.localizedDescription)
+        }
+    }
+
+    // MARK: — currentServerTimeISO (NO wall-clock fallback)
+
+    private func currentServerTimeISO() async -> String? {
+        guard let serverTimeMs = await clockSyncService.adjustedServerTimeMs else {
+            return nil
+        }
+        let date = Date(timeIntervalSince1970: serverTimeMs / 1000.0)
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.string(from: date)
+    }
+
+    // MARK: — Capture state subscription
+
+    private func subscribeToCaptureState(
+        token: String,
+        sessionUuid: String,
+        cycleId: Int,
+        sessionDeviceId: Int,
+        cycleDeviceRevision: Int
+    ) {
+        captureSubscription?.cancel()
+        captureSubscription = captureController.captureStatePublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] captureState in
+                guard let self else { return }
+                switch captureState {
+                case .capturing:
+                    Task { @MainActor [weak self] in
+                        await self?.handleCaptureStarted(
+                            token: token,
+                            sessionUuid: sessionUuid,
+                            cycleId: cycleId,
+                            sessionDeviceId: sessionDeviceId,
+                            cycleDeviceRevision: cycleDeviceRevision
+                        )
+                    }
+                case .completed:
+                    Task { @MainActor [weak self] in
+                        await self?.handleCaptureCompleted(
+                            token: token,
+                            sessionUuid: sessionUuid,
+                            cycleId: cycleId,
+                            sessionDeviceId: sessionDeviceId,
+                            cycleDeviceRevision: cycleDeviceRevision
+                        )
+                    }
+                default:
+                    break
+                }
+            }
+    }
+
+    // MARK: — Confirm start
+
+    private func handleCaptureStarted(
+        token: String,
+        sessionUuid: String,
+        cycleId: Int,
+        sessionDeviceId: Int,
+        cycleDeviceRevision: Int
+    ) async {
+        // Transition orchestrator state to .capturing now that physical capture has started
+        // (regardless of previous orchestrator state — could be .waitingForStart)
+        state = .capturing(cycleId: cycleId)
+
+        guard let startedAt = await currentServerTimeISO() else {
+            state = .failed(.clockSyncRequired)
+            return
+        }
+
+        do {
+            let updated = try await cycleAPIClient.confirmDeviceStart(
+                token: token,
+                uuid: sessionUuid,
+                cycleId: cycleId,
+                sessionDeviceId: sessionDeviceId,
+                startedAt: startedAt,
+                cycleDeviceRevision: cycleDeviceRevision
+            )
+            currentCycle = updated
+            // state stays .capturing(cycleId:) — already set by caller or stays from previous
+        } catch {
+            let nsErr = error as NSError
+            if nsErr.code == 409 {
+                // idempotent success — already confirmed, keep .capturing state
+                return
+            } else if nsErr.code == 422 {
+                state = .failed(.confirmStartRejected(detail: nsErr.localizedDescription))
+            } else {
+                // retry once
+                do {
+                    let updated = try await cycleAPIClient.confirmDeviceStart(
+                        token: token,
+                        uuid: sessionUuid,
+                        cycleId: cycleId,
+                        sessionDeviceId: sessionDeviceId,
+                        startedAt: startedAt,
+                        cycleDeviceRevision: cycleDeviceRevision
+                    )
+                    currentCycle = updated
+                } catch let retryError {
+                    let retryNsErr = retryError as NSError
+                    if retryNsErr.code == 409 {
+                        // idempotent on retry
+                        return
+                    } else if retryNsErr.code == 422 {
+                        state = .failed(.confirmStartRejected(detail: retryNsErr.localizedDescription))
+                    } else {
+                        state = .failed(.apiError(statusCode: retryNsErr.code, detail: retryNsErr.localizedDescription))
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: — Confirm stop
+
+    private func handleCaptureCompleted(
+        token: String,
+        sessionUuid: String,
+        cycleId: Int,
+        sessionDeviceId: Int,
+        cycleDeviceRevision: Int
+    ) async {
+        guard let stoppedAt = await currentServerTimeISO() else {
+            state = .failed(.clockSyncRequired)
+            return
+        }
+
+        do {
+            let updated = try await cycleAPIClient.confirmDeviceStop(
+                token: token,
+                uuid: sessionUuid,
+                cycleId: cycleId,
+                sessionDeviceId: sessionDeviceId,
+                stoppedAt: stoppedAt,
+                cycleDeviceRevision: cycleDeviceRevision
+            )
+            currentCycle = updated
+            state = .completed(cycleId: cycleId)
+        } catch {
+            let nsErr = error as NSError
+            if nsErr.code == 409 {
+                // idempotent — already confirmed stop, treat as completed
+                state = .completed(cycleId: cycleId)
+            } else if nsErr.code == 422 {
+                state = .failed(.confirmStopRejected(detail: nsErr.localizedDescription))
+            } else {
+                // retry once
+                do {
+                    let updated = try await cycleAPIClient.confirmDeviceStop(
+                        token: token,
+                        uuid: sessionUuid,
+                        cycleId: cycleId,
+                        sessionDeviceId: sessionDeviceId,
+                        stoppedAt: stoppedAt,
+                        cycleDeviceRevision: cycleDeviceRevision
+                    )
+                    currentCycle = updated
+                    state = .completed(cycleId: cycleId)
+                } catch let retryError {
+                    let retryNsErr = retryError as NSError
+                    if retryNsErr.code == 409 {
+                        state = .completed(cycleId: cycleId)
+                    } else if retryNsErr.code == 422 {
+                        state = .failed(.confirmStopRejected(detail: retryNsErr.localizedDescription))
+                    } else {
+                        state = .failed(.apiError(statusCode: retryNsErr.code, detail: retryNsErr.localizedDescription))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ios/LFAEducationCenter/MultiCamera/CycleCaptureOrchestrator.swift
+++ b/ios/LFAEducationCenter/MultiCamera/CycleCaptureOrchestrator.swift
@@ -13,6 +13,8 @@ enum OrchestratorFailure: Error, Equatable {
     case apiError(statusCode: Int, detail: String)
     case confirmStartRejected(detail: String)
     case confirmStopRejected(detail: String)
+    case cycleDeviceMissing(sessionDeviceId: Int)
+    case revisionConflict(detail: String)
 }
 
 // MARK: — OrchestratorState
@@ -237,8 +239,7 @@ final class CycleCaptureOrchestrator: ObservableObject {
             token: token,
             sessionUuid: sessionUuid,
             cycleId: scheduledCycle.id,
-            sessionDeviceId: sessionDeviceId,
-            cycleDeviceRevision: 0
+            sessionDeviceId: sessionDeviceId
         )
 
         // 6. Start capture
@@ -307,8 +308,7 @@ final class CycleCaptureOrchestrator: ObservableObject {
         token: String,
         sessionUuid: String,
         cycleId: Int,
-        sessionDeviceId: Int,
-        cycleDeviceRevision: Int
+        sessionDeviceId: Int
     ) {
         captureSubscription?.cancel()
         captureSubscription = captureController.captureStatePublisher
@@ -322,8 +322,7 @@ final class CycleCaptureOrchestrator: ObservableObject {
                             token: token,
                             sessionUuid: sessionUuid,
                             cycleId: cycleId,
-                            sessionDeviceId: sessionDeviceId,
-                            cycleDeviceRevision: cycleDeviceRevision
+                            sessionDeviceId: sessionDeviceId
                         )
                     }
                 case .completed:
@@ -332,8 +331,7 @@ final class CycleCaptureOrchestrator: ObservableObject {
                             token: token,
                             sessionUuid: sessionUuid,
                             cycleId: cycleId,
-                            sessionDeviceId: sessionDeviceId,
-                            cycleDeviceRevision: cycleDeviceRevision
+                            sessionDeviceId: sessionDeviceId
                         )
                     }
                 default:
@@ -348,12 +346,14 @@ final class CycleCaptureOrchestrator: ObservableObject {
         token: String,
         sessionUuid: String,
         cycleId: Int,
-        sessionDeviceId: Int,
-        cycleDeviceRevision: Int
+        sessionDeviceId: Int
     ) async {
-        // Transition orchestrator state to .capturing now that physical capture has started
-        // (regardless of previous orchestrator state — could be .waitingForStart)
         state = .capturing(cycleId: cycleId)
+
+        guard let cycleDevice = currentCycle?.cycleDevices.first(where: { $0.sessionDeviceId == sessionDeviceId }) else {
+            state = .failed(.cycleDeviceMissing(sessionDeviceId: sessionDeviceId))
+            return
+        }
 
         guard let startedAt = await currentServerTimeISO() else {
             state = .failed(.clockSyncRequired)
@@ -367,19 +367,18 @@ final class CycleCaptureOrchestrator: ObservableObject {
                 cycleId: cycleId,
                 sessionDeviceId: sessionDeviceId,
                 startedAt: startedAt,
-                cycleDeviceRevision: cycleDeviceRevision
+                cycleDeviceRevision: cycleDevice.revision
             )
             currentCycle = updated
-            // state stays .capturing(cycleId:) — already set by caller or stays from previous
         } catch {
             let nsErr = error as NSError
             if nsErr.code == 409 {
-                // idempotent success — already confirmed, keep .capturing state
-                return
+                // 409 may be revision mismatch, not just already-confirmed — treat as conflict
+                state = .failed(.revisionConflict(detail: nsErr.localizedDescription))
             } else if nsErr.code == 422 {
                 state = .failed(.confirmStartRejected(detail: nsErr.localizedDescription))
             } else {
-                // retry once
+                // retry once for transient network errors
                 do {
                     let updated = try await cycleAPIClient.confirmDeviceStart(
                         token: token,
@@ -387,14 +386,13 @@ final class CycleCaptureOrchestrator: ObservableObject {
                         cycleId: cycleId,
                         sessionDeviceId: sessionDeviceId,
                         startedAt: startedAt,
-                        cycleDeviceRevision: cycleDeviceRevision
+                        cycleDeviceRevision: cycleDevice.revision
                     )
                     currentCycle = updated
                 } catch let retryError {
                     let retryNsErr = retryError as NSError
                     if retryNsErr.code == 409 {
-                        // idempotent on retry
-                        return
+                        state = .failed(.revisionConflict(detail: retryNsErr.localizedDescription))
                     } else if retryNsErr.code == 422 {
                         state = .failed(.confirmStartRejected(detail: retryNsErr.localizedDescription))
                     } else {
@@ -411,9 +409,13 @@ final class CycleCaptureOrchestrator: ObservableObject {
         token: String,
         sessionUuid: String,
         cycleId: Int,
-        sessionDeviceId: Int,
-        cycleDeviceRevision: Int
+        sessionDeviceId: Int
     ) async {
+        guard let cycleDevice = currentCycle?.cycleDevices.first(where: { $0.sessionDeviceId == sessionDeviceId }) else {
+            state = .failed(.cycleDeviceMissing(sessionDeviceId: sessionDeviceId))
+            return
+        }
+
         guard let stoppedAt = await currentServerTimeISO() else {
             state = .failed(.clockSyncRequired)
             return
@@ -426,19 +428,19 @@ final class CycleCaptureOrchestrator: ObservableObject {
                 cycleId: cycleId,
                 sessionDeviceId: sessionDeviceId,
                 stoppedAt: stoppedAt,
-                cycleDeviceRevision: cycleDeviceRevision
+                cycleDeviceRevision: cycleDevice.revision
             )
             currentCycle = updated
             state = .completed(cycleId: cycleId)
         } catch {
             let nsErr = error as NSError
             if nsErr.code == 409 {
-                // idempotent — already confirmed stop, treat as completed
-                state = .completed(cycleId: cycleId)
+                // 409 may be revision mismatch — do not silently treat as success
+                state = .failed(.revisionConflict(detail: nsErr.localizedDescription))
             } else if nsErr.code == 422 {
                 state = .failed(.confirmStopRejected(detail: nsErr.localizedDescription))
             } else {
-                // retry once
+                // retry once for transient network errors
                 do {
                     let updated = try await cycleAPIClient.confirmDeviceStop(
                         token: token,
@@ -446,14 +448,14 @@ final class CycleCaptureOrchestrator: ObservableObject {
                         cycleId: cycleId,
                         sessionDeviceId: sessionDeviceId,
                         stoppedAt: stoppedAt,
-                        cycleDeviceRevision: cycleDeviceRevision
+                        cycleDeviceRevision: cycleDevice.revision
                     )
                     currentCycle = updated
                     state = .completed(cycleId: cycleId)
                 } catch let retryError {
                     let retryNsErr = retryError as NSError
                     if retryNsErr.code == 409 {
-                        state = .completed(cycleId: cycleId)
+                        state = .failed(.revisionConflict(detail: retryNsErr.localizedDescription))
                     } else if retryNsErr.code == 422 {
                         state = .failed(.confirmStopRejected(detail: retryNsErr.localizedDescription))
                     } else {

--- a/ios/LFAEducationCenter/MultiCamera/CycleIdempotencyKey.swift
+++ b/ios/LFAEducationCenter/MultiCamera/CycleIdempotencyKey.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+enum CycleIdempotencyKey {
+    // Format: "<devUUID.prefix(8)>:<sessionUuid.prefix(8)>:c<cycleIndex>"
+    // Max ~22 chars, well under 64 char backend limit
+    // Stable: same (device, session, cycleIndex) → same key → idempotent retry
+    static func make(sessionUuid: String, cycleIndex: Int) -> String {
+        let deviceUUID = DeviceIdentity.stableDeviceUUID()
+        let devPrefix  = String(deviceUUID.replacingOccurrences(of: "-", with: "").prefix(8))
+        let sessPrefix = String(sessionUuid.replacingOccurrences(of: "-", with: "").prefix(8))
+        return "\(devPrefix):\(sessPrefix):c\(cycleIndex)"
+    }
+}

--- a/ios/LFAEducationCenter/MultiCamera/MultiCameraSessionViewModel.swift
+++ b/ios/LFAEducationCenter/MultiCamera/MultiCameraSessionViewModel.swift
@@ -44,16 +44,20 @@ final class MultiCameraSessionViewModel: ObservableObject {
     private let heartbeatInterval: UInt64
     private static let maxRetries = 3
 
+    private let cycleOrchestrator: CycleCaptureOrchestrator?
+
     init(
         authManager: AuthManager,
         clockSyncService: ClockSyncService = ClockSyncService(),
         pollingIntervalSeconds: Double = 3.0,
-        heartbeatIntervalSeconds: Double = 5.0
+        heartbeatIntervalSeconds: Double = 5.0,
+        cycleOrchestrator: CycleCaptureOrchestrator? = nil
     ) {
         self.authManager = authManager
         self.clockSyncService = clockSyncService
         self.pollingInterval = UInt64(pollingIntervalSeconds * 1_000_000_000)
         self.heartbeatInterval = UInt64(heartbeatIntervalSeconds * 1_000_000_000)
+        self.cycleOrchestrator = cycleOrchestrator
     }
 
     deinit {
@@ -146,7 +150,18 @@ final class MultiCameraSessionViewModel: ObservableObject {
         sessionDeviceId = nil
         isCreateInProgress = false
         clockSyncState = .notSynced
+        cycleOrchestrator?.reset()
         state = .idle
+    }
+
+    func beginCycle() {
+        guard canStartCapture, let uuid = sessionUuid, let sdId = sessionDeviceId else { return }
+        cycleOrchestrator?.startCycle(sessionUuid: uuid, sessionDeviceId: sdId)
+    }
+
+    func endCycle() {
+        guard sessionUuid != nil else { return }
+        Task { await cycleOrchestrator?.stopCycle() }
     }
 
     // MARK: — Auto device register

--- a/ios/LFAEducationCenter/MultiCamera/SessionCaptureManager.swift
+++ b/ios/LFAEducationCenter/MultiCamera/SessionCaptureManager.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import Combine
 import UIKit
 
 enum CaptureState: Equatable {
@@ -295,6 +296,14 @@ final class SessionCaptureManager: NSObject, ObservableObject {
 
     private func handleInterruptionEnded() {
         if state == .interrupted { stopCapture() }
+    }
+}
+
+// MARK: — CaptureController
+
+extension SessionCaptureManager: CaptureController {
+    var captureStatePublisher: AnyPublisher<CaptureState, Never> {
+        $state.eraseToAnyPublisher()
     }
 }
 

--- a/ios/LFAEducationCenterTests/MultiCamera/CycleCaptureOrchestratorTests.swift
+++ b/ios/LFAEducationCenterTests/MultiCamera/CycleCaptureOrchestratorTests.swift
@@ -19,10 +19,12 @@ private final class MockCycleAPIClient: CycleAPIClient {
     var confirmStartResult: Result<CaptureCycleDTO, Error> = .success(makeTestCycle(id: 1, revision: 4, status: .recording))
     var confirmStopResult:  Result<CaptureCycleDTO, Error> = .success(makeTestCycle(id: 1, revision: 5, status: .completed))
 
-    private(set) var createCallCount       = 0
-    private(set) var scheduleCallCount     = 0
-    private(set) var confirmStartCallCount = 0
-    private(set) var confirmStopCallCount  = 0
+    private(set) var createCallCount              = 0
+    private(set) var scheduleCallCount            = 0
+    private(set) var confirmStartCallCount        = 0
+    private(set) var confirmStopCallCount         = 0
+    private(set) var lastConfirmStartRevision: Int? = nil
+    private(set) var lastConfirmStopRevision:  Int? = nil
 
     func createCycle(token: String, uuid: String, idempotencyKey: String) async throws -> CaptureCycleDTO {
         createCallCount += 1
@@ -40,11 +42,13 @@ private final class MockCycleAPIClient: CycleAPIClient {
 
     func confirmDeviceStart(token: String, uuid: String, cycleId: Int, sessionDeviceId: Int, startedAt: String, cycleDeviceRevision: Int) async throws -> CaptureCycleDTO {
         confirmStartCallCount += 1
+        lastConfirmStartRevision = cycleDeviceRevision
         return try confirmStartResult.get()
     }
 
     func confirmDeviceStop(token: String, uuid: String, cycleId: Int, sessionDeviceId: Int, stoppedAt: String, cycleDeviceRevision: Int) async throws -> CaptureCycleDTO {
         confirmStopCallCount += 1
+        lastConfirmStopRevision = cycleDeviceRevision
         return try confirmStopResult.get()
     }
 }
@@ -69,9 +73,22 @@ private func makeTestCycle(
     id: Int = 1,
     revision: Int = 1,
     scheduledStartAt: String? = nil,
-    status: CycleStatus = .preparing
+    status: CycleStatus = .preparing,
+    sessionDeviceId: Int = 1,
+    deviceRevision: Int = 0
 ) -> CaptureCycleDTO {
-    CaptureCycleDTO(
+    let device = CaptureCycleDeviceDTO(
+        id: 1,
+        captureCycleId: id,
+        sessionDeviceId: sessionDeviceId,
+        required: true,
+        recordingStatus: .pending,
+        startedAt: nil,
+        stoppedAt: nil,
+        failureReason: nil,
+        revision: deviceRevision
+    )
+    return CaptureCycleDTO(
         id: id,
         sessionId: 1,
         cycleIndex: 0,
@@ -88,7 +105,7 @@ private func makeTestCycle(
         revision: revision,
         createdAt: "2026-06-25T10:00:00.000Z",
         updatedAt: "2026-06-25T10:00:00.000Z",
-        cycleDevices: []
+        cycleDevices: [device]
     )
 }
 
@@ -451,14 +468,13 @@ final class CycleCaptureOrchestratorTests: XCTestCase {
         XCTAssertEqual(apiClient.confirmStartCallCount, 1)
     }
 
-    // CYC-O-10: confirmStart 409 → idempotent success (not .failed)
-    func test_CYC_O_10_confirmStart409_idempotentSuccess() async throws {
+    // CYC-O-10: confirmStart 409 → .failed(.revisionConflict) — not silently swallowed
+    func test_CYC_O_10_confirmStart409_isRevisionConflict() async throws {
         let authProvider = FakeAccessTokenProvider()
         let apiClient = MockCycleAPIClient()
         apiClient.createResult = .success(makeTestCycle(id: 1, revision: 1))
         apiClient.scheduleResult = .success(makeTestCycle(id: 1, revision: 2, scheduledStartAt: futureISO(offsetSeconds: 0.001), status: .recordingPending))
-        // 409 error on confirmStart
-        apiClient.confirmStartResult = .failure(NSError(domain: "APIClient", code: 409, userInfo: [NSLocalizedDescriptionKey: "already confirmed"]))
+        apiClient.confirmStartResult = .failure(NSError(domain: "APIClient", code: 409, userInfo: [NSLocalizedDescriptionKey: "conflict"]))
         let clockService = await makeSyncedClockService()
         let captureController = FakeCaptureController()
         let sleepProvider: (UInt64) async throws -> Void = { _ in }
@@ -474,21 +490,18 @@ final class CycleCaptureOrchestratorTests: XCTestCase {
         orchestrator.startCycle(sessionUuid: "test-uuid", sessionDeviceId: 1)
 
         await waitForOrchestratorState(orchestrator, timeout: 3.0) {
-            if case .capturing = $0 { return true }
             if case .failed = $0 { return true }
             return false
         }
 
-        // Give time for confirmStart to settle
-        try? await Task.sleep(nanoseconds: 200_000_000)
-
-        // Should NOT be failed — 409 is idempotent success
         if case .failed(let failure) = orchestrator.state {
-            XCTFail("Expected NOT .failed for 409 confirmStart, got .failed(\(failure))")
-        }
-        // State should still be .capturing
-        if case .capturing(let cycleId) = orchestrator.state {
-            XCTAssertEqual(cycleId, 1)
+            if case .revisionConflict = failure {
+                // expected
+            } else {
+                XCTFail("Expected .revisionConflict for 409 confirmStart, got \(failure)")
+            }
+        } else {
+            XCTFail("Expected .failed(.revisionConflict) for 409 confirmStart, got \(orchestrator.state)")
         }
     }
 
@@ -577,14 +590,14 @@ final class CycleCaptureOrchestratorTests: XCTestCase {
         }
     }
 
-    // CYC-O-13: confirmStop 409 → idempotent → .completed
-    func test_CYC_O_13_confirmStop409_idempotentCompleted() async throws {
+    // CYC-O-13: confirmStop 409 → .failed(.revisionConflict) — not silently swallowed
+    func test_CYC_O_13_confirmStop409_isRevisionConflict() async throws {
         let authProvider = FakeAccessTokenProvider()
         let apiClient = MockCycleAPIClient()
         apiClient.createResult = .success(makeTestCycle(id: 1, revision: 1))
         apiClient.scheduleResult = .success(makeTestCycle(id: 1, revision: 2, scheduledStartAt: futureISO(offsetSeconds: 0.001), status: .recordingPending))
         apiClient.confirmStartResult = .success(makeTestCycle(id: 1, revision: 4, status: .recording))
-        apiClient.confirmStopResult = .failure(NSError(domain: "APIClient", code: 409, userInfo: [NSLocalizedDescriptionKey: "already confirmed"]))
+        apiClient.confirmStopResult = .failure(NSError(domain: "APIClient", code: 409, userInfo: [NSLocalizedDescriptionKey: "conflict"]))
         let clockService = await makeSyncedClockService()
         let captureController = FakeCaptureController()
         let sleepProvider: (UInt64) async throws -> Void = { _ in }
@@ -610,15 +623,19 @@ final class CycleCaptureOrchestratorTests: XCTestCase {
         captureController.simulateState(.completed(fileURL: URL(fileURLWithPath: "/tmp/test.mov")))
 
         await waitForOrchestratorState(orchestrator, timeout: 3.0) {
-            if case .completed = $0 { return true }
             if case .failed = $0 { return true }
+            if case .completed = $0 { return true }
             return false
         }
 
-        if case .completed(let cycleId) = orchestrator.state {
-            XCTAssertEqual(cycleId, 1, "409 on confirmStop should be idempotent completed")
+        if case .failed(let failure) = orchestrator.state {
+            if case .revisionConflict = failure {
+                // expected
+            } else {
+                XCTFail("Expected .revisionConflict for 409 confirmStop, got \(failure)")
+            }
         } else {
-            XCTFail("Expected .completed for 409 confirmStop, got \(orchestrator.state)")
+            XCTFail("Expected .failed(.revisionConflict) for 409 confirmStop, got \(orchestrator.state)")
         }
     }
 
@@ -711,6 +728,182 @@ final class CycleCaptureOrchestratorTests: XCTestCase {
         try? await Task.sleep(nanoseconds: 50_000_000)
 
         XCTAssertEqual(orchestrator.state, .idle, "After reset(), state should be .idle")
+    }
+
+    // CYC-O-17: confirm-start sends the cycle device's actual revision, not 0
+    func test_CYC_O_17_confirmStart_sendsDeviceRevision() async throws {
+        let authProvider = FakeAccessTokenProvider()
+        let apiClient = MockCycleAPIClient()
+        apiClient.createResult = .success(makeTestCycle(id: 1, revision: 1))
+        // Device has revision 3 — orchestrator must forward this, not hardcode 0
+        apiClient.scheduleResult = .success(makeTestCycle(
+            id: 1, revision: 2,
+            scheduledStartAt: futureISO(offsetSeconds: 0.001),
+            status: .recordingPending,
+            sessionDeviceId: 1,
+            deviceRevision: 3
+        ))
+        apiClient.confirmStartResult = .success(makeTestCycle(id: 1, revision: 4, status: .recording))
+        let clockService = await makeSyncedClockService()
+        let captureController = FakeCaptureController()
+        let sleepProvider: (UInt64) async throws -> Void = { _ in }
+
+        let orchestrator = CycleCaptureOrchestrator(
+            authManager: authProvider,
+            clockSyncService: clockService,
+            captureController: captureController,
+            cycleAPIClient: apiClient,
+            sleepProvider: sleepProvider
+        )
+
+        orchestrator.startCycle(sessionUuid: "test-uuid", sessionDeviceId: 1)
+
+        await waitForOrchestratorState(orchestrator, timeout: 3.0) {
+            if case .capturing = $0 { return true }
+            if case .failed = $0 { return true }
+            return false
+        }
+
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        XCTAssertEqual(apiClient.lastConfirmStartRevision, 3,
+            "confirmStart must send the device's actual revision (3), not a hardcoded 0")
+    }
+
+    // CYC-O-18: missing cycle device → .failed(.cycleDeviceMissing)
+    func test_CYC_O_18_missingCycleDevice_failsWithDeviceMissing() async throws {
+        let authProvider = FakeAccessTokenProvider()
+        let apiClient = MockCycleAPIClient()
+        apiClient.createResult = .success(makeTestCycle(id: 1, revision: 1))
+        // Schedule result has device with sessionDeviceId 99, but startCycle called with sdId=1
+        apiClient.scheduleResult = .success(makeTestCycle(
+            id: 1, revision: 2,
+            scheduledStartAt: futureISO(offsetSeconds: 0.001),
+            status: .recordingPending,
+            sessionDeviceId: 99,   // mismatch
+            deviceRevision: 0
+        ))
+        apiClient.confirmStartResult = .success(makeTestCycle(id: 1, revision: 4, status: .recording))
+        let clockService = await makeSyncedClockService()
+        let captureController = FakeCaptureController()
+        let sleepProvider: (UInt64) async throws -> Void = { _ in }
+
+        let orchestrator = CycleCaptureOrchestrator(
+            authManager: authProvider,
+            clockSyncService: clockService,
+            captureController: captureController,
+            cycleAPIClient: apiClient,
+            sleepProvider: sleepProvider
+        )
+
+        orchestrator.startCycle(sessionUuid: "test-uuid", sessionDeviceId: 1)  // sdId=1 ≠ 99
+
+        await waitForOrchestratorState(orchestrator, timeout: 3.0) {
+            if case .failed = $0 { return true }
+            return false
+        }
+
+        if case .failed(let failure) = orchestrator.state {
+            if case .cycleDeviceMissing(let sdId) = failure {
+                XCTAssertEqual(sdId, 1)
+            } else {
+                XCTFail("Expected .cycleDeviceMissing(1), got \(failure)")
+            }
+        } else {
+            XCTFail("Expected .failed(.cycleDeviceMissing), got \(orchestrator.state)")
+        }
+        XCTAssertEqual(apiClient.confirmStartCallCount, 0, "confirmStart must NOT be called when device is missing")
+    }
+
+    // CYC-O-19: 409 on confirm-start is not silently treated as success
+    func test_CYC_O_19_confirmStart409_notSilentSuccess() async throws {
+        let authProvider = FakeAccessTokenProvider()
+        let apiClient = MockCycleAPIClient()
+        apiClient.createResult = .success(makeTestCycle(id: 1, revision: 1))
+        apiClient.scheduleResult = .success(makeTestCycle(
+            id: 1, revision: 2,
+            scheduledStartAt: futureISO(offsetSeconds: 0.001),
+            status: .recordingPending
+        ))
+        apiClient.confirmStartResult = .failure(NSError(domain: "APIClient", code: 409,
+            userInfo: [NSLocalizedDescriptionKey: "revision mismatch"]))
+        let clockService = await makeSyncedClockService()
+        let captureController = FakeCaptureController()
+        let sleepProvider: (UInt64) async throws -> Void = { _ in }
+
+        let orchestrator = CycleCaptureOrchestrator(
+            authManager: authProvider,
+            clockSyncService: clockService,
+            captureController: captureController,
+            cycleAPIClient: apiClient,
+            sleepProvider: sleepProvider
+        )
+
+        orchestrator.startCycle(sessionUuid: "test-uuid", sessionDeviceId: 1)
+
+        await waitForOrchestratorState(orchestrator, timeout: 3.0) {
+            if case .failed = $0 { return true }
+            return false
+        }
+
+        // 409 must NOT become a quiet success — it must surface as .revisionConflict
+        if case .failed(let failure) = orchestrator.state {
+            if case .revisionConflict = failure { /* expected */ }
+            else { XCTFail("409 must surface as .revisionConflict, got \(failure)") }
+        } else {
+            XCTFail("409 on confirmStart must not be swallowed — expected .failed, got \(orchestrator.state)")
+        }
+    }
+
+    // CYC-O-20: confirm-stop sends the cycle device's actual revision
+    func test_CYC_O_20_confirmStop_sendsDeviceRevision() async throws {
+        let authProvider = FakeAccessTokenProvider()
+        let apiClient = MockCycleAPIClient()
+        apiClient.createResult = .success(makeTestCycle(id: 1, revision: 1))
+        // Device has revision 5
+        apiClient.scheduleResult = .success(makeTestCycle(
+            id: 1, revision: 2,
+            scheduledStartAt: futureISO(offsetSeconds: 0.001),
+            status: .recordingPending,
+            sessionDeviceId: 1,
+            deviceRevision: 5
+        ))
+        apiClient.confirmStartResult = .success(makeTestCycle(id: 1, revision: 4, status: .recording,
+            sessionDeviceId: 1, deviceRevision: 5))
+        apiClient.confirmStopResult  = .success(makeTestCycle(id: 1, revision: 5, status: .completed,
+            sessionDeviceId: 1, deviceRevision: 5))
+        let clockService = await makeSyncedClockService()
+        let captureController = FakeCaptureController()
+        let sleepProvider: (UInt64) async throws -> Void = { _ in }
+
+        let orchestrator = CycleCaptureOrchestrator(
+            authManager: authProvider,
+            clockSyncService: clockService,
+            captureController: captureController,
+            cycleAPIClient: apiClient,
+            sleepProvider: sleepProvider
+        )
+
+        orchestrator.startCycle(sessionUuid: "test-uuid", sessionDeviceId: 1)
+
+        await waitForOrchestratorState(orchestrator, timeout: 3.0) {
+            if case .capturing = $0 { return true }
+            if case .failed = $0 { return true }
+            return false
+        }
+
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        captureController.simulateState(.completed(fileURL: URL(fileURLWithPath: "/tmp/test.mov")))
+
+        await waitForOrchestratorState(orchestrator, timeout: 3.0) {
+            if case .completed = $0 { return true }
+            if case .failed = $0 { return true }
+            return false
+        }
+
+        XCTAssertEqual(apiClient.lastConfirmStopRevision, 5,
+            "confirmStop must send the device's actual revision (5), not a hardcoded 0")
     }
 
     // CYC-O-16: noAuth → .failed(.noAuth)

--- a/ios/LFAEducationCenterTests/MultiCamera/CycleCaptureOrchestratorTests.swift
+++ b/ios/LFAEducationCenterTests/MultiCamera/CycleCaptureOrchestratorTests.swift
@@ -1,0 +1,742 @@
+import XCTest
+import Combine
+import QuartzCore
+@testable import LFAEducationCenter
+
+// MARK: — FakeAccessTokenProvider
+
+private final class FakeAccessTokenProvider: AccessTokenProvider {
+    var accessToken: String? = "test-token"
+}
+
+// MARK: — MockCycleAPIClient
+
+@MainActor
+private final class MockCycleAPIClient: CycleAPIClient {
+    var createResult:       Result<CaptureCycleDTO, Error> = .success(makeTestCycle(id: 1, revision: 1))
+    var scheduleResult:     Result<CaptureCycleDTO, Error> = .success(makeTestCycle(id: 1, revision: 2, scheduledStartAt: futureISO(offsetSeconds: 10), status: .recordingPending))
+    var stopResult:         Result<CaptureCycleDTO, Error> = .success(makeTestCycle(id: 1, revision: 3, status: .stopping))
+    var confirmStartResult: Result<CaptureCycleDTO, Error> = .success(makeTestCycle(id: 1, revision: 4, status: .recording))
+    var confirmStopResult:  Result<CaptureCycleDTO, Error> = .success(makeTestCycle(id: 1, revision: 5, status: .completed))
+
+    private(set) var createCallCount       = 0
+    private(set) var scheduleCallCount     = 0
+    private(set) var confirmStartCallCount = 0
+    private(set) var confirmStopCallCount  = 0
+
+    func createCycle(token: String, uuid: String, idempotencyKey: String) async throws -> CaptureCycleDTO {
+        createCallCount += 1
+        return try createResult.get()
+    }
+
+    func scheduleCycle(token: String, uuid: String, cycleId: Int, revision: Int) async throws -> CaptureCycleDTO {
+        scheduleCallCount += 1
+        return try scheduleResult.get()
+    }
+
+    func stopCycle(token: String, uuid: String, cycleId: Int, revision: Int) async throws -> CaptureCycleDTO {
+        return try stopResult.get()
+    }
+
+    func confirmDeviceStart(token: String, uuid: String, cycleId: Int, sessionDeviceId: Int, startedAt: String, cycleDeviceRevision: Int) async throws -> CaptureCycleDTO {
+        confirmStartCallCount += 1
+        return try confirmStartResult.get()
+    }
+
+    func confirmDeviceStop(token: String, uuid: String, cycleId: Int, sessionDeviceId: Int, stoppedAt: String, cycleDeviceRevision: Int) async throws -> CaptureCycleDTO {
+        confirmStopCallCount += 1
+        return try confirmStopResult.get()
+    }
+}
+
+// MARK: — Helpers
+
+private func futureISO(offsetSeconds: Double) -> String {
+    let date = Date().addingTimeInterval(offsetSeconds)
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return formatter.string(from: date)
+}
+
+private func pastISO(offsetSeconds: Double) -> String {
+    let date = Date().addingTimeInterval(-offsetSeconds)
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return formatter.string(from: date)
+}
+
+private func makeTestCycle(
+    id: Int = 1,
+    revision: Int = 1,
+    scheduledStartAt: String? = nil,
+    status: CycleStatus = .preparing
+) -> CaptureCycleDTO {
+    CaptureCycleDTO(
+        id: id,
+        sessionId: 1,
+        cycleIndex: 0,
+        status: status,
+        result: nil,
+        scheduledStartAt: scheduledStartAt,
+        recordingStartedAt: nil,
+        stopRequestedAt: nil,
+        recordingStoppedAt: nil,
+        completedAt: nil,
+        failureReason: nil,
+        createdByParticipantId: 1,
+        idempotencyKey: "test-key",
+        revision: revision,
+        createdAt: "2026-06-25T10:00:00.000Z",
+        updatedAt: "2026-06-25T10:00:00.000Z",
+        cycleDevices: []
+    )
+}
+
+// MARK: — ClockSyncService helpers
+
+/// Creates a synced ClockSyncService using a fake API client that reports the real current time.
+/// The returned service has already been synced so adjustedServerTimeMs is non-nil and accurate.
+private func makeSyncedClockService() async -> ClockSyncService {
+    // Use real current time so that scheduledStartAt (computed with Date()) lines up correctly
+    let nowMs = Int(Date().timeIntervalSince1970 * 1000)
+    let dto = ServerTimeDTO(
+        serverTimeUtc: "2026-06-25T10:00:00.000Z",
+        serverEpochMs: nowMs,
+        precision: "milliseconds",
+        source: "backend_app_clock"
+    )
+    let fakeClient = FakeSystemTimeAPIClient(responses: Array(repeating: .success(dto), count: 10))
+    // Use real wall clock and monotonic so adjustedServerTimeMs extrapolation stays accurate
+    let service = ClockSyncService(
+        apiClient: fakeClient,
+        wallClockMs: { Date().timeIntervalSince1970 * 1000.0 },
+        monotonicClock: { CACurrentMediaTime() },
+        sampleCount: 1
+    )
+    _ = try? await service.sync()
+    return service
+}
+
+/// Creates a fresh (never-synced) ClockSyncService → adjustedServerTimeMs == nil
+private func makeUnsyncedClockService() -> ClockSyncService {
+    let err = NSError(domain: "test", code: -1)
+    let fakeClient = FakeSystemTimeAPIClient(responses: Array(repeating: .failure(err), count: 10))
+    return ClockSyncService(apiClient: fakeClient, sampleCount: 1)
+}
+
+// MARK: — Test wait helpers
+
+@MainActor
+private func waitForOrchestratorState(
+    _ orchestrator: CycleCaptureOrchestrator,
+    timeout: TimeInterval = 3.0,
+    check: (OrchestratorState) -> Bool
+) async {
+    let deadline = Date().addingTimeInterval(timeout)
+    while !check(orchestrator.state) && Date() < deadline {
+        await Task.yield()
+        try? await Task.sleep(nanoseconds: 5_000_000) // 5ms
+    }
+}
+
+// MARK: — Tests
+
+@MainActor
+final class CycleCaptureOrchestratorTests: XCTestCase {
+
+    // CYC-O-01: createCycle API error → .failed(.apiError(...))
+    func test_CYC_O_01_createCycleAPIError_failsWithApiError() async throws {
+        let authProvider = FakeAccessTokenProvider()
+        let apiClient = MockCycleAPIClient()
+        apiClient.createResult = .failure(NSError(domain: "APIClient", code: 500, userInfo: [NSLocalizedDescriptionKey: "server error"]))
+        let clockService = await makeSyncedClockService()
+        let captureController = FakeCaptureController()
+        let sleepProvider: (UInt64) async throws -> Void = { _ in } // immediate
+
+        let orchestrator = CycleCaptureOrchestrator(
+            authManager: authProvider,
+            clockSyncService: clockService,
+            captureController: captureController,
+            cycleAPIClient: apiClient,
+            sleepProvider: sleepProvider
+        )
+
+        orchestrator.startCycle(sessionUuid: "test-uuid", sessionDeviceId: 1)
+
+        await waitForOrchestratorState(orchestrator) {
+            if case .failed = $0 { return true }
+            return false
+        }
+
+        if case .failed(let failure) = orchestrator.state {
+            if case .apiError(let code, _) = failure {
+                XCTAssertEqual(code, 500)
+            } else {
+                XCTFail("Expected .apiError, got \(failure)")
+            }
+        } else {
+            XCTFail("Expected .failed, got \(orchestrator.state)")
+        }
+    }
+
+    // CYC-O-02: scheduleCycle API error → .failed(.apiError(...))
+    func test_CYC_O_02_scheduleCycleAPIError_failsWithApiError() async throws {
+        let authProvider = FakeAccessTokenProvider()
+        let apiClient = MockCycleAPIClient()
+        // create OK, schedule fails
+        apiClient.createResult = .success(makeTestCycle(id: 1, revision: 1))
+        apiClient.scheduleResult = .failure(NSError(domain: "APIClient", code: 503, userInfo: [NSLocalizedDescriptionKey: "unavailable"]))
+        let clockService = await makeSyncedClockService()
+        let captureController = FakeCaptureController()
+        let sleepProvider: (UInt64) async throws -> Void = { _ in }
+
+        let orchestrator = CycleCaptureOrchestrator(
+            authManager: authProvider,
+            clockSyncService: clockService,
+            captureController: captureController,
+            cycleAPIClient: apiClient,
+            sleepProvider: sleepProvider
+        )
+
+        orchestrator.startCycle(sessionUuid: "test-uuid", sessionDeviceId: 1)
+
+        await waitForOrchestratorState(orchestrator) {
+            if case .failed = $0 { return true }
+            return false
+        }
+
+        if case .failed(let failure) = orchestrator.state {
+            if case .apiError(let code, _) = failure {
+                XCTAssertEqual(code, 503)
+            } else {
+                XCTFail("Expected .apiError, got \(failure)")
+            }
+        } else {
+            XCTFail("Expected .failed, got \(orchestrator.state)")
+        }
+    }
+
+    // CYC-O-03: scheduledStartAt == nil → .failed(.scheduledStartAtMissing)
+    func test_CYC_O_03_scheduledStartAtNil_failsWithMissing() async throws {
+        let authProvider = FakeAccessTokenProvider()
+        let apiClient = MockCycleAPIClient()
+        apiClient.createResult = .success(makeTestCycle(id: 1, revision: 1))
+        // scheduledStartAt explicitly nil
+        apiClient.scheduleResult = .success(makeTestCycle(id: 1, revision: 2, scheduledStartAt: nil, status: .recordingPending))
+        let clockService = await makeSyncedClockService()
+        let captureController = FakeCaptureController()
+        let sleepProvider: (UInt64) async throws -> Void = { _ in }
+
+        let orchestrator = CycleCaptureOrchestrator(
+            authManager: authProvider,
+            clockSyncService: clockService,
+            captureController: captureController,
+            cycleAPIClient: apiClient,
+            sleepProvider: sleepProvider
+        )
+
+        orchestrator.startCycle(sessionUuid: "test-uuid", sessionDeviceId: 1)
+
+        await waitForOrchestratorState(orchestrator) {
+            if case .failed = $0 { return true }
+            return false
+        }
+
+        XCTAssertEqual(orchestrator.state, .failed(.scheduledStartAtMissing))
+    }
+
+    // CYC-O-04: scheduledStartAt invalid format → .failed(.scheduledStartAtInvalid)
+    func test_CYC_O_04_scheduledStartAtInvalidFormat_failsWithInvalid() async throws {
+        let authProvider = FakeAccessTokenProvider()
+        let apiClient = MockCycleAPIClient()
+        apiClient.createResult = .success(makeTestCycle(id: 1, revision: 1))
+        apiClient.scheduleResult = .success(makeTestCycle(id: 1, revision: 2, scheduledStartAt: "not-a-date", status: .recordingPending))
+        let clockService = await makeSyncedClockService()
+        let captureController = FakeCaptureController()
+        let sleepProvider: (UInt64) async throws -> Void = { _ in }
+
+        let orchestrator = CycleCaptureOrchestrator(
+            authManager: authProvider,
+            clockSyncService: clockService,
+            captureController: captureController,
+            cycleAPIClient: apiClient,
+            sleepProvider: sleepProvider
+        )
+
+        orchestrator.startCycle(sessionUuid: "test-uuid", sessionDeviceId: 1)
+
+        await waitForOrchestratorState(orchestrator) {
+            if case .failed = $0 { return true }
+            return false
+        }
+
+        XCTAssertEqual(orchestrator.state, .failed(.scheduledStartAtInvalid))
+    }
+
+    // CYC-O-05: no clock sync → .failed(.clockSyncRequired)
+    func test_CYC_O_05_noClockSync_failsWithClockSyncRequired() async throws {
+        let authProvider = FakeAccessTokenProvider()
+        let apiClient = MockCycleAPIClient()
+        apiClient.createResult = .success(makeTestCycle(id: 1, revision: 1))
+        apiClient.scheduleResult = .success(makeTestCycle(id: 1, revision: 2, scheduledStartAt: futureISO(offsetSeconds: 5), status: .recordingPending))
+        // Fresh (never-synced) clock service
+        let clockService = makeUnsyncedClockService()
+        let captureController = FakeCaptureController()
+        let sleepProvider: (UInt64) async throws -> Void = { _ in }
+
+        let orchestrator = CycleCaptureOrchestrator(
+            authManager: authProvider,
+            clockSyncService: clockService,
+            captureController: captureController,
+            cycleAPIClient: apiClient,
+            sleepProvider: sleepProvider
+        )
+
+        orchestrator.startCycle(sessionUuid: "test-uuid", sessionDeviceId: 1)
+
+        await waitForOrchestratorState(orchestrator) {
+            if case .failed = $0 { return true }
+            return false
+        }
+
+        XCTAssertEqual(orchestrator.state, .failed(.clockSyncRequired))
+    }
+
+    // CYC-O-06: expired schedule (>2s in the past) → .failed(.cycleExpired(...))
+    func test_CYC_O_06_expiredSchedule_failsWithExpired() async throws {
+        let authProvider = FakeAccessTokenProvider()
+        let apiClient = MockCycleAPIClient()
+        apiClient.createResult = .success(makeTestCycle(id: 1, revision: 1))
+        // 10s in the past → lag = 10000ms > 2000ms → expired
+        apiClient.scheduleResult = .success(makeTestCycle(id: 1, revision: 2, scheduledStartAt: pastISO(offsetSeconds: 10), status: .recordingPending))
+        let clockService = await makeSyncedClockService()
+        let captureController = FakeCaptureController()
+        let sleepProvider: (UInt64) async throws -> Void = { _ in }
+
+        let orchestrator = CycleCaptureOrchestrator(
+            authManager: authProvider,
+            clockSyncService: clockService,
+            captureController: captureController,
+            cycleAPIClient: apiClient,
+            sleepProvider: sleepProvider
+        )
+
+        orchestrator.startCycle(sessionUuid: "test-uuid", sessionDeviceId: 1)
+
+        await waitForOrchestratorState(orchestrator) {
+            if case .failed = $0 { return true }
+            return false
+        }
+
+        if case .failed(let failure) = orchestrator.state {
+            if case .cycleExpired(let lagMs) = failure {
+                XCTAssertGreaterThan(lagMs, 2000, "Lag should be > 2000ms for a 10s past schedule")
+            } else {
+                XCTFail("Expected .cycleExpired, got \(failure)")
+            }
+        } else {
+            XCTFail("Expected .failed(.cycleExpired), got \(orchestrator.state)")
+        }
+    }
+
+    // CYC-O-07: near-past schedule (≤2s ago) → starts immediately, sleepProvider NOT called
+    func test_CYC_O_07_nearPastSchedule_startsImmediately() async throws {
+        let authProvider = FakeAccessTokenProvider()
+        let apiClient = MockCycleAPIClient()
+        apiClient.createResult = .success(makeTestCycle(id: 1, revision: 1))
+        // 1s in the past → lag = 1000ms ≤ 2000ms → tolerance, start immediately
+        apiClient.scheduleResult = .success(makeTestCycle(id: 1, revision: 2, scheduledStartAt: pastISO(offsetSeconds: 1), status: .recordingPending))
+        apiClient.confirmStartResult = .success(makeTestCycle(id: 1, revision: 4, status: .recording))
+        let clockService = await makeSyncedClockService()
+        let captureController = FakeCaptureController()
+
+        var sleepWasCalled = false
+        let sleepProvider: (UInt64) async throws -> Void = { _ in sleepWasCalled = true }
+
+        let orchestrator = CycleCaptureOrchestrator(
+            authManager: authProvider,
+            clockSyncService: clockService,
+            captureController: captureController,
+            cycleAPIClient: apiClient,
+            sleepProvider: sleepProvider
+        )
+
+        orchestrator.startCycle(sessionUuid: "test-uuid", sessionDeviceId: 1)
+
+        // Wait for startCapture to be called
+        await waitForOrchestratorState(orchestrator) {
+            if case .capturing = $0 { return true }
+            if case .failed = $0 { return true }
+            return false
+        }
+
+        XCTAssertFalse(sleepWasCalled, "sleepProvider should NOT have been called for near-past schedule")
+        XCTAssertGreaterThanOrEqual(captureController.startCallCount, 1, "startCapture should have been called")
+    }
+
+    // CYC-O-08: future schedule → sleepProvider called with ~5000ms ns value
+    func test_CYC_O_08_futureSchedule_sleepProviderCalled() async throws {
+        let authProvider = FakeAccessTokenProvider()
+        let apiClient = MockCycleAPIClient()
+        apiClient.createResult = .success(makeTestCycle(id: 1, revision: 1))
+        // 5s in the future
+        apiClient.scheduleResult = .success(makeTestCycle(id: 1, revision: 2, scheduledStartAt: futureISO(offsetSeconds: 5), status: .recordingPending))
+        apiClient.confirmStartResult = .success(makeTestCycle(id: 1, revision: 4, status: .recording))
+        let clockService = await makeSyncedClockService()
+        let captureController = FakeCaptureController()
+
+        var sleepNsCalled: UInt64? = nil
+        let sleepProvider: (UInt64) async throws -> Void = { ns in sleepNsCalled = ns }
+
+        let orchestrator = CycleCaptureOrchestrator(
+            authManager: authProvider,
+            clockSyncService: clockService,
+            captureController: captureController,
+            cycleAPIClient: apiClient,
+            sleepProvider: sleepProvider
+        )
+
+        orchestrator.startCycle(sessionUuid: "test-uuid", sessionDeviceId: 1)
+
+        await waitForOrchestratorState(orchestrator) {
+            if case .capturing = $0 { return true }
+            if case .failed = $0 { return true }
+            return false
+        }
+
+        XCTAssertNotNil(sleepNsCalled, "sleepProvider should have been called")
+        if let ns = sleepNsCalled {
+            // Should be approximately 5000ms = 5_000_000_000 ns (within ±2s tolerance)
+            let msWaited = Double(ns) / 1_000_000
+            XCTAssertGreaterThan(msWaited, 2_000, "Sleep should be > 2000ms for 5s future schedule")
+            XCTAssertLessThan(msWaited, 8_000, "Sleep should be < 8000ms for 5s future schedule")
+        }
+    }
+
+    // CYC-O-09: confirmStart 200 → .capturing state, confirmStart called once
+    func test_CYC_O_09_confirmStart200_currentCycleUpdated() async throws {
+        let authProvider = FakeAccessTokenProvider()
+        let apiClient = MockCycleAPIClient()
+        apiClient.createResult = .success(makeTestCycle(id: 1, revision: 1))
+        apiClient.scheduleResult = .success(makeTestCycle(id: 1, revision: 2, scheduledStartAt: futureISO(offsetSeconds: 0.001), status: .recordingPending))
+        apiClient.confirmStartResult = .success(makeTestCycle(id: 1, revision: 4, status: .recording))
+        let clockService = await makeSyncedClockService()
+        let captureController = FakeCaptureController()
+        let sleepProvider: (UInt64) async throws -> Void = { _ in }
+
+        let orchestrator = CycleCaptureOrchestrator(
+            authManager: authProvider,
+            clockSyncService: clockService,
+            captureController: captureController,
+            cycleAPIClient: apiClient,
+            sleepProvider: sleepProvider
+        )
+
+        orchestrator.startCycle(sessionUuid: "test-uuid", sessionDeviceId: 1)
+
+        await waitForOrchestratorState(orchestrator, timeout: 3.0) {
+            if case .capturing = $0 { return true }
+            if case .failed = $0 { return true }
+            return false
+        }
+
+        // Give time for confirmStart to be called
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        if case .capturing(let cycleId) = orchestrator.state {
+            XCTAssertEqual(cycleId, 1)
+        } else {
+            XCTFail("Expected .capturing(1), got \(orchestrator.state)")
+        }
+        XCTAssertEqual(apiClient.confirmStartCallCount, 1)
+    }
+
+    // CYC-O-10: confirmStart 409 → idempotent success (not .failed)
+    func test_CYC_O_10_confirmStart409_idempotentSuccess() async throws {
+        let authProvider = FakeAccessTokenProvider()
+        let apiClient = MockCycleAPIClient()
+        apiClient.createResult = .success(makeTestCycle(id: 1, revision: 1))
+        apiClient.scheduleResult = .success(makeTestCycle(id: 1, revision: 2, scheduledStartAt: futureISO(offsetSeconds: 0.001), status: .recordingPending))
+        // 409 error on confirmStart
+        apiClient.confirmStartResult = .failure(NSError(domain: "APIClient", code: 409, userInfo: [NSLocalizedDescriptionKey: "already confirmed"]))
+        let clockService = await makeSyncedClockService()
+        let captureController = FakeCaptureController()
+        let sleepProvider: (UInt64) async throws -> Void = { _ in }
+
+        let orchestrator = CycleCaptureOrchestrator(
+            authManager: authProvider,
+            clockSyncService: clockService,
+            captureController: captureController,
+            cycleAPIClient: apiClient,
+            sleepProvider: sleepProvider
+        )
+
+        orchestrator.startCycle(sessionUuid: "test-uuid", sessionDeviceId: 1)
+
+        await waitForOrchestratorState(orchestrator, timeout: 3.0) {
+            if case .capturing = $0 { return true }
+            if case .failed = $0 { return true }
+            return false
+        }
+
+        // Give time for confirmStart to settle
+        try? await Task.sleep(nanoseconds: 200_000_000)
+
+        // Should NOT be failed — 409 is idempotent success
+        if case .failed(let failure) = orchestrator.state {
+            XCTFail("Expected NOT .failed for 409 confirmStart, got .failed(\(failure))")
+        }
+        // State should still be .capturing
+        if case .capturing(let cycleId) = orchestrator.state {
+            XCTAssertEqual(cycleId, 1)
+        }
+    }
+
+    // CYC-O-11: confirmStart 422 → .failed(.confirmStartRejected(...))
+    func test_CYC_O_11_confirmStart422_failsWithRejected() async throws {
+        let authProvider = FakeAccessTokenProvider()
+        let apiClient = MockCycleAPIClient()
+        apiClient.createResult = .success(makeTestCycle(id: 1, revision: 1))
+        apiClient.scheduleResult = .success(makeTestCycle(id: 1, revision: 2, scheduledStartAt: futureISO(offsetSeconds: 0.001), status: .recordingPending))
+        apiClient.confirmStartResult = .failure(NSError(domain: "APIClient", code: 422, userInfo: [NSLocalizedDescriptionKey: "invalid transition"]))
+        let clockService = await makeSyncedClockService()
+        let captureController = FakeCaptureController()
+        let sleepProvider: (UInt64) async throws -> Void = { _ in }
+
+        let orchestrator = CycleCaptureOrchestrator(
+            authManager: authProvider,
+            clockSyncService: clockService,
+            captureController: captureController,
+            cycleAPIClient: apiClient,
+            sleepProvider: sleepProvider
+        )
+
+        orchestrator.startCycle(sessionUuid: "test-uuid", sessionDeviceId: 1)
+
+        await waitForOrchestratorState(orchestrator, timeout: 3.0) {
+            if case .failed = $0 { return true }
+            return false
+        }
+
+        if case .failed(let failure) = orchestrator.state {
+            if case .confirmStartRejected = failure {
+                // expected
+            } else {
+                XCTFail("Expected .confirmStartRejected, got \(failure)")
+            }
+        } else {
+            XCTFail("Expected .failed(.confirmStartRejected), got \(orchestrator.state)")
+        }
+    }
+
+    // CYC-O-12: confirmStop 200 → .completed(cycleId: 1)
+    func test_CYC_O_12_confirmStop200_completedState() async throws {
+        let authProvider = FakeAccessTokenProvider()
+        let apiClient = MockCycleAPIClient()
+        apiClient.createResult = .success(makeTestCycle(id: 1, revision: 1))
+        apiClient.scheduleResult = .success(makeTestCycle(id: 1, revision: 2, scheduledStartAt: futureISO(offsetSeconds: 0.001), status: .recordingPending))
+        apiClient.confirmStartResult = .success(makeTestCycle(id: 1, revision: 4, status: .recording))
+        apiClient.confirmStopResult = .success(makeTestCycle(id: 1, revision: 5, status: .completed))
+        let clockService = await makeSyncedClockService()
+        let captureController = FakeCaptureController()
+        let sleepProvider: (UInt64) async throws -> Void = { _ in }
+
+        let orchestrator = CycleCaptureOrchestrator(
+            authManager: authProvider,
+            clockSyncService: clockService,
+            captureController: captureController,
+            cycleAPIClient: apiClient,
+            sleepProvider: sleepProvider
+        )
+
+        orchestrator.startCycle(sessionUuid: "test-uuid", sessionDeviceId: 1)
+
+        // Wait for capturing state
+        await waitForOrchestratorState(orchestrator, timeout: 3.0) {
+            if case .capturing = $0 { return true }
+            if case .failed = $0 { return true }
+            return false
+        }
+
+        // Wait for confirmStart to settle
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        // Simulate capture completion
+        captureController.simulateState(.completed(fileURL: URL(fileURLWithPath: "/tmp/test.mov")))
+
+        await waitForOrchestratorState(orchestrator, timeout: 3.0) {
+            if case .completed = $0 { return true }
+            if case .failed = $0 { return true }
+            return false
+        }
+
+        if case .completed(let cycleId) = orchestrator.state {
+            XCTAssertEqual(cycleId, 1)
+        } else {
+            XCTFail("Expected .completed(1), got \(orchestrator.state)")
+        }
+    }
+
+    // CYC-O-13: confirmStop 409 → idempotent → .completed
+    func test_CYC_O_13_confirmStop409_idempotentCompleted() async throws {
+        let authProvider = FakeAccessTokenProvider()
+        let apiClient = MockCycleAPIClient()
+        apiClient.createResult = .success(makeTestCycle(id: 1, revision: 1))
+        apiClient.scheduleResult = .success(makeTestCycle(id: 1, revision: 2, scheduledStartAt: futureISO(offsetSeconds: 0.001), status: .recordingPending))
+        apiClient.confirmStartResult = .success(makeTestCycle(id: 1, revision: 4, status: .recording))
+        apiClient.confirmStopResult = .failure(NSError(domain: "APIClient", code: 409, userInfo: [NSLocalizedDescriptionKey: "already confirmed"]))
+        let clockService = await makeSyncedClockService()
+        let captureController = FakeCaptureController()
+        let sleepProvider: (UInt64) async throws -> Void = { _ in }
+
+        let orchestrator = CycleCaptureOrchestrator(
+            authManager: authProvider,
+            clockSyncService: clockService,
+            captureController: captureController,
+            cycleAPIClient: apiClient,
+            sleepProvider: sleepProvider
+        )
+
+        orchestrator.startCycle(sessionUuid: "test-uuid", sessionDeviceId: 1)
+
+        await waitForOrchestratorState(orchestrator, timeout: 3.0) {
+            if case .capturing = $0 { return true }
+            if case .failed = $0 { return true }
+            return false
+        }
+
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        captureController.simulateState(.completed(fileURL: URL(fileURLWithPath: "/tmp/test.mov")))
+
+        await waitForOrchestratorState(orchestrator, timeout: 3.0) {
+            if case .completed = $0 { return true }
+            if case .failed = $0 { return true }
+            return false
+        }
+
+        if case .completed(let cycleId) = orchestrator.state {
+            XCTAssertEqual(cycleId, 1, "409 on confirmStop should be idempotent completed")
+        } else {
+            XCTFail("Expected .completed for 409 confirmStop, got \(orchestrator.state)")
+        }
+    }
+
+    // CYC-O-14: confirmStop 422 → .failed(.confirmStopRejected(...))
+    func test_CYC_O_14_confirmStop422_failsWithRejected() async throws {
+        let authProvider = FakeAccessTokenProvider()
+        let apiClient = MockCycleAPIClient()
+        apiClient.createResult = .success(makeTestCycle(id: 1, revision: 1))
+        apiClient.scheduleResult = .success(makeTestCycle(id: 1, revision: 2, scheduledStartAt: futureISO(offsetSeconds: 0.001), status: .recordingPending))
+        apiClient.confirmStartResult = .success(makeTestCycle(id: 1, revision: 4, status: .recording))
+        apiClient.confirmStopResult = .failure(NSError(domain: "APIClient", code: 422, userInfo: [NSLocalizedDescriptionKey: "invalid stop"]))
+        let clockService = await makeSyncedClockService()
+        let captureController = FakeCaptureController()
+        let sleepProvider: (UInt64) async throws -> Void = { _ in }
+
+        let orchestrator = CycleCaptureOrchestrator(
+            authManager: authProvider,
+            clockSyncService: clockService,
+            captureController: captureController,
+            cycleAPIClient: apiClient,
+            sleepProvider: sleepProvider
+        )
+
+        orchestrator.startCycle(sessionUuid: "test-uuid", sessionDeviceId: 1)
+
+        await waitForOrchestratorState(orchestrator, timeout: 3.0) {
+            if case .capturing = $0 { return true }
+            if case .failed = $0 { return true }
+            return false
+        }
+
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        captureController.simulateState(.completed(fileURL: URL(fileURLWithPath: "/tmp/test.mov")))
+
+        await waitForOrchestratorState(orchestrator, timeout: 3.0) {
+            if case .failed = $0 { return true }
+            if case .completed = $0 { return true }
+            return false
+        }
+
+        if case .failed(let failure) = orchestrator.state {
+            if case .confirmStopRejected = failure {
+                // expected
+            } else {
+                XCTFail("Expected .confirmStopRejected, got \(failure)")
+            }
+        } else {
+            XCTFail("Expected .failed(.confirmStopRejected), got \(orchestrator.state)")
+        }
+    }
+
+    // CYC-O-15: reset() cancels and clears state → .idle
+    func test_CYC_O_15_reset_cancelsAndClearsState() async throws {
+        let authProvider = FakeAccessTokenProvider()
+        let apiClient = MockCycleAPIClient()
+        apiClient.createResult = .success(makeTestCycle(id: 1, revision: 1))
+        // Schedule with a 10s future start — so it gets stuck in waitingForStart
+        apiClient.scheduleResult = .success(makeTestCycle(id: 1, revision: 2, scheduledStartAt: futureISO(offsetSeconds: 10), status: .recordingPending))
+        let clockService = await makeSyncedClockService()
+        let captureController = FakeCaptureController()
+
+        // A sleep that we can cancel
+        let sleepProvider: (UInt64) async throws -> Void = { ns in
+            try await Task.sleep(nanoseconds: ns)
+        }
+
+        let orchestrator = CycleCaptureOrchestrator(
+            authManager: authProvider,
+            clockSyncService: clockService,
+            captureController: captureController,
+            cycleAPIClient: apiClient,
+            sleepProvider: sleepProvider
+        )
+
+        orchestrator.startCycle(sessionUuid: "test-uuid", sessionDeviceId: 1)
+
+        // Wait for it to reach waitingForStart
+        await waitForOrchestratorState(orchestrator, timeout: 2.0) {
+            if case .waitingForStart = $0 { return true }
+            if case .creating = $0 { return false }
+            if case .scheduling = $0 { return false }
+            return false
+        }
+
+        // Now reset
+        orchestrator.reset()
+
+        // Allow any in-flight tasks to settle
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(orchestrator.state, .idle, "After reset(), state should be .idle")
+    }
+
+    // CYC-O-16: noAuth → .failed(.noAuth)
+    func test_CYC_O_16_noAuth_failsWithNoAuth() async throws {
+        let authProvider = FakeAccessTokenProvider()
+        authProvider.accessToken = nil // no token
+        let apiClient = MockCycleAPIClient()
+        let clockService = await makeSyncedClockService()
+        let captureController = FakeCaptureController()
+        let sleepProvider: (UInt64) async throws -> Void = { _ in }
+
+        let orchestrator = CycleCaptureOrchestrator(
+            authManager: authProvider,
+            clockSyncService: clockService,
+            captureController: captureController,
+            cycleAPIClient: apiClient,
+            sleepProvider: sleepProvider
+        )
+
+        orchestrator.startCycle(sessionUuid: "test-uuid", sessionDeviceId: 1)
+
+        await waitForOrchestratorState(orchestrator) {
+            if case .failed = $0 { return true }
+            return false
+        }
+
+        XCTAssertEqual(orchestrator.state, .failed(.noAuth))
+    }
+}

--- a/ios/LFAEducationCenterTests/MultiCamera/CycleIdempotencyKeyTests.swift
+++ b/ios/LFAEducationCenterTests/MultiCamera/CycleIdempotencyKeyTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+@testable import LFAEducationCenter
+
+final class CycleIdempotencyKeyTests: XCTestCase {
+
+    // IDK-01: output matches pattern <8hex>:<8hex>:c<index>
+    func test_IDK_01_format() {
+        let key = CycleIdempotencyKey.make(sessionUuid: "AABBCCDD-1122-3344-5566-778899AABBCC", cycleIndex: 3)
+        // Three colon-separated parts
+        let parts = key.split(separator: ":", maxSplits: 2, omittingEmptySubsequences: false)
+        XCTAssertEqual(parts.count, 3, "Key should have 3 colon-separated parts")
+        // First two parts are 8 hex chars
+        XCTAssertEqual(parts[0].count, 8, "Device prefix should be 8 chars")
+        XCTAssertEqual(parts[1].count, 8, "Session prefix should be 8 chars")
+        // Third part matches c<index>
+        XCTAssertEqual(parts[2], "c3", "Cycle part should be c3")
+    }
+
+    // IDK-02: length always <= 64 chars
+    func test_IDK_02_length() {
+        let sessionUuid = UUID().uuidString
+        for index in [0, 1, 99, 1000] {
+            let key = CycleIdempotencyKey.make(sessionUuid: sessionUuid, cycleIndex: index)
+            XCTAssertLessThanOrEqual(key.count, 64, "Key should be <= 64 chars for cycleIndex=\(index)")
+        }
+    }
+
+    // IDK-03: same input same output (idempotent)
+    func test_IDK_03_sameInputSameOutput() {
+        let sessionUuid = "12345678-ABCD-EF12-3456-789ABCDEF012"
+        let key1 = CycleIdempotencyKey.make(sessionUuid: sessionUuid, cycleIndex: 0)
+        let key2 = CycleIdempotencyKey.make(sessionUuid: sessionUuid, cycleIndex: 0)
+        XCTAssertEqual(key1, key2, "Same inputs should produce same key")
+    }
+
+    // IDK-04: different cycleIndex → different key
+    func test_IDK_04_differentCycleIndexDifferentKey() {
+        let sessionUuid = UUID().uuidString
+        let key0 = CycleIdempotencyKey.make(sessionUuid: sessionUuid, cycleIndex: 0)
+        let key1 = CycleIdempotencyKey.make(sessionUuid: sessionUuid, cycleIndex: 1)
+        XCTAssertNotEqual(key0, key1, "Different cycleIndex should produce different key")
+    }
+
+    // IDK-05: different sessionUuid → different key
+    func test_IDK_05_differentSessionDifferentKey() {
+        let session1 = "AAAAAAAA-1111-1111-1111-AAAAAAAAAAAA"
+        let session2 = "BBBBBBBB-2222-2222-2222-BBBBBBBBBBBB"
+        let key1 = CycleIdempotencyKey.make(sessionUuid: session1, cycleIndex: 0)
+        let key2 = CycleIdempotencyKey.make(sessionUuid: session2, cycleIndex: 0)
+        XCTAssertNotEqual(key1, key2, "Different sessionUuid should produce different key")
+    }
+}

--- a/ios/LFAEducationCenterTests/MultiCamera/FakeCaptureController.swift
+++ b/ios/LFAEducationCenterTests/MultiCamera/FakeCaptureController.swift
@@ -1,0 +1,13 @@
+import Combine
+@testable import LFAEducationCenter
+
+@MainActor
+final class FakeCaptureController: CaptureController {
+    private let subject = CurrentValueSubject<CaptureState, Never>(.idle)
+    var captureStatePublisher: AnyPublisher<CaptureState, Never> { subject.eraseToAnyPublisher() }
+    private(set) var startCallCount = 0
+    private(set) var stopCallCount  = 0
+    func startCapture() { startCallCount += 1; subject.send(.capturing) }
+    func stopCapture()  { stopCallCount  += 1; subject.send(.stopping) }
+    func simulateState(_ s: CaptureState) { subject.send(s) }
+}


### PR DESCRIPTION
## Summary

- `CaptureController` protocol (`@MainActor`, `captureStatePublisher: AnyPublisher<CaptureState, Never>`, `startCapture()`, `stopCapture()`) + `SessionCaptureManager` conformance extension
- `CycleIdempotencyKey.make(sessionUuid:cycleIndex:)` — Keychain device UUID prefix, `"<8hex>:<8hex>:c<n>"` format, ≤22 chars, idempotent retry-safe
- `CycleCaptureOrchestrator` — strict-mode state machine: idle → creating → scheduling → waitingForStart → capturing → stopping → completed/failed
- `OrchestratorFailure` + `CycleAPIClient` protocol (injectable, `LiveCycleAPIClient` wraps static `MultiCameraAPIClient`)
- `AccessTokenProvider` protocol + `AuthManager` conformance (testability)
- Minimal ViewModel extension: `beginCycle()`, `endCycle()`, `reset()` cleanup, optional `cycleOrchestrator` param

## Strict-mode rules enforced

| Rule | Implementation |
|------|---------------|
| No `try? await sleepProvider` | `do/catch is CancellationError/catch` — explicit rethrow or `.timerError` |
| No wall-clock fallback | `currentServerTimeISO()` returns nil if `adjustedServerTimeMs == nil` |
| `scheduledStartAt == nil` → `.failed` | `guard let scheduledStartAtStr = cycle.scheduledStartAt else { throw .scheduledStartAtMissing }` |
| 409 → idempotent success | `if nsErr.code == 409 { return }` (confirmStart) / `state = .completed` (confirmStop) |
| 422 → `.failed` | `.confirmStartRejected` / `.confirmStopRejected` |
| Other network → retry once | retry block, then `.apiError` |
| ISO8601 with fractional seconds | `[.withInternetDateTime, .withFractionalSeconds]` both in parse and format |
| 2000ms tolerance | `scheduledStartToleranceMs = 2_000` |
| lag > 2s → `.cycleExpired` | `if lagMs > Self.scheduledStartToleranceMs { throw .cycleExpired(lagMs: lagMs) }` |

## Test plan

- [x] CYC-O-01..16 (`CycleCaptureOrchestratorTests`) — 16/16 PASS
- [x] IDK-01..05 (`CycleIdempotencyKeyTests`) — 5/5 PASS
- [x] iOS build: `** TEST SUCCEEDED **`
- [ ] Full CI run (required checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)