### PR TITLE
fix(mc1): P0 player capture-session conflict + capture-start watchdog + physical-evidence hardening

### DIFF
--- a/docs/MC1_TRICAMERA_RC_CHECKLIST.md
+++ b/docs/MC1_TRICAMERA_RC_CHECKLIST.md
@@ -1,0 +1,211 @@
+# MC1 Tricamera Release Candidate Checklist v1.1
+
+**Cél:** a fizikai `tricamera-capture-skeleton-proof` teszt, illetve bármely későbbi MC1 release előtti teljes rendszer-ellenőrzés. Minden pont objektíven eldönthető PASS/FAIL-re, a megadott bizonyítéktípussal. Kitöltetlen státusz = még nem ellenőrzött.
+
+**Használati szabályok:**
+1. Egy pont csak akkor PASS, ha a bizonyíték rögzítve van (parancs-output, CI link, fájl, screenshot). Bizonyíték nélküli PASS érvénytelen.
+2. Minden bizonyítéken szerepelnie kell a release commit SHA-nak vagy a futás timestampjének, hogy a bizonyíték a vizsgált állapothoz köthető legyen.
+3. FAIL vagy N/A esetén kötelező az indoklás a Megjegyzés mezőben. N/A csak akkor adható, ha a pont az adott release-re bizonyíthatóan nem értelmezhető (indoklással).
+4. A M. szekció döntése kizárólag a kitöltött szekciók alapján hozható meg, az ott megadott képlettel.
+
+**Bizonyítéktípus-rövidítések:**
+- `CMD` — parancs + teljes output másolat
+- `CI` — GitHub Actions run URL + konklúzió
+- `FILE` — repo- vagy artifact-fájl útvonala + releváns tartalom-kivonat
+- `JSON` — konkrét JSON mező értéke a megnevezett artifactból
+- `SCR` — screenshot/fotó, fájlnévben timestamppel
+- `GH` — GitHub UI állapot (PR/issue lista) permalinkkel
+
+---
+
+## A. Repository state
+
+| ID | Ellenőrzés | Módszer | Bizonyíték | Státusz | Megjegyzés |
+|---|---|---|---|---|---|
+| A1 | A release commit SHA rögzítve, és azonos az `origin/main` HEAD-del | `git fetch origin && git rev-parse origin/main` — a kapott SHA kerül a checklist fejlécébe; minden további pont erre a SHA-ra vonatkozik | CMD | | |
+| A2 | A lokális working tree tiszta a release SHA-n | `git checkout <SHA> && git status --porcelain` — output üres (a szándékosan ignorált untracked fájlok listája előre deklarálva) | CMD | | |
+| A3 | Nincs félbemaradt merge/rebase állapot | `git status` nem tartalmaz "You have unmerged paths" / "rebase in progress" sort; `ls .git/MERGE_HEAD` → nincs ilyen fájl | CMD | | |
+| A4 | Nincs nyitott PR, amely MC1 scope-ú fájlt módosít és merge-re vár a fizikai teszt előtt | `gh pr list --state open --json number,title,files` — egyetlen nyitott PR sem érinti a `ios/LFAEducationCenter/MultiCamera/**`, `scripts/mc1_regression/**`, `scripts/run_mc1_regression.sh` útvonalakat; VAGY az érintő PR-ok explicit "nem blokkoló" döntéssel listázva | GH + CMD | | |
+| A5 | Nincs nyitott critical/blocker címkéjű issue MC1 scope-ban | `gh issue list --state open --label critical` és `--label blocker` — üres, vagy egyik sem MC1-et érint (tételes indoklással) | GH | | |
+| A6 | A fizikai teszten futó build pontosan a release SHA-ból készül | A build előtt: `git rev-parse HEAD` == release SHA; a `MultiCameraLobbyView.buildFingerprint` értéke frissítve az adott release-hez, és a Debug Snapshotban ugyanez jelenik meg | CMD + SCR (Debug Snapshot) | | |
+| A7 | Az eszközökre telepített build fingerprint egyezik | Mindkét eszközön `dump-snapshot` deep link → console logban `build: <fingerprint>` sor egyezik az A6-ban rögzítettel | FILE (console log) | | |
+
+## B. GitHub CI
+
+| ID | Ellenőrzés | Módszer | Bizonyíték | Státusz | Megjegyzés |
+|---|---|---|---|---|---|
+| B1 | A release SHA-n minden required check zöld | `gh api repos/:owner/:repo/commits/<SHA>/check-runs --paginate` vagy `gh pr checks <PR>` — 0 fail, 0 pending a required checkek közt | CI | | |
+| B2 | A nem-required, de MC1-releváns workflow-k is zöldek: `ios-ci.yml`, `mc1-regression-harness.yml`, `mc1-e2e-orch2b.yml` | Mindhárom workflow legutóbbi, release SHA-hoz tartozó runja `conclusion: success` | CI (3 run URL) | | |
+| B3 | Nincs pending/queued check a release SHA-n | Ugyanaz a lekérdezés, mint B1 — `status: completed` mindenhol | CI | | |
+| B4 | Egyetlen zöld check sem rerun-nal lett zöld (flaky-mentesség) | Minden MC1-releváns run `run_attempt == 1`; ha >1, a rerun oka dokumentált és determinisztikusnak bizonyított (a hiba nem MC1 kódban volt) | CI (`gh run view <id> --json attempt`) | | |
+| B5 | Branch protection a main-en aktív és a merge azon keresztül történt | `gh api repos/:owner/:repo/branches/main/protection` — required checks lista nem üres; a release commit PR-on keresztül került be (`gh pr view <PR> --json mergedAt,mergeCommit`) | GH + CMD | | |
+| B6 | A `mc1-regression-harness` workflow ténylegesen lefuttatta a preflightot ÉS a pytestet (nem skippelt) | A run logban jelen van a `preflight_static_check.py` "X passed, 0 failed" sora és a pytest "N passed" sora | CI (log kivonat) | | |
+
+## C. Build
+
+| ID | Ellenőrzés | Módszer | Bizonyíték | Státusz | Megjegyzés |
+|---|---|---|---|---|---|
+| C1 | Debug build fordul szimulátorra a release SHA-n | `xcodebuild build-for-testing -project ios/LFAEducationCenter.xcodeproj -scheme LFAEducationCenter -destination 'platform=iOS Simulator,id=<UDID>'` → exit 0 | CMD | | |
+| C2 | Debug build települ és elindul a fizikai iPhone-on | `xcodebuild ... -destination 'platform=iOS,id=<IPHONE_UDID>'` build+install exit 0; app elindul, Session Lab megnyílik | CMD + SCR | | |
+| C3 | Debug build települ és elindul a fizikai iPadon | Ugyanaz iPad UDID-vel | CMD + SCR | | |
+| C4 | Release konfiguráció fordul (regresszió-őr: a DEBUG-only MC1 kód nem töri a Release buildet) | `xcodebuild build -configuration Release -scheme LFAEducationCenter -destination generic/platform=iOS CODE_SIGNING_ALLOWED=NO` → exit 0 | CMD | | |
+| C5 | A fizikai teszthez Debug buildet használunk (a teljes MC1 automation `#if DEBUG` mögött van) — ez explicit rögzítve | A telepítési parancsban `-configuration Debug`; a `lfa-mc1://` scheme válaszol (lásd E-szekció preflight) | CMD | | |
+| C6 | `lfa-mc1://` URL scheme regisztrált mindkét eszközön | `lib.preflight_url_scheme` fut a runner indulásakor és nem dob (a runner log "[preflight] ... scheme OK" mindkét eszközre) | FILE (runner output) | | |
+
+## D. Tests
+
+| ID | Ellenőrzés | Módszer | Bizonyíték | Státusz | Megjegyzés |
+|---|---|---|---|---|---|
+| D1 | iOS unit tesztek: teljes `LFAEducationCenterTests` suite 0 failure a release SHA-n | CI `ios-ci.yml` "Executed N tests, with 0 failures", N rögzítve | CI | | |
+| D2 | MC1 célzott unit tesztek lokálisan is zöldek: `MC1AutomationBridgeTests` (benne AB-17* replay guard), `LivePoseOverlayProcessorTests`, `PCOInstructorRoleGateTests`, `PlayerCaptureOrchestratorTests`, `CycleCaptureOrchestratorTests`, `CaptureAuthorityTests`, `OrientationMapperTests`, `CaptureFormatSelectorTests` | `xcodebuild test-without-building -only-testing:...` → "TEST EXECUTE SUCCEEDED", suite-onkénti Executed/failures sorok | CMD | | |
+| D3 | Backend integration: MC1 ORCH-2B E2E (16 lépés) zöld a release SHA-n | `mc1-e2e-orch2b.yml` run success | CI | | |
+| D4 | Regression harness pytest: `scripts/mc1_regression/tests/` — minden teszt zöld, benne a `test_diag_contract.py` writer↔reader kontraktus tesztek | `python3 -m pytest scripts/mc1_regression/tests/ -q` → "N passed, 0 failed" | CMD | | |
+| D5 | Statikus preflight: minden check PASS, exit 0 | `python3 scripts/mc1_regression/preflight_static_check.py` → "X passed, 0 failed", exit 0 | CMD | | |
+| D6 | A preflight NEM lett skippelve az utolsó futásnál | `scripts/mc1_regression_runs/static_preflight_skip_audit.log` — nincs a release időszakára eső bejegyzés; a legutóbbi `report.json`-ban `static_preflight_skipped == false` | FILE + JSON | | |
+| D7 | Runtime gate-ek definíció szerint aktívak: a tricamera `critical_ok` listában szerepel mind a 14 gate-step (stale-invalidation, backend confirmok, GoPro preview quality+aspect, 3× panel frame traffic, 2× orientation, 2× aspect, timestamp sync) | `grep -A20 "critical_ok = all" scripts/mc1_regression/scenarios.py` a release SHA-n — a lista tételesen egyezik a dokumentált PASS-definícióval | CMD | | |
+| D8 | Unattended regresszió (`--scenario all`: smoke + multicycle) fizikai eszközökön PASS a release buildekkel | `./scripts/run_mc1_regression.sh --scenario all` → `report.json` `overall_pass == true` | JSON (`report.json`) + FILE (artifact könyvtár) | | |
+
+## E. Device routing
+
+| ID | Ellenőrzés | Módszer | Bizonyíték | Státusz | Megjegyzés |
+|---|---|---|---|---|---|
+| E1 | iPhone CoreDevice UDID rögzítve és él | `xcrun devicectl list devices` — az iPhone szerepel, UDID egyezik a futtatási env-vel (`IPHONE_UDID`) | CMD | | |
+| E2 | iPad CoreDevice UDID rögzítve és él | Ugyanaz `IPAD_UDID`-re | CMD | | |
+| E3 | Console log ↔ eszköz hozzárendelés identitás-alapú | A runner shell log tartalmazza a `_map_legacy_udid` eredményét mindkét eszközre (CoreDevice→legacy mapping), NEM sorrend-alapú fallbackot; a két legacy UDID különbözik | FILE (shell output) | | |
+| E4 | iPhone = instructor: a backend session-ben az iPhone-hoz tartozó device `device_role == "instructor_primary"` | `GET /sessions/{uuid}` a futás alatt (a scenario `backend_state/*_session.json` dumpja) — device_name/UDID alapján azonosítva | JSON | | |
+| E5 | iPad = player: `device_role == "player_primary"` ugyanígy | Ugyanaz a session dump | JSON | | |
+| E6 | GoPro = auxiliary: `device_role == "auxiliary_camera"` ÉS `managed_by_device_id == <instructor device id>` | Session dump + a scenario "gopro registered" step detailje | JSON | | |
+| E7 | Instructor eszközön `IsController: yes`, player eszközön `IsController: no` a Debug Snapshotban | Mindkét eszköz `dump-snapshot` kivonata a futás alatt (`debug_snapshots/*`) | FILE | | |
+| E8 | Player eszközön PCO attach megtörtént, instructor eszközön NEM (role gate) | Player console: `[PCO]` sorok jelen; instructor console: nincs `[PCO] confirmed` a saját device_id-jére; `PCOInstructorRoleGateTests` zöld (D2) | FILE (console) + CMD | | |
+| E9 | Minden device_id egyedi, nincs duplikált session_device ugyanarra a fizikai eszközre | Session dump `devices[]` — eszközönként pontosan 1 nem-removed bejegyzés | JSON | | |
+| E10 | Dual-console hard precondition: MINDKÉT eszköz USB-n csatlakozik, trusted, és látható az `idevicesyslog` számára — tricamera scenariónál e nélkül a futás el sem indulhat (a 2026-07-04-i futás a player-oldali console evidencia nélkül futott és bukott) | `idevice_id -l` mindkét legacy UDID-t listázza; a shell wrapper és a runner.py hard-fail ága NEM triggerelt (`check_dual_console_precondition`); `console/iphone_console.log` ÉS `console/ipad_console.log` létrejött | CMD + FILE | | |
+
+## F. Capture lifecycle
+
+| ID | Ellenőrzés | Módszer | Bizonyíték | Státusz | Megjegyzés |
+|---|---|---|---|---|---|
+| F1 | Prepare: mindkét iOS eszköz eléri a `ready` capture state-et a cycle előtt | Debug Snapshot `capture: ready ✓` mindkét eszközön; scenario nem timeoutol a join/prepare fázisban | FILE (snapshot) | | |
+| F2 | Preview: az instructor dashboardon mindhárom panel él a felvétel előtt | SCR a dashboardról (3 panel, timestamp látszik); pose diag `sourceFramesSeen > 0` mindhárom panelre | SCR + JSON (`pose_overlay_diag.json`) | | |
+| F3 | confirmed_start: mindhárom cycle_device `recording_status == "confirmed_start"` `started_at` timestamppel | `proof_cycle_timing.json` / cycles dump | JSON | | |
+| F4 | Recording: a felvételi ablak a tervezett hosszú (± 2 s); mindkét iOS fájl `actualDurationSeconds` konzisztens a cycle started/stopped delta-val | `capture_metadata_diag.json` (mindkét eszköz) vs `proof_cycle_timing.json` | JSON | | |
+| F5 | confirmed_stop: mindhárom cycle_device `recording_status == "confirmed_stop"` `stopped_at`-tal, cycle `status == "completed"` | Cycles dump / scenario "all 3 confirmed_stop" step | JSON | | |
+| F6 | Fájl-validáció: mindkét iOS fájl `fileSizeBytes > 0`, codec `h264`, fps ≈ 30, a `CaptureFormatSelector` profil (1280x720 vagy dokumentált 640x360 fallback) érvényesült | `capture_metadata_diag.json` mezők mindkét eszközről | JSON | | |
+| F7 | Cleanup/reset: a scenario utáni `reset-session` után a ViewModel `.idle`, következő join sikeres (multicycle/all futásban bizonyítva) | Következő scenario join stepje PASS ugyanabban a runban | FILE (report.json steps) | | |
+| F8 | Timestamp sync: a 3 eszköz `started_at` értékei közti max eltérés rögzítve és ≤ az előre deklarált tűrésnél (tűrést a futás ELŐTT kell számszerűsíteni és ide beírni: ___ ms) | `proof_cycle_timing.json` started_at delták kiszámolva | JSON + CMD | | |
+
+## G. GoPro
+
+| ID | Ellenőrzés | Módszer | Bizonyíték | Státusz | Megjegyzés |
+|---|---|---|---|---|---|
+| G1 | BLE: a connect flow eljut `awaitingManualWiFiJoin(ssid:)`-ig (SSID kinyerve BLE-n) | Console log `gopro_connection: Csatlakozz: <SSID>` vagy snapshot ugyanezzel | FILE | | |
+| G2 | Wi-Fi: manuális join után HTTP verify sikeres, GoPro state `ready` | `gopro_diag.json` `outcome == "signalReady_ok"` (vagy `_after_409_retry`) | JSON | | |
+| G3 | Backend ready: a GoPro session_device `status == "ready"` a backend oldalon | Scenario "gopro ready" step PASS + session dump | JSON | | |
+| G4 | Preview: friss `gopro_stream_diag.json` — `udpPacketsReceived > 0` ÉS `videoPIDFound == true` ÉS `decodeSuccesses > 0` | JSON mezők; a fájl frissessége az I-szekció szerint bizonyított | JSON | | |
+| G5 | Preview aspect: `previewAspectRatio` a mért SPS-ből 16:9 (± a `_aspect_ratio_matches` tűrés) | Ugyanazon diag `previewWidth/previewHeight/previewAspectRatio` | JSON | | |
+| G6 | Recording: shutter start/stop OK ÉS a media/list diff új fájlt mutat az SD kártyán | Scenario "gopro confirmed_start"/"confirmed_stop" + `[GOPRO-MEDIA-BEGIN]` blokk az iPhone console logban | JSON + FILE | | |
+| G7 | Stop után a GoPro ténylegesen nem vesz fel | Fizikai ellenőrzés: a kamera kijelzőjén nincs REC a scenario vége után (K-szekció manuális pont hivatkozása) + `recordingStateAfterStop == "stopped"` ha combined-proof diag készült | SCR + JSON | | |
+| G8 | Diag artifactok hiánytalanok: a scenario minden GoPro diag fájlja bekerült az artifact könyvtárba | `ls <run_dir>/video_artifacts/` + report.json artifact stepek PASS | FILE | | |
+| G9 | Ismert korlát explicit elfogadva: auto Wi-Fi join entitlement hiányában manuális (SystemWiFiTransport mindig `.unavailable`) — operátor jelen van | L-szekcióban dokumentált, futtatási tervben operátor nevesítve | FILE (checklist) | | |
+
+## H. Skeleton pipeline
+
+| ID | Ellenőrzés | Módszer | Bizonyíték | Státusz | Megjegyzés |
+|---|---|---|---|---|---|
+| H1 | Frame-forgalom instructor panel: friss `pose_overlay_diag.json` `instructor.framesReceived ≥ 1` | JSON (frissesség I-szekció szerint) | JSON | | |
+| H2 | Frame-forgalom player panel: `player.framesReceived ≥ 1` ÉS `player.sourceFramesSeen > 0` (MPC ténylegesen szállított) | JSON | JSON | | |
+| H3 | Frame-forgalom GoPro panel: `gopro.framesReceived ≥ 1` ÉS `gopro.sourceFramesSeen > 0` (decode ténylegesen történt) | JSON | JSON | | |
+| H4 | Vision fut: legalább egy panelen `framesProcessed > 0` és `visionDetectionSuccesses` rögzítve (érték lehet 0, ha nem volt ember a képben — de a mező jelen van) | JSON | JSON | | |
+| H5 | Overlay vizuálisan látszik: cyan skeleton mindhárom panelen, miközben ember áll a képben | Operátor screenshot: `visual_skeleton_overlay.png` az artifact könyvtárban (K-szekció) | SCR | | |
+| H6 | Export: `skeleton_output.json` friss, `sampled_frames > 0`, `total_joints_detected` rögzítve, `generated_at` a futás utáni | JSON | JSON | | |
+| H7 | A pose diag kulcs-kontraktus a release SHA-n garantált (writer `framesReceived` ↔ reader `framesReceived`) | D4 kontraktus tesztek zöldek + D5 preflight CHECK 11 PASS | CMD | | |
+
+## I. Artifact integrity
+
+| ID | Ellenőrzés | Módszer | Bizonyíték | Státusz | Megjegyzés |
+|---|---|---|---|---|---|
+| I1 | Sentinel-invalidálás lefutott: a report `"stale diag artifacts invalidated"` step PASS, minden targetre `true` | `report.json` step detailek | JSON | | |
+| I2 | Egyetlen gate-elt artifact sem sentinel: a begyűjtött diag fájlokban nincs `mc1_invalidated: true` | `grep -l mc1_invalidated <run_dir>/video_artifacts/*.json` → üres | CMD | | |
+| I3 | Frissesség: minden gate-elt diag `timestamp`/`generated_at` mezője a scenario indulása UTÁNI (a gate ezt kikényszeríti — bizonyíték: nincs "stale"/"predates" error a report stepekben) | `report.json` stepek + a diag fájlok timestamp mezői kézzel szúrópróbázva (min. 2 fájl) | JSON | | |
+| I4 | run_id lánc: a report `run_id`-ja egyezik a sentinel-fájlokban rögzítettel (a `diag_sentinels/` könyvtárban) | `report.json` "stale diag artifacts invalidated" step `run_id` == `diag_sentinels/sentinel_*.json` `run_id` | FILE + JSON | | |
+| I5 | JSON kontraktus: minden gate által olvasott mező létezik a writer oldalon (pose: kontraktus-teszt; capture metadata: `orientationConsistent`, `effectiveAspectRatio`, `fileSizeBytes` jelen; gopro stream: `udpPacketsReceived`, `videoPIDFound`, `decodeSuccesses` jelen) | D4/D5 + a begyűjtött fájlok mezőlistája | CMD + JSON | | |
+| I6 | A console log a helyes eszközhöz tartozik: az `iphone_console.log`-ban instructor-oldali markerek ([CCO], GOPRO-AUTO), az `ipad_console.log`-ban player-oldaliak ([PCO]) | `grep` mindkét logban; E3 mapping-bizonyíték | CMD + FILE | | |
+| I7 | Az artifact könyvtár teljes és archiválva: `report.json`, `report.txt`, `backend_state/*`, `console/*`, `debug_snapshots/*`, `video_artifacts/*` mind jelen, a run könyvtár neve (timestamp) rögzítve a checklistben | `ls -R <run_dir>` | FILE | | |
+
+## J. Orientation
+
+> **P1 DÖNTÉS (2026-07-04, issue #357):** az app portrait-only (`Info.plist`), ezért az
+> `OrientationMapper` mindig portrait-ot ad — landscape-re szerelt eszköznél a player
+> preview ÉS a rögzített fájl orientációja hibás (az első fizikai futás bizonyította).
+> Amíg a #357 nincs javítva: **capture-start chain validációs futás CSAK portrait
+> szereléssel** végezhető (J1 ennek megfelelően értelmezendő); **landscape tricamera
+> futás a #357 javításáig BLOKKOLT.** A #357 javítása külön PR — nem keverendő a
+> capture-session P0 fixszel.
+
+| ID | Ellenőrzés | Módszer | Bizonyíték | Státusz | Megjegyzés |
+|---|---|---|---|---|---|
+| J1 | Előfeltétel deklarálva: mindkét iOS eszköz állványon, elforgatás-mentesen rögzítve a futás alatt — a #357 javításáig PORTRAIT állásban (a fenti P1 döntés szerint); a #357 lezárása után landscape-ben (a 16:9 gate akkor válik teljes értékűvé) | Futtatási terv + setup fotó | SCR | | |
+| J2 | Rotation lock állapot rögzítve a futás előtt (KI/BE), és a futás alatt nem változik | Setup fotó a Vezérlőközpontról vagy explicit operátor-nyilatkozat a futási jegyzőkönyvben | SCR/FILE | | |
+| J3 | iPhone: `orientationConsistent == true` ÉS `deviceOrientationAtRecordingStart == fileOrientationCoarse` | `capture_metadata_diag.json` (iPhone) | JSON | | |
+| J4 | iPad: ugyanaz | `capture_metadata_diag.json` (iPad) | JSON | | |
+| J5 | iPhone/iPad effektív aspect 16:9: `effectiveAspectRatio` a tűrésen belül | Ugyanazon diagok | JSON | | |
+| J6 | GoPro preview aspect 16:9 a mért SPS-ből (== G5) | `gopro_stream_diag.json` | JSON | | |
+| J7 | Vizuális ellenőrzés: a felvett fájlok lejátszva helyes állásúak (nem elfordítottak) — mivel az automata gate csak interface↔fájl konzisztenciát mér, gravitáció-helyességet nem | Operátor visszanézi mindkét iOS videót + rögzíti (K-szekció) | SCR + FILE (jegyzőkönyv) | | |
+| J8 | Metadata: a fájlok `preferredTransform`-ból derivált orientation mező jelen van és nem "unknown" | `capture_metadata_diag.json` `actualOrientation` | JSON | | |
+
+## K. Physical validation — manuális, nem automatizálható pontok
+
+Ezeket ember végzi; mindegyikhez timestampelt bizonyíték kötelező.
+
+| ID | Manuális ellenőrzés | Miért nem automatizálható | Bizonyíték | Státusz | Megjegyzés |
+|---|---|---|---|---|---|
+| K1 | Mindhárom panelen látható cyan skeleton overlay, miközben ember mozog a képtérben | A Vision "talált-e embert" nem wiring kérdés; képtartalom-helyesség pixel-szinten nem gate-elt | `visual_skeleton_overlay.png` az artifact könyvtárban | | |
+| K2 | GoPro Wi-Fi manuális join elvégzése a script promptjára | HotspotConfiguration entitlement hiánya (personal team) | Futási jegyzőkönyv bejegyzés (ki, mikor) | | |
+| K3 | A felvett videók visszanézése: kép éles, hang van, orientáció helyes, nincs korrupció | Fájl-validáció csak konténer-szintű; percepciós minőség nem automatizált | Rövid képernyővideó vagy jegyzőkönyv mindhárom felvételről | | |
+| K4 | GoPro fizikai állapot a futás után: nem vesz fel, nem forró, akku > 20%, SD-n ott az új fájl | Kamera kijelző/hardver állapot kívül esik az API-diagnosztikán | Fotó a kamera kijelzőjéről + media/list kivonat | | |
+| K5 | Dashboard UX folyamatosság: a futás alatt nem volt fagyás/fekete panel/app crash | UI-folytonosság futás közben nem gate-elt (nincs XCUITest fizikai eszközön) | Operátor jegyzőkönyv; crash esetén ips log csatolva | | |
+| K6 | Preset-write jellegű scenariók után: a GoPro beállításai az eredetiek (ha ilyen scenario futott) | Rollback-verify automata, de a kamera menüjének végső állapotát ember erősíti meg | Fotó a kamera beállítás-képernyőjéről | | |
+| K7 | Környezet rögzítése: helyszín, világítás, kamera-távolságok, Wi-Fi környezet (más GoPro/MPC eszközök jelenléte a térben) | Reprodukálhatósághoz kell; automatikusan nem gyűjtött | Setup fotó + jegyzőkönyv | | |
+
+## L. Known limitations — explicit kockázat-elfogadás
+
+Minden tétel PASS-a azt jelenti: "a korlát dokumentált, a döntéshozó név szerint elfogadta erre a futásra/release-re". Nem azt, hogy a hiba javítva van.
+
+| ID | Korlát | Kategória | Elfogadás módja | Státusz | Elfogadó + dátum |
+|---|---|---|---|---|---|
+| L1 | GoPro stop-recovery hiánya: shutter/start HTTP timeout + ténylegesen elindult felvétel esetén az app nem tudja leállítani a kamerát (recordingState=.failed → stopRecording blokkolt); mitigáció: K4 fizikai ellenőrzés | P1 | Jegyzőkönyvi elfogadás | | |
+| L2 | MPC session-validáció hiánya: a player bármely invite-ot elfogad, az instructor bármely peert meghív (session UUID nincs egyeztetve); mitigáció: futás alatt nincs másik MC1 session a térben (K7) | P1 | Jegyzőkönyvi elfogadás | | |
+| L3 | MPC titkosítatlan (`encryptionPreference: .none`) — élő videó a lokális hálón; production előtt kötelező javítás | P1 / production blocker | Jegyzőkönyvi elfogadás fizikai tesztre; production: NEM elfogadható | | |
+| L4 | Instructor role-flash: session-létrehozás után ~3 s-ig PlayerCaptureView jelenhet meg az instructoron (isController az első pollig false) | P1 | Jegyzőkönyvi elfogadás | | |
+| L5 | SkeletonProcessor a MainActort blokkolja a feldolgozás alatt (UI fagy, heartbeat kiesés lehetséges a skeleton-process lépés alatt) — a scenario ezt a confirmed_stop UTÁN futtatja | P1 | Jegyzőkönyvi elfogadás | | |
+| L6 | PCO stop/start átfedési race + timeout nélküli stop-várakozás (beragadhat .stoppingCapture-ben) | P1 | Jegyzőkönyvi elfogadás | | |
+| L7 | GoProStreamProbe: nincs reentrancia-guard, NWConnection-ök nem záródnak, minden a main queue-n — egy futáson belül csak EGY stream-probe action engedélyezett (futtatási terv betartja) | P1 | Jegyzőkönyvi elfogadás | | |
+| L8 | Orientation gate csak interface↔fájl konzisztenciát mér; rotation lock + elfordított eszköz mellett vizuálisan rossz videó is PASS-olhat — mitigáció: J1/J2/J7 | P2 | Jegyzőkönyvi elfogadás | | |
+| L9 | Per-frame CIContext, objectWillChange 1-frame-lag/duplikált feed, dashboard nem observeli a GoPro managert, InstructorCaptureView halott kód, MPEGTSDemuxer teszteletlen, firmware-gate halott kód, capture-quality-proof nincs regisztrálva | P2 / tech debt | Backlog-hivatkozás elég | | |
+| L10 | Production blockerek (fizikai tesztet NEM blokkolják): nincs upload pipeline (`uploadStatus: not_implemented`), manuális GoPro Wi-Fi join (entitlement), MPC titkosítás (L3), TD-01 device dedup, teljes MC1 UI `#if DEBUG` mögött | Production blocker | Listázva; M2 döntésnél kötelezően NO-t okoz, amíg nyitott | | |
+| L12 | Portrait-only app: OrientationMapper mindig portrait; landscape szerelésnél elforgatott preview + elforgatott rögzített fájl (issue #357) — mitigáció: portrait szerelés a J-szekció döntése szerint | P1 (landscape tricamera célra BLOCKER) | Jegyzőkönyvi elfogadás portrait futásra; landscape futás: NEM engedélyezett a #357-ig | | |
+| L11 | A fenti lista teljessége: a 2026-07-04-i review P1/P2 találatai közül egy sem hiányzik erről a listáról | — | Tételes összevetés a review dokumentummal | | |
+
+## M. Release decision
+
+A döntés kizárólag a fenti szekciók kitöltött státuszai alapján hozható meg.
+
+**M1 — READY FOR PHYSICAL VALIDATION feltétele:**
+A1–A7, B1–B6, C1–C3+C5–C6, D1–D8, E1–E9 mind PASS; F/G/H/I/J szekciókból a futás ELŐTT eldönthető pontok (D7, G9, H7, I5-statikus fele, J1, J2) PASS; K-szekció előkészítve (operátor + jegyzőkönyv-sablon megvan); L1–L9 + L11 elfogadva. (F/G/H/I/J futás-függő pontjai magát a fizikai futást minősítik, nem előfeltételei.)
+
+```
+READY FOR PHYSICAL VALIDATION
+
+YES / NO
+```
+
+**M2 — READY FOR PRODUCTION feltétele:**
+M1 = YES ÉS a fizikai validáció minden futás-függő pontja (F, G, H, I, J, K) PASS bizonyítékkal ÉS L10 minden production blockere lezárva (nem "elfogadva" — lezárva) ÉS L1–L7 P1 tételekre javítás vagy formális, határidős kivétel van.
+
+```
+READY FOR PRODUCTION
+
+YES / NO
+```
+
+---
+*Checklist verzió: v1.1 (2026-07-04 — E10 dual-console precondition, J-szekció orientation P1 döntés #357, L12). A checklist maga is release-artifact: kitöltött példánya a futás artifact-könyvtárába kerül (`<run_dir>/rc_checklist_filled.md`), a release SHA-val a fejlécében.*

--- a/ios/LFAEducationCenter.xcodeproj/project.pbxproj
+++ b/ios/LFAEducationCenter.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		LP500004000000000000001 /* LivePoseOverlayProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = LP500003000000000000001 /* LivePoseOverlayProcessorTests.swift */; };
 		EE17B48457527F7794F443C8 /* CaptureFormatSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF129189081C742189A7992 /* CaptureFormatSelector.swift */; };
 		454C32E7DA3BE12D732D0262 /* OrientationMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B15830F87FDBEAAF430EA8 /* OrientationMapper.swift */; };
