### PR TITLE
feat(mc1-ios-orch4): capture authority — device_role auto-assign, isController gate, non-controller auto-prepare

### DIFF
--- a/app/services/multicamera/session_service.py
+++ b/app/services/multicamera/session_service.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session
 
 from app.models.multicamera_session import (
     SESSION_TRANSITIONS, DEVICE_TRANSITIONS,
-    DeviceRole, DeviceStatus, SessionStatus,
+    DeviceRole, DeviceStatus, ParticipantRole, SessionStatus,
     MultiCameraSession, SessionDevice, SessionParticipant,
 )
 from app.repositories.multicamera_session_repo import MultiCameraSessionRepo
@@ -87,6 +87,9 @@ class SessionService:
         count = self.repo.count_active_devices(s.id)
         if count >= s.max_devices:
             raise SessionFullError("devices", count, s.max_devices)
+
+        # Backend decides the authoritative device_role; client hint is overridden.
+        device_role = self._resolve_device_role(s, device_role, participant_id)
 
         self._validate_device_role_invariants(s, device_role, participant_id, managed_by_device_id)
 
@@ -265,6 +268,49 @@ class SessionService:
         if started_at is None and stopped_at is None and capture_result is None:
             return False
         return True
+
+    def _resolve_device_role(
+        self,
+        session: MultiCameraSession,
+        requested_role: str,
+        participant_id: Optional[int],
+    ) -> str:
+        """Override the client-supplied device_role with the authoritative backend assignment.
+
+        Rules:
+          - no participant → passthrough client hint unchanged
+          - auxiliary_camera requested → passthrough unchanged (invariant validation handles participant_id rejection)
+          - instructor participant → always instructor_primary
+          - player participant, no player_primary in session yet → player_primary
+          - player participant, player_primary already exists → player_secondary
+        """
+        if participant_id is None:
+            return requested_role
+        if requested_role == DeviceRole.AUXILIARY_CAMERA.value:
+            return requested_role
+
+        participant = self.db.query(SessionParticipant).filter(
+            SessionParticipant.id == participant_id
+        ).first()
+        if not participant:
+            return requested_role
+
+        try:
+            p_role = ParticipantRole(participant.role)
+        except ValueError:
+            return requested_role
+
+        if p_role == ParticipantRole.INSTRUCTOR:
+            return DeviceRole.INSTRUCTOR_PRIMARY.value
+
+        if p_role == ParticipantRole.PLAYER:
+            has_primary = any(
+                d.device_role == DeviceRole.PLAYER_PRIMARY.value and d.removed_at is None
+                for d in session.devices
+            )
+            return DeviceRole.PLAYER_PRIMARY.value if not has_primary else DeviceRole.PLAYER_SECONDARY.value
+
+        return requested_role
 
     def _require_session(self, session_uuid: uuid.UUID) -> MultiCameraSession:
         s = self.repo.get_session_by_uuid(session_uuid)

--- a/ios/LFAEducationCenter.xcodeproj/project.pbxproj
+++ b/ios/LFAEducationCenter.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		DI500004000000000000001 /* DeviceIdentityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DI500003000000000000001 /* DeviceIdentityTests.swift */; };
 		CS500004000000000000001 /* ClockSyncServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CS500003000000000000001 /* ClockSyncServiceTests.swift */; };
 		06881AF7704345FF9DCED8DD /* CaptureCycleContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16BA790BA9964D4A9E64F6E3 /* CaptureCycleContractTests.swift */; };
+		CA500004000000000000001 /* CaptureAuthorityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA500003000000000000001 /* CaptureAuthorityTests.swift */; };
 		942FE944E7544114B645BB37 /* MultiCameraSessionViewModelClockSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7923EAF385B2497998AA5258 /* MultiCameraSessionViewModelClockSyncTests.swift */; };
 		GP000004000000000000005 /* GoProConnectionDebugView.swift in Sources */ = {isa = PBXBuildFile; fileRef = GP000003000000000000005 /* GoProConnectionDebugView.swift */; };
 		GP000004000000000000006 /* CoreBluetoothBLETransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = GP000003000000000000006 /* CoreBluetoothBLETransport.swift */; };
