### PR TITLE
fix(mc1): P0 evidence-chain hardening — diag key contract, stale-artifact sentinels, action replay guard

### DIFF
--- a/.github/workflows/mc1-regression-harness.yml
+++ b/.github/workflows/mc1-regression-harness.yml
@@ -1,0 +1,60 @@
+name: MC1 Regression Harness — Preflight + Diag Contract
+
+# ── Purpose ────────────────────────────────────────────────────────────────────
+# Guards the MC1 physical-regression EVIDENCE CHAIN (P0 hardening, 2026-07-04):
+#   1. Static preflight (scripts/mc1_regression/preflight_static_check.py):
+#      deep-link parity, PCO role gate, artifact collectors, stale-artifact
+#      invalidation wiring, action-consume mechanism, console-log UDID mapping.
+#   2. pytest (scripts/mc1_regression/tests/): devicectl invocation contract,
+#      transition body contract, and the Swift-writer ↔ Python-reader diag JSON
+#      key contract (the framesReceived gate bug class) + load_fresh_diag
+#      stale-artifact rejection semantics.
+#
+# No devices, no backend, no secrets — pure source-level + unit-level checks.
+# A red run here means a physical tricamera run would produce a false verdict.
+# ──────────────────────────────────────────────────────────────────────────────
+
+on:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'scripts/mc1_regression/**'
+      - 'scripts/run_mc1_regression.sh'
+      - 'ios/LFAEducationCenter/MultiCamera/**'
+      - '.github/workflows/mc1-regression-harness.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/mc1_regression/**'
+      - 'scripts/run_mc1_regression.sh'
+      - 'ios/LFAEducationCenter/MultiCamera/**'
+      - '.github/workflows/mc1-regression-harness.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: mc1-regression-harness-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  preflight-and-contract:
+    name: Static preflight + diag key contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install pytest
+        run: pip install pytest
+
+      - name: Run static preflight check
+        run: python3 scripts/mc1_regression/preflight_static_check.py
+
+      - name: Run mc1_regression unit + contract tests
+        run: python3 -m pytest scripts/mc1_regression/tests/ -q

--- a/ios/LFAEducationCenter/MultiCamera/InstructorDashboardView.swift
+++ b/ios/LFAEducationCenter/MultiCamera/InstructorDashboardView.swift
@@ -47,8 +47,13 @@ struct InstructorDashboardView: View {
         }
         // pose-overlay-diag deep link → export per-panel frame diagnostics. Handled here
         // (not MultiCameraLobbyView) because the 3 processor instances are owned by this view.
