### PR TITLE
feat(mc1-ios-orch3b): PlayerCaptureOrchestrator — player-side capture start

### DIFF
--- a/ios/LFAEducationCenter.xcodeproj/project.pbxproj
+++ b/ios/LFAEducationCenter.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		OR000004000000000000002 /* CycleIdempotencyKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = OR000003000000000000002 /* CycleIdempotencyKey.swift */; };
 		OR000004000000000000003 /* CycleCaptureOrchestrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OR000003000000000000003 /* CycleCaptureOrchestrator.swift */; };
 		PC000004000000000000001 /* PlayerCycleListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = PC000003000000000000001 /* PlayerCycleListener.swift */; };
+		PC000004000000000000002 /* PlayerCaptureOrchestrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = PC000003000000000000002 /* PlayerCaptureOrchestrator.swift */; };
 		QR000004000000000000001 /* SessionQRPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = QR000003000000000000001 /* SessionQRPayload.swift */; };
 		QR000004000000000000002 /* QRScannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = QR000003000000000000002 /* QRScannerView.swift */; };
 		QR500004000000000000001 /* SessionQRPayloadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = QR500003000000000000001 /* SessionQRPayloadTests.swift */; };
@@ -42,6 +43,7 @@
 		OR500004000000000000002 /* CycleIdempotencyKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OR500003000000000000002 /* CycleIdempotencyKeyTests.swift */; };
 		OR500004000000000000003 /* CycleCaptureOrchestratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OR500003000000000000003 /* CycleCaptureOrchestratorTests.swift */; };
 		PC500004000000000000001 /* PlayerCycleListenerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = PC500003000000000000001 /* PlayerCycleListenerTests.swift */; };
+		PC500004000000000000002 /* PlayerCaptureOrchestratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = PC500003000000000000002 /* PlayerCaptureOrchestratorTests.swift */; };
 		MC500004000000000000003 /* SessionCaptureManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = MC500003000000000000003 /* SessionCaptureManagerTests.swift */; };
 		DI500004000000000000001 /* DeviceIdentityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DI500003000000000000001 /* DeviceIdentityTests.swift */; };
 		CS500004000000000000001 /* ClockSyncServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CS500003000000000000001 /* ClockSyncServiceTests.swift */; };
@@ -284,6 +286,7 @@
 		OR000003000000000000002 /* CycleIdempotencyKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CycleIdempotencyKey.swift; sourceTree = "<group>"; };
 		OR000003000000000000003 /* CycleCaptureOrchestrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CycleCaptureOrchestrator.swift; sourceTree = "<group>"; };
 		PC000003000000000000001 /* PlayerCycleListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerCycleListener.swift; sourceTree = "<group>"; };
+		PC000003000000000000002 /* PlayerCaptureOrchestrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerCaptureOrchestrator.swift; sourceTree = "<group>"; };
 		QR000003000000000000001 /* SessionQRPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionQRPayload.swift; sourceTree = "<group>"; };
 		QR000003000000000000002 /* QRScannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRScannerView.swift; sourceTree = "<group>"; };
 		QR500003000000000000001 /* SessionQRPayloadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionQRPayloadTests.swift; sourceTree = "<group>"; };
@@ -291,6 +294,7 @@
 		OR500003000000000000002 /* CycleIdempotencyKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CycleIdempotencyKeyTests.swift; sourceTree = "<group>"; };
 		OR500003000000000000003 /* CycleCaptureOrchestratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CycleCaptureOrchestratorTests.swift; sourceTree = "<group>"; };
 		PC500003000000000000001 /* PlayerCycleListenerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerCycleListenerTests.swift; sourceTree = "<group>"; };
+		PC500003000000000000002 /* PlayerCaptureOrchestratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerCaptureOrchestratorTests.swift; sourceTree = "<group>"; };
 		GP000003000000000000005 /* GoProConnectionDebugView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoProConnectionDebugView.swift; sourceTree = "<group>"; };
 		GP000003000000000000006 /* CoreBluetoothBLETransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreBluetoothBLETransport.swift; sourceTree = "<group>"; };
 		GP000003000000000000007 /* GoProHTTPClientTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoProHTTPClientTransport.swift; sourceTree = "<group>"; };
@@ -736,6 +740,7 @@
 				OR000003000000000000002 /* CycleIdempotencyKey.swift */,
 				OR000003000000000000003 /* CycleCaptureOrchestrator.swift */,
 				PC000003000000000000001 /* PlayerCycleListener.swift */,
+				PC000003000000000000002 /* PlayerCaptureOrchestrator.swift */,
 				QR000003000000000000001 /* SessionQRPayload.swift */,
 				QR000003000000000000002 /* QRScannerView.swift */,
 				GP000003000000000000005 /* GoProConnectionDebugView.swift */,
@@ -1029,6 +1034,7 @@
 				OR500003000000000000002 /* CycleIdempotencyKeyTests.swift */,
 				OR500003000000000000003 /* CycleCaptureOrchestratorTests.swift */,
 				PC500003000000000000001 /* PlayerCycleListenerTests.swift */,
+				PC500003000000000000002 /* PlayerCaptureOrchestratorTests.swift */,
 				QR500003000000000000001 /* SessionQRPayloadTests.swift */,
 				MC500003000000000000002 /* session_full.json */,
 				CYC00003000000000000001 /* cycle_full.json */,
@@ -1325,6 +1331,7 @@
 				OR000004000000000000002 /* CycleIdempotencyKey.swift in Sources */,
 				OR000004000000000000003 /* CycleCaptureOrchestrator.swift in Sources */,
 				PC000004000000000000001 /* PlayerCycleListener.swift in Sources */,
+				PC000004000000000000002 /* PlayerCaptureOrchestrator.swift in Sources */,
 				QR000004000000000000001 /* SessionQRPayload.swift in Sources */,
 				QR000004000000000000002 /* QRScannerView.swift in Sources */,
 				GP000004000000000000005 /* GoProConnectionDebugView.swift in Sources */,