@@ -305,6 +306,7 @@
 		DI500003000000000000001 /* DeviceIdentityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceIdentityTests.swift; sourceTree = "<group>"; };
 		CS500003000000000000001 /* ClockSyncServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClockSyncServiceTests.swift; sourceTree = "<group>"; };
 		16BA790BA9964D4A9E64F6E3 /* CaptureCycleContractTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureCycleContractTests.swift; sourceTree = "<group>"; };
+		CA500003000000000000001 /* CaptureAuthorityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureAuthorityTests.swift; sourceTree = "<group>"; };
 		7923EAF385B2497998AA5258 /* MultiCameraSessionViewModelClockSyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiCameraSessionViewModelClockSyncTests.swift; sourceTree = "<group>"; };
 		MC500003000000000000002 /* session_full.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; name = "session_full.json"; path = "../tests/fixtures/multicamera/session_full.json"; sourceTree = SOURCE_ROOT; };
 		CYC00003000000000000001 /* cycle_full.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; name = "cycle_full.json"; path = "../tests/fixtures/multicamera/cycle_full.json"; sourceTree = SOURCE_ROOT; };
@@ -1030,6 +1032,7 @@
 				CS500003000000000000001 /* ClockSyncServiceTests.swift */,
 				7923EAF385B2497998AA5258 /* MultiCameraSessionViewModelClockSyncTests.swift */,
 				16BA790BA9964D4A9E64F6E3 /* CaptureCycleContractTests.swift */,
+				CA500003000000000000001 /* CaptureAuthorityTests.swift */,
 				OR500003000000000000001 /* FakeCaptureController.swift */,
 				OR500003000000000000002 /* CycleIdempotencyKeyTests.swift */,
 				OR500003000000000000003 /* CycleCaptureOrchestratorTests.swift */,
@@ -1399,6 +1402,7 @@
 				CS500004000000000000001 /* ClockSyncServiceTests.swift in Sources */,
 				942FE944E7544114B645BB37 /* MultiCameraSessionViewModelClockSyncTests.swift in Sources */,
 				06881AF7704345FF9DCED8DD /* CaptureCycleContractTests.swift in Sources */,
+				CA500004000000000000001 /* CaptureAuthorityTests.swift in Sources */,
 				OR500004000000000000001 /* FakeCaptureController.swift in Sources */,
 				OR500004000000000000002 /* CycleIdempotencyKeyTests.swift in Sources */,
 				OR500004000000000000003 /* CycleCaptureOrchestratorTests.swift in Sources */,

--- a/ios/LFAEducationCenter/MultiCamera/MultiCameraLobbyView.swift
+++ b/ios/LFAEducationCenter/MultiCamera/MultiCameraLobbyView.swift
@@ -1,5 +1,5 @@
 import SwiftUI
-// Repo: football-investment → footballinvestmentkft (2026-06-26); ORCH-3C player stop
+// ORCH-4: capture authority — device_role auto-assignment, isController gate, non-controller auto-prepare
 
 #if DEBUG
 struct MultiCameraLobbyView: View {
@@ -38,11 +38,12 @@ struct MultiCameraLobbyView: View {
             clockSyncService: clockSync,
             cycleOrchestrator: orch,
             playerCycleListener: listener,
-            playerCaptureOrchestrator: playerOrch
+            playerCaptureOrchestrator: playerOrch,
+            capturePreparable: captureMgr
         ))
     }
 