-        .onReceive(MC1AutomationBridge.shared.$lastAction.compactMap { $0 }) { [self] action in
-            guard case .poseOverlayDiag = action else { return }
+        //
+        // consume() gate (P0 hardening): without it, a re-presented dashboard would
+        // replay a stale .poseOverlayDiag and clobber pose_overlay_diag.json with
+        // freshly-zeroed counters before the regression script copies it.
+        .onReceive(MC1AutomationBridge.shared.$lastAction.compactMap { $0 }) { [self] envelope in
+            guard case .poseOverlayDiag = envelope.action,
+                  MC1AutomationBridge.shared.consume(envelope) else { return }
             PoseOverlayDiagWriter.write(
                 instructor: localPoseOverlay,
                 player: remotePoseOverlay, playerSourceFramesSeen: streamService.totalFramesReceived,

--- a/ios/LFAEducationCenter/MultiCamera/MC1AutomationBridge.swift
+++ b/ios/LFAEducationCenter/MultiCamera/MC1AutomationBridge.swift
@@ -66,6 +66,21 @@ enum MC1AutomationAction: Equatable {
     case poseOverlayDiag
 }
 
+/// One posted automation action with a monotonically increasing sequence number.
+///
+/// The sequence number exists because `@Published var lastAction` REPLAYS its
+/// current value to every new subscriber — a re-presented MultiCameraLobbyView /
+/// InstructorDashboardView would otherwise re-execute the last deep-link action
+/// (double GoPro shutter + duplicate confirmDeviceStart, spurious resetSession,
+/// pose_overlay_diag.json clobbered with zeroed counters). Consumers must call
+/// `MC1AutomationBridge.consume(_:)` before dispatching; it returns true exactly
+/// once per posted action, so a Combine replay of an already-handled envelope is
+/// a no-op (P0 hardening, 2026-07-04 review).
+struct MC1SequencedAction: Equatable {
+    let seq: Int
+    let action: MC1AutomationAction
+}
+
 final class MC1AutomationBridge: ObservableObject {
     static let shared = MC1AutomationBridge()
     private init() {}
@@ -73,7 +88,24 @@ final class MC1AutomationBridge: ObservableObject {
     static let urlScheme = "lfa-mc1"
 
     @Published var presentSessionLab = false
-    @Published private(set) var lastAction: MC1AutomationAction?
+    @Published private(set) var lastAction: MC1SequencedAction?
+
+    private var nextSeq = 1
+    private var consumedSeqs: Set<Int> = []
+
+    private func post(_ action: MC1AutomationAction) {
+        lastAction = MC1SequencedAction(seq: nextSeq, action: action)
+        nextSeq += 1
+    }
+
+    /// Claims an envelope for execution. Returns true exactly once per posted
+    /// action; any later delivery of the same envelope (Combine replay on view
+    /// rebuild / re-subscription) returns false and must not be dispatched.
+    func consume(_ envelope: MC1SequencedAction) -> Bool {
+        guard !consumedSeqs.contains(envelope.seq) else { return false }
+        consumedSeqs.insert(envelope.seq)
+        return true
+    }
 
     /// Returns true if the URL matched this bridge's scheme and was handled.
     @discardableResult
@@ -89,102 +121,102 @@ final class MC1AutomationBridge: ObservableObject {
             let role: ParticipantRole = value("role") == "instructor" ? .instructor : .player
             print("[MC1-AUTO] received action=join uuid=\(uuid) role=\(role)")
             presentSessionLab = true
-            lastAction = .joinSession(uuid: uuid, role: role)
+            post(.joinSession(uuid: uuid, role: role))
             return true
         case "mark-ready":
             print("[MC1-AUTO] received action=mark-ready")
-            lastAction = .markDevicesReady
+            post(.markDevicesReady)
             return true
         case "begin-cycle":
             print("[MC1-AUTO] received action=begin-cycle")
-            lastAction = .beginCycle
+            post(.beginCycle)
             return true
         case "end-cycle":
             print("[MC1-AUTO] received action=end-cycle")
-            lastAction = .endCycle
+            post(.endCycle)
             return true
         case "dump-snapshot":
             print("[MC1-AUTO] received action=dump-snapshot")
-            lastAction = .dumpSnapshot
+            post(.dumpSnapshot)
             return true
         case "reset-session":
             print("[MC1-AUTO] received action=reset-session")
-            lastAction = .resetSession
+            post(.resetSession)
             return true
         case "gopro-connect":
             let did = value("gopro_device_id").flatMap(Int.init)
             print("[MC1-AUTO] received action=gopro-connect gopro_device_id=\(did ?? -1)")
-            lastAction = .goProConnect(goProDeviceId: did)
+            post(.goProConnect(goProDeviceId: did))
             return true
         case "gopro-start":
             guard let did = value("gopro_device_id").flatMap(Int.init) else { return false }
             print("[MC1-AUTO] received action=gopro-start gopro_device_id=\(did)")
-            lastAction = .goProStartRecording(goProDeviceId: did)
+            post(.goProStartRecording(goProDeviceId: did))
             return true
         case "gopro-stop":
             guard let did = value("gopro_device_id").flatMap(Int.init) else { return false }
             print("[MC1-AUTO] received action=gopro-stop gopro_device_id=\(did)")
-            lastAction = .goProStopRecording(goProDeviceId: did)
+            post(.goProStopRecording(goProDeviceId: did))
             return true
         case "gopro-status":
             print("[MC1-AUTO] received action=gopro-status")
-            lastAction = .goProStatus
+            post(.goProStatus)
             return true
         case "gopro-media-list":
             print("[MC1-AUTO] received action=gopro-media-list")
-            lastAction = .goProMediaList
+            post(.goProMediaList)
             return true
         case "gopro-http-diag":
             print("[MC1-AUTO] received action=gopro-http-diag")
-            lastAction = .goProHttpDiag
+            post(.goProHttpDiag)
             return true
         case "gopro-download-latest":
             print("[MC1-AUTO] received action=gopro-download-latest")
-            lastAction = .goProDownloadLatest
+            post(.goProDownloadLatest)
             return true
         case "skeleton-process":
             print("[MC1-AUTO] received action=skeleton-process")
-            lastAction = .skeletonProcess
+            post(.skeletonProcess)
             return true
         case "capture-info":
             print("[MC1-AUTO] received action=capture-info")
-            lastAction = .captureInfo
+            post(.captureInfo)
             return true
         case "network-routing-diag":
             let label = value("label") ?? "unlabeled"
             print("[MC1-AUTO] received action=network-routing-diag label=\(label)")
-            lastAction = .networkRoutingDiag(label: label)
+            post(.networkRoutingDiag(label: label))
             return true
         case "gopro-preview-poc":
             let duration = value("duration_s").flatMap(Double.init) ?? 25
             print("[MC1-AUTO] received action=gopro-preview-poc duration_s=\(duration)")
-            lastAction = .goProPreviewPOC(durationSeconds: duration)
+            post(.goProPreviewPOC(durationSeconds: duration))
             return true
         case "gopro-combined-cycle-proof":
             let duration = value("duration_s").flatMap(Double.init) ?? 15
             print("[MC1-AUTO] received action=gopro-combined-cycle-proof duration_s=\(duration)")
-            lastAction = .goProCombinedCycleProof(durationSeconds: duration)
+            post(.goProCombinedCycleProof(durationSeconds: duration))
             return true
         case "gopro-camera-state-probe":
             print("[MC1-AUTO] received action=gopro-camera-state-probe")
-            lastAction = .goProCameraStateProbe
+            post(.goProCameraStateProbe)
             return true
         case "gopro-preview-aspect-probe":
             let duration = value("duration_s").flatMap(Double.init) ?? 20
             print("[MC1-AUTO] received action=gopro-preview-aspect-probe duration_s=\(duration)")
-            lastAction = .goProPreviewAspectProbe(durationSeconds: duration)
+            post(.goProPreviewAspectProbe(durationSeconds: duration))
             return true
         case "gopro-preset-write-validation":
             print("[MC1-AUTO] received action=gopro-preset-write-validation")
-            lastAction = .goProPresetWriteValidation
+            post(.goProPresetWriteValidation)
             return true
         case "gopro-stream-start":
             print("[MC1-AUTO] received action=gopro-stream-start")
-            lastAction = .goProStreamStart
+            post(.goProStreamStart)
             return true
         case "pose-overlay-diag":
             print("[MC1-AUTO] received action=pose-overlay-diag")
-            lastAction = .poseOverlayDiag
+            post(.poseOverlayDiag)
             return true
         default:
             print("[MC1-AUTO] received unknown action=\(action)")

--- a/ios/LFAEducationCenter/MultiCamera/MultiCameraLobbyView.swift
+++ b/ios/LFAEducationCenter/MultiCamera/MultiCameraLobbyView.swift
@@ -97,7 +97,17 @@ struct MultiCameraLobbyView: View {
         }
         // MC1-AUTO-1: dispatches automation commands from lfa-mc1:// deep links
         // onto the same vm methods the manual buttons call.
-        .onReceive(MC1AutomationBridge.shared.$lastAction.compactMap { $0 }) { action in
+        //
+        // consume() gate (P0 hardening): @Published replays the last envelope to
+        // every new subscription — without the consume() claim, a re-built view
+        // would re-execute the last action (double GoPro shutter, spurious
+        // reset-session). consume() returns true exactly once per posted action.
+        .onReceive(MC1AutomationBridge.shared.$lastAction.compactMap { $0 }) { envelope in
+            // poseOverlayDiag belongs to InstructorDashboardView (owns the 3
+            // processor instances) — leave it unconsumed for that view.
+            if case .poseOverlayDiag = envelope.action { return }
+            guard MC1AutomationBridge.shared.consume(envelope) else { return }
+            let action = envelope.action
             switch action {
             case .joinSession(let uuid, let role):
                 print("[MC1-AUTO] dispatching action=join uuid=\(uuid) role=\(role) state=\(vm.state)")

--- a/ios/LFAEducationCenter/MultiCamera/SkeletonProcessor.swift
+++ b/ios/LFAEducationCenter/MultiCamera/SkeletonProcessor.swift
@@ -112,6 +112,10 @@ final class SkeletonProcessor: ObservableObject {
         }
 
         let result: [String: Any] = [
+            // Freshness marker (P0 hardening): every runtime diag artifact carries a
+            // write-time timestamp so the regression gate can reject stale files
+            // left in Documents/ by a previous run.
+            "generated_at": ISO8601DateFormatter().string(from: Date()),
             "session_uuid": sessionUuid,
             "device_id": deviceId,
             "video_file": videoURL.lastPathComponent,

--- a/ios/LFAEducationCenterTests/MultiCamera/MC1AutomationBridgeTests.swift
+++ b/ios/LFAEducationCenterTests/MultiCamera/MC1AutomationBridgeTests.swift
@@ -19,7 +19,7 @@ final class MC1AutomationBridgeTests: XCTestCase {
         let bridge = makeBridge()
         let handled = bridge.handle(url: URL(string: "lfa-mc1://automate?action=join&session_uuid=abc-123&role=player")!)
         XCTAssertTrue(handled)
-        XCTAssertEqual(bridge.lastAction, .joinSession(uuid: "abc-123", role: .player))
+        XCTAssertEqual(bridge.lastAction?.action, .joinSession(uuid: "abc-123", role: .player))
         XCTAssertTrue(bridge.presentSessionLab)
     }
 
@@ -29,7 +29,7 @@ final class MC1AutomationBridgeTests: XCTestCase {
         let bridge = makeBridge()
         let handled = bridge.handle(url: URL(string: "lfa-mc1://automate?action=join&session_uuid=xyz-789&role=instructor")!)
         XCTAssertTrue(handled)
-        XCTAssertEqual(bridge.lastAction, .joinSession(uuid: "xyz-789", role: .instructor))
+        XCTAssertEqual(bridge.lastAction?.action, .joinSession(uuid: "xyz-789", role: .instructor))
     }
 
     // MARK: — AB-03: join with missing role defaults to player
@@ -38,7 +38,7 @@ final class MC1AutomationBridgeTests: XCTestCase {
         let bridge = makeBridge()
         let handled = bridge.handle(url: URL(string: "lfa-mc1://automate?action=join&session_uuid=def-456")!)
         XCTAssertTrue(handled)
-        XCTAssertEqual(bridge.lastAction, .joinSession(uuid: "def-456", role: .player))
+        XCTAssertEqual(bridge.lastAction?.action, .joinSession(uuid: "def-456", role: .player))
     }
 
     // MARK: — AB-04: join with missing session_uuid is rejected
@@ -55,7 +55,7 @@ final class MC1AutomationBridgeTests: XCTestCase {
         let bridge = makeBridge()
         let handled = bridge.handle(url: URL(string: "lfa-mc1://automate?action=mark-ready")!)
         XCTAssertTrue(handled)
-        XCTAssertEqual(bridge.lastAction, .markDevicesReady)
+        XCTAssertEqual(bridge.lastAction?.action, .markDevicesReady)
     }
 
     // MARK: — AB-06: begin-cycle
@@ -64,7 +64,7 @@ final class MC1AutomationBridgeTests: XCTestCase {
         let bridge = makeBridge()
         let handled = bridge.handle(url: URL(string: "lfa-mc1://automate?action=begin-cycle")!)
         XCTAssertTrue(handled)
-        XCTAssertEqual(bridge.lastAction, .beginCycle)
+        XCTAssertEqual(bridge.lastAction?.action, .beginCycle)
     }
 
     // MARK: — AB-07: end-cycle
@@ -73,7 +73,7 @@ final class MC1AutomationBridgeTests: XCTestCase {
         let bridge = makeBridge()
         let handled = bridge.handle(url: URL(string: "lfa-mc1://automate?action=end-cycle")!)
         XCTAssertTrue(handled)
-        XCTAssertEqual(bridge.lastAction, .endCycle)
+        XCTAssertEqual(bridge.lastAction?.action, .endCycle)
     }
 
     // MARK: — AB-07b: dump-snapshot
@@ -82,7 +82,7 @@ final class MC1AutomationBridgeTests: XCTestCase {
         let bridge = makeBridge()
         let handled = bridge.handle(url: URL(string: "lfa-mc1://automate?action=dump-snapshot")!)
         XCTAssertTrue(handled)
-        XCTAssertEqual(bridge.lastAction, .dumpSnapshot)
+        XCTAssertEqual(bridge.lastAction?.action, .dumpSnapshot)
     }
 
     // MARK: — AB-08: unknown action is rejected
@@ -123,7 +123,7 @@ final class MC1AutomationBridgeTests: XCTestCase {
         let bridge = makeBridge()
         let handled = bridge.handle(url: URL(string: "lfa-mc1://automate?action=reset-session")!)
         XCTAssertTrue(handled)
-        XCTAssertEqual(bridge.lastAction, .resetSession)
+        XCTAssertEqual(bridge.lastAction?.action, .resetSession)
     }
 
     // MARK: — AB-12b: gopro-connect
@@ -132,14 +132,14 @@ final class MC1AutomationBridgeTests: XCTestCase {
         let bridge = makeBridge()
         let handled = bridge.handle(url: URL(string: "lfa-mc1://automate?action=gopro-connect&gopro_device_id=99")!)
         XCTAssertTrue(handled)
-        XCTAssertEqual(bridge.lastAction, .goProConnect(goProDeviceId: 99))
+        XCTAssertEqual(bridge.lastAction?.action, .goProConnect(goProDeviceId: 99))
     }
 
     func test_AB_12c_goProConnect_withoutDeviceId() {
         let bridge = makeBridge()
         let handled = bridge.handle(url: URL(string: "lfa-mc1://automate?action=gopro-connect")!)
         XCTAssertTrue(handled)
-        XCTAssertEqual(bridge.lastAction, .goProConnect(goProDeviceId: nil))
+        XCTAssertEqual(bridge.lastAction?.action, .goProConnect(goProDeviceId: nil))
     }
 
     // MARK: — AB-13: gopro-start
@@ -148,7 +148,7 @@ final class MC1AutomationBridgeTests: XCTestCase {
         let bridge = makeBridge()
         let handled = bridge.handle(url: URL(string: "lfa-mc1://automate?action=gopro-start&gopro_device_id=42")!)
         XCTAssertTrue(handled)
-        XCTAssertEqual(bridge.lastAction, .goProStartRecording(goProDeviceId: 42))
+        XCTAssertEqual(bridge.lastAction?.action, .goProStartRecording(goProDeviceId: 42))
     }
 
     func test_AB_13b_goProStart_missingDeviceId_rejected() {
@@ -163,7 +163,7 @@ final class MC1AutomationBridgeTests: XCTestCase {
         let bridge = makeBridge()
         let handled = bridge.handle(url: URL(string: "lfa-mc1://automate?action=gopro-stop&gopro_device_id=42")!)
         XCTAssertTrue(handled)
-        XCTAssertEqual(bridge.lastAction, .goProStopRecording(goProDeviceId: 42))
+        XCTAssertEqual(bridge.lastAction?.action, .goProStopRecording(goProDeviceId: 42))
     }
 
     func test_AB_14b_goProStop_missingDeviceId_rejected() {
@@ -178,7 +178,7 @@ final class MC1AutomationBridgeTests: XCTestCase {
         let bridge = makeBridge()
         let handled = bridge.handle(url: URL(string: "lfa-mc1://automate?action=gopro-status")!)
         XCTAssertTrue(handled)
-        XCTAssertEqual(bridge.lastAction, .goProStatus)
+        XCTAssertEqual(bridge.lastAction?.action, .goProStatus)
     }
 
     // MARK: — AB-16: gopro-media-list
@@ -187,6 +187,48 @@ final class MC1AutomationBridgeTests: XCTestCase {
         let bridge = makeBridge()
         let handled = bridge.handle(url: URL(string: "lfa-mc1://automate?action=gopro-media-list")!)
         XCTAssertTrue(handled)
-        XCTAssertEqual(bridge.lastAction, .goProMediaList)
+        XCTAssertEqual(bridge.lastAction?.action, .goProMediaList)
+    }
+
+    // MARK: — AB-17: consume() replay protection (P0 hardening, 2026-07-04 review)
+    //
+    // @Published lastAction replays its current value to every new subscriber.
+    // consume() must return true exactly once per posted action so a view
+    // rebuild / re-subscription cannot re-dispatch a stale gopro-start,
+    // reset-session, or pose-overlay-diag.
+
+    func test_AB_17_consume_returnsTrueExactlyOnce() {
+        let bridge = makeBridge()
+        bridge.handle(url: URL(string: "lfa-mc1://automate?action=gopro-start&gopro_device_id=7")!)
+        guard let envelope = bridge.lastAction else { return XCTFail("no action posted") }
+        XCTAssertTrue(bridge.consume(envelope), "first delivery must be dispatchable")
+        XCTAssertFalse(bridge.consume(envelope), "replayed envelope must NOT be dispatchable")
+        XCTAssertFalse(bridge.consume(envelope), "every further replay must stay consumed")
+    }
+
+    func test_AB_17b_identicalActionsGetDistinctSeqs_eachConsumableOnce() {
+        let bridge = makeBridge()
+        bridge.handle(url: URL(string: "lfa-mc1://automate?action=begin-cycle")!)
+        guard let first = bridge.lastAction else { return XCTFail("no first action") }
+        bridge.handle(url: URL(string: "lfa-mc1://automate?action=begin-cycle")!)
+        guard let second = bridge.lastAction else { return XCTFail("no second action") }
+
+        XCTAssertEqual(first.action, second.action)
+        XCTAssertNotEqual(first.seq, second.seq, "identical actions must be distinguishable by seq")
+        XCTAssertGreaterThan(second.seq, first.seq, "seq must be monotonically increasing")
+        XCTAssertTrue(bridge.consume(first))
+        XCTAssertTrue(bridge.consume(second), "a genuinely new identical action must still run")
+        XCTAssertFalse(bridge.consume(first))
+        XCTAssertFalse(bridge.consume(second))
+    }
+
+    func test_AB_17c_resetSessionReplay_notDispatchableTwice() {
+        let bridge = makeBridge()
+        bridge.handle(url: URL(string: "lfa-mc1://automate?action=reset-session")!)
+        guard let envelope = bridge.lastAction else { return XCTFail("no action posted") }
+        XCTAssertTrue(bridge.consume(envelope))
+        // Simulates the fullScreenCover re-present: a new .onReceive subscription
+        // receives the same envelope via @Published replay.
+        XCTAssertFalse(bridge.consume(envelope), "re-presented view must not re-run reset-session")
     }
 }

--- a/scripts/README_mc1_regression.md
+++ b/scripts/README_mc1_regression.md
@@ -36,6 +36,25 @@ PLAYER_PASSWORD=<player-password> \
 `--scenario` accepts `smoke`, `multicycle`, `retry`, `finalization`, or `all`
 (default `all`). `--cycles N` (default 3) only affects `multicycle`.
 
+`all` is strictly UNATTENDED: it excludes both `gopro-*` scenarios (physical
+GoPro required) and every scenario listed in `INTERACTIVE_SCENARIOS`
+(`scenarios.py`) that blocks on operator `input()` — including
+`tricamera-capture-skeleton-proof`. Interactive scenarios must be run
+explicitly by name (P0 hardening, 2026-07-04).
+
+Stale-artifact protection (P0 hardening, 2026-07-04): diag-file-gated
+scenarios begin by overwriting every on-device diag file they later read
+(`gopro_stream_diag.json`, `pose_overlay_diag.json`,
+`capture_metadata_diag.json`, `skeleton_output.json`, ...) with a
+`mc1_invalidated` sentinel, and gates load artifacts through
+`lib.load_fresh_diag`, which rejects the sentinel and any diag whose own
+timestamp predates the scenario start. A leftover diag from a previous run
+can therefore never be read back as this run's evidence; in
+`tricamera-capture-skeleton-proof` the `stale diag artifacts invalidated`
+step itself gates PASS. Console logs are attributed to devices via a
+`devicectl list devices --json-output` CoreDevice-to-legacy UDID mapping,
+never via `idevice_id -l` enumeration order.
+
 ## Supported scenarios
 
 | Scenario | Status | What it checks |

--- a/scripts/mc1_regression/lib.py
+++ b/scripts/mc1_regression/lib.py
@@ -205,6 +205,95 @@ def copy_app_container_file(udid: str, relative_path: str, local_path: str,
     return False
 
 
+# ── Stale-artifact protection (P0 hardening, 2026-07-04 review) ─────────────
+#
+# Diag files persist in the app's Documents/ directory across runs, and
+# devicectl has no delete verb for the appDataContainer domain — so a scenario
+# whose on-device probe silently never ran could previously copy back a STALE
+# file from an earlier run and PASS on old evidence. Two-layer defence:
+#
+#   1. invalidate_app_container_file(): at scenario start, every diag file the
+#      scenario will later gate on is OVERWRITTEN with a sentinel JSON
+#      ({"mc1_invalidated": true, ...}). Only the app writing a fresh diag
+#      during THIS run replaces the sentinel.
+#   2. load_fresh_diag(): when the gate reads the copied-back file, it rejects
+#      (a) the sentinel and (b) any diag whose own timestamp predates the
+#      scenario start (belt-and-braces for clock-skewed devices).
+
+STALE_DIAG_SENTINEL_KEY = "mc1_invalidated"
+# Device wall clock vs. script wall clock can disagree; the sentinel is the
+# primary defence, the timestamp check only needs to catch grossly old files.
+DIAG_FRESHNESS_SKEW_TOLERANCE_S = 120.0
+
+
+def push_app_container_file(udid: str, local_path: str, relative_path: str,
+                            bundle_id: str = LFA_BUNDLE_ID) -> bool:
+    """Copy a local file INTO the app's data container (inverse of
+    copy_app_container_file)."""
+    result = subprocess.run(
+        ["xcrun", "devicectl", "device", "copy", "to", "--device", udid,
+         "--domain-type", "appDataContainer", "--domain-identifier", bundle_id,
+         "--source", local_path, "--destination", relative_path],
+        capture_output=True, text=True, timeout=60,
+    )
+    if result.returncode == 0:
+        print(f"  -> pushed app container file: {local_path} → {relative_path}")
+        return True
+    print(f"  -> app container push failed ({relative_path}): {result.stderr.strip()[:300]}")
+    return False
+
+
+def invalidate_app_container_file(udid: str, relative_path: str, run_id: str,
+                                  scratch_dir: Path,
+                                  bundle_id: str = LFA_BUNDLE_ID) -> bool:
+    """Overwrite one on-device diag file with a stale-marker sentinel."""
+    sentinel = {
+        STALE_DIAG_SENTINEL_KEY: True,
+        "invalidated_at": utc_now_iso(),
+        "run_id": run_id,
+        "note": "overwritten at scenario start; a gate reading this sentinel "
+                "means the app never wrote a fresh diag during this run",
+    }
+    scratch_dir.mkdir(parents=True, exist_ok=True)
+    local = scratch_dir / f"sentinel_{Path(relative_path).name}"
+    local.write_text(json.dumps(sentinel, indent=2))
+    return push_app_container_file(udid, str(local), relative_path, bundle_id=bundle_id)
+
+
+def load_fresh_diag(local_path: str, scenario_started_at: datetime,
+                    timestamp_keys: tuple[str, ...] = ("timestamp", "generated_at"),
+                    ) -> tuple[dict | None, str | None]:
+    """Load a copied-back diag JSON, rejecting stale evidence.
+
+    Returns (diag_dict, None) when the file is fresh, or (None, reason) when it
+    must not be trusted: sentinel still in place, unparseable, missing its
+    timestamp, or timestamped before scenario start (minus skew tolerance).
+    """
+    try:
+        diag = json.loads(Path(local_path).read_text())
+    except (OSError, json.JSONDecodeError) as e:
+        return None, f"unreadable diag file: {e}"
+    if not isinstance(diag, dict):
+        return None, "diag file is not a JSON object"
+    if diag.get(STALE_DIAG_SENTINEL_KEY) is True:
+        return None, ("stale sentinel still in place — the app never wrote this "
+                      "diag during the current run")
+    ts_raw = next((diag[k] for k in timestamp_keys if diag.get(k)), None)
+    if not ts_raw:
+        return None, f"diag has no freshness timestamp (looked for {timestamp_keys})"
+    try:
+        ts = datetime.fromisoformat(str(ts_raw).replace("Z", "+00:00"))
+    except ValueError:
+        return None, f"diag timestamp unparseable: {ts_raw!r}"
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    threshold = scenario_started_at.timestamp() - DIAG_FRESHNESS_SKEW_TOLERANCE_S
+    if ts.timestamp() < threshold:
+        return None, (f"diag timestamp {ts_raw} predates scenario start "
+                      f"{scenario_started_at.isoformat()} — stale artifact from an earlier run")
+    return diag, None
+
+
 def extract_capture_path_from_log(console_log: str, tag: str = "[CAPTURE-INFO]") -> str | None:
     """Parse outputFile= from console log CAPTURE-INFO line."""
     for line in console_log.splitlines():

--- a/scripts/mc1_regression/preflight_static_check.py
+++ b/scripts/mc1_regression/preflight_static_check.py
@@ -55,7 +55,9 @@ def check_deep_link_parity() -> None:
                                  re.M))
     enum_cases = {a or b for a, b in enum_cases if (a or b)}
 
-    handled_actions = set(re.findall(r'lastAction = \.(\w+)', bridge))
+    # Actions are posted via post(.case) since the sequenced-envelope refactor
+    # (P0 hardening, 2026-07-04 — replay protection).
+    handled_actions = set(re.findall(r'post\(\.(\w+)', bridge))
     dispatch_cases = set(re.findall(r'case \.(\w+)\(', lobby)) | set(re.findall(r'case \.(\w+):', lobby))
 
     missing_dispatch = handled_actions - dispatch_cases
@@ -260,19 +262,23 @@ def check_artifact_collectors() -> None:
     # corroborating evidence — a scenario that only writes the file but never checks
     # udpPacketsReceived/videoPIDFound/decodeSuccesses would let a silently-dead GoPro
     # preview report PASS.
-    gate_ok = '"gopro preview stream quality"' in body and bool(re.search(
-        r'critical_ok = all\(.*?"gopro preview stream quality".*?\)', scenarios_src, re.S,
-    ))
+    #
+    # Scoped to the tricamera scenario BODY (2026-07-04 hardening) — the previous
+    # whole-file regex matched any `critical_ok = all(` anywhere before the step
+    # string anywhere, i.e. it never actually verified THIS scenario's gate.
+    critical_block_match = re.search(r"critical_ok = all\(.*?\n        \)", body, re.S)
+    critical_block = critical_block_match.group(0) if critical_block_match else ""
+    check("tricamera scenario has a critical_ok gate block", bool(critical_block))
+
+    gate_ok = '"gopro preview stream quality"' in body and \
+        '"gopro preview stream quality"' in critical_block
     check("gopro preview stream quality gates PASS (critical_ok)", gate_ok)
 
     # Per-panel (instructor/player/gopro) pose overlay frame-traffic collection must also
     # be present AND gate critical_ok — same reasoning as the GoPro preview quality check.
     panel_names = ("instructor", "player", "gopro")
     pose_collected = "pose_overlay_diag" in body
-    pose_gated = all(
-        bool(re.search(rf'critical_ok = all\(.*?"{p} panel frame traffic".*?\)', scenarios_src, re.S))
-        for p in panel_names
-    )
+    pose_gated = all(f'"{p} panel frame traffic"' in critical_block for p in panel_names)
     check("pose_overlay_diag.json collected (per-panel frame traffic)", pose_collected)
     check("per-panel frame traffic gates PASS (critical_ok) for instructor+player+gopro", pose_gated)
 
@@ -298,7 +304,8 @@ def check_pose_overlay_diagnostics_wiring() -> None:
 
     dashboard_src = read(IOS_MC / "InstructorDashboardView.swift")
     export_ok = bool(re.search(
-        r"case \.poseOverlayDiag = action.*?PoseOverlayDiagWriter\.write\(", dashboard_src, re.S,
+        r"case \.poseOverlayDiag = envelope\.action.*?PoseOverlayDiagWriter\.write\(",
+        dashboard_src, re.S,
     ))
     check("InstructorDashboardView exports pose overlay diag on pose-overlay-diag action", export_ok)
 
@@ -327,20 +334,26 @@ def check_orientation_aspect_wiring() -> None:
           f"missing: {[f for f in consistency_fields if f not in capture_mgr_src]}" if not consistency_ok else "")
 
     scenarios_src = read(SCENARIOS_PY)
+    fn_match = re.search(
+        r"def scenario_tricamera_capture_skeleton_proof.*?(?=\ndef scenario_gopro_network_routing_diag)",
+        scenarios_src, re.S,
+    )
+    body = fn_match.group(0) if fn_match else ""
+    critical_block_match = re.search(r"critical_ok = all\(.*?\n        \)", body, re.S)
+    critical_block = critical_block_match.group(0) if critical_block_match else ""
     orientation_gate_steps = [
         "iphone orientation consistent", "iphone effective aspect ratio is 16:9",
         "ipad orientation consistent", "ipad effective aspect ratio is 16:9",
         "gopro preview aspect ratio is 16:9",
     ]
-    scenario_asserts_ok = all(f'"{step}"' in scenarios_src for step in orientation_gate_steps)
-    missing_steps = [s for s in orientation_gate_steps if f'"{s}"' not in scenarios_src]
+    scenario_asserts_ok = all(f'"{step}"' in body for step in orientation_gate_steps)
+    missing_steps = [s for s in orientation_gate_steps if f'"{s}"' not in body]
     check("scenario asserts orientation-consistency + 16:9 aspect for iPhone/iPad/GoPro",
           scenario_asserts_ok,
           f"missing report.step(...) for: {missing_steps}" if not scenario_asserts_ok else "")
-    gated_ok = all(
-        bool(re.search(rf'critical_ok = all\(.*?"{re.escape(step)}".*?\)', scenarios_src, re.S))
-        for step in orientation_gate_steps
-    )
+    # Scoped to the tricamera critical_ok block (2026-07-04 hardening) — the
+    # previous whole-file regex could match a different scenario's gate.
+    gated_ok = all(f'"{step}"' in critical_block for step in orientation_gate_steps)
     check("orientation/aspect assertions gate PASS (critical_ok)", gated_ok)
 
     # "No distorting stretch" is a SwiftUI layout property, not runtime data — verify the
@@ -364,6 +377,147 @@ def check_log_capture_config() -> None:
     check("run_mc1_regression.sh guards against iPad/iPhone UDID collision (duplicate log)", ok)
     ok_override = "IPHONE_LEGACY_UDID" in src and "IPAD_LEGACY_UDID" in src
     check("run_mc1_regression.sh supports manual UDID override env vars", ok_override)
+
+    # P0 hardening (2026-07-04): legacy UDIDs must come from a real CoreDevice→legacy
+    # mapping (devicectl list devices --json-output → hardwareProperties.udid), NOT
+    # from `idevice_id -l` enumeration order — order-based assignment silently swapped
+    # the iPhone/iPad console logs and misattributed every console-grounded check.
+    mapping_ok = "_map_legacy_udid" in src and "hardwareProperties" in src
+    check("console log capture maps legacy UDIDs via devicectl identity (not list order)",
+          mapping_ok)
+    order_heuristic = bool(re.search(r'_LEGACY_UDIDS.*\|\s*head -1', src)) or \
+        bool(re.search(r"sed -n '2p'", src))
+    check("order-based legacy-UDID guessing (head -1 / sed -n 2p) is gone",
+          not order_heuristic)
+
+
+# ── CHECK 11: pose overlay diag writer↔reader key contract ──────────────────
+#
+# P0 hardening (2026-07-04 review): the tricamera panel gate read a per-panel
+# key the Swift writer never emits, so every panel gate was a guaranteed false
+# FAIL. This check re-derives both sides of the contract from source; the same
+# contract is also pinned at test time by tests/test_diag_contract.py.
+
+def check_pose_diag_key_contract() -> None:
+    processor_src = read(IOS_MC / "LivePoseOverlayProcessor.swift")
+    snap = re.search(r"var diagnosticSnapshot: \[String: Any\] \{\s*\[(.*?)\]\s*\}",
+                     processor_src, re.S)
+    writer_keys = set(re.findall(r'"(\w+)":', snap.group(1))) if snap else set()
+    if re.search(r'd\["sourceFramesSeen"\]\s*=', processor_src):
+        writer_keys.add("sourceFramesSeen")
+    check("diagnosticSnapshot writer keys extractable", bool(writer_keys))
+
+    scenarios_src = read(SCENARIOS_PY)
+    reader_keys = set(re.findall(r'panel\.get\("(\w+)"', scenarios_src))
+    check("scenario reads at least one per-panel pose key", bool(reader_keys))
+
+    unknown = reader_keys - writer_keys
+    check(
+        "every per-panel key scenarios.py reads is emitted by PoseOverlayDiagWriter",
+        not unknown,
+        f"scenarios.py reads {sorted(unknown)} but the writer only emits "
+        f"{sorted(writer_keys)}" if unknown else "",
+    )
+    check("panel frame-traffic gate reads the writer's framesReceived counter",
+          "framesReceived" in reader_keys)
+
+
+# ── CHECK 12: stale-artifact invalidation + freshness gating ─────────────────
+
+def check_stale_artifact_protection() -> None:
+    lib_src = read(LIB_PY)
+    helpers_ok = ("def invalidate_app_container_file(" in lib_src
+                  and "def load_fresh_diag(" in lib_src
+                  and "STALE_DIAG_SENTINEL_KEY" in lib_src)
+    check("lib.py provides invalidate_app_container_file + load_fresh_diag + sentinel key",
+          helpers_ok)
+
+    scenarios_src = read(SCENARIOS_PY)
+    fn_match = re.search(
+        r"def scenario_tricamera_capture_skeleton_proof.*?(?=\ndef scenario_gopro_network_routing_diag)",
+        scenarios_src, re.S,
+    )
+    body = fn_match.group(0) if fn_match else ""
+
+    # Invalidation must run BEFORE the first device interaction (join), and its
+    # step must gate critical_ok — a failed invalidation means stale evidence
+    # cannot be ruled out.
+    inv_pos = body.find("_invalidate_stale_diags(")
+    join_pos = body.find("_join_both_devices(")
+    check("tricamera invalidates stale diag artifacts before joining devices",
+          inv_pos != -1 and join_pos != -1 and inv_pos < join_pos,
+          f"inv_pos={inv_pos} join_pos={join_pos}")
+    critical_block_match = re.search(r"critical_ok = all\(.*?\n        \)", body, re.S)
+    critical_block = critical_block_match.group(0) if critical_block_match else ""
+    check("stale-diag invalidation step gates PASS (critical_ok)",
+          '"stale diag artifacts invalidated"' in critical_block)
+
+    # Every gating diag read in the tricamera scenario must go through the
+    # freshness loader instead of raw json.loads.
+    fresh_reads = body.count("load_fresh_diag(")
+    check("tricamera gating diag reads use load_fresh_diag (>=5 call sites)",
+          fresh_reads >= 5, f"found {fresh_reads} load_fresh_diag call(s)")
+
+
+# ── CHECK 13: deep-link action replay protection (consume mechanism) ─────────
+
+def check_action_consume_mechanism() -> None:
+    bridge_src = read(IOS_MC / "MC1AutomationBridge.swift")
+    envelope_ok = ("struct MC1SequencedAction" in bridge_src
+                   and re.search(r"let seq: Int", bridge_src) is not None)
+    check("MC1AutomationBridge posts sequenced action envelopes", envelope_ok)
+    consume_ok = bool(re.search(
+        r"func consume\(_ envelope: MC1SequencedAction\) -> Bool", bridge_src))
+    check("MC1AutomationBridge.consume() exists (once-only claim per action)", consume_ok)
+
+    # Both subscribers must claim via consume() before dispatching — otherwise a
+    # @Published replay on view rebuild re-runs the last action (double GoPro
+    # shutter / spurious reset-session / clobbered pose_overlay_diag.json).
+    lobby_src = read(IOS_MC / "MultiCameraLobbyView.swift")
+    lobby_recv = re.search(r"onReceive\(MC1AutomationBridge\.shared\.\$lastAction.*?switch",
+                           lobby_src, re.S)
+    lobby_gated = bool(lobby_recv and "consume(" in lobby_recv.group(0))
+    check("MultiCameraLobbyView dispatch is gated by consume()", lobby_gated)
+
+    dash_src = read(IOS_MC / "InstructorDashboardView.swift")
+    dash_recv = re.search(
+        r"onReceive\(MC1AutomationBridge\.shared\.\$lastAction.*?PoseOverlayDiagWriter",
+        dash_src, re.S)
+    dash_gated = bool(dash_recv and "consume(" in dash_recv.group(0))
+    check("InstructorDashboardView poseOverlayDiag export is gated by consume()", dash_gated)
+
+
+# ── CHECK 14: interactive scenarios excluded from unattended `all` ───────────
+
+def check_interactive_scenarios_excluded_from_all() -> None:
+    scenarios_src = read(SCENARIOS_PY)
+    set_match = re.search(r"INTERACTIVE_SCENARIOS = \{(.*?)\}", scenarios_src, re.S)
+    declared = set(re.findall(r'"([\w-]+)"', set_match.group(1))) if set_match else set()
+    check("INTERACTIVE_SCENARIOS declared in scenarios.py", bool(declared))
+
+    # Every scenario function that calls input() must be in the interactive set.
+    # Map input() call positions back to their enclosing scenario name.
+    fn_spans: list[tuple[int, str]] = [
+        (m.start(), m.group(1)) for m in
+        re.finditer(r'    report = ScenarioReport\(name="([\w-]+)"', scenarios_src)
+    ]
+    undeclared = set()
+    for m in re.finditer(r"\binput\(", scenarios_src):
+        owner = None
+        for start, name in fn_spans:
+            if start < m.start():
+                owner = name
+        if owner and owner not in declared:
+            undeclared.add(owner)
+    check("every input()-blocking scenario is declared interactive",
+          not undeclared,
+          f"scenario(s) with input() missing from INTERACTIVE_SCENARIOS: {sorted(undeclared)}"
+          if undeclared else "")
+
+    runner_src = read(REPO_ROOT / "scripts" / "mc1_regression" / "runner.py")
+    filter_ok = "INTERACTIVE_SCENARIOS" in runner_src and bool(re.search(
+        r'k not in INTERACTIVE_SCENARIOS', runner_src))
+    check("runner.py excludes INTERACTIVE_SCENARIOS from --scenario all", filter_ok)
 
 
 # ── CHECK 10: SKIP_STATIC_PREFLIGHT can never produce a valid PASS ─────────
@@ -403,6 +557,10 @@ def main() -> int:
     check_orientation_aspect_wiring()
     check_log_capture_config()
     check_skip_preflight_cannot_pass()
+    check_pose_diag_key_contract()
+    check_stale_artifact_protection()
+    check_action_consume_mechanism()
+    check_interactive_scenarios_excluded_from_all()
 
     print("=== MC1 static preflight check ===\n")
     for line in PASSES:

--- a/scripts/mc1_regression/runner.py
+++ b/scripts/mc1_regression/runner.py
@@ -31,7 +31,7 @@ from mc1_regression.lib import (  # noqa: E402
     send_deep_link,
     utc_now_iso,
 )
-from mc1_regression.scenarios import SCENARIOS  # noqa: E402
+from mc1_regression.scenarios import INTERACTIVE_SCENARIOS, SCENARIOS  # noqa: E402
 
 _DEFAULT_INSTRUCTOR_EMAIL = "staging-instructor@lfa-staging.io"
 _DEFAULT_PLAYER_EMAIL = "staging-player1@lfa-staging.io"
@@ -72,7 +72,21 @@ def run(args: argparse.Namespace) -> int:
     preflight_url_scheme(args.iphone_udid, "iPhone")
 
     if args.scenario == "all":
-        scenario_names = [k for k in SCENARIOS.keys() if not k.startswith("gopro-")]
+        # `all` must stay unattended: exclude gopro-* (physical GoPro required)
+        # AND any scenario that blocks on operator input() (INTERACTIVE_SCENARIOS).
+        # Before this filter, tricamera-capture-skeleton-proof slipped into `all`
+        # and hung the whole run on an input() prompt (P0 hardening, 2026-07-04).
+        scenario_names = [
+            k for k in SCENARIOS.keys()
+            if not k.startswith("gopro-") and k not in INTERACTIVE_SCENARIOS
+        ]
+        excluded_interactive = [
+            k for k in SCENARIOS.keys()
+            if not k.startswith("gopro-") and k in INTERACTIVE_SCENARIOS
+        ]
+        for name in excluded_interactive:
+            print(f"NOTE: '{name}' is interactive (operator input required) — excluded "
+                  f"from 'all'. Run it explicitly: --scenario {name}")
     else:
         scenario_names = [args.scenario]
     overall_pass = True

--- a/scripts/mc1_regression/scenarios.py
+++ b/scripts/mc1_regression/scenarios.py
@@ -31,13 +31,29 @@ from .lib import (
     extract_skeleton_path_from_log,
     get_server_time_iso,
     get_session,
+    invalidate_app_container_file,
     latest_cycle,
     list_cycles,
+    load_fresh_diag,
     poll_until,
     register_device,
     send_deep_link,
     transition_session,
+    utc_now_iso,
 )
+
+# Scenarios that block on operator input() (manual GoPro WiFi join, visual
+# checks). runner.py MUST exclude these from an unattended `--scenario all`
+# run — they only run when named explicitly (P0 hardening, 2026-07-04 review).
+INTERACTIVE_SCENARIOS = {
+    "tricamera-capture-skeleton-proof",
+    "gopro-network-routing-diag",
+    "gopro-preview-poc",
+    "gopro-combined-cycle-proof",
+    "gopro-camera-state-probe",
+    "gopro-preview-aspect-probe",
+    "gopro-preset-write-validation",
+}
 
 DEVICE_REGISTER_TIMEOUT_SECONDS = 120
 CYCLE_CONFIRM_TIMEOUT_SECONDS = 30
@@ -142,6 +158,28 @@ def _mark_devices_ready(ctx: ScenarioContext, report: ScenarioReport, session_uu
 
     print(f"Waiting {POST_DEVICES_READY_SETTLE_SECONDS}s for iOS VM to poll updated session...")
     _time.sleep(POST_DEVICES_READY_SETTLE_SECONDS)
+
+
+def _invalidate_stale_diags(ctx: ScenarioContext, report: ScenarioReport,
+                            targets: list[tuple[str, str]], run_id: str,
+                            step_name: str = "stale diag artifacts invalidated") -> bool:
+    """Overwrite every on-device diag file this scenario will gate on with a
+    stale-marker sentinel (P0 hardening — see lib.invalidate_app_container_file).
+
+    `targets` is a list of (udid, container-relative path). Records one report
+    step; returns True only if EVERY target was invalidated. A failed
+    invalidation means this run cannot distinguish fresh evidence from a
+    previous run's leftovers, so callers must treat False as gate-critical.
+    """
+    results = {}
+    all_ok = True
+    scratch = ctx.artifact.dir / "diag_sentinels"
+    for udid, relative_path in targets:
+        ok = invalidate_app_container_file(udid, relative_path, run_id, scratch)
+        results[f"{udid[:8]}:{relative_path}"] = ok
+        all_ok = all_ok and ok
+    report.step(step_name, all_ok, run_id=run_id, **results)
+    return all_ok
 
 
 def _run_one_cycle(
@@ -686,8 +724,11 @@ def scenario_tricamera_capture_skeleton_proof(ctx: ScenarioContext) -> ScenarioR
       - gopro media evidence          ([GOPRO-MEDIA-BEGIN] in iPhone log)
     """
     import time as _time
+    from datetime import datetime as _dt, timezone as _tz
 
     report = ScenarioReport(name="tricamera-capture-skeleton-proof", passed=False)
+    scenario_started_at = _dt.now(_tz.utc)
+    run_id = f"tricamera-capture-skeleton-proof-{scenario_started_at.strftime('%Y%m%dT%H%M%SZ')}"
     session = create_session(ctx.api_base, ctx.instructor_token)
     session_uuid = session["session_uuid"]
     report.session_uuid = session_uuid
@@ -695,6 +736,19 @@ def scenario_tricamera_capture_skeleton_proof(ctx: ScenarioContext) -> ScenarioR
     print(f"[proof] iPhone=instructor+GoPro, iPad=player")
 
     try:
+        # 0. Stale-artifact protection (P0 hardening): overwrite every diag file
+        #    this scenario later gates on with a sentinel, so a leftover file from
+        #    a previous run can never be read back as this run's evidence. This
+        #    step is gate-critical — if it fails, no PASS is possible.
+        _invalidate_stale_diags(ctx, report, run_id=run_id, targets=[
+            (ctx.iphone_udid, "Documents/capture_metadata_diag.json"),
+            (ctx.iphone_udid, "Documents/gopro_stream_diag.json"),
+            (ctx.iphone_udid, "Documents/pose_overlay_diag.json"),
+            (ctx.iphone_udid, "Documents/skeleton_output.json"),
+            (ctx.iphone_udid, "Documents/gopro_diag.json"),
+            (ctx.ipad_udid, "Documents/capture_metadata_diag.json"),
+        ])
+
         # 1. Join both devices
         instructor_id, player_id = _join_both_devices(ctx, report, session_uuid)
 
@@ -891,8 +945,6 @@ def scenario_tricamera_capture_skeleton_proof(ctx: ScenarioContext) -> ScenarioR
         #     the capture-info deep link fires (step 13 above).
         #     skeleton_output.json is written by SkeletonProcessor to Documents/ (fixed name).
         print("[proof] === ARTIFACT COLLECTION ===")
-        import json as _json
-        import os
 
         artifacts_dir = ctx.artifact.dir / "video_artifacts"
         artifacts_dir.mkdir(parents=True, exist_ok=True)
@@ -901,8 +953,12 @@ def scenario_tricamera_capture_skeleton_proof(ctx: ScenarioContext) -> ScenarioR
         local_iphone_meta = str(artifacts_dir / "iphone_capture_metadata.json")
         iphone_meta_ok = copy_app_container_file(ctx.iphone_udid, "Documents/capture_metadata_diag.json", local_iphone_meta)
         if iphone_meta_ok:
-            try:
-                meta = _json.loads(open(local_iphone_meta).read())
+            meta, stale_reason = load_fresh_diag(local_iphone_meta, scenario_started_at)
+            if meta is None:
+                report.step("iphone capture metadata", False, error=stale_reason)
+                report.step("iphone orientation consistent", False, error=stale_reason)
+                report.step("iphone effective aspect ratio is 16:9", False, error=stale_reason)
+            else:
                 file_size = meta.get("fileSizeBytes", 0) or 0
                 report.step("iphone capture metadata", file_size > 0,
                             fileSizeBytes=file_size, outputFilePath=meta.get("outputFilePath"),
@@ -920,8 +976,6 @@ def scenario_tricamera_capture_skeleton_proof(ctx: ScenarioContext) -> ScenarioR
                             effectiveAspectRatio=meta.get("effectiveAspectRatio"),
                             effectiveDisplayWidth=meta.get("effectiveDisplayWidth"),
                             effectiveDisplayHeight=meta.get("effectiveDisplayHeight"))
-            except Exception as e:
-                report.step("iphone capture metadata", False, error=f"parse error: {e}")
         else:
             report.step("iphone capture metadata", False, error="copy_app_container_file failed")
 
@@ -929,8 +983,12 @@ def scenario_tricamera_capture_skeleton_proof(ctx: ScenarioContext) -> ScenarioR
         local_ipad_meta = str(artifacts_dir / "ipad_capture_metadata.json")
         ipad_meta_ok = copy_app_container_file(ctx.ipad_udid, "Documents/capture_metadata_diag.json", local_ipad_meta)
         if ipad_meta_ok:
-            try:
-                meta = _json.loads(open(local_ipad_meta).read())
+            meta, stale_reason = load_fresh_diag(local_ipad_meta, scenario_started_at)
+            if meta is None:
+                report.step("ipad capture metadata", False, error=stale_reason)
+                report.step("ipad orientation consistent", False, error=stale_reason)
+                report.step("ipad effective aspect ratio is 16:9", False, error=stale_reason)
+            else:
                 file_size = meta.get("fileSizeBytes", 0) or 0
                 report.step("ipad capture metadata", file_size > 0,
                             fileSizeBytes=file_size, outputFilePath=meta.get("outputFilePath"),
@@ -944,8 +1002,6 @@ def scenario_tricamera_capture_skeleton_proof(ctx: ScenarioContext) -> ScenarioR
                             effectiveAspectRatio=meta.get("effectiveAspectRatio"),
                             effectiveDisplayWidth=meta.get("effectiveDisplayWidth"),
                             effectiveDisplayHeight=meta.get("effectiveDisplayHeight"))
-            except Exception as e:
-                report.step("ipad capture metadata", False, error=f"parse error: {e}")
         else:
             report.step("ipad capture metadata", False, error="copy_app_container_file failed")
 
@@ -969,8 +1025,11 @@ def scenario_tricamera_capture_skeleton_proof(ctx: ScenarioContext) -> ScenarioR
         gopro_stream_diag_ok = copy_app_container_file(
             ctx.iphone_udid, "Documents/gopro_stream_diag.json", local_gopro_stream_diag)
         if gopro_stream_diag_ok:
-            try:
-                stream_diag = _json.loads(open(local_gopro_stream_diag).read())
+            stream_diag, stale_reason = load_fresh_diag(local_gopro_stream_diag, scenario_started_at)
+            if stream_diag is None:
+                report.step("gopro preview stream quality", False, error=stale_reason)
+                report.step("gopro preview aspect ratio is 16:9", False, error=stale_reason)
+            else:
                 packets = stream_diag.get("udpPacketsReceived", 0) or 0
                 video_pid_found = bool(stream_diag.get("videoPIDFound", False))
                 decodes = stream_diag.get("decodeSuccesses", 0) or 0
@@ -994,9 +1053,6 @@ def scenario_tricamera_capture_skeleton_proof(ctx: ScenarioContext) -> ScenarioR
                     previewAspectRatio=stream_diag.get("previewAspectRatio"),
                     previewWidth=stream_diag.get("previewWidth"), previewHeight=stream_diag.get("previewHeight"),
                 )
-            except Exception as e:
-                report.step("gopro preview stream quality", False, error=f"parse error: {e}")
-                report.step("gopro preview aspect ratio is 16:9", False, error=f"parse error: {e}")
         else:
             report.step("gopro preview stream quality", False,
                         error="gopro_stream_diag.json not found — GoProStreamProbe.run() "
@@ -1017,23 +1073,28 @@ def scenario_tricamera_capture_skeleton_proof(ctx: ScenarioContext) -> ScenarioR
         local_pose_diag = str(artifacts_dir / "pose_overlay_diag.json")
         pose_diag_ok = copy_app_container_file(ctx.iphone_udid, "Documents/pose_overlay_diag.json", local_pose_diag)
         if pose_diag_ok:
-            try:
-                pose_diag = _json.loads(open(local_pose_diag).read())
+            pose_diag, stale_reason = load_fresh_diag(local_pose_diag, scenario_started_at)
+            if pose_diag is None:
+                for panel_name in ("instructor", "player", "gopro"):
+                    report.step(f"{panel_name} panel frame traffic", False, error=stale_reason)
+            else:
                 for panel_name in ("instructor", "player", "gopro"):
                     panel = pose_diag.get(panel_name, {}) or {}
-                    frames_received = panel.get("framesReceivedByProcessor", 0) or 0
+                    # Key contract with PoseOverlayDiagWriter (LivePoseOverlayProcessor.swift):
+                    # the writer emits "framesReceived" — pinned by
+                    # tests/test_diag_contract.py and the static preflight, after the
+                    # 2026-07-04 review found this gate reading a key the writer never
+                    # emits (guaranteed false FAIL on every physical run).
+                    frames_received = panel.get("framesReceived", 0) or 0
                     report.step(
                         f"{panel_name} panel frame traffic", frames_received >= MIN_PANEL_FRAMES,
-                        framesReceivedByProcessor=frames_received,
+                        framesReceived=frames_received,
                         sourceFramesSeen=panel.get("sourceFramesSeen"),
                         framesProcessed=panel.get("framesProcessed"),
                         visionDetectionSuccesses=panel.get("visionDetectionSuccesses"),
                         framesWithSkeletonPoints=panel.get("framesWithSkeletonPoints"),
                         lastFrameReceivedAt=panel.get("lastFrameReceivedAt"),
                     )
-            except Exception as e:
-                for panel_name in ("instructor", "player", "gopro"):
-                    report.step(f"{panel_name} panel frame traffic", False, error=f"parse error: {e}")
         else:
             for panel_name in ("instructor", "player", "gopro"):
                 report.step(f"{panel_name} panel frame traffic", False,
@@ -1044,15 +1105,15 @@ def scenario_tricamera_capture_skeleton_proof(ctx: ScenarioContext) -> ScenarioR
         local_skeleton = str(artifacts_dir / "skeleton_output.json")
         skeleton_ok = copy_app_container_file(ctx.iphone_udid, "Documents/skeleton_output.json", local_skeleton)
         if skeleton_ok:
-            try:
-                skel = _json.loads(open(local_skeleton).read())
+            skel, stale_reason = load_fresh_diag(local_skeleton, scenario_started_at)
+            if skel is None:
+                report.step("skeleton json collected", False, error=stale_reason)
+            else:
                 frames = skel.get("sampled_frames", 0) or 0
                 joints = skel.get("total_joints_detected", 0) or 0
                 report.step("skeleton json collected", frames > 0,
                             sampled_frames=frames, total_joints_detected=joints,
                             video_duration_s=skel.get("video_duration_s"))
-            except Exception as e:
-                report.step("skeleton json collected", False, error=f"parse error: {e}")
         else:
             report.step("skeleton json collected", False, error="copy_app_container_file failed — SkeletonProcessor may not have completed")
 
@@ -1063,6 +1124,9 @@ def scenario_tricamera_capture_skeleton_proof(ctx: ScenarioContext) -> ScenarioR
         critical_ok = all(
             s.get("ok") for s in report.steps
             if s["description"] in (
+                # If sentinel invalidation failed, this run cannot distinguish fresh
+                # evidence from a previous run's leftovers — no PASS is possible.
+                "stale diag artifacts invalidated",
                 "instructor+player confirmed_start", "gopro confirmed_start",
                 "all 3 confirmed_stop", "timestamp sync report",
                 "gopro preview stream quality", "gopro preview aspect ratio is 16:9",
@@ -1125,6 +1189,12 @@ def scenario_gopro_network_routing_diag(ctx: ScenarioContext) -> ScenarioReport:
     from pathlib import Path
 
     report = ScenarioReport(name="gopro-network-routing-diag", passed=False)
+    # Stale-artifact protection (P0 hardening): sentinel-overwrite every diag
+    # file this scenario reads back, so leftovers from a previous run can
+    # never be presented as this run's evidence.
+    _invalidate_stale_diags(ctx, report, run_id=f"gopro-network-routing-diag-{utc_now_iso()}", targets=[
+        (ctx.iphone_udid, "Documents/gopro_diag.json"),
+    ])
     session = create_session(ctx.api_base, ctx.instructor_token)
     session_uuid = session["session_uuid"]
     report.session_uuid = session_uuid
@@ -1347,6 +1417,12 @@ def scenario_gopro_preview_poc(ctx: ScenarioContext) -> ScenarioReport:
     from pathlib import Path
 
     report = ScenarioReport(name="gopro-preview-poc", passed=False)
+    # Stale-artifact protection (P0 hardening): sentinel-overwrite every diag
+    # file this scenario reads back, so leftovers from a previous run can
+    # never be presented as this run's evidence.
+    _invalidate_stale_diags(ctx, report, run_id=f"gopro-preview-poc-{utc_now_iso()}", targets=[
+        (ctx.iphone_udid, "Documents/gopro_stream_diag.json"),
+    ])
     session = create_session(ctx.api_base, ctx.instructor_token)
     session_uuid = session["session_uuid"]
     report.session_uuid = session_uuid
@@ -1590,6 +1666,13 @@ def scenario_gopro_combined_cycle_proof(ctx: ScenarioContext) -> ScenarioReport:
     from pathlib import Path
 
     report = ScenarioReport(name="gopro-combined-cycle-proof", passed=False)
+    # Stale-artifact protection (P0 hardening): sentinel-overwrite every diag
+    # file this scenario reads back, so leftovers from a previous run can
+    # never be presented as this run's evidence.
+    _invalidate_stale_diags(ctx, report, run_id=f"gopro-combined-cycle-proof-{utc_now_iso()}", targets=[
+        (ctx.iphone_udid, "Documents/gopro_recording_diag.json"),
+        (ctx.iphone_udid, "Documents/gopro_stream_diag.json"),
+    ])
     session = create_session(ctx.api_base, ctx.instructor_token)
     session_uuid = session["session_uuid"]
     report.session_uuid = session_uuid
@@ -1792,6 +1875,12 @@ def scenario_gopro_camera_state_probe(ctx: ScenarioContext) -> ScenarioReport:
     from pathlib import Path
 
     report = ScenarioReport(name="gopro-camera-state-probe", passed=False)
+    # Stale-artifact protection (P0 hardening): sentinel-overwrite every diag
+    # file this scenario reads back, so leftovers from a previous run can
+    # never be presented as this run's evidence.
+    _invalidate_stale_diags(ctx, report, run_id=f"gopro-camera-state-probe-{utc_now_iso()}", targets=[
+        (ctx.iphone_udid, "Documents/gopro_camera_state_diag.json"),
+    ])
     session = create_session(ctx.api_base, ctx.instructor_token)
     session_uuid = session["session_uuid"]
     report.session_uuid = session_uuid
@@ -1934,6 +2023,13 @@ def scenario_gopro_preview_aspect_probe(ctx: ScenarioContext) -> ScenarioReport:
     from pathlib import Path
 
     report = ScenarioReport(name="gopro-preview-aspect-probe", passed=False)
+    # Stale-artifact protection (P0 hardening): sentinel-overwrite every diag
+    # file this scenario reads back, so leftovers from a previous run can
+    # never be presented as this run's evidence.
+    _invalidate_stale_diags(ctx, report, run_id=f"gopro-preview-aspect-probe-{utc_now_iso()}", targets=[
+        (ctx.iphone_udid, "Documents/gopro_preview_aspect_diag.json"),
+        (ctx.iphone_udid, "Documents/gopro_stream_diag.json"),
+    ])
     session = create_session(ctx.api_base, ctx.instructor_token)
     session_uuid = session["session_uuid"]
     report.session_uuid = session_uuid
@@ -2102,6 +2198,17 @@ def scenario_gopro_preset_write_validation(ctx: ScenarioContext) -> ScenarioRepo
     from pathlib import Path
 
     report = ScenarioReport(name="gopro-preset-write-validation", passed=False)
+    # Stale-artifact protection (P0 hardening): sentinel-overwrite every diag
+    # file this scenario reads back, so leftovers from a previous run can
+    # never be presented as this run's evidence.
+    _invalidate_stale_diags(ctx, report, run_id=f"gopro-preset-write-validation-{utc_now_iso()}", targets=[
+        (ctx.iphone_udid, "Documents/gopro_preset_before_diag.json"),
+        (ctx.iphone_udid, "Documents/gopro_preset_write_diag.json"),
+        (ctx.iphone_udid, "Documents/gopro_preset_after_diag.json"),
+        (ctx.iphone_udid, "Documents/gopro_recording_diag.json"),
+        (ctx.iphone_udid, "Documents/gopro_preview_aspect_diag.json"),
+        (ctx.iphone_udid, "Documents/gopro_preset_final_diag.json"),
+    ])
     session = create_session(ctx.api_base, ctx.instructor_token)
     session_uuid = session["session_uuid"]
     report.session_uuid = session_uuid

--- a/scripts/mc1_regression/tests/test_diag_contract.py
+++ b/scripts/mc1_regression/tests/test_diag_contract.py
@@ -1,0 +1,153 @@
+"""Writer↔reader contract tests for the MC1 diag artifacts (P0 hardening).
+
+The 2026-07-04 review found scenarios.py gating the tricamera proof on a JSON
+key ("framesReceivedByProcessor") that the Swift writer never emits (it writes
+"framesReceived") — every panel gate read 0 and the scenario could never PASS.
+These tests pin the cross-language key contract by parsing BOTH sides from
+source, so any future rename on either side fails fast in CI instead of on a
+physical test day.
+
+Also covers the stale-artifact freshness loader (lib.load_fresh_diag), which
+is the runtime half of the same evidence-integrity guarantee.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCENARIOS_PY = REPO_ROOT / "scripts" / "mc1_regression" / "scenarios.py"
+PROCESSOR_SWIFT = (REPO_ROOT / "ios" / "LFAEducationCenter" / "MultiCamera"
+                   / "LivePoseOverlayProcessor.swift")
+
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+from mc1_regression.lib import (  # noqa: E402
+    DIAG_FRESHNESS_SKEW_TOLERANCE_S,
+    STALE_DIAG_SENTINEL_KEY,
+    load_fresh_diag,
+)
+
+
+# ── Contract extraction helpers ──────────────────────────────────────────────
+
+def swift_pose_writer_keys() -> set[str]:
+    """Keys PoseOverlayDiagWriter actually emits per panel: the
+    diagnosticSnapshot dictionary literal's string keys, plus the
+    sourceFramesSeen field panelDict() adds on top."""
+    src = PROCESSOR_SWIFT.read_text(encoding="utf-8")
+    snap = re.search(r"var diagnosticSnapshot: \[String: Any\] \{\s*\[(.*?)\]\s*\}", src, re.S)
+    assert snap, "diagnosticSnapshot dictionary not found in LivePoseOverlayProcessor.swift"
+    keys = set(re.findall(r'"(\w+)":', snap.group(1)))
+    if re.search(r'd\["sourceFramesSeen"\]\s*=', src):
+        keys.add("sourceFramesSeen")
+    return keys
+
+
+def scenario_pose_reader_keys() -> set[str]:
+    """Keys the tricamera scenario reads off a per-panel dict (panel.get(...))."""
+    src = SCENARIOS_PY.read_text(encoding="utf-8")
+    return set(re.findall(r'panel\.get\("(\w+)"', src))
+
+
+# ── Contract tests ───────────────────────────────────────────────────────────
+
+def test_pose_overlay_reader_keys_are_subset_of_writer_keys():
+    writer = swift_pose_writer_keys()
+    reader = scenario_pose_reader_keys()
+    assert reader, "scenarios.py reads no per-panel keys — extraction regex broke?"
+    missing = reader - writer
+    assert not missing, (
+        f"scenarios.py reads per-panel key(s) {sorted(missing)} that "
+        f"PoseOverlayDiagWriter never writes (writer emits: {sorted(writer)}). "
+        f"This is exactly the framesReceivedByProcessor bug class — fix the key "
+        f"name on one side."
+    )
+
+
+def test_pose_overlay_gate_uses_frames_received():
+    """The frame-traffic gate must read the writer's real counter key."""
+    assert "framesReceived" in scenario_pose_reader_keys()
+
+
+def test_phantom_key_framesreceivedbyprocessor_is_gone():
+    src = SCENARIOS_PY.read_text(encoding="utf-8")
+    assert "framesReceivedByProcessor" not in src, (
+        "framesReceivedByProcessor resurfaced in scenarios.py — this key has "
+        "never existed in the Swift writer and guarantees a false FAIL."
+    )
+
+
+def test_writer_emits_all_five_diagnostic_counters():
+    expected = {"framesReceived", "framesProcessed", "visionDetectionSuccesses",
+                "framesWithSkeletonPoints", "lastFrameReceivedAt"}
+    assert expected <= swift_pose_writer_keys()
+
+
+# ── Freshness loader tests (stale-artifact protection) ───────────────────────
+
+NOW = datetime.now(timezone.utc)
+
+
+def _write(tmp_path: Path, payload: dict) -> str:
+    p = tmp_path / "diag.json"
+    p.write_text(json.dumps(payload))
+    return str(p)
+
+
+def test_fresh_diag_is_accepted(tmp_path):
+    path = _write(tmp_path, {"timestamp": NOW.isoformat(), "udpPacketsReceived": 5})
+    diag, reason = load_fresh_diag(path, NOW - timedelta(seconds=30))
+    assert reason is None
+    assert diag["udpPacketsReceived"] == 5
+
+
+def test_sentinel_is_rejected(tmp_path):
+    path = _write(tmp_path, {STALE_DIAG_SENTINEL_KEY: True,
+                             "invalidated_at": NOW.isoformat(), "run_id": "x"})
+    diag, reason = load_fresh_diag(path, NOW - timedelta(seconds=30))
+    assert diag is None
+    assert "sentinel" in reason
+
+
+def test_stale_timestamp_is_rejected(tmp_path):
+    stale_ts = NOW - timedelta(seconds=DIAG_FRESHNESS_SKEW_TOLERANCE_S + 3600)
+    path = _write(tmp_path, {"timestamp": stale_ts.isoformat()})
+    diag, reason = load_fresh_diag(path, NOW)
+    assert diag is None
+    assert "predates scenario start" in reason
+
+
+def test_missing_timestamp_is_rejected(tmp_path):
+    path = _write(tmp_path, {"udpPacketsReceived": 99})
+    diag, reason = load_fresh_diag(path, NOW)
+    assert diag is None
+    assert "no freshness timestamp" in reason
+
+
+def test_generated_at_accepted_for_skeleton_output(tmp_path):
+    """skeleton_output.json uses generated_at (SkeletonProcessor) instead of
+    timestamp — both must satisfy the freshness check."""
+    path = _write(tmp_path, {"generated_at": NOW.isoformat(), "sampled_frames": 12})
+    diag, reason = load_fresh_diag(path, NOW - timedelta(seconds=30))
+    assert reason is None
+    assert diag["sampled_frames"] == 12
+
+
+def test_swift_iso8601_zulu_format_parses(tmp_path):
+    """ISO8601DateFormatter emits e.g. 2026-07-04T10:20:30Z — the Z suffix must
+    parse (datetime.fromisoformat rejects 'Z' before Python 3.11)."""
+    zulu = NOW.strftime("%Y-%m-%dT%H:%M:%SZ")
+    path = _write(tmp_path, {"timestamp": zulu})
+    diag, reason = load_fresh_diag(path, NOW - timedelta(seconds=30))
+    assert reason is None, f"Zulu-suffixed ISO8601 must be accepted, got: {reason}"
+
+
+def test_unparseable_json_is_rejected(tmp_path):
+    p = tmp_path / "diag.json"
+    p.write_text("{not json")
+    diag, reason = load_fresh_diag(str(p), NOW)
+    assert diag is None
+    assert "unreadable" in reason

--- a/scripts/run_mc1_regression.sh
+++ b/scripts/run_mc1_regression.sh
@@ -146,19 +146,56 @@ if [[ -z "${_IDEVICESYSLOG}" ]]; then
 elif [[ -z "${_IDEVICEID}" ]]; then
   echo "WARNING: idevice_id not found. Console capture disabled."
 else
-  # Get all legacy UDIDs visible to libimobiledevice (USB-connected only).
-  # Optional override: set IPHONE_LEGACY_UDID / IPAD_LEGACY_UDID env vars to
-  # skip auto-detection (get them via: idevice_id -l).
-  _LEGACY_UDIDS="$("${_IDEVICEID}" -l 2>/dev/null || true)"
-  if [[ -z "${IPHONE_LEGACY_UDID:-}" ]]; then
-    _IPHONE_LEGACY_UDID="$(echo "${_LEGACY_UDIDS}" | head -1)"
-  else
+  # Map each CoreDevice UUID (IPHONE_UDID/IPAD_UDID) to its libimobiledevice
+  # legacy UDID via `devicectl list devices --json-output`, whose
+  # hardwareProperties.udid IS the legacy identifier. The previous approach
+  # (idevice_id -l | head -1 / sed -n 2p) assigned logs by ENUMERATION ORDER —
+  # if the list came back iPad-first, iphone_console.log silently contained the
+  # iPad's log and every console-log-grounded check read the wrong device
+  # (P0 hardening, 2026-07-04 review). Manual override env vars still win.
+  _map_legacy_udid() {  # $1 = CoreDevice UUID → prints legacy UDID or nothing
+    local coredevice_udid="$1"
+    local json_out
+    json_out="$(mktemp)"
+    if ! xcrun devicectl list devices --json-output "${json_out}" >/dev/null 2>&1; then
+      rm -f "${json_out}"
+      return 1
+    fi
+    python3 - "${json_out}" "${coredevice_udid}" <<'PYEOF'
+import json, sys
+data = json.load(open(sys.argv[1]))
+wanted = sys.argv[2].lower()
+for dev in data.get("result", {}).get("devices", []):
+    if str(dev.get("identifier", "")).lower() == wanted:
+        legacy = (dev.get("hardwareProperties", {}) or {}).get("udid", "")
+        if legacy:
+            print(legacy)
+        break
+PYEOF
+    rm -f "${json_out}"
+  }
+
+  if [[ -n "${IPHONE_LEGACY_UDID:-}" ]]; then
     _IPHONE_LEGACY_UDID="${IPHONE_LEGACY_UDID}"
-  fi
-  if [[ -z "${IPAD_LEGACY_UDID:-}" ]]; then
-    _IPAD_LEGACY_UDID="$(echo "${_LEGACY_UDIDS}" | sed -n '2p')"
   else
+    _IPHONE_LEGACY_UDID="$(_map_legacy_udid "${IPHONE_UDID}" || true)"
+  fi
+  if [[ -n "${IPAD_LEGACY_UDID:-}" ]]; then
     _IPAD_LEGACY_UDID="${IPAD_LEGACY_UDID}"
+  else
+    _IPAD_LEGACY_UDID="$(_map_legacy_udid "${IPAD_UDID}" || true)"
+  fi
+
+  # A mapped legacy UDID must actually be visible to libimobiledevice —
+  # otherwise idevicesyslog would just sit there producing an empty log.
+  _LEGACY_UDIDS="$("${_IDEVICEID}" -l 2>/dev/null || true)"
+  if [[ -n "${_IPHONE_LEGACY_UDID}" ]] && ! grep -qi "^${_IPHONE_LEGACY_UDID}$" <<<"${_LEGACY_UDIDS}"; then
+    echo "WARNING: mapped iPhone legacy UDID ${_IPHONE_LEGACY_UDID} not visible to idevice_id -l."
+    _IPHONE_LEGACY_UDID=""
+  fi
+  if [[ -n "${_IPAD_LEGACY_UDID}" ]] && ! grep -qi "^${_IPAD_LEGACY_UDID}$" <<<"${_LEGACY_UDIDS}"; then
+    echo "WARNING: mapped iPad legacy UDID ${_IPAD_LEGACY_UDID} not visible to idevice_id -l."
+    _IPAD_LEGACY_UDID=""
   fi
 
   if [[ -z "${_IPHONE_LEGACY_UDID}" ]]; then


### PR DESCRIPTION
## Mi ez

A 2026-07-04-i független review P0 találatainak célzott javítása. **Nincs új feature, nincs production-scope változás** — kizárólag a fizikai `tricamera-capture-skeleton-proof` teszt bizonyíték-láncának integritása, hogy a verdikt mindkét irányban megbízható legyen (se hamis FAIL, se hamis PASS).

## P0 javítások

### 1. Pose overlay diag kulcs-kontraktus (hamis-FAIL fix)
- A panel gate a `framesReceivedByProcessor` kulcsot olvasta, amit a Swift writer (`PoseOverlayDiagWriter` / `diagnosticSnapshot`) soha nem ír — mindhárom panel gate garantáltan FAIL volt. A gate most a writer valódi `framesReceived` számlálóját olvassa (`scenarios.py`).
- Writer↔reader kontraktus tesztek: `scripts/mc1_regression/tests/test_diag_contract.py` mindkét oldalt a forrásból parzolja; a `framesReceivedByProcessor` visszatérését explicit teszt tiltja. Ugyanezt a kontraktust a preflight CHECK 11 is őrzi.

### 2. Stale-artifact védelem (hamis-PASS fix)
- `lib.invalidate_app_container_file()`: a szcenárió indulásakor minden gate-elt on-device diag fájl `mc1_invalidated` sentinellel felülíródik (devicectl-nek nincs delete verb-je). Bekötve: tricamera (**gate-kritikus step**: `stale diag artifacts invalidated` a `critical_ok`-ban) + mind a 6 diag-gate-elt `gopro-*` szcenárió.
- `lib.load_fresh_diag()`: a gate-ek elutasítják a sentinelt ÉS minden olyan diagot, aminek a saját timestampje a szcenárió-start előtti (120 s skew-tolerancia). `SkeletonProcessor` mostantól `generated_at`-et ír. Preflight CHECK 12 őrzi a bekötést.

### 3. MC1AutomationBridge action replay guard (duplicate-action fix)
- Az actionök `MC1SequencedAction{seq, action}` borítékként posztolódnak; a `consume(envelope)` pontosan egyszer ad `true`-t. Mindkét subscriber view (`MultiCameraLobbyView`, `InstructorDashboardView`) `consume()`-mal claimel dispatch előtt — a `@Published` replay view-újraépítéskor nem tud stale `gopro-start`-ot/`reset-session`-t újrafuttatni, és nem tudja lenullázott számlálókkal felülírni a `pose_overlay_diag.json`-t.
- Új AB-17/17b/17c unit tesztek + preflight CHECK 13.

### 4. Preflight megerősítés
- A `critical_ok` gate-ellenőrzések a tricamera szcenárió TÖRZSÉRE szűkítve (a korábbi whole-file regex bármely `critical_ok`-ra matchelt bárhol).
- Új checkek: kulcs-kontraktus (11), stale-artifact bekötés (12), consume mechanizmus (13), interaktív kizárás + input()-birtokos leképezés (14), UDID-mapping és a sorrend-heurisztika tilalma (CHECK 7 bővítés).

### 5. `--scenario all` szigorúan unattended
- `INTERACTIVE_SCENARIOS` deklarálva (`scenarios.py`); a `runner.py` kizárja őket az `all`-ból (a tricamera proof korábban `input()`-on lógatta az egész futást), explicit névvel továbbra is futtathatók.

### 6. Console log device mapping
- `run_mc1_regression.sh`: CoreDevice UUID → legacy UDID a `devicectl list devices --json-output` `hardwareProperties.udid` mezőjéből, az `idevice_id -l` felsorolási sorrend (`head -1` / `sed 2p`) helyett — az iPhone/iPad console log többé nem cserélődhet fel némán. A mapelt UDID láthatóságát `idevice_id -l` ellen is validálja.

## Új CI
`.github/workflows/mc1-regression-harness.yml`: statikus preflight + mc1_regression pytest minden PR-on, ami a harnesst vagy az `ios/**/MultiCamera`-t érinti.

## Lokális evidencia
- Preflight: **56/56 PASS**
- pytest (`scripts/mc1_regression/tests/`): **20/20 PASS** (9 új kontraktus/freshness teszt)
- iOS: `MC1AutomationBridgeTests` 21 + `LivePoseOverlayProcessorTests` 11 = **32/32 PASS** (iPhone 15 Pro sim), teljes `build-for-testing` OK

## PASS/FAIL definíció (tricamera, e PR után)
PASS ⇔ minden `critical_ok` step OK, beleértve: `stale diag artifacts invalidated` + backend confirmed_start/stop mindhárom eszközre + GoPro preview quality/aspect + mindhárom panel `framesReceived ≥ 1` **friss** (sentinel-mentes, szcenárió-start utáni timestampű) diagból + orientation/aspect konzisztencia friss metadatából. Skip-elt preflighttal futott run soha nem PASS (változatlan).

Fizikai tricamera futás CSAK e PR merge-e és zöld CI után.

🤖 Generated with [Claude Code](https://claude.com/claude-code)