### PR TITLE
fix(mc1-ios-orch5): CycleCaptureOrchestrator — revision conflict retry + orphaned capture rollback

### DIFF
--- a/ios/LFAEducationCenter/MultiCamera/CycleCaptureOrchestrator.swift
+++ b/ios/LFAEducationCenter/MultiCamera/CycleCaptureOrchestrator.swift
@@ -41,6 +41,7 @@ extension AuthManager: AccessTokenProvider {}
 // MARK: — CycleAPIClient
 
 protocol CycleAPIClient {
+    func getSession(token: String, uuid: String) async throws -> MultiCameraSessionDTO
     func activateSession(token: String, uuid: String, revision: Int) async throws -> MultiCameraSessionDTO
     func createCycle(token: String, uuid: String, idempotencyKey: String) async throws -> CaptureCycleDTO
     func scheduleCycle(token: String, uuid: String, cycleId: Int, revision: Int) async throws -> CaptureCycleDTO
@@ -52,6 +53,10 @@ protocol CycleAPIClient {
 // MARK: — LiveCycleAPIClient
 
 struct LiveCycleAPIClient: CycleAPIClient {
+    func getSession(token: String, uuid: String) async throws -> MultiCameraSessionDTO {
+        try await MultiCameraAPIClient.getSession(token: token, uuid: uuid)
+    }
+
     func activateSession(token: String, uuid: String, revision: Int) async throws -> MultiCameraSessionDTO {
         try await MultiCameraAPIClient.activateSession(token: token, uuid: uuid, revision: revision)
     }
@@ -95,6 +100,7 @@ final class CycleCaptureOrchestrator: ObservableObject {
 
     // MARK: — Published state
     @Published private(set) var state: OrchestratorState = .idle
+    @Published private(set) var revisionConflictRetried: Bool = false
 
     private static func mapToFailure(_ error: Error) -> OrchestratorFailure {
         if let apiErr = error as? APIError {
@@ -180,6 +186,7 @@ final class CycleCaptureOrchestrator: ObservableObject {
         currentCycle = nil
         currentCycleSessionUuid = nil
         currentSessionDeviceId  = nil
+        revisionConflictRetried = false
         state = .idle
     }
 
@@ -208,12 +215,28 @@ final class CycleCaptureOrchestrator: ObservableObject {
             )
         } catch {
             if Task.isCancelled { return }
-            if let apiErr = error as? APIError,
-               case .httpError(let code, _) = apiErr,
-               code == 409 {
-                // 409 = already active or revision conflict from concurrent activate — proceed
-            } else {
+            guard let apiErr = error as? APIError,
+                  case .httpError(let code, _) = apiErr,
+                  code == 409 else {
                 state = .failed(Self.mapToFailure(error))
+                return
+            }
+            // 409: fetch fresh session to distinguish "already active" from "stale revision"
+            do {
+                let fresh = try await cycleAPIClient.getSession(token: token, uuid: sessionUuid)
+                if Task.isCancelled { return }
+                if fresh.status != .active {
+                    // Session not yet active — retry with fresh revision (max 1x)
+                    revisionConflictRetried = true
+                    _ = try await cycleAPIClient.activateSession(
+                        token: token, uuid: sessionUuid, revision: fresh.revision
+                    )
+                    if Task.isCancelled { return }
+                }
+                // fresh.status == .active: concurrent activation succeeded — proceed
+            } catch {
+                if Task.isCancelled { return }
+                state = .failed(.revisionConflict(detail: "activate retry: \(Self.mapToFailure(error))"))
                 return
             }
         }
@@ -411,6 +434,10 @@ final class CycleCaptureOrchestrator: ObservableObject {
             currentCycle = updated
         } catch {
             if let apiErr = error as? APIError, case .httpError(let code, let detail) = apiErr {
+                // Definitive API failure — cancel subscription and stop orphaned capture
+                captureSubscription?.cancel()
+                captureSubscription = nil
+                captureController.stopCapture()
                 if code == 409 {
                     state = .failed(.revisionConflict(detail: detail ?? "409"))
                 } else if code == 422 {
@@ -419,6 +446,7 @@ final class CycleCaptureOrchestrator: ObservableObject {
                     state = .failed(.apiError(statusCode: code, detail: "confirm-start HTTP \(code): \(detail ?? "")"))
                 }
             } else {
+                // Non-API error — retry once
                 do {
                     let updated = try await cycleAPIClient.confirmDeviceStart(
                         token: token,
@@ -430,6 +458,9 @@ final class CycleCaptureOrchestrator: ObservableObject {
                     )
                     currentCycle = updated
                 } catch let retryError {
+                    captureSubscription?.cancel()
+                    captureSubscription = nil
+                    captureController.stopCapture()
                     state = .failed(Self.mapToFailure(retryError))
                 }
             }

--- a/ios/LFAEducationCenter/MultiCamera/MultiCameraLobbyView.swift
+++ b/ios/LFAEducationCenter/MultiCamera/MultiCameraLobbyView.swift
@@ -290,6 +290,7 @@ struct MultiCameraLobbyView: View {
             LabeledRow("Clock", clockSyncDescription)
             LabeledRow("Capture", captureStateDescription)
             LabeledRow("Orchestrator", orchestratorStateDescription)
+            LabeledRow("RC Retry", orchestrator.revisionConflictRetried ? "yes" : "no")
             LabeledRow("Listener", playerListenerDescription)
             LabeledRow("PlayerOrch", playerOrchestratorDescription)
             LabeledRow("DevReg Error", vm.deviceRegisterError ?? "—")
@@ -344,6 +345,7 @@ struct MultiCameraLobbyView: View {
             "clock: \(clockSyncDescription)",
             "capture: \(captureStateDescription)",
             "orchestrator: \(orchestratorStateDescription)",
+            "revision_conflict_retried: \(orchestrator.revisionConflictRetried ? "yes" : "no")",
             "player_listener: \(playerListenerDescription)",
             "player_orch: \(playerOrchestratorDescription)",
             "device_reg_error: \(vm.deviceRegisterError ?? "—")",

--- a/ios/LFAEducationCenterTests/MultiCamera/CycleCaptureOrchestratorTests.swift
+++ b/ios/LFAEducationCenterTests/MultiCamera/CycleCaptureOrchestratorTests.swift
@@ -13,14 +13,17 @@ private final class FakeAccessTokenProvider: AccessTokenProvider {
 
 @MainActor
 private final class MockCycleAPIClient: CycleAPIClient {
-    var activateResult:     Result<MultiCameraSessionDTO, Error> = .success(makeTestSession())
-    var createResult:       Result<CaptureCycleDTO, Error> = .success(makeTestCycle(id: 1, revision: 1))
-    var scheduleResult:     Result<CaptureCycleDTO, Error> = .success(makeTestCycle(id: 1, revision: 2, scheduledStartAt: futureISO(offsetSeconds: 10), status: .recordingPending))
-    var stopResult:         Result<CaptureCycleDTO, Error> = .success(makeTestCycle(id: 1, revision: 3, status: .stopping))
-    var confirmStartResult: Result<CaptureCycleDTO, Error> = .success(makeTestCycle(id: 1, revision: 4, status: .recording))
-    var confirmStopResult:  Result<CaptureCycleDTO, Error> = .success(makeTestCycle(id: 1, revision: 5, status: .completed))
+    var activateResult:      Result<MultiCameraSessionDTO, Error> = .success(makeTestSession())
+    var activateRetryResult: Result<MultiCameraSessionDTO, Error>? = nil
+    var getSessionResult:    Result<MultiCameraSessionDTO, Error> = .success(makeTestSession(status: .active))
+    var createResult:        Result<CaptureCycleDTO, Error> = .success(makeTestCycle(id: 1, revision: 1))
+    var scheduleResult:      Result<CaptureCycleDTO, Error> = .success(makeTestCycle(id: 1, revision: 2, scheduledStartAt: futureISO(offsetSeconds: 10), status: .recordingPending))
+    var stopResult:          Result<CaptureCycleDTO, Error> = .success(makeTestCycle(id: 1, revision: 3, status: .stopping))
+    var confirmStartResult:  Result<CaptureCycleDTO, Error> = .success(makeTestCycle(id: 1, revision: 4, status: .recording))
+    var confirmStopResult:   Result<CaptureCycleDTO, Error> = .success(makeTestCycle(id: 1, revision: 5, status: .completed))
 
     private(set) var activateCallCount            = 0
+    private(set) var getSessionCallCount          = 0
     private(set) var createCallCount              = 0
     private(set) var scheduleCallCount            = 0
     private(set) var confirmStartCallCount        = 0
@@ -28,8 +31,16 @@ private final class MockCycleAPIClient: CycleAPIClient {
     private(set) var lastConfirmStartRevision: Int? = nil
     private(set) var lastConfirmStopRevision:  Int? = nil
 
+    func getSession(token: String, uuid: String) async throws -> MultiCameraSessionDTO {
+        getSessionCallCount += 1
+        return try getSessionResult.get()
+    }
+
     func activateSession(token: String, uuid: String, revision: Int) async throws -> MultiCameraSessionDTO {
         activateCallCount += 1
+        if activateCallCount > 1, let retryResult = activateRetryResult {
+            return try retryResult.get()
+        }
         return try activateResult.get()
     }
 
@@ -1003,6 +1014,138 @@ final class CycleCaptureOrchestratorTests: XCTestCase {
 
         XCTAssertEqual(apiClient.activateCallCount, 1)
         XCTAssertGreaterThanOrEqual(apiClient.createCallCount, 1, "409 on activate should not block createCycle")
+    }
+
+    // MARK: — CYC-RC: Revision Conflict Retry
+
+    // CYC-RC-01: stale revision → 409 → getSession (lobby) → retry with fresh revision → success → cycle created
+    func test_CYC_RC_01_activate409_revisionConflict_refreshAndRetry_success() async throws {
+        let authProvider = FakeAccessTokenProvider()
+        let apiClient = MockCycleAPIClient()
+        apiClient.activateResult      = .failure(APIError.httpError(statusCode: 409, detail: "cycle: revision conflict (expected 2, actual 3)"))
+        apiClient.getSessionResult    = .success(makeTestSession(status: .lobby, revision: 3))
+        apiClient.activateRetryResult = .success(makeTestSession(status: .active, revision: 4))
+        let clockService = await makeSyncedClockService()
+        let captureController = FakeCaptureController()
+
+        let orchestrator = CycleCaptureOrchestrator(
+            authManager: authProvider, clockSyncService: clockService,
+            captureController: captureController, cycleAPIClient: apiClient,
+            sleepProvider: { _ in }
+        )
+
+        orchestrator.startCycle(sessionUuid: "test-uuid", sessionDeviceId: 1, sessionRevision: 2)
+
+        await waitForOrchestratorState(orchestrator, timeout: 3.0) {
+            if case .capturing = $0 { return true }
+            if case .failed = $0 { return true }
+            return false
+        }
+
+        XCTAssertEqual(apiClient.activateCallCount, 2, "CYC-RC-01: activate must be called twice (original + retry)")
+        XCTAssertEqual(apiClient.getSessionCallCount, 1, "CYC-RC-01: getSession must be called once to refresh revision")
+        XCTAssertGreaterThanOrEqual(apiClient.createCallCount, 1, "CYC-RC-01: createCycle must proceed after successful retry")
+        XCTAssertTrue(orchestrator.revisionConflictRetried, "CYC-RC-01: revisionConflictRetried must be true")
+        if case .failed = orchestrator.state {
+            XCTFail("CYC-RC-01: expected .capturing after successful retry, got \(orchestrator.state)")
+        }
+    }
+
+    // CYC-RC-02: stale revision → 409 → getSession (lobby) → retry also 409 → failed(.revisionConflict)
+    func test_CYC_RC_02_activate409_revisionConflict_retryAlso409_fails() async throws {
+        let authProvider = FakeAccessTokenProvider()
+        let apiClient = MockCycleAPIClient()
+        apiClient.activateResult      = .failure(APIError.httpError(statusCode: 409, detail: "cycle: revision conflict (expected 2, actual 3)"))
+        apiClient.getSessionResult    = .success(makeTestSession(status: .lobby, revision: 3))
+        apiClient.activateRetryResult = .failure(APIError.httpError(statusCode: 409, detail: "cycle: revision conflict (expected 3, actual 4)"))
+        let clockService = await makeSyncedClockService()
+        let captureController = FakeCaptureController()
+
+        let orchestrator = CycleCaptureOrchestrator(
+            authManager: authProvider, clockSyncService: clockService,
+            captureController: captureController, cycleAPIClient: apiClient,
+            sleepProvider: { _ in }
+        )
+
+        orchestrator.startCycle(sessionUuid: "test-uuid", sessionDeviceId: 1, sessionRevision: 2)
+
+        await waitForOrchestratorState(orchestrator, timeout: 3.0) {
+            if case .failed = $0 { return true }
+            return false
+        }
+
+        XCTAssertEqual(apiClient.activateCallCount, 2, "CYC-RC-02: activate must be called twice (original + retry)")
+        XCTAssertEqual(apiClient.getSessionCallCount, 1, "CYC-RC-02: getSession must be called once")
+        XCTAssertEqual(apiClient.createCallCount, 0, "CYC-RC-02: createCycle must NOT be called after retry failure")
+        if case .failed(let failure) = orchestrator.state {
+            if case .revisionConflict = failure { /* expected */ }
+            else { XCTFail("CYC-RC-02: expected .revisionConflict after double 409, got \(failure)") }
+        } else {
+            XCTFail("CYC-RC-02: expected .failed(.revisionConflict), got \(orchestrator.state)")
+        }
+    }
+
+    // CYC-RC-03: local capture started → confirmDeviceStart 409 → stopCapture called (no orphaned capture)
+    func test_CYC_RC_03_confirmStartFails_stopsOrphanedCapture() async throws {
+        let authProvider = FakeAccessTokenProvider()
+        let apiClient = MockCycleAPIClient()
+        apiClient.createResult       = .success(makeTestCycle(id: 1, revision: 1))
+        apiClient.scheduleResult     = .success(makeTestCycle(id: 1, revision: 2, scheduledStartAt: futureISO(offsetSeconds: 0.001), status: .recordingPending))
+        apiClient.confirmStartResult = .failure(APIError.httpError(statusCode: 409, detail: "revision conflict"))
+        let clockService = await makeSyncedClockService()
+        let captureController = FakeCaptureController()
+
+        let orchestrator = CycleCaptureOrchestrator(
+            authManager: authProvider, clockSyncService: clockService,
+            captureController: captureController, cycleAPIClient: apiClient,
+            sleepProvider: { _ in }
+        )
+
+        orchestrator.startCycle(sessionUuid: "test-uuid", sessionDeviceId: 1, sessionRevision: 1)
+
+        await waitForOrchestratorState(orchestrator, timeout: 3.0) {
+            if case .failed = $0 { return true }
+            return false
+        }
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(captureController.startCallCount, 1, "CYC-RC-03: local capture must have started before failure")
+        XCTAssertEqual(captureController.stopCallCount, 1, "CYC-RC-03: stopCapture must be called to prevent orphaned capture")
+        if case .failed(let failure) = orchestrator.state {
+            if case .revisionConflict = failure { /* expected */ }
+            else { XCTFail("CYC-RC-03: expected .revisionConflict, got \(failure)") }
+        } else {
+            XCTFail("CYC-RC-03: expected .failed(.revisionConflict), got \(orchestrator.state)")
+        }
+    }
+
+    // CYC-RC-04: successful retry → createCycle called exactly once (no duplicate)
+    func test_CYC_RC_04_successfulRetry_noDuplicateCycleCreate() async throws {
+        let authProvider = FakeAccessTokenProvider()
+        let apiClient = MockCycleAPIClient()
+        apiClient.activateResult      = .failure(APIError.httpError(statusCode: 409, detail: "cycle: revision conflict (expected 2, actual 3)"))
+        apiClient.getSessionResult    = .success(makeTestSession(status: .lobby, revision: 3))
+        apiClient.activateRetryResult = .success(makeTestSession(status: .active, revision: 4))
+        let clockService = await makeSyncedClockService()
+        let captureController = FakeCaptureController()
+
+        let orchestrator = CycleCaptureOrchestrator(
+            authManager: authProvider, clockSyncService: clockService,
+            captureController: captureController, cycleAPIClient: apiClient,
+            sleepProvider: { _ in }
+        )
+
+        orchestrator.startCycle(sessionUuid: "test-uuid", sessionDeviceId: 1, sessionRevision: 2)
+
+        await waitForOrchestratorState(orchestrator, timeout: 3.0) {
+            if case .capturing = $0 { return true }
+            if case .failed = $0 { return true }
+            return false
+        }
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(apiClient.createCallCount, 1, "CYC-RC-04: createCycle must be called exactly once — no duplicate after retry")
+        XCTAssertEqual(apiClient.scheduleCallCount, 1, "CYC-RC-04: scheduleCycle must be called exactly once")
     }
 
     // CYC-O-23: activateSession non-409 error → failed, createCycle not called

--- a/ios/LFAEducationCenterTests/MultiCamera/PlayerCaptureOrchestratorTests.swift
+++ b/ios/LFAEducationCenterTests/MultiCamera/PlayerCaptureOrchestratorTests.swift
@@ -22,6 +22,9 @@ private final class MockCycleAPIClientForPCO: CycleAPIClient {
 
     private(set) var confirmStartCallCount = 0
 
+    func getSession(token: String, uuid: String) async throws -> MultiCameraSessionDTO {
+        fatalError("not used in PCO tests")
+    }
     func activateSession(token: String, uuid: String, revision: Int) async throws -> MultiCameraSessionDTO {
         fatalError("not used in PCO tests")
     }


### PR DESCRIPTION
## Summary

- **Root cause**: `activateSession` 409 on Begin Cycle when session revision was stale (iPhone registered → revision +1 before iPad polled). Old code silently swallowed the 409 and proceeded; `createCycle` then failed with the same 409, producing an orphaned `capture: capturing` state.
- **Fix 1 — activate retry**: On 409 from `activateSession`, fetch fresh session (`getSession`). If session is already `.active` (concurrent activation), proceed without retry. If still `.lobby`, retry `activateSession` with the fresh revision (max 1x). Double 409 → `.failed(.revisionConflict(...))`.
- **Fix 2 — orphaned capture rollback**: On definitive `confirmDeviceStart` failure (4xx), cancel `captureSubscription` and call `captureController.stopCapture()` so local capture does not remain in `.capturing` without a backend cycle.
- **Debug Snapshot**: adds `revision_conflict_retried: yes/no` field, visible in both the UI and the copied text snapshot. Resets to `no` on `reset()`.

## Tests

| ID | Scenario | Assertion |
|----|----------|-----------|
| CYC-RC-01 | stale revision → 409 → getSession(lobby) → retry → success | `activateCallCount==2`, `createCallCount≥1`, `revisionConflictRetried==true` |
| CYC-RC-02 | stale revision → 409 → getSession(lobby) → retry 409 → failed | `.revisionConflict`, `createCallCount==0` |
| CYC-RC-03 | confirmStart 409 → `stopCapture()` called | `startCallCount==1`, `stopCallCount==1` |
| CYC-RC-04 | successful retry → no duplicate cycle | `createCallCount==1`, `scheduleCallCount==1` |

Existing CYC-O-22 (`activate409_proceedsToCreate`) preserved: default `getSessionResult = .active` → proceed without retry.

## Test plan

- [ ] `CYC-RC-01..04` PASS
- [ ] `CYC-O-01..23` regression PASS
- [ ] iOS build PASS (no new compiler warnings)
- [ ] CI all green before merge
- Physical re-test gated on CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)