-    private static let buildFingerprint = "mc1-debug-v9-2026-06-26"
+    private static let buildFingerprint = "mc1-debug-v9-2026-06-27"
 
     var body: some View {
         NavigationView {
@@ -200,12 +201,12 @@ struct MultiCameraLobbyView: View {
                     }
                     .disabled(captureManager.state == .requestingPermissions)
                 }
-                if vm.canStartCapture && captureManager.state == .ready {
+                if vm.isController && vm.canStartCapture && captureManager.state == .ready {
                     Button("Begin Cycle") { vm.beginCycle() }
                         .font(.body.weight(.semibold))
                         .foregroundColor(.blue)
                 }
-                if case .capturing = orchestrator.state {
+                if vm.isController, case .capturing = orchestrator.state {
                     Button("End Cycle") { vm.endCycle() }
                         .font(.body.weight(.semibold))
                         .foregroundColor(.orange)
@@ -283,6 +284,8 @@ struct MultiCameraLobbyView: View {
             LabeledRow("Participants", "\(session.participants.count)/\(session.maxParticipants)")
             LabeledRow("Devices", "\(session.devices.count)/\(session.maxDevices)")
             LabeledRow("Device ID", vm.sessionDeviceId.map { "\($0)" } ?? "—")
+            LabeledRow("DeviceRole", vm.myDeviceRole?.rawValue ?? "—")
+            LabeledRow("IsController", vm.isController ? "yes" : "no")
             LabeledRow("Heartbeat", vm.sessionDeviceId != nil ? "Active" : "—")
             LabeledRow("Clock", clockSyncDescription)
             LabeledRow("Capture", captureStateDescription)
@@ -335,6 +338,8 @@ struct MultiCameraLobbyView: View {
             "participants: \(session.participants.count)/\(session.maxParticipants)",
             "devices: \(session.devices.count)/\(session.maxDevices)",
             "session_device_id: \(vm.sessionDeviceId.map { "\($0)" } ?? "—")",
+            "device_role: \(vm.myDeviceRole?.rawValue ?? "—")",
+            "is_controller: \(vm.isController ? "yes" : "no")",
             "heartbeat: \(vm.sessionDeviceId != nil ? "active" : "—")",
             "clock: \(clockSyncDescription)",
             "capture: \(captureStateDescription)",

--- a/ios/LFAEducationCenter/MultiCamera/MultiCameraSessionViewModel.swift
+++ b/ios/LFAEducationCenter/MultiCamera/MultiCameraSessionViewModel.swift
@@ -48,6 +48,7 @@ final class MultiCameraSessionViewModel: ObservableObject {
     private let cycleOrchestrator: CycleCaptureOrchestrator?
     private let playerCycleListener: PlayerCycleListener?
     private let playerCaptureOrchestrator: PlayerCaptureOrchestrator?
+    private let capturePreparable: (any CapturePreparable)?
 
     init(
         authManager: AuthManager,
@@ -56,7 +57,8 @@ final class MultiCameraSessionViewModel: ObservableObject {
         heartbeatIntervalSeconds: Double = 5.0,
         cycleOrchestrator: CycleCaptureOrchestrator? = nil,
         playerCycleListener: PlayerCycleListener? = nil,
-        playerCaptureOrchestrator: PlayerCaptureOrchestrator? = nil
+        playerCaptureOrchestrator: PlayerCaptureOrchestrator? = nil,
+        capturePreparable: (any CapturePreparable)? = nil
     ) {
         self.authManager = authManager
         self.clockSyncService = clockSyncService
@@ -65,6 +67,7 @@ final class MultiCameraSessionViewModel: ObservableObject {
         self.cycleOrchestrator = cycleOrchestrator
         self.playerCycleListener = playerCycleListener
         self.playerCaptureOrchestrator = playerCaptureOrchestrator
+        self.capturePreparable = capturePreparable
     }
 
     deinit {
@@ -167,7 +170,8 @@ final class MultiCameraSessionViewModel: ObservableObject {
     }
 
     func beginCycle() {
-        guard canStartCapture,
+        guard isController,
+              canStartCapture,
               case .inLobby(let session) = state,
               let sdId = sessionDeviceId else { return }
         cycleOrchestrator?.startCycle(
@@ -178,7 +182,7 @@ final class MultiCameraSessionViewModel: ObservableObject {
     }
 
     func endCycle() {
-        guard sessionUuid != nil else { return }
+        guard isController, sessionUuid != nil else { return }
         Task { await cycleOrchestrator?.stopCycle() }
     }
 
@@ -213,6 +217,9 @@ final class MultiCameraSessionViewModel: ObservableObject {
             print("[LobbyVM] autoRegisterDevice: device \(sd.id) → ready")
             if let listener = playerCycleListener, let orch = playerCaptureOrchestrator {
                 orch.attach(listener: listener, sessionUuid: sessionUuid, playerSessionDeviceId: sd.id)
+            }
+            if sd.deviceRole != .instructorPrimary && sd.deviceRole != .playerPrimary {
+                await capturePreparable?.autoPrepare(sessionUUID: sessionUuid, deviceId: sd.id)
             }
         } catch {
             deviceRegisterError = "\(error)"
@@ -305,6 +312,28 @@ final class MultiCameraSessionViewModel: ObservableObject {
         guard case .inLobby = state else { return false }
         guard isClockSynced else { return false }
         return true
+    }
+
+    // MARK: — Capture authority
+
+    static func resolveDeviceRole(state: LobbyState, sessionDeviceId: Int?) -> MCDeviceRole? {
+        guard case .inLobby(let session) = state, let sdId = sessionDeviceId else { return nil }
+        return session.devices.first { $0.id == sdId && $0.removedAt == nil }?.deviceRole
+    }
+
+    static func resolveIsController(role: MCDeviceRole?) -> Bool {
+        switch role {
+        case .instructorPrimary, .playerPrimary: return true
+        default: return false
+        }
+    }
+
+    var myDeviceRole: MCDeviceRole? {
+        Self.resolveDeviceRole(state: state, sessionDeviceId: sessionDeviceId)
+    }
+
+    var isController: Bool {
+        Self.resolveIsController(role: myDeviceRole)
     }
 
     // MARK: — Helpers

--- a/ios/LFAEducationCenter/MultiCamera/SessionCaptureManager.swift
+++ b/ios/LFAEducationCenter/MultiCamera/SessionCaptureManager.swift
@@ -2,6 +2,11 @@ import AVFoundation
 import Combine
 import UIKit
 
+@MainActor
+protocol CapturePreparable: AnyObject {
+    func autoPrepare(sessionUUID: String, deviceId: Int) async
+}
+
 enum CaptureState: Equatable {
     case idle
     case requestingPermissions
@@ -304,6 +309,17 @@ final class SessionCaptureManager: NSObject, ObservableObject {
 extension SessionCaptureManager: CaptureController {
     var captureStatePublisher: AnyPublisher<CaptureState, Never> {
         $state.eraseToAnyPublisher()
+    }
+}
+
+// MARK: — CapturePreparable
+
+extension SessionCaptureManager: CapturePreparable {
+    func autoPrepare(sessionUUID: String, deviceId: Int) async {
+        guard state == .idle else { return }
+        await requestPermissions()
+        guard case .configuring = state else { return }
+        prepare(sessionUUID: sessionUUID, deviceId: deviceId)
     }
 }
 

--- a/ios/LFAEducationCenterTests/MultiCamera/CaptureAuthorityTests.swift
+++ b/ios/LFAEducationCenterTests/MultiCamera/CaptureAuthorityTests.swift
@@ -1,0 +1,125 @@
+@testable import LFAEducationCenter
+import XCTest
+
+// MARK: — ORCH-4 Capture Authority: CTL-01..08
+// Tests for myDeviceRole + isController logic via static helpers on MultiCameraSessionViewModel.
+// Calls MultiCameraSessionViewModel.resolveDeviceRole / resolveIsController directly so no
+// network or AVFoundation is touched.
+
+@MainActor
+final class CaptureAuthorityTests: XCTestCase {
+
+    // MARK: — Helpers
+
+    private func makeDevice(
+        id: Int,
+        role: MCDeviceRole,
+        removedAt: String? = nil
+    ) -> SessionDeviceDTO {
+        SessionDeviceDTO(
+            id: id, sessionId: 1, deviceId: id + 100,
+            participantId: nil, managedByDeviceId: nil,
+            deviceRole: role, status: .ready,
+            revision: 1, lastHeartbeat: nil,
+            registeredAt: "2026-06-27T00:00:00Z", removedAt: removedAt
+        )
+    }
+
+    private func makeSession(devices: [SessionDeviceDTO]) -> MultiCameraSessionDTO {
+        MultiCameraSessionDTO(
+            id: 1, sessionUuid: "ctl-test-uuid", status: .lobby,
+            createdByUserId: 1, maxParticipants: 4, maxDevices: 8,
+            revision: 1, calibration: nil, scheduledStartAt: nil,
+            createdAt: "2026-06-27T00:00:00Z", startedAt: nil,
+            stoppedAt: nil, finalizedAt: nil, cancelledAt: nil,
+            participants: [], devices: devices, streams: []
+        )
+    }
+
+    private func inLobby(devices: [SessionDeviceDTO]) -> LobbyState {
+        .inLobby(session: makeSession(devices: devices))
+    }
+
+    // MARK: — CTL-01: resolveDeviceRole returns nil when not inLobby
+
+    func test_CTL_01_resolveDeviceRole_nil_whenIdle() {
+        let result = MultiCameraSessionViewModel.resolveDeviceRole(state: .idle, sessionDeviceId: 1)
+        XCTAssertNil(result, "CTL-01: must be nil in .idle state")
+    }
+
+    // MARK: — CTL-02: resolveDeviceRole returns nil when sessionDeviceId is nil
+
+    func test_CTL_02_resolveDeviceRole_nil_whenNoDeviceId() {
+        let state = inLobby(devices: [makeDevice(id: 1, role: .playerPrimary)])
+        let result = MultiCameraSessionViewModel.resolveDeviceRole(state: state, sessionDeviceId: nil)
+        XCTAssertNil(result, "CTL-02: must be nil when sessionDeviceId is nil")
+    }
+
+    // MARK: — CTL-03: resolveDeviceRole returns correct role for the matching device
+
+    func test_CTL_03_resolveDeviceRole_returnsRole_forMatchingDevice() {
+        let state = inLobby(devices: [
+            makeDevice(id: 1, role: .playerPrimary),
+            makeDevice(id: 2, role: .playerSecondary),
+            makeDevice(id: 3, role: .instructorPrimary),
+        ])
+        XCTAssertEqual(
+            MultiCameraSessionViewModel.resolveDeviceRole(state: state, sessionDeviceId: 1),
+            .playerPrimary, "CTL-03a"
+        )
+        XCTAssertEqual(
+            MultiCameraSessionViewModel.resolveDeviceRole(state: state, sessionDeviceId: 2),
+            .playerSecondary, "CTL-03b"
+        )
+        XCTAssertEqual(
+            MultiCameraSessionViewModel.resolveDeviceRole(state: state, sessionDeviceId: 3),
+            .instructorPrimary, "CTL-03c"
+        )
+    }
+
+    // MARK: — CTL-04: resolveDeviceRole returns nil for a removed device
+
+    func test_CTL_04_resolveDeviceRole_nil_forRemovedDevice() {
+        let state = inLobby(devices: [
+            makeDevice(id: 1, role: .playerPrimary, removedAt: "2026-06-27T01:00:00Z"),
+        ])
+        let result = MultiCameraSessionViewModel.resolveDeviceRole(state: state, sessionDeviceId: 1)
+        XCTAssertNil(result, "CTL-04: removed device must not be returned")
+    }
+
+    // MARK: — CTL-05: isController is true for instructorPrimary
+
+    func test_CTL_05_isController_trueFor_instructorPrimary() {
+        XCTAssertTrue(
+            MultiCameraSessionViewModel.resolveIsController(role: .instructorPrimary),
+            "CTL-05: instructorPrimary must be a controller"
+        )
+    }
+
+    // MARK: — CTL-06: isController is true for playerPrimary
+
+    func test_CTL_06_isController_trueFor_playerPrimary() {
+        XCTAssertTrue(
+            MultiCameraSessionViewModel.resolveIsController(role: .playerPrimary),
+            "CTL-06: playerPrimary must be a controller"
+        )
+    }
+
+    // MARK: — CTL-07: isController is false for playerSecondary
+
+    func test_CTL_07_isController_falseFor_playerSecondary() {
+        XCTAssertFalse(
+            MultiCameraSessionViewModel.resolveIsController(role: .playerSecondary),
+            "CTL-07: playerSecondary must NOT be a controller"
+        )
+    }
+
+    // MARK: — CTL-08: isController is false for auxiliaryCamera
+
+    func test_CTL_08_isController_falseFor_auxiliaryCamera() {
+        XCTAssertFalse(
+            MultiCameraSessionViewModel.resolveIsController(role: .auxiliaryCamera),
+            "CTL-08: auxiliaryCamera must NOT be a controller"
+        )
+    }
+}

--- a/tests/unit/multicamera/test_device_role_auto_assignment.py
+++ b/tests/unit/multicamera/test_device_role_auto_assignment.py
@@ -1,0 +1,330 @@
+"""ORCH-4 — Device Role Auto-Assignment + CA-E2E tests.
+
+DRA-01..07: Backend _resolve_device_role logic.
+CA-E2E-01..04: Full API flow — instructor + multi-player sessions.
+"""
+import uuid as _uuid
+import pytest
+from fastapi.testclient import TestClient
+from app.main import app
+from app.database import SessionLocal
+from app.models.user import User, UserRole
+
+client = TestClient(app)
+
+
+@pytest.fixture()
+def db():
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.rollback()
+        session.close()
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+def _create_user(db, role=UserRole.INSTRUCTOR):
+    tag = _uuid.uuid4().hex[:8]
+    u = User(
+        name=f"DRA-{tag}", email=f"dra-{tag}@test.com",
+        password_hash="x", role=role, is_active=True,
+    )
+    db.add(u)
+    db.commit()
+    db.refresh(u)
+    return u
+
+
+def _auth(user):
+    from app.core.auth import create_access_token
+    token = create_access_token(data={"sub": user.email})
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _create_session(headers):
+    r = client.post(
+        "/api/v1/multicamera/sessions",
+        json={"max_participants": 4, "max_devices": 8},
+        headers=headers,
+    )
+    assert r.status_code == 201
+    return r.json()
+
+
+def _join_session(session_uuid, headers, role="player"):
+    r = client.post(
+        f"/api/v1/multicamera/sessions/{session_uuid}/join",
+        json={"role": role},
+        headers=headers,
+    )
+    assert r.status_code in (200, 201), f"join_session failed: {r.status_code} {r.text}"
+    return r.json()
+
+
+def _get_session(session_uuid, headers):
+    r = client.get(f"/api/v1/multicamera/sessions/{session_uuid}", headers=headers)
+    assert r.status_code == 200
+    return r.json()
+
+
+def _register_device(session_uuid, headers, participant_id, hint_role="player_primary"):
+    """Register a device with given role hint; returns the SessionDeviceDTO."""
+    dev_uuid = str(_uuid.uuid4())
+    r = client.post(
+        f"/api/v1/multicamera/sessions/{session_uuid}/devices",
+        json={
+            "device_uuid": dev_uuid,
+            "device_type": "iphone",
+            "device_name": f"Test-{dev_uuid[:6]}",
+            "device_role": hint_role,
+            "participant_id": participant_id,
+        },
+        headers=headers,
+    )
+    assert r.status_code == 201, f"register_device failed: {r.status_code} {r.text}"
+    return r.json()
+
+
+# ── DRA: Device Role Auto-Assignment unit-style API tests ────────────────────
+
+class TestDeviceRoleAutoAssignment:
+
+    def test_dra_01_instructor_device_gets_instructor_primary(self, db):
+        """Instructor participant → always instructor_primary regardless of hint."""
+        instructor = _create_user(db, UserRole.INSTRUCTOR)
+        session = _create_session(_auth(instructor))
+        uuid = session["session_uuid"]
+        participant_id = session["participants"][0]["id"]
+
+        sd = _register_device(uuid, _auth(instructor), participant_id, hint_role="player_primary")
+        assert sd["device_role"] == "instructor_primary", (
+            f"Expected instructor_primary, got {sd['device_role']}"
+        )
+
+    def test_dra_02_first_player_gets_player_primary(self, db):
+        """First player device → player_primary."""
+        instructor = _create_user(db, UserRole.INSTRUCTOR)
+        player = _create_user(db, UserRole.STUDENT)
+        session = _create_session(_auth(instructor))
+        uuid = session["session_uuid"]
+
+        p = _join_session(uuid, _auth(player), role="player")
+        sd = _register_device(uuid, _auth(player), p["id"], hint_role="player_primary")
+        assert sd["device_role"] == "player_primary"
+
+    def test_dra_03_second_player_gets_player_secondary(self, db):
+        """Second player device → player_secondary even if client sends player_primary."""
+        instructor = _create_user(db, UserRole.INSTRUCTOR)
+        p1_user = _create_user(db, UserRole.STUDENT)
+        p2_user = _create_user(db, UserRole.STUDENT)
+        session = _create_session(_auth(instructor))
+        uuid = session["session_uuid"]
+
+        p1 = _join_session(uuid, _auth(p1_user), role="player")
+        _register_device(uuid, _auth(p1_user), p1["id"], hint_role="player_primary")
+
+        p2 = _join_session(uuid, _auth(p2_user), role="player")
+        sd2 = _register_device(uuid, _auth(p2_user), p2["id"], hint_role="player_primary")
+        assert sd2["device_role"] == "player_secondary", (
+            f"Expected player_secondary, got {sd2['device_role']}"
+        )
+
+    def test_dra_04_third_player_gets_player_secondary(self, db):
+        """Third player device → player_secondary."""
+        instructor = _create_user(db, UserRole.INSTRUCTOR)
+        session = _create_session(_auth(instructor))
+        uuid = session["session_uuid"]
+
+        players = [_create_user(db, UserRole.STUDENT) for _ in range(3)]
+        for i, pu in enumerate(players):
+            p = _join_session(uuid, _auth(pu), role="player")
+            sd = _register_device(uuid, _auth(pu), p["id"])
+            if i == 0:
+                assert sd["device_role"] == "player_primary"
+            else:
+                assert sd["device_role"] == "player_secondary", (
+                    f"Player {i+1}: expected player_secondary, got {sd['device_role']}"
+                )
+
+    def test_dra_05_player_gets_primary_even_when_instructor_present(self, db):
+        """Player device registers in instructor-present session → still player_primary (first player)."""
+        instructor = _create_user(db, UserRole.INSTRUCTOR)
+        player = _create_user(db, UserRole.STUDENT)
+        session = _create_session(_auth(instructor))
+        uuid = session["session_uuid"]
+
+        # Register instructor device first
+        inst_p_id = session["participants"][0]["id"]
+        _register_device(uuid, _auth(instructor), inst_p_id, hint_role="instructor_primary")
+
+        # Player joins and registers
+        p = _join_session(uuid, _auth(player), role="player")
+        sd = _register_device(uuid, _auth(player), p["id"], hint_role="player_primary")
+        assert sd["device_role"] == "player_primary"
+
+    def test_dra_06_client_hints_secondary_but_is_first_player_gets_primary(self, db):
+        """Client sends player_secondary hint, but is first player → backend assigns player_primary."""
+        instructor = _create_user(db, UserRole.INSTRUCTOR)
+        player = _create_user(db, UserRole.STUDENT)
+        session = _create_session(_auth(instructor))
+        uuid = session["session_uuid"]
+
+        p = _join_session(uuid, _auth(player), role="player")
+        sd = _register_device(uuid, _auth(player), p["id"], hint_role="player_secondary")
+        assert sd["device_role"] == "player_primary", (
+            "Backend must override player_secondary hint to player_primary for first player"
+        )
+
+    def test_dra_07_client_hints_primary_but_slot_taken_gets_secondary(self, db):
+        """Client sends player_primary hint, slot already taken → backend assigns player_secondary."""
+        instructor = _create_user(db, UserRole.INSTRUCTOR)
+        p1_user = _create_user(db, UserRole.STUDENT)
+        p2_user = _create_user(db, UserRole.STUDENT)
+        session = _create_session(_auth(instructor))
+        uuid = session["session_uuid"]
+
+        p1 = _join_session(uuid, _auth(p1_user), role="player")
+        _register_device(uuid, _auth(p1_user), p1["id"], hint_role="player_primary")
+
+        p2 = _join_session(uuid, _auth(p2_user), role="player")
+        sd2 = _register_device(uuid, _auth(p2_user), p2["id"], hint_role="player_primary")
+        assert sd2["device_role"] == "player_secondary", (
+            "Backend must override player_primary hint to player_secondary when slot taken"
+        )
+
+
+# ── CA-E2E: Full Session Capture Authority E2E ───────────────────────────────
+
+class TestCaptureAuthorityE2E:
+
+    def test_ca_e2e_01_instructor_plus_one_player(self, db):
+        """1 instructor + 1 player: instructor→instructor_primary, player→player_primary."""
+        instructor = _create_user(db, UserRole.INSTRUCTOR)
+        player = _create_user(db, UserRole.STUDENT)
+
+        session = _create_session(_auth(instructor))
+        uuid = session["session_uuid"]
+        inst_p_id = session["participants"][0]["id"]
+
+        inst_sd = _register_device(uuid, _auth(instructor), inst_p_id, hint_role="instructor_primary")
+        assert inst_sd["device_role"] == "instructor_primary"
+
+        p = _join_session(uuid, _auth(player), role="player")
+        player_sd = _register_device(uuid, _auth(player), p["id"], hint_role="player_primary")
+        assert player_sd["device_role"] == "player_primary"
+
+        full = _get_session(uuid, _auth(instructor))
+        device_roles = {d["id"]: d["device_role"] for d in full["devices"]}
+        assert device_roles[inst_sd["id"]] == "instructor_primary"
+        assert device_roles[player_sd["id"]] == "player_primary"
+
+    def test_ca_e2e_02_two_players_no_instructor(self, db):
+        """2-player session (no instructor): first→player_primary, second→player_secondary.
+
+        Uses service layer directly because the API always auto-joins the session
+        creator as 'instructor'. This test models the pure player-only scenario.
+        """
+        import uuid as _uuid_mod
+        from app.services.multicamera.session_service import SessionService
+        from app.services.multicamera.device_service import DeviceService
+
+        p1_user = _create_user(db, UserRole.STUDENT)
+        p2_user = _create_user(db, UserRole.STUDENT)
+
+        ss = SessionService(db)
+        ds = DeviceService(db)
+
+        session_obj = ss.create_session(p1_user.id)
+
+        p1_part = ss.join_session(session_obj.session_uuid, p1_user.id, "player")
+        p2_part = ss.join_session(session_obj.session_uuid, p2_user.id, "player")
+        db.refresh(session_obj)
+
+        dev1 = ds.register_managed_device_with_uuid(p1_user.id, _uuid_mod.uuid4(), "iphone", "P1")
+        sd1 = ss.register_device(session_obj.session_uuid, dev1.device_uuid, "player_primary", p1_part.id)
+        assert sd1.device_role == "player_primary"
+
+        dev2 = ds.register_managed_device_with_uuid(p2_user.id, _uuid_mod.uuid4(), "iphone", "P2")
+        sd2 = ss.register_device(session_obj.session_uuid, dev2.device_uuid, "player_primary", p2_part.id)
+        assert sd2.device_role == "player_secondary", (
+            f"Second player must get player_secondary, got {sd2.device_role}"
+        )
+
+    def test_ca_e2e_03_instructor_plus_two_players(self, db):
+        """1 instructor + 2 players: instructor_primary + player_primary + player_secondary."""
+        instructor = _create_user(db, UserRole.INSTRUCTOR)
+        p1_user = _create_user(db, UserRole.STUDENT)
+        p2_user = _create_user(db, UserRole.STUDENT)
+
+        session = _create_session(_auth(instructor))
+        uuid = session["session_uuid"]
+        inst_p_id = session["participants"][0]["id"]
+
+        inst_sd = _register_device(uuid, _auth(instructor), inst_p_id, hint_role="instructor_primary")
+
+        p1 = _join_session(uuid, _auth(p1_user), role="player")
+        sd1 = _register_device(uuid, _auth(p1_user), p1["id"])
+
+        p2 = _join_session(uuid, _auth(p2_user), role="player")
+        sd2 = _register_device(uuid, _auth(p2_user), p2["id"])
+
+        assert inst_sd["device_role"] == "instructor_primary"
+        assert sd1["device_role"] == "player_primary"
+        assert sd2["device_role"] == "player_secondary"
+
+    def test_ca_e2e_04_removed_primary_slot_reopens_for_new_player(self, db):
+        """After player_primary device is removed (service layer), next player gets player_primary."""
+        import uuid as _uuid_mod
+        from app.services.multicamera.session_service import SessionService
+        from app.services.multicamera.device_service import DeviceService
+
+        instructor = _create_user(db, UserRole.INSTRUCTOR)
+        p1_user = _create_user(db, UserRole.STUDENT)
+        p2_user = _create_user(db, UserRole.STUDENT)
+
+        ss = SessionService(db)
+        ds = DeviceService(db)
+
+        # Create session with instructor (max_participants=4 to fit instructor + p1 + p2)
+        session_obj = ss.create_session(instructor.id, max_participants=4, max_devices=8)
+        ss.join_session(session_obj.session_uuid, instructor.id, "instructor")
+        db.refresh(session_obj)
+
+        # Player 1 joins and registers
+        ss.join_session(session_obj.session_uuid, p1_user.id, "player")
+        db.refresh(session_obj)
+        p1_participant = next(
+            p for p in session_obj.participants if p.user_id == p1_user.id
+        )
+        dev1 = ds.register_managed_device_with_uuid(
+            p1_user.id, _uuid_mod.uuid4(), "iphone", "P1-Device"
+        )
+        sd1 = ss.register_device(
+            session_obj.session_uuid, dev1.device_uuid,
+            "player_primary", p1_participant.id
+        )
+        assert sd1.device_role == "player_primary"
+
+        # Remove player_primary device
+        db.refresh(session_obj)
+        ss.remove_device(sd1.id, session_obj.revision)
+        db.refresh(session_obj)
+
+        # Player 2 joins and registers — slot should be open
+        ss.join_session(session_obj.session_uuid, p2_user.id, "player")
+        db.refresh(session_obj)
+        p2_participant = next(
+            p for p in session_obj.participants if p.user_id == p2_user.id
+        )
+        dev2 = ds.register_managed_device_with_uuid(
+            p2_user.id, _uuid_mod.uuid4(), "iphone", "P2-Device"
+        )
+        sd2 = ss.register_device(
+            session_obj.session_uuid, dev2.device_uuid,
+            "player_primary", p2_participant.id
+        )
+        assert sd2.device_role == "player_primary", (
+            "After player_primary removal, next player must get player_primary"
+        )


### PR DESCRIPTION
## Summary
- **Backend**: `_resolve_device_role()` in `SessionService` — instructor participant → `instructor_primary`; first player → `player_primary`; subsequent players → `player_secondary`; `auxiliary_camera` hint passthrough (invariant validation handles the `participant_id` rejection case)
- **iOS ViewModel**: `resolveDeviceRole()` + `resolveIsController()` static helpers; `myDeviceRole` + `isController` computed properties; `beginCycle()`/`endCycle()` gated on `isController`; `capturePreparable` param; non-controller devices auto-prepared after `autoRegisterDevice`
- **iOS LobbyView**: `isController` gate on Begin/End Cycle buttons; `DeviceRole` + `IsController` in Debug Snapshot; fingerprint `mc1-debug-v9-2026-06-27`
- **SessionCaptureManager**: `CapturePreparable` conformance (`autoPrepare` = `requestPermissions` + `prepare`)

## Tests
- DRA-01..07 (device role auto-assignment unit tests) — **7 PASS**
- CA-E2E-01..04 (full session capture authority E2E) — **4 PASS**
- CTL-01..08 (iOS controller logic, `CaptureAuthorityTests.swift`) — **8 PASS**
- 214/214 multicamera backend regression — **PASS**
- iOS build — **BUILD SUCCEEDED**

## Bug fix included
`auxiliary_camera` + `participant_id` registration was incorrectly remapped to `instructor_primary` by the resolver before invariant validation could catch it. Fixed by passthrough guard in `_resolve_device_role()`.

## Test plan
- [ ] CI green on all jobs
- [ ] Physical device validation: instructor iPad creates session → sees Begin/End Cycle; player iPhone (secondary) joins → no Begin/End Cycle buttons, camera auto-prepares

🤖 Generated with [Claude Code](https://claude.com/claude-code)