### PR TITLE
fix(mc1-activate): make activate_session idempotent when session already ACTIVE

### DIFF
--- a/app/services/multicamera/cycle_service.py
+++ b/app/services/multicamera/cycle_service.py
@@ -46,11 +46,13 @@ class CycleService:
     # ── Session activation ────────────────────────────────────────────────────
 
     def activate_session(self, session_uuid: uuid.UUID, session_revision: int):
-        """Transition session LOBBY → ACTIVE for multi-cycle use."""
+        """Transition session → ACTIVE for multi-cycle use. Idempotent if already active."""
         s = self._require_session(session_uuid)
         if s.revision != session_revision:
             raise RevisionConflictError("session", session_revision, s.revision)
         current = SessionStatus(s.status)
+        if current == SessionStatus.ACTIVE:
+            return s
         if SessionStatus.ACTIVE not in SESSION_TRANSITIONS.get(current, set()):
             raise InvalidTransitionError("session", s.status, "active")
         s.status = SessionStatus.ACTIVE.value

--- a/tests/unit/multicamera/test_capture_cycles.py
+++ b/tests/unit/multicamera/test_capture_cycles.py
@@ -786,6 +786,61 @@ class TestTransitionGuards:
         with pytest.raises(InvalidTransitionError):
             svc.activate_session(s.session_uuid, s.revision)
 
+    def test_tr_04_activate_twice_from_lobby_second_call_idempotent(self, db, users):
+        """TR-04: LOBBY → ACTIVE (first call), ACTIVE → ACTIVE (second call) — regression for
+        physical-test blocker where Begin Cycle retried on an already-active session.
+
+        Invariants:
+        - Both calls succeed (no exception).
+        - Revision increments exactly once (only the LOBBY → ACTIVE transition writes).
+        - Status remains ACTIVE after both calls.
+        """
+        instructor, _ = users
+        s = MultiCameraSession(
+            created_by_user_id=instructor.id,
+            status=SessionStatus.LOBBY.value,
+        )
+        db.add(s)
+        db.flush()
+        revision_initial = s.revision
+
+        svc = CycleService(db)
+
+        # First call: LOBBY → ACTIVE, revision must increment.
+        r1 = svc.activate_session(s.session_uuid, revision_initial)
+        assert SessionStatus(r1.status) == SessionStatus.ACTIVE
+        assert r1.revision == revision_initial + 1
+
+        # Second call: session already ACTIVE, same revision — must not raise, must not write.
+        r2 = svc.activate_session(s.session_uuid, r1.revision)
+        assert SessionStatus(r2.status) == SessionStatus.ACTIVE
+        assert r2.revision == r1.revision  # revision unchanged
+
+    def test_tr_05_repeated_activate_never_increments_revision(self, db, active_session):
+        """TR-05: N repeated activateSession() calls on an already-ACTIVE session —
+        revision stays constant throughout; status stays ACTIVE.
+
+        Covers the full retry loop an orchestrator might execute before giving up.
+        """
+        s, p_inst, sd1, sd2 = active_session
+        revision_before = s.revision
+        svc = CycleService(db)
+
+        for _ in range(5):
+            result = svc.activate_session(s.session_uuid, revision_before)
+            assert SessionStatus(result.status) == SessionStatus.ACTIVE
+            assert result.revision == revision_before
+
+    def test_tr_06_activate_cancelled_session_raises(self, db, users):
+        """TR-06: CANCELLED session → InvalidTransitionError (not silently treated as active)."""
+        instructor, _ = users
+        s = MultiCameraSession(created_by_user_id=instructor.id, status=SessionStatus.CANCELLED.value)
+        db.add(s)
+        db.flush()
+        svc = CycleService(db)
+        with pytest.raises(InvalidTransitionError):
+            svc.activate_session(s.session_uuid, s.revision)
+
 
 # ── Concurrent idempotency ────────────────────────────────────────────────────
 

--- a/tests/unit/multicamera/test_capture_cycles.py
+++ b/tests/unit/multicamera/test_capture_cycles.py
@@ -767,12 +767,14 @@ class TestTransitionGuards:
         result = svc.activate_session(s.session_uuid, s.revision)
         assert SessionStatus(result.status) == SessionStatus.ACTIVE
 
-    def test_tr_02_activate_from_active_raises(self, db, active_session):
-        """TR-02: already ACTIVE session → InvalidTransitionError on second activate."""
+    def test_tr_02_activate_from_active_is_idempotent(self, db, active_session):
+        """TR-02: already ACTIVE session → idempotent success (same revision, no DB write)."""
         s, p_inst, sd1, sd2 = active_session
+        revision_before = s.revision
         svc = CycleService(db)
-        with pytest.raises(InvalidTransitionError):
-            svc.activate_session(s.session_uuid, s.revision)
+        result = svc.activate_session(s.session_uuid, s.revision)
+        assert SessionStatus(result.status) == SessionStatus.ACTIVE
+        assert result.revision == revision_before
 
     def test_tr_03_activate_from_completed_raises(self, db, users):
         """TR-03: COMPLETED session → InvalidTransitionError."""


### PR DESCRIPTION
## Summary

- `activate_session` returned HTTP 422 when called on a session already in `ACTIVE` state — no early-return existed for the already-active case
- Physical iPad+iPhone test was blocked: first Begin Cycle press activated the session, then failed elsewhere; second press hit the 422
- Fix: 2-line early return in `CycleService.activate_session` — if `current == ACTIVE` and revision matches, return session immediately (no DB write)
- `test_tr_02` updated from "expect InvalidTransitionError" to "expect idempotent success"

## Test plan

- [x] `TestTransitionGuards::test_tr_01/02/03` — 3/3 PASS locally
- [x] Full multicamera suite — 196/196 PASS locally
- [ ] CI green on all required checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)