@@ -1396,6 +1403,7 @@
 				OR500004000000000000002 /* CycleIdempotencyKeyTests.swift in Sources */,
 				OR500004000000000000003 /* CycleCaptureOrchestratorTests.swift in Sources */,
 				PC500004000000000000001 /* PlayerCycleListenerTests.swift in Sources */,
+				PC500004000000000000002 /* PlayerCaptureOrchestratorTests.swift in Sources */,
 				QR500004000000000000001 /* SessionQRPayloadTests.swift in Sources */,
 				BB100004000000000000004 /* AnnotationVideoLoaderTests.swift in Sources */,
 				BB100004000000000000005 /* PlaybackBarTests.swift in Sources */,

--- a/ios/LFAEducationCenter/MultiCamera/MultiCameraLobbyView.swift
+++ b/ios/LFAEducationCenter/MultiCamera/MultiCameraLobbyView.swift
@@ -7,6 +7,7 @@ struct MultiCameraLobbyView: View {
     @StateObject private var orchestrator: CycleCaptureOrchestrator
     @StateObject private var captureManager: SessionCaptureManager
     @StateObject private var playerListener: PlayerCycleListener
+    @StateObject private var playerOrchestrator: PlayerCaptureOrchestrator
     @State private var joinUuid = ""
     @State private var showQRScanner = false
     @State private var qrDecodeError: String?
@@ -22,18 +23,25 @@ struct MultiCameraLobbyView: View {
             clockSyncService: clockSync,
             captureController: captureMgr
         )
+        let playerOrch = PlayerCaptureOrchestrator(
+            authManager: authManager,
+            clockSyncService: clockSync,
+            captureController: captureMgr
+        )
         _captureManager = StateObject(wrappedValue: captureMgr)
         _orchestrator = StateObject(wrappedValue: orch)
         _playerListener = StateObject(wrappedValue: listener)
+        _playerOrchestrator = StateObject(wrappedValue: playerOrch)
         _vm = StateObject(wrappedValue: MultiCameraSessionViewModel(
             authManager: authManager,
             clockSyncService: clockSync,
             cycleOrchestrator: orch,
-            playerCycleListener: listener
+            playerCycleListener: listener,
+            playerCaptureOrchestrator: playerOrch
         ))
     }
 