+		A1C2E3F4B5D6079811223344 /* MC1Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C2E3F4B5D6079855667788 /* MC1Log.swift */; };
 		686220A0F4100D89AC13A181 /* RecordingOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D54BAB82A7CBBC4E3EC9A67 /* RecordingOverlay.swift */; };
 		7FC19EF38DE99E82AE19FBE0 /* JugglingVideoListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89E393EC38D4612DE04DD285 /* JugglingVideoListView.swift */; };
 		87BED4D6C4B4C29E7F7DA470 /* CapturePreviewLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C2BB6FD929990D04B3B473 /* CapturePreviewLayer.swift */; };
@@ -303,6 +304,7 @@
 		LP500003000000000000001 /* LivePoseOverlayProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LivePoseOverlayProcessorTests.swift; sourceTree = "<group>"; };
 		CEF129189081C742189A7992 /* CaptureFormatSelector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CaptureFormatSelector.swift; sourceTree = "<group>"; };
 		B2B15830F87FDBEAAF430EA8 /* OrientationMapper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OrientationMapper.swift; sourceTree = "<group>"; };
+		A1C2E3F4B5D6079855667788 /* MC1Log.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MC1Log.swift; sourceTree = "<group>"; };
 		65C2BB6FD929990D04B3B473 /* CapturePreviewLayer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CapturePreviewLayer.swift; sourceTree = "<group>"; };
 		78224C0D4526FCB6A5998DE2 /* CameraFramePublisher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CameraFramePublisher.swift; sourceTree = "<group>"; };
 		7923EAF385B2497998AA5258 /* MultiCameraSessionViewModelClockSyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiCameraSessionViewModelClockSyncTests.swift; sourceTree = "<group>"; };
@@ -1067,6 +1069,7 @@
 				LP500001000000000000001 /* LivePoseOverlayProcessor.swift */,
 				CEF129189081C742189A7992 /* CaptureFormatSelector.swift */,
 				B2B15830F87FDBEAAF430EA8 /* OrientationMapper.swift */,
+				A1C2E3F4B5D6079855667788 /* MC1Log.swift */,
 			);
 			path = MultiCamera;
 			sourceTree = "<group>";
@@ -1424,6 +1427,7 @@
 				LP500002000000000000001 /* LivePoseOverlayProcessor.swift in Sources */,
 				EE17B48457527F7794F443C8 /* CaptureFormatSelector.swift in Sources */,
 				454C32E7DA3BE12D732D0262 /* OrientationMapper.swift in Sources */,
