### PR TITLE
fix(mc1-ios-orch4f): playerPrimary is non-controller in instructor-present sessions

### DIFF
--- a/ios/LFAEducationCenter/MultiCamera/MultiCameraSessionViewModel.swift
+++ b/ios/LFAEducationCenter/MultiCamera/MultiCameraSessionViewModel.swift
@@ -218,7 +218,7 @@ final class MultiCameraSessionViewModel: ObservableObject {
             if let listener = playerCycleListener, let orch = playerCaptureOrchestrator {
                 orch.attach(listener: listener, sessionUuid: sessionUuid, playerSessionDeviceId: sd.id)
             }
-            if sd.deviceRole != .instructorPrimary && sd.deviceRole != .playerPrimary {
+            if sd.deviceRole != .instructorPrimary {
                 await capturePreparable?.autoPrepare(sessionUUID: sessionUuid, deviceId: sd.id)
             }
         } catch {
@@ -322,10 +322,7 @@ final class MultiCameraSessionViewModel: ObservableObject {
     }
 
     static func resolveIsController(role: MCDeviceRole?) -> Bool {
-        switch role {
-        case .instructorPrimary, .playerPrimary: return true
-        default: return false
-        }
+        role == .instructorPrimary
     }
 
     var myDeviceRole: MCDeviceRole? {

--- a/ios/LFAEducationCenterTests/MultiCamera/CaptureAuthorityTests.swift
+++ b/ios/LFAEducationCenterTests/MultiCamera/CaptureAuthorityTests.swift
@@ -96,12 +96,12 @@ final class CaptureAuthorityTests: XCTestCase {
         )
     }
 
-    // MARK: — CTL-06: isController is true for playerPrimary
+    // MARK: — CTL-06: isController is false for playerPrimary (instructor-present sessions)
 
-    func test_CTL_06_isController_trueFor_playerPrimary() {
-        XCTAssertTrue(
+    func test_CTL_06_isController_falseFor_playerPrimary() {
+        XCTAssertFalse(
             MultiCameraSessionViewModel.resolveIsController(role: .playerPrimary),
-            "CTL-06: playerPrimary must be a controller"
+            "CTL-06: playerPrimary must NOT be a controller when instructor is present"
         )
     }
 


### PR DESCRIPTION
## Summary

- `resolveIsController` now returns `true` only for `instructorPrimary`; `playerPrimary`, `playerSecondary`, `auxiliaryCamera` are all non-controllers
- `autoPrepare` triggers for all non-instructor devices (condition simplified to `role != .instructorPrimary`)
- CTL-06 updated: `playerPrimary` → `isController == false`

## Root cause

ORCH-4 incorrectly treated `playerPrimary` as a controller alongside `instructorPrimary`. Physical validation (ORCH-6 test session) revealed that with 1 iPad (instructor) + 1 iPhone (player), the iPhone received `is_controller: yes`, which blocked `autoPrepare` from running, leaving `capture: idle` and `player_orch: waitingForStart` — the player never captured.

## Scope

- iOS only; no backend changes
- Does not touch ORCH-6 (422/cycleIndex), GoPro, upload, or finalization
- Player-vs-player controller authority (instructor-absent sessions) is explicitly out of scope — separate future work

## Test plan

- [ ] CTL-01..08 all pass (CTL-06 flipped from `true` → `false`)
- [ ] Physical: iPhone joins session with iPad instructor → `is_controller: no`, `capture: ready` without manual Prepare Capture tap
- [ ] 3 consecutive cycles complete on both devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)