-    private static let buildFingerprint = "mc1-debug-v5-2026-06-26"
+    private static let buildFingerprint = "mc1-debug-v6-2026-06-26"
 
     var body: some View {
         NavigationView {
@@ -229,6 +237,7 @@ struct MultiCameraLobbyView: View {
                     LabeledRow("User ID", "\(Self.cachedUserId ?? 0)")
                     LabeledRow("State", "\(vm.state)")
                     LabeledRow("Orchestrator", orchestratorStateDescription)
+                    LabeledRow("PlayerOrch", playerOrchestratorDescription)
                     if case .error(let msg) = vm.state {
                         LabeledRow("Error", msg)
                     }
@@ -242,6 +251,7 @@ struct MultiCameraLobbyView: View {
                             "state: \(vm.state)",
                             "orchestrator: \(orchestratorStateDescription)",
                             "player_listener: \(playerListenerDescription)",
+                            "player_orch: \(playerOrchestratorDescription)",
                             "======================================",
                         ].joined(separator: "\n")
                         UIPasteboard.general.string = text
@@ -277,6 +287,7 @@ struct MultiCameraLobbyView: View {
             LabeledRow("Capture", captureStateDescription)
             LabeledRow("Orchestrator", orchestratorStateDescription)
             LabeledRow("Listener", playerListenerDescription)
+            LabeledRow("PlayerOrch", playerOrchestratorDescription)
             LabeledRow("DevReg Error", vm.deviceRegisterError ?? "—")
             if case .failed = vm.clockSyncState {
                 Button("Retry Clock Sync") { vm.retryClockSync() }
@@ -328,6 +339,7 @@ struct MultiCameraLobbyView: View {
             "capture: \(captureStateDescription)",
             "orchestrator: \(orchestratorStateDescription)",
             "player_listener: \(playerListenerDescription)",
+            "player_orch: \(playerOrchestratorDescription)",
             "device_reg_error: \(vm.deviceRegisterError ?? "—")",
             "last_error: \(lastError)",
             "last_orch_failure: \(orchError)",
@@ -399,6 +411,16 @@ struct MultiCameraLobbyView: View {
         case .recordingDetected(let id):    return "recording(#\(id))"
         case .stoppingDetected(let id):     return "stopping(#\(id))"
         case .failed(let msg):              return "error: \(msg)"
+        }
+    }
+
+    private var playerOrchestratorDescription: String {
+        switch playerOrchestrator.state {
+        case .idle:                         return "idle"
+        case .waitingForStart(let id):      return "waitingForStart(#\(id))"
+        case .capturing(let id):            return "capturing(#\(id)) ●"
+        case .confirmed(let id):            return "confirmed(#\(id)) ✓"
+        case .failed(let msg):              return "failed: \(msg)"
         }
     }
 

--- a/ios/LFAEducationCenter/MultiCamera/MultiCameraSessionViewModel.swift
+++ b/ios/LFAEducationCenter/MultiCamera/MultiCameraSessionViewModel.swift
@@ -47,6 +47,7 @@ final class MultiCameraSessionViewModel: ObservableObject {
 
     private let cycleOrchestrator: CycleCaptureOrchestrator?
     private let playerCycleListener: PlayerCycleListener?
+    private let playerCaptureOrchestrator: PlayerCaptureOrchestrator?
 
     init(
         authManager: AuthManager,
@@ -54,7 +55,8 @@ final class MultiCameraSessionViewModel: ObservableObject {
         pollingIntervalSeconds: Double = 3.0,
         heartbeatIntervalSeconds: Double = 5.0,
         cycleOrchestrator: CycleCaptureOrchestrator? = nil,
-        playerCycleListener: PlayerCycleListener? = nil
+        playerCycleListener: PlayerCycleListener? = nil,
+        playerCaptureOrchestrator: PlayerCaptureOrchestrator? = nil
     ) {
         self.authManager = authManager
         self.clockSyncService = clockSyncService
@@ -62,6 +64,7 @@ final class MultiCameraSessionViewModel: ObservableObject {
         self.heartbeatInterval = UInt64(heartbeatIntervalSeconds * 1_000_000_000)
         self.cycleOrchestrator = cycleOrchestrator
         self.playerCycleListener = playerCycleListener
+        self.playerCaptureOrchestrator = playerCaptureOrchestrator
     }
 
     deinit {
@@ -159,6 +162,7 @@ final class MultiCameraSessionViewModel: ObservableObject {
         clockSyncState = .notSynced
         cycleOrchestrator?.reset()
         playerCycleListener?.reset()
+        playerCaptureOrchestrator?.reset()
         state = .idle
     }
 
@@ -207,6 +211,9 @@ final class MultiCameraSessionViewModel: ObservableObject {
                 deviceRevision: sd.revision
             )
             print("[LobbyVM] autoRegisterDevice: device \(sd.id) → ready")
+            if let listener = playerCycleListener, let orch = playerCaptureOrchestrator {
+                orch.attach(listener: listener, sessionUuid: sessionUuid, playerSessionDeviceId: sd.id)
+            }
         } catch {
             deviceRegisterError = "\(error)"
             print("[LobbyVM] autoRegisterDevice: FAILED error=\(error)")

--- a/ios/LFAEducationCenter/MultiCamera/PlayerCaptureOrchestrator.swift
+++ b/ios/LFAEducationCenter/MultiCamera/PlayerCaptureOrchestrator.swift
@@ -1,0 +1,292 @@
+import Foundation
+import Combine
+
+// MARK: — PlayerOrchestratorState
+
+enum PlayerOrchestratorState: Equatable {
+    case idle
+    case waitingForStart(cycleId: Int)  // clock wait in progress (or immediate for late-join)
+    case capturing(cycleId: Int)        // startCapture() called; awaiting confirmDeviceStart
+    case confirmed(cycleId: Int)        // confirmDeviceStart succeeded
+    case failed(String)
+}
+
+// MARK: — PlayerCaptureOrchestrator
+
+@MainActor
+final class PlayerCaptureOrchestrator: ObservableObject {
+
+    // MARK: — Constants
+    private static let scheduledStartToleranceMs: Double = 2_000
+
+    // MARK: — Published state
+    @Published private(set) var state: PlayerOrchestratorState = .idle
+
+    // MARK: — Dependencies
+    private let authManager: any AccessTokenProvider
+    private let clockSyncService: ClockSyncService
+    private let captureController: CaptureController
+    private let cycleAPIClient: CycleAPIClient
+    private let sleepProvider: (UInt64) async throws -> Void
+
+    // MARK: — Session context (set at attach time)
+    private var sessionUuid: String?
+    private var playerSessionDeviceId: Int?
+
+    // MARK: — Tracking
+    private var listenerSubscription: AnyCancellable?
+    private var captureSubscription: AnyCancellable?
+    private var startTask: Task<Void, Never>?
+    private var handledCycleIds: Set<Int> = []  // prevents duplicate confirm-start
+
+    // MARK: — Active cycle (stored when start begins; needed for confirmDeviceStart)
+    private var activeCycle: CaptureCycleDTO?
+
+    // MARK: — Init
+
+    init(
+        authManager: any AccessTokenProvider,
+        clockSyncService: ClockSyncService,
+        captureController: CaptureController,
+        cycleAPIClient: CycleAPIClient = LiveCycleAPIClient(),
+        sleepProvider: @escaping (UInt64) async throws -> Void = { ns in
+            try await Task.sleep(nanoseconds: ns)
+        }
+    ) {
+        self.authManager = authManager
+        self.clockSyncService = clockSyncService
+        self.captureController = captureController
+        self.cycleAPIClient = cycleAPIClient
+        self.sleepProvider = sleepProvider
+    }
+
+    // MARK: — Public API
+
+    /// Call after autoRegisterDevice completes so playerSessionDeviceId is known.
+    /// Subscribing to listener.$state delivers the current value immediately,
+    /// so late-attach is handled without a separate "read current state" step.
+    func attach(listener: PlayerCycleListener, sessionUuid: String, playerSessionDeviceId: Int) {
+        self.sessionUuid = sessionUuid
+        self.playerSessionDeviceId = playerSessionDeviceId
+
+        listenerSubscription?.cancel()
+        listenerSubscription = listener.$state
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self, weak listener] newState in
+                self?.handleListenerState(newState, currentCycle: listener?.currentCycle)
+            }
+    }
+
+    func detach() {
+        listenerSubscription?.cancel()
+        listenerSubscription = nil
+        startTask?.cancel()
+        startTask = nil
+        captureSubscription?.cancel()
+        captureSubscription = nil
+        activeCycle = nil
+        sessionUuid = nil
+        playerSessionDeviceId = nil
+        state = .idle
+    }
+
+    func reset() {
+        detach()
+        handledCycleIds = []
+    }
+
+    // MARK: — Listener state handler (internal for testability)
+
+    func handleListenerState(_ listenerState: PlayerListenerState, currentCycle: CaptureCycleDTO?) {
+        switch listenerState {
+        case .pendingCycleDetected(let cycleId):
+            guard case .idle = state else { return }
+            guard !handledCycleIds.contains(cycleId) else { return }
+            guard let cycle = currentCycle else { return }
+            beginStart(cycle: cycle, immediate: false)
+
+        case .recordingDetected(let cycleId):
+            guard case .idle = state else { return }
+            guard !handledCycleIds.contains(cycleId) else { return }
+            guard let cycle = currentCycle else { return }
+            beginStart(cycle: cycle, immediate: true)
+
+        default:
+            break
+        }
+    }
+
+    private func beginStart(cycle: CaptureCycleDTO, immediate: Bool) {
+        state = .waitingForStart(cycleId: cycle.id)
+        activeCycle = cycle
+        startTask?.cancel()
+        startTask = Task { [weak self] in
+            await self?.performStart(cycle: cycle, immediate: immediate)
+        }
+    }
+
+    // MARK: — Start orchestration
+
+    private func performStart(cycle: CaptureCycleDTO, immediate: Bool) async {
+        if !immediate {
+            do {
+                try await waitForScheduledStart(cycle: cycle)
+            } catch is CancellationError {
+                return
+            } catch let failure as PlayerOrchestratorFailure {
+                state = .failed(failure.description)
+                return
+            } catch {
+                state = .failed(error.localizedDescription)
+                return
+            }
+        }
+
+        guard !Task.isCancelled else { return }
+
+        subscribeToCaptureState()
+        captureController.startCapture()
+    }
+
+    // MARK: — Scheduled start wait (mirrors CycleCaptureOrchestrator)
+
+    private func waitForScheduledStart(cycle: CaptureCycleDTO) async throws {
+        guard let scheduledStartAtStr = cycle.scheduledStartAt else {
+            throw PlayerOrchestratorFailure.scheduledStartAtMissing
+        }
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        guard let scheduledDate = formatter.date(from: scheduledStartAtStr) else {
+            throw PlayerOrchestratorFailure.scheduledStartAtInvalid
+        }
+        guard let serverTimeMs = await clockSyncService.adjustedServerTimeMs else {
+            throw PlayerOrchestratorFailure.clockSyncRequired
+        }
+        let scheduledMs = scheduledDate.timeIntervalSince1970 * 1000.0
+        let waitMs = scheduledMs - serverTimeMs
+
+        if waitMs < 0 {
+            let lagMs = -waitMs
+            if lagMs > Self.scheduledStartToleranceMs {
+                throw PlayerOrchestratorFailure.cycleExpired(lagMs: lagMs)
+            }
+            return  // within tolerance — start immediately
+        }
+
+        let waitNs = UInt64(waitMs * 1_000_000)
+        do {
+            try await sleepProvider(waitNs)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            throw PlayerOrchestratorFailure.timerError(error.localizedDescription)
+        }
+    }
+
+    // MARK: — Capture state subscription
+
+    private func subscribeToCaptureState() {
+        captureSubscription?.cancel()
+        captureSubscription = captureController.captureStatePublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] captureState in
+                guard let self else { return }
+                if case .capturing = captureState {
+                    Task { @MainActor [weak self] in
+                        await self?.handleCaptureStarted()
+                    }
+                }
+            }
+    }
+
+    // MARK: — Confirm device start
+
+    private func handleCaptureStarted() async {
+        guard let cycle = activeCycle,
+              let uuid = sessionUuid,
+              let sdId = playerSessionDeviceId else { return }
+
+        let cycleId = cycle.id
+
+        // Duplicate confirm guard: check if already in handledCycleIds
+        guard !handledCycleIds.contains(cycleId) else {
+            state = .confirmed(cycleId: cycleId)
+            return
+        }
+
+        state = .capturing(cycleId: cycleId)
+
+        // If the cycle device is already confirmed_start, skip the API call
+        if let device = cycle.cycleDevices.first(where: { $0.sessionDeviceId == sdId }),
+           device.recordingStatus == .confirmedStart {
+            handledCycleIds.insert(cycleId)
+            state = .confirmed(cycleId: cycleId)
+            return
+        }
+
+        guard let cycleDevice = cycle.cycleDevices.first(where: { $0.sessionDeviceId == sdId }) else {
+            state = .failed("cycleDeviceMissing(sessionDeviceId: \(sdId))")
+            return
+        }
+
+        guard let startedAt = await currentServerTimeISO() else {
+            state = .failed("clockSyncRequired")
+            return
+        }
+
+        guard let token = authManager.accessToken else {
+            state = .failed("noAuth")
+            return
+        }
+
+        do {
+            _ = try await cycleAPIClient.confirmDeviceStart(
+                token: token,
+                uuid: uuid,
+                cycleId: cycleId,
+                sessionDeviceId: sdId,
+                startedAt: startedAt,
+                cycleDeviceRevision: cycleDevice.revision
+            )
+            handledCycleIds.insert(cycleId)
+            state = .confirmed(cycleId: cycleId)
+        } catch {
+            if let apiErr = error as? APIError,
+               case .httpError(let code, let detail) = apiErr {
+                state = .failed("HTTP \(code): \(detail ?? "confirm-start rejected")")
+            } else {
+                state = .failed("\(error)")
+            }
+        }
+    }
+
+    // MARK: — Server time helper
+
+    private func currentServerTimeISO() async -> String? {
+        guard let serverTimeMs = await clockSyncService.adjustedServerTimeMs else { return nil }
+        let date = Date(timeIntervalSince1970: serverTimeMs / 1000.0)
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.string(from: date)
+    }
+}
+
+// MARK: — PlayerOrchestratorFailure (internal)
+
+private enum PlayerOrchestratorFailure: Error {
+    case scheduledStartAtMissing
+    case scheduledStartAtInvalid
+    case clockSyncRequired
+    case cycleExpired(lagMs: Double)
+    case timerError(String)
+
+    var description: String {
+        switch self {
+        case .scheduledStartAtMissing:      return "scheduledStartAtMissing"
+        case .scheduledStartAtInvalid:      return "scheduledStartAtInvalid"
+        case .clockSyncRequired:            return "clockSyncRequired"
+        case .cycleExpired(let ms):         return "cycleExpired(lagMs: \(ms))"
+        case .timerError(let msg):          return "timerError: \(msg)"
+        }
+    }
+}

--- a/ios/LFAEducationCenter/MultiCamera/PlayerCycleListener.swift
+++ b/ios/LFAEducationCenter/MultiCamera/PlayerCycleListener.swift
@@ -33,7 +33,8 @@ final class PlayerCycleListener: ObservableObject {
     @Published private(set) var state: PlayerListenerState = .idle
 
     private var pollingTask: Task<Void, Never>?
-    var handledCycleIds: Set<Int> = []  // internal visibility for testability
+    var handledCycleIds: Set<Int> = []          // internal visibility for testability
+    private(set) var currentCycle: CaptureCycleDTO?  // latest active cycle; nil when waiting
 
     private let authManager: any AccessTokenProvider
     private let cycleListClient: CycleListClient
@@ -108,19 +109,25 @@ final class PlayerCycleListener: ObservableObject {
         guard let cycle = cycles.first(where: {
             !isTerminal($0.status) && !handledCycleIds.contains($0.id)
         }) else {
+            currentCycle = nil
             return .waitingForCycle
         }
         switch cycle.status {
         case .preparing:
+            currentCycle = nil
             return .waitingForCycle
         case .recordingPending:
+            currentCycle = cycle
             return .pendingCycleDetected(cycleId: cycle.id)
         case .recording:
+            currentCycle = cycle
             return .recordingDetected(cycleId: cycle.id)
         case .stopping:
+            currentCycle = cycle
             return .stoppingDetected(cycleId: cycle.id)
         case .completed, .failed, .aborted:
             handledCycleIds.insert(cycle.id)
+            currentCycle = nil
             return .waitingForCycle
         }
     }

--- a/ios/LFAEducationCenterTests/MultiCamera/PlayerCaptureOrchestratorTests.swift
+++ b/ios/LFAEducationCenterTests/MultiCamera/PlayerCaptureOrchestratorTests.swift
@@ -1,0 +1,379 @@
+import XCTest
+import Combine
+import QuartzCore
+@testable import LFAEducationCenter
+
+// MARK: — Fakes
+
+private final class FakePCOTokenProvider: AccessTokenProvider {
+    var accessToken: String? = "test-token"
+}
+
+/// No-op list client — used to construct a PlayerCycleListener for attach() context only.
+@MainActor
+private final class StubCycleListClient: CycleListClient {
+    func listCycles(token: String, uuid: String) async throws -> [CaptureCycleDTO] { [] }
+}
+
+@MainActor
+private final class MockCycleAPIClientForPCO: CycleAPIClient {
+    var confirmStartResult: Result<CaptureCycleDTO, Error> =
+        .success(makePCOCycle(id: 1, revision: 4, status: .recording))
+
+    private(set) var confirmStartCallCount = 0
+
+    func activateSession(token: String, uuid: String, revision: Int) async throws -> MultiCameraSessionDTO {
+        fatalError("not used in PCO tests")
+    }
+    func createCycle(token: String, uuid: String, idempotencyKey: String) async throws -> CaptureCycleDTO {
+        fatalError("not used in PCO tests")
+    }
+    func scheduleCycle(token: String, uuid: String, cycleId: Int, revision: Int) async throws -> CaptureCycleDTO {
+        fatalError("not used in PCO tests")
+    }
+    func stopCycle(token: String, uuid: String, cycleId: Int, revision: Int) async throws -> CaptureCycleDTO {
+        fatalError("not used in PCO tests")
+    }
+    func confirmDeviceStart(
+        token: String, uuid: String, cycleId: Int, sessionDeviceId: Int,
+        startedAt: String, cycleDeviceRevision: Int
+    ) async throws -> CaptureCycleDTO {
+        confirmStartCallCount += 1
+        return try confirmStartResult.get()
+    }
+    func confirmDeviceStop(
+        token: String, uuid: String, cycleId: Int, sessionDeviceId: Int,
+        stoppedAt: String, cycleDeviceRevision: Int
+    ) async throws -> CaptureCycleDTO {
+        fatalError("not used in PCO tests")
+    }
+}
+
+// MARK: — Helpers
+
+private let pcoTestSessionDeviceId = 42
+
+private func makePCOCycle(
+    id: Int = 1,
+    revision: Int = 2,
+    scheduledStartAt: String? = nil,
+    status: CycleStatus = .recordingPending,
+    deviceRecordingStatus: CycleDeviceRecordingStatus = .pending
+) -> CaptureCycleDTO {
+    let device = CaptureCycleDeviceDTO(
+        id: 1, captureCycleId: id, sessionDeviceId: pcoTestSessionDeviceId,
+        required: true, recordingStatus: deviceRecordingStatus,
+        startedAt: nil, stoppedAt: nil, failureReason: nil, revision: 1
+    )
+    return CaptureCycleDTO(
+        id: id, sessionId: 1, cycleIndex: 0, status: status, result: nil,
+        scheduledStartAt: scheduledStartAt,
+        recordingStartedAt: nil, stopRequestedAt: nil,
+        recordingStoppedAt: nil, completedAt: nil, failureReason: nil,
+        createdByParticipantId: 1, idempotencyKey: "pco-test-\(id)",
+        revision: revision,
+        createdAt: "2026-06-26T00:00:00Z",
+        updatedAt: "2026-06-26T00:00:00Z",
+        cycleDevices: [device]
+    )
+}
+
+private func futureISOForPCO(offsetSeconds: Double) -> String {
+    let fmt = ISO8601DateFormatter()
+    fmt.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return fmt.string(from: Date().addingTimeInterval(offsetSeconds))
+}
+
+private func pastISOForPCO(offsetSeconds: Double) -> String {
+    let fmt = ISO8601DateFormatter()
+    fmt.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return fmt.string(from: Date().addingTimeInterval(-offsetSeconds))
+}
+
+/// Synced ClockSyncService — adjustedServerTimeMs is non-nil and tracks real wall clock.
+private func makePCOSyncedClock() async -> ClockSyncService {
+    let nowMs = Int(Date().timeIntervalSince1970 * 1000)
+    let dto = ServerTimeDTO(
+        serverTimeUtc: "2026-06-26T00:00:00.000Z",
+        serverEpochMs: nowMs,
+        precision: "milliseconds",
+        source: "test"
+    )
+    let client = FakeSystemTimeAPIClient(responses: Array(repeating: .success(dto), count: 5))
+    let svc = ClockSyncService(
+        apiClient: client,
+        wallClockMs: { Date().timeIntervalSince1970 * 1000.0 },
+        monotonicClock: { CACurrentMediaTime() },
+        sampleCount: 1
+    )
+    _ = try? await svc.sync()
+    return svc
+}
+
+private func makePCOUnsyncedClock() -> ClockSyncService {
+    let err = NSError(domain: "test", code: -1)
+    let client = FakeSystemTimeAPIClient(responses: Array(repeating: .failure(err), count: 5))
+    return ClockSyncService(apiClient: client, sampleCount: 1)
+}
+
+// MARK: — PlayerCaptureOrchestratorTests
+
+@MainActor
+final class PlayerCaptureOrchestratorTests: XCTestCase {
+
+    private var fakeToken: FakePCOTokenProvider!
+    private var mockAPI: MockCycleAPIClientForPCO!
+    private var fakeCapture: FakeCaptureController!
+
+    override func setUp() {
+        super.setUp()
+        fakeToken   = FakePCOTokenProvider()
+        mockAPI     = MockCycleAPIClientForPCO()
+        fakeCapture = FakeCaptureController()
+    }
+
+    override func tearDown() {
+        fakeToken   = nil
+        mockAPI     = nil
+        fakeCapture = nil
+        super.tearDown()
+    }
+
+    private func makeOrchestrator(
+        clockService: ClockSyncService? = nil,
+        sleepProvider: @escaping (UInt64) async throws -> Void = { _ in }
+    ) -> PlayerCaptureOrchestrator {
+        PlayerCaptureOrchestrator(
+            authManager: fakeToken,
+            clockSyncService: clockService ?? makePCOUnsyncedClock(),
+            captureController: fakeCapture,
+            cycleAPIClient: mockAPI,
+            sleepProvider: sleepProvider
+        )
+    }
+
+    /// Creates an orchestrator with session context set via attach().
+    /// Returns both so ARC keeps the listener alive (orchestrator holds a weak ref).
+    private func makeAttachedOrchestrator(
+        clockService: ClockSyncService? = nil,
+        sleepProvider: @escaping (UInt64) async throws -> Void = { _ in }
+    ) -> (PlayerCaptureOrchestrator, PlayerCycleListener) {
+        let orch = makeOrchestrator(clockService: clockService, sleepProvider: sleepProvider)
+        let listener = PlayerCycleListener(
+            authManager: fakeToken,
+            cycleListClient: StubCycleListClient(),
+            pollingIntervalNs: 0,
+            sleepProvider: { _ in }
+        )
+        // attach() delivers current .idle state immediately → default: break, no side effects.
+        orch.attach(listener: listener, sessionUuid: "pco-test-session",
+                    playerSessionDeviceId: pcoTestSessionDeviceId)
+        return (orch, listener)
+    }
+
+    // PCO-01: Initial state is .idle.
+    func test_pco_01_initial_state_is_idle() {
+        let orch = makeOrchestrator()
+        XCTAssertEqual(orch.state, .idle)
+    }
+
+    // PCO-02: handleListenerState(.pendingCycleDetected) from .idle → .waitingForStart immediately.
+    func test_pco_02_pending_cycle_detected_transitions_to_waiting_for_start() async {
+        let clock = await makePCOSyncedClock()
+        let orch  = makeOrchestrator(clockService: clock)
+        let cycle = makePCOCycle(scheduledStartAt: futureISOForPCO(offsetSeconds: 60))
+        orch.handleListenerState(.pendingCycleDetected(cycleId: cycle.id), currentCycle: cycle)
+        XCTAssertEqual(orch.state, .waitingForStart(cycleId: cycle.id))
+    }
+
+    // PCO-03: Future scheduledStartAt → sleepProvider called with non-zero nanoseconds.
+    func test_pco_03_future_scheduled_start_calls_sleep_provider() async {
+        let clock = await makePCOSyncedClock()
+        var sleepCalledNs: UInt64 = 0
+        let orch = makeOrchestrator(clockService: clock, sleepProvider: { ns in
+            sleepCalledNs = ns
+        })
+        let cycle = makePCOCycle(scheduledStartAt: futureISOForPCO(offsetSeconds: 5))
+        orch.handleListenerState(.pendingCycleDetected(cycleId: cycle.id), currentCycle: cycle)
+
+        for _ in 0..<10 { await Task.yield() }
+
+        XCTAssertGreaterThan(sleepCalledNs, 0, "sleepProvider must be called for a future scheduledStartAt")
+    }
+
+    // PCO-04: scheduledStartAt within tolerance (lag ≤ 2000ms) → sleepProvider NOT called.
+    func test_pco_04_within_tolerance_starts_without_sleep() async {
+        let clock = await makePCOSyncedClock()
+        var sleepCalled = false
+        let orch = makeOrchestrator(clockService: clock, sleepProvider: { _ in sleepCalled = true })
+        // 0.5s ago → lag ≈ 500ms < 2000ms tolerance
+        let cycle = makePCOCycle(scheduledStartAt: pastISOForPCO(offsetSeconds: 0.5))
+        orch.handleListenerState(.pendingCycleDetected(cycleId: cycle.id), currentCycle: cycle)
+
+        for _ in 0..<10 { await Task.yield() }
+
+        XCTAssertFalse(sleepCalled, "sleepProvider must NOT be called within the tolerance window")
+    }
+
+    // PCO-05: Clock not synced → .failed containing "clockSyncRequired".
+    func test_pco_05_unsynced_clock_causes_failure() async {
+        let orch  = makeOrchestrator(clockService: makePCOUnsyncedClock())
+        let cycle = makePCOCycle(scheduledStartAt: futureISOForPCO(offsetSeconds: 10))
+        orch.handleListenerState(.pendingCycleDetected(cycleId: cycle.id), currentCycle: cycle)
+
+        for _ in 0..<10 { await Task.yield() }
+
+        guard case .failed(let msg) = orch.state else {
+            return XCTFail("Expected .failed but got \(orch.state)")
+        }
+        XCTAssertTrue(msg.contains("clockSyncRequired"), "Got: \(msg)")
+    }
+
+    // PCO-06: scheduledStartAt expired beyond 2000ms tolerance → .failed containing "cycleExpired".
+    func test_pco_06_expired_cycle_causes_failure() async {
+        let clock = await makePCOSyncedClock()
+        let orch  = makeOrchestrator(clockService: clock)
+        // 5s ago → lag ≈ 5000ms > 2000ms tolerance
+        let cycle = makePCOCycle(scheduledStartAt: pastISOForPCO(offsetSeconds: 5))
+        orch.handleListenerState(.pendingCycleDetected(cycleId: cycle.id), currentCycle: cycle)
+
+        for _ in 0..<10 { await Task.yield() }
+
+        guard case .failed(let msg) = orch.state else {
+            return XCTFail("Expected .failed but got \(orch.state)")
+        }
+        XCTAssertTrue(msg.contains("cycleExpired"), "Got: \(msg)")
+    }
+
+    // PCO-07: nil scheduledStartAt → .failed containing "scheduledStartAtMissing".
+    func test_pco_07_nil_scheduled_start_at_causes_failure() async {
+        let clock = await makePCOSyncedClock()
+        let orch  = makeOrchestrator(clockService: clock)
+        let cycle = makePCOCycle(scheduledStartAt: nil)
+        orch.handleListenerState(.pendingCycleDetected(cycleId: cycle.id), currentCycle: cycle)
+
+        for _ in 0..<10 { await Task.yield() }
+
+        guard case .failed(let msg) = orch.state else {
+            return XCTFail("Expected .failed but got \(orch.state)")
+        }
+        XCTAssertTrue(msg.contains("scheduledStartAtMissing"), "Got: \(msg)")
+    }
+
+    // PCO-08: Successful wait → captureController.startCapture() called once.
+    func test_pco_08_start_capture_called_after_scheduled_wait() async {
+        let clock = await makePCOSyncedClock()
+        let orch  = makeOrchestrator(clockService: clock)
+        // Within tolerance — no sleep, proceeds immediately
+        let cycle = makePCOCycle(scheduledStartAt: pastISOForPCO(offsetSeconds: 0.5))
+        orch.handleListenerState(.pendingCycleDetected(cycleId: cycle.id), currentCycle: cycle)
+
+        for _ in 0..<10 { await Task.yield() }
+
+        XCTAssertEqual(fakeCapture.startCallCount, 1, "startCapture() must be called once after the scheduled wait")
+    }
+
+    // PCO-09: captureStatePublisher .capturing → confirmDeviceStart called → state .confirmed.
+    func test_pco_09_capture_started_triggers_confirm_and_confirmed_state() async {
+        let clock = await makePCOSyncedClock()
+        let (orch, _listener) = makeAttachedOrchestrator(clockService: clock)
+        let cycle = makePCOCycle(scheduledStartAt: pastISOForPCO(offsetSeconds: 0.5))
+        orch.handleListenerState(.pendingCycleDetected(cycleId: cycle.id), currentCycle: cycle)
+
+        // Let: wait → subscribeToCaptureState → startCapture → .capturing sink → confirmDeviceStart
+        for _ in 0..<20 { await Task.yield() }
+
+        XCTAssertEqual(mockAPI.confirmStartCallCount, 1, "confirmDeviceStart must be called once")
+        XCTAssertEqual(orch.state, .confirmed(cycleId: cycle.id))
+    }
+
+    // PCO-10: confirmDeviceStart API error → state .failed.
+    func test_pco_10_confirm_start_api_error_causes_failure() async {
+        let clock = await makePCOSyncedClock()
+        let err   = NSError(domain: "test", code: 500, userInfo: [NSLocalizedDescriptionKey: "server error"])
+        mockAPI.confirmStartResult = .failure(err)
+
+        let (orch, _listener) = makeAttachedOrchestrator(clockService: clock)
+        let cycle = makePCOCycle(scheduledStartAt: pastISOForPCO(offsetSeconds: 0.5))
+        orch.handleListenerState(.pendingCycleDetected(cycleId: cycle.id), currentCycle: cycle)
+
+        for _ in 0..<20 { await Task.yield() }
+
+        guard case .failed = orch.state else {
+            return XCTFail("Expected .failed but got \(orch.state)")
+        }
+    }
+
+    // PCO-11: .recordingDetected late-join → startCapture() without sleep → state .confirmed.
+    func test_pco_11_recording_detected_starts_capture_immediately_no_sleep() async {
+        let clock = await makePCOSyncedClock()
+        var sleepCalled = false
+        let (orch, _listener) = makeAttachedOrchestrator(
+            clockService: clock,
+            sleepProvider: { _ in sleepCalled = true }
+        )
+        // Late-join: cycle already in .recording; immediate = true skips scheduledStartAt entirely
+        let cycle = makePCOCycle(scheduledStartAt: nil, status: .recording)
+        orch.handleListenerState(.recordingDetected(cycleId: cycle.id), currentCycle: cycle)
+
+        for _ in 0..<20 { await Task.yield() }
+
+        XCTAssertFalse(sleepCalled, "sleepProvider must NOT be called for .recordingDetected late-join")
+        XCTAssertEqual(fakeCapture.startCallCount, 1, "startCapture() must be called once")
+        XCTAssertEqual(mockAPI.confirmStartCallCount, 1, "confirmDeviceStart must be called once")
+        XCTAssertEqual(orch.state, .confirmed(cycleId: cycle.id))
+    }
+
+    // PCO-12: reset() cancels in-flight task and returns state to .idle.
+    func test_pco_12_reset_returns_to_idle_and_cancels_task() async {
+        let clock = await makePCOSyncedClock()
+        var sleepCompleted = false
+        let orch = makeOrchestrator(clockService: clock, sleepProvider: { ns in
+            try await Task.sleep(nanoseconds: ns)  // real sleep so we can cancel it
+            sleepCompleted = true
+        })
+        // Future cycle → will be sleeping when we reset
+        let cycle = makePCOCycle(scheduledStartAt: futureISOForPCO(offsetSeconds: 60))
+        orch.handleListenerState(.pendingCycleDetected(cycleId: cycle.id), currentCycle: cycle)
+        await Task.yield()
+
+        orch.reset()
+
+        XCTAssertEqual(orch.state, .idle)
+        for _ in 0..<5 { await Task.yield() }
+        XCTAssertFalse(sleepCompleted, "Cancelled sleep must not complete after reset()")
+    }
+
+    // PCO-13: Second .pendingCycleDetected while state != .idle → ignored; one capture+confirm only.
+    func test_pco_13_duplicate_pending_cycle_no_second_task() async {
+        let clock = await makePCOSyncedClock()
+        let (orch, _listener) = makeAttachedOrchestrator(clockService: clock)
+        let cycle = makePCOCycle(scheduledStartAt: pastISOForPCO(offsetSeconds: 0.5))
+
+        orch.handleListenerState(.pendingCycleDetected(cycleId: cycle.id), currentCycle: cycle)
+        // State is now .waitingForStart → second trigger is blocked by idle guard
+        orch.handleListenerState(.pendingCycleDetected(cycleId: cycle.id), currentCycle: cycle)
+
+        for _ in 0..<20 { await Task.yield() }
+
+        XCTAssertEqual(fakeCapture.startCallCount, 1, "startCapture must be called exactly once")
+        XCTAssertEqual(mockAPI.confirmStartCallCount, 1, "confirmDeviceStart must be called exactly once")
+    }
+
+    // PCO-14: cycleDevice already .confirmedStart → confirmDeviceStart API skipped → state .confirmed.
+    func test_pco_14_already_confirmed_device_skips_api_call() async {
+        let clock = await makePCOSyncedClock()
+        let (orch, _listener) = makeAttachedOrchestrator(clockService: clock)
+        let cycle = makePCOCycle(
+            scheduledStartAt: pastISOForPCO(offsetSeconds: 0.5),
+            deviceRecordingStatus: .confirmedStart
+        )
+        orch.handleListenerState(.pendingCycleDetected(cycleId: cycle.id), currentCycle: cycle)
+
+        for _ in 0..<20 { await Task.yield() }
+
+        XCTAssertEqual(mockAPI.confirmStartCallCount, 0,
+                       "confirmDeviceStart must NOT be called when device is already confirmedStart")
+        XCTAssertEqual(orch.state, .confirmed(cycleId: cycle.id))
+    }
+}


### PR DESCRIPTION
## Summary

- **PlayerCaptureOrchestrator** (`@MainActor`): player-side analog to `CycleCaptureOrchestrator`; subscribes to `PlayerCycleListener.$state` after `autoRegisterDevice` completes; `@Published.sink` immediate delivery handles late-attach without separate state read
- **`.pendingCycleDetected`** path: `waitForScheduledStart` (2000ms tolerance, ClockSync) → `startCapture()` → `confirmDeviceStart`
- **`.recordingDetected` late-join** (in scope per ORCH-3B decision B): immediate `startCapture()` without scheduled wait; `confirmDeviceStart` after `.capturing`
- **Duplicate guard**: `handledCycleIds` set + `cycleDevices[].recordingStatus == .confirmedStart` check prevents double-confirm
- **`PlayerCycleListener`**: adds `currentCycle: CaptureCycleDTO?` property (set in `classify()`); enables orchestrator to read active cycle without extra API call
- **`MultiCameraSessionViewModel`**: wires orchestrator via `attach()` after device registers → ready
- **`MultiCameraLobbyView`**: `player_orch` debug snapshot row, fingerprint `mc1-debug-v6-2026-06-26`

## Test plan

- [x] PCO-01..PCO-14: 14/14 PASS (idle, pendingCycle→waitingForStart, sleep call, tolerance, clockSync fail, expired fail, nil scheduledStartAt, startCapture call, confirm→confirmed, API error, recordingDetected no-sleep, reset, duplicate guard, already-confirmed skip)
- [x] PCL-01..PCL-12: 12/12 PASS (regression)
- [x] CYC-O-01..23: 23/23 PASS (regression)
- [x] IDK-01..05: 5/5 PASS (regression)
- [x] BUILD SUCCEEDED (iOS Simulator, iPhone 16, iOS 18.1)
- [ ] CI: iOS Build + Unit Tests
- [ ] CI: MC1 ORCH-2B E2E (16-step, includes player confirmDeviceStart Step 12)
- [ ] CI: Load Gate
- [ ] CI: Cypress

## Scope boundary

Out of scope (ORCH-3B explicit exclusions): stop detection, `stopCapture()`, `confirmDeviceStop`, upload pipeline, GoPro, session finalize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)