+				A1C2E3F4B5D6079811223344 /* MC1Log.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/LFAEducationCenter/MultiCamera/CameraFramePublisher.swift
+++ b/ios/LFAEducationCenter/MultiCamera/CameraFramePublisher.swift
@@ -1,23 +1,41 @@
 import AVFoundation
+import Combine
 import UIKit
 
+// MARK: — CameraFramePublisher
+//
+// Publishes low-fidelity preview JPEG frames from the PLAYER device to the
+// instructor dashboard over CameraStreamService (MultipeerConnectivity).
+//
+// SINGLE-SESSION CAMERA OWNERSHIP (2026-07-04 tricamera physical run RCA):
+// this type previously owned its own AVCaptureSession on the same back camera
+// that SessionCaptureManager records from. iOS hands the camera to whichever
+// session starts last and silently interrupts the other — on the failed run
+// the publisher won, SessionCaptureManager stayed a lying `.ready`, and the
+// player never reached confirmed_start. The publisher now owns NO session:
+// it configures one AVCaptureVideoDataOutput and attaches it to the
+// SessionCaptureManager's session via attachPreviewOutput(). Recording is
+// authoritative; preview is a side branch of the same camera pipeline, so
+// both run concurrently without contention.
 @MainActor
 final class CameraFramePublisher: NSObject, ObservableObject {
 
     @Published private(set) var frameIndex: Int = 0
     @Published private(set) var publishedFPS: Double = 0
 
-    private let captureSession = AVCaptureSession()
     private let videoOutput = AVCaptureVideoDataOutput()
     private let processingQueue = DispatchQueue(label: "com.lfa.frame-publisher", qos: .userInitiated)
 
+    private weak var captureManager: SessionCaptureManager?
     private var streamService: CameraStreamService?
+    private var managerStateSubscription: AnyCancellable?
+    private var isOutputConfigured = false
+    private var isAttached = false
+    private var attachInFlight = false
     private nonisolated(unsafe) var lastSentTime: CFTimeInterval = 0
     private var publishCount = 0
     private var fpsWindowStart = Date()
     private var orientationObserver: NSObjectProtocol?
-
-    var previewSession: AVCaptureSession { captureSession }
 
     deinit {
         if let token = orientationObserver {
@@ -25,35 +43,53 @@ final class CameraFramePublisher: NSObject, ObservableObject {
         }
     }
 
-    func configure() {
-        captureSession.beginConfiguration()
-        captureSession.sessionPreset = .medium // preview profile — intentionally separate/lower-fidelity than archival recording
+    /// Starts publishing preview frames by tapping `captureManager`'s capture
+    /// session. Attach is deferred until the manager's session is actually
+    /// configured and running (`.ready` / `.capturing`) — its state publisher
+    /// replays the current value, so a manager that is already ready attaches
+    /// immediately.
+    func startCapture(sharing captureManager: SessionCaptureManager, streamService: CameraStreamService) {
+        self.captureManager = captureManager
+        self.streamService = streamService
+        frameIndex = 0
+        publishCount = 0
+        fpsWindowStart = Date()
+        configureOutputIfNeeded()
 
-        guard let camera = AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: .back),
-              let input = try? AVCaptureDeviceInput(device: camera),
-              captureSession.canAddInput(input) else {
-            captureSession.commitConfiguration()
-            print("[FramePublisher] camera setup failed")
-            return
+        managerStateSubscription = captureManager.captureStatePublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] captureState in
+                switch captureState {
+                case .ready, .capturing:
+                    self?.attachIfNeeded()
+                default:
+                    break
+                }
+            }
+        MC1Log.notice("[FramePublisher] start requested: waiting for shared capture session (state=\(captureManager.state))")
+    }
+
+    func stopCapture() {
+        managerStateSubscription?.cancel()
+        managerStateSubscription = nil
+        if isAttached {
+            captureManager?.detachPreviewOutput()
+            isAttached = false
         }
-        captureSession.addInput(input)
+        streamService = nil
+        captureManager = nil
+        MC1Log.notice("[FramePublisher] capture stopped (preview output detached)")
+    }
+
+    // MARK: — Private
+
+    private func configureOutputIfNeeded() {
+        guard !isOutputConfigured else { return }
+        isOutputConfigured = true
 
         videoOutput.alwaysDiscardsLateVideoFrames = true
         videoOutput.videoSettings = [kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA]
         videoOutput.setSampleBufferDelegate(self, queue: processingQueue)
-
-        guard captureSession.canAddOutput(videoOutput) else {
-            captureSession.commitConfiguration()
-            print("[FramePublisher] cannot add video output")
-            return
-        }
-        captureSession.addOutput(videoOutput)
-
-        OrientationMapper.applyCurrentOrientation(to: videoOutput.connection(with: .video))
-
-        captureSession.commitConfiguration()
-        print("[FramePublisher] configured: preset=medium, target=\(Int(1.0/Self.targetInterval))fps, "
-              + "orientation=\(OrientationMapper.currentOrientationLabel)")
 
         UIDevice.current.beginGeneratingDeviceOrientationNotifications()
         orientationObserver = NotificationCenter.default.addObserver(
@@ -64,30 +100,28 @@ final class CameraFramePublisher: NSObject, ObservableObject {
         }
     }
 
-    func startCapture(streamService: CameraStreamService) {
-        self.streamService = streamService
-        frameIndex = 0
-        publishCount = 0
-        fpsWindowStart = Date()
-        processingQueue.async { [weak self] in
-            self?.captureSession.startRunning()
-            DispatchQueue.main.async { print("[FramePublisher] capture started") }
+    private func attachIfNeeded() {
+        guard !isAttached, !attachInFlight, let manager = captureManager else { return }
+        attachInFlight = true
+        manager.attachPreviewOutput(videoOutput) { [weak self] attached in
+            guard let self else { return }
+            self.attachInFlight = false
+            self.isAttached = attached
+            MC1Log.notice("[FramePublisher] preview output attach \(attached ? "OK" : "FAILED") — target=\(Int(1.0 / Self.targetInterval))fps, orientation=\(OrientationMapper.currentOrientationLabel)")
         }
-    }
-
-    func stopCapture() {
-        processingQueue.async { [weak self] in
-            self?.captureSession.stopRunning()
-            DispatchQueue.main.async { print("[FramePublisher] capture stopped") }
-        }
-        streamService = nil
     }
 }
 
 // MARK: — AVCaptureVideoDataOutputSampleBufferDelegate
 
 extension CameraFramePublisher: AVCaptureVideoDataOutputSampleBufferDelegate {
-    private static let targetInterval: CFTimeInterval = 1.0 / 12.0
+    private nonisolated static let targetInterval: CFTimeInterval = 1.0 / 12.0
+    /// Longest edge of a published preview frame. The shared session runs at the
+    /// RECORDING profile (1280x720 — see CaptureFormatSelector), unlike the old
+    /// dedicated preview session's `.medium` preset; a full 720p JPEG can exceed
+    /// what MCSession `.unreliable` reliably delivers, so downscale to roughly
+    /// the previous preview fidelity before encoding.
+    private nonisolated static let maxPreviewEdge: CGFloat = 640
 
     nonisolated func captureOutput(_ output: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer, from connection: AVCaptureConnection) {
         let now = CACurrentMediaTime()
@@ -96,7 +130,12 @@ extension CameraFramePublisher: AVCaptureVideoDataOutputSampleBufferDelegate {
 
         guard let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
 
-        let ciImage = CIImage(cvPixelBuffer: pixelBuffer)
+        var ciImage = CIImage(cvPixelBuffer: pixelBuffer)
+        let longestEdge = max(ciImage.extent.width, ciImage.extent.height)
+        if longestEdge > Self.maxPreviewEdge {
+            let scale = Self.maxPreviewEdge / longestEdge
+            ciImage = ciImage.transformed(by: CGAffineTransform(scaleX: scale, y: scale))
+        }
         let context = CIContext()
         guard let cgImage = context.createCGImage(ciImage, from: ciImage.extent) else { return }
         let uiImage = UIImage(cgImage: cgImage)

--- a/ios/LFAEducationCenter/MultiCamera/CameraStreamService.swift
+++ b/ios/LFAEducationCenter/MultiCamera/CameraStreamService.swift
@@ -59,14 +59,14 @@ final class CameraStreamService: NSObject, ObservableObject {
             adv.delegate = self
             adv.startAdvertisingPeer()
             self.advertiser = adv
-            print("[StreamService] player advertising: \(myPeerID.displayName)")
+            MC1Log.notice("[StreamService] player advertising: \(myPeerID.displayName)")
 
         case .instructor:
             let brw = MCNearbyServiceBrowser(peer: myPeerID, serviceType: Self.serviceType)
             brw.delegate = self
             brw.startBrowsingForPeers()
             self.browser = brw
-            print("[StreamService] instructor browsing for players")
+            MC1Log.notice("[StreamService] instructor browsing for players")
         }
 
         fpsTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
@@ -115,14 +115,14 @@ extension CameraStreamService: MCSessionDelegate {
             case .connected:
                 connectedPeer = peerID
                 peerState = .connected(peerName: peerID.displayName)
-                print("[StreamService] connected to \(peerID.displayName)")
+                MC1Log.notice("[StreamService] connected to \(peerID.displayName)")
             case .connecting:
                 peerState = .connecting
-                print("[StreamService] connecting to \(peerID.displayName)")
+                MC1Log.notice("[StreamService] connecting to \(peerID.displayName)")
             case .notConnected:
                 if connectedPeer == peerID { connectedPeer = nil }
                 peerState = .disconnected
-                print("[StreamService] disconnected from \(peerID.displayName)")
+                MC1Log.notice("[StreamService] disconnected from \(peerID.displayName)")
                 if role == .instructor {
                     browser?.startBrowsingForPeers()
                 }
@@ -151,13 +151,13 @@ extension CameraStreamService: MCSessionDelegate {
 extension CameraStreamService: MCNearbyServiceAdvertiserDelegate {
     nonisolated func advertiser(_ advertiser: MCNearbyServiceAdvertiser, didReceiveInvitationFromPeer peerID: MCPeerID, withContext: Data?, invitationHandler: @escaping (Bool, MCSession?) -> Void) {
         Task { @MainActor in
-            print("[StreamService] received invitation from \(peerID.displayName)")
+            MC1Log.notice("[StreamService] received invitation from \(peerID.displayName)")
             invitationHandler(true, session)
         }
     }
 
     nonisolated func advertiser(_ advertiser: MCNearbyServiceAdvertiser, didNotStartAdvertisingPeer error: Error) {
-        print("[StreamService] advertising failed: \(error)")
+        MC1Log.notice("[StreamService] advertising failed: \(error)")
     }
 }
 
@@ -166,17 +166,17 @@ extension CameraStreamService: MCNearbyServiceAdvertiserDelegate {
 extension CameraStreamService: MCNearbyServiceBrowserDelegate {
     nonisolated func browser(_ browser: MCNearbyServiceBrowser, foundPeer peerID: MCPeerID, withDiscoveryInfo info: [String: String]?) {
         Task { @MainActor in
-            print("[StreamService] found peer: \(peerID.displayName) info=\(info ?? [:])")
+            MC1Log.notice("[StreamService] found peer: \(peerID.displayName) info=\(info ?? [:])")
             guard let session else { return }
             browser.invitePeer(peerID, to: session, withContext: nil, timeout: 10)
         }
     }
 
     nonisolated func browser(_ browser: MCNearbyServiceBrowser, lostPeer peerID: MCPeerID) {
-        print("[StreamService] lost peer: \(peerID.displayName)")
+        MC1Log.notice("[StreamService] lost peer: \(peerID.displayName)")
     }
 
     nonisolated func browser(_ browser: MCNearbyServiceBrowser, didNotStartBrowsingForPeers error: Error) {
-        print("[StreamService] browsing failed: \(error)")
+        MC1Log.notice("[StreamService] browsing failed: \(error)")
     }
 }

--- a/ios/LFAEducationCenter/MultiCamera/CycleCaptureOrchestrator.swift
+++ b/ios/LFAEducationCenter/MultiCamera/CycleCaptureOrchestrator.swift
@@ -104,9 +104,9 @@ final class CycleCaptureOrchestrator: ObservableObject {
     @Published private(set) var state: OrchestratorState = .idle {
         didSet {
             switch state {
-            case .capturing(let cycleId): print("[CCO] confirmed start: cycleId=\(cycleId)")
-            case .completed(let cycleId): print("[CCO] confirmed stop: cycleId=\(cycleId)")
-            case .failed(let failure): print("[CCO] FAILURE: \(failure)")
+            case .capturing(let cycleId): MC1Log.notice("[CCO] confirmed start: cycleId=\(cycleId)")
+            case .completed(let cycleId): MC1Log.notice("[CCO] confirmed stop: cycleId=\(cycleId)")
+            case .failed(let failure): MC1Log.notice("[CCO] FAILURE: \(failure)")
             default: break
             }
         }

--- a/ios/LFAEducationCenter/MultiCamera/GoProConnectionManager.swift
+++ b/ios/LFAEducationCenter/MultiCamera/GoProConnectionManager.swift
@@ -128,10 +128,10 @@ final class GoProConnectionManager: ObservableObject {
         do {
             _ = try await httpTransport.get(path: GoProSpec.shutterStartPath, timeout: GoProSpec.commandTimeout)
             recordingState = .recording
-            print("[GOPRO] shutter start OK")
+            MC1Log.notice("[GOPRO] shutter start OK")
         } catch {
             recordingState = .failed("\(error)")
-            print("[GOPRO] shutter start FAILED: \(error)")
+            MC1Log.notice("[GOPRO] shutter start FAILED: \(error)")
             throw GoProRecordingError.shutterFailed("\(error)")
         }
     }
@@ -142,10 +142,10 @@ final class GoProConnectionManager: ObservableObject {
         do {
             _ = try await httpTransport.get(path: GoProSpec.shutterStopPath, timeout: GoProSpec.commandTimeout)
             recordingState = .stopped
-            print("[GOPRO] shutter stop OK")
+            MC1Log.notice("[GOPRO] shutter stop OK")
         } catch {
             recordingState = .failed("\(error)")
-            print("[GOPRO] shutter stop FAILED: \(error)")
+            MC1Log.notice("[GOPRO] shutter stop FAILED: \(error)")
             throw GoProRecordingError.shutterFailed("\(error)")
         }
     }
@@ -154,7 +154,7 @@ final class GoProConnectionManager: ObservableObject {
         do {
             return try await httpTransport.get(path: GoProSpec.mediaListPath, timeout: GoProSpec.commandTimeout)
         } catch {
-            print("[GOPRO] media list failed: \(error)")
+            MC1Log.notice("[GOPRO] media list failed: \(error)")
             return nil
         }
     }
@@ -269,18 +269,18 @@ final class GoProConnectionManager: ObservableObject {
         do {
             try await wifiTransport.joinAccessPoint(ssid: ssid, password: password)
             cancelTimeout()
-            print("[GoPro] WiFi joined via NEHotspotConfiguration: \(ssid)")
+            MC1Log.notice("[GoPro] WiFi joined via NEHotspotConfiguration: \(ssid)")
             startHTTPVerify(trigger: "wifi_joined_auto")
         } catch GoProWiFiError.alreadyAssociated {
             cancelTimeout()
-            print("[GoPro] WiFi already associated: \(ssid)")
+            MC1Log.notice("[GoPro] WiFi already associated: \(ssid)")
             startHTTPVerify(trigger: "wifi_already_associated")
         } catch GoProWiFiError.userDenied {
             cancelTimeout()
             transition(to: .failed(.wifiUserDenied), trigger: "wifi_user_denied")
         } catch {
             cancelTimeout()
-            print("[GoPro] WiFi auto-join failed: \(error), falling back to manual")
+            MC1Log.notice("[GoPro] WiFi auto-join failed: \(error), falling back to manual")
             transition(to: .awaitingManualWiFiJoin(ssid: ssid), trigger: "wifi_auto_failed_fallback")
         }
     }

--- a/ios/LFAEducationCenter/MultiCamera/MC1AutomationBridge.swift
+++ b/ios/LFAEducationCenter/MultiCamera/MC1AutomationBridge.swift
@@ -119,107 +119,107 @@ final class MC1AutomationBridge: ObservableObject {
         case "join":
             guard let uuid = value("session_uuid"), !uuid.isEmpty else { return false }
             let role: ParticipantRole = value("role") == "instructor" ? .instructor : .player
-            print("[MC1-AUTO] received action=join uuid=\(uuid) role=\(role)")
+            MC1Log.notice("[MC1-AUTO] received action=join uuid=\(uuid) role=\(role)")
             presentSessionLab = true
             post(.joinSession(uuid: uuid, role: role))
             return true
         case "mark-ready":
-            print("[MC1-AUTO] received action=mark-ready")
+            MC1Log.notice("[MC1-AUTO] received action=mark-ready")
             post(.markDevicesReady)
             return true
         case "begin-cycle":
-            print("[MC1-AUTO] received action=begin-cycle")
+            MC1Log.notice("[MC1-AUTO] received action=begin-cycle")
             post(.beginCycle)
             return true
         case "end-cycle":
-            print("[MC1-AUTO] received action=end-cycle")
+            MC1Log.notice("[MC1-AUTO] received action=end-cycle")
             post(.endCycle)
             return true
         case "dump-snapshot":
-            print("[MC1-AUTO] received action=dump-snapshot")
+            MC1Log.notice("[MC1-AUTO] received action=dump-snapshot")
             post(.dumpSnapshot)
             return true
         case "reset-session":
-            print("[MC1-AUTO] received action=reset-session")
+            MC1Log.notice("[MC1-AUTO] received action=reset-session")
             post(.resetSession)
             return true
         case "gopro-connect":
             let did = value("gopro_device_id").flatMap(Int.init)
-            print("[MC1-AUTO] received action=gopro-connect gopro_device_id=\(did ?? -1)")
+            MC1Log.notice("[MC1-AUTO] received action=gopro-connect gopro_device_id=\(did ?? -1)")
             post(.goProConnect(goProDeviceId: did))
             return true
         case "gopro-start":
             guard let did = value("gopro_device_id").flatMap(Int.init) else { return false }
-            print("[MC1-AUTO] received action=gopro-start gopro_device_id=\(did)")
+            MC1Log.notice("[MC1-AUTO] received action=gopro-start gopro_device_id=\(did)")
             post(.goProStartRecording(goProDeviceId: did))
             return true
         case "gopro-stop":
             guard let did = value("gopro_device_id").flatMap(Int.init) else { return false }
-            print("[MC1-AUTO] received action=gopro-stop gopro_device_id=\(did)")
+            MC1Log.notice("[MC1-AUTO] received action=gopro-stop gopro_device_id=\(did)")
             post(.goProStopRecording(goProDeviceId: did))
             return true
         case "gopro-status":
-            print("[MC1-AUTO] received action=gopro-status")
+            MC1Log.notice("[MC1-AUTO] received action=gopro-status")
             post(.goProStatus)
             return true
         case "gopro-media-list":
-            print("[MC1-AUTO] received action=gopro-media-list")
+            MC1Log.notice("[MC1-AUTO] received action=gopro-media-list")
             post(.goProMediaList)
             return true
         case "gopro-http-diag":
-            print("[MC1-AUTO] received action=gopro-http-diag")
+            MC1Log.notice("[MC1-AUTO] received action=gopro-http-diag")
             post(.goProHttpDiag)
             return true
         case "gopro-download-latest":
-            print("[MC1-AUTO] received action=gopro-download-latest")
+            MC1Log.notice("[MC1-AUTO] received action=gopro-download-latest")
             post(.goProDownloadLatest)
             return true
         case "skeleton-process":
-            print("[MC1-AUTO] received action=skeleton-process")
+            MC1Log.notice("[MC1-AUTO] received action=skeleton-process")
             post(.skeletonProcess)
             return true
         case "capture-info":
-            print("[MC1-AUTO] received action=capture-info")
+            MC1Log.notice("[MC1-AUTO] received action=capture-info")
             post(.captureInfo)
             return true
         case "network-routing-diag":
             let label = value("label") ?? "unlabeled"
-            print("[MC1-AUTO] received action=network-routing-diag label=\(label)")
+            MC1Log.notice("[MC1-AUTO] received action=network-routing-diag label=\(label)")
             post(.networkRoutingDiag(label: label))
             return true
         case "gopro-preview-poc":
             let duration = value("duration_s").flatMap(Double.init) ?? 25
-            print("[MC1-AUTO] received action=gopro-preview-poc duration_s=\(duration)")
+            MC1Log.notice("[MC1-AUTO] received action=gopro-preview-poc duration_s=\(duration)")
             post(.goProPreviewPOC(durationSeconds: duration))
             return true
         case "gopro-combined-cycle-proof":
             let duration = value("duration_s").flatMap(Double.init) ?? 15
-            print("[MC1-AUTO] received action=gopro-combined-cycle-proof duration_s=\(duration)")
+            MC1Log.notice("[MC1-AUTO] received action=gopro-combined-cycle-proof duration_s=\(duration)")
             post(.goProCombinedCycleProof(durationSeconds: duration))
             return true
         case "gopro-camera-state-probe":
-            print("[MC1-AUTO] received action=gopro-camera-state-probe")
+            MC1Log.notice("[MC1-AUTO] received action=gopro-camera-state-probe")
             post(.goProCameraStateProbe)
             return true
         case "gopro-preview-aspect-probe":
             let duration = value("duration_s").flatMap(Double.init) ?? 20
-            print("[MC1-AUTO] received action=gopro-preview-aspect-probe duration_s=\(duration)")
+            MC1Log.notice("[MC1-AUTO] received action=gopro-preview-aspect-probe duration_s=\(duration)")
             post(.goProPreviewAspectProbe(durationSeconds: duration))
             return true
         case "gopro-preset-write-validation":
-            print("[MC1-AUTO] received action=gopro-preset-write-validation")
+            MC1Log.notice("[MC1-AUTO] received action=gopro-preset-write-validation")
             post(.goProPresetWriteValidation)
             return true
         case "gopro-stream-start":
-            print("[MC1-AUTO] received action=gopro-stream-start")
+            MC1Log.notice("[MC1-AUTO] received action=gopro-stream-start")
             post(.goProStreamStart)
             return true
         case "pose-overlay-diag":
-            print("[MC1-AUTO] received action=pose-overlay-diag")
+            MC1Log.notice("[MC1-AUTO] received action=pose-overlay-diag")
             post(.poseOverlayDiag)
             return true
         default:
-            print("[MC1-AUTO] received unknown action=\(action)")
+            MC1Log.notice("[MC1-AUTO] received unknown action=\(action)")
             return false
         }
     }

--- a/ios/LFAEducationCenter/MultiCamera/MC1Log.swift
+++ b/ios/LFAEducationCenter/MultiCamera/MC1Log.swift
@@ -1,0 +1,29 @@
+import Foundation
+import os
+
+// MARK: — MC1Log
+//
+// Physical-evidence logging for the MC1 multicamera stack.
+//
+// The 2026-07-04 tricamera physical run proved that `print()` output is
+// INVISIBLE to idevicesyslog on physical devices: the 78k-line iPhone console
+// capture contained ZERO app-tagged lines ([PCO]/[CCO]/[MC1-AUTO]/[GOPRO-AUTO])
+// even though the code printed them — print() goes to stdout, which the syslog
+// relay never sees. Every console-grounded evidence extraction in the
+// regression harness (ConsoleOffsetTracker.extract_tagged_lines, debug
+// snapshots, GOPRO-MEDIA markers) was silently blind.
+//
+// os_log entries at .default level DO appear in idevicesyslog (the same
+// capture was full of CFNetwork/UIKitCore os_log lines). The `%{public}@`
+// format is load-bearing: without it, iOS redacts the interpolated message to
+// `<private>` on physical devices, which is exactly as useless as no line.
+enum MC1Log {
+    private static let osLog = OSLog(subsystem: "com.lfa.educationcenter.mc1", category: "MC1")
+
+    /// Drop-in replacement for `print()` in the MC1 evidence path. Message text
+    /// (including the leading `[TAG]`) must stay byte-identical to what the
+    /// harness greps for.
+    static func notice(_ message: String) {
+        os_log("%{public}@", log: osLog, type: .default, message)
+    }
+}

--- a/ios/LFAEducationCenter/MultiCamera/MultiCameraLobbyView.swift
+++ b/ios/LFAEducationCenter/MultiCamera/MultiCameraLobbyView.swift
@@ -50,7 +50,7 @@ struct MultiCameraLobbyView: View {
         ))
     }
 
-    private static let buildFingerprint = "mc1-debug-v12-2026-07-04"
+    private static let buildFingerprint = "mc1-debug-v13-2026-07-12"
 
     var body: some View {
         NavigationView {

--- a/ios/LFAEducationCenter/MultiCamera/MultiCameraLobbyView.swift
+++ b/ios/LFAEducationCenter/MultiCamera/MultiCameraLobbyView.swift
@@ -50,7 +50,7 @@ struct MultiCameraLobbyView: View {
         ))
     }
 
-    private static let buildFingerprint = "mc1-debug-v11-2026-06-28"
+    private static let buildFingerprint = "mc1-debug-v12-2026-07-04"
 
     var body: some View {
         NavigationView {
@@ -110,64 +110,64 @@ struct MultiCameraLobbyView: View {
             let action = envelope.action
             switch action {
             case .joinSession(let uuid, let role):
-                print("[MC1-AUTO] dispatching action=join uuid=\(uuid) role=\(role) state=\(vm.state)")
+                MC1Log.notice("[MC1-AUTO] dispatching action=join uuid=\(uuid) role=\(role) state=\(vm.state)")
                 vm.joinSession(uuid: uuid, role: role)
             case .markDevicesReady:
-                print("[MC1-AUTO] dispatching action=mark-ready state=\(vm.state)")
+                MC1Log.notice("[MC1-AUTO] dispatching action=mark-ready state=\(vm.state)")
                 vm.transitionToDevicesReady()
             case .beginCycle:
-                print("[MC1-AUTO] dispatching action=begin-cycle state=\(vm.state) canStartCapture=\(vm.canStartCapture) isClockSynced=\(vm.isClockSynced)")
+                MC1Log.notice("[MC1-AUTO] dispatching action=begin-cycle state=\(vm.state) canStartCapture=\(vm.canStartCapture) isClockSynced=\(vm.isClockSynced)")
                 vm.beginCycle()
             case .endCycle:
-                print("[MC1-AUTO] dispatching action=end-cycle state=\(vm.state)")
+                MC1Log.notice("[MC1-AUTO] dispatching action=end-cycle state=\(vm.state)")
                 vm.endCycle()
             case .dumpSnapshot:
-                print("[MC1-AUTO] dispatching action=dump-snapshot")
+                MC1Log.notice("[MC1-AUTO] dispatching action=dump-snapshot")
                 dumpSnapshotToConsole()
             case .resetSession:
-                print("[MC1-AUTO] dispatching action=reset-session state=\(vm.state) capture=\(captureManager.state)")
+                MC1Log.notice("[MC1-AUTO] dispatching action=reset-session state=\(vm.state) capture=\(captureManager.state)")
                 vm.reset()
                 captureManager.resetForReuse()
             case .goProConnect(let goProDeviceId):
                 let gp = GoProConnectionManager.shared
-                print("[GOPRO-AUTO] dispatching gopro-connect connection=\(gp.state) goProDeviceId=\(goProDeviceId ?? -1)")
+                MC1Log.notice("[GOPRO-AUTO] dispatching gopro-connect connection=\(gp.state) goProDeviceId=\(goProDeviceId ?? -1)")
                 if case .ready = gp.state {
-                    print("[GOPRO-AUTO] already connected+ready")
+                    MC1Log.notice("[GOPRO-AUTO] already connected+ready")
                     Task { await self.signalGoProReady(goProDeviceId: goProDeviceId) }
                 } else if case .awaitingManualWiFiJoin = gp.state {
-                    print("[GOPRO-AUTO] attempting confirmManualWiFiJoined...")
+                    MC1Log.notice("[GOPRO-AUTO] attempting confirmManualWiFiJoined...")
                     gp.confirmManualWiFiJoined()
                     Task { await self.waitAndSignalGoProReady(goProDeviceId: goProDeviceId) }
                 } else if case .failed(let err) = gp.state, err.isRecoverable {
-                    print("[GOPRO-AUTO] retrying from failed state...")
+                    MC1Log.notice("[GOPRO-AUTO] retrying from failed state...")
                     gp.retry()
                     Task { await self.waitAndSignalGoProReady(goProDeviceId: goProDeviceId) }
                 } else if gp.state == .idle {
-                    print("[GOPRO-AUTO] starting fresh connection...")
+                    MC1Log.notice("[GOPRO-AUTO] starting fresh connection...")
                     gp.startConnection()
                     Task { await self.waitAndSignalGoProReady(goProDeviceId: goProDeviceId) }
                 } else {
-                    print("[GOPRO-AUTO] cannot connect from state=\(gp.state)")
+                    MC1Log.notice("[GOPRO-AUTO] cannot connect from state=\(gp.state)")
                 }
             case .goProStartRecording(let goProDeviceId):
                 let gp = GoProConnectionManager.shared
-                print("[GOPRO-AUTO] dispatching gopro-start connection=\(gp.state) recording=\(gp.recordingState) goProDeviceId=\(goProDeviceId)")
+                MC1Log.notice("[GOPRO-AUTO] dispatching gopro-start connection=\(gp.state) recording=\(gp.recordingState) goProDeviceId=\(goProDeviceId)")
                 Task {
                     do {
                         try await gp.startRecording()
-                        print("[GOPRO-AUTO] shutter start OK, confirming to backend...")
+                        MC1Log.notice("[GOPRO-AUTO] shutter start OK, confirming to backend...")
                         guard let token = vm.authManager.accessToken,
                               let sessionUuid = vm.sessionUuid else {
-                            print("[GOPRO-AUTO] confirm skipped: no auth/session")
+                            MC1Log.notice("[GOPRO-AUTO] confirm skipped: no auth/session")
                             return
                         }
                         let cycles = try await MultiCameraAPIClient.listCycles(token: token, uuid: sessionUuid)
                         guard let cycle = cycles.max(by: { $0.cycleIndex < $1.cycleIndex }) else {
-                            print("[GOPRO-AUTO] confirm skipped: no cycle found")
+                            MC1Log.notice("[GOPRO-AUTO] confirm skipped: no cycle found")
                             return
                         }
                         guard let cd = cycle.cycleDevices.first(where: { $0.sessionDeviceId == goProDeviceId }) else {
-                            print("[GOPRO-AUTO] confirm skipped: no cycle_device for GoPro")
+                            MC1Log.notice("[GOPRO-AUTO] confirm skipped: no cycle_device for GoPro")
                             return
                         }
                         let ts = Self.isoNow()
@@ -176,30 +176,30 @@ struct MultiCameraLobbyView: View {
                             sessionDeviceId: goProDeviceId, startedAt: ts,
                             cycleDeviceRevision: cd.revision
                         )
-                        print("[GOPRO-AUTO] confirmDeviceStart OK cycleId=\(cycle.id)")
+                        MC1Log.notice("[GOPRO-AUTO] confirmDeviceStart OK cycleId=\(cycle.id)")
                     } catch {
-                        print("[GOPRO-AUTO] start FAILED: \(error)")
+                        MC1Log.notice("[GOPRO-AUTO] start FAILED: \(error)")
                     }
                 }
             case .goProStopRecording(let goProDeviceId):
                 let gp = GoProConnectionManager.shared
-                print("[GOPRO-AUTO] dispatching gopro-stop connection=\(gp.state) recording=\(gp.recordingState) goProDeviceId=\(goProDeviceId)")
+                MC1Log.notice("[GOPRO-AUTO] dispatching gopro-stop connection=\(gp.state) recording=\(gp.recordingState) goProDeviceId=\(goProDeviceId)")
                 Task {
                     do {
                         try await gp.stopRecording()
-                        print("[GOPRO-AUTO] shutter stop OK, confirming to backend...")
+                        MC1Log.notice("[GOPRO-AUTO] shutter stop OK, confirming to backend...")
                         guard let token = vm.authManager.accessToken,
                               let sessionUuid = vm.sessionUuid else {
-                            print("[GOPRO-AUTO] confirm skipped: no auth/session")
+                            MC1Log.notice("[GOPRO-AUTO] confirm skipped: no auth/session")
                             return
                         }
                         let cycles = try await MultiCameraAPIClient.listCycles(token: token, uuid: sessionUuid)
                         guard let cycle = cycles.max(by: { $0.cycleIndex < $1.cycleIndex }) else {
-                            print("[GOPRO-AUTO] confirm skipped: no cycle found")
+                            MC1Log.notice("[GOPRO-AUTO] confirm skipped: no cycle found")
                             return
                         }
                         guard let cd = cycle.cycleDevices.first(where: { $0.sessionDeviceId == goProDeviceId }) else {
-                            print("[GOPRO-AUTO] confirm skipped: no cycle_device for GoPro")
+                            MC1Log.notice("[GOPRO-AUTO] confirm skipped: no cycle_device for GoPro")
                             return
                         }
                         let ts = Self.isoNow()
@@ -208,81 +208,81 @@ struct MultiCameraLobbyView: View {
                             sessionDeviceId: goProDeviceId, stoppedAt: ts,
                             cycleDeviceRevision: cd.revision
                         )
-                        print("[GOPRO-AUTO] confirmDeviceStop OK cycleId=\(cycle.id)")
+                        MC1Log.notice("[GOPRO-AUTO] confirmDeviceStop OK cycleId=\(cycle.id)")
                     } catch {
-                        print("[GOPRO-AUTO] stop FAILED: \(error)")
+                        MC1Log.notice("[GOPRO-AUTO] stop FAILED: \(error)")
                     }
                 }
             case .goProHttpDiag:
-                print("[GOPRO-DIAG] === GoPro HERO13 HTTP Diagnostics ===")
+                MC1Log.notice("[GOPRO-DIAG] === GoPro HERO13 HTTP Diagnostics ===")
                 let gp = GoProConnectionManager.shared
-                print("[GOPRO-DIAG] connection_state=\(gp.state)")
-                print("[GOPRO-DIAG] recording_state=\(gp.recordingState)")
-                print("[GOPRO-DIAG] camera_status=\(String(describing: gp.cameraStatus))")
+                MC1Log.notice("[GOPRO-DIAG] connection_state=\(gp.state)")
+                MC1Log.notice("[GOPRO-DIAG] recording_state=\(gp.recordingState)")
+                MC1Log.notice("[GOPRO-DIAG] camera_status=\(String(describing: gp.cameraStatus))")
                 Task {
                     let transport = GoProHTTPClientTransport()
 
                     // 1. HTTP reachability
                     let reachable = await transport.isReachable(timeout: 5)
-                    print("[GOPRO-DIAG] http_reachable=\(reachable)")
+                    MC1Log.notice("[GOPRO-DIAG] http_reachable=\(reachable)")
 
                     // 2. Camera state (firmware version, battery, recording)
                     do {
                         let data = try await transport.get(path: GoProSpec.cameraStatePath, timeout: 5)
                         let text = String(data: data, encoding: .utf8) ?? "(binary \(data.count)B)"
-                        print("[GOPRO-DIAG] camera_state_response=\(text.prefix(800))")
+                        MC1Log.notice("[GOPRO-DIAG] camera_state_response=\(text.prefix(800))")
                     } catch {
-                        print("[GOPRO-DIAG] camera_state_error=\(error)")
+                        MC1Log.notice("[GOPRO-DIAG] camera_state_error=\(error)")
                     }
 
                     // 3. Preview stream start endpoint (HERO13 validation)
-                    print("[GOPRO-DIAG] testing preview stream: GET \(GoProSpec.streamStartPath)...")
+                    MC1Log.notice("[GOPRO-DIAG] testing preview stream: GET \(GoProSpec.streamStartPath)...")
                     do {
                         let data = try await transport.get(path: GoProSpec.streamStartPath, timeout: 5)
                         let text = String(data: data, encoding: .utf8) ?? "(binary \(data.count)B)"
-                        print("[GOPRO-DIAG] stream_start_response=\(text.prefix(500))")
-                        print("[GOPRO-DIAG] stream_start=SUCCESS — preview should be available on UDP:\(GoProSpec.previewStreamPort)")
+                        MC1Log.notice("[GOPRO-DIAG] stream_start_response=\(text.prefix(500))")
+                        MC1Log.notice("[GOPRO-DIAG] stream_start=SUCCESS — preview should be available on UDP:\(GoProSpec.previewStreamPort)")
                     } catch {
-                        print("[GOPRO-DIAG] stream_start_error=\(error)")
+                        MC1Log.notice("[GOPRO-DIAG] stream_start_error=\(error)")
                     }
 
                     // 4. Preview stream stop (cleanup)
                     do {
                         _ = try await transport.get(path: GoProSpec.streamStopPath, timeout: 5)
-                        print("[GOPRO-DIAG] stream_stop=OK")
+                        MC1Log.notice("[GOPRO-DIAG] stream_stop=OK")
                     } catch {
-                        print("[GOPRO-DIAG] stream_stop_error=\(error)")
+                        MC1Log.notice("[GOPRO-DIAG] stream_stop_error=\(error)")
                     }
 
                     // 5. Backend reachable (cellular alongside GoPro WiFi)
                     if let token = vm.authManager.accessToken {
                         do {
                             let session = try await MultiCameraAPIClient.getSession(token: token, uuid: vm.sessionUuid ?? "none")
-                            print("[GOPRO-DIAG] backend_reachable=true session_status=\(session.status.rawValue)")
+                            MC1Log.notice("[GOPRO-DIAG] backend_reachable=true session_status=\(session.status.rawValue)")
                         } catch {
-                            print("[GOPRO-DIAG] backend_reachable=false error=\(error)")
+                            MC1Log.notice("[GOPRO-DIAG] backend_reachable=false error=\(error)")
                         }
                     } else {
-                        print("[GOPRO-DIAG] backend_reachable=unknown (no token)")
+                        MC1Log.notice("[GOPRO-DIAG] backend_reachable=unknown (no token)")
                     }
-                    print("[GOPRO-DIAG] === end ===")
+                    MC1Log.notice("[GOPRO-DIAG] === end ===")
                 }
             case .goProStatus:
                 let gp = GoProConnectionManager.shared
-                print("[GOPRO-AUTO] status connection=\(gp.state) recording=\(gp.recordingState) battery=\(gp.cameraStatus?.batteryLevel ?? -1)")
+                MC1Log.notice("[GOPRO-AUTO] status connection=\(gp.state) recording=\(gp.recordingState) battery=\(gp.cameraStatus?.batteryLevel ?? -1)")
             case .goProMediaList:
                 let gp = GoProConnectionManager.shared
-                print("[GOPRO-AUTO] fetching media list...")
+                MC1Log.notice("[GOPRO-AUTO] fetching media list...")
                 Task {
                     if let data = await gp.fetchMediaList(),
                        let text = String(data: data, encoding: .utf8) {
-                        print("[GOPRO-MEDIA-BEGIN]\n\(text)\n[GOPRO-MEDIA-END]")
+                        MC1Log.notice("[GOPRO-MEDIA-BEGIN]\n\(text)\n[GOPRO-MEDIA-END]")
                     } else {
-                        print("[GOPRO-AUTO] media list: unavailable")
+                        MC1Log.notice("[GOPRO-AUTO] media list: unavailable")
                     }
                 }
             case .goProDownloadLatest:
-                print("[GOPRO-AUTO] downloading latest GoPro media...")
+                MC1Log.notice("[GOPRO-AUTO] downloading latest GoPro media...")
                 Task {
                     let gp = GoProConnectionManager.shared
                     guard let listData = await gp.fetchMediaList(),
@@ -293,11 +293,11 @@ struct MultiCameraLobbyView: View {
                           let lastFile = files.last,
                           let filename = lastFile["n"] as? String,
                           let dirName = lastDir["d"] as? String else {
-                        print("[GOPRO-AUTO] download: no media found")
+                        MC1Log.notice("[GOPRO-AUTO] download: no media found")
                         return
                     }
                     let path = "\(GoProSpec.mediaDownloadBase)/\(dirName)/\(filename)"
-                    print("[GOPRO-AUTO] downloading: \(path)...")
+                    MC1Log.notice("[GOPRO-AUTO] downloading: \(path)...")
                     let transport = GoProHTTPClientTransport()
                     do {
                         let data = try await transport.get(path: path, timeout: 60)
@@ -305,24 +305,24 @@ struct MultiCameraLobbyView: View {
                         try? FileManager.default.createDirectory(at: outputDir, withIntermediateDirectories: true)
                         let outputFile = outputDir.appendingPathComponent(filename)
                         try data.write(to: outputFile)
-                        print("[GOPRO-DOWNLOAD] saved: \(outputFile.path) size=\(data.count)")
+                        MC1Log.notice("[GOPRO-DOWNLOAD] saved: \(outputFile.path) size=\(data.count)")
                     } catch {
-                        print("[GOPRO-AUTO] download failed: \(error)")
+                        MC1Log.notice("[GOPRO-AUTO] download failed: \(error)")
                     }
                 }
             case .skeletonProcess:
-                print("[SKELETON] starting skeleton processing on local video...")
+                MC1Log.notice("[SKELETON] starting skeleton processing on local video...")
                 Task {
                     let processor = SkeletonProcessor()
                     guard let videoURL = captureManager.outputFileURL else {
-                        print("[SKELETON] no local video file to process")
+                        MC1Log.notice("[SKELETON] no local video file to process")
                         return
                     }
                     let sessionUuid = vm.sessionUuid ?? "unknown"
                     let deviceId = vm.sessionDeviceId.map { "\($0)" } ?? "unknown"
                     await processor.process(videoURL: videoURL, sessionUuid: sessionUuid, deviceId: deviceId)
                     if case .failed(let msg) = processor.state {
-                        print("[SKELETON-RESULT] FAILED: \(msg)")
+                        MC1Log.notice("[SKELETON-RESULT] FAILED: \(msg)")
                     }
                 }
             case .captureInfo:
@@ -331,7 +331,7 @@ struct MultiCameraLobbyView: View {
                     guard let url = fileURL else { return 0 }
                     return (try? FileManager.default.attributesOfItem(atPath: url.path)[.size] as? Int) ?? 0
                 }()
-                print("[CAPTURE-INFO] state=\(captureManager.state) outputFile=\(fileURL?.path ?? "nil") size=\(fileSize)")
+                MC1Log.notice("[CAPTURE-INFO] state=\(captureManager.state) outputFile=\(fileURL?.path ?? "nil") size=\(fileSize)")
                 CaptureMetadataDiagWriter.write(from: captureManager)
             case .networkRoutingDiag(let label):
                 Task { await BackendNetworkDiagnostics.probe(label: label) }
@@ -352,14 +352,14 @@ struct MultiCameraLobbyView: View {
                 }
             case .goProPreviewAspectProbe(let durationSeconds):
                 Task {
-                    print("[GOPRO-PREVIEW-ASPECT] starting live preview (camera/state probe has NO preview — this one does)...")
+                    MC1Log.notice("[GOPRO-PREVIEW-ASPECT] starting live preview (camera/state probe has NO preview — this one does)...")
                     let diag = await GoProStreamProbe.shared.run(durationSeconds: durationSeconds)
                     GoProStreamDiagWriter.write(diag)
                     GoProPreviewAspectDiagWriter.write(from: diag)
                 }
             case .goProPresetWriteValidation:
                 Task {
-                    print("[GOPRO-PRESET-POC] starting 8:7 preset read/write/verify/recording/preview chain...")
+                    MC1Log.notice("[GOPRO-PRESET-POC] starting 8:7 preset read/write/verify/recording/preview chain...")
                     _ = await GoProRecordingPresetProbe.run()
                 }
             case .goProStreamStart:
@@ -374,7 +374,7 @@ struct MultiCameraLobbyView: View {
                 // so a silently-failed GoPro preview was invisible to anything but a
                 // human eyeballing the dashboard screenshot (2026-07-01 flow audit).
                 Task {
-                    print("[MC1-AUTO] gopro-stream-start → GoProStreamProbe.shared.run(60s)")
+                    MC1Log.notice("[MC1-AUTO] gopro-stream-start → GoProStreamProbe.shared.run(60s)")
                     let diag = await GoProStreamProbe.shared.run(durationSeconds: 60)
                     GoProStreamDiagWriter.write(diag)
                 }
@@ -414,9 +414,11 @@ struct MultiCameraLobbyView: View {
                     playerOrchestrator: playerOrchestrator
                 )
                 .onAppear {
-                    framePublisher.configure()
                     playerStreamService.start()
-                    framePublisher.startCapture(streamService: playerStreamService)
+                    // Single-session camera ownership (2026-07-04 RCA): the publisher
+                    // taps captureManager's session instead of opening a second
+                    // AVCaptureSession on the same camera.
+                    framePublisher.startCapture(sharing: captureManager, streamService: playerStreamService)
                 }
                 .onDisappear {
                     framePublisher.stopCapture()
@@ -697,7 +699,7 @@ struct MultiCameraLobbyView: View {
         guard let did = goProDeviceId,
               let token = vm.authManager.accessToken,
               let sessionUuid = vm.sessionUuid else {
-            print("[GOPRO-AUTO] signalReady skipped: no deviceId/auth/session")
+            MC1Log.notice("[GOPRO-AUTO] signalReady skipped: no deviceId/auth/session")
             GoProDiagRecorder.write(
                 goProDeviceId: goProDeviceId, localState: "\(GoProConnectionManager.shared.state)",
                 outcome: "skipped_no_context", httpStatus: nil, detail: nil
@@ -706,7 +708,7 @@ struct MultiCameraLobbyView: View {
         }
         // Log gopro connection state at call time — if we're on GoPro WiFi here,
         // the APIClient.backendSession (waitsForConnectivity=true) handles routing.
-        print("[GOPRO-AUTO] signalReady: deviceId=\(did) gopro_state=\(GoProConnectionManager.shared.state)")
+        MC1Log.notice("[GOPRO-AUTO] signalReady: deviceId=\(did) gopro_state=\(GoProConnectionManager.shared.state)")
         // session_device.revision server_default is 1, not 0 (see
         // app/models/multicamera_session.py) — a freshly-registered device is
         // already at revision=1. Fetch the current revision instead of
@@ -718,7 +720,7 @@ struct MultiCameraLobbyView: View {
         }
         do {
             let sd = try await updateGoProStatus(token: token, sessionUuid: sessionUuid, did: did, revision: revision)
-            print("[GOPRO-AUTO] signalReady OK: GoPro device \(did) → ready (rev=\(sd.revision))")
+            MC1Log.notice("[GOPRO-AUTO] signalReady OK: GoPro device \(did) → ready (rev=\(sd.revision))")
             GoProDiagRecorder.write(
                 goProDeviceId: did, localState: "\(GoProConnectionManager.shared.state)",
                 outcome: "signalReady_ok", httpStatus: nil, detail: "revision=\(sd.revision)"
@@ -735,7 +737,7 @@ struct MultiCameraLobbyView: View {
                let device = session.devices.first(where: { $0.id == did }) {
                 do {
                     let sd = try await updateGoProStatus(token: token, sessionUuid: sessionUuid, did: did, revision: device.revision)
-                    print("[GOPRO-AUTO] signalReady OK after 409 retry: GoPro device \(did) → ready (rev=\(sd.revision))")
+                    MC1Log.notice("[GOPRO-AUTO] signalReady OK after 409 retry: GoPro device \(did) → ready (rev=\(sd.revision))")
                     GoProDiagRecorder.write(
                         goProDeviceId: did, localState: "\(GoProConnectionManager.shared.state)",
                         outcome: "signalReady_ok_after_409_retry", httpStatus: nil, detail: "revision=\(sd.revision)"
@@ -745,7 +747,7 @@ struct MultiCameraLobbyView: View {
                     let retryHttpErr = (error as? APIError).flatMap {
                         if case .httpError(let code, let detail) = $0 { return (code, detail) } else { return nil }
                     }
-                    print("[GOPRO-AUTO] signalReady FAILED after 409 retry: \(error)")
+                    MC1Log.notice("[GOPRO-AUTO] signalReady FAILED after 409 retry: \(error)")
                     GoProDiagRecorder.write(
                         goProDeviceId: did, localState: "\(GoProConnectionManager.shared.state)",
                         outcome: "signalReady_failed_after_409_retry",
@@ -758,7 +760,7 @@ struct MultiCameraLobbyView: View {
                 if case .networkError(let e) = $0 { return e as? URLError } else { return nil }
             }
             let errDetail = urlErr.map { "URLError(\($0.code.rawValue))" } ?? "\(error)"
-            print("[GOPRO-AUTO] signalReady FAILED: \(errDetail)")
+            MC1Log.notice("[GOPRO-AUTO] signalReady FAILED: \(errDetail)")
             GoProDiagRecorder.write(
                 goProDeviceId: did, localState: "\(GoProConnectionManager.shared.state)",
                 outcome: "signalReady_failed", httpStatus: httpErr?.0, detail: httpErr?.1 ?? errDetail
@@ -779,12 +781,12 @@ struct MultiCameraLobbyView: View {
         while Date() < deadline {
             try? await Task.sleep(nanoseconds: 1_000_000_000)
             if case .ready = gp.state {
-                print("[GOPRO-AUTO] GoPro reached .ready state")
+                MC1Log.notice("[GOPRO-AUTO] GoPro reached .ready state")
                 await signalGoProReady(goProDeviceId: goProDeviceId)
                 return
             }
             if case .failed(let err) = gp.state {
-                print("[GOPRO-AUTO] GoPro connect failed: \(err)")
+                MC1Log.notice("[GOPRO-AUTO] GoPro connect failed: \(err)")
                 GoProDiagRecorder.write(
                     goProDeviceId: goProDeviceId, localState: "\(gp.state)",
                     outcome: "connect_failed", httpStatus: nil, detail: "\(err)"
@@ -792,7 +794,7 @@ struct MultiCameraLobbyView: View {
                 return
             }
         }
-        print("[GOPRO-AUTO] GoPro connect timeout (45s), state=\(gp.state)")
+        MC1Log.notice("[GOPRO-AUTO] GoPro connect timeout (45s), state=\(gp.state)")
         GoProDiagRecorder.write(
             goProDeviceId: goProDeviceId, localState: "\(gp.state)",
             outcome: "wait_timeout_45s", httpStatus: nil, detail: nil
@@ -819,7 +821,7 @@ struct MultiCameraLobbyView: View {
         } else {
             text = "=== MC1 Session Lab Debug Snapshot ===\nstate: \(vm.state)\n======================================"
         }
-        print("[MC1-SNAPSHOT-BEGIN]\n\(text)\n[MC1-SNAPSHOT-END]")
+        MC1Log.notice("[MC1-SNAPSHOT-BEGIN]\n\(text)\n[MC1-SNAPSHOT-END]")
     }
 
     // MARK: — Error
@@ -922,8 +924,9 @@ private struct LabeledRow: View {
 
 // MARK: — GoPro ready-signal diagnostics (Block 1)
 //
-// idevicesyslog does not reliably capture Swift print() output on physical
-// devices (privacy redaction varies by attach timing/lock state), so the
+// idevicesyslog never captures Swift print() output on physical devices
+// (stdout is invisible to the syslog relay — proven by the 2026-07-04 run's
+// zero app-tagged lines; console lines now go through MC1Log/os_log), so the
 // outcome of every signalGoProReady attempt is also persisted to a fixed
 // path in the app's Documents directory. The regression script pulls this
 // file directly via `devicectl device copy from --domain-type

--- a/ios/LFAEducationCenter/MultiCamera/MultiCameraSessionViewModel.swift
+++ b/ios/LFAEducationCenter/MultiCamera/MultiCameraSessionViewModel.swift
@@ -210,7 +210,7 @@ final class MultiCameraSessionViewModel: ObservableObject {
             let sd = try await MultiCameraAPIClient.registerDevice(token: token, uuid: sessionUuid, request: request)
             sessionDeviceId = sd.id
             deviceRegisterError = nil
-            print("[LobbyVM] autoRegisterDevice: OK sdId=\(sd.id)")
+            MC1Log.notice("[LobbyVM] autoRegisterDevice: OK sdId=\(sd.id)")
             // Attach PCO immediately after registration — must not be gated on updateDeviceStatus.
             // If updateDeviceStatus throws (revision conflict, network), PCO would never subscribe
             // to PCL state changes and the player would stay "pending" forever.
@@ -236,13 +236,13 @@ final class MultiCameraSessionViewModel: ObservableObject {
                     sessionDeviceId: sd.id, targetStatus: .ready,
                     deviceRevision: sd.revision
                 )
-                print("[LobbyVM] autoRegisterDevice: device \(sd.id) → ready")
+                MC1Log.notice("[LobbyVM] autoRegisterDevice: device \(sd.id) → ready")
             } catch {
-                print("[LobbyVM] autoRegisterDevice: updateDeviceStatus FAILED (non-fatal) error=\(error)")
+                MC1Log.notice("[LobbyVM] autoRegisterDevice: updateDeviceStatus FAILED (non-fatal) error=\(error)")
             }
         } catch {
             deviceRegisterError = "\(error)"
-            print("[LobbyVM] autoRegisterDevice: FAILED error=\(error)")
+            MC1Log.notice("[LobbyVM] autoRegisterDevice: FAILED error=\(error)")
         }
     }
 

--- a/ios/LFAEducationCenter/MultiCamera/PlayerCaptureOrchestrator.swift
+++ b/ios/LFAEducationCenter/MultiCamera/PlayerCaptureOrchestrator.swift
@@ -21,6 +21,15 @@ final class PlayerCaptureOrchestrator: ObservableObject {
 
     // MARK: — Constants
     private static let scheduledStartToleranceMs: Double = 2_000
+    /// How long startCapture() may take to reach `.capturing` before the
+    /// orchestrator declares failure instead of hanging silently. A healthy
+    /// AVCaptureMovieFileOutput.startRecording fires didStartRecording well
+    /// under 1s; 5s is >10x that margin while still finishing INSIDE the
+    /// harness's confirmed_start poll window, so the failure is visible as a
+    /// concrete `.failed` state + diag artifact rather than a bare scenario
+    /// timeout (2026-07-04 tricamera physical run RCA: the player hung in
+    /// .waitingForStart forever with zero evidence).
+    static let captureStartWatchdogSeconds: Double = 5
 
     // MARK: — Published state
     // didSet logs key transitions for MC1-AUTO-1 console-based physical validation —
@@ -28,9 +37,15 @@ final class PlayerCaptureOrchestrator: ObservableObject {
     @Published private(set) var state: PlayerOrchestratorState = .idle {
         didSet {
             switch state {
-            case .confirmed(let cycleId): print("[PCO] confirmed start: cycleId=\(cycleId)")
-            case .confirmedStop(let cycleId): print("[PCO] confirmed stop: cycleId=\(cycleId)")
-            case .failed(let message): print("[PCO] FAILURE: \(message)")
+            case .confirmed(let cycleId): MC1Log.notice("[PCO] confirmed start: cycleId=\(cycleId)")
+            case .confirmedStop(let cycleId): MC1Log.notice("[PCO] confirmed stop: cycleId=\(cycleId)")
+            case .failed(let message):
+                MC1Log.notice("[PCO] FAILURE: \(message)")
+                PCOFailureDiagWriter.write(
+                    reason: message,
+                    cycleId: activeCycle?.id,
+                    captureState: lastObservedCaptureState.map { "\($0)" }
+                )
             default: break
             }
         }
@@ -42,6 +57,14 @@ final class PlayerCaptureOrchestrator: ObservableObject {
     private let captureController: CaptureController
     private let cycleAPIClient: CycleAPIClient
     private let sleepProvider: (UInt64) async throws -> Void
+    /// Separate from `sleepProvider` (which tests stub to return instantly for
+    /// scheduled-start waits): the watchdog must NOT fire before the capture
+    /// state's async main-queue hop delivers `.capturing` in those same tests.
+    private let watchdogSleepProvider: (UInt64) async throws -> Void
+    /// Last capture state seen via subscribeToCaptureState — included in the
+    /// watchdog failure evidence so the diag says WHY start never committed
+    /// (e.g. "interrupted" = camera lost, "ready" = movieOutput never fired).
+    private var lastObservedCaptureState: CaptureState?
 
     // MARK: — Session context (set at attach time)
     private var sessionUuid: String?
@@ -67,6 +90,9 @@ final class PlayerCaptureOrchestrator: ObservableObject {
         cycleAPIClient: CycleAPIClient = LiveCycleAPIClient(),
         sleepProvider: @escaping (UInt64) async throws -> Void = { ns in
             try await Task.sleep(nanoseconds: ns)
+        },
+        watchdogSleepProvider: @escaping (UInt64) async throws -> Void = { ns in
+            try await Task.sleep(nanoseconds: ns)
         }
     ) {
         self.authManager = authManager
@@ -74,6 +100,7 @@ final class PlayerCaptureOrchestrator: ObservableObject {
         self.captureController = captureController
         self.cycleAPIClient = cycleAPIClient
         self.sleepProvider = sleepProvider
+        self.watchdogSleepProvider = watchdogSleepProvider
     }
 
     // MARK: — Public API
@@ -111,6 +138,7 @@ final class PlayerCaptureOrchestrator: ObservableObject {
         activeCycle = nil
         sessionUuid = nil
         playerSessionDeviceId = nil
+        lastObservedCaptureState = nil
         state = .idle
     }
 
@@ -234,6 +262,26 @@ final class PlayerCaptureOrchestrator: ObservableObject {
         captureController.rearmForNextCycle()
         subscribeToCaptureState()
         captureController.startCapture()
+        await watchCaptureStart(cycleId: cycle.id)
+    }
+
+    // MARK: — Capture-start watchdog
+    //
+    // startCapture() has silent no-op paths (SessionCaptureManager refuses when
+    // its session lost the camera) and AVFoundation paths where didStartRecording
+    // simply never fires. Without a deadline the orchestrator sat in
+    // .waitingForStart forever and the only symptom was the harness's generic
+    // confirmed_start timeout (2026-07-04 physical run).
+    private func watchCaptureStart(cycleId: Int) async {
+        do {
+            try await watchdogSleepProvider(UInt64(Self.captureStartWatchdogSeconds * 1_000_000_000))
+        } catch {
+            return  // cancelled (detach/reset or stop-detected) — no verdict
+        }
+        guard !Task.isCancelled else { return }
+        guard case .waitingForStart(let id) = state, id == cycleId else { return }
+        let captureStateLabel = lastObservedCaptureState.map { "\($0)" } ?? "never-observed"
+        state = .failed("captureStartTimeout(\(Self.captureStartWatchdogSeconds)s): capture state never reached .capturing (last=\(captureStateLabel))")
     }
 
     // MARK: — Scheduled start wait (mirrors CycleCaptureOrchestrator)
@@ -361,6 +409,7 @@ final class PlayerCaptureOrchestrator: ObservableObject {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] captureState in
                 guard let self else { return }
+                self.lastObservedCaptureState = captureState
                 if case .capturing = captureState {
                     Task { @MainActor [weak self] in
                         await self?.handleCaptureStarted()
@@ -458,5 +507,32 @@ private enum PlayerOrchestratorFailure: Error {
         case .cycleExpired(let ms):         return "cycleExpired(lagMs: \(ms))"
         case .timerError(let msg):          return "timerError: \(msg)"
         }
+    }
+}
+
+// MARK: — PCO failure diagnostics
+//
+// Structured, file-based evidence for player-side orchestration failures —
+// same rationale and pull pattern as CaptureMetadataDiagWriter (console print
+// capture is unreliable on physical devices; the regression harness copies
+// Documents/pco_failure_diag.json via devicectl on scenario failure). Written
+// on EVERY transition to .failed so the harness can distinguish "player never
+// saw the cycle" (no file) from "player saw it and failed for <reason>".
+enum PCOFailureDiagWriter {
+    static let fileName = "pco_failure_diag.json"
+
+    @MainActor
+    static func write(reason: String, cycleId: Int?, captureState: String?) {
+        let diag: [String: Any] = [
+            "timestamp": ISO8601DateFormatter().string(from: Date()),
+            "reason": reason,
+            "cycleId": cycleId ?? NSNull(),
+            "lastObservedCaptureState": captureState ?? NSNull(),
+        ]
+        guard let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first,
+              JSONSerialization.isValidJSONObject(diag),
+              let data = try? JSONSerialization.data(withJSONObject: diag, options: [.prettyPrinted]) else { return }
+        try? data.write(to: docs.appendingPathComponent(fileName), options: .atomic)
+        MC1Log.notice("[PCO] wrote \(fileName): reason=\(reason)")
     }
 }

--- a/ios/LFAEducationCenter/MultiCamera/SessionCaptureManager.swift
+++ b/ios/LFAEducationCenter/MultiCamera/SessionCaptureManager.swift
@@ -47,6 +47,12 @@ final class SessionCaptureManager: NSObject, ObservableObject {
     private var sessionUUID: String = ""
     private var deviceId: Int = 0
     private var isTornDown = false
+    /// Whether the interruption began while a recording was in flight — decides
+    /// whether interruption-end resumes to `.ready` or finalizes via stopCapture().
+    private var wasCapturingWhenInterrupted = false
+    /// Preview side-tap output currently attached to the shared session (see
+    /// attachPreviewOutput). At most one at a time.
+    private var attachedPreviewOutput: AVCaptureVideoDataOutput?
 
     var isCapturing: Bool { state == .capturing }
     var previewSession: AVCaptureSession { captureSession }
@@ -115,7 +121,7 @@ final class SessionCaptureManager: NSObject, ObservableObject {
 
         captureQueue.async { [weak self] in
             guard let self else { return }
-            let log = { (msg: String) in print("[SessionCapture] \(msg)") }
+            let log = { (msg: String) in MC1Log.notice("[SessionCapture] \(msg)") }
             log("prepare: captureQueue entered (thread: \(Thread.current))")
             assert(!Thread.isMainThread, "Capture configure must not run on main thread")
 
@@ -251,7 +257,7 @@ final class SessionCaptureManager: NSObject, ObservableObject {
             guard let self, !didComplete, !self.isTornDown else { return }
             if self.state == .configuring {
                 self.state = .failed("Kamera inicializálási timeout (\(Int(Self.prepareTimeoutSeconds))s)")
-                print("[SessionCapture] prepare: TIMEOUT after \(Self.prepareTimeoutSeconds)s")
+                MC1Log.notice("[SessionCapture] prepare: TIMEOUT after \(Self.prepareTimeoutSeconds)s")
             }
         }
     }
@@ -286,6 +292,66 @@ final class SessionCaptureManager: NSObject, ObservableObject {
         }
     }
 
+    // MARK: — Preview side-tap (single-session camera ownership)
+    //
+    // The recording session is the ONLY AVCaptureSession that may own the
+    // camera on a capture device. The 2026-07-04 tricamera physical run failed
+    // because CameraFramePublisher ran a SECOND AVCaptureSession on the same
+    // back camera: iOS gave the camera to one session, silently interrupted the
+    // other, and the player never reached confirmed_start. The preview frame
+    // stream now taps THIS session via an added AVCaptureVideoDataOutput —
+    // recording stays authoritative, preview is a side branch of the same
+    // camera pipeline.
+
+    /// Adds a preview AVCaptureVideoDataOutput to the shared session. The caller
+    /// configures the output (settings + delegate) before attaching. Runs on the
+    /// capture queue; completion is delivered on the main queue with whether the
+    /// output was actually added.
+    func attachPreviewOutput(_ output: AVCaptureVideoDataOutput,
+                             completion: @escaping @MainActor (Bool) -> Void) {
+        guard !isTornDown else {
+            Task { @MainActor in completion(false) }
+            return
+        }
+        guard attachedPreviewOutput == nil else {
+            let alreadyAttached = attachedPreviewOutput === output
+            MC1Log.notice("[SessionCapture] attachPreviewOutput: \(alreadyAttached ? "already attached" : "another preview output is attached") — skipping")
+            Task { @MainActor in completion(alreadyAttached) }
+            return
+        }
+        captureQueue.async { [weak self] in
+            guard let self else { return }
+            self.captureSession.beginConfiguration()
+            let canAdd = self.captureSession.canAddOutput(output)
+            if canAdd {
+                self.captureSession.addOutput(output)
+                OrientationMapper.applyCurrentOrientation(to: output.connection(with: .video))
+            }
+            self.captureSession.commitConfiguration()
+            DispatchQueue.main.async {
+                if canAdd { self.attachedPreviewOutput = output }
+                MC1Log.notice("[SessionCapture] attachPreviewOutput: \(canAdd ? "attached" : "canAddOutput=false")")
+                completion(canAdd)
+            }
+        }
+    }
+
+    /// Removes a previously attached preview output from the shared session.
+    /// Safe to call when nothing is attached.
+    func detachPreviewOutput() {
+        guard let output = attachedPreviewOutput else { return }
+        attachedPreviewOutput = nil
+        captureQueue.async { [weak self] in
+            guard let self else { return }
+            self.captureSession.beginConfiguration()
+            self.captureSession.removeOutput(output)
+            self.captureSession.commitConfiguration()
+            DispatchQueue.main.async {
+                MC1Log.notice("[SessionCapture] detachPreviewOutput: removed")
+            }
+        }
+    }
+
     // MARK: — Re-arm for next cycle (multi-cycle support)
 
     func rearmForNextCycle() {
@@ -315,6 +381,10 @@ final class SessionCaptureManager: NSObject, ObservableObject {
         outputFileURL = nil
         lastValidation = nil
         isTornDown = false
+        // The loop above removed every output, including an attached preview
+        // side-tap — forget it so the next attachPreviewOutput doesn't skip.
+        attachedPreviewOutput = nil
+        wasCapturingWhenInterrupted = false
         state = .idle
     }
 
@@ -382,14 +452,49 @@ final class SessionCaptureManager: NSObject, ObservableObject {
         OrientationMapper.applyCurrentOrientation(to: conn)
     }
 
-    private func handleInterruption() {
-        guard state == .capturing else { return }
-        state = .interrupted
+    // Internal (not private) — the interruption path is exercised directly by
+    // SessionCaptureManagerTests; a real AVCaptureSessionWasInterrupted cannot
+    // be triggered on the simulator (same seam as the fileOutput delegate calls).
+    func handleInterruption() {
+        switch state {
+        case .capturing:
+            wasCapturingWhenInterrupted = true
+            state = .interrupted
+        case .ready:
+            // Camera lost while armed — e.g. another AVCaptureSession claimed the
+            // device. Before this case existed, `.ready` silently survived the
+            // interruption and the next startCapture() ran against a session with
+            // no camera: movieOutput never reached didStartRecording, the player
+            // never confirmed start, and the cycle hung with zero evidence
+            // (2026-07-04 tricamera physical run RCA).
+            wasCapturingWhenInterrupted = false
+            state = .interrupted
+            MC1Log.notice("[SessionCapture] INTERRUPTED while ready — camera lost (another session claimed the device?)")
+        default:
+            break
+        }
     }
 
-    private func handleInterruptionEnded() {
-        if state == .interrupted { stopCapture() }
+    func handleInterruptionEnded() {
+        guard state == .interrupted else { return }
+        if wasCapturingWhenInterrupted {
+            stopCapture()
+        } else {
+            // Interrupted while merely armed — nothing was recording, so there is
+            // nothing to finalize; the session is running again, re-arm.
+            state = .ready
+            MC1Log.notice("[SessionCapture] interruption ended — re-armed to ready")
+        }
     }
+
+    #if DEBUG
+    /// Test-only: force a state that normally requires physical camera hardware
+    /// to reach (`.ready`, `.capturing`). Interruption-path unit tests use this
+    /// because prepare() cannot complete on the simulator.
+    func forceStateForTesting(_ forced: CaptureState) {
+        state = forced
+    }
+    #endif
 }
 
 // MARK: — CaptureController
@@ -447,10 +552,10 @@ extension SessionCaptureManager: AVCaptureFileOutputRecordingDelegate {
 
 // MARK: — Capture metadata diagnostics (Capture Quality + Metadata block)
 //
-// Structured, file-based evidence — idevicesyslog print() capture has
-// repeatedly proven unreliable on physical devices this session (see
+// Structured, file-based evidence — console capture (formerly print(), now
+// MC1Log/os_log) has repeatedly proven unreliable on physical devices (see
 // gopro_diag.json / gopro_stream_diag.json history). capture-info now
-// writes the same fields it prints, to Documents/capture_metadata_diag.json,
+// writes the same fields it logs, to Documents/capture_metadata_diag.json,
 // pulled by the regression script via the established devicectl
 // appDataContainer copy pattern.
 enum CaptureMetadataDiagWriter {
@@ -527,6 +632,6 @@ enum CaptureMetadataDiagWriter {
               JSONSerialization.isValidJSONObject(diag),
               let data = try? JSONSerialization.data(withJSONObject: diag, options: [.prettyPrinted]) else { return }
         try? data.write(to: docs.appendingPathComponent(fileName), options: .atomic)
-        print("[CAPTURE-METADATA] wrote \(fileName): \(diag)")
+        MC1Log.notice("[CAPTURE-METADATA] wrote \(fileName): \(diag)")
     }
 }

--- a/ios/LFAEducationCenterTests/MultiCamera/FakeCaptureController.swift
+++ b/ios/LFAEducationCenterTests/MultiCamera/FakeCaptureController.swift
@@ -9,7 +9,14 @@ final class FakeCaptureController: CaptureController {
     private(set) var startCallCount = 0
     private(set) var stopCallCount  = 0
     private(set) var rearmCallCount = 0
-    func startCapture() { startCallCount += 1; subject.send(.capturing) }
+    /// When false, startCapture() is a silent no-op that never reaches
+    /// `.capturing` — reproduces the 2026-07-04 physical failure mode
+    /// (camera lost while `.ready`) for the PCO watchdog tests.
+    var startAdvancesToCapturing = true
+    func startCapture() {
+        startCallCount += 1
+        if startAdvancesToCapturing { subject.send(.capturing) }
+    }
     func stopCapture()  {
         stopCallCount += 1
         subject.send(.stopping)

--- a/ios/LFAEducationCenterTests/MultiCamera/PlayerCaptureOrchestratorTests.swift
+++ b/ios/LFAEducationCenterTests/MultiCamera/PlayerCaptureOrchestratorTests.swift
@@ -152,14 +152,21 @@ final class PlayerCaptureOrchestratorTests: XCTestCase {
 
     private func makeOrchestrator(
         clockService: ClockSyncService? = nil,
-        sleepProvider: @escaping (UInt64) async throws -> Void = { _ in }
+        sleepProvider: @escaping (UInt64) async throws -> Void = { _ in },
+        // Default: real sleep — the 5s watchdog never fires within a fast test,
+        // so pre-watchdog tests keep their exact semantics. Watchdog tests
+        // inject a fast provider explicitly.
+        watchdogSleepProvider: @escaping (UInt64) async throws -> Void = { ns in
+            try await Task.sleep(nanoseconds: ns)
+        }
     ) -> PlayerCaptureOrchestrator {
         PlayerCaptureOrchestrator(
             authManager: fakeToken,
             clockSyncService: clockService ?? makePCOUnsyncedClock(),
             captureController: fakeCapture,
             cycleAPIClient: mockAPI,
-            sleepProvider: sleepProvider
+            sleepProvider: sleepProvider,
+            watchdogSleepProvider: watchdogSleepProvider
         )
     }
 
@@ -167,9 +174,13 @@ final class PlayerCaptureOrchestratorTests: XCTestCase {
     /// Returns both so ARC keeps the listener alive (orchestrator holds a weak ref).
     private func makeAttachedOrchestrator(
         clockService: ClockSyncService? = nil,
-        sleepProvider: @escaping (UInt64) async throws -> Void = { _ in }
+        sleepProvider: @escaping (UInt64) async throws -> Void = { _ in },
+        watchdogSleepProvider: @escaping (UInt64) async throws -> Void = { ns in
+            try await Task.sleep(nanoseconds: ns)
+        }
     ) -> (PlayerCaptureOrchestrator, PlayerCycleListener) {
-        let orch = makeOrchestrator(clockService: clockService, sleepProvider: sleepProvider)
+        let orch = makeOrchestrator(clockService: clockService, sleepProvider: sleepProvider,
+                                    watchdogSleepProvider: watchdogSleepProvider)
         let listener = PlayerCycleListener(
             authManager: fakeToken,
             cycleListClient: StubCycleListClient(),
@@ -386,6 +397,78 @@ final class PlayerCaptureOrchestratorTests: XCTestCase {
         XCTAssertEqual(mockAPI.confirmStartCallCount, 0,
                        "confirmDeviceStart must NOT be called when device is already confirmedStart")
         XCTAssertEqual(orch.state, .confirmed(cycleId: cycle.id))
+    }
+
+    // MARK: — Capture-start watchdog (2026-07-04 tricamera physical run RCA)
+
+    /// Yields long enough for any pending main-queue capture-state delivery to
+    /// land before the watchdog checks state — keeps the no-false-positive test
+    /// deterministic without real sleeping.
+    private static func yieldingWatchdog(_ cycles: Int = 30) -> (UInt64) async throws -> Void {
+        { _ in for _ in 0..<cycles { await Task.yield() } }
+    }
+
+    // PCO-22: capture never reaches .capturing → watchdog fails with explicit evidence.
+    func test_pco_22_watchdog_fails_when_capture_never_starts() async {
+        let clock = await makePCOSyncedClock()
+        fakeCapture.startAdvancesToCapturing = false  // silent no-op start (camera lost)
+        let (orch, _listener) = makeAttachedOrchestrator(
+            clockService: clock,
+            watchdogSleepProvider: Self.yieldingWatchdog()
+        )
+        let cycle = makePCOCycle(scheduledStartAt: nil, status: .recording)
+        orch.handleListenerState(.recordingDetected(cycleId: cycle.id), currentCycle: cycle)
+
+        for _ in 0..<60 { await Task.yield() }
+
+        XCTAssertEqual(fakeCapture.startCallCount, 1, "startCapture must have been attempted")
+        XCTAssertEqual(mockAPI.confirmStartCallCount, 0, "confirmDeviceStart must NOT be called")
+        guard case .failed(let message) = orch.state else {
+            return XCTFail("Expected .failed(captureStartTimeout), got \(orch.state)")
+        }
+        XCTAssertTrue(message.contains("captureStartTimeout"), "unexpected failure message: \(message)")
+    }
+
+    // PCO-23: healthy start — watchdog must NOT fire even with an instant-ish provider.
+    func test_pco_23_watchdog_no_false_positive_on_healthy_start() async {
+        let clock = await makePCOSyncedClock()
+        let (orch, _listener) = makeAttachedOrchestrator(
+            clockService: clock,
+            watchdogSleepProvider: Self.yieldingWatchdog()
+        )
+        let cycle = makePCOCycle(scheduledStartAt: nil, status: .recording)
+        orch.handleListenerState(.recordingDetected(cycleId: cycle.id), currentCycle: cycle)
+
+        for _ in 0..<60 { await Task.yield() }
+
+        XCTAssertEqual(orch.state, .confirmed(cycleId: cycle.id),
+                       "watchdog must not override a healthy confirm flow")
+    }
+
+    // PCO-24: watchdog failure writes the pco_failure_diag.json evidence artifact.
+    func test_pco_24_watchdog_failure_writes_diag_artifact() async throws {
+        let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        let diagURL = docs.appendingPathComponent(PCOFailureDiagWriter.fileName)
+        try? FileManager.default.removeItem(at: diagURL)
+
+        let clock = await makePCOSyncedClock()
+        fakeCapture.startAdvancesToCapturing = false
+        let (orch, _listener) = makeAttachedOrchestrator(
+            clockService: clock,
+            watchdogSleepProvider: Self.yieldingWatchdog()
+        )
+        let cycle = makePCOCycle(scheduledStartAt: nil, status: .recording)
+        orch.handleListenerState(.recordingDetected(cycleId: cycle.id), currentCycle: cycle)
+        for _ in 0..<60 { await Task.yield() }
+
+        guard case .failed = orch.state else {
+            return XCTFail("Expected .failed, got \(orch.state)")
+        }
+        let data = try Data(contentsOf: diagURL)
+        let diag = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        XCTAssertNotNil(diag?["timestamp"], "diag must carry a freshness timestamp")
+        XCTAssertTrue((diag?["reason"] as? String ?? "").contains("captureStartTimeout"))
+        XCTAssertEqual(diag?["cycleId"] as? Int, cycle.id)
     }
 }
 

--- a/ios/LFAEducationCenterTests/MultiCamera/SessionCaptureManagerTests.swift
+++ b/ios/LFAEducationCenterTests/MultiCamera/SessionCaptureManagerTests.swift
@@ -226,17 +226,54 @@ final class SessionCaptureManagerTests: XCTestCase {
         XCTAssertEqual(mgr.state, .idle)
     }
 
-    // SC-14: Interruption → interrupted (tested via notification)
-    func test_SC_14_interruption_state() {
-        // Can't trigger real interruption in simulator — test state enum
-        let state: CaptureState = .interrupted
-        XCTAssertEqual(state, .interrupted)
+    // SC-14: Interruption while CAPTURING → .interrupted, and interruption-end
+    // finalizes the recording (stopCapture → .stopping). Exercised directly via
+    // the internal handlers — a real AVCaptureSessionWasInterrupted cannot be
+    // posted meaningfully on the simulator (same seam as the fileOutput
+    // delegate tests above).
+    func test_SC_14_interruption_while_capturing_then_ended_stops() {
+        let (mgr, _, _) = makeManager()
+        mgr.forceStateForTesting(.capturing)
+        mgr.handleInterruption()
+        XCTAssertEqual(mgr.state, .interrupted)
+        mgr.handleInterruptionEnded()
+        XCTAssertEqual(mgr.state, .stopping,
+            "interruption during recording must finalize via stopCapture")
     }
 
-    // SC-15: Interruption ended → auto stop
-    func test_SC_15_interruption_ended() {
-        // Verified by observer registration in code review
-        // Real test requires physical device capture
+    // SC-15: Interruption while READY (camera claimed by another session) must
+    // NOT be silently ignored — before the 2026-07-04 RCA fix the state stayed
+    // a lying .ready and the next startCapture() no-oped with zero evidence.
+    func test_SC_15_interruption_while_ready_degrades_state() {
+        let (mgr, _, _) = makeManager()
+        mgr.forceStateForTesting(.ready)
+        mgr.handleInterruption()
+        XCTAssertEqual(mgr.state, .interrupted,
+            "ready-state interruption must degrade the state, not preserve .ready")
+    }
+
+    // SC-15b: Interruption-end after a ready-state interruption re-arms to
+    // .ready (nothing was recording — there is nothing to finalize).
+    func test_SC_15b_ready_interruption_ended_rearms() {
+        let (mgr, _, _) = makeManager()
+        mgr.forceStateForTesting(.ready)
+        mgr.handleInterruption()
+        XCTAssertEqual(mgr.state, .interrupted)
+        mgr.handleInterruptionEnded()
+        XCTAssertEqual(mgr.state, .ready,
+            "ready-interruption end must re-arm, not call stopCapture")
+    }
+
+    // SC-15c: startCapture() while interrupted refuses instead of recording
+    // on a session that lost the camera — the PCO watchdog turns this refusal
+    // into an explicit failure with evidence.
+    func test_SC_15c_start_capture_refused_while_interrupted() {
+        let (mgr, _, _) = makeManager()
+        mgr.forceStateForTesting(.ready)
+        mgr.handleInterruption()
+        mgr.startCapture()
+        XCTAssertEqual(mgr.state, .interrupted,
+            "startCapture must not proceed while the session is interrupted")
     }
 
     // SC-16: Runtime error → failed

--- a/scripts/mc1_regression/lib.py
+++ b/scripts/mc1_regression/lib.py
@@ -23,6 +23,40 @@ from urllib.parse import urlencode
 POLL_INTERVAL_SECONDS = 1.5
 SNAPSHOT_RE = re.compile(r"\[MC1-SNAPSHOT-BEGIN\](.*?)\[MC1-SNAPSHOT-END\]", re.DOTALL)
 
+# Scenarios where console capture from BOTH devices is a HARD precondition.
+# The 2026-07-04 tricamera run failed on the PLAYER (iPad) side while the
+# WARN-only console path had silently skipped the iPad capture — the exact
+# evidence the failure needed did not exist. Tricamera scenarios exercise the
+# player-side capture chain, so running them without the iPad console is
+# running blind.
+DUAL_CONSOLE_REQUIRED_SCENARIOS = frozenset({
+    "tricamera-capture-skeleton-proof",
+    "gopro-tricamera-smoke",
+})
+
+
+def check_dual_console_precondition(scenario_names: list[str],
+                                    console_dir: Path | str) -> list[str]:
+    """Returns human-readable errors when a requested scenario requires both
+    device console captures and one is missing; empty list = precondition holds.
+    Console log files are created by run_mc1_regression.sh BEFORE the runner
+    starts, so a missing file here means capture never started for that device
+    (not USB-connected / not visible to idevicesyslog)."""
+    required_by = [n for n in scenario_names if n in DUAL_CONSOLE_REQUIRED_SCENARIOS]
+    if not required_by:
+        return []
+    errors: list[str] = []
+    for filename, label in (("iphone_console.log", "iPhone"),
+                            ("ipad_console.log", "iPad")):
+        if not (Path(console_dir) / filename).exists():
+            errors.append(
+                f"{label} console capture missing ({filename} not found) — "
+                f"hard precondition for: {', '.join(required_by)}. "
+                f"Both devices must be USB-connected, trusted, and visible to "
+                f"idevicesyslog (idevice_id -l)."
+            )
+    return errors
+
 
 class ValidationError(RuntimeError):
     pass

--- a/scripts/mc1_regression/preflight_static_check.py
+++ b/scripts/mc1_regression/preflight_static_check.py
@@ -342,19 +342,29 @@ def check_orientation_aspect_wiring() -> None:
     critical_block_match = re.search(r"critical_ok = all\(.*?\n        \)", body, re.S)
     critical_block = critical_block_match.group(0) if critical_block_match else ""
     orientation_gate_steps = [
-        "iphone orientation consistent", "iphone effective aspect ratio is 16:9",
-        "ipad orientation consistent", "ipad effective aspect ratio is 16:9",
+        "iphone orientation consistent", "iphone effective aspect ratio matches orientation",
+        "iphone encoded aspect ratio is 16:9",
+        "ipad orientation consistent", "ipad effective aspect ratio matches orientation",
+        "ipad encoded aspect ratio is 16:9",
         "gopro preview aspect ratio is 16:9",
     ]
     scenario_asserts_ok = all(f'"{step}"' in body for step in orientation_gate_steps)
     missing_steps = [s for s in orientation_gate_steps if f'"{s}"' not in body]
-    check("scenario asserts orientation-consistency + 16:9 aspect for iPhone/iPad/GoPro",
+    check("scenario asserts orientation-consistency + orientation-aware aspect for iPhone/iPad/GoPro",
           scenario_asserts_ok,
           f"missing report.step(...) for: {missing_steps}" if not scenario_asserts_ok else "")
     # Scoped to the tricamera critical_ok block (2026-07-04 hardening) — the
     # previous whole-file regex could match a different scenario's gate.
     gated_ok = all(f'"{step}"' in critical_block for step in orientation_gate_steps)
     check("orientation/aspect assertions gate PASS (critical_ok)", gated_ok)
+
+    # The effective-aspect EXPECTATION must be orientation-aware (2026-07-04
+    # physical-run proof): a portrait-mandated run (RC checklist J / #357)
+    # records a correct 9:16 effective aspect, so an unconditional 16:9
+    # expectation is unsatisfiable there. Pin the mapping itself.
+    aware_ok = bool(re.search(r'"portrait":\s*\(9,\s*16\)', scenarios_src)) \
+        and bool(re.search(r'"landscape":\s*\(16,\s*9\)', scenarios_src))
+    check("effective-aspect expectation is orientation-aware (portrait→9:16, landscape→16:9)", aware_ok)
 
     # "No distorting stretch" is a SwiftUI layout property, not runtime data — verify the
     # GoPro preview panel uses aspectRatio(contentMode: .fit), which by definition letterboxes

--- a/scripts/mc1_regression/preflight_static_check.py
+++ b/scripts/mc1_regression/preflight_static_check.py
@@ -390,6 +390,20 @@ def check_log_capture_config() -> None:
     check("order-based legacy-UDID guessing (head -1 / sed -n 2p) is gone",
           not order_heuristic)
 
+    # 2026-07-04 RCA: tricamera ran with the iPad console capture silently
+    # SKIPPED (WARN only) — the player-side failure left zero console evidence.
+    # Both the shell wrapper and the runner must hard-fail tricamera scenarios
+    # when either device console capture is unavailable.
+    check("run_mc1_regression.sh hard-fails tricamera scenarios without dual console capture",
+          "Dual-console hard precondition" in src and "exit 1" in src)
+    runner_src = read(REPO_ROOT / "scripts" / "mc1_regression" / "runner.py")
+    lib_src = read(REPO_ROOT / "scripts" / "mc1_regression" / "lib.py")
+    check("runner.py enforces check_dual_console_precondition before scenarios",
+          "check_dual_console_precondition" in runner_src)
+    check("lib.DUAL_CONSOLE_REQUIRED_SCENARIOS covers the tricamera proof",
+          '"tricamera-capture-skeleton-proof"' in lib_src
+          and "DUAL_CONSOLE_REQUIRED_SCENARIOS" in lib_src)
+
 
 # ── CHECK 11: pose overlay diag writer↔reader key contract ──────────────────
 #

--- a/scripts/mc1_regression/runner.py
+++ b/scripts/mc1_regression/runner.py
@@ -26,6 +26,7 @@ from mc1_regression.lib import (  # noqa: E402
     ConsoleOffsetTracker,
     ScenarioContext,
     ValidationError,
+    check_dual_console_precondition,
     login,
     preflight_url_scheme,
     send_deep_link,
@@ -55,6 +56,18 @@ def run(args: argparse.Namespace) -> int:
     out_dir = Path(args.out_dir)
     artifact = ArtifactRun(out_dir)
     offsets = ConsoleOffsetTracker(artifact)
+
+    # Dual-console hard precondition (2026-07-04 RCA): tricamera scenarios
+    # exercise the PLAYER capture chain — running them without the iPad
+    # console capture already cost one physical test day's evidence. The
+    # shell wrapper enforces this too; this is defense-in-depth for direct
+    # runner.py invocations.
+    console_errors = check_dual_console_precondition([args.scenario], artifact.console_dir)
+    if console_errors:
+        for err in console_errors:
+            print(f"ERROR: {err}")
+        print("Aborting before any scenario runs — fix USB/console capture and retry.")
+        return 2
 
     instructor_email, instructor_password, player_email, player_password = _prompt_credentials()
 

--- a/scripts/mc1_regression/scenarios.py
+++ b/scripts/mc1_regression/scenarios.py
@@ -75,6 +75,49 @@ def _aspect_ratio_matches(aspect_str, expected_w=16, expected_h=9, tolerance=0.0
     except ValueError:
         return False
 
+
+def _expected_effective_aspect(file_orientation_coarse):
+    """Orientation-aware expected EFFECTIVE (post-rotation display) aspect.
+
+    2026-07-04 physical-run proof (ffprobe on the pulled .mov files): the app
+    always encodes the sensor's landscape 1280x720 buffer and bakes rotation
+    into preferredTransform, so a portrait-mounted device's effective display
+    aspect is BY DEFINITION 9:16. The old unconditional 16:9 expectation could
+    never pass under the RC-checklist J-section portrait mandate (issue #357)
+    even though the recording itself was correct. Returns None for unknown
+    orientation — no expectation can be derived there, and "unknown" is itself
+    an evidence failure (the orientation-consistent gate catches it too).
+    """
+    return {"portrait": (9, 16), "landscape": (16, 9)}.get(file_orientation_coarse)
+
+
+def _effective_aspect_gate(meta):
+    """(ok, expected_label) for the orientation-aware effective-aspect gate."""
+    expected = _expected_effective_aspect((meta or {}).get("fileOrientationCoarse"))
+    if expected is None:
+        return False, None
+    w, h = expected
+    return _aspect_ratio_matches(meta.get("effectiveAspectRatio"), w, h), f"{w}:{h}"
+
+
+def _encoded_aspect_is_16_9(meta):
+    """16:9 check on the ENCODED buffer (actualResolution "WxH") — orientation-
+    independent, because the sensor buffer is landscape 16:9 regardless of how
+    the device is mounted. Returns None when actualResolution is absent or
+    unparseable: there is no metadata to check, so the caller skips the step
+    instead of asserting on a guess."""
+    raw = (meta or {}).get("actualResolution")
+    if not raw or "x" not in str(raw):
+        return None
+    try:
+        w_str, h_str = str(raw).lower().split("x", 1)
+        w, h = float(w_str), float(h_str)
+    except ValueError:
+        return None
+    if h == 0:
+        return None
+    return abs((w / h) - (16 / 9)) <= 0.02
+
 # After the script PATCHes session to DEVICES_READY the iOS VM needs one 3s poll
 # cycle to see the updated status + fresh revision before begin-cycle is sent.
 # CCO already retries activateSession on 409, so 4s is a safe conservative buffer.
@@ -987,25 +1030,32 @@ def scenario_tricamera_capture_skeleton_proof(ctx: ScenarioContext) -> ScenarioR
             if meta is None:
                 report.step("iphone capture metadata", False, error=stale_reason)
                 report.step("iphone orientation consistent", False, error=stale_reason)
-                report.step("iphone effective aspect ratio is 16:9", False, error=stale_reason)
+                report.step("iphone effective aspect ratio matches orientation", False, error=stale_reason)
             else:
                 file_size = meta.get("fileSizeBytes", 0) or 0
                 report.step("iphone capture metadata", file_size > 0,
                             fileSizeBytes=file_size, outputFilePath=meta.get("outputFilePath"),
                             durationSeconds=meta.get("actualDurationSeconds"),
                             codec=meta.get("actualCodec"))
-                # Orientation/aspect automatic assertions (2026-07-01 flow audit) — not just
-                # recorded in the JSON, actually checked: does the FILE's baked-in rotation
-                # match the device's own interface orientation at recording start, and is the
-                # effective (post-rotation) aspect ratio the expected 16:9?
+                # Orientation/aspect automatic assertions (2026-07-01 flow audit, made
+                # orientation-aware 2026-07-04): does the FILE's baked-in rotation match the
+                # device's own interface orientation at recording start, does the effective
+                # (post-rotation) aspect match what that orientation implies (portrait→9:16,
+                # landscape→16:9), and is the encoded sensor buffer the expected 16:9?
                 report.step("iphone orientation consistent", meta.get("orientationConsistent") is True,
                             deviceOrientationAtRecordingStart=meta.get("deviceOrientationAtRecordingStart"),
                             fileOrientationCoarse=meta.get("fileOrientationCoarse"))
-                report.step("iphone effective aspect ratio is 16:9",
-                            _aspect_ratio_matches(meta.get("effectiveAspectRatio")),
+                eff_ok, eff_expected = _effective_aspect_gate(meta)
+                report.step("iphone effective aspect ratio matches orientation", eff_ok,
+                            expectedEffectiveAspect=eff_expected,
+                            fileOrientationCoarse=meta.get("fileOrientationCoarse"),
                             effectiveAspectRatio=meta.get("effectiveAspectRatio"),
                             effectiveDisplayWidth=meta.get("effectiveDisplayWidth"),
                             effectiveDisplayHeight=meta.get("effectiveDisplayHeight"))
+                encoded_ok = _encoded_aspect_is_16_9(meta)
+                if encoded_ok is not None:
+                    report.step("iphone encoded aspect ratio is 16:9", encoded_ok,
+                                actualResolution=meta.get("actualResolution"))
         else:
             report.step("iphone capture metadata", False, error="copy_app_container_file failed")
 
@@ -1017,7 +1067,7 @@ def scenario_tricamera_capture_skeleton_proof(ctx: ScenarioContext) -> ScenarioR
             if meta is None:
                 report.step("ipad capture metadata", False, error=stale_reason)
                 report.step("ipad orientation consistent", False, error=stale_reason)
-                report.step("ipad effective aspect ratio is 16:9", False, error=stale_reason)
+                report.step("ipad effective aspect ratio matches orientation", False, error=stale_reason)
             else:
                 file_size = meta.get("fileSizeBytes", 0) or 0
                 report.step("ipad capture metadata", file_size > 0,
@@ -1027,11 +1077,17 @@ def scenario_tricamera_capture_skeleton_proof(ctx: ScenarioContext) -> ScenarioR
                 report.step("ipad orientation consistent", meta.get("orientationConsistent") is True,
                             deviceOrientationAtRecordingStart=meta.get("deviceOrientationAtRecordingStart"),
                             fileOrientationCoarse=meta.get("fileOrientationCoarse"))
-                report.step("ipad effective aspect ratio is 16:9",
-                            _aspect_ratio_matches(meta.get("effectiveAspectRatio")),
+                eff_ok, eff_expected = _effective_aspect_gate(meta)
+                report.step("ipad effective aspect ratio matches orientation", eff_ok,
+                            expectedEffectiveAspect=eff_expected,
+                            fileOrientationCoarse=meta.get("fileOrientationCoarse"),
                             effectiveAspectRatio=meta.get("effectiveAspectRatio"),
                             effectiveDisplayWidth=meta.get("effectiveDisplayWidth"),
                             effectiveDisplayHeight=meta.get("effectiveDisplayHeight"))
+                encoded_ok = _encoded_aspect_is_16_9(meta)
+                if encoded_ok is not None:
+                    report.step("ipad encoded aspect ratio is 16:9", encoded_ok,
+                                actualResolution=meta.get("actualResolution"))
         else:
             report.step("ipad capture metadata", False, error="copy_app_container_file failed")
 
@@ -1161,8 +1217,10 @@ def scenario_tricamera_capture_skeleton_proof(ctx: ScenarioContext) -> ScenarioR
                 "all 3 confirmed_stop", "timestamp sync report",
                 "gopro preview stream quality", "gopro preview aspect ratio is 16:9",
                 "instructor panel frame traffic", "player panel frame traffic", "gopro panel frame traffic",
-                "iphone orientation consistent", "iphone effective aspect ratio is 16:9",
-                "ipad orientation consistent", "ipad effective aspect ratio is 16:9",
+                "iphone orientation consistent", "iphone effective aspect ratio matches orientation",
+                "iphone encoded aspect ratio is 16:9",
+                "ipad orientation consistent", "ipad effective aspect ratio matches orientation",
+                "ipad encoded aspect ratio is 16:9",
             )
         )
         report.passed = critical_ok

--- a/scripts/mc1_regression/scenarios.py
+++ b/scripts/mc1_regression/scenarios.py
@@ -139,6 +139,35 @@ def _dump_session_state(ctx: ScenarioContext, session_uuid: str, label: str) -> 
         print(f"  [{label}] diagnostic dump failed: {e}")
 
 
+def _pull_pco_failure_diag(ctx: ScenarioContext, report: ScenarioReport,
+                           scenario_started_at) -> None:
+    """Pull the player-side PCO failure evidence (Documents/pco_failure_diag.json,
+    written by PCOFailureDiagWriter on every PlayerCaptureOrchestrator .failed
+    transition — 2026-07-04 RCA). Best-effort: turns a bare
+    "Timeout waiting for: instructor+player confirmed_start" into a concrete
+    player-side reason (e.g. captureStartTimeout with the last capture state).
+    Never raises; reported as evidence, never gates PASS."""
+    local = str(ctx.artifact.dir / "pco_failure_diag.json")
+    try:
+        if not copy_app_container_file(ctx.ipad_udid, "Documents/pco_failure_diag.json", local):
+            report.step("player pco failure diag", False,
+                        error="pco_failure_diag.json not found on iPad — player PCO "
+                              "never transitioned to .failed during this run "
+                              "(cycle never seen, or hang predates the watchdog build)")
+            return
+        diag, stale_reason = load_fresh_diag(local, scenario_started_at)
+        if diag is None:
+            report.step("player pco failure diag", False, error=stale_reason)
+            return
+        report.step("player pco failure diag", True,
+                    reason=diag.get("reason"),
+                    cycleId=diag.get("cycleId"),
+                    lastObservedCaptureState=diag.get("lastObservedCaptureState"),
+                    diagTimestamp=diag.get("timestamp"))
+    except Exception as e:  # noqa: BLE001 — evidence pull must never mask the scenario error
+        report.step("player pco failure diag", False, error=f"pull failed: {e}")
+
+
 def _mark_devices_ready(ctx: ScenarioContext, report: ScenarioReport, session_uuid: str) -> None:
     import time as _time
     # Script-driven backend transition: GET fresh revision + PATCH devices_ready.
@@ -747,6 +776,7 @@ def scenario_tricamera_capture_skeleton_proof(ctx: ScenarioContext) -> ScenarioR
             (ctx.iphone_udid, "Documents/skeleton_output.json"),
             (ctx.iphone_udid, "Documents/gopro_diag.json"),
             (ctx.ipad_udid, "Documents/capture_metadata_diag.json"),
+            (ctx.ipad_udid, "Documents/pco_failure_diag.json"),
         ])
 
         # 1. Join both devices
@@ -1141,6 +1171,11 @@ def scenario_tricamera_capture_skeleton_proof(ctx: ScenarioContext) -> ScenarioR
     except ValidationError as e:
         report.error = str(e)
         report.passed = False
+        # 2026-07-04 RCA: a bare confirmed_start timeout carried zero player-side
+        # evidence. Pull the PCO failure diag from the iPad and dump backend
+        # state so the report explains the failure, not just names it.
+        _pull_pco_failure_diag(ctx, report, scenario_started_at)
+        _dump_session_state(ctx, session_uuid, "tricamera-fail")
     return report
 
 

--- a/scripts/mc1_regression/tests/test_aspect_gates.py
+++ b/scripts/mc1_regression/tests/test_aspect_gates.py
@@ -1,0 +1,136 @@
+"""Orientation-aware aspect-ratio gate tests (2026-07-04 physical-run fix).
+
+The first passing tricamera capture run FAILED only on the unconditional
+"effective aspect ratio is 16:9" assertion: the app correctly encodes the
+sensor's landscape 1280x720 buffer and bakes portrait rotation into
+preferredTransform (verified with ffprobe on the pulled .mov files —
+encoded 1280x720 + rotation -90 => effective display 720x1280 = 9:16).
+Under the RC-checklist J-section portrait mandate (issue #357) the 16:9
+effective expectation was therefore unsatisfiable while the recording was
+in fact correct.
+
+These tests pin the corrected gate semantics:
+  - portrait metadata  -> expected effective aspect 9:16 (PASSes on 9:16)
+  - portrait metadata  -> a 16:9 EFFECTIVE aspect now FAILs (that would mean
+    the rotation was NOT baked in)
+  - landscape metadata -> expected effective aspect 16:9 (PASSes on 16:9)
+  - the encoded-buffer check stays 16:9 regardless of orientation
+  - the GoPro preview gate (_aspect_ratio_matches default 16:9) is unchanged
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from mc1_regression.scenarios import (  # noqa: E402
+    _aspect_ratio_matches,
+    _effective_aspect_gate,
+    _encoded_aspect_is_16_9,
+    _expected_effective_aspect,
+)
+
+
+def _portrait_meta(effective="9:16"):
+    return {
+        "fileOrientationCoarse": "portrait",
+        "effectiveAspectRatio": effective,
+        "actualResolution": "1280x720",
+    }
+
+
+def _landscape_meta(effective="16:9"):
+    return {
+        "fileOrientationCoarse": "landscape",
+        "effectiveAspectRatio": effective,
+        "actualResolution": "1280x720",
+    }
+
+
+# ── expected-aspect mapping ──────────────────────────────────────────────────
+
+def test_expected_effective_aspect_portrait_is_9_16():
+    assert _expected_effective_aspect("portrait") == (9, 16)
+
+
+def test_expected_effective_aspect_landscape_is_16_9():
+    assert _expected_effective_aspect("landscape") == (16, 9)
+
+
+def test_expected_effective_aspect_unknown_has_no_expectation():
+    assert _expected_effective_aspect("unknown") is None
+    assert _expected_effective_aspect(None) is None
+
+
+# ── effective-aspect gate ────────────────────────────────────────────────────
+
+def test_portrait_9_16_effective_passes():
+    ok, expected = _effective_aspect_gate(_portrait_meta("9:16"))
+    assert ok is True
+    assert expected == "9:16"
+
+
+def test_portrait_16_9_effective_fails():
+    # A 16:9 EFFECTIVE aspect on a portrait file would mean the rotation was
+    # never baked in — exactly what the old gate wrongly demanded.
+    ok, expected = _effective_aspect_gate(_portrait_meta("16:9"))
+    assert ok is False
+    assert expected == "9:16"
+
+
+def test_landscape_16_9_effective_passes():
+    ok, expected = _effective_aspect_gate(_landscape_meta("16:9"))
+    assert ok is True
+    assert expected == "16:9"
+
+
+def test_landscape_9_16_effective_fails():
+    ok, _ = _effective_aspect_gate(_landscape_meta("9:16"))
+    assert ok is False
+
+
+def test_unknown_orientation_fails_gate():
+    ok, expected = _effective_aspect_gate({"fileOrientationCoarse": "unknown",
+                                           "effectiveAspectRatio": "16:9"})
+    assert ok is False
+    assert expected is None
+
+
+def test_missing_meta_fails_gate():
+    ok, expected = _effective_aspect_gate({})
+    assert ok is False
+    assert expected is None
+
+
+# ── encoded-buffer gate (orientation-independent 16:9) ───────────────────────
+
+def test_encoded_1280x720_is_16_9_for_both_orientations():
+    assert _encoded_aspect_is_16_9(_portrait_meta()) is True
+    assert _encoded_aspect_is_16_9(_landscape_meta()) is True
+
+
+def test_encoded_portrait_shaped_buffer_fails():
+    meta = _portrait_meta()
+    meta["actualResolution"] = "720x1280"
+    assert _encoded_aspect_is_16_9(meta) is False
+
+
+def test_encoded_missing_metadata_returns_none_step_skipped():
+    assert _encoded_aspect_is_16_9({}) is None
+    assert _encoded_aspect_is_16_9({"actualResolution": "garbage"}) is None
+
+
+# ── GoPro preview gate unchanged ─────────────────────────────────────────────
+
+def test_gopro_preview_gate_unchanged_16_9_passes():
+    assert _aspect_ratio_matches("16:9") is True
+    # near-16:9 real SPS dims still pass (tolerant numeric compare)
+    assert _aspect_ratio_matches("1280:720") is True
+
+
+def test_gopro_preview_gate_unchanged_non_16_9_fails():
+    assert _aspect_ratio_matches("9:16") is False
+    assert _aspect_ratio_matches("4:3") is False
+    assert _aspect_ratio_matches(None) is False

--- a/scripts/mc1_regression/tests/test_console_preconditions.py
+++ b/scripts/mc1_regression/tests/test_console_preconditions.py
@@ -1,0 +1,70 @@
+"""Dual-console hard precondition tests (2026-07-04 tricamera RCA).
+
+The first tricamera physical run failed on the PLAYER (iPad) side while the
+shell wrapper had silently SKIPPED the iPad console capture with a warning —
+the exact evidence the failure needed was never collected. These tests pin
+the runner-side enforcement: tricamera scenarios must refuse to run unless
+BOTH device console log files exist (created by run_mc1_regression.sh before
+the runner starts).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from mc1_regression.lib import (  # noqa: E402
+    DUAL_CONSOLE_REQUIRED_SCENARIOS,
+    check_dual_console_precondition,
+)
+
+TRICAMERA = "tricamera-capture-skeleton-proof"
+
+
+def _console_dir(tmp_path: Path, *files: str) -> Path:
+    d = tmp_path / "console"
+    d.mkdir()
+    for f in files:
+        (d / f).write_text("")
+    return d
+
+
+def test_tricamera_proof_is_dual_console_required():
+    assert TRICAMERA in DUAL_CONSOLE_REQUIRED_SCENARIOS
+    assert "gopro-tricamera-smoke" in DUAL_CONSOLE_REQUIRED_SCENARIOS
+
+
+def test_both_consoles_present_passes(tmp_path):
+    d = _console_dir(tmp_path, "iphone_console.log", "ipad_console.log")
+    assert check_dual_console_precondition([TRICAMERA], d) == []
+
+
+def test_missing_ipad_console_fails(tmp_path):
+    d = _console_dir(tmp_path, "iphone_console.log")
+    errors = check_dual_console_precondition([TRICAMERA], d)
+    assert len(errors) == 1
+    assert "iPad" in errors[0]
+    assert "ipad_console.log" in errors[0]
+    assert TRICAMERA in errors[0]
+
+
+def test_missing_both_consoles_reports_both(tmp_path):
+    d = _console_dir(tmp_path)
+    errors = check_dual_console_precondition([TRICAMERA], d)
+    assert len(errors) == 2
+    assert any("iPhone" in e for e in errors)
+    assert any("iPad" in e for e in errors)
+
+
+def test_non_tricamera_scenario_is_exempt(tmp_path):
+    d = _console_dir(tmp_path)  # no console files at all
+    assert check_dual_console_precondition(["smoke"], d) == []
+    assert check_dual_console_precondition(["all"], d) == []
+
+
+def test_scenario_list_with_mixed_names_still_enforces(tmp_path):
+    d = _console_dir(tmp_path, "iphone_console.log")
+    errors = check_dual_console_precondition(["smoke", TRICAMERA], d)
+    assert len(errors) == 1 and "iPad" in errors[0]

--- a/scripts/run_mc1_regression.sh
+++ b/scripts/run_mc1_regression.sh
@@ -225,6 +225,29 @@ PYEOF
   fi
 fi
 
+# ── Dual-console hard precondition (tricamera scenarios) ──────────────────
+# The 2026-07-04 tricamera run failed on the PLAYER (iPad) side while the
+# WARN-only path above had silently skipped the iPad console capture — the
+# exact evidence the failure needed was never collected. Tricamera scenarios
+# exercise the player-side capture chain, so BOTH device consoles are a hard
+# precondition: both devices must be USB-connected, trusted, and visible to
+# idevicesyslog. (runner.py re-checks this — defense in depth.)
+if [[ "${SCENARIO}" == *tricamera* ]]; then
+  if [[ -z "${IPHONE_CONSOLE_PID}" || -z "${IPAD_CONSOLE_PID}" ]]; then
+    echo
+    echo "ERROR: scenario '${SCENARIO}' requires console capture from BOTH devices."
+    echo "  iPhone console capture: $([[ -n "${IPHONE_CONSOLE_PID}" ]] && echo running || echo MISSING)"
+    echo "  iPad   console capture: $([[ -n "${IPAD_CONSOLE_PID}" ]] && echo running || echo MISSING)"
+    echo
+    echo "  Connect BOTH devices via USB, trust this Mac on each, then verify:"
+    echo "    idevice_id -l   # must list both legacy UDIDs"
+    echo "  Manual overrides: IPHONE_LEGACY_UDID / IPAD_LEGACY_UDID env vars."
+    [[ -n "${IPHONE_CONSOLE_PID}" ]] && kill "${IPHONE_CONSOLE_PID}" 2>/dev/null || true
+    [[ -n "${IPAD_CONSOLE_PID}" ]]   && kill "${IPAD_CONSOLE_PID}"   2>/dev/null || true
+    exit 1
+  fi
+fi
+
 cleanup() {
   [[ -n "${IPAD_CONSOLE_PID:-}" ]]   && kill "${IPAD_CONSOLE_PID}"   2>/dev/null || true
   [[ -n "${IPHONE_CONSOLE_PID:-}" ]] && kill "${IPHONE_CONSOLE_PID}" 2>/dev/null || true


### PR DESCRIPTION
## Kontextus

A 2026-07-04-i első fizikai tricamera futás (`20260704T091635Z_tricamera-capture-skeleton-proof`) FAIL: `Timeout waiting for: instructor+player confirmed_start`. RCA: a player (iPad) `pending`-ben ragadt, mert **két külön AVCaptureSession versengett ugyanazért a hátsó kameráért** (SessionCaptureManager recording session + CameraFramePublisher saját preview session); a vesztes session interrupcióját a `.ready` állapot némán elnyelte, a PCO pedig watchdog nélkül örökre lógott. A player-oldali evidencia közben teljesen hiányzott: az iPad console capture SKIP-elve volt (WARN-only), és a `print()` sorokat az idevicesyslog fizikai eszközön nem látja (78k sor, 0 app-tag).

Stacked PR a #356-ra — a #356 merge marad az egyetlen kapu a következő fizikai futás előtt.

## P0 javítások

1. **Single-session camera ownership (player):** `CameraFramePublisher` nem hoz létre saját `AVCaptureSession`-t; egy `AVCaptureVideoDataOutput`-ot csatol a `SessionCaptureManager` sessionjére (`attachPreviewOutput`/`detachPreviewOutput`, capture queue-n, begin/commitConfiguration alatt). A recording session authoritative, a preview mellékág — egyszerre futnak, kamera-verseny nélkül. Garancia: a MultiCamera modulban `AVCaptureSession()` konstruktor kizárólag a `SessionCaptureManager`-ben marad.
2. **Ready-state interruption tracking:** kamera-vesztés `.ready`-ben → `.interrupted` (eddig: hamis `.ready` maradt); interruption-end: felvétel közbeni megszakadásnál `stopCapture` finalizálás, armed-only esetben visszaáll `.ready`-re.
3. **PCO capture-start watchdog (5 s):** ha a capture nem éri el a `.capturing`-ot, explicit `.failed("captureStartTimeout…")` az utolsó megfigyelt capture state-tel + `Documents/pco_failure_diag.json` artifact (minden `.failed` átmenetnél íródik). 5 s indoklás: egészséges `startRecording→didStartRecording` < 1 s (>10× margin), és bőven a harness confirmed_start poll-ablakán belül marad, így a scenario a konkrét okot jelenti, nem csak generikus timeoutot.
4. **Fizikai evidencia:** `MC1Log` (os_log `%{public}@`) váltja a `print()`-et a teljes MC1 evidencia-útvonalon ([PCO]/[CCO]/[MC1-AUTO]/[GOPRO-AUTO]/[SessionCapture]/[FramePublisher]/[StreamService]/[LobbyVM]/[GOPRO]) — üzenetszövegek változatlanok, a harness grep-jei működnek. A shell wrapper tricamera scenariónál **hard-fail** (exit 1), ha bármelyik eszköz console capture nem indul; `runner.py` defense-in-depth check (`check_dual_console_precondition`, exit 2). Failure-ágon a scenario lehúzza a `pco_failure_diag.json`-t (freshness-gated) és backend state dumpot ír.
5. **Orientáció külön kezelve (nincs ebben a PR-ban kód-fix):** #357 issue + RC checklist v1.1 J-szekció P1 döntés — a capture-start chain validációs futás **portrait szereléssel** megy; landscape tricamera a #357-ig BLOKKOLT.

## Tesztek

- Swift (mind zöld szimulátoron): PCO-22 (watchdog fail + confirm nem hívódik), PCO-23 (no false positive), PCO-24 (diag artifact tartalom), SC-14 (capturing-interruption → stop), SC-15 (ready-interruption → degraded), SC-15b (re-arm), SC-15c (startCapture refusal); + teljes PCO/PSO/attach-race/SessionCaptureManager suite-ok PASS.
- Python: `pytest scripts/mc1_regression/tests/` 26 passed (6 új console-precondition teszt); `preflight_static_check.py` 59 passed, 0 failed (3 új pin).
- Release-config build guard és teljes iOS suite: CI-ben.

## PASS/FAIL definíció frissítés

A tricamera scenario PASS-definíciója (backend-grounded critical_ok lista) változatlan. Új: (a) a futás EL SEM INDUL mindkét eszköz console capture-je nélkül (shell exit 1 / runner exit 2), (b) FAIL esetén a report tartalmazza a `player pco failure diag` stepet a konkrét player-oldali okkal, + backend state dump.

## Manuális fizikai validáció marad

- A megosztott session melletti egyidejű preview-stream + felvétel fizikai eszközön (szimulátoron nincs kamera).
- MPC `offline / 0 fps` disconnect trigger (gyanú: GoPro AP váltás) — az új os_log + dual-console evidenciával lesz diagnosztizálható.
- GoPro flow, skeleton overlay vizuális ellenőrzés (RC checklist K-szekció).

🤖 Generated with [Claude Code](https://claude.com/claude-code)