### PR TITLE
MC2-PR1: non-recording instructor cycles + no-MPC roadmap

### DIFF
--- a/.github/workflows/mc1-regression-harness.yml
+++ b/.github/workflows/mc1-regression-harness.yml
@@ -1,0 +1,60 @@
+name: MC1 Regression Harness — Preflight + Diag Contract
+
+# ── Purpose ────────────────────────────────────────────────────────────────────
+# Guards the MC1 physical-regression EVIDENCE CHAIN (P0 hardening, 2026-07-04):
+#   1. Static preflight (scripts/mc1_regression/preflight_static_check.py):
+#      deep-link parity, PCO role gate, artifact collectors, stale-artifact
+#      invalidation wiring, action-consume mechanism, console-log UDID mapping.
+#   2. pytest (scripts/mc1_regression/tests/): devicectl invocation contract,
+#      transition body contract, and the Swift-writer ↔ Python-reader diag JSON
+#      key contract (the framesReceived gate bug class) + load_fresh_diag
+#      stale-artifact rejection semantics.
+#
+# No devices, no backend, no secrets — pure source-level + unit-level checks.
+# A red run here means a physical tricamera run would produce a false verdict.
+# ──────────────────────────────────────────────────────────────────────────────
+
+on:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'scripts/mc1_regression/**'
+      - 'scripts/run_mc1_regression.sh'
+      - 'ios/LFAEducationCenter/MultiCamera/**'
+      - '.github/workflows/mc1-regression-harness.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/mc1_regression/**'
+      - 'scripts/run_mc1_regression.sh'
+      - 'ios/LFAEducationCenter/MultiCamera/**'
+      - '.github/workflows/mc1-regression-harness.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: mc1-regression-harness-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  preflight-and-contract:
+    name: Static preflight + diag key contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install pytest
+        run: pip install pytest
+
+      - name: Run static preflight check
+        run: python3 scripts/mc1_regression/preflight_static_check.py
+
+      - name: Run mc1_regression unit + contract tests
+        run: python3 -m pytest scripts/mc1_regression/tests/ -q

--- a/app/services/multicamera/cycle_service.py
+++ b/app/services/multicamera/cycle_service.py
@@ -79,7 +79,10 @@ class CycleService:
     ) -> CaptureCycle:
         """
         Snapshot all non-removed session devices → CaptureCycleDevice rows.
-        required = True for all roles except auxiliary_camera.
+        required = True only for player roles (player_primary/player_secondary).
+        The instructor device is a non-recording coordinator (MC2-PR1, final
+        topology: iPad instructor without camera); auxiliary_camera (GoPro)
+        completion is enforced at the regression-gate level, not here.
 
         Session must be ACTIVE.  Only one non-terminal cycle may exist per
         session at a time.  The session row is locked (SELECT FOR UPDATE)
@@ -123,7 +126,10 @@ class CycleService:
             idempotency_key=idempotency_key,
         )
         for sd in devices:
-            required = DeviceRole(sd.device_role) != DeviceRole.AUXILIARY_CAMERA
+            required = DeviceRole(sd.device_role) in (
+                DeviceRole.PLAYER_PRIMARY,
+                DeviceRole.PLAYER_SECONDARY,
+            )
             self.repo.add_cycle_device(
                 capture_cycle_id=cycle.id,
                 session_device_id=sd.id,
@@ -225,17 +231,22 @@ class CycleService:
         cycle_device_revision: int,
     ) -> CaptureCycle:
         cycle = self._require_cycle(cycle_id)
+
+        # Idempotent duplicate MUST be checked before the cycle-status guard:
+        # with players-only required sets (MC2-PR1) the first confirm_stop of
+        # the last required device completes the cycle, so a duplicate confirm
+        # arrives at a COMPLETED cycle — the documented contract is that a
+        # duplicate confirm_stop is always a safe 200, never a 422 race.
+        ccd = self._require_cycle_device(cycle_id, session_device_id)
+        if CycleDeviceRecordingStatus(ccd.recording_status) == CycleDeviceRecordingStatus.CONFIRMED_STOP:
+            self.db.refresh(cycle)
+            return cycle
+
         current_status = CycleStatus(cycle.status)
         if current_status not in (CycleStatus.RECORDING, CycleStatus.STOPPING):
             raise InvalidTransitionError(
                 "cycle", cycle.status, "confirm_device_stop requires recording or stopping"
             )
-
-        ccd = self._require_cycle_device(cycle_id, session_device_id)
-        # Idempotent: already confirmed stop — return current cycle state
-        if CycleDeviceRecordingStatus(ccd.recording_status) == CycleDeviceRecordingStatus.CONFIRMED_STOP:
-            self.db.refresh(cycle)
-            return cycle
         if ccd.revision != cycle_device_revision:
             raise RevisionConflictError("cycle_device", cycle_device_revision, ccd.revision)
         if CycleDeviceRecordingStatus(ccd.recording_status) != CycleDeviceRecordingStatus.CONFIRMED_START:

--- a/docs/AN3B_PR4B_GOPRO_CAPTURE_POC_PLAN.md
+++ b/docs/AN3B_PR4B_GOPRO_CAPTURE_POC_PLAN.md
@@ -8,6 +8,13 @@
 > dashboard live preview követelményét (GoPro élőkép megjelenítése a többi kamera mellett);
 > arra lásd [GOPRO_LIVE_PREVIEW_POC_PLAN.md](GOPRO_LIVE_PREVIEW_POC_PLAN.md).
 
+> **2026-07-12 frissítés — végleges fizikai topológia**: a célrendszer 2× iPhone 12 Pro/Max
+> (két külön player kamera) + 1× GoPro (3. nézet) + 1× iPad (instruktori vezérlő/megjelenítő,
+> kamerája NEM vesz részt). A **PR-4B1 (GoPro connection) scope változatlan, visszamenőleg
+> nem bővül**. A PR-4B2 SUPERSEDED (MC1 ORCH-sorozat), a PR-4B3 rescope (audio sync 3 forrásra
+> → MC3-B), a PR-4B4-et az RC checklist + regression harness váltotta ki. A gap analysist és
+> a frissített fázissort lásd: [MC1_FINAL_TOPOLOGY_GAP_ANALYSIS.md](MC1_FINAL_TOPOLOGY_GAP_ANALYSIS.md).
+
 ---
 
 ## I. Jelenlegi iOS állapot

--- a/docs/MC1_FINAL_TOPOLOGY_GAP_ANALYSIS.md
+++ b/docs/MC1_FINAL_TOPOLOGY_GAP_ANALYSIS.md
@@ -1,0 +1,219 @@
+# MC1 Végleges Fizikai Topológia — Gap Analysis és Frissített Roadmap
+
+**Dátum:** 2026-07-12
+**Státusz:** TERVEZÉSI DOKUMENTUM — implementáció külön jóváhagyással.
+**Trigger:** Végleges fizikai topológia rögzítése (lásd 1. pont). Ez a dokumentum
+felülírja a [MULTICAMERA_3D_IOS_ROADMAP.md](MULTICAMERA_3D_IOS_ROADMAP.md) Phase 2+
+fázisbontását és lezárja az [AN3B_PR4B_GOPRO_CAPTURE_POC_PLAN.md](AN3B_PR4B_GOPRO_CAPTURE_POC_PLAN.md)
+PR-4B2/4B3/4B4 bontásának rescope-ját. **A PR-4B1 connection scope visszamenőleg NEM bővül.**
+
+> **v1.1 REVÍZIÓ — ARCHITEKTÚRA-DÖNTÉS (user, 2026-07-12):** az MPC/peer-to-peer réteg
+> **teljes kivezetése**. Végleges architektúra: backend-orchestrált session, lokális
+> rögzítés minden kamerán, post-cycle upload, audio-alapú fine sync, iPad =
+> státusz/thumbnail dashboard (backend-polling, élő stream nélkül), GoPro manager =
+> SIM-es Player A. Következmények e dokumentumban: G-4 okafogyott (helyette
+> dashboard-átállás), MC2-C fázis átírva, TOPO-G3/G4 átfogalmazva, D2 véglegesítve,
+> D3 és R1 törölve, R2 egyszerűsödött. A PR-szintű bontást a
+> [MC2_MINIMAL_IMPLEMENTATION_PLAN.md](MC2_MINIMAL_IMPLEMENTATION_PLAN.md) v1.1 tartalmazza.
+
+---
+
+## 1. Végleges topológia (követelmény)
+
+| Eszköz | Szerep | Kamera részt vesz? | Backend `device_role` cél |
+|---|---|---|---|
+| iPhone 12 Pro (A) | Player kamera #1 | ✅ | `player_primary` |
+| iPhone 12 Pro Max (B) | Player kamera #2 | ✅ | `player_secondary` |
+| GoPro (HERO12*) | Kiegészítő 3. kameranézet | ✅ | `auxiliary_camera` |
+| iPad | Instruktori vezérlő + megjelenítő | ❌ **NEM** | `instructor_primary` (nem-felvevő) |
+
+- A három kameraforrás **egy közös MC1 sessionben** és közös cycle-ban fut.
+- Az iPaden a két iPhone és a GoPro **státusza + pre-cycle thumbnail** jelenik meg backend-pollinggal (v1.1 — élő videóstream nincs).
+- A későbbi 3D skeleton rekonstrukció a három **időben szinkronizált és kalibrált** nézetből készül.
+
+\* *Elnevezési higiénia: a kódbázis vegyesen hivatkozik HERO12-re
+([GoProConstants.swift:8](../ios/LFAEducationCenter/MultiCamera/GoProConstants.swift)) és HERO13-ra
+(handoff report, `scenarios.py` device_name stringek). A fizikai eszköz típusát a következő
+futás jegyzőkönyvében egyértelműen rögzíteni kell; a scenario `device_name` stringeket ehhez
+kell igazítani (kozmetikai, nem blokkoló).*
+
+---
+
+## 2. Mit támogat MÁR a jelenlegi rendszer (kód-referenciákkal)
+
+### 2a. Backend — nagyrészt kész
+
+| Képesség | Kód | Státusz |
+|---|---|---|
+| 4 device-role, köztük `player_secondary` | `app/models/multicamera_session.py:33-37` (`DeviceRole` enum) | ✅ KÉSZ |
+| Második player automatikus szerep-kiosztás (player → `player_primary`, ha már van → `player_secondary`) | `app/services/multicamera/session_service.py:284-311` | ✅ KÉSZ — de **soha nem futott** sem scenarióban, sem fizikai teszten |
+| N-eszközös cycle lifecycle (minden nem-removed device snapshotolva a cycle-ba) | `app/services/multicamera/cycle_service.py` `create_cycle` | ✅ KÉSZ — 3 device-szal fizikailag bizonyított (2026-07-04) |
+| GoPro registration + `managed_by_device_id` ownership + confirm start/stop | `device_service.py` + scenariók | ✅ KÉSZ, fizikailag bizonyított |
+| **Required-szabály**: `required = True` minden szerepre, kivéve `auxiliary_camera` | `cycle_service.py:82` | ❌ **BLOKKOLÓ GAP**: az `instructor_primary` iPad kötelező felvevő lenne — az új topológiában az iPad NEM vesz fel |
+
+### 2b. iOS — a váz megvan, a topológia-specifikus részek hiányoznak
+
+| Képesség | Kód | Státusz |
+|---|---|---|
+| `playerSecondary` device role + PCO attach allow-list engedi | `MultiCameraSessionModels.swift:29`, `MultiCameraSessionViewModel.swift:368-377` | ✅ enum-szinten kész, fizikailag nem tesztelt |
+| Controller-feloldás participant-role alapú (nem device-type) → iPad instruktorként elvben működik | `MultiCameraSessionViewModel.swift` `resolveIsController` + `resolvedParticipantRole` | ✅ elvben; ❌ iPad=instructor irányban fizikailag nem validált (a jelenlegi futások iPhone=instructor modellen mennek) |
+| `shouldAutoPrepare`: instructor is capture-t készít | `MultiCameraSessionViewModel.swift:356-363` | ❌ GAP: nincs "megjelenítő-koordinátor kamera nélkül" mód |
+| MPC live stream player → controller | `CameraStreamService.swift` | ⚠️ v1.1: **KIVEZETENDŐ** (MC2-PR3) — az MPC-réteg a 2026-07-12 döntés szerint teljes egészében megszűnik; a korábbi single-peer gap okafogyott |
+| Instructor dashboard | `InstructorDashboardView.swift` | ❌ GAP (v1.1 átfogalmazva): a cél 3 **státusz/thumbnail panel** (player A, player B, GoPro) backend-pollinggal, lokális panel és élő stream NÉLKÜL |
+| Közös óra-alap: szerveridő-offset sync (NTP-szerű RTT-mintavétel) | `ClockSyncService.swift` | ✅ software-szintű közös timestamp (started_at delta gate: RC checklist F8) |
+| Per-kamera 2D skeleton (Vision) | `SkeletonProcessor.swift` | ✅ kód kész, fizikai proof folyamatban |
+
+### 2c. Contract / séma
+
+| Képesség | Kód | Státusz |
+|---|---|---|
+| Kalibrációs DTO-k: `IntrinsicCalibrationDTO`, `StereoCalibrationDTO` | `app/schemas/skeleton_3d.py:150,174` | ✅ séma létezik; ❌ **0 sor** capture/kalibráló kód (se iOS, se OpenCV pipeline) |
+| `calibration_json` oszlop a sessionön | `app/models/multicamera_session.py:131` | ✅ tárolóhely van, író nincs |
+| `Skeleton3DFrame` | `app/schemas/skeleton_3d.py:126-148` | ❌ GAP: 1 `camera_id`/frame, `coordinate_system` fixen `camera_a_origin_rh_meters` — **2-kamerás párra** tervezve, tri-view bundle nincs |
+
+### 2d. Regression harness
+
+| Képesség | Kód | Státusz |
+|---|---|---|
+| `ScenarioContext` | `scripts/mc1_regression/lib.py:501-511` | ❌ GAP: pontosan **2 iOS UDID** (`ipad_udid`, `iphone_udid`) + **2 token** (instructor, player). Harmadik iOS eszköz és második player token nem létezik |
+| Scenariók szerepmodellje | `scenarios.py` (`iphone_role="instructor"`, `ipad_role="player"` default) | ❌ a végleges topológia ennek **inverze** (iPad=instructor) + 1 extra player |
+
+---
+
+## 3. Mit validál a futó fizikai HERO12 smoke teszt a végleges topológiából
+
+A jelenlegi branch (`fix/mc1-p0-player-camera-session`) fizikai futásai a
+`gopro-tricamera-smoke` / `tricamera-capture-skeleton-proof` scenariót futtatják
+**iPhone=instructor(+kamera) + iPad=player(+kamera) + GoPro** topológián. A legutóbbi
+futás (`20260704T115717Z`) minden capture-lifecycle stepet PASS-olt (gopro ready, 3×
+confirmed_start/stop, timestamp sync report); a FAIL a player-oldali evidencia-pull USB
+hibáján (CoreDeviceError 4016) történt — erre irányulnak a branch P0 fixei.
+
+| Végleges-topológia elem | A futó smoke validálja? | Megjegyzés |
+|---|---|---|
+| Közös session + cycle 3 kameraforrással (backend lifecycle) | ✅ IGEN | Strukturálisan azonos: 3 device, 1 cycle, 3× confirmed_start/stop |
+| GoPro vezérlés: registration, ownership, ready, shutter, media evidence, preview probe | ✅ IGEN | Az `auxiliary_camera` láb 1:1 átvihető |
+| Player capture-session ownership P0 fix (2×AVCaptureSession kontenció) | ✅ IGEN | A player-láb viselkedése mindkét leendő player iPhone-ra átvihető |
+| 1 MPC live stream → controller dashboard | ✅ IGEN (1 forrásra) | 2 párhuzamos streamet NEM bizonyít |
+| Közös timestamp-alap (ClockSync + started_at delta) | ✅ IGEN | Software-szintű; frame-szintűt nem |
+| Per-kamera 2D skeleton + artifact/evidencia-lánc | ✅ IGEN | |
+| **iPad mint master coordinator** | ❌ NEM | A controller iPhone |
+| **Nem-felvevő koordinátor** | ❌ NEM | Az instructor eszköz kamerával, kötelező felvevőként vesz részt |
+| **Két külön player iPhone** | ❌ NEM | 1 player van; `player_secondary` útvonal még soha nem futott |
+| ~~2 párhuzamos MPC stream az iPaden~~ *(v1.1: okafogyott — MPC kivezetve)* | — | A dashboard státusz/thumbnail-alapú lesz |
+| **Frame-szintű sync, kalibráció, tri-view contract** | ❌ NEM | Nem is scope-ja a smoke-nak |
+
+**Következtetés:** a futó smoke a végleges topológia **közös építőelemeit** validálja
+(session/cycle lifecycle, GoPro-láb, player-láb, evidencia-lánc), a
+**topológia-specifikus** elemeket (szerep-inverzió, 2. player, státusz/thumbnail
+dashboard, nem-felvevő koordinátor) nem. Ezért a smoke PASS **szükséges, de nem elégséges** előfeltétele az
+átállásnak — értéke változatlan, futtatása nem függ ettől a gap analysistől.
+
+---
+
+## 4. Gap-lista tételesen
+
+| # | Elem | Státusz | Hiányzó munka |
+|---|---|---|---|
+| G-1 | iPad mint master coordinator | RÉSZBEN | Szerep-feloldás eszközfüggetlen (✅), de: (a) instructor kötelező felvevő (`cycle_service.py:82` + `shouldAutoPrepare`), (b) dashboard lokális-kamera panelre épít, (c) scenariók `iphone_role="instructor"` defaultúak, (d) **GoPro ownership döntés** — lásd D1 |
+| G-2 | Két player iPhone regisztrációja | RÉSZBEN | Backend auto-kiosztás + iOS enum kész; hiányzik: 2. player user/token, harness 3. UDID, `player_secondary` első valós futása, dedikált unit/E2E tesztek |
+| G-3 | Három kamera közös sessionje | NAGYRÉSZT KÉSZ | 3 felvevő device egy cycle-ban bizonyított; a hiány a **4. (nem-felvevő) device** viselkedése — G-1(a) |
+| G-4 | ~~Több stream megjelenítése iPaden~~ → **Státusz/thumbnail dashboard (v1.1)** | ÁTFOGALMAZVA | Az MPC-kivezetés után: dashboard-panelek backend-pollingos státusszal + pre-cycle thumbnail-lel; `CameraStreamService` és fogyasztóinak kivezetése; thumbnail endpoint (MC2-PR3 v1.1) |
+| G-5 | Közös timestamp és frame-szinkron | RÉSZBEN | ClockSync + F8 gate megvan (~100 ms nagyságrend). Frame-szintű: audio-clap cross-correlation (az eredeti PR-4B3 `AudioSyncEngine`/`FrameTimeMatcher` — **0 sor implementálva**), GoPro GPMF telemetria parsing szintén nincs |
+| G-6 | Per-camera calibration | CSAK SÉMA | `IntrinsicCalibrationDTO`/`StereoCalibrationDTO` létezik; nincs kalibrációs capture flow (checkerboard), nincs OpenCV pipeline, nincs `calibration_json` író |
+| G-7 | Háromnézetes 3D skeleton input contract | HIÁNYZIK | `Skeleton3DFrame` 2-kamerás pár feltevésű (`camera_a_origin_rh_meters`); kell: synchronized multi-view frame-bundle (3 camera_id + közös timestamp + sync_quality), kalibrációs gráf (3 kamera → 2-3 pairwise `StereoCalibrationDTO`), `coordinate_system` általánosítás |
+
+---
+
+## 5. PR-4B2/4B3 roadmap módosítás — IGEN, szükséges
+
+| Eredeti PR | Eredeti scope | Döntés |
+|---|---|---|
+| **PR-4B1** | GoPro BLE/WiFi connection + state machine | **VÁLTOZATLAN, visszamenőleg nem bővül.** A GoPro-lábat a jelenlegi smoke validálja; a 40 SM teszt + fizikai bizonyíték él |
+| **PR-4B2** | Dual capture session + iPhone recording | **SUPERSEDED** az MC1 ORCH-sorozat által (`SessionCaptureManager`, `CycleCaptureOrchestrator`, `PlayerCaptureOrchestrator`, backend cycle lifecycle) — lezárandó "superseded by MC1 ORCH-2B..5" megjegyzéssel, külön implementáció nem kell |
+| **PR-4B3** | GoPro media retrieval + offline audio sync | **RESCOPE**: a media retrieval részben kész (media/list + download a scenariókban); az audio sync (AudioSyncEngine, FrameTimeMatcher, SYNC/DROP tesztsuite) él, de **2 helyett 3 forrásra** kell tervezni → átkerül **MC3-B**-be |
+| **PR-4B4** | Physical benchmark + gate report | **KIVÁLTVA** az RC checklisttel (`MC1_TRICAMERA_RC_CHECKLIST.md`) + regression harness-szel — külön PR nem kell |
+
+### Frissített fázissor (javaslat — mindegyik külön jóváhagyással indul)
+
+```
+[FUT]  HERO12 smoke PASS a P0 branch-en  (előfeltétele mindennek)
+   │
+MC2 — Topológia-átállás (2 iPhone player + GoPro + iPad coordinator)
+   ├─ MC2-A  Nem-felvevő koordinátor mód
+   │         backend: required-szabály szereptől/recording_capable flagtől függjön
+   │         (cycle_service.py:82); iOS: shouldAutoPrepare display-only ág,
+   │         dashboard lokális panel nélkül; RC checklist E4 átírás (iPad=instructor)
+   ├─ MC2-B  Dual-player regisztráció
+   │         2. player user/token; harness: ScenarioContext 3 iOS UDID + 2 player token;
+   │         player_secondary első fizikai futása; új scenario: dual-player-smoke
+   ├─ MC2-C  Státusz/thumbnail dashboard + MPC-kivezetés  (v1.1 — a volt N-peer
+   │         MPC fázist váltja): panelenként backend-pollingos státusz + pre-cycle
+   │         thumbnail; CameraStreamService és fogyasztóinak kivezetése a diag/
+   │         preflight kulcsokkal együtt; thumbnail endpoint (egyetlen új backend-elem)
+   ├─ MC2-D  GoPro ownership az iPad-instructor modellben  (D1/D2 döntések;
+   │         D3 v1.1-ben törölve)
+   ├─ MC2-E  Teljes végleges-topológia fizikai smoke  (TOPO-G gate-ek, lásd 6.)
+   └─ MC2-F  Post-cycle upload pipeline  (v1.1 új: videó+metadata upload a backendre
+   │         cycle után — az MC3/MC4 bemenete; a proof USB-pull-lal is teljes értékű)
+   │
+MC3 — Szinkron + kalibráció
+   ├─ MC3-A  Kalibrációs flow: per-camera intrinsic + pairwise extrinsic
+   │         (checkerboard felvétel iOS-en, offline OpenCV, calibration_json upload)
+   ├─ MC3-B  Frame-szintű sync 3 forrásra (audio clap cross-correlation —
+   │         az eredeti PR-4B3 öröksége; SY-G1..G5 gate-ek megtartva)
+   └─ MC3-C  Tri-view skeleton input contract (schema PR: multi-view bundle,
+   │         kalibrációs gráf, coordinate_system általánosítás)
+   │
+MC4 — Trianguláció + 3D viewer  (a régi roadmap Phase 3 megfelelője, változatlan)
+```
+
+---
+
+## 6. Új acceptance gate-ek a 2 iPhone + GoPro + iPad fizikai futáshoz (MC2-E)
+
+A meglévő RC checklist (A–M szekciók) érvényben marad; az alábbi TOPO-gate-ek
+**kiegészítik**, nem helyettesítik.
+
+| Gate | Metrika | Target |
+|---|---|---|
+| TOPO-G1 | Session device-összetétel: pontosan 4 nem-removed device, szerepek = `instructor_primary` (iPad) + `player_primary` + `player_secondary` + `auxiliary_camera`; mindegyik a helyes fizikai eszközhöz rendelve (session dump + UDID mapping) | 4/4 egyezik |
+| TOPO-G2 | Cycle required-halmaz: az instructor device NINCS a required felvevők közt; a cycle 3 felvevő confirmed_start + confirmed_stop-pal zárul | 10/10 cycle |
+| TOPO-G3 *(v1.1)* | iPad dashboard: 3 **státusz/thumbnail panel** (player A, player B, GoPro), panelenként friss backend-státusz (nem stale) ÉS megérkezett pre-cycle thumbnail, session_device_id-hez kötött megjelenítéssel | 3/3 panel |
+| TOPO-G4 *(v1.1)* | Panel-attribúció: minden panel a HELYES session_device státuszát/thumbnail-jét mutatja (nincs kereszt-hozzárendelés); player kiesésekor a panel explicit disconnected állapotot jelez | 0 kereszt-hozzárendelés |
+| TOPO-G5 | Timestamp sync: a 3 felvevő `started_at` max deltája ≤ előre deklarált tűrés (software-szint, javaslat: ≤ 150 ms; frame-szintű < 33 ms cél MC3-B után) | delta ≤ tűrés |
+| TOPO-G6 | Artifact-teljesség: 3 videófájl (2 iOS + 1 GoPro letöltés) + 3 per-kamera skeleton JSON fizikailag begyűjtve | 3+3 fájl |
+| TOPO-G7 | iPad nem vesz fel: az iPad-en NEM jön létre capture fájl, és a cycle alatt nincs aktív capture-célú AVCaptureSession (a P0 kamera-kontenció tanulsága — a dashboard nem nyithat kamerát) | 0 fájl, 0 session |
+| TOPO-G8 | Silent partial: nincs olyan cycle, amely csendben 3-nál kevesebb felvevővel zárul PASS-ként | 0 |
+| TOPO-G9 *(MC3 után)* | Kalibrációs artifact: per-camera intrinsic + ≥ 2 pairwise extrinsic, preset-egyezés validálva (`validate_preset_match`) | 3 intrinsic + 2 extrinsic |
+
+---
+
+## 7. Döntési pontok és kockázatok
+
+| # | Döntés/kockázat | Részletek | Ajánlás |
+|---|---|---|---|
+| D1 | **Ki vezérli a GoPro-t?** Az iPad (SIM nélkül) nem tud egyszerre a GoPro AP-n ÉS a backenden lenni | A jelenlegi modellben a GoPro manager = instructor iPhone (cellular + GoPro WiFi). iPad-instructor mellett ez nem vihető át 1:1 | GoPro manager = **player iPhone A** (cellular backend + GoPro AP WiFi — a ma bizonyított minta); a backend `managed_by_device_id` ezt már támogatja |
+| D2 *(v1.1: VÉGLEGES)* | GoPro megjelenítése az iPaden | A UDP preview csak a GoPro AP-ra csatlakozott eszközön (player A) érhető el | **Státusz/thumbnail** GoPro panel az iPaden (backend-polling) + felvétel-evidencia — a 2026-07-12 döntéssel véglegesítve, élőkép-relay nem készül |
+| ~~D3~~ *(v1.1: TÖRÖLVE)* | ~~MPC (AWDL) koexisztencia~~ | MPC híján okafogyott; a Player A cellular↔GoPro-AP kettős elérése a meglévő gopro-scenariókkal bizonyított | — |
+| D4 | GoPro legyen-e required a cycle-ban? | Ma `auxiliary_camera` nem required — 3D-hez viszont mindhárom nézet kell | Tri-view proof futásnál gate-szinten kényszerítjük (TOPO-G2/G8), a backend required-szabályt nem változtatjuk meg emiatt |
+| ~~R1~~ *(v1.1: TÖRÖLVE)* | ~~L2/L3 (MPC session-validáció + titkosítatlanság)~~ | MPC-kivezetéssel okafogyott — a volt L3 production blocker megszűnik | — |
+| R2 *(v1.1: egyszerűsödött)* | iPhone 12 Pro/Pro Max teljesítmény | 2 player eszközön egyszerre: rögzítés + (player A-n) GoPro vezérlés — MPC JPEG stream már nincs | FPS/hőmérséklet mérés a MC2-E futásban |
+| R3 *(v1.1: új)* | Instructor a cycle alatt élő kép nélkül | Beállítási hiba (framing, takarás) csak cycle után derül ki | Pre-cycle thumbnail framing-ellenőrzés (MC2-C) — tudatosan vállalt trade-off |
+
+---
+
+## 8. Összefoglaló döntési tábla
+
+| Kérdés | Válasz |
+|---|---|
+| A jelenlegi rendszer támogatja a topológiát? | Backend: ~80% (required-szabály a fő gap). iOS: váz kész, topológia-specifikus rétegek (státusz/thumbnail dashboard, nem-felvevő mód) hiányoznak. Harness: 2-eszköz limit |
+| v1.1 architektúra-delta? | MPC/P2P teljes kivezetés; dashboard = státusz/thumbnail; + post-cycle upload fázis (MC2-F); D3/R1 törölve; TOPO-G3/G4 átfogalmazva |
+| A PR-4B1 scope elég? | A GoPro-lábra igen; nem bővítjük visszamenőleg |
+| A futó HERO12 smoke mit validál? | A közös építőelemeket (lásd 3. pont) — futtatása változatlanul indokolt |
+| PR-4B2/4B3 módosítás kell? | IGEN: 4B2 superseded, 4B3 rescope → MC3-B, 4B4 kiváltva; új MC2/MC3 fázissor (5. pont) |
+| Új gate-ek? | TOPO-G1..G9 (6. pont) |
+
+---
+
+**Implementációt, branchet vagy PR-t külön jóváhagyás nélkül nem kezdünk.**

--- a/docs/MC1_TRICAMERA_RC_CHECKLIST.md
+++ b/docs/MC1_TRICAMERA_RC_CHECKLIST.md
@@ -1,0 +1,211 @@
+# MC1 Tricamera Release Candidate Checklist v1.1
+
+**Cél:** a fizikai `tricamera-capture-skeleton-proof` teszt, illetve bármely későbbi MC1 release előtti teljes rendszer-ellenőrzés. Minden pont objektíven eldönthető PASS/FAIL-re, a megadott bizonyítéktípussal. Kitöltetlen státusz = még nem ellenőrzött.
+
+**Használati szabályok:**
+1. Egy pont csak akkor PASS, ha a bizonyíték rögzítve van (parancs-output, CI link, fájl, screenshot). Bizonyíték nélküli PASS érvénytelen.
+2. Minden bizonyítéken szerepelnie kell a release commit SHA-nak vagy a futás timestampjének, hogy a bizonyíték a vizsgált állapothoz köthető legyen.
+3. FAIL vagy N/A esetén kötelező az indoklás a Megjegyzés mezőben. N/A csak akkor adható, ha a pont az adott release-re bizonyíthatóan nem értelmezhető (indoklással).
+4. A M. szekció döntése kizárólag a kitöltött szekciók alapján hozható meg, az ott megadott képlettel.
+
+**Bizonyítéktípus-rövidítések:**
+- `CMD` — parancs + teljes output másolat
+- `CI` — GitHub Actions run URL + konklúzió
+- `FILE` — repo- vagy artifact-fájl útvonala + releváns tartalom-kivonat
+- `JSON` — konkrét JSON mező értéke a megnevezett artifactból
+- `SCR` — screenshot/fotó, fájlnévben timestamppel
+- `GH` — GitHub UI állapot (PR/issue lista) permalinkkel
+
+---
+
+## A. Repository state
+
+| ID | Ellenőrzés | Módszer | Bizonyíték | Státusz | Megjegyzés |
+|---|---|---|---|---|---|
+| A1 | A release commit SHA rögzítve, és azonos az `origin/main` HEAD-del | `git fetch origin && git rev-parse origin/main` — a kapott SHA kerül a checklist fejlécébe; minden további pont erre a SHA-ra vonatkozik | CMD | | |
+| A2 | A lokális working tree tiszta a release SHA-n | `git checkout <SHA> && git status --porcelain` — output üres (a szándékosan ignorált untracked fájlok listája előre deklarálva) | CMD | | |
+| A3 | Nincs félbemaradt merge/rebase állapot | `git status` nem tartalmaz "You have unmerged paths" / "rebase in progress" sort; `ls .git/MERGE_HEAD` → nincs ilyen fájl | CMD | | |
+| A4 | Nincs nyitott PR, amely MC1 scope-ú fájlt módosít és merge-re vár a fizikai teszt előtt | `gh pr list --state open --json number,title,files` — egyetlen nyitott PR sem érinti a `ios/LFAEducationCenter/MultiCamera/**`, `scripts/mc1_regression/**`, `scripts/run_mc1_regression.sh` útvonalakat; VAGY az érintő PR-ok explicit "nem blokkoló" döntéssel listázva | GH + CMD | | |
+| A5 | Nincs nyitott critical/blocker címkéjű issue MC1 scope-ban | `gh issue list --state open --label critical` és `--label blocker` — üres, vagy egyik sem MC1-et érint (tételes indoklással) | GH | | |
+| A6 | A fizikai teszten futó build pontosan a release SHA-ból készül | A build előtt: `git rev-parse HEAD` == release SHA; a `MultiCameraLobbyView.buildFingerprint` értéke frissítve az adott release-hez, és a Debug Snapshotban ugyanez jelenik meg | CMD + SCR (Debug Snapshot) | | |
+| A7 | Az eszközökre telepített build fingerprint egyezik | Mindkét eszközön `dump-snapshot` deep link → console logban `build: <fingerprint>` sor egyezik az A6-ban rögzítettel | FILE (console log) | | |
+
+## B. GitHub CI
+
+| ID | Ellenőrzés | Módszer | Bizonyíték | Státusz | Megjegyzés |
+|---|---|---|---|---|---|
+| B1 | A release SHA-n minden required check zöld | `gh api repos/:owner/:repo/commits/<SHA>/check-runs --paginate` vagy `gh pr checks <PR>` — 0 fail, 0 pending a required checkek közt | CI | | |
+| B2 | A nem-required, de MC1-releváns workflow-k is zöldek: `ios-ci.yml`, `mc1-regression-harness.yml`, `mc1-e2e-orch2b.yml` | Mindhárom workflow legutóbbi, release SHA-hoz tartozó runja `conclusion: success` | CI (3 run URL) | | |
+| B3 | Nincs pending/queued check a release SHA-n | Ugyanaz a lekérdezés, mint B1 — `status: completed` mindenhol | CI | | |
+| B4 | Egyetlen zöld check sem rerun-nal lett zöld (flaky-mentesség) | Minden MC1-releváns run `run_attempt == 1`; ha >1, a rerun oka dokumentált és determinisztikusnak bizonyított (a hiba nem MC1 kódban volt) | CI (`gh run view <id> --json attempt`) | | |
+| B5 | Branch protection a main-en aktív és a merge azon keresztül történt | `gh api repos/:owner/:repo/branches/main/protection` — required checks lista nem üres; a release commit PR-on keresztül került be (`gh pr view <PR> --json mergedAt,mergeCommit`) | GH + CMD | | |
+| B6 | A `mc1-regression-harness` workflow ténylegesen lefuttatta a preflightot ÉS a pytestet (nem skippelt) | A run logban jelen van a `preflight_static_check.py` "X passed, 0 failed" sora és a pytest "N passed" sora | CI (log kivonat) | | |
+
+## C. Build
+
+| ID | Ellenőrzés | Módszer | Bizonyíték | Státusz | Megjegyzés |
+|---|---|---|---|---|---|
+| C1 | Debug build fordul szimulátorra a release SHA-n | `xcodebuild build-for-testing -project ios/LFAEducationCenter.xcodeproj -scheme LFAEducationCenter -destination 'platform=iOS Simulator,id=<UDID>'` → exit 0 | CMD | | |
+| C2 | Debug build települ és elindul a fizikai iPhone-on | `xcodebuild ... -destination 'platform=iOS,id=<IPHONE_UDID>'` build+install exit 0; app elindul, Session Lab megnyílik | CMD + SCR | | |
+| C3 | Debug build települ és elindul a fizikai iPadon | Ugyanaz iPad UDID-vel | CMD + SCR | | |
+| C4 | Release konfiguráció fordul (regresszió-őr: a DEBUG-only MC1 kód nem töri a Release buildet) | `xcodebuild build -configuration Release -scheme LFAEducationCenter -destination generic/platform=iOS CODE_SIGNING_ALLOWED=NO` → exit 0 | CMD | | |
+| C5 | A fizikai teszthez Debug buildet használunk (a teljes MC1 automation `#if DEBUG` mögött van) — ez explicit rögzítve | A telepítési parancsban `-configuration Debug`; a `lfa-mc1://` scheme válaszol (lásd E-szekció preflight) | CMD | | |
+| C6 | `lfa-mc1://` URL scheme regisztrált mindkét eszközön | `lib.preflight_url_scheme` fut a runner indulásakor és nem dob (a runner log "[preflight] ... scheme OK" mindkét eszközre) | FILE (runner output) | | |
+
+## D. Tests
+
+| ID | Ellenőrzés | Módszer | Bizonyíték | Státusz | Megjegyzés |
+|---|---|---|---|---|---|
+| D1 | iOS unit tesztek: teljes `LFAEducationCenterTests` suite 0 failure a release SHA-n | CI `ios-ci.yml` "Executed N tests, with 0 failures", N rögzítve | CI | | |
+| D2 | MC1 célzott unit tesztek lokálisan is zöldek: `MC1AutomationBridgeTests` (benne AB-17* replay guard), `LivePoseOverlayProcessorTests`, `PCOInstructorRoleGateTests`, `PlayerCaptureOrchestratorTests`, `CycleCaptureOrchestratorTests`, `CaptureAuthorityTests`, `OrientationMapperTests`, `CaptureFormatSelectorTests` | `xcodebuild test-without-building -only-testing:...` → "TEST EXECUTE SUCCEEDED", suite-onkénti Executed/failures sorok | CMD | | |
+| D3 | Backend integration: MC1 ORCH-2B E2E (16 lépés) zöld a release SHA-n | `mc1-e2e-orch2b.yml` run success | CI | | |
+| D4 | Regression harness pytest: `scripts/mc1_regression/tests/` — minden teszt zöld, benne a `test_diag_contract.py` writer↔reader kontraktus tesztek | `python3 -m pytest scripts/mc1_regression/tests/ -q` → "N passed, 0 failed" | CMD | | |
+| D5 | Statikus preflight: minden check PASS, exit 0 | `python3 scripts/mc1_regression/preflight_static_check.py` → "X passed, 0 failed", exit 0 | CMD | | |
+| D6 | A preflight NEM lett skippelve az utolsó futásnál | `scripts/mc1_regression_runs/static_preflight_skip_audit.log` — nincs a release időszakára eső bejegyzés; a legutóbbi `report.json`-ban `static_preflight_skipped == false` | FILE + JSON | | |
+| D7 | Runtime gate-ek definíció szerint aktívak: a tricamera `critical_ok` listában szerepel mind a 14 gate-step (stale-invalidation, backend confirmok, GoPro preview quality+aspect, 3× panel frame traffic, 2× orientation, 2× aspect, timestamp sync) | `grep -A20 "critical_ok = all" scripts/mc1_regression/scenarios.py` a release SHA-n — a lista tételesen egyezik a dokumentált PASS-definícióval | CMD | | |
+| D8 | Unattended regresszió (`--scenario all`: smoke + multicycle) fizikai eszközökön PASS a release buildekkel | `./scripts/run_mc1_regression.sh --scenario all` → `report.json` `overall_pass == true` | JSON (`report.json`) + FILE (artifact könyvtár) | | |
+
+## E. Device routing
+
+| ID | Ellenőrzés | Módszer | Bizonyíték | Státusz | Megjegyzés |
+|---|---|---|---|---|---|
+| E1 | iPhone CoreDevice UDID rögzítve és él | `xcrun devicectl list devices` — az iPhone szerepel, UDID egyezik a futtatási env-vel (`IPHONE_UDID`) | CMD | | |
+| E2 | iPad CoreDevice UDID rögzítve és él | Ugyanaz `IPAD_UDID`-re | CMD | | |
+| E3 | Console log ↔ eszköz hozzárendelés identitás-alapú | A runner shell log tartalmazza a `_map_legacy_udid` eredményét mindkét eszközre (CoreDevice→legacy mapping), NEM sorrend-alapú fallbackot; a két legacy UDID különbözik | FILE (shell output) | | |
+| E4 | iPhone = instructor: a backend session-ben az iPhone-hoz tartozó device `device_role == "instructor_primary"` | `GET /sessions/{uuid}` a futás alatt (a scenario `backend_state/*_session.json` dumpja) — device_name/UDID alapján azonosítva | JSON | | |
+| E5 | iPad = player: `device_role == "player_primary"` ugyanígy | Ugyanaz a session dump | JSON | | |
+| E6 | GoPro = auxiliary: `device_role == "auxiliary_camera"` ÉS `managed_by_device_id == <instructor device id>` | Session dump + a scenario "gopro registered" step detailje | JSON | | |
+| E7 | Instructor eszközön `IsController: yes`, player eszközön `IsController: no` a Debug Snapshotban | Mindkét eszköz `dump-snapshot` kivonata a futás alatt (`debug_snapshots/*`) | FILE | | |
+| E8 | Player eszközön PCO attach megtörtént, instructor eszközön NEM (role gate) | Player console: `[PCO]` sorok jelen; instructor console: nincs `[PCO] confirmed` a saját device_id-jére; `PCOInstructorRoleGateTests` zöld (D2) | FILE (console) + CMD | | |
+| E9 | Minden device_id egyedi, nincs duplikált session_device ugyanarra a fizikai eszközre | Session dump `devices[]` — eszközönként pontosan 1 nem-removed bejegyzés | JSON | | |
+| E10 | Dual-console hard precondition: MINDKÉT eszköz USB-n csatlakozik, trusted, és látható az `idevicesyslog` számára — tricamera scenariónál e nélkül a futás el sem indulhat (a 2026-07-04-i futás a player-oldali console evidencia nélkül futott és bukott) | `idevice_id -l` mindkét legacy UDID-t listázza; a shell wrapper és a runner.py hard-fail ága NEM triggerelt (`check_dual_console_precondition`); `console/iphone_console.log` ÉS `console/ipad_console.log` létrejött | CMD + FILE | | |
+
+## F. Capture lifecycle
+
+| ID | Ellenőrzés | Módszer | Bizonyíték | Státusz | Megjegyzés |
+|---|---|---|---|---|---|
+| F1 | Prepare: mindkét iOS eszköz eléri a `ready` capture state-et a cycle előtt | Debug Snapshot `capture: ready ✓` mindkét eszközön; scenario nem timeoutol a join/prepare fázisban | FILE (snapshot) | | |
+| F2 | Preview: az instructor dashboardon mindhárom panel él a felvétel előtt | SCR a dashboardról (3 panel, timestamp látszik); pose diag `sourceFramesSeen > 0` mindhárom panelre | SCR + JSON (`pose_overlay_diag.json`) | | |
+| F3 | confirmed_start: mindhárom cycle_device `recording_status == "confirmed_start"` `started_at` timestamppel | `proof_cycle_timing.json` / cycles dump | JSON | | |
+| F4 | Recording: a felvételi ablak a tervezett hosszú (± 2 s); mindkét iOS fájl `actualDurationSeconds` konzisztens a cycle started/stopped delta-val | `capture_metadata_diag.json` (mindkét eszköz) vs `proof_cycle_timing.json` | JSON | | |
+| F5 | confirmed_stop: mindhárom cycle_device `recording_status == "confirmed_stop"` `stopped_at`-tal, cycle `status == "completed"` | Cycles dump / scenario "all 3 confirmed_stop" step | JSON | | |
+| F6 | Fájl-validáció: mindkét iOS fájl `fileSizeBytes > 0`, codec `h264`, fps ≈ 30, a `CaptureFormatSelector` profil (1280x720 vagy dokumentált 640x360 fallback) érvényesült | `capture_metadata_diag.json` mezők mindkét eszközről | JSON | | |
+| F7 | Cleanup/reset: a scenario utáni `reset-session` után a ViewModel `.idle`, következő join sikeres (multicycle/all futásban bizonyítva) | Következő scenario join stepje PASS ugyanabban a runban | FILE (report.json steps) | | |
+| F8 | Timestamp sync: a 3 eszköz `started_at` értékei közti max eltérés rögzítve és ≤ az előre deklarált tűrésnél (tűrést a futás ELŐTT kell számszerűsíteni és ide beírni: ___ ms) | `proof_cycle_timing.json` started_at delták kiszámolva | JSON + CMD | | |
+
+## G. GoPro
+
+| ID | Ellenőrzés | Módszer | Bizonyíték | Státusz | Megjegyzés |
+|---|---|---|---|---|---|
+| G1 | BLE: a connect flow eljut `awaitingManualWiFiJoin(ssid:)`-ig (SSID kinyerve BLE-n) | Console log `gopro_connection: Csatlakozz: <SSID>` vagy snapshot ugyanezzel | FILE | | |
+| G2 | Wi-Fi: manuális join után HTTP verify sikeres, GoPro state `ready` | `gopro_diag.json` `outcome == "signalReady_ok"` (vagy `_after_409_retry`) | JSON | | |
+| G3 | Backend ready: a GoPro session_device `status == "ready"` a backend oldalon | Scenario "gopro ready" step PASS + session dump | JSON | | |
+| G4 | Preview: friss `gopro_stream_diag.json` — `udpPacketsReceived > 0` ÉS `videoPIDFound == true` ÉS `decodeSuccesses > 0` | JSON mezők; a fájl frissessége az I-szekció szerint bizonyított | JSON | | |
+| G5 | Preview aspect: `previewAspectRatio` a mért SPS-ből 16:9 (± a `_aspect_ratio_matches` tűrés) | Ugyanazon diag `previewWidth/previewHeight/previewAspectRatio` | JSON | | |
+| G6 | Recording: shutter start/stop OK ÉS a media/list diff új fájlt mutat az SD kártyán | Scenario "gopro confirmed_start"/"confirmed_stop" + `[GOPRO-MEDIA-BEGIN]` blokk az iPhone console logban | JSON + FILE | | |
+| G7 | Stop után a GoPro ténylegesen nem vesz fel | Fizikai ellenőrzés: a kamera kijelzőjén nincs REC a scenario vége után (K-szekció manuális pont hivatkozása) + `recordingStateAfterStop == "stopped"` ha combined-proof diag készült | SCR + JSON | | |
+| G8 | Diag artifactok hiánytalanok: a scenario minden GoPro diag fájlja bekerült az artifact könyvtárba | `ls <run_dir>/video_artifacts/` + report.json artifact stepek PASS | FILE | | |
+| G9 | Ismert korlát explicit elfogadva: auto Wi-Fi join entitlement hiányában manuális (SystemWiFiTransport mindig `.unavailable`) — operátor jelen van | L-szekcióban dokumentált, futtatási tervben operátor nevesítve | FILE (checklist) | | |
+
+## H. Skeleton pipeline
+
+| ID | Ellenőrzés | Módszer | Bizonyíték | Státusz | Megjegyzés |
+|---|---|---|---|---|---|
+| H1 | Frame-forgalom instructor panel: friss `pose_overlay_diag.json` `instructor.framesReceived ≥ 1` | JSON (frissesség I-szekció szerint) | JSON | | |
+| H2 | Frame-forgalom player panel: `player.framesReceived ≥ 1` ÉS `player.sourceFramesSeen > 0` (MPC ténylegesen szállított) | JSON | JSON | | |
+| H3 | Frame-forgalom GoPro panel: `gopro.framesReceived ≥ 1` ÉS `gopro.sourceFramesSeen > 0` (decode ténylegesen történt) | JSON | JSON | | |
+| H4 | Vision fut: legalább egy panelen `framesProcessed > 0` és `visionDetectionSuccesses` rögzítve (érték lehet 0, ha nem volt ember a képben — de a mező jelen van) | JSON | JSON | | |
+| H5 | Overlay vizuálisan látszik: cyan skeleton mindhárom panelen, miközben ember áll a képben | Operátor screenshot: `visual_skeleton_overlay.png` az artifact könyvtárban (K-szekció) | SCR | | |
+| H6 | Export: `skeleton_output.json` friss, `sampled_frames > 0`, `total_joints_detected` rögzítve, `generated_at` a futás utáni | JSON | JSON | | |
+| H7 | A pose diag kulcs-kontraktus a release SHA-n garantált (writer `framesReceived` ↔ reader `framesReceived`) | D4 kontraktus tesztek zöldek + D5 preflight CHECK 11 PASS | CMD | | |
+
+## I. Artifact integrity
+
+| ID | Ellenőrzés | Módszer | Bizonyíték | Státusz | Megjegyzés |
+|---|---|---|---|---|---|
+| I1 | Sentinel-invalidálás lefutott: a report `"stale diag artifacts invalidated"` step PASS, minden targetre `true` | `report.json` step detailek | JSON | | |
+| I2 | Egyetlen gate-elt artifact sem sentinel: a begyűjtött diag fájlokban nincs `mc1_invalidated: true` | `grep -l mc1_invalidated <run_dir>/video_artifacts/*.json` → üres | CMD | | |
+| I3 | Frissesség: minden gate-elt diag `timestamp`/`generated_at` mezője a scenario indulása UTÁNI (a gate ezt kikényszeríti — bizonyíték: nincs "stale"/"predates" error a report stepekben) | `report.json` stepek + a diag fájlok timestamp mezői kézzel szúrópróbázva (min. 2 fájl) | JSON | | |
+| I4 | run_id lánc: a report `run_id`-ja egyezik a sentinel-fájlokban rögzítettel (a `diag_sentinels/` könyvtárban) | `report.json` "stale diag artifacts invalidated" step `run_id` == `diag_sentinels/sentinel_*.json` `run_id` | FILE + JSON | | |
+| I5 | JSON kontraktus: minden gate által olvasott mező létezik a writer oldalon (pose: kontraktus-teszt; capture metadata: `orientationConsistent`, `effectiveAspectRatio`, `fileSizeBytes` jelen; gopro stream: `udpPacketsReceived`, `videoPIDFound`, `decodeSuccesses` jelen) | D4/D5 + a begyűjtött fájlok mezőlistája | CMD + JSON | | |
+| I6 | A console log a helyes eszközhöz tartozik: az `iphone_console.log`-ban instructor-oldali markerek ([CCO], GOPRO-AUTO), az `ipad_console.log`-ban player-oldaliak ([PCO]) | `grep` mindkét logban; E3 mapping-bizonyíték | CMD + FILE | | |
+| I7 | Az artifact könyvtár teljes és archiválva: `report.json`, `report.txt`, `backend_state/*`, `console/*`, `debug_snapshots/*`, `video_artifacts/*` mind jelen, a run könyvtár neve (timestamp) rögzítve a checklistben | `ls -R <run_dir>` | FILE | | |
+
+## J. Orientation
+
+> **P1 DÖNTÉS (2026-07-04, issue #357):** az app portrait-only (`Info.plist`), ezért az
+> `OrientationMapper` mindig portrait-ot ad — landscape-re szerelt eszköznél a player
+> preview ÉS a rögzített fájl orientációja hibás (az első fizikai futás bizonyította).
+> Amíg a #357 nincs javítva: **capture-start chain validációs futás CSAK portrait
+> szereléssel** végezhető (J1 ennek megfelelően értelmezendő); **landscape tricamera
+> futás a #357 javításáig BLOKKOLT.** A #357 javítása külön PR — nem keverendő a
+> capture-session P0 fixszel.
+
+| ID | Ellenőrzés | Módszer | Bizonyíték | Státusz | Megjegyzés |
+|---|---|---|---|---|---|
+| J1 | Előfeltétel deklarálva: mindkét iOS eszköz állványon, elforgatás-mentesen rögzítve a futás alatt — a #357 javításáig PORTRAIT állásban (a fenti P1 döntés szerint); a #357 lezárása után landscape-ben (a 16:9 gate akkor válik teljes értékűvé) | Futtatási terv + setup fotó | SCR | | |
+| J2 | Rotation lock állapot rögzítve a futás előtt (KI/BE), és a futás alatt nem változik | Setup fotó a Vezérlőközpontról vagy explicit operátor-nyilatkozat a futási jegyzőkönyvben | SCR/FILE | | |
+| J3 | iPhone: `orientationConsistent == true` ÉS `deviceOrientationAtRecordingStart == fileOrientationCoarse` | `capture_metadata_diag.json` (iPhone) | JSON | | |
+| J4 | iPad: ugyanaz | `capture_metadata_diag.json` (iPad) | JSON | | |
+| J5 | iPhone/iPad effektív aspect 16:9: `effectiveAspectRatio` a tűrésen belül | Ugyanazon diagok | JSON | | |
+| J6 | GoPro preview aspect 16:9 a mért SPS-ből (== G5) | `gopro_stream_diag.json` | JSON | | |
+| J7 | Vizuális ellenőrzés: a felvett fájlok lejátszva helyes állásúak (nem elfordítottak) — mivel az automata gate csak interface↔fájl konzisztenciát mér, gravitáció-helyességet nem | Operátor visszanézi mindkét iOS videót + rögzíti (K-szekció) | SCR + FILE (jegyzőkönyv) | | |
+| J8 | Metadata: a fájlok `preferredTransform`-ból derivált orientation mező jelen van és nem "unknown" | `capture_metadata_diag.json` `actualOrientation` | JSON | | |
+
+## K. Physical validation — manuális, nem automatizálható pontok
+
+Ezeket ember végzi; mindegyikhez timestampelt bizonyíték kötelező.
+
+| ID | Manuális ellenőrzés | Miért nem automatizálható | Bizonyíték | Státusz | Megjegyzés |
+|---|---|---|---|---|---|
+| K1 | Mindhárom panelen látható cyan skeleton overlay, miközben ember mozog a képtérben | A Vision "talált-e embert" nem wiring kérdés; képtartalom-helyesség pixel-szinten nem gate-elt | `visual_skeleton_overlay.png` az artifact könyvtárban | | |
+| K2 | GoPro Wi-Fi manuális join elvégzése a script promptjára | HotspotConfiguration entitlement hiánya (personal team) | Futási jegyzőkönyv bejegyzés (ki, mikor) | | |
+| K3 | A felvett videók visszanézése: kép éles, hang van, orientáció helyes, nincs korrupció | Fájl-validáció csak konténer-szintű; percepciós minőség nem automatizált | Rövid képernyővideó vagy jegyzőkönyv mindhárom felvételről | | |
+| K4 | GoPro fizikai állapot a futás után: nem vesz fel, nem forró, akku > 20%, SD-n ott az új fájl | Kamera kijelző/hardver állapot kívül esik az API-diagnosztikán | Fotó a kamera kijelzőjéről + media/list kivonat | | |
+| K5 | Dashboard UX folyamatosság: a futás alatt nem volt fagyás/fekete panel/app crash | UI-folytonosság futás közben nem gate-elt (nincs XCUITest fizikai eszközön) | Operátor jegyzőkönyv; crash esetén ips log csatolva | | |
+| K6 | Preset-write jellegű scenariók után: a GoPro beállításai az eredetiek (ha ilyen scenario futott) | Rollback-verify automata, de a kamera menüjének végső állapotát ember erősíti meg | Fotó a kamera beállítás-képernyőjéről | | |
+| K7 | Környezet rögzítése: helyszín, világítás, kamera-távolságok, Wi-Fi környezet (más GoPro/MPC eszközök jelenléte a térben) | Reprodukálhatósághoz kell; automatikusan nem gyűjtött | Setup fotó + jegyzőkönyv | | |
+
+## L. Known limitations — explicit kockázat-elfogadás
+
+Minden tétel PASS-a azt jelenti: "a korlát dokumentált, a döntéshozó név szerint elfogadta erre a futásra/release-re". Nem azt, hogy a hiba javítva van.
+
+| ID | Korlát | Kategória | Elfogadás módja | Státusz | Elfogadó + dátum |
+|---|---|---|---|---|---|
+| L1 | GoPro stop-recovery hiánya: shutter/start HTTP timeout + ténylegesen elindult felvétel esetén az app nem tudja leállítani a kamerát (recordingState=.failed → stopRecording blokkolt); mitigáció: K4 fizikai ellenőrzés | P1 | Jegyzőkönyvi elfogadás | | |
+| L2 | MPC session-validáció hiánya: a player bármely invite-ot elfogad, az instructor bármely peert meghív (session UUID nincs egyeztetve); mitigáció: futás alatt nincs másik MC1 session a térben (K7) | P1 | Jegyzőkönyvi elfogadás | | |
+| L3 | MPC titkosítatlan (`encryptionPreference: .none`) — élő videó a lokális hálón; production előtt kötelező javítás | P1 / production blocker | Jegyzőkönyvi elfogadás fizikai tesztre; production: NEM elfogadható | | |
+| L4 | Instructor role-flash: session-létrehozás után ~3 s-ig PlayerCaptureView jelenhet meg az instructoron (isController az első pollig false) | P1 | Jegyzőkönyvi elfogadás | | |
+| L5 | SkeletonProcessor a MainActort blokkolja a feldolgozás alatt (UI fagy, heartbeat kiesés lehetséges a skeleton-process lépés alatt) — a scenario ezt a confirmed_stop UTÁN futtatja | P1 | Jegyzőkönyvi elfogadás | | |
+| L6 | PCO stop/start átfedési race + timeout nélküli stop-várakozás (beragadhat .stoppingCapture-ben) | P1 | Jegyzőkönyvi elfogadás | | |
+| L7 | GoProStreamProbe: nincs reentrancia-guard, NWConnection-ök nem záródnak, minden a main queue-n — egy futáson belül csak EGY stream-probe action engedélyezett (futtatási terv betartja) | P1 | Jegyzőkönyvi elfogadás | | |
+| L8 | Orientation gate csak interface↔fájl konzisztenciát mér; rotation lock + elfordított eszköz mellett vizuálisan rossz videó is PASS-olhat — mitigáció: J1/J2/J7 | P2 | Jegyzőkönyvi elfogadás | | |
+| L9 | Per-frame CIContext, objectWillChange 1-frame-lag/duplikált feed, dashboard nem observeli a GoPro managert, InstructorCaptureView halott kód, MPEGTSDemuxer teszteletlen, firmware-gate halott kód, capture-quality-proof nincs regisztrálva | P2 / tech debt | Backlog-hivatkozás elég | | |
+| L10 | Production blockerek (fizikai tesztet NEM blokkolják): nincs upload pipeline (`uploadStatus: not_implemented`), manuális GoPro Wi-Fi join (entitlement), MPC titkosítás (L3), TD-01 device dedup, teljes MC1 UI `#if DEBUG` mögött | Production blocker | Listázva; M2 döntésnél kötelezően NO-t okoz, amíg nyitott | | |
+| L12 | Portrait-only app: OrientationMapper mindig portrait; landscape szerelésnél elforgatott preview + elforgatott rögzített fájl (issue #357) — mitigáció: portrait szerelés a J-szekció döntése szerint | P1 (landscape tricamera célra BLOCKER) | Jegyzőkönyvi elfogadás portrait futásra; landscape futás: NEM engedélyezett a #357-ig | | |
+| L11 | A fenti lista teljessége: a 2026-07-04-i review P1/P2 találatai közül egy sem hiányzik erről a listáról | — | Tételes összevetés a review dokumentummal | | |
+
+## M. Release decision
+
+A döntés kizárólag a fenti szekciók kitöltött státuszai alapján hozható meg.
+
+**M1 — READY FOR PHYSICAL VALIDATION feltétele:**
+A1–A7, B1–B6, C1–C3+C5–C6, D1–D8, E1–E9 mind PASS; F/G/H/I/J szekciókból a futás ELŐTT eldönthető pontok (D7, G9, H7, I5-statikus fele, J1, J2) PASS; K-szekció előkészítve (operátor + jegyzőkönyv-sablon megvan); L1–L9 + L11 elfogadva. (F/G/H/I/J futás-függő pontjai magát a fizikai futást minősítik, nem előfeltételei.)
+
+```
+READY FOR PHYSICAL VALIDATION
+
+YES / NO
+```
+
+**M2 — READY FOR PRODUCTION feltétele:**
+M1 = YES ÉS a fizikai validáció minden futás-függő pontja (F, G, H, I, J, K) PASS bizonyítékkal ÉS L10 minden production blockere lezárva (nem "elfogadva" — lezárva) ÉS L1–L7 P1 tételekre javítás vagy formális, határidős kivétel van.
+
+```
+READY FOR PRODUCTION
+
+YES / NO
+```
+
+---
+*Checklist verzió: v1.1 (2026-07-04 — E10 dual-console precondition, J-szekció orientation P1 döntés #357, L12). A checklist maga is release-artifact: kitöltött példánya a futás artifact-könyvtárába kerül (`<run_dir>/rc_checklist_filled.md`), a release SHA-val a fejlécében.*

--- a/docs/MC2_MINIMAL_IMPLEMENTATION_PLAN.md
+++ b/docs/MC2_MINIMAL_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,200 @@
+# MC2 Minimális Implementációs Terv — 2 iPhone + GoPro + iPad POC
+
+**Dátum:** 2026-07-12
+**Státusz:** ELFOGADVA (2026-07-12, feltételekkel — lásd 6. pont) — implementáció PR-onként külön jóváhagyással, merge kizárólag külön jóváhagyás után.
+**Alap:** [MC1_FINAL_TOPOLOGY_GAP_ANALYSIS.md](MC1_FINAL_TOPOLOGY_GAP_ANALYSIS.md) (elfogadva 2026-07-12).
+**Cél:** a leggyorsabb út egy működő 2 iPhone + GoPro + iPad POC-hoz — minimális új kód, minimális PR-szám, nulla architekturális átépítés.
+
+> **ARCHITEKTÚRA-DÖNTÉS (user, 2026-07-12 — v1.1 revízió):** az MPC/peer-to-peer réteg
+> **teljes kivezetése**. Végleges architektúra: (1) backend-orchestrált session-koordináció,
+> (2) minden kamera lokálisan rögzít, (3) post-cycle upload pipeline, (4) audio-alapú fine
+> synchronization (backend-óra csak koarse igazításra), (5) iPad = státusz/thumbnail
+> dashboard backend-pollinggal — élő videóstream nélkül, (6) GoPro manager = SIM-es
+> Player A iPhone. E revízió törölte a multi-peer MPC PR-t (volt PR3), az AWDL/GoPro
+> koegzisztencia-probe-ot és a kapcsolódó K1/K2 kockázatokat; az L2/L3 MPC-találatok
+> okafogyottá váltak. A 3D rekonstrukciós adatút SOHA nem függött az MPC-től — az csak
+> élő monitoring volt.
+
+---
+
+## 0. Rögzített döntések (user, 2026-07-12)
+
+| Eszköz | Szerep | Hálózat |
+|---|---|---|
+| iPhone #1 (SIM) | Player A (`player_primary`) + **GoPro manager** | backend: cellular; GoPro AP: WiFi (a ma bizonyított minta) |
+| iPhone #2 (nincs SIM) | Player B (`player_secondary`) | backend: lab WiFi (mint ma az iPad) |
+| GoPro | 3. kamera (`auxiliary_camera`), `managed_by_device_id` = Player A | GoPro AP ← iPhone #1 |
+| iPad (WiFi) | Instructor dashboard + session coordinator (`instructor_primary`), **NEM felvevő**; kamerája ebben a fázisban nem használható | backend: lab WiFi (nincs P2P) |
+
+- iPad **minden** panelje: **státusz/thumbnail** (backend polling) — nincs élő videóstream, se MPC, se relay (2026-07-12 architektúra-döntés).
+- PR-4B1 scope változatlan; `GoProConnectionManager` / BLE / HTTP réteghez nem nyúlunk.
+- Prioritás: (1) non-recording instructor → (2) dual-player → (3) státusz/thumbnail dashboard + MPC-kivezetés → (4) GoPro→Player A + proof → (5) post-cycle upload → MC3/MC4-re halasztva a többi.
+
+---
+
+## 1. Vezérelvek — amit tudatosan NEM csinálunk
+
+| Elkerült munka | Indoklás |
+|---|---|
+| Új `DeviceRole` / `recording_capable` oszlop / Alembic migration | A required-szabály szerep-alapú átírása 1 sor, a meglévő enum elég |
+| **Bármilyen MPC/peer-to-peer munka** (multi-peer refactor, frame-attribúció, session-validate invite, MPC titkosítás) | 2026-07-12 architektúra-döntés: az MPC teljes kivezetésre kerül — a 3D adatút soha nem függött tőle, a monitoring-igényt a státusz/thumbnail dashboard fedi |
+| Élő videóstream bármely útvonalon (MPC, UDP relay, backend streaming) | A dashboard státusz/thumbnail-alapú; élőkép egyik panelen sincs |
+| Tri-view contract, kalibráció, audio fine-sync implementáció, trianguláció | MC3-A/B/C és MC4 — e terv scope-ján kívül |
+| Backend API/séma változás a session/cycle koordinációban | A `player_secondary` auto-kiosztás és a `managed_by_device_id` már működik (a thumbnail- és upload-endpoint az egyetlen új backend-elem, PR3/PR5) |
+
+---
+
+## 2. PR-bontás — 5 PR összesen (v1.1: a volt multi-peer MPC PR3 törölve)
+
+### MC2-PR1 — Instructor non-recording mode (= MC2-A)
+
+**A legkisebb változtatás, ami után az iPad koordinálhat felvétel nélkül.**
+
+| Réteg | Változás | Méret |
+|---|---|---|
+| Backend | [cycle_service.py:126](../app/services/multicamera/cycle_service.py): `required = DeviceRole(sd.device_role) != AUXILIARY_CAMERA` → `required = role in (PLAYER_PRIMARY, PLAYER_SECONDARY)`. A completion-logika (`get_required_cycle_devices`) változatlanul csak a required halmazt nézi — más sor nem változik | **1 sor** + tesztek |
+| iOS | `shouldAutoPrepare(.instructorPrimary)` → `false` ([MultiCameraSessionViewModel.swift:356](../ios/LFAEducationCenter/MultiCamera/MultiCameraSessionViewModel.swift)) | 1 sor + AP tesztek frissítése |
+| iOS | `CycleCaptureOrchestrator`: `recordsLocally: Bool` konstruktor-paraméter (default `true`). `false` esetén kihagyja: `startCapture()` (335. sor), `stopCapture()` (188/467/490. sor), és a saját confirm_start/stop hívást. Így a backend-en NEM keletkezik confirm-evidencia fájl nélkül | ~10 sor guard |
+| iOS | Begin-cycle UI gate ([MultiCameraLobbyView.swift:533](../ios/LFAEducationCenter/MultiCamera/MultiCameraLobbyView.swift)): a `captureManager.state == .ready` feltétel csak `recordsLocally` esetén kötelező | ~2 sor |
+| iOS | `InstructorDashboardView`: a lokális kamera panel `recordsLocally == false` esetén "coordinator" placeholder (nem nyit AVCaptureSession-t — a P0 kamera-kontenció tanulsága). A 3-panelesítés az MC2-PR3-ban jön | ~10 sor guard |
+| Harness | `smoke`/`multicycle`/tricamera scenariók assert-frissítése: az instructor confirm_start/stop elvárás törlése; helyette assert, hogy az instructor cycle_device `required == false` és `pending` maradhat | scenario-módosítás |
+
+**Tesztek:** meglévő CYC-O suite zöld marad + új CYC-NR-01..04 (non-recording: nincs startCapture hívás — `FakeCaptureController`-rel ellenőrizve —, cycle completes players-only confirmokkal); backend: cycle required-halmaz unit tesztek.
+**Fizikai validáció:** 2-eszközös smoke **iPad=instructor(non-recording) + iPhone#1=player** — ez egyben az első iPad-instructor irányú fizikai futás.
+
+### MC2-PR2 — Dual-player support (= MC2-B)
+
+**Cél: a `player_secondary` útvonal első valós futása. App-kód elvárt változás: 0 sor.**
+
+| Réteg | Változás |
+|---|---|
+| Harness | `ScenarioContext` ([lib.py:501](../scripts/mc1_regression/lib.py)): + `iphone2_udid: str \| None = None`, + `player2_token: str \| None = None`; runner env: `IPHONE2_UDID`; console capture + preflight (URL scheme, dual→**tri**-console precondition) kiterjesztése a 3. iOS eszközre |
+| Harness | Új scenario: `dual-player-smoke` — iPad instructor (non-recording) + 2 player iPhone, **GoPro nélkül**, 1 cycle; assert: a 2. player device `device_role == "player_secondary"` (a backend auto-kiosztás első fizikai bizonyítéka), mindkét player confirmed_start/stop |
+| Backend/iOS | **0 sor** — ha mégis elakad, az hibajegy, nem scope-bővítés |
+
+**Előfeltétel (nem kód):** második player user + token a staging backendben; iPhone #2 provisioning (Debug build, `lfa-mc1://` scheme, USB trust).
+
+### MC2-PR3 — iPad státusz/thumbnail dashboard + MPC-kivezetés (v1.1, a volt multi-peer MPC PR-t váltja)
+
+**A dashboard élő videópanelek helyett backend-pollingos státusz- és thumbnail-panelekre áll át; az MPC réteg kódja kivezetésre kerül.**
+
+| Réteg | Változás |
+|---|---|
+| iOS | `InstructorDashboardView`: panelenként (Player A, Player B, GoPro) backend-polling alapú státusz — device_status, cycle recording_status, utolsó heartbeat kora; a `RemoteCameraView` élő-frame útvonala helyett thumbnail-megjelenítés. A meglévő GoPro státusz-panel mintája terjed ki mindenre |
+| iOS | Pre-cycle framing-ellenőrzés: a player Begin Cycle előtt EGY thumbnail-t (kisfelbontású JPEG) tölt fel a backendre; az iPad ezt pollozza és mutatja. Nem stream — cycle-onként legfeljebb néhány kép |
+| iOS | **MPC-kivezetés**: `CameraStreamService` és fogyasztói (`RemoteCameraView` élő útvonal, `LivePoseOverlayProcessor` MPC-forrás, `CameraFramePublisher` P2P-ág) eltávolítása/deaktiválása. A `pose_overlay_diag.json` élő-panel kulcsai és a rájuk épülő preflight CHECK kivezetése a writerrel EGY PR-ban (P0 kulcs-kontraktus tanulság) |
+| Backend | Kis thumbnail-endpoint: feltöltés a player tokennel + lekérés az instructor tokennel (per session_device, felülíró — nem galéria). Az egyetlen új backend-elem ebben a PR-ban |
+| Harness | Dashboard-evidencia átállítása: élő frame-forgalom gate-ek helyett státusz-frissesség + thumbnail-megérkezés assert |
+
+**Tesztek:** thumbnail endpoint unit tesztek (ownership: player tölt, instructor olvas); dashboard státusz-mapping unit tesztek; a törölt MPC-tesztek kivezetése ugyanebben a PR-ban.
+**Fizikai validáció:** dashboard vizuális futás — 2 player + GoPro panel státusszal és thumbnail-lel, élő stream nélkül.
+
+### MC2-PR4 — GoPro ownership átirányítás + végleges topológia proof (= MC2-D + MC2-E, összevonva)
+
+**Mindkettő dominánsan harness/doksi — egy PR-ban a legolcsóbb.** (v1.1: az AWDL/MPC koegzisztencia-probe TÖRÖLVE — MPC híján okafogyott; a Player A cellular↔GoPro-AP kettős elérése a meglévő gopro-scenariókkal már bizonyított.)
+
+| Réteg | Változás |
+|---|---|
+| Harness | GoPro deep link-ek célja: instructor → **`iphone_udid` (Player A)**; `register_device`: `managed_by_device_id` = Player A device id (a backend ownership-check ezt már támogatja — a 2026-06-28-i "iPad=instructor modellen GoPro iPad-ről vezérelve" PASS-ok pont ezt a mintát bizonyították, csak fordított szereposztásban) |
+| Harness | Új scenario: `final-topology-proof` — 4 device (TOPO-G1), cycle 3 felvevő confirmmal, instructor nincs a required-ben (TOPO-G2), dashboard státusz/thumbnail evidencia (TOPO-G3/G4 v1.1 — lásd gap analysis), started_at delta (TOPO-G5), 3 videó + 3 skeleton JSON begyűjtve (TOPO-G6), iPaden nincs capture fájl (TOPO-G7), silent-partial tiltás (TOPO-G8). A meglévő `tricamera-capture-skeleton-proof` váz újrafelhasználásával — nem nulláról írjuk |
+| iOS | Elvárt: **0 sor.** Verifikálandó (a PR első commitja előtt): a `[GOPRO-AUTO]` automation handlerek nem `isController`-gateltek ([MultiCameraLobbyView.swift:133](../ios/LFAEducationCenter/MultiCamera/MultiCameraLobbyView.swift) — a dispatch nem a 402. sori `isController` blokkban van); ha mégis gate mögött vannak, a gate feloldása player-re ~2 sor |
+| Doksi | RC checklist v1.2 delta: E4/E5 szerep-átírás (iPad=instructor, iPhone#1=player_primary+GoPro manager, iPhone#2=player_secondary), E10 dual→tri-console, TOPO-G gate-ek felvétele a D7 critical_ok listába |
+
+**Fizikai validáció:** ez maga az MC2-E záró futás — a 2 iPhone + GoPro + iPad POC proof.
+
+### MC2-PR5 — Post-cycle upload pipeline (új, 2026-07-12 architektúra-döntés)
+
+**A rögzített videók és metaadatok cycle utáni feltöltése a backendre — a 3D pipeline (MC3/MC4) bemenete. A final-topology-proof (PR4) ettől még nem függ: ott az evidencia USB-n is lehúzható; az upload a produkciós/MC3 út.**
+
+| Réteg | Változás |
+|---|---|
+| Backend | Capture-artifact upload endpoint: per cycle_device videó + capture-metadata JSON fogadása (player token, ownership-check), tárolás session/cycle/device szerint címezve |
+| iOS | Confirm_stop után háttér-upload a lokális fájlból (retry-val); GoPro fájl: Player A húzza le a GoPro HTTP media API-ról és továbbítja, VAGY USB-s utólagos import — a POC-ban a kisebb kockázatú út választandó, döntés a PR elején |
+| Harness | Assert: cycle completion után az upload megérkezik, mérete > 0, metadata konzisztens a lokális diaggal |
+
+**Tesztek:** upload endpoint unit tesztek (ownership, duplikátum, méret-limit); iOS upload-retry unit teszt.
+**Fizikai validáció:** 1 cycle → mindhárom felvevő artifactja a backenden.
+
+---
+
+## 3. Sorrend és függőségek
+
+```
+[előfeltétel]  Futó HERO12 smoke PASS a fix/mc1-p0-player-camera-session branchen
+      │
+MC2-PR1 (non-recording instructor)          ← fizikai: iPad-instructor 2-device smoke
+      │
+MC2-PR2 (dual-player, harness-only)         ← fizikai: dual-player-smoke, player_secondary első futás
+      │
+MC2-PR3 (státusz/thumbnail dashboard,       ← fizikai: dashboard vizuális futás, élő stream nélkül
+         MPC-kivezetés)
+      │
+MC2-PR4 (GoPro→Player A + proof)            ← fizikai: final-topology-proof = a POC cél
+      │
+MC2-PR5 (post-cycle upload)                 ← fizikai: 3 felvevő artifactja a backenden
+```
+
+A sorrend szándékosan kockázat-lépcső: minden PR pontosan egy új ismeretlent visz fizikai tesztre (szerep-inverzió → 2. eszköz → dashboard-átállás → GoPro-átirányítás → upload), így egy FAIL egyértelműen lokalizálható. A PR5 a PR4 után is indulhat párhuzamosan az MC3-előkészítéssel — a final-topology-proof USB-s evidencia-pull-lal is teljes értékű.
+
+## 4. Kockázatok (maradék; v1.1: K1/K2 törölve — MPC híján okafogyottak)
+
+| # | Kockázat | Kezelés |
+|---|---|---|
+| K3 | Player B (SIM nélkül) backend-elérése lab WiFi-n | Azonos a mai iPad-player mintával — bizonyított útvonal |
+| K4 | A scenario assert-frissítések (PR1) a régi 2-device smoke-ot érintik | A smoke/multicycle a PR1 után is fut CI-ben és fizikailag — a non-recording instructor az ÚJ elvárás, nem opció |
+| K5 | Thumbnail-feltöltés terhelése/ütemezése (PR3) | Cycle-onként legfeljebb néhány kisfelbontású kép, felülíró tárolás — nem stream, nem galéria; méret-limit az endpointon |
+| K6 | Upload-pipeline tárolás/méret (PR5) | POC-ban méret-limit + lokális megőrzés feltöltés után is; storage-stratégia (retention, formátum) MC3 előtt döntendő |
+| K7 | Instructor a cycle alatt élő kép nélkül dolgozik | Pre-cycle thumbnail framing-ellenőrzés (PR3) + cycle utáni azonnali evidencia; tudatosan vállalt trade-off a 2026-07-12 döntésben |
+
+## 5. Explicit módon elhalasztva (MC3/MC4) vagy okafogyott
+
+Elhalasztva: tri-view `Skeleton3DFrame` contract (MC3-C), audio-alapú fine sync 3 forrásra (MC3-B, a volt PR-4B3; cél ≤5–10 ms, a backend-óra csak koarse igazítás), per-camera kalibráció (MC3-A), trianguláció (MC4), 3D skeleton viewer. **Ezek csak a `final-topology-proof` PASS után indulhatnak.**
+
+Okafogyott (2026-07-12 MPC-kivezetés): MPC titkosítás (volt L3 production blocker), MPC session-validate invite (volt L2), GoPro élőkép az iPaden, multi-peer stream-attribúció.
+
+---
+
+## 6. Jóváhagyási feltételek és kötelező gate-ek (user, 2026-07-12)
+
+### 6.1 Előfeltétel (minden MC2 munka előtt)
+
+Az MC2-PR1 CSAK akkor indulhat, ha a futó HERO12 P0 smoke: (a) fizikai PASS, (b) teljes CI zöld, (c) nincs unresolved hardware/USB blocker, (d) a PR-4B1 scope lezárható. Indulás külön user-jóváhagyással, külön branchen.
+
+### 6.2 MC2-PR1 kötelező gate-ek
+
+- Instructor NEM required recorder; az iPad nem készít lokális capture fájlt és nem küld saját capture confirmationt (a `recordsLocally=false` ág a confirmot is kihagyja — **nincs silent fake confirmation**).
+- Bizonyítandó: az iPaden nincs aktív capture-célú AVCaptureSession; nincs iPad media file.
+- Cycle completion kizárólag a felvevő eszközök evidenciája alapján. *Fázis-pontosítás:* a "3 tényleges felvevővel lezáruló cycle" teljes gate-je fizikailag csak PR4-ben bizonyítható (a 2. player PR2-ben, a GoPro-átirányítás PR4-ben érkezik); PR1 fizikai proofja: 2-eszközös futás, ahol a required-halmaz = players-only és az instructor evidencia nélkül marad. A GoPro backend-szinten nem required (D4 döntés) — a 3-felvevős teljesség gate-szinten kényszerített (TOPO-G2/G8, PR4).
+
+### 6.3 MC2-PR2 kötelező gate-ek
+
+- Először bizonyítani, hogy a dual-player útvonal MEGLÉVŐ app-kóddal működik. **Ha app-kód-módosítás kellene: STOP + riport — nem automatikus scope-bővítés.**
+- Külön staging user + token Player B-hez; külön `camera_id` és `capture_id` per player; `player_primary`/`player_secondary` helyes kiosztás; két iPhone egy sessionben; nincs role collision; nincs token/device ownership keveredés.
+
+### 6.4 MC2-PR3 kötelező scope (v1.1 — státusz/thumbnail dashboard, nem csak happy path)
+
+Panelenkénti determinisztikus device-azonosítás (session_device_id alapján, nem név alapján); státusz-frissesség jelzése (stale/disconnected állapot explicit megjelenítése, ha a polling elakad); thumbnail ownership-check (player tölt fel, instructor olvas, más session-ből nem látható); az iPad továbbra sem indít lokális kamerát; a teljes MPC-kód és a rá épülő diag/preflight kulcsok EGY PR-ban kerülnek ki a writerrel (kulcs-kontraktus szabály). Disconnect-viselkedés: player kiesésekor a panel explicit "disconnected"-et mutat, a session/cycle nem omlik össze (TOPO-G10 előkép).
+
+### 6.5 MC2-PR4 kötelező előfeltétel (v1.1 — a koegzisztencia-probe törölve)
+
+Az AWDL/MPC koegzisztencia-probe okafogyott (nincs MPC). Megmaradó hálózati előfeltétel-ellenőrzés a proof futás elején: Player A mobiladat aktív + GoPro AP-n + backend session coordination működik (a meglévő gopro-scenariókkal már bizonyított minta), Player B (SIM nélkül) stabil a lab WiFi-n. **Ha a GoPro AP megtöri a backend-kommunikációt: STOP, BLOCKED riport + alternatív hálózati terv.**
+
+### 6.6 Final-topology-proof — bizonyítandók
+
+Fizikai eszközpark: iPhone 12 Pro Max + iPhone 12 Pro + iPad (Wi-Fi) + GoPro HERO12.
+
+TOPO-G1..G8 (gap analysis 6. pont) + kiegészítés:
+
+| Gate | Metrika |
+|---|---|
+| TOPO-G10 | **Graceful degradation** (v1.1, státusz-alapú): egy player státusz/heartbeat kiesésekor a dashboard explicit disconnected állapotot mutat, a session/cycle nem omlik össze, nincs crash; a polling helyreállása után a panel visszaáll; a kiesés SOHA nem eredményez silent partial completion-t (kapcsolódik: TOPO-G8) |
+
+Továbbá: közös `session_id`, per-camera `capture_id` + `camera_id`, teljes started/stopped evidence chain mindhárom felvevőre.
+
+### 6.7 Riportálási kötelezettség
+
+Minden PR után: külön fizikai proof + teljes CI + **MERGE-READY / BLOCKED** riport. Merge kizárólag külön user-jóváhagyás után.
+
+---
+
+**Összesen: 5 PR (v1.1). PR1 = 1 backend-sor + iOS guardok (folyamatban); PR2 = harness-only; PR3 = dashboard-átállás + MPC-kivezetés + thumbnail endpoint; PR4 = dominánsan harness; PR5 = upload pipeline (backend + iOS háttér-upload). Implementációt PR-onként külön jóváhagyás után kezdünk; merge kizárólag külön jóváhagyással.**

--- a/docs/MULTICAMERA_3D_IOS_ROADMAP.md
+++ b/docs/MULTICAMERA_3D_IOS_ROADMAP.md
@@ -12,6 +12,25 @@
 > connected kamera élőképe egy képernyőn, GoPro HERO13-mal együtt). A live preview külön,
 > e mellett futó útvonal — lásd [GOPRO_LIVE_PREVIEW_POC_PLAN.md](GOPRO_LIVE_PREVIEW_POC_PLAN.md).
 
+> **2026-07-12 frissítés — végleges fizikai topológia**: a Phase 2–4 fázisbontást felülírja
+> az [MC1_FINAL_TOPOLOGY_GAP_ANALYSIS.md](MC1_FINAL_TOPOLOGY_GAP_ANALYSIS.md) MC2/MC3/MC4
+> fázissora. Végleges összeállítás: 2× iPhone 12 Pro/Max = két player kamera
+> (`player_primary`/`player_secondary`), 1× GoPro = `auxiliary_camera`, 1× iPad =
+> nem-felvevő instruktori koordinátor. Az e dokumentumban leírt technikai tartalom
+> (kalibráció, sync, trianguláció) érvényes referencia marad, de a "iPhone + GoPro"
+> 2-kamerás párra írt részek 3 nézetre általánosítandók (tri-view contract: MC3-C).
+>
+> **2026-07-12 architektúra-döntés (v1.1)**: az MPC/peer-to-peer réteg **teljes
+> kivezetése** — backend-orchestrált session, lokális rögzítés minden kamerán,
+> post-cycle upload, iPad státusz/thumbnail dashboard (élő stream nélkül; a fenti
+> 2026-06-29 live-preview követelmény ezzel VISSZAVONVA), GoPro manager = SIM-es
+> Player A iPhone. Az időszinkron-cél szigorítva: a lenti "< 33 ms (1 frame @ 30fps)"
+> hibacél csak lassú mozgásra elég — gyors mozgásanalízishez (rúgás, sprint)
+> **sub-frame, ≤ 5–10 ms** a cél, audio-alapú fine sync-kel és drift-korrekcióval
+> (a szinkronhiba térbeli hibává alakul: ~v×Δt, azaz 33 ms @ 10–15 m/s ≈ 30–50 cm
+> triangulációs hiba). A backend-óra (NTP-jellegű, 10–50 ms) csak koarse igazításra
+> szolgál.
+
 ---
 
 ## Phase 1 — Single-player 3D skeleton foundation

--- a/ios/LFAEducationCenter.xcodeproj/project.pbxproj
+++ b/ios/LFAEducationCenter.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		LP500004000000000000001 /* LivePoseOverlayProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = LP500003000000000000001 /* LivePoseOverlayProcessorTests.swift */; };
 		EE17B48457527F7794F443C8 /* CaptureFormatSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF129189081C742189A7992 /* CaptureFormatSelector.swift */; };
 		454C32E7DA3BE12D732D0262 /* OrientationMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B15830F87FDBEAAF430EA8 /* OrientationMapper.swift */; };
+		A1C2E3F4B5D6079811223344 /* MC1Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C2E3F4B5D6079855667788 /* MC1Log.swift */; };
 		686220A0F4100D89AC13A181 /* RecordingOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D54BAB82A7CBBC4E3EC9A67 /* RecordingOverlay.swift */; };
 		7FC19EF38DE99E82AE19FBE0 /* JugglingVideoListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89E393EC38D4612DE04DD285 /* JugglingVideoListView.swift */; };
 		87BED4D6C4B4C29E7F7DA470 /* CapturePreviewLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C2BB6FD929990D04B3B473 /* CapturePreviewLayer.swift */; };
@@ -303,6 +304,7 @@
 		LP500003000000000000001 /* LivePoseOverlayProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LivePoseOverlayProcessorTests.swift; sourceTree = "<group>"; };
 		CEF129189081C742189A7992 /* CaptureFormatSelector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CaptureFormatSelector.swift; sourceTree = "<group>"; };
 		B2B15830F87FDBEAAF430EA8 /* OrientationMapper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OrientationMapper.swift; sourceTree = "<group>"; };
+		A1C2E3F4B5D6079855667788 /* MC1Log.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MC1Log.swift; sourceTree = "<group>"; };
 		65C2BB6FD929990D04B3B473 /* CapturePreviewLayer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CapturePreviewLayer.swift; sourceTree = "<group>"; };
 		78224C0D4526FCB6A5998DE2 /* CameraFramePublisher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CameraFramePublisher.swift; sourceTree = "<group>"; };
 		7923EAF385B2497998AA5258 /* MultiCameraSessionViewModelClockSyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiCameraSessionViewModelClockSyncTests.swift; sourceTree = "<group>"; };
@@ -1067,6 +1069,7 @@
 				LP500001000000000000001 /* LivePoseOverlayProcessor.swift */,
 				CEF129189081C742189A7992 /* CaptureFormatSelector.swift */,
 				B2B15830F87FDBEAAF430EA8 /* OrientationMapper.swift */,
+				A1C2E3F4B5D6079855667788 /* MC1Log.swift */,
 			);
 			path = MultiCamera;
 			sourceTree = "<group>";
@@ -1424,6 +1427,7 @@
 				LP500002000000000000001 /* LivePoseOverlayProcessor.swift in Sources */,
 				EE17B48457527F7794F443C8 /* CaptureFormatSelector.swift in Sources */,
 				454C32E7DA3BE12D732D0262 /* OrientationMapper.swift in Sources */,
+				A1C2E3F4B5D6079811223344 /* MC1Log.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/LFAEducationCenter/MultiCamera/CameraFramePublisher.swift
+++ b/ios/LFAEducationCenter/MultiCamera/CameraFramePublisher.swift
@@ -1,23 +1,41 @@
 import AVFoundation
+import Combine
 import UIKit
 
+// MARK: — CameraFramePublisher
+//
+// Publishes low-fidelity preview JPEG frames from the PLAYER device to the
+// instructor dashboard over CameraStreamService (MultipeerConnectivity).
+//
+// SINGLE-SESSION CAMERA OWNERSHIP (2026-07-04 tricamera physical run RCA):
+// this type previously owned its own AVCaptureSession on the same back camera
+// that SessionCaptureManager records from. iOS hands the camera to whichever
+// session starts last and silently interrupts the other — on the failed run
+// the publisher won, SessionCaptureManager stayed a lying `.ready`, and the
+// player never reached confirmed_start. The publisher now owns NO session:
+// it configures one AVCaptureVideoDataOutput and attaches it to the
+// SessionCaptureManager's session via attachPreviewOutput(). Recording is
+// authoritative; preview is a side branch of the same camera pipeline, so
+// both run concurrently without contention.
 @MainActor
 final class CameraFramePublisher: NSObject, ObservableObject {
 
     @Published private(set) var frameIndex: Int = 0
     @Published private(set) var publishedFPS: Double = 0
 
-    private let captureSession = AVCaptureSession()
     private let videoOutput = AVCaptureVideoDataOutput()
     private let processingQueue = DispatchQueue(label: "com.lfa.frame-publisher", qos: .userInitiated)
 
+    private weak var captureManager: SessionCaptureManager?
     private var streamService: CameraStreamService?
+    private var managerStateSubscription: AnyCancellable?
+    private var isOutputConfigured = false
+    private var isAttached = false
+    private var attachInFlight = false
     private nonisolated(unsafe) var lastSentTime: CFTimeInterval = 0
     private var publishCount = 0
     private var fpsWindowStart = Date()
     private var orientationObserver: NSObjectProtocol?
-
-    var previewSession: AVCaptureSession { captureSession }
 
     deinit {
         if let token = orientationObserver {
@@ -25,35 +43,53 @@ final class CameraFramePublisher: NSObject, ObservableObject {
         }
     }
 
-    func configure() {
-        captureSession.beginConfiguration()
-        captureSession.sessionPreset = .medium // preview profile — intentionally separate/lower-fidelity than archival recording
+    /// Starts publishing preview frames by tapping `captureManager`'s capture
+    /// session. Attach is deferred until the manager's session is actually
+    /// configured and running (`.ready` / `.capturing`) — its state publisher
+    /// replays the current value, so a manager that is already ready attaches
+    /// immediately.
+    func startCapture(sharing captureManager: SessionCaptureManager, streamService: CameraStreamService) {
+        self.captureManager = captureManager
+        self.streamService = streamService
+        frameIndex = 0
+        publishCount = 0
+        fpsWindowStart = Date()
+        configureOutputIfNeeded()
 
-        guard let camera = AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: .back),
-              let input = try? AVCaptureDeviceInput(device: camera),
-              captureSession.canAddInput(input) else {
-            captureSession.commitConfiguration()
-            print("[FramePublisher] camera setup failed")
-            return
+        managerStateSubscription = captureManager.captureStatePublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] captureState in
+                switch captureState {
+                case .ready, .capturing:
+                    self?.attachIfNeeded()
+                default:
+                    break
+                }
+            }
+        MC1Log.notice("[FramePublisher] start requested: waiting for shared capture session (state=\(captureManager.state))")
+    }
+
+    func stopCapture() {
+        managerStateSubscription?.cancel()
+        managerStateSubscription = nil
+        if isAttached {
+            captureManager?.detachPreviewOutput()
+            isAttached = false
         }
-        captureSession.addInput(input)
+        streamService = nil
+        captureManager = nil
+        MC1Log.notice("[FramePublisher] capture stopped (preview output detached)")
+    }
+
+    // MARK: — Private
+
+    private func configureOutputIfNeeded() {
+        guard !isOutputConfigured else { return }
+        isOutputConfigured = true
 
         videoOutput.alwaysDiscardsLateVideoFrames = true
         videoOutput.videoSettings = [kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA]
         videoOutput.setSampleBufferDelegate(self, queue: processingQueue)
-
-        guard captureSession.canAddOutput(videoOutput) else {
-            captureSession.commitConfiguration()
-            print("[FramePublisher] cannot add video output")
-            return
-        }
-        captureSession.addOutput(videoOutput)
-
-        OrientationMapper.applyCurrentOrientation(to: videoOutput.connection(with: .video))
-
-        captureSession.commitConfiguration()
-        print("[FramePublisher] configured: preset=medium, target=\(Int(1.0/Self.targetInterval))fps, "
-              + "orientation=\(OrientationMapper.currentOrientationLabel)")
 
         UIDevice.current.beginGeneratingDeviceOrientationNotifications()
         orientationObserver = NotificationCenter.default.addObserver(
@@ -64,30 +100,28 @@ final class CameraFramePublisher: NSObject, ObservableObject {
         }
     }
 
-    func startCapture(streamService: CameraStreamService) {
-        self.streamService = streamService
-        frameIndex = 0
-        publishCount = 0
-        fpsWindowStart = Date()
-        processingQueue.async { [weak self] in
-            self?.captureSession.startRunning()
-            DispatchQueue.main.async { print("[FramePublisher] capture started") }
+    private func attachIfNeeded() {
+        guard !isAttached, !attachInFlight, let manager = captureManager else { return }
+        attachInFlight = true
+        manager.attachPreviewOutput(videoOutput) { [weak self] attached in
+            guard let self else { return }
+            self.attachInFlight = false
+            self.isAttached = attached
+            MC1Log.notice("[FramePublisher] preview output attach \(attached ? "OK" : "FAILED") — target=\(Int(1.0 / Self.targetInterval))fps, orientation=\(OrientationMapper.currentOrientationLabel)")
         }
-    }
-
-    func stopCapture() {
-        processingQueue.async { [weak self] in
-            self?.captureSession.stopRunning()
-            DispatchQueue.main.async { print("[FramePublisher] capture stopped") }
-        }
-        streamService = nil
     }
 }
 
 // MARK: — AVCaptureVideoDataOutputSampleBufferDelegate
 
 extension CameraFramePublisher: AVCaptureVideoDataOutputSampleBufferDelegate {
-    private static let targetInterval: CFTimeInterval = 1.0 / 12.0
+    private nonisolated static let targetInterval: CFTimeInterval = 1.0 / 12.0
+    /// Longest edge of a published preview frame. The shared session runs at the
+    /// RECORDING profile (1280x720 — see CaptureFormatSelector), unlike the old
+    /// dedicated preview session's `.medium` preset; a full 720p JPEG can exceed
+    /// what MCSession `.unreliable` reliably delivers, so downscale to roughly
+    /// the previous preview fidelity before encoding.
+    private nonisolated static let maxPreviewEdge: CGFloat = 640
 
     nonisolated func captureOutput(_ output: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer, from connection: AVCaptureConnection) {
         let now = CACurrentMediaTime()
@@ -96,7 +130,12 @@ extension CameraFramePublisher: AVCaptureVideoDataOutputSampleBufferDelegate {
 
         guard let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
 
-        let ciImage = CIImage(cvPixelBuffer: pixelBuffer)
+        var ciImage = CIImage(cvPixelBuffer: pixelBuffer)
+        let longestEdge = max(ciImage.extent.width, ciImage.extent.height)
+        if longestEdge > Self.maxPreviewEdge {
+            let scale = Self.maxPreviewEdge / longestEdge
+            ciImage = ciImage.transformed(by: CGAffineTransform(scaleX: scale, y: scale))
+        }
         let context = CIContext()
         guard let cgImage = context.createCGImage(ciImage, from: ciImage.extent) else { return }
         let uiImage = UIImage(cgImage: cgImage)

--- a/ios/LFAEducationCenter/MultiCamera/CameraStreamService.swift
+++ b/ios/LFAEducationCenter/MultiCamera/CameraStreamService.swift
@@ -59,14 +59,14 @@ final class CameraStreamService: NSObject, ObservableObject {
             adv.delegate = self
             adv.startAdvertisingPeer()
             self.advertiser = adv
-            print("[StreamService] player advertising: \(myPeerID.displayName)")
+            MC1Log.notice("[StreamService] player advertising: \(myPeerID.displayName)")
 
         case .instructor:
             let brw = MCNearbyServiceBrowser(peer: myPeerID, serviceType: Self.serviceType)
             brw.delegate = self
             brw.startBrowsingForPeers()
             self.browser = brw
-            print("[StreamService] instructor browsing for players")
+            MC1Log.notice("[StreamService] instructor browsing for players")
         }
 
         fpsTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
@@ -115,14 +115,14 @@ extension CameraStreamService: MCSessionDelegate {
             case .connected:
                 connectedPeer = peerID
                 peerState = .connected(peerName: peerID.displayName)
-                print("[StreamService] connected to \(peerID.displayName)")
+                MC1Log.notice("[StreamService] connected to \(peerID.displayName)")
             case .connecting:
                 peerState = .connecting
-                print("[StreamService] connecting to \(peerID.displayName)")
+                MC1Log.notice("[StreamService] connecting to \(peerID.displayName)")
             case .notConnected:
                 if connectedPeer == peerID { connectedPeer = nil }
                 peerState = .disconnected
-                print("[StreamService] disconnected from \(peerID.displayName)")
+                MC1Log.notice("[StreamService] disconnected from \(peerID.displayName)")
                 if role == .instructor {
                     browser?.startBrowsingForPeers()
                 }
@@ -151,13 +151,13 @@ extension CameraStreamService: MCSessionDelegate {
 extension CameraStreamService: MCNearbyServiceAdvertiserDelegate {
     nonisolated func advertiser(_ advertiser: MCNearbyServiceAdvertiser, didReceiveInvitationFromPeer peerID: MCPeerID, withContext: Data?, invitationHandler: @escaping (Bool, MCSession?) -> Void) {
         Task { @MainActor in
-            print("[StreamService] received invitation from \(peerID.displayName)")
+            MC1Log.notice("[StreamService] received invitation from \(peerID.displayName)")
             invitationHandler(true, session)
         }
     }
 
     nonisolated func advertiser(_ advertiser: MCNearbyServiceAdvertiser, didNotStartAdvertisingPeer error: Error) {
-        print("[StreamService] advertising failed: \(error)")
+        MC1Log.notice("[StreamService] advertising failed: \(error)")
     }
 }
 
@@ -166,17 +166,17 @@ extension CameraStreamService: MCNearbyServiceAdvertiserDelegate {
 extension CameraStreamService: MCNearbyServiceBrowserDelegate {
     nonisolated func browser(_ browser: MCNearbyServiceBrowser, foundPeer peerID: MCPeerID, withDiscoveryInfo info: [String: String]?) {
         Task { @MainActor in
-            print("[StreamService] found peer: \(peerID.displayName) info=\(info ?? [:])")
+            MC1Log.notice("[StreamService] found peer: \(peerID.displayName) info=\(info ?? [:])")
             guard let session else { return }
             browser.invitePeer(peerID, to: session, withContext: nil, timeout: 10)
         }
     }
 
     nonisolated func browser(_ browser: MCNearbyServiceBrowser, lostPeer peerID: MCPeerID) {
-        print("[StreamService] lost peer: \(peerID.displayName)")
+        MC1Log.notice("[StreamService] lost peer: \(peerID.displayName)")
     }
 
     nonisolated func browser(_ browser: MCNearbyServiceBrowser, didNotStartBrowsingForPeers error: Error) {
-        print("[StreamService] browsing failed: \(error)")
+        MC1Log.notice("[StreamService] browsing failed: \(error)")
     }
 }

--- a/ios/LFAEducationCenter/MultiCamera/CycleCaptureOrchestrator.swift
+++ b/ios/LFAEducationCenter/MultiCamera/CycleCaptureOrchestrator.swift
@@ -104,9 +104,9 @@ final class CycleCaptureOrchestrator: ObservableObject {
     @Published private(set) var state: OrchestratorState = .idle {
         didSet {
             switch state {
-            case .capturing(let cycleId): print("[CCO] confirmed start: cycleId=\(cycleId)")
-            case .completed(let cycleId): print("[CCO] confirmed stop: cycleId=\(cycleId)")
-            case .failed(let failure): print("[CCO] FAILURE: \(failure)")
+            case .capturing(let cycleId): MC1Log.notice("[CCO] confirmed start: cycleId=\(cycleId)")
+            case .completed(let cycleId): MC1Log.notice("[CCO] confirmed stop: cycleId=\(cycleId)")
+            case .failed(let failure): MC1Log.notice("[CCO] FAILURE: \(failure)")
             default: break
             }
         }

--- a/ios/LFAEducationCenter/MultiCamera/CycleCaptureOrchestrator.swift
+++ b/ios/LFAEducationCenter/MultiCamera/CycleCaptureOrchestrator.swift
@@ -46,6 +46,7 @@ protocol CycleAPIClient {
     func createCycle(token: String, uuid: String, idempotencyKey: String) async throws -> CaptureCycleDTO
     func scheduleCycle(token: String, uuid: String, cycleId: Int, revision: Int) async throws -> CaptureCycleDTO
     func stopCycle(token: String, uuid: String, cycleId: Int, revision: Int) async throws -> CaptureCycleDTO
+    func listCycles(token: String, uuid: String) async throws -> [CaptureCycleDTO]
     func confirmDeviceStart(token: String, uuid: String, cycleId: Int, sessionDeviceId: Int, startedAt: String, cycleDeviceRevision: Int) async throws -> CaptureCycleDTO
     func confirmDeviceStop(token: String, uuid: String, cycleId: Int, sessionDeviceId: Int, stoppedAt: String, cycleDeviceRevision: Int) async throws -> CaptureCycleDTO
 }
@@ -71,6 +72,10 @@ struct LiveCycleAPIClient: CycleAPIClient {
 
     func stopCycle(token: String, uuid: String, cycleId: Int, revision: Int) async throws -> CaptureCycleDTO {
         try await MultiCameraAPIClient.stopCycle(token: token, uuid: uuid, cycleId: cycleId, revision: revision)
+    }
+
+    func listCycles(token: String, uuid: String) async throws -> [CaptureCycleDTO] {
+        try await MultiCameraAPIClient.listCycles(token: token, uuid: uuid)
     }
 
     func confirmDeviceStart(token: String, uuid: String, cycleId: Int, sessionDeviceId: Int, startedAt: String, cycleDeviceRevision: Int) async throws -> CaptureCycleDTO {
@@ -192,16 +197,43 @@ final class CycleCaptureOrchestrator: ObservableObject {
                 cycleId: cycleId,
                 revision: cycle.revision
             )
-            if recordsLocally {
-                captureController.stopCapture()
-            } else {
-                // Non-recording coordinator: nothing to stop locally and no
-                // capture-completed event will arrive — terminal state now.
-                MC1Log.notice("[CCO] non-recording coordinator: stop requested for cycle \(cycleId), no local capture")
-                state = .completed(cycleId: cycleId)
-            }
         } catch {
-            state = .failed(Self.mapToFailure(error))
+            guard let apiErr = error as? APIError,
+                  case .httpError(let code, _) = apiErr, code == 409 else {
+                state = .failed(Self.mapToFailure(error))
+                return
+            }
+            // 409: the cached revision is stale — on a non-recording coordinator
+            // the players' confirm_start advances the cycle revision without any
+            // response passing through this device. Refetch once, retry once;
+            // a second 409 is a real conflict and stays terminal.
+            do {
+                let cycles = try await cycleAPIClient.listCycles(
+                    token: token, uuid: currentCycleSessionUuid ?? ""
+                )
+                guard let fresh = cycles.first(where: { $0.id == cycleId }) else {
+                    state = .failed(.revisionConflict(detail: "stop retry: cycle \(cycleId) missing from refetch"))
+                    return
+                }
+                revisionConflictRetried = true
+                _ = try await cycleAPIClient.stopCycle(
+                    token: token,
+                    uuid: currentCycleSessionUuid ?? "",
+                    cycleId: cycleId,
+                    revision: fresh.revision
+                )
+            } catch {
+                state = .failed(.revisionConflict(detail: "stop retry: \(Self.mapToFailure(error))"))
+                return
+            }
+        }
+        if recordsLocally {
+            captureController.stopCapture()
+        } else {
+            // Non-recording coordinator: nothing to stop locally and no
+            // capture-completed event will arrive — terminal state now.
+            MC1Log.notice("[CCO] non-recording coordinator: stop requested for cycle \(cycleId), no local capture")
+            state = .completed(cycleId: cycleId)
         }
     }
 

--- a/ios/LFAEducationCenter/MultiCamera/CycleCaptureOrchestrator.swift
+++ b/ios/LFAEducationCenter/MultiCamera/CycleCaptureOrchestrator.swift
@@ -145,6 +145,13 @@ final class CycleCaptureOrchestrator: ObservableObject {
     private var startTask: Task<Void, Never>?
     private var captureSubscription: AnyCancellable?
 
+    /// MC2-PR1 non-recording coordinator: when false, this device drives the
+    /// cycle lifecycle (create/schedule/stop) but contributes NO local capture
+    /// and NO confirm_start/confirm_stop — the players' confirms complete the
+    /// cycle on the backend. Set by the ViewModel from the device role before
+    /// each startCycle; defaults to true (recording controller).
+    var recordsLocally: Bool = true
+
     // MARK: — Init
 
     init(
@@ -185,7 +192,14 @@ final class CycleCaptureOrchestrator: ObservableObject {
                 cycleId: cycleId,
                 revision: cycle.revision
             )
-            captureController.stopCapture()
+            if recordsLocally {
+                captureController.stopCapture()
+            } else {
+                // Non-recording coordinator: nothing to stop locally and no
+                // capture-completed event will arrive — terminal state now.
+                MC1Log.notice("[CCO] non-recording coordinator: stop requested for cycle \(cycleId), no local capture")
+                state = .completed(cycleId: cycleId)
+            }
         } catch {
             state = .failed(Self.mapToFailure(error))
         }
@@ -319,6 +333,16 @@ final class CycleCaptureOrchestrator: ObservableObject {
         }
 
         if Task.isCancelled { return }
+
+        // 5. Non-recording coordinator (MC2-PR1): no local capture, no
+        // self-confirm — the players' confirms drive the cycle on the backend.
+        // Deliberately NO confirm call here: a confirm without a capture file
+        // would be fabricated evidence.
+        guard recordsLocally else {
+            MC1Log.notice("[CCO] non-recording coordinator: cycle \(scheduledCycle.id) started without local capture")
+            state = .capturing(cycleId: scheduledCycle.id)
+            return
+        }
 
         // 5. Re-arm capture from previous cycle's .completed state
         captureController.rearmForNextCycle()

--- a/ios/LFAEducationCenter/MultiCamera/GoProConnectionManager.swift
+++ b/ios/LFAEducationCenter/MultiCamera/GoProConnectionManager.swift
@@ -128,10 +128,10 @@ final class GoProConnectionManager: ObservableObject {
         do {
             _ = try await httpTransport.get(path: GoProSpec.shutterStartPath, timeout: GoProSpec.commandTimeout)
             recordingState = .recording
-            print("[GOPRO] shutter start OK")
+            MC1Log.notice("[GOPRO] shutter start OK")
         } catch {
             recordingState = .failed("\(error)")
-            print("[GOPRO] shutter start FAILED: \(error)")
+            MC1Log.notice("[GOPRO] shutter start FAILED: \(error)")
             throw GoProRecordingError.shutterFailed("\(error)")
         }
     }
@@ -142,10 +142,10 @@ final class GoProConnectionManager: ObservableObject {
         do {
             _ = try await httpTransport.get(path: GoProSpec.shutterStopPath, timeout: GoProSpec.commandTimeout)
             recordingState = .stopped
-            print("[GOPRO] shutter stop OK")
+            MC1Log.notice("[GOPRO] shutter stop OK")
         } catch {
             recordingState = .failed("\(error)")
-            print("[GOPRO] shutter stop FAILED: \(error)")
+            MC1Log.notice("[GOPRO] shutter stop FAILED: \(error)")
             throw GoProRecordingError.shutterFailed("\(error)")
         }
     }
@@ -154,7 +154,7 @@ final class GoProConnectionManager: ObservableObject {
         do {
             return try await httpTransport.get(path: GoProSpec.mediaListPath, timeout: GoProSpec.commandTimeout)
         } catch {
-            print("[GOPRO] media list failed: \(error)")
+            MC1Log.notice("[GOPRO] media list failed: \(error)")
             return nil
         }
     }
@@ -269,18 +269,18 @@ final class GoProConnectionManager: ObservableObject {
         do {
             try await wifiTransport.joinAccessPoint(ssid: ssid, password: password)
             cancelTimeout()
-            print("[GoPro] WiFi joined via NEHotspotConfiguration: \(ssid)")
+            MC1Log.notice("[GoPro] WiFi joined via NEHotspotConfiguration: \(ssid)")
             startHTTPVerify(trigger: "wifi_joined_auto")
         } catch GoProWiFiError.alreadyAssociated {
             cancelTimeout()
-            print("[GoPro] WiFi already associated: \(ssid)")
+            MC1Log.notice("[GoPro] WiFi already associated: \(ssid)")
             startHTTPVerify(trigger: "wifi_already_associated")
         } catch GoProWiFiError.userDenied {
             cancelTimeout()
             transition(to: .failed(.wifiUserDenied), trigger: "wifi_user_denied")
         } catch {
             cancelTimeout()
-            print("[GoPro] WiFi auto-join failed: \(error), falling back to manual")
+            MC1Log.notice("[GoPro] WiFi auto-join failed: \(error), falling back to manual")
             transition(to: .awaitingManualWiFiJoin(ssid: ssid), trigger: "wifi_auto_failed_fallback")
         }
     }

--- a/ios/LFAEducationCenter/MultiCamera/InstructorDashboardView.swift
+++ b/ios/LFAEducationCenter/MultiCamera/InstructorDashboardView.swift
@@ -28,10 +28,17 @@ struct InstructorDashboardView: View {
         }
         .statusBarHidden(true)
         .onAppear {
-            localPoseOverlay.attach(to: captureManager.previewSession)
+            // MC2-PR1: the non-recording coordinator has no local camera feed —
+            // never touch the capture session (TOPO-G7: no capture
+            // AVCaptureSession may run on the instructor iPad).
+            if vm.localCaptureExpected {
+                localPoseOverlay.attach(to: captureManager.previewSession)
+            }
         }
         .onDisappear {
-            localPoseOverlay.detach(from: captureManager.previewSession)
+            if vm.localCaptureExpected {
+                localPoseOverlay.detach(from: captureManager.previewSession)
+            }
         }
         // Feed remote (iPad) frames to the remote overlay processor.
         .onReceive(streamService.objectWillChange) { [self] in
@@ -69,7 +76,9 @@ struct InstructorDashboardView: View {
         return session.devices.filter { $0.removedAt == nil }
     }
 
-    // Ordering: instructor first, then players (by id), then auxiliary cameras (GoPro)
+    // Ordering: instructor first, then players (by id), then auxiliary cameras (GoPro).
+    // MC2-PR1: when this device is a non-recording coordinator, its own panel is
+    // dropped — there is no local feed to show, only the players + GoPro.
     private var orderedPanels: [SessionDeviceDTO] {
         let rank: (MCDeviceRole) -> Int = {
             switch $0 {
@@ -79,10 +88,12 @@ struct InstructorDashboardView: View {
             case .auxiliaryCamera:   return 3
             }
         }
-        return sessionDevices.sorted {
-            let ra = rank($0.deviceRole), rb = rank($1.deviceRole)
-            return ra != rb ? ra < rb : $0.id < $1.id
-        }
+        return sessionDevices
+            .filter { vm.localCaptureExpected || $0.id != vm.sessionDeviceId }
+            .sorted {
+                let ra = rank($0.deviceRole), rb = rank($1.deviceRole)
+                return ra != rb ? ra < rb : $0.id < $1.id
+            }
     }
 
     // MARK: - Top bar

--- a/ios/LFAEducationCenter/MultiCamera/InstructorDashboardView.swift
+++ b/ios/LFAEducationCenter/MultiCamera/InstructorDashboardView.swift
@@ -47,8 +47,13 @@ struct InstructorDashboardView: View {
         }
         // pose-overlay-diag deep link → export per-panel frame diagnostics. Handled here
         // (not MultiCameraLobbyView) because the 3 processor instances are owned by this view.
-        .onReceive(MC1AutomationBridge.shared.$lastAction.compactMap { $0 }) { [self] action in
-            guard case .poseOverlayDiag = action else { return }
+        //
+        // consume() gate (P0 hardening): without it, a re-presented dashboard would
+        // replay a stale .poseOverlayDiag and clobber pose_overlay_diag.json with
+        // freshly-zeroed counters before the regression script copies it.
+        .onReceive(MC1AutomationBridge.shared.$lastAction.compactMap { $0 }) { [self] envelope in
+            guard case .poseOverlayDiag = envelope.action,
+                  MC1AutomationBridge.shared.consume(envelope) else { return }
             PoseOverlayDiagWriter.write(
                 instructor: localPoseOverlay,
                 player: remotePoseOverlay, playerSourceFramesSeen: streamService.totalFramesReceived,

--- a/ios/LFAEducationCenter/MultiCamera/MC1AutomationBridge.swift
+++ b/ios/LFAEducationCenter/MultiCamera/MC1AutomationBridge.swift
@@ -66,6 +66,21 @@ enum MC1AutomationAction: Equatable {
     case poseOverlayDiag
 }
 
+/// One posted automation action with a monotonically increasing sequence number.
+///
+/// The sequence number exists because `@Published var lastAction` REPLAYS its
+/// current value to every new subscriber — a re-presented MultiCameraLobbyView /
+/// InstructorDashboardView would otherwise re-execute the last deep-link action
+/// (double GoPro shutter + duplicate confirmDeviceStart, spurious resetSession,
+/// pose_overlay_diag.json clobbered with zeroed counters). Consumers must call
+/// `MC1AutomationBridge.consume(_:)` before dispatching; it returns true exactly
+/// once per posted action, so a Combine replay of an already-handled envelope is
+/// a no-op (P0 hardening, 2026-07-04 review).
+struct MC1SequencedAction: Equatable {
+    let seq: Int
+    let action: MC1AutomationAction
+}
+
 final class MC1AutomationBridge: ObservableObject {
     static let shared = MC1AutomationBridge()
     private init() {}
@@ -73,7 +88,24 @@ final class MC1AutomationBridge: ObservableObject {
     static let urlScheme = "lfa-mc1"
 
     @Published var presentSessionLab = false
-    @Published private(set) var lastAction: MC1AutomationAction?
+    @Published private(set) var lastAction: MC1SequencedAction?
+
+    private var nextSeq = 1
+    private var consumedSeqs: Set<Int> = []
+
+    private func post(_ action: MC1AutomationAction) {
+        lastAction = MC1SequencedAction(seq: nextSeq, action: action)
+        nextSeq += 1
+    }
+
+    /// Claims an envelope for execution. Returns true exactly once per posted
+    /// action; any later delivery of the same envelope (Combine replay on view
+    /// rebuild / re-subscription) returns false and must not be dispatched.
+    func consume(_ envelope: MC1SequencedAction) -> Bool {
+        guard !consumedSeqs.contains(envelope.seq) else { return false }
+        consumedSeqs.insert(envelope.seq)
+        return true
+    }
 
     /// Returns true if the URL matched this bridge's scheme and was handled.
     @discardableResult
@@ -89,102 +121,102 @@ final class MC1AutomationBridge: ObservableObject {
             let role: ParticipantRole = value("role") == "instructor" ? .instructor : .player
             print("[MC1-AUTO] received action=join uuid=\(uuid) role=\(role)")
             presentSessionLab = true
-            lastAction = .joinSession(uuid: uuid, role: role)
+            post(.joinSession(uuid: uuid, role: role))
             return true
         case "mark-ready":
             print("[MC1-AUTO] received action=mark-ready")
-            lastAction = .markDevicesReady
+            post(.markDevicesReady)
             return true
         case "begin-cycle":
             print("[MC1-AUTO] received action=begin-cycle")
-            lastAction = .beginCycle
+            post(.beginCycle)
             return true
         case "end-cycle":
             print("[MC1-AUTO] received action=end-cycle")
-            lastAction = .endCycle
+            post(.endCycle)
             return true
         case "dump-snapshot":
             print("[MC1-AUTO] received action=dump-snapshot")
-            lastAction = .dumpSnapshot
+            post(.dumpSnapshot)
             return true
         case "reset-session":
             print("[MC1-AUTO] received action=reset-session")
-            lastAction = .resetSession
+            post(.resetSession)
             return true
         case "gopro-connect":
             let did = value("gopro_device_id").flatMap(Int.init)
             print("[MC1-AUTO] received action=gopro-connect gopro_device_id=\(did ?? -1)")
-            lastAction = .goProConnect(goProDeviceId: did)
+            post(.goProConnect(goProDeviceId: did))
             return true
         case "gopro-start":
             guard let did = value("gopro_device_id").flatMap(Int.init) else { return false }
             print("[MC1-AUTO] received action=gopro-start gopro_device_id=\(did)")
-            lastAction = .goProStartRecording(goProDeviceId: did)
+            post(.goProStartRecording(goProDeviceId: did))
             return true
         case "gopro-stop":
             guard let did = value("gopro_device_id").flatMap(Int.init) else { return false }
             print("[MC1-AUTO] received action=gopro-stop gopro_device_id=\(did)")
-            lastAction = .goProStopRecording(goProDeviceId: did)
+            post(.goProStopRecording(goProDeviceId: did))
             return true
         case "gopro-status":
             print("[MC1-AUTO] received action=gopro-status")
-            lastAction = .goProStatus
+            post(.goProStatus)
             return true
         case "gopro-media-list":
             print("[MC1-AUTO] received action=gopro-media-list")
-            lastAction = .goProMediaList
+            post(.goProMediaList)
             return true
         case "gopro-http-diag":
             print("[MC1-AUTO] received action=gopro-http-diag")
-            lastAction = .goProHttpDiag
+            post(.goProHttpDiag)
             return true
         case "gopro-download-latest":
             print("[MC1-AUTO] received action=gopro-download-latest")
-            lastAction = .goProDownloadLatest
+            post(.goProDownloadLatest)
             return true
         case "skeleton-process":
             print("[MC1-AUTO] received action=skeleton-process")
-            lastAction = .skeletonProcess
+            post(.skeletonProcess)
             return true
         case "capture-info":
             print("[MC1-AUTO] received action=capture-info")
-            lastAction = .captureInfo
+            post(.captureInfo)
             return true
         case "network-routing-diag":
             let label = value("label") ?? "unlabeled"
             print("[MC1-AUTO] received action=network-routing-diag label=\(label)")
-            lastAction = .networkRoutingDiag(label: label)
+            post(.networkRoutingDiag(label: label))
             return true
         case "gopro-preview-poc":
             let duration = value("duration_s").flatMap(Double.init) ?? 25
             print("[MC1-AUTO] received action=gopro-preview-poc duration_s=\(duration)")
-            lastAction = .goProPreviewPOC(durationSeconds: duration)
+            post(.goProPreviewPOC(durationSeconds: duration))
             return true
         case "gopro-combined-cycle-proof":
             let duration = value("duration_s").flatMap(Double.init) ?? 15
             print("[MC1-AUTO] received action=gopro-combined-cycle-proof duration_s=\(duration)")
-            lastAction = .goProCombinedCycleProof(durationSeconds: duration)
+            post(.goProCombinedCycleProof(durationSeconds: duration))
             return true
         case "gopro-camera-state-probe":
             print("[MC1-AUTO] received action=gopro-camera-state-probe")
-            lastAction = .goProCameraStateProbe
+            post(.goProCameraStateProbe)
             return true
         case "gopro-preview-aspect-probe":
             let duration = value("duration_s").flatMap(Double.init) ?? 20
             print("[MC1-AUTO] received action=gopro-preview-aspect-probe duration_s=\(duration)")
-            lastAction = .goProPreviewAspectProbe(durationSeconds: duration)
+            post(.goProPreviewAspectProbe(durationSeconds: duration))
             return true
         case "gopro-preset-write-validation":
             print("[MC1-AUTO] received action=gopro-preset-write-validation")
-            lastAction = .goProPresetWriteValidation
+            post(.goProPresetWriteValidation)
             return true
         case "gopro-stream-start":
             print("[MC1-AUTO] received action=gopro-stream-start")
-            lastAction = .goProStreamStart
+            post(.goProStreamStart)
             return true
         case "pose-overlay-diag":
             print("[MC1-AUTO] received action=pose-overlay-diag")
-            lastAction = .poseOverlayDiag
+            post(.poseOverlayDiag)
             return true
         default:
             print("[MC1-AUTO] received unknown action=\(action)")

--- a/ios/LFAEducationCenter/MultiCamera/MC1AutomationBridge.swift
+++ b/ios/LFAEducationCenter/MultiCamera/MC1AutomationBridge.swift
@@ -119,107 +119,107 @@ final class MC1AutomationBridge: ObservableObject {
         case "join":
             guard let uuid = value("session_uuid"), !uuid.isEmpty else { return false }
             let role: ParticipantRole = value("role") == "instructor" ? .instructor : .player
-            print("[MC1-AUTO] received action=join uuid=\(uuid) role=\(role)")
+            MC1Log.notice("[MC1-AUTO] received action=join uuid=\(uuid) role=\(role)")
             presentSessionLab = true
             post(.joinSession(uuid: uuid, role: role))
             return true
         case "mark-ready":
-            print("[MC1-AUTO] received action=mark-ready")
+            MC1Log.notice("[MC1-AUTO] received action=mark-ready")
             post(.markDevicesReady)
             return true
         case "begin-cycle":
-            print("[MC1-AUTO] received action=begin-cycle")
+            MC1Log.notice("[MC1-AUTO] received action=begin-cycle")
             post(.beginCycle)
             return true
         case "end-cycle":
-            print("[MC1-AUTO] received action=end-cycle")
+            MC1Log.notice("[MC1-AUTO] received action=end-cycle")
             post(.endCycle)
             return true
         case "dump-snapshot":
-            print("[MC1-AUTO] received action=dump-snapshot")
+            MC1Log.notice("[MC1-AUTO] received action=dump-snapshot")
             post(.dumpSnapshot)
             return true
         case "reset-session":
-            print("[MC1-AUTO] received action=reset-session")
+            MC1Log.notice("[MC1-AUTO] received action=reset-session")
             post(.resetSession)
             return true
         case "gopro-connect":
             let did = value("gopro_device_id").flatMap(Int.init)
-            print("[MC1-AUTO] received action=gopro-connect gopro_device_id=\(did ?? -1)")
+            MC1Log.notice("[MC1-AUTO] received action=gopro-connect gopro_device_id=\(did ?? -1)")
             post(.goProConnect(goProDeviceId: did))
             return true
         case "gopro-start":
             guard let did = value("gopro_device_id").flatMap(Int.init) else { return false }
-            print("[MC1-AUTO] received action=gopro-start gopro_device_id=\(did)")
+            MC1Log.notice("[MC1-AUTO] received action=gopro-start gopro_device_id=\(did)")
             post(.goProStartRecording(goProDeviceId: did))
             return true
         case "gopro-stop":
             guard let did = value("gopro_device_id").flatMap(Int.init) else { return false }
-            print("[MC1-AUTO] received action=gopro-stop gopro_device_id=\(did)")
+            MC1Log.notice("[MC1-AUTO] received action=gopro-stop gopro_device_id=\(did)")
             post(.goProStopRecording(goProDeviceId: did))
             return true
         case "gopro-status":
-            print("[MC1-AUTO] received action=gopro-status")
+            MC1Log.notice("[MC1-AUTO] received action=gopro-status")
             post(.goProStatus)
             return true
         case "gopro-media-list":
-            print("[MC1-AUTO] received action=gopro-media-list")
+            MC1Log.notice("[MC1-AUTO] received action=gopro-media-list")
             post(.goProMediaList)
             return true
         case "gopro-http-diag":
-            print("[MC1-AUTO] received action=gopro-http-diag")
+            MC1Log.notice("[MC1-AUTO] received action=gopro-http-diag")
             post(.goProHttpDiag)
             return true
         case "gopro-download-latest":
-            print("[MC1-AUTO] received action=gopro-download-latest")
+            MC1Log.notice("[MC1-AUTO] received action=gopro-download-latest")
             post(.goProDownloadLatest)
             return true
         case "skeleton-process":
-            print("[MC1-AUTO] received action=skeleton-process")
+            MC1Log.notice("[MC1-AUTO] received action=skeleton-process")
             post(.skeletonProcess)
             return true
         case "capture-info":
-            print("[MC1-AUTO] received action=capture-info")
+            MC1Log.notice("[MC1-AUTO] received action=capture-info")
             post(.captureInfo)
             return true
         case "network-routing-diag":
             let label = value("label") ?? "unlabeled"
-            print("[MC1-AUTO] received action=network-routing-diag label=\(label)")
+            MC1Log.notice("[MC1-AUTO] received action=network-routing-diag label=\(label)")
             post(.networkRoutingDiag(label: label))
             return true
         case "gopro-preview-poc":
             let duration = value("duration_s").flatMap(Double.init) ?? 25
-            print("[MC1-AUTO] received action=gopro-preview-poc duration_s=\(duration)")
+            MC1Log.notice("[MC1-AUTO] received action=gopro-preview-poc duration_s=\(duration)")
             post(.goProPreviewPOC(durationSeconds: duration))
             return true
         case "gopro-combined-cycle-proof":
             let duration = value("duration_s").flatMap(Double.init) ?? 15
-            print("[MC1-AUTO] received action=gopro-combined-cycle-proof duration_s=\(duration)")
+            MC1Log.notice("[MC1-AUTO] received action=gopro-combined-cycle-proof duration_s=\(duration)")
             post(.goProCombinedCycleProof(durationSeconds: duration))
             return true
         case "gopro-camera-state-probe":
-            print("[MC1-AUTO] received action=gopro-camera-state-probe")
+            MC1Log.notice("[MC1-AUTO] received action=gopro-camera-state-probe")
             post(.goProCameraStateProbe)
             return true
         case "gopro-preview-aspect-probe":
             let duration = value("duration_s").flatMap(Double.init) ?? 20
-            print("[MC1-AUTO] received action=gopro-preview-aspect-probe duration_s=\(duration)")
+            MC1Log.notice("[MC1-AUTO] received action=gopro-preview-aspect-probe duration_s=\(duration)")
             post(.goProPreviewAspectProbe(durationSeconds: duration))
             return true
         case "gopro-preset-write-validation":
-            print("[MC1-AUTO] received action=gopro-preset-write-validation")
+            MC1Log.notice("[MC1-AUTO] received action=gopro-preset-write-validation")
             post(.goProPresetWriteValidation)
             return true
         case "gopro-stream-start":
-            print("[MC1-AUTO] received action=gopro-stream-start")
+            MC1Log.notice("[MC1-AUTO] received action=gopro-stream-start")
             post(.goProStreamStart)
             return true
         case "pose-overlay-diag":
-            print("[MC1-AUTO] received action=pose-overlay-diag")
+            MC1Log.notice("[MC1-AUTO] received action=pose-overlay-diag")
             post(.poseOverlayDiag)
             return true
         default:
-            print("[MC1-AUTO] received unknown action=\(action)")
+            MC1Log.notice("[MC1-AUTO] received unknown action=\(action)")
             return false
         }
     }

--- a/ios/LFAEducationCenter/MultiCamera/MC1Log.swift
+++ b/ios/LFAEducationCenter/MultiCamera/MC1Log.swift
@@ -1,0 +1,29 @@
+import Foundation
+import os
+
+// MARK: — MC1Log
+//
+// Physical-evidence logging for the MC1 multicamera stack.
+//
+// The 2026-07-04 tricamera physical run proved that `print()` output is
+// INVISIBLE to idevicesyslog on physical devices: the 78k-line iPhone console
+// capture contained ZERO app-tagged lines ([PCO]/[CCO]/[MC1-AUTO]/[GOPRO-AUTO])
+// even though the code printed them — print() goes to stdout, which the syslog
+// relay never sees. Every console-grounded evidence extraction in the
+// regression harness (ConsoleOffsetTracker.extract_tagged_lines, debug
+// snapshots, GOPRO-MEDIA markers) was silently blind.
+//
+// os_log entries at .default level DO appear in idevicesyslog (the same
+// capture was full of CFNetwork/UIKitCore os_log lines). The `%{public}@`
+// format is load-bearing: without it, iOS redacts the interpolated message to
+// `<private>` on physical devices, which is exactly as useless as no line.
+enum MC1Log {
+    private static let osLog = OSLog(subsystem: "com.lfa.educationcenter.mc1", category: "MC1")
+
+    /// Drop-in replacement for `print()` in the MC1 evidence path. Message text
+    /// (including the leading `[TAG]`) must stay byte-identical to what the
+    /// harness greps for.
+    static func notice(_ message: String) {
+        os_log("%{public}@", log: osLog, type: .default, message)
+    }
+}

--- a/ios/LFAEducationCenter/MultiCamera/MultiCameraLobbyView.swift
+++ b/ios/LFAEducationCenter/MultiCamera/MultiCameraLobbyView.swift
@@ -50,7 +50,7 @@ struct MultiCameraLobbyView: View {
         ))
     }
 
-    private static let buildFingerprint = "mc2-pr1-v1-2026-07-12"
+    private static let buildFingerprint = "mc2-pr1-v2-2026-07-12"
 
     var body: some View {
         NavigationView {

--- a/ios/LFAEducationCenter/MultiCamera/MultiCameraLobbyView.swift
+++ b/ios/LFAEducationCenter/MultiCamera/MultiCameraLobbyView.swift
@@ -97,7 +97,17 @@ struct MultiCameraLobbyView: View {
         }
         // MC1-AUTO-1: dispatches automation commands from lfa-mc1:// deep links
         // onto the same vm methods the manual buttons call.
-        .onReceive(MC1AutomationBridge.shared.$lastAction.compactMap { $0 }) { action in
+        //
+        // consume() gate (P0 hardening): @Published replays the last envelope to
+        // every new subscription — without the consume() claim, a re-built view
+        // would re-execute the last action (double GoPro shutter, spurious
+        // reset-session). consume() returns true exactly once per posted action.
+        .onReceive(MC1AutomationBridge.shared.$lastAction.compactMap { $0 }) { envelope in
+            // poseOverlayDiag belongs to InstructorDashboardView (owns the 3
+            // processor instances) — leave it unconsumed for that view.
+            if case .poseOverlayDiag = envelope.action { return }
+            guard MC1AutomationBridge.shared.consume(envelope) else { return }
+            let action = envelope.action
             switch action {
             case .joinSession(let uuid, let role):
                 print("[MC1-AUTO] dispatching action=join uuid=\(uuid) role=\(role) state=\(vm.state)")

--- a/ios/LFAEducationCenter/MultiCamera/MultiCameraLobbyView.swift
+++ b/ios/LFAEducationCenter/MultiCamera/MultiCameraLobbyView.swift
@@ -50,7 +50,7 @@ struct MultiCameraLobbyView: View {
         ))
     }
 
-    private static let buildFingerprint = "mc1-debug-v13-2026-07-12"
+    private static let buildFingerprint = "mc2-pr1-v1-2026-07-12"
 
     var body: some View {
         NavigationView {

--- a/ios/LFAEducationCenter/MultiCamera/MultiCameraLobbyView.swift
+++ b/ios/LFAEducationCenter/MultiCamera/MultiCameraLobbyView.swift
@@ -519,7 +519,11 @@ struct MultiCameraLobbyView: View {
                     Text("Várakozás az instructor-ra…")
                         .font(.caption).foregroundColor(.secondary)
                 }
-                if captureManager.state == .idle || captureManager.state == .requestingPermissions {
+                // MC2-PR1: a non-recording coordinator must never open a local
+                // capture session — hide Prepare Capture and drop the local
+                // capture-readiness requirement from the Begin Cycle gate.
+                if vm.localCaptureExpected,
+                   captureManager.state == .idle || captureManager.state == .requestingPermissions {
                     Button("Prepare Capture") {
                         Task {
                             await captureManager.requestPermissions()
@@ -530,7 +534,8 @@ struct MultiCameraLobbyView: View {
                     }
                     .disabled(captureManager.state == .requestingPermissions)
                 }
-                if vm.isController && vm.canStartCapture && captureManager.state == .ready {
+                if vm.isController && vm.canStartCapture
+                    && (!vm.localCaptureExpected || captureManager.state == .ready) {
                     Button("Begin Cycle") { vm.beginCycle() }
                         .font(.body.weight(.semibold))
                         .foregroundColor(.blue)

--- a/ios/LFAEducationCenter/MultiCamera/MultiCameraLobbyView.swift
+++ b/ios/LFAEducationCenter/MultiCamera/MultiCameraLobbyView.swift
@@ -50,7 +50,7 @@ struct MultiCameraLobbyView: View {
         ))
     }
 
-    private static let buildFingerprint = "mc1-debug-v12-2026-07-04"
+    private static let buildFingerprint = "mc1-debug-v13-2026-07-12"
 
     var body: some View {
         NavigationView {

--- a/ios/LFAEducationCenter/MultiCamera/MultiCameraLobbyView.swift
+++ b/ios/LFAEducationCenter/MultiCamera/MultiCameraLobbyView.swift
@@ -50,7 +50,7 @@ struct MultiCameraLobbyView: View {
         ))
     }
 
-    private static let buildFingerprint = "mc1-debug-v11-2026-06-28"
+    private static let buildFingerprint = "mc1-debug-v12-2026-07-04"
 
     var body: some View {
         NavigationView {
@@ -110,64 +110,64 @@ struct MultiCameraLobbyView: View {
             let action = envelope.action
             switch action {
             case .joinSession(let uuid, let role):
-                print("[MC1-AUTO] dispatching action=join uuid=\(uuid) role=\(role) state=\(vm.state)")
+                MC1Log.notice("[MC1-AUTO] dispatching action=join uuid=\(uuid) role=\(role) state=\(vm.state)")
                 vm.joinSession(uuid: uuid, role: role)
             case .markDevicesReady:
-                print("[MC1-AUTO] dispatching action=mark-ready state=\(vm.state)")
+                MC1Log.notice("[MC1-AUTO] dispatching action=mark-ready state=\(vm.state)")
                 vm.transitionToDevicesReady()
             case .beginCycle:
-                print("[MC1-AUTO] dispatching action=begin-cycle state=\(vm.state) canStartCapture=\(vm.canStartCapture) isClockSynced=\(vm.isClockSynced)")
+                MC1Log.notice("[MC1-AUTO] dispatching action=begin-cycle state=\(vm.state) canStartCapture=\(vm.canStartCapture) isClockSynced=\(vm.isClockSynced)")
                 vm.beginCycle()
             case .endCycle:
-                print("[MC1-AUTO] dispatching action=end-cycle state=\(vm.state)")
+                MC1Log.notice("[MC1-AUTO] dispatching action=end-cycle state=\(vm.state)")
                 vm.endCycle()
             case .dumpSnapshot:
-                print("[MC1-AUTO] dispatching action=dump-snapshot")
+                MC1Log.notice("[MC1-AUTO] dispatching action=dump-snapshot")
                 dumpSnapshotToConsole()
             case .resetSession:
-                print("[MC1-AUTO] dispatching action=reset-session state=\(vm.state) capture=\(captureManager.state)")
+                MC1Log.notice("[MC1-AUTO] dispatching action=reset-session state=\(vm.state) capture=\(captureManager.state)")
                 vm.reset()
                 captureManager.resetForReuse()
             case .goProConnect(let goProDeviceId):
                 let gp = GoProConnectionManager.shared
-                print("[GOPRO-AUTO] dispatching gopro-connect connection=\(gp.state) goProDeviceId=\(goProDeviceId ?? -1)")
+                MC1Log.notice("[GOPRO-AUTO] dispatching gopro-connect connection=\(gp.state) goProDeviceId=\(goProDeviceId ?? -1)")
                 if case .ready = gp.state {
-                    print("[GOPRO-AUTO] already connected+ready")
+                    MC1Log.notice("[GOPRO-AUTO] already connected+ready")
                     Task { await self.signalGoProReady(goProDeviceId: goProDeviceId) }
                 } else if case .awaitingManualWiFiJoin = gp.state {
-                    print("[GOPRO-AUTO] attempting confirmManualWiFiJoined...")
+                    MC1Log.notice("[GOPRO-AUTO] attempting confirmManualWiFiJoined...")
                     gp.confirmManualWiFiJoined()
                     Task { await self.waitAndSignalGoProReady(goProDeviceId: goProDeviceId) }
                 } else if case .failed(let err) = gp.state, err.isRecoverable {
-                    print("[GOPRO-AUTO] retrying from failed state...")
+                    MC1Log.notice("[GOPRO-AUTO] retrying from failed state...")
                     gp.retry()
                     Task { await self.waitAndSignalGoProReady(goProDeviceId: goProDeviceId) }
                 } else if gp.state == .idle {
-                    print("[GOPRO-AUTO] starting fresh connection...")
+                    MC1Log.notice("[GOPRO-AUTO] starting fresh connection...")
                     gp.startConnection()
                     Task { await self.waitAndSignalGoProReady(goProDeviceId: goProDeviceId) }
                 } else {
-                    print("[GOPRO-AUTO] cannot connect from state=\(gp.state)")
+                    MC1Log.notice("[GOPRO-AUTO] cannot connect from state=\(gp.state)")
                 }
             case .goProStartRecording(let goProDeviceId):
                 let gp = GoProConnectionManager.shared
-                print("[GOPRO-AUTO] dispatching gopro-start connection=\(gp.state) recording=\(gp.recordingState) goProDeviceId=\(goProDeviceId)")
+                MC1Log.notice("[GOPRO-AUTO] dispatching gopro-start connection=\(gp.state) recording=\(gp.recordingState) goProDeviceId=\(goProDeviceId)")
                 Task {
                     do {
                         try await gp.startRecording()
-                        print("[GOPRO-AUTO] shutter start OK, confirming to backend...")
+                        MC1Log.notice("[GOPRO-AUTO] shutter start OK, confirming to backend...")
                         guard let token = vm.authManager.accessToken,
                               let sessionUuid = vm.sessionUuid else {
-                            print("[GOPRO-AUTO] confirm skipped: no auth/session")
+                            MC1Log.notice("[GOPRO-AUTO] confirm skipped: no auth/session")
                             return
                         }
                         let cycles = try await MultiCameraAPIClient.listCycles(token: token, uuid: sessionUuid)
                         guard let cycle = cycles.max(by: { $0.cycleIndex < $1.cycleIndex }) else {
-                            print("[GOPRO-AUTO] confirm skipped: no cycle found")
+                            MC1Log.notice("[GOPRO-AUTO] confirm skipped: no cycle found")
                             return
                         }
                         guard let cd = cycle.cycleDevices.first(where: { $0.sessionDeviceId == goProDeviceId }) else {
-                            print("[GOPRO-AUTO] confirm skipped: no cycle_device for GoPro")
+                            MC1Log.notice("[GOPRO-AUTO] confirm skipped: no cycle_device for GoPro")
                             return
                         }
                         let ts = Self.isoNow()
@@ -176,30 +176,30 @@ struct MultiCameraLobbyView: View {
                             sessionDeviceId: goProDeviceId, startedAt: ts,
                             cycleDeviceRevision: cd.revision
                         )
-                        print("[GOPRO-AUTO] confirmDeviceStart OK cycleId=\(cycle.id)")
+                        MC1Log.notice("[GOPRO-AUTO] confirmDeviceStart OK cycleId=\(cycle.id)")
                     } catch {
-                        print("[GOPRO-AUTO] start FAILED: \(error)")
+                        MC1Log.notice("[GOPRO-AUTO] start FAILED: \(error)")
                     }
                 }
             case .goProStopRecording(let goProDeviceId):
                 let gp = GoProConnectionManager.shared
-                print("[GOPRO-AUTO] dispatching gopro-stop connection=\(gp.state) recording=\(gp.recordingState) goProDeviceId=\(goProDeviceId)")
+                MC1Log.notice("[GOPRO-AUTO] dispatching gopro-stop connection=\(gp.state) recording=\(gp.recordingState) goProDeviceId=\(goProDeviceId)")
                 Task {
                     do {
                         try await gp.stopRecording()
-                        print("[GOPRO-AUTO] shutter stop OK, confirming to backend...")
+                        MC1Log.notice("[GOPRO-AUTO] shutter stop OK, confirming to backend...")
                         guard let token = vm.authManager.accessToken,
                               let sessionUuid = vm.sessionUuid else {
-                            print("[GOPRO-AUTO] confirm skipped: no auth/session")
+                            MC1Log.notice("[GOPRO-AUTO] confirm skipped: no auth/session")
                             return
                         }
                         let cycles = try await MultiCameraAPIClient.listCycles(token: token, uuid: sessionUuid)
                         guard let cycle = cycles.max(by: { $0.cycleIndex < $1.cycleIndex }) else {
-                            print("[GOPRO-AUTO] confirm skipped: no cycle found")
+                            MC1Log.notice("[GOPRO-AUTO] confirm skipped: no cycle found")
                             return
                         }
                         guard let cd = cycle.cycleDevices.first(where: { $0.sessionDeviceId == goProDeviceId }) else {
-                            print("[GOPRO-AUTO] confirm skipped: no cycle_device for GoPro")
+                            MC1Log.notice("[GOPRO-AUTO] confirm skipped: no cycle_device for GoPro")
                             return
                         }
                         let ts = Self.isoNow()
@@ -208,81 +208,81 @@ struct MultiCameraLobbyView: View {
                             sessionDeviceId: goProDeviceId, stoppedAt: ts,
                             cycleDeviceRevision: cd.revision
                         )
-                        print("[GOPRO-AUTO] confirmDeviceStop OK cycleId=\(cycle.id)")
+                        MC1Log.notice("[GOPRO-AUTO] confirmDeviceStop OK cycleId=\(cycle.id)")
                     } catch {
-                        print("[GOPRO-AUTO] stop FAILED: \(error)")
+                        MC1Log.notice("[GOPRO-AUTO] stop FAILED: \(error)")
                     }
                 }
             case .goProHttpDiag:
-                print("[GOPRO-DIAG] === GoPro HERO13 HTTP Diagnostics ===")
+                MC1Log.notice("[GOPRO-DIAG] === GoPro HERO13 HTTP Diagnostics ===")
                 let gp = GoProConnectionManager.shared
-                print("[GOPRO-DIAG] connection_state=\(gp.state)")
-                print("[GOPRO-DIAG] recording_state=\(gp.recordingState)")
-                print("[GOPRO-DIAG] camera_status=\(String(describing: gp.cameraStatus))")
+                MC1Log.notice("[GOPRO-DIAG] connection_state=\(gp.state)")
+                MC1Log.notice("[GOPRO-DIAG] recording_state=\(gp.recordingState)")
+                MC1Log.notice("[GOPRO-DIAG] camera_status=\(String(describing: gp.cameraStatus))")
                 Task {
                     let transport = GoProHTTPClientTransport()
 
                     // 1. HTTP reachability
                     let reachable = await transport.isReachable(timeout: 5)
-                    print("[GOPRO-DIAG] http_reachable=\(reachable)")
+                    MC1Log.notice("[GOPRO-DIAG] http_reachable=\(reachable)")
 
                     // 2. Camera state (firmware version, battery, recording)
                     do {
                         let data = try await transport.get(path: GoProSpec.cameraStatePath, timeout: 5)
                         let text = String(data: data, encoding: .utf8) ?? "(binary \(data.count)B)"
-                        print("[GOPRO-DIAG] camera_state_response=\(text.prefix(800))")
+                        MC1Log.notice("[GOPRO-DIAG] camera_state_response=\(text.prefix(800))")
                     } catch {
-                        print("[GOPRO-DIAG] camera_state_error=\(error)")
+                        MC1Log.notice("[GOPRO-DIAG] camera_state_error=\(error)")
                     }
 
                     // 3. Preview stream start endpoint (HERO13 validation)
-                    print("[GOPRO-DIAG] testing preview stream: GET \(GoProSpec.streamStartPath)...")
+                    MC1Log.notice("[GOPRO-DIAG] testing preview stream: GET \(GoProSpec.streamStartPath)...")
                     do {
                         let data = try await transport.get(path: GoProSpec.streamStartPath, timeout: 5)
                         let text = String(data: data, encoding: .utf8) ?? "(binary \(data.count)B)"
-                        print("[GOPRO-DIAG] stream_start_response=\(text.prefix(500))")
-                        print("[GOPRO-DIAG] stream_start=SUCCESS — preview should be available on UDP:\(GoProSpec.previewStreamPort)")
+                        MC1Log.notice("[GOPRO-DIAG] stream_start_response=\(text.prefix(500))")
+                        MC1Log.notice("[GOPRO-DIAG] stream_start=SUCCESS — preview should be available on UDP:\(GoProSpec.previewStreamPort)")
                     } catch {
-                        print("[GOPRO-DIAG] stream_start_error=\(error)")
+                        MC1Log.notice("[GOPRO-DIAG] stream_start_error=\(error)")
                     }
 
                     // 4. Preview stream stop (cleanup)
                     do {
                         _ = try await transport.get(path: GoProSpec.streamStopPath, timeout: 5)
-                        print("[GOPRO-DIAG] stream_stop=OK")
+                        MC1Log.notice("[GOPRO-DIAG] stream_stop=OK")
                     } catch {
-                        print("[GOPRO-DIAG] stream_stop_error=\(error)")
+                        MC1Log.notice("[GOPRO-DIAG] stream_stop_error=\(error)")
                     }
 
                     // 5. Backend reachable (cellular alongside GoPro WiFi)
                     if let token = vm.authManager.accessToken {
                         do {
                             let session = try await MultiCameraAPIClient.getSession(token: token, uuid: vm.sessionUuid ?? "none")
-                            print("[GOPRO-DIAG] backend_reachable=true session_status=\(session.status.rawValue)")
+                            MC1Log.notice("[GOPRO-DIAG] backend_reachable=true session_status=\(session.status.rawValue)")
                         } catch {
-                            print("[GOPRO-DIAG] backend_reachable=false error=\(error)")
+                            MC1Log.notice("[GOPRO-DIAG] backend_reachable=false error=\(error)")
                         }
                     } else {
-                        print("[GOPRO-DIAG] backend_reachable=unknown (no token)")
+                        MC1Log.notice("[GOPRO-DIAG] backend_reachable=unknown (no token)")
                     }
-                    print("[GOPRO-DIAG] === end ===")
+                    MC1Log.notice("[GOPRO-DIAG] === end ===")
                 }
             case .goProStatus:
                 let gp = GoProConnectionManager.shared
-                print("[GOPRO-AUTO] status connection=\(gp.state) recording=\(gp.recordingState) battery=\(gp.cameraStatus?.batteryLevel ?? -1)")
+                MC1Log.notice("[GOPRO-AUTO] status connection=\(gp.state) recording=\(gp.recordingState) battery=\(gp.cameraStatus?.batteryLevel ?? -1)")
             case .goProMediaList:
                 let gp = GoProConnectionManager.shared
-                print("[GOPRO-AUTO] fetching media list...")
+                MC1Log.notice("[GOPRO-AUTO] fetching media list...")
                 Task {
                     if let data = await gp.fetchMediaList(),
                        let text = String(data: data, encoding: .utf8) {
-                        print("[GOPRO-MEDIA-BEGIN]\n\(text)\n[GOPRO-MEDIA-END]")
+                        MC1Log.notice("[GOPRO-MEDIA-BEGIN]\n\(text)\n[GOPRO-MEDIA-END]")
                     } else {
-                        print("[GOPRO-AUTO] media list: unavailable")
+                        MC1Log.notice("[GOPRO-AUTO] media list: unavailable")
                     }
                 }
             case .goProDownloadLatest:
-                print("[GOPRO-AUTO] downloading latest GoPro media...")
+                MC1Log.notice("[GOPRO-AUTO] downloading latest GoPro media...")
                 Task {
                     let gp = GoProConnectionManager.shared
                     guard let listData = await gp.fetchMediaList(),
@@ -293,11 +293,11 @@ struct MultiCameraLobbyView: View {
                           let lastFile = files.last,
                           let filename = lastFile["n"] as? String,
                           let dirName = lastDir["d"] as? String else {
-                        print("[GOPRO-AUTO] download: no media found")
+                        MC1Log.notice("[GOPRO-AUTO] download: no media found")
                         return
                     }
                     let path = "\(GoProSpec.mediaDownloadBase)/\(dirName)/\(filename)"
-                    print("[GOPRO-AUTO] downloading: \(path)...")
+                    MC1Log.notice("[GOPRO-AUTO] downloading: \(path)...")
                     let transport = GoProHTTPClientTransport()
                     do {
                         let data = try await transport.get(path: path, timeout: 60)
@@ -305,24 +305,24 @@ struct MultiCameraLobbyView: View {
                         try? FileManager.default.createDirectory(at: outputDir, withIntermediateDirectories: true)
                         let outputFile = outputDir.appendingPathComponent(filename)
                         try data.write(to: outputFile)
-                        print("[GOPRO-DOWNLOAD] saved: \(outputFile.path) size=\(data.count)")
+                        MC1Log.notice("[GOPRO-DOWNLOAD] saved: \(outputFile.path) size=\(data.count)")
                     } catch {
-                        print("[GOPRO-AUTO] download failed: \(error)")
+                        MC1Log.notice("[GOPRO-AUTO] download failed: \(error)")
                     }
                 }
             case .skeletonProcess:
-                print("[SKELETON] starting skeleton processing on local video...")
+                MC1Log.notice("[SKELETON] starting skeleton processing on local video...")
                 Task {
                     let processor = SkeletonProcessor()
                     guard let videoURL = captureManager.outputFileURL else {
-                        print("[SKELETON] no local video file to process")
+                        MC1Log.notice("[SKELETON] no local video file to process")
                         return
                     }
                     let sessionUuid = vm.sessionUuid ?? "unknown"
                     let deviceId = vm.sessionDeviceId.map { "\($0)" } ?? "unknown"
                     await processor.process(videoURL: videoURL, sessionUuid: sessionUuid, deviceId: deviceId)
                     if case .failed(let msg) = processor.state {
-                        print("[SKELETON-RESULT] FAILED: \(msg)")
+                        MC1Log.notice("[SKELETON-RESULT] FAILED: \(msg)")
                     }
                 }
             case .captureInfo:
@@ -331,7 +331,7 @@ struct MultiCameraLobbyView: View {
                     guard let url = fileURL else { return 0 }
                     return (try? FileManager.default.attributesOfItem(atPath: url.path)[.size] as? Int) ?? 0
                 }()
-                print("[CAPTURE-INFO] state=\(captureManager.state) outputFile=\(fileURL?.path ?? "nil") size=\(fileSize)")
+                MC1Log.notice("[CAPTURE-INFO] state=\(captureManager.state) outputFile=\(fileURL?.path ?? "nil") size=\(fileSize)")
                 CaptureMetadataDiagWriter.write(from: captureManager)
             case .networkRoutingDiag(let label):
                 Task { await BackendNetworkDiagnostics.probe(label: label) }
@@ -352,14 +352,14 @@ struct MultiCameraLobbyView: View {
                 }
             case .goProPreviewAspectProbe(let durationSeconds):
                 Task {
-                    print("[GOPRO-PREVIEW-ASPECT] starting live preview (camera/state probe has NO preview — this one does)...")
+                    MC1Log.notice("[GOPRO-PREVIEW-ASPECT] starting live preview (camera/state probe has NO preview — this one does)...")
                     let diag = await GoProStreamProbe.shared.run(durationSeconds: durationSeconds)
                     GoProStreamDiagWriter.write(diag)
                     GoProPreviewAspectDiagWriter.write(from: diag)
                 }
             case .goProPresetWriteValidation:
                 Task {
-                    print("[GOPRO-PRESET-POC] starting 8:7 preset read/write/verify/recording/preview chain...")
+                    MC1Log.notice("[GOPRO-PRESET-POC] starting 8:7 preset read/write/verify/recording/preview chain...")
                     _ = await GoProRecordingPresetProbe.run()
                 }
             case .goProStreamStart:
@@ -374,7 +374,7 @@ struct MultiCameraLobbyView: View {
                 // so a silently-failed GoPro preview was invisible to anything but a
                 // human eyeballing the dashboard screenshot (2026-07-01 flow audit).
                 Task {
-                    print("[MC1-AUTO] gopro-stream-start → GoProStreamProbe.shared.run(60s)")
+                    MC1Log.notice("[MC1-AUTO] gopro-stream-start → GoProStreamProbe.shared.run(60s)")
                     let diag = await GoProStreamProbe.shared.run(durationSeconds: 60)
                     GoProStreamDiagWriter.write(diag)
                 }
@@ -414,9 +414,11 @@ struct MultiCameraLobbyView: View {
                     playerOrchestrator: playerOrchestrator
                 )
                 .onAppear {
-                    framePublisher.configure()
                     playerStreamService.start()
-                    framePublisher.startCapture(streamService: playerStreamService)
+                    // Single-session camera ownership (2026-07-04 RCA): the publisher
+                    // taps captureManager's session instead of opening a second
+                    // AVCaptureSession on the same camera.
+                    framePublisher.startCapture(sharing: captureManager, streamService: playerStreamService)
                 }
                 .onDisappear {
                     framePublisher.stopCapture()
@@ -697,7 +699,7 @@ struct MultiCameraLobbyView: View {
         guard let did = goProDeviceId,
               let token = vm.authManager.accessToken,
               let sessionUuid = vm.sessionUuid else {
-            print("[GOPRO-AUTO] signalReady skipped: no deviceId/auth/session")
+            MC1Log.notice("[GOPRO-AUTO] signalReady skipped: no deviceId/auth/session")
             GoProDiagRecorder.write(
                 goProDeviceId: goProDeviceId, localState: "\(GoProConnectionManager.shared.state)",
                 outcome: "skipped_no_context", httpStatus: nil, detail: nil
@@ -706,7 +708,7 @@ struct MultiCameraLobbyView: View {
         }
         // Log gopro connection state at call time — if we're on GoPro WiFi here,
         // the APIClient.backendSession (waitsForConnectivity=true) handles routing.
-        print("[GOPRO-AUTO] signalReady: deviceId=\(did) gopro_state=\(GoProConnectionManager.shared.state)")
+        MC1Log.notice("[GOPRO-AUTO] signalReady: deviceId=\(did) gopro_state=\(GoProConnectionManager.shared.state)")
         // session_device.revision server_default is 1, not 0 (see
         // app/models/multicamera_session.py) — a freshly-registered device is
         // already at revision=1. Fetch the current revision instead of
@@ -718,7 +720,7 @@ struct MultiCameraLobbyView: View {
         }
         do {
             let sd = try await updateGoProStatus(token: token, sessionUuid: sessionUuid, did: did, revision: revision)
-            print("[GOPRO-AUTO] signalReady OK: GoPro device \(did) → ready (rev=\(sd.revision))")
+            MC1Log.notice("[GOPRO-AUTO] signalReady OK: GoPro device \(did) → ready (rev=\(sd.revision))")
             GoProDiagRecorder.write(
                 goProDeviceId: did, localState: "\(GoProConnectionManager.shared.state)",
                 outcome: "signalReady_ok", httpStatus: nil, detail: "revision=\(sd.revision)"
@@ -735,7 +737,7 @@ struct MultiCameraLobbyView: View {
                let device = session.devices.first(where: { $0.id == did }) {
                 do {
                     let sd = try await updateGoProStatus(token: token, sessionUuid: sessionUuid, did: did, revision: device.revision)
-                    print("[GOPRO-AUTO] signalReady OK after 409 retry: GoPro device \(did) → ready (rev=\(sd.revision))")
+                    MC1Log.notice("[GOPRO-AUTO] signalReady OK after 409 retry: GoPro device \(did) → ready (rev=\(sd.revision))")
                     GoProDiagRecorder.write(
                         goProDeviceId: did, localState: "\(GoProConnectionManager.shared.state)",
                         outcome: "signalReady_ok_after_409_retry", httpStatus: nil, detail: "revision=\(sd.revision)"
@@ -745,7 +747,7 @@ struct MultiCameraLobbyView: View {
                     let retryHttpErr = (error as? APIError).flatMap {
                         if case .httpError(let code, let detail) = $0 { return (code, detail) } else { return nil }
                     }
-                    print("[GOPRO-AUTO] signalReady FAILED after 409 retry: \(error)")
+                    MC1Log.notice("[GOPRO-AUTO] signalReady FAILED after 409 retry: \(error)")
                     GoProDiagRecorder.write(
                         goProDeviceId: did, localState: "\(GoProConnectionManager.shared.state)",
                         outcome: "signalReady_failed_after_409_retry",
@@ -758,7 +760,7 @@ struct MultiCameraLobbyView: View {
                 if case .networkError(let e) = $0 { return e as? URLError } else { return nil }
             }
             let errDetail = urlErr.map { "URLError(\($0.code.rawValue))" } ?? "\(error)"
-            print("[GOPRO-AUTO] signalReady FAILED: \(errDetail)")
+            MC1Log.notice("[GOPRO-AUTO] signalReady FAILED: \(errDetail)")
             GoProDiagRecorder.write(
                 goProDeviceId: did, localState: "\(GoProConnectionManager.shared.state)",
                 outcome: "signalReady_failed", httpStatus: httpErr?.0, detail: httpErr?.1 ?? errDetail
@@ -779,12 +781,12 @@ struct MultiCameraLobbyView: View {
         while Date() < deadline {
             try? await Task.sleep(nanoseconds: 1_000_000_000)
             if case .ready = gp.state {
-                print("[GOPRO-AUTO] GoPro reached .ready state")
+                MC1Log.notice("[GOPRO-AUTO] GoPro reached .ready state")
                 await signalGoProReady(goProDeviceId: goProDeviceId)
                 return
             }
             if case .failed(let err) = gp.state {
-                print("[GOPRO-AUTO] GoPro connect failed: \(err)")
+                MC1Log.notice("[GOPRO-AUTO] GoPro connect failed: \(err)")
                 GoProDiagRecorder.write(
                     goProDeviceId: goProDeviceId, localState: "\(gp.state)",
                     outcome: "connect_failed", httpStatus: nil, detail: "\(err)"
@@ -792,7 +794,7 @@ struct MultiCameraLobbyView: View {
                 return
             }
         }
-        print("[GOPRO-AUTO] GoPro connect timeout (45s), state=\(gp.state)")
+        MC1Log.notice("[GOPRO-AUTO] GoPro connect timeout (45s), state=\(gp.state)")
         GoProDiagRecorder.write(
             goProDeviceId: goProDeviceId, localState: "\(gp.state)",
             outcome: "wait_timeout_45s", httpStatus: nil, detail: nil
@@ -819,7 +821,7 @@ struct MultiCameraLobbyView: View {
         } else {
             text = "=== MC1 Session Lab Debug Snapshot ===\nstate: \(vm.state)\n======================================"
         }
-        print("[MC1-SNAPSHOT-BEGIN]\n\(text)\n[MC1-SNAPSHOT-END]")
+        MC1Log.notice("[MC1-SNAPSHOT-BEGIN]\n\(text)\n[MC1-SNAPSHOT-END]")
     }
 
     // MARK: — Error
@@ -922,8 +924,9 @@ private struct LabeledRow: View {
 
 // MARK: — GoPro ready-signal diagnostics (Block 1)
 //
-// idevicesyslog does not reliably capture Swift print() output on physical
-// devices (privacy redaction varies by attach timing/lock state), so the
+// idevicesyslog never captures Swift print() output on physical devices
+// (stdout is invisible to the syslog relay — proven by the 2026-07-04 run's
+// zero app-tagged lines; console lines now go through MC1Log/os_log), so the
 // outcome of every signalGoProReady attempt is also persisted to a fixed
 // path in the app's Documents directory. The regression script pulls this
 // file directly via `devicectl device copy from --domain-type

--- a/ios/LFAEducationCenter/MultiCamera/MultiCameraSessionViewModel.swift
+++ b/ios/LFAEducationCenter/MultiCamera/MultiCameraSessionViewModel.swift
@@ -174,6 +174,7 @@ final class MultiCameraSessionViewModel: ObservableObject {
               canStartCapture,
               case .inLobby(let session) = state,
               let sdId = sessionDeviceId else { return }
+        cycleOrchestrator?.recordsLocally = localCaptureExpected
         cycleOrchestrator?.startCycle(
             sessionUuid: session.sessionUuid,
             sessionDeviceId: sdId,
@@ -355,11 +356,23 @@ final class MultiCameraSessionViewModel: ObservableObject {
 
     static func shouldAutoPrepare(deviceRole: MCDeviceRole) -> Bool {
         switch deviceRole {
-        case .instructorPrimary, .playerPrimary, .playerSecondary:
+        case .playerPrimary, .playerSecondary:
             return true
-        case .auxiliaryCamera:
+        case .instructorPrimary, .auxiliaryCamera:
+            // MC2-PR1 final topology: the instructor (iPad) is a non-recording
+            // coordinator — it must never open a capture session or produce a
+            // capture file. Auxiliary (GoPro) capture is driven over HTTP.
             return false
         }
+    }
+
+    /// True when this device is expected to produce a local capture file
+    /// during a cycle. Single source of truth = shouldAutoPrepare: a device
+    /// that never prepares a capture session must not be treated as a
+    /// recorder anywhere else (begin-cycle gate, CCO, dashboard panel).
+    var localCaptureExpected: Bool {
+        guard let role = myDeviceRole else { return true }
+        return Self.shouldAutoPrepare(deviceRole: role)
     }
 
     /// Explicit POSITIVE allow-list — only these device roles may attach a

--- a/ios/LFAEducationCenter/MultiCamera/MultiCameraSessionViewModel.swift
+++ b/ios/LFAEducationCenter/MultiCamera/MultiCameraSessionViewModel.swift
@@ -210,7 +210,7 @@ final class MultiCameraSessionViewModel: ObservableObject {
             let sd = try await MultiCameraAPIClient.registerDevice(token: token, uuid: sessionUuid, request: request)
             sessionDeviceId = sd.id
             deviceRegisterError = nil
-            print("[LobbyVM] autoRegisterDevice: OK sdId=\(sd.id)")
+            MC1Log.notice("[LobbyVM] autoRegisterDevice: OK sdId=\(sd.id)")
             // Attach PCO immediately after registration — must not be gated on updateDeviceStatus.
             // If updateDeviceStatus throws (revision conflict, network), PCO would never subscribe
             // to PCL state changes and the player would stay "pending" forever.
@@ -236,13 +236,13 @@ final class MultiCameraSessionViewModel: ObservableObject {
                     sessionDeviceId: sd.id, targetStatus: .ready,
                     deviceRevision: sd.revision
                 )
-                print("[LobbyVM] autoRegisterDevice: device \(sd.id) → ready")
+                MC1Log.notice("[LobbyVM] autoRegisterDevice: device \(sd.id) → ready")
             } catch {
-                print("[LobbyVM] autoRegisterDevice: updateDeviceStatus FAILED (non-fatal) error=\(error)")
+                MC1Log.notice("[LobbyVM] autoRegisterDevice: updateDeviceStatus FAILED (non-fatal) error=\(error)")
             }
         } catch {
             deviceRegisterError = "\(error)"
-            print("[LobbyVM] autoRegisterDevice: FAILED error=\(error)")
+            MC1Log.notice("[LobbyVM] autoRegisterDevice: FAILED error=\(error)")
         }
     }
 

--- a/ios/LFAEducationCenter/MultiCamera/PlayerCaptureOrchestrator.swift
+++ b/ios/LFAEducationCenter/MultiCamera/PlayerCaptureOrchestrator.swift
@@ -21,6 +21,15 @@ final class PlayerCaptureOrchestrator: ObservableObject {
 
     // MARK: — Constants
     private static let scheduledStartToleranceMs: Double = 2_000
+    /// How long startCapture() may take to reach `.capturing` before the
+    /// orchestrator declares failure instead of hanging silently. A healthy
+    /// AVCaptureMovieFileOutput.startRecording fires didStartRecording well
+    /// under 1s; 5s is >10x that margin while still finishing INSIDE the
+    /// harness's confirmed_start poll window, so the failure is visible as a
+    /// concrete `.failed` state + diag artifact rather than a bare scenario
+    /// timeout (2026-07-04 tricamera physical run RCA: the player hung in
+    /// .waitingForStart forever with zero evidence).
+    static let captureStartWatchdogSeconds: Double = 5
 
     // MARK: — Published state
     // didSet logs key transitions for MC1-AUTO-1 console-based physical validation —
@@ -28,9 +37,15 @@ final class PlayerCaptureOrchestrator: ObservableObject {
     @Published private(set) var state: PlayerOrchestratorState = .idle {
         didSet {
             switch state {
-            case .confirmed(let cycleId): print("[PCO] confirmed start: cycleId=\(cycleId)")
-            case .confirmedStop(let cycleId): print("[PCO] confirmed stop: cycleId=\(cycleId)")
-            case .failed(let message): print("[PCO] FAILURE: \(message)")
+            case .confirmed(let cycleId): MC1Log.notice("[PCO] confirmed start: cycleId=\(cycleId)")
+            case .confirmedStop(let cycleId): MC1Log.notice("[PCO] confirmed stop: cycleId=\(cycleId)")
+            case .failed(let message):
+                MC1Log.notice("[PCO] FAILURE: \(message)")
+                PCOFailureDiagWriter.write(
+                    reason: message,
+                    cycleId: activeCycle?.id,
+                    captureState: lastObservedCaptureState.map { "\($0)" }
+                )
             default: break
             }
         }
@@ -42,6 +57,14 @@ final class PlayerCaptureOrchestrator: ObservableObject {
     private let captureController: CaptureController
     private let cycleAPIClient: CycleAPIClient
     private let sleepProvider: (UInt64) async throws -> Void
+    /// Separate from `sleepProvider` (which tests stub to return instantly for
+    /// scheduled-start waits): the watchdog must NOT fire before the capture
+    /// state's async main-queue hop delivers `.capturing` in those same tests.
+    private let watchdogSleepProvider: (UInt64) async throws -> Void
+    /// Last capture state seen via subscribeToCaptureState — included in the
+    /// watchdog failure evidence so the diag says WHY start never committed
+    /// (e.g. "interrupted" = camera lost, "ready" = movieOutput never fired).
+    private var lastObservedCaptureState: CaptureState?
 
     // MARK: — Session context (set at attach time)
     private var sessionUuid: String?
@@ -67,6 +90,9 @@ final class PlayerCaptureOrchestrator: ObservableObject {
         cycleAPIClient: CycleAPIClient = LiveCycleAPIClient(),
         sleepProvider: @escaping (UInt64) async throws -> Void = { ns in
             try await Task.sleep(nanoseconds: ns)
+        },
+        watchdogSleepProvider: @escaping (UInt64) async throws -> Void = { ns in
+            try await Task.sleep(nanoseconds: ns)
         }
     ) {
         self.authManager = authManager
@@ -74,6 +100,7 @@ final class PlayerCaptureOrchestrator: ObservableObject {
         self.captureController = captureController
         self.cycleAPIClient = cycleAPIClient
         self.sleepProvider = sleepProvider
+        self.watchdogSleepProvider = watchdogSleepProvider
     }
 
     // MARK: — Public API
@@ -111,6 +138,7 @@ final class PlayerCaptureOrchestrator: ObservableObject {
         activeCycle = nil
         sessionUuid = nil
         playerSessionDeviceId = nil
+        lastObservedCaptureState = nil
         state = .idle
     }
 
@@ -234,6 +262,26 @@ final class PlayerCaptureOrchestrator: ObservableObject {
         captureController.rearmForNextCycle()
         subscribeToCaptureState()
         captureController.startCapture()
+        await watchCaptureStart(cycleId: cycle.id)
+    }
+
+    // MARK: — Capture-start watchdog
+    //
+    // startCapture() has silent no-op paths (SessionCaptureManager refuses when
+    // its session lost the camera) and AVFoundation paths where didStartRecording
+    // simply never fires. Without a deadline the orchestrator sat in
+    // .waitingForStart forever and the only symptom was the harness's generic
+    // confirmed_start timeout (2026-07-04 physical run).
+    private func watchCaptureStart(cycleId: Int) async {
+        do {
+            try await watchdogSleepProvider(UInt64(Self.captureStartWatchdogSeconds * 1_000_000_000))
+        } catch {
+            return  // cancelled (detach/reset or stop-detected) — no verdict
+        }
+        guard !Task.isCancelled else { return }
+        guard case .waitingForStart(let id) = state, id == cycleId else { return }
+        let captureStateLabel = lastObservedCaptureState.map { "\($0)" } ?? "never-observed"
+        state = .failed("captureStartTimeout(\(Self.captureStartWatchdogSeconds)s): capture state never reached .capturing (last=\(captureStateLabel))")
     }
 
     // MARK: — Scheduled start wait (mirrors CycleCaptureOrchestrator)
@@ -361,6 +409,7 @@ final class PlayerCaptureOrchestrator: ObservableObject {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] captureState in
                 guard let self else { return }
+                self.lastObservedCaptureState = captureState
                 if case .capturing = captureState {
                     Task { @MainActor [weak self] in
                         await self?.handleCaptureStarted()
@@ -458,5 +507,32 @@ private enum PlayerOrchestratorFailure: Error {
         case .cycleExpired(let ms):         return "cycleExpired(lagMs: \(ms))"
         case .timerError(let msg):          return "timerError: \(msg)"
         }
+    }
+}
+
+// MARK: — PCO failure diagnostics
+//
+// Structured, file-based evidence for player-side orchestration failures —
+// same rationale and pull pattern as CaptureMetadataDiagWriter (console print
+// capture is unreliable on physical devices; the regression harness copies
+// Documents/pco_failure_diag.json via devicectl on scenario failure). Written
+// on EVERY transition to .failed so the harness can distinguish "player never
+// saw the cycle" (no file) from "player saw it and failed for <reason>".
+enum PCOFailureDiagWriter {
+    static let fileName = "pco_failure_diag.json"
+
+    @MainActor
+    static func write(reason: String, cycleId: Int?, captureState: String?) {
+        let diag: [String: Any] = [
+            "timestamp": ISO8601DateFormatter().string(from: Date()),
+            "reason": reason,
+            "cycleId": cycleId ?? NSNull(),
+            "lastObservedCaptureState": captureState ?? NSNull(),
+        ]
+        guard let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first,
+              JSONSerialization.isValidJSONObject(diag),
+              let data = try? JSONSerialization.data(withJSONObject: diag, options: [.prettyPrinted]) else { return }
+        try? data.write(to: docs.appendingPathComponent(fileName), options: .atomic)
+        MC1Log.notice("[PCO] wrote \(fileName): reason=\(reason)")
     }
 }

--- a/ios/LFAEducationCenter/MultiCamera/SessionCaptureManager.swift
+++ b/ios/LFAEducationCenter/MultiCamera/SessionCaptureManager.swift
@@ -47,6 +47,12 @@ final class SessionCaptureManager: NSObject, ObservableObject {
     private var sessionUUID: String = ""
     private var deviceId: Int = 0
     private var isTornDown = false
+    /// Whether the interruption began while a recording was in flight — decides
+    /// whether interruption-end resumes to `.ready` or finalizes via stopCapture().
+    private var wasCapturingWhenInterrupted = false
+    /// Preview side-tap output currently attached to the shared session (see
+    /// attachPreviewOutput). At most one at a time.
+    private var attachedPreviewOutput: AVCaptureVideoDataOutput?
 
     var isCapturing: Bool { state == .capturing }
     var previewSession: AVCaptureSession { captureSession }
@@ -115,7 +121,7 @@ final class SessionCaptureManager: NSObject, ObservableObject {
 
         captureQueue.async { [weak self] in
             guard let self else { return }
-            let log = { (msg: String) in print("[SessionCapture] \(msg)") }
+            let log = { (msg: String) in MC1Log.notice("[SessionCapture] \(msg)") }
             log("prepare: captureQueue entered (thread: \(Thread.current))")
             assert(!Thread.isMainThread, "Capture configure must not run on main thread")
 
@@ -251,7 +257,7 @@ final class SessionCaptureManager: NSObject, ObservableObject {
             guard let self, !didComplete, !self.isTornDown else { return }
             if self.state == .configuring {
                 self.state = .failed("Kamera inicializálási timeout (\(Int(Self.prepareTimeoutSeconds))s)")
-                print("[SessionCapture] prepare: TIMEOUT after \(Self.prepareTimeoutSeconds)s")
+                MC1Log.notice("[SessionCapture] prepare: TIMEOUT after \(Self.prepareTimeoutSeconds)s")
             }
         }
     }
@@ -286,6 +292,66 @@ final class SessionCaptureManager: NSObject, ObservableObject {
         }
     }
 
+    // MARK: — Preview side-tap (single-session camera ownership)
+    //
+    // The recording session is the ONLY AVCaptureSession that may own the
+    // camera on a capture device. The 2026-07-04 tricamera physical run failed
+    // because CameraFramePublisher ran a SECOND AVCaptureSession on the same
+    // back camera: iOS gave the camera to one session, silently interrupted the
+    // other, and the player never reached confirmed_start. The preview frame
+    // stream now taps THIS session via an added AVCaptureVideoDataOutput —
+    // recording stays authoritative, preview is a side branch of the same
+    // camera pipeline.
+
+    /// Adds a preview AVCaptureVideoDataOutput to the shared session. The caller
+    /// configures the output (settings + delegate) before attaching. Runs on the
+    /// capture queue; completion is delivered on the main queue with whether the
+    /// output was actually added.
+    func attachPreviewOutput(_ output: AVCaptureVideoDataOutput,
+                             completion: @escaping @MainActor (Bool) -> Void) {
+        guard !isTornDown else {
+            Task { @MainActor in completion(false) }
+            return
+        }
+        guard attachedPreviewOutput == nil else {
+            let alreadyAttached = attachedPreviewOutput === output
+            MC1Log.notice("[SessionCapture] attachPreviewOutput: \(alreadyAttached ? "already attached" : "another preview output is attached") — skipping")
+            Task { @MainActor in completion(alreadyAttached) }
+            return
+        }
+        captureQueue.async { [weak self] in
+            guard let self else { return }
+            self.captureSession.beginConfiguration()
+            let canAdd = self.captureSession.canAddOutput(output)
+            if canAdd {
+                self.captureSession.addOutput(output)
+                OrientationMapper.applyCurrentOrientation(to: output.connection(with: .video))
+            }
+            self.captureSession.commitConfiguration()
+            DispatchQueue.main.async {
+                if canAdd { self.attachedPreviewOutput = output }
+                MC1Log.notice("[SessionCapture] attachPreviewOutput: \(canAdd ? "attached" : "canAddOutput=false")")
+                completion(canAdd)
+            }
+        }
+    }
+
+    /// Removes a previously attached preview output from the shared session.
+    /// Safe to call when nothing is attached.
+    func detachPreviewOutput() {
+        guard let output = attachedPreviewOutput else { return }
+        attachedPreviewOutput = nil
+        captureQueue.async { [weak self] in
+            guard let self else { return }
+            self.captureSession.beginConfiguration()
+            self.captureSession.removeOutput(output)
+            self.captureSession.commitConfiguration()
+            DispatchQueue.main.async {
+                MC1Log.notice("[SessionCapture] detachPreviewOutput: removed")
+            }
+        }
+    }
+
     // MARK: — Re-arm for next cycle (multi-cycle support)
 
     func rearmForNextCycle() {
@@ -315,6 +381,10 @@ final class SessionCaptureManager: NSObject, ObservableObject {
         outputFileURL = nil
         lastValidation = nil
         isTornDown = false
+        // The loop above removed every output, including an attached preview
+        // side-tap — forget it so the next attachPreviewOutput doesn't skip.
+        attachedPreviewOutput = nil
+        wasCapturingWhenInterrupted = false
         state = .idle
     }
 
@@ -382,14 +452,49 @@ final class SessionCaptureManager: NSObject, ObservableObject {
         OrientationMapper.applyCurrentOrientation(to: conn)
     }
 
-    private func handleInterruption() {
-        guard state == .capturing else { return }
-        state = .interrupted
+    // Internal (not private) — the interruption path is exercised directly by
+    // SessionCaptureManagerTests; a real AVCaptureSessionWasInterrupted cannot
+    // be triggered on the simulator (same seam as the fileOutput delegate calls).
+    func handleInterruption() {
+        switch state {
+        case .capturing:
+            wasCapturingWhenInterrupted = true
+            state = .interrupted
+        case .ready:
+            // Camera lost while armed — e.g. another AVCaptureSession claimed the
+            // device. Before this case existed, `.ready` silently survived the
+            // interruption and the next startCapture() ran against a session with
+            // no camera: movieOutput never reached didStartRecording, the player
+            // never confirmed start, and the cycle hung with zero evidence
+            // (2026-07-04 tricamera physical run RCA).
+            wasCapturingWhenInterrupted = false
+            state = .interrupted
+            MC1Log.notice("[SessionCapture] INTERRUPTED while ready — camera lost (another session claimed the device?)")
+        default:
+            break
+        }
     }
 
-    private func handleInterruptionEnded() {
-        if state == .interrupted { stopCapture() }
+    func handleInterruptionEnded() {
+        guard state == .interrupted else { return }
+        if wasCapturingWhenInterrupted {
+            stopCapture()
+        } else {
+            // Interrupted while merely armed — nothing was recording, so there is
+            // nothing to finalize; the session is running again, re-arm.
+            state = .ready
+            MC1Log.notice("[SessionCapture] interruption ended — re-armed to ready")
+        }
     }
+
+    #if DEBUG
+    /// Test-only: force a state that normally requires physical camera hardware
+    /// to reach (`.ready`, `.capturing`). Interruption-path unit tests use this
+    /// because prepare() cannot complete on the simulator.
+    func forceStateForTesting(_ forced: CaptureState) {
+        state = forced
+    }
+    #endif
 }
 
 // MARK: — CaptureController
@@ -447,10 +552,10 @@ extension SessionCaptureManager: AVCaptureFileOutputRecordingDelegate {
 
 // MARK: — Capture metadata diagnostics (Capture Quality + Metadata block)
 //
-// Structured, file-based evidence — idevicesyslog print() capture has
-// repeatedly proven unreliable on physical devices this session (see
+// Structured, file-based evidence — console capture (formerly print(), now
+// MC1Log/os_log) has repeatedly proven unreliable on physical devices (see
 // gopro_diag.json / gopro_stream_diag.json history). capture-info now
-// writes the same fields it prints, to Documents/capture_metadata_diag.json,
+// writes the same fields it logs, to Documents/capture_metadata_diag.json,
 // pulled by the regression script via the established devicectl
 // appDataContainer copy pattern.
 enum CaptureMetadataDiagWriter {
@@ -527,6 +632,6 @@ enum CaptureMetadataDiagWriter {
               JSONSerialization.isValidJSONObject(diag),
               let data = try? JSONSerialization.data(withJSONObject: diag, options: [.prettyPrinted]) else { return }
         try? data.write(to: docs.appendingPathComponent(fileName), options: .atomic)
-        print("[CAPTURE-METADATA] wrote \(fileName): \(diag)")
+        MC1Log.notice("[CAPTURE-METADATA] wrote \(fileName): \(diag)")
     }
 }

--- a/ios/LFAEducationCenter/MultiCamera/SkeletonProcessor.swift
+++ b/ios/LFAEducationCenter/MultiCamera/SkeletonProcessor.swift
@@ -112,6 +112,10 @@ final class SkeletonProcessor: ObservableObject {
         }
 
         let result: [String: Any] = [
+            // Freshness marker (P0 hardening): every runtime diag artifact carries a
+            // write-time timestamp so the regression gate can reject stale files
+            // left in Documents/ by a previous run.
+            "generated_at": ISO8601DateFormatter().string(from: Date()),
             "session_uuid": sessionUuid,
             "device_id": deviceId,
             "video_file": videoURL.lastPathComponent,

--- a/ios/LFAEducationCenterTests/MultiCamera/CaptureAuthorityTests.swift
+++ b/ios/LFAEducationCenterTests/MultiCamera/CaptureAuthorityTests.swift
@@ -123,12 +123,16 @@ final class CaptureAuthorityTests: XCTestCase {
         )
     }
 
-    // MARK: — AP-01: instructorPrimary must auto-prepare
+    // MARK: — AP-01: instructorPrimary must NOT auto-prepare (MC2-PR1)
+    //
+    // Final topology (2026-07-12): the instructor iPad is a non-recording
+    // coordinator — it must never open a capture session or produce a capture
+    // file. Flipped from `true` when MC2-PR1 landed.
 
-    func test_AP_01_shouldAutoPrepare_instructorPrimary() {
-        XCTAssertTrue(
+    func test_AP_01_shouldAutoPrepare_instructorPrimary_false() {
+        XCTAssertFalse(
             MultiCameraSessionViewModel.shouldAutoPrepare(deviceRole: .instructorPrimary),
-            "AP-01: instructorPrimary must auto-prepare capture pipeline"
+            "AP-01: instructorPrimary is a non-recording coordinator — must NOT auto-prepare"
         )
     }
 

--- a/ios/LFAEducationCenterTests/MultiCamera/CycleCaptureOrchestratorTests.swift
+++ b/ios/LFAEducationCenterTests/MultiCamera/CycleCaptureOrchestratorTests.swift
@@ -1404,4 +1404,146 @@ final class CycleCaptureOrchestratorTests: XCTestCase {
         captureController.rearmForNextCycle()
         XCTAssertEqual(captureController.rearmCallCount, 1)
     }
+
+    // MARK: — CYC-NR-01..04: non-recording coordinator (MC2-PR1)
+    //
+    // Final topology: the instructor iPad drives the cycle lifecycle but is NOT
+    // a recorder. recordsLocally == false must skip startCapture/stopCapture AND
+    // every confirm call — a confirm without a capture file would be fabricated
+    // evidence on the backend (silent fake confirmation, explicitly banned by
+    // the MC2-PR1 gates).
+
+    private func makeNonRecordingFixture(
+        apiClient: MockCycleAPIClient
+    ) async -> (CycleCaptureOrchestrator, FakeCaptureController) {
+        let clockService = await makeSyncedClockService()
+        let captureController = FakeCaptureController()
+        let orchestrator = CycleCaptureOrchestrator(
+            authManager: FakeAccessTokenProvider(),
+            clockSyncService: clockService,
+            captureController: captureController,
+            cycleAPIClient: apiClient,
+            sleepProvider: { _ in }
+        )
+        orchestrator.recordsLocally = false
+        return (orchestrator, captureController)
+    }
+
+    // CYC-NR-01: start flow reaches .capturing with ZERO capture-controller and
+    // ZERO confirm_start traffic
+    func test_CYC_NR_01_nonRecording_startReachesCapturing_noCaptureNoConfirm() async throws {
+        let apiClient = MockCycleAPIClient()
+        apiClient.scheduleResult = .success(makeTestCycle(
+            id: 1, revision: 2,
+            scheduledStartAt: futureISO(offsetSeconds: 0.001), status: .recordingPending))
+        let (orchestrator, captureController) = await makeNonRecordingFixture(apiClient: apiClient)
+
+        orchestrator.startCycle(sessionUuid: "test-uuid", sessionDeviceId: 1, sessionRevision: 1)
+
+        await waitForOrchestratorState(orchestrator) {
+            if case .capturing = $0 { return true }
+            return false
+        }
+
+        if case .capturing(let cycleId) = orchestrator.state {
+            XCTAssertEqual(cycleId, 1)
+        } else {
+            XCTFail("CYC-NR-01: expected .capturing(1), got \(orchestrator.state)")
+        }
+        XCTAssertEqual(captureController.startCallCount, 0,
+                       "CYC-NR-01: non-recording coordinator must never call startCapture")
+        XCTAssertEqual(captureController.rearmCallCount, 0,
+                       "CYC-NR-01: non-recording coordinator must never touch the capture pipeline")
+        XCTAssertEqual(apiClient.confirmStartCallCount, 0,
+                       "CYC-NR-01: confirm_start without a capture file is fabricated evidence")
+    }
+
+    // CYC-NR-02: stopCycle → .completed with ZERO stopCapture and ZERO confirm_stop
+    func test_CYC_NR_02_nonRecording_stopCompletes_noStopCaptureNoConfirm() async throws {
+        let apiClient = MockCycleAPIClient()
+        apiClient.scheduleResult = .success(makeTestCycle(
+            id: 1, revision: 2,
+            scheduledStartAt: futureISO(offsetSeconds: 0.001), status: .recordingPending))
+        let (orchestrator, captureController) = await makeNonRecordingFixture(apiClient: apiClient)
+
+        orchestrator.startCycle(sessionUuid: "test-uuid", sessionDeviceId: 1, sessionRevision: 1)
+        await waitForOrchestratorState(orchestrator) {
+            if case .capturing = $0 { return true }
+            return false
+        }
+
+        await orchestrator.stopCycle()
+
+        if case .completed(let cycleId) = orchestrator.state {
+            XCTAssertEqual(cycleId, 1)
+        } else {
+            XCTFail("CYC-NR-02: expected .completed(1), got \(orchestrator.state)")
+        }
+        XCTAssertEqual(captureController.stopCallCount, 0,
+                       "CYC-NR-02: nothing to stop locally on a non-recording coordinator")
+        XCTAssertEqual(apiClient.confirmStopCallCount, 0,
+                       "CYC-NR-02: confirm_stop without a capture file is fabricated evidence")
+    }
+
+    // CYC-NR-03: recordsLocally defaults to TRUE and the recording path still
+    // captures + confirms (regression guard for players/legacy controllers)
+    func test_CYC_NR_03_recordsLocallyDefaultsTrue_recordingPathUnchanged() async throws {
+        let apiClient = MockCycleAPIClient()
+        apiClient.scheduleResult = .success(makeTestCycle(
+            id: 1, revision: 2,
+            scheduledStartAt: futureISO(offsetSeconds: 0.001), status: .recordingPending))
+        let clockService = await makeSyncedClockService()
+        let captureController = FakeCaptureController()
+        let orchestrator = CycleCaptureOrchestrator(
+            authManager: FakeAccessTokenProvider(),
+            clockSyncService: clockService,
+            captureController: captureController,
+            cycleAPIClient: apiClient,
+            sleepProvider: { _ in }
+        )
+        XCTAssertTrue(orchestrator.recordsLocally,
+                      "CYC-NR-03: recordsLocally must default to true (recording controller)")
+
+        orchestrator.startCycle(sessionUuid: "test-uuid", sessionDeviceId: 1, sessionRevision: 1)
+        await waitForOrchestratorState(orchestrator) {
+            if case .capturing = $0 { return true }
+            return false
+        }
+
+        XCTAssertEqual(captureController.startCallCount, 1,
+                       "CYC-NR-03: recording path must still start local capture")
+        XCTAssertEqual(apiClient.confirmStartCallCount, 1,
+                       "CYC-NR-03: recording path must still send confirm_start")
+    }
+
+    // CYC-NR-04: stopCycle API error on the non-recording path → .failed, NOT a
+    // fake .completed
+    func test_CYC_NR_04_nonRecording_stopAPIError_failsNotCompleted() async throws {
+        let apiClient = MockCycleAPIClient()
+        apiClient.scheduleResult = .success(makeTestCycle(
+            id: 1, revision: 2,
+            scheduledStartAt: futureISO(offsetSeconds: 0.001), status: .recordingPending))
+        apiClient.stopResult = .failure(APIError.httpError(statusCode: 503, detail: "unavailable"))
+        let (orchestrator, captureController) = await makeNonRecordingFixture(apiClient: apiClient)
+
+        orchestrator.startCycle(sessionUuid: "test-uuid", sessionDeviceId: 1, sessionRevision: 1)
+        await waitForOrchestratorState(orchestrator) {
+            if case .capturing = $0 { return true }
+            return false
+        }
+
+        await orchestrator.stopCycle()
+
+        if case .failed(let failure) = orchestrator.state {
+            if case .apiError(let code, _) = failure {
+                XCTAssertEqual(code, 503)
+            } else {
+                XCTFail("CYC-NR-04: expected .apiError(503), got \(failure)")
+            }
+        } else {
+            XCTFail("CYC-NR-04: expected .failed, got \(orchestrator.state)")
+        }
+        XCTAssertEqual(captureController.stopCallCount, 0)
+        XCTAssertEqual(apiClient.confirmStopCallCount, 0)
+    }
 }

--- a/ios/LFAEducationCenterTests/MultiCamera/CycleCaptureOrchestratorTests.swift
+++ b/ios/LFAEducationCenterTests/MultiCamera/CycleCaptureOrchestratorTests.swift
@@ -19,9 +19,14 @@ private final class MockCycleAPIClient: CycleAPIClient {
     var createResult:        Result<CaptureCycleDTO, Error> = .success(makeTestCycle(id: 1, revision: 1))
     var scheduleResult:      Result<CaptureCycleDTO, Error> = .success(makeTestCycle(id: 1, revision: 2, scheduledStartAt: futureISO(offsetSeconds: 10), status: .recordingPending))
     var stopResult:          Result<CaptureCycleDTO, Error> = .success(makeTestCycle(id: 1, revision: 3, status: .stopping))
+    var stopRetryResult:     Result<CaptureCycleDTO, Error>? = nil
+    var listCyclesResult:    Result<[CaptureCycleDTO], Error> = .success([])
     var confirmStartResult:  Result<CaptureCycleDTO, Error> = .success(makeTestCycle(id: 1, revision: 4, status: .recording))
     var confirmStopResult:   Result<CaptureCycleDTO, Error> = .success(makeTestCycle(id: 1, revision: 5, status: .completed))
 
+    private(set) var stopCallCount                = 0
+    private(set) var listCyclesCallCount          = 0
+    private(set) var lastStopRevision: Int?       = nil
     private(set) var activateCallCount            = 0
     private(set) var getSessionCallCount          = 0
     private(set) var createCallCount              = 0
@@ -60,7 +65,17 @@ private final class MockCycleAPIClient: CycleAPIClient {
     }
 
     func stopCycle(token: String, uuid: String, cycleId: Int, revision: Int) async throws -> CaptureCycleDTO {
+        stopCallCount += 1
+        lastStopRevision = revision
+        if stopCallCount > 1, let retryResult = stopRetryResult {
+            return try retryResult.get()
+        }
         return try stopResult.get()
+    }
+
+    func listCycles(token: String, uuid: String) async throws -> [CaptureCycleDTO] {
+        listCyclesCallCount += 1
+        return try listCyclesResult.get()
     }
 
     func confirmDeviceStart(token: String, uuid: String, cycleId: Int, sessionDeviceId: Int, startedAt: String, cycleDeviceRevision: Int) async throws -> CaptureCycleDTO {
@@ -1545,5 +1560,131 @@ final class CycleCaptureOrchestratorTests: XCTestCase {
         }
         XCTAssertEqual(captureController.stopCallCount, 0)
         XCTAssertEqual(apiClient.confirmStopCallCount, 0)
+    }
+
+    // CYC-RC-05: non-recording coordinator stop with stale cached revision —
+    // first stop 409s (a player's confirm_start advanced the cycle revision
+    // invisibly), one refetch + one retry with the fresh revision succeeds.
+    // This is the exact failure of physical run 20260712T155629Z_smoke.
+    func test_CYC_RC_05_stop409_staleRevision_refetchAndRetry_success() async throws {
+        let apiClient = MockCycleAPIClient()
+        apiClient.scheduleResult = .success(makeTestCycle(
+            id: 1, revision: 2,
+            scheduledStartAt: futureISO(offsetSeconds: 0.001), status: .recordingPending))
+        apiClient.stopResult = .failure(APIError.httpError(
+            statusCode: 409, detail: "cycle: revision conflict (expected 2, actual 3)"))
+        apiClient.listCyclesResult = .success([makeTestCycle(id: 1, revision: 3, status: .recording)])
+        apiClient.stopRetryResult = .success(makeTestCycle(id: 1, revision: 4, status: .stopping))
+        let (orchestrator, captureController) = await makeNonRecordingFixture(apiClient: apiClient)
+
+        orchestrator.startCycle(sessionUuid: "test-uuid", sessionDeviceId: 1, sessionRevision: 1)
+        await waitForOrchestratorState(orchestrator) {
+            if case .capturing = $0 { return true }
+            return false
+        }
+
+        await orchestrator.stopCycle()
+
+        if case .completed(let cycleId) = orchestrator.state {
+            XCTAssertEqual(cycleId, 1)
+        } else {
+            XCTFail("CYC-RC-05: expected .completed(1), got \(orchestrator.state)")
+        }
+        XCTAssertTrue(orchestrator.revisionConflictRetried,
+                      "CYC-RC-05: the retry must be flagged for diagnostics")
+        XCTAssertEqual(apiClient.stopCallCount, 2,
+                       "CYC-RC-05: exactly one retry after the 409")
+        XCTAssertEqual(apiClient.listCyclesCallCount, 1,
+                       "CYC-RC-05: exactly one refetch")
+        XCTAssertEqual(apiClient.lastStopRevision, 3,
+                       "CYC-RC-05: retry must use the refetched revision")
+        XCTAssertEqual(captureController.stopCallCount, 0)
+        XCTAssertEqual(apiClient.confirmStopCallCount, 0,
+                       "CYC-RC-05: still no fabricated confirm on the retry path")
+    }
+
+    // CYC-RC-06: second 409 on the stop retry → terminal .revisionConflict,
+    // no infinite retry loop
+    func test_CYC_RC_06_stop409_retryAlso409_failsTerminal() async throws {
+        let apiClient = MockCycleAPIClient()
+        apiClient.scheduleResult = .success(makeTestCycle(
+            id: 1, revision: 2,
+            scheduledStartAt: futureISO(offsetSeconds: 0.001), status: .recordingPending))
+        apiClient.stopResult = .failure(APIError.httpError(statusCode: 409, detail: "conflict 1"))
+        apiClient.listCyclesResult = .success([makeTestCycle(id: 1, revision: 3, status: .recording)])
+        apiClient.stopRetryResult = .failure(APIError.httpError(statusCode: 409, detail: "conflict 2"))
+        let (orchestrator, _) = await makeNonRecordingFixture(apiClient: apiClient)
+
+        orchestrator.startCycle(sessionUuid: "test-uuid", sessionDeviceId: 1, sessionRevision: 1)
+        await waitForOrchestratorState(orchestrator) {
+            if case .capturing = $0 { return true }
+            return false
+        }
+
+        await orchestrator.stopCycle()
+
+        if case .failed(.revisionConflict) = orchestrator.state {
+            // expected
+        } else {
+            XCTFail("CYC-RC-06: expected .failed(.revisionConflict), got \(orchestrator.state)")
+        }
+        XCTAssertEqual(apiClient.stopCallCount, 2,
+                       "CYC-RC-06: max one retry — a second 409 must be terminal")
+        XCTAssertEqual(apiClient.listCyclesCallCount, 1)
+    }
+
+    // CYC-RC-07: refetch itself fails after the 409 → terminal .revisionConflict
+    func test_CYC_RC_07_stop409_refetchFails_failsTerminal() async throws {
+        let apiClient = MockCycleAPIClient()
+        apiClient.scheduleResult = .success(makeTestCycle(
+            id: 1, revision: 2,
+            scheduledStartAt: futureISO(offsetSeconds: 0.001), status: .recordingPending))
+        apiClient.stopResult = .failure(APIError.httpError(statusCode: 409, detail: "conflict"))
+        apiClient.listCyclesResult = .failure(APIError.httpError(statusCode: 503, detail: "unavailable"))
+        let (orchestrator, _) = await makeNonRecordingFixture(apiClient: apiClient)
+
+        orchestrator.startCycle(sessionUuid: "test-uuid", sessionDeviceId: 1, sessionRevision: 1)
+        await waitForOrchestratorState(orchestrator) {
+            if case .capturing = $0 { return true }
+            return false
+        }
+
+        await orchestrator.stopCycle()
+
+        if case .failed(.revisionConflict) = orchestrator.state {
+            // expected
+        } else {
+            XCTFail("CYC-RC-07: expected .failed(.revisionConflict), got \(orchestrator.state)")
+        }
+        XCTAssertEqual(apiClient.stopCallCount, 1,
+                       "CYC-RC-07: no blind retry when the refetch failed")
+    }
+
+    // CYC-RC-08: refetch succeeds but the cycle is missing from the list →
+    // terminal .revisionConflict, no blind retry
+    func test_CYC_RC_08_stop409_cycleMissingFromRefetch_failsTerminal() async throws {
+        let apiClient = MockCycleAPIClient()
+        apiClient.scheduleResult = .success(makeTestCycle(
+            id: 1, revision: 2,
+            scheduledStartAt: futureISO(offsetSeconds: 0.001), status: .recordingPending))
+        apiClient.stopResult = .failure(APIError.httpError(statusCode: 409, detail: "conflict"))
+        apiClient.listCyclesResult = .success([makeTestCycle(id: 99, revision: 1, status: .preparing)])
+        let (orchestrator, _) = await makeNonRecordingFixture(apiClient: apiClient)
+
+        orchestrator.startCycle(sessionUuid: "test-uuid", sessionDeviceId: 1, sessionRevision: 1)
+        await waitForOrchestratorState(orchestrator) {
+            if case .capturing = $0 { return true }
+            return false
+        }
+
+        await orchestrator.stopCycle()
+
+        if case .failed(.revisionConflict) = orchestrator.state {
+            // expected
+        } else {
+            XCTFail("CYC-RC-08: expected .failed(.revisionConflict), got \(orchestrator.state)")
+        }
+        XCTAssertEqual(apiClient.stopCallCount, 1,
+                       "CYC-RC-08: no retry without a fresh revision")
     }
 }

--- a/ios/LFAEducationCenterTests/MultiCamera/FakeCaptureController.swift
+++ b/ios/LFAEducationCenterTests/MultiCamera/FakeCaptureController.swift
@@ -9,7 +9,14 @@ final class FakeCaptureController: CaptureController {
     private(set) var startCallCount = 0
     private(set) var stopCallCount  = 0
     private(set) var rearmCallCount = 0
-    func startCapture() { startCallCount += 1; subject.send(.capturing) }
+    /// When false, startCapture() is a silent no-op that never reaches
+    /// `.capturing` — reproduces the 2026-07-04 physical failure mode
+    /// (camera lost while `.ready`) for the PCO watchdog tests.
+    var startAdvancesToCapturing = true
+    func startCapture() {
+        startCallCount += 1
+        if startAdvancesToCapturing { subject.send(.capturing) }
+    }
     func stopCapture()  {
         stopCallCount += 1
         subject.send(.stopping)

--- a/ios/LFAEducationCenterTests/MultiCamera/MC1AutomationBridgeTests.swift
+++ b/ios/LFAEducationCenterTests/MultiCamera/MC1AutomationBridgeTests.swift
@@ -19,7 +19,7 @@ final class MC1AutomationBridgeTests: XCTestCase {
         let bridge = makeBridge()
         let handled = bridge.handle(url: URL(string: "lfa-mc1://automate?action=join&session_uuid=abc-123&role=player")!)
         XCTAssertTrue(handled)
-        XCTAssertEqual(bridge.lastAction, .joinSession(uuid: "abc-123", role: .player))
+        XCTAssertEqual(bridge.lastAction?.action, .joinSession(uuid: "abc-123", role: .player))
         XCTAssertTrue(bridge.presentSessionLab)
     }
 
@@ -29,7 +29,7 @@ final class MC1AutomationBridgeTests: XCTestCase {
         let bridge = makeBridge()
         let handled = bridge.handle(url: URL(string: "lfa-mc1://automate?action=join&session_uuid=xyz-789&role=instructor")!)
         XCTAssertTrue(handled)
-        XCTAssertEqual(bridge.lastAction, .joinSession(uuid: "xyz-789", role: .instructor))
+        XCTAssertEqual(bridge.lastAction?.action, .joinSession(uuid: "xyz-789", role: .instructor))
     }
 
     // MARK: — AB-03: join with missing role defaults to player
@@ -38,7 +38,7 @@ final class MC1AutomationBridgeTests: XCTestCase {
         let bridge = makeBridge()
         let handled = bridge.handle(url: URL(string: "lfa-mc1://automate?action=join&session_uuid=def-456")!)
         XCTAssertTrue(handled)
-        XCTAssertEqual(bridge.lastAction, .joinSession(uuid: "def-456", role: .player))
+        XCTAssertEqual(bridge.lastAction?.action, .joinSession(uuid: "def-456", role: .player))
     }
 
     // MARK: — AB-04: join with missing session_uuid is rejected
@@ -55,7 +55,7 @@ final class MC1AutomationBridgeTests: XCTestCase {
         let bridge = makeBridge()
         let handled = bridge.handle(url: URL(string: "lfa-mc1://automate?action=mark-ready")!)
         XCTAssertTrue(handled)
-        XCTAssertEqual(bridge.lastAction, .markDevicesReady)
+        XCTAssertEqual(bridge.lastAction?.action, .markDevicesReady)
     }
 
     // MARK: — AB-06: begin-cycle
@@ -64,7 +64,7 @@ final class MC1AutomationBridgeTests: XCTestCase {
         let bridge = makeBridge()
         let handled = bridge.handle(url: URL(string: "lfa-mc1://automate?action=begin-cycle")!)
         XCTAssertTrue(handled)
-        XCTAssertEqual(bridge.lastAction, .beginCycle)
+        XCTAssertEqual(bridge.lastAction?.action, .beginCycle)
     }
 
     // MARK: — AB-07: end-cycle
@@ -73,7 +73,7 @@ final class MC1AutomationBridgeTests: XCTestCase {
         let bridge = makeBridge()
         let handled = bridge.handle(url: URL(string: "lfa-mc1://automate?action=end-cycle")!)
         XCTAssertTrue(handled)
-        XCTAssertEqual(bridge.lastAction, .endCycle)
+        XCTAssertEqual(bridge.lastAction?.action, .endCycle)
     }
 
     // MARK: — AB-07b: dump-snapshot
@@ -82,7 +82,7 @@ final class MC1AutomationBridgeTests: XCTestCase {
         let bridge = makeBridge()
         let handled = bridge.handle(url: URL(string: "lfa-mc1://automate?action=dump-snapshot")!)
         XCTAssertTrue(handled)
-        XCTAssertEqual(bridge.lastAction, .dumpSnapshot)
+        XCTAssertEqual(bridge.lastAction?.action, .dumpSnapshot)
     }
 
     // MARK: — AB-08: unknown action is rejected
@@ -123,7 +123,7 @@ final class MC1AutomationBridgeTests: XCTestCase {
         let bridge = makeBridge()
         let handled = bridge.handle(url: URL(string: "lfa-mc1://automate?action=reset-session")!)
         XCTAssertTrue(handled)
-        XCTAssertEqual(bridge.lastAction, .resetSession)
+        XCTAssertEqual(bridge.lastAction?.action, .resetSession)
     }
 
     // MARK: — AB-12b: gopro-connect
@@ -132,14 +132,14 @@ final class MC1AutomationBridgeTests: XCTestCase {
         let bridge = makeBridge()
         let handled = bridge.handle(url: URL(string: "lfa-mc1://automate?action=gopro-connect&gopro_device_id=99")!)
         XCTAssertTrue(handled)
-        XCTAssertEqual(bridge.lastAction, .goProConnect(goProDeviceId: 99))
+        XCTAssertEqual(bridge.lastAction?.action, .goProConnect(goProDeviceId: 99))
     }
 
     func test_AB_12c_goProConnect_withoutDeviceId() {
         let bridge = makeBridge()
         let handled = bridge.handle(url: URL(string: "lfa-mc1://automate?action=gopro-connect")!)
         XCTAssertTrue(handled)
-        XCTAssertEqual(bridge.lastAction, .goProConnect(goProDeviceId: nil))
+        XCTAssertEqual(bridge.lastAction?.action, .goProConnect(goProDeviceId: nil))
     }
 
     // MARK: — AB-13: gopro-start
@@ -148,7 +148,7 @@ final class MC1AutomationBridgeTests: XCTestCase {
         let bridge = makeBridge()
         let handled = bridge.handle(url: URL(string: "lfa-mc1://automate?action=gopro-start&gopro_device_id=42")!)
         XCTAssertTrue(handled)
-        XCTAssertEqual(bridge.lastAction, .goProStartRecording(goProDeviceId: 42))
+        XCTAssertEqual(bridge.lastAction?.action, .goProStartRecording(goProDeviceId: 42))
     }
 
     func test_AB_13b_goProStart_missingDeviceId_rejected() {
@@ -163,7 +163,7 @@ final class MC1AutomationBridgeTests: XCTestCase {
         let bridge = makeBridge()
         let handled = bridge.handle(url: URL(string: "lfa-mc1://automate?action=gopro-stop&gopro_device_id=42")!)
         XCTAssertTrue(handled)
-        XCTAssertEqual(bridge.lastAction, .goProStopRecording(goProDeviceId: 42))
+        XCTAssertEqual(bridge.lastAction?.action, .goProStopRecording(goProDeviceId: 42))
     }
 
     func test_AB_14b_goProStop_missingDeviceId_rejected() {
@@ -178,7 +178,7 @@ final class MC1AutomationBridgeTests: XCTestCase {
         let bridge = makeBridge()
         let handled = bridge.handle(url: URL(string: "lfa-mc1://automate?action=gopro-status")!)
         XCTAssertTrue(handled)
-        XCTAssertEqual(bridge.lastAction, .goProStatus)
+        XCTAssertEqual(bridge.lastAction?.action, .goProStatus)
     }
 
     // MARK: — AB-16: gopro-media-list
@@ -187,6 +187,48 @@ final class MC1AutomationBridgeTests: XCTestCase {
         let bridge = makeBridge()
         let handled = bridge.handle(url: URL(string: "lfa-mc1://automate?action=gopro-media-list")!)
         XCTAssertTrue(handled)
-        XCTAssertEqual(bridge.lastAction, .goProMediaList)
+        XCTAssertEqual(bridge.lastAction?.action, .goProMediaList)
+    }
+
+    // MARK: — AB-17: consume() replay protection (P0 hardening, 2026-07-04 review)
+    //
+    // @Published lastAction replays its current value to every new subscriber.
+    // consume() must return true exactly once per posted action so a view
+    // rebuild / re-subscription cannot re-dispatch a stale gopro-start,
+    // reset-session, or pose-overlay-diag.
+
+    func test_AB_17_consume_returnsTrueExactlyOnce() {
+        let bridge = makeBridge()
+        bridge.handle(url: URL(string: "lfa-mc1://automate?action=gopro-start&gopro_device_id=7")!)
+        guard let envelope = bridge.lastAction else { return XCTFail("no action posted") }
+        XCTAssertTrue(bridge.consume(envelope), "first delivery must be dispatchable")
+        XCTAssertFalse(bridge.consume(envelope), "replayed envelope must NOT be dispatchable")
+        XCTAssertFalse(bridge.consume(envelope), "every further replay must stay consumed")
+    }
+
+    func test_AB_17b_identicalActionsGetDistinctSeqs_eachConsumableOnce() {
+        let bridge = makeBridge()
+        bridge.handle(url: URL(string: "lfa-mc1://automate?action=begin-cycle")!)
+        guard let first = bridge.lastAction else { return XCTFail("no first action") }
+        bridge.handle(url: URL(string: "lfa-mc1://automate?action=begin-cycle")!)
+        guard let second = bridge.lastAction else { return XCTFail("no second action") }
+
+        XCTAssertEqual(first.action, second.action)
+        XCTAssertNotEqual(first.seq, second.seq, "identical actions must be distinguishable by seq")
+        XCTAssertGreaterThan(second.seq, first.seq, "seq must be monotonically increasing")
+        XCTAssertTrue(bridge.consume(first))
+        XCTAssertTrue(bridge.consume(second), "a genuinely new identical action must still run")
+        XCTAssertFalse(bridge.consume(first))
+        XCTAssertFalse(bridge.consume(second))
+    }
+
+    func test_AB_17c_resetSessionReplay_notDispatchableTwice() {
+        let bridge = makeBridge()
+        bridge.handle(url: URL(string: "lfa-mc1://automate?action=reset-session")!)
+        guard let envelope = bridge.lastAction else { return XCTFail("no action posted") }
+        XCTAssertTrue(bridge.consume(envelope))
+        // Simulates the fullScreenCover re-present: a new .onReceive subscription
+        // receives the same envelope via @Published replay.
+        XCTAssertFalse(bridge.consume(envelope), "re-presented view must not re-run reset-session")
     }
 }

--- a/ios/LFAEducationCenterTests/MultiCamera/PCOInstructorRoleGateTests.swift
+++ b/ios/LFAEducationCenterTests/MultiCamera/PCOInstructorRoleGateTests.swift
@@ -56,6 +56,7 @@ private final class MockCCOClientForGateTest: CycleAPIClient {
     func stopCycle(token: String, uuid: String, cycleId: Int, revision: Int) async throws -> CaptureCycleDTO {
         makeGateTestCycle(id: cycleId, revision: revision + 1, status: .stopping)
     }
+    func listCycles(token: String, uuid: String) async throws -> [CaptureCycleDTO] { [] }
     func confirmDeviceStart(token: String, uuid: String, cycleId: Int, sessionDeviceId: Int,
                              startedAt: String, cycleDeviceRevision: Int) async throws -> CaptureCycleDTO {
         confirmStartCallCount += 1
@@ -78,6 +79,7 @@ private final class MockPCOClientForGateTest: CycleAPIClient {
     func createCycle(token: String, uuid: String, idempotencyKey: String) async throws -> CaptureCycleDTO { fatalError("not used") }
     func scheduleCycle(token: String, uuid: String, cycleId: Int, revision: Int) async throws -> CaptureCycleDTO { fatalError("not used") }
     func stopCycle(token: String, uuid: String, cycleId: Int, revision: Int) async throws -> CaptureCycleDTO { fatalError("not used") }
+    func listCycles(token: String, uuid: String) async throws -> [CaptureCycleDTO] { fatalError("not used") }
     func confirmDeviceStart(token: String, uuid: String, cycleId: Int, sessionDeviceId: Int,
                              startedAt: String, cycleDeviceRevision: Int) async throws -> CaptureCycleDTO {
         confirmStartCallCount += 1

--- a/ios/LFAEducationCenterTests/MultiCamera/PlayerCaptureOrchestratorTests.swift
+++ b/ios/LFAEducationCenterTests/MultiCamera/PlayerCaptureOrchestratorTests.swift
@@ -152,14 +152,21 @@ final class PlayerCaptureOrchestratorTests: XCTestCase {
 
     private func makeOrchestrator(
         clockService: ClockSyncService? = nil,
-        sleepProvider: @escaping (UInt64) async throws -> Void = { _ in }
+        sleepProvider: @escaping (UInt64) async throws -> Void = { _ in },
+        // Default: real sleep — the 5s watchdog never fires within a fast test,
+        // so pre-watchdog tests keep their exact semantics. Watchdog tests
+        // inject a fast provider explicitly.
+        watchdogSleepProvider: @escaping (UInt64) async throws -> Void = { ns in
+            try await Task.sleep(nanoseconds: ns)
+        }
     ) -> PlayerCaptureOrchestrator {
         PlayerCaptureOrchestrator(
             authManager: fakeToken,
             clockSyncService: clockService ?? makePCOUnsyncedClock(),
             captureController: fakeCapture,
             cycleAPIClient: mockAPI,
-            sleepProvider: sleepProvider
+            sleepProvider: sleepProvider,
+            watchdogSleepProvider: watchdogSleepProvider
         )
     }
 
@@ -167,9 +174,13 @@ final class PlayerCaptureOrchestratorTests: XCTestCase {
     /// Returns both so ARC keeps the listener alive (orchestrator holds a weak ref).
     private func makeAttachedOrchestrator(
         clockService: ClockSyncService? = nil,
-        sleepProvider: @escaping (UInt64) async throws -> Void = { _ in }
+        sleepProvider: @escaping (UInt64) async throws -> Void = { _ in },
+        watchdogSleepProvider: @escaping (UInt64) async throws -> Void = { ns in
+            try await Task.sleep(nanoseconds: ns)
+        }
     ) -> (PlayerCaptureOrchestrator, PlayerCycleListener) {
-        let orch = makeOrchestrator(clockService: clockService, sleepProvider: sleepProvider)
+        let orch = makeOrchestrator(clockService: clockService, sleepProvider: sleepProvider,
+                                    watchdogSleepProvider: watchdogSleepProvider)
         let listener = PlayerCycleListener(
             authManager: fakeToken,
             cycleListClient: StubCycleListClient(),
@@ -386,6 +397,78 @@ final class PlayerCaptureOrchestratorTests: XCTestCase {
         XCTAssertEqual(mockAPI.confirmStartCallCount, 0,
                        "confirmDeviceStart must NOT be called when device is already confirmedStart")
         XCTAssertEqual(orch.state, .confirmed(cycleId: cycle.id))
+    }
+
+    // MARK: — Capture-start watchdog (2026-07-04 tricamera physical run RCA)
+
+    /// Yields long enough for any pending main-queue capture-state delivery to
+    /// land before the watchdog checks state — keeps the no-false-positive test
+    /// deterministic without real sleeping.
+    private static func yieldingWatchdog(_ cycles: Int = 30) -> (UInt64) async throws -> Void {
+        { _ in for _ in 0..<cycles { await Task.yield() } }
+    }
+
+    // PCO-22: capture never reaches .capturing → watchdog fails with explicit evidence.
+    func test_pco_22_watchdog_fails_when_capture_never_starts() async {
+        let clock = await makePCOSyncedClock()
+        fakeCapture.startAdvancesToCapturing = false  // silent no-op start (camera lost)
+        let (orch, _listener) = makeAttachedOrchestrator(
+            clockService: clock,
+            watchdogSleepProvider: Self.yieldingWatchdog()
+        )
+        let cycle = makePCOCycle(scheduledStartAt: nil, status: .recording)
+        orch.handleListenerState(.recordingDetected(cycleId: cycle.id), currentCycle: cycle)
+
+        for _ in 0..<60 { await Task.yield() }
+
+        XCTAssertEqual(fakeCapture.startCallCount, 1, "startCapture must have been attempted")
+        XCTAssertEqual(mockAPI.confirmStartCallCount, 0, "confirmDeviceStart must NOT be called")
+        guard case .failed(let message) = orch.state else {
+            return XCTFail("Expected .failed(captureStartTimeout), got \(orch.state)")
+        }
+        XCTAssertTrue(message.contains("captureStartTimeout"), "unexpected failure message: \(message)")
+    }
+
+    // PCO-23: healthy start — watchdog must NOT fire even with an instant-ish provider.
+    func test_pco_23_watchdog_no_false_positive_on_healthy_start() async {
+        let clock = await makePCOSyncedClock()
+        let (orch, _listener) = makeAttachedOrchestrator(
+            clockService: clock,
+            watchdogSleepProvider: Self.yieldingWatchdog()
+        )
+        let cycle = makePCOCycle(scheduledStartAt: nil, status: .recording)
+        orch.handleListenerState(.recordingDetected(cycleId: cycle.id), currentCycle: cycle)
+
+        for _ in 0..<60 { await Task.yield() }
+
+        XCTAssertEqual(orch.state, .confirmed(cycleId: cycle.id),
+                       "watchdog must not override a healthy confirm flow")
+    }
+
+    // PCO-24: watchdog failure writes the pco_failure_diag.json evidence artifact.
+    func test_pco_24_watchdog_failure_writes_diag_artifact() async throws {
+        let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        let diagURL = docs.appendingPathComponent(PCOFailureDiagWriter.fileName)
+        try? FileManager.default.removeItem(at: diagURL)
+
+        let clock = await makePCOSyncedClock()
+        fakeCapture.startAdvancesToCapturing = false
+        let (orch, _listener) = makeAttachedOrchestrator(
+            clockService: clock,
+            watchdogSleepProvider: Self.yieldingWatchdog()
+        )
+        let cycle = makePCOCycle(scheduledStartAt: nil, status: .recording)
+        orch.handleListenerState(.recordingDetected(cycleId: cycle.id), currentCycle: cycle)
+        for _ in 0..<60 { await Task.yield() }
+
+        guard case .failed = orch.state else {
+            return XCTFail("Expected .failed, got \(orch.state)")
+        }
+        let data = try Data(contentsOf: diagURL)
+        let diag = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        XCTAssertNotNil(diag?["timestamp"], "diag must carry a freshness timestamp")
+        XCTAssertTrue((diag?["reason"] as? String ?? "").contains("captureStartTimeout"))
+        XCTAssertEqual(diag?["cycleId"] as? Int, cycle.id)
     }
 }
 

--- a/ios/LFAEducationCenterTests/MultiCamera/PlayerCaptureOrchestratorTests.swift
+++ b/ios/LFAEducationCenterTests/MultiCamera/PlayerCaptureOrchestratorTests.swift
@@ -37,6 +37,9 @@ private final class MockCycleAPIClientForPCO: CycleAPIClient {
     func stopCycle(token: String, uuid: String, cycleId: Int, revision: Int) async throws -> CaptureCycleDTO {
         fatalError("not used in PCO tests")
     }
+    func listCycles(token: String, uuid: String) async throws -> [CaptureCycleDTO] {
+        fatalError("not used in PCO tests")
+    }
     func confirmDeviceStart(
         token: String, uuid: String, cycleId: Int, sessionDeviceId: Int,
         startedAt: String, cycleDeviceRevision: Int

--- a/ios/LFAEducationCenterTests/MultiCamera/SessionCaptureManagerTests.swift
+++ b/ios/LFAEducationCenterTests/MultiCamera/SessionCaptureManagerTests.swift
@@ -226,17 +226,54 @@ final class SessionCaptureManagerTests: XCTestCase {
         XCTAssertEqual(mgr.state, .idle)
     }
 
-    // SC-14: Interruption → interrupted (tested via notification)
-    func test_SC_14_interruption_state() {
-        // Can't trigger real interruption in simulator — test state enum
-        let state: CaptureState = .interrupted
-        XCTAssertEqual(state, .interrupted)
+    // SC-14: Interruption while CAPTURING → .interrupted, and interruption-end
+    // finalizes the recording (stopCapture → .stopping). Exercised directly via
+    // the internal handlers — a real AVCaptureSessionWasInterrupted cannot be
+    // posted meaningfully on the simulator (same seam as the fileOutput
+    // delegate tests above).
+    func test_SC_14_interruption_while_capturing_then_ended_stops() {
+        let (mgr, _, _) = makeManager()
+        mgr.forceStateForTesting(.capturing)
+        mgr.handleInterruption()
+        XCTAssertEqual(mgr.state, .interrupted)
+        mgr.handleInterruptionEnded()
+        XCTAssertEqual(mgr.state, .stopping,
+            "interruption during recording must finalize via stopCapture")
     }
 
-    // SC-15: Interruption ended → auto stop
-    func test_SC_15_interruption_ended() {
-        // Verified by observer registration in code review
-        // Real test requires physical device capture
+    // SC-15: Interruption while READY (camera claimed by another session) must
+    // NOT be silently ignored — before the 2026-07-04 RCA fix the state stayed
+    // a lying .ready and the next startCapture() no-oped with zero evidence.
+    func test_SC_15_interruption_while_ready_degrades_state() {
+        let (mgr, _, _) = makeManager()
+        mgr.forceStateForTesting(.ready)
+        mgr.handleInterruption()
+        XCTAssertEqual(mgr.state, .interrupted,
+            "ready-state interruption must degrade the state, not preserve .ready")
+    }
+
+    // SC-15b: Interruption-end after a ready-state interruption re-arms to
+    // .ready (nothing was recording — there is nothing to finalize).
+    func test_SC_15b_ready_interruption_ended_rearms() {
+        let (mgr, _, _) = makeManager()
+        mgr.forceStateForTesting(.ready)
+        mgr.handleInterruption()
+        XCTAssertEqual(mgr.state, .interrupted)
+        mgr.handleInterruptionEnded()
+        XCTAssertEqual(mgr.state, .ready,
+            "ready-interruption end must re-arm, not call stopCapture")
+    }
+
+    // SC-15c: startCapture() while interrupted refuses instead of recording
+    // on a session that lost the camera — the PCO watchdog turns this refusal
+    // into an explicit failure with evidence.
+    func test_SC_15c_start_capture_refused_while_interrupted() {
+        let (mgr, _, _) = makeManager()
+        mgr.forceStateForTesting(.ready)
+        mgr.handleInterruption()
+        mgr.startCapture()
+        XCTAssertEqual(mgr.state, .interrupted,
+            "startCapture must not proceed while the session is interrupted")
     }
 
     // SC-16: Runtime error → failed

--- a/scripts/README_mc1_regression.md
+++ b/scripts/README_mc1_regression.md
@@ -36,6 +36,25 @@ PLAYER_PASSWORD=<player-password> \
 `--scenario` accepts `smoke`, `multicycle`, `retry`, `finalization`, or `all`
 (default `all`). `--cycles N` (default 3) only affects `multicycle`.
 
+`all` is strictly UNATTENDED: it excludes both `gopro-*` scenarios (physical
+GoPro required) and every scenario listed in `INTERACTIVE_SCENARIOS`
+(`scenarios.py`) that blocks on operator `input()` — including
+`tricamera-capture-skeleton-proof`. Interactive scenarios must be run
+explicitly by name (P0 hardening, 2026-07-04).
+
+Stale-artifact protection (P0 hardening, 2026-07-04): diag-file-gated
+scenarios begin by overwriting every on-device diag file they later read
+(`gopro_stream_diag.json`, `pose_overlay_diag.json`,
+`capture_metadata_diag.json`, `skeleton_output.json`, ...) with a
+`mc1_invalidated` sentinel, and gates load artifacts through
+`lib.load_fresh_diag`, which rejects the sentinel and any diag whose own
+timestamp predates the scenario start. A leftover diag from a previous run
+can therefore never be read back as this run's evidence; in
+`tricamera-capture-skeleton-proof` the `stale diag artifacts invalidated`
+step itself gates PASS. Console logs are attributed to devices via a
+`devicectl list devices --json-output` CoreDevice-to-legacy UDID mapping,
+never via `idevice_id -l` enumeration order.
+
 ## Supported scenarios
 
 | Scenario | Status | What it checks |

--- a/scripts/mc1_regression/lib.py
+++ b/scripts/mc1_regression/lib.py
@@ -182,6 +182,18 @@ def device_recording_status(cycle: dict, session_device_id: int) -> str | None:
     return None
 
 
+def device_required(cycle: dict, session_device_id: int) -> bool | None:
+    """The cycle_device's backend `required` flag (None if device not in cycle).
+
+    MC2-PR1 gate: only player roles may be required recorders — the instructor
+    cycle_device must carry required == False.
+    """
+    for cd in cycle.get("cycle_devices", []):
+        if cd.get("session_device_id") == session_device_id:
+            return cd.get("required")
+    return None
+
+
 def latest_cycle(cycles: list[dict]) -> dict | None:
     if not cycles:
         return None
@@ -507,8 +519,10 @@ class ScenarioContext:
     artifact: ArtifactRun
     offsets: ConsoleOffsetTracker
     cycles: int = 3
-    ipad_role: str = "player"
-    iphone_role: str = "instructor"
+    # Final topology (MC2-PR1, 2026-07-12): iPad = non-recording instructor /
+    # coordinator, iPhone = player (recorder + GoPro bridge over its WiFi).
+    ipad_role: str = "instructor"
+    iphone_role: str = "player"
 
 
 @dataclass

--- a/scripts/mc1_regression/lib.py
+++ b/scripts/mc1_regression/lib.py
@@ -205,6 +205,95 @@ def copy_app_container_file(udid: str, relative_path: str, local_path: str,
     return False
 
 
+# ── Stale-artifact protection (P0 hardening, 2026-07-04 review) ─────────────
+#
+# Diag files persist in the app's Documents/ directory across runs, and
+# devicectl has no delete verb for the appDataContainer domain — so a scenario
+# whose on-device probe silently never ran could previously copy back a STALE
+# file from an earlier run and PASS on old evidence. Two-layer defence:
+#
+#   1. invalidate_app_container_file(): at scenario start, every diag file the
+#      scenario will later gate on is OVERWRITTEN with a sentinel JSON
+#      ({"mc1_invalidated": true, ...}). Only the app writing a fresh diag
+#      during THIS run replaces the sentinel.
+#   2. load_fresh_diag(): when the gate reads the copied-back file, it rejects
+#      (a) the sentinel and (b) any diag whose own timestamp predates the
+#      scenario start (belt-and-braces for clock-skewed devices).
+
+STALE_DIAG_SENTINEL_KEY = "mc1_invalidated"
+# Device wall clock vs. script wall clock can disagree; the sentinel is the
+# primary defence, the timestamp check only needs to catch grossly old files.
+DIAG_FRESHNESS_SKEW_TOLERANCE_S = 120.0
+
+
+def push_app_container_file(udid: str, local_path: str, relative_path: str,
+                            bundle_id: str = LFA_BUNDLE_ID) -> bool:
+    """Copy a local file INTO the app's data container (inverse of
+    copy_app_container_file)."""
+    result = subprocess.run(
+        ["xcrun", "devicectl", "device", "copy", "to", "--device", udid,
+         "--domain-type", "appDataContainer", "--domain-identifier", bundle_id,
+         "--source", local_path, "--destination", relative_path],
+        capture_output=True, text=True, timeout=60,
+    )
+    if result.returncode == 0:
+        print(f"  -> pushed app container file: {local_path} → {relative_path}")
+        return True
+    print(f"  -> app container push failed ({relative_path}): {result.stderr.strip()[:300]}")
+    return False
+
+
+def invalidate_app_container_file(udid: str, relative_path: str, run_id: str,
+                                  scratch_dir: Path,
+                                  bundle_id: str = LFA_BUNDLE_ID) -> bool:
+    """Overwrite one on-device diag file with a stale-marker sentinel."""
+    sentinel = {
+        STALE_DIAG_SENTINEL_KEY: True,
+        "invalidated_at": utc_now_iso(),
+        "run_id": run_id,
+        "note": "overwritten at scenario start; a gate reading this sentinel "
+                "means the app never wrote a fresh diag during this run",
+    }
+    scratch_dir.mkdir(parents=True, exist_ok=True)
+    local = scratch_dir / f"sentinel_{Path(relative_path).name}"
+    local.write_text(json.dumps(sentinel, indent=2))
+    return push_app_container_file(udid, str(local), relative_path, bundle_id=bundle_id)
+
+
+def load_fresh_diag(local_path: str, scenario_started_at: datetime,
+                    timestamp_keys: tuple[str, ...] = ("timestamp", "generated_at"),
+                    ) -> tuple[dict | None, str | None]:
+    """Load a copied-back diag JSON, rejecting stale evidence.
+
+    Returns (diag_dict, None) when the file is fresh, or (None, reason) when it
+    must not be trusted: sentinel still in place, unparseable, missing its
+    timestamp, or timestamped before scenario start (minus skew tolerance).
+    """
+    try:
+        diag = json.loads(Path(local_path).read_text())
+    except (OSError, json.JSONDecodeError) as e:
+        return None, f"unreadable diag file: {e}"
+    if not isinstance(diag, dict):
+        return None, "diag file is not a JSON object"
+    if diag.get(STALE_DIAG_SENTINEL_KEY) is True:
+        return None, ("stale sentinel still in place — the app never wrote this "
+                      "diag during the current run")
+    ts_raw = next((diag[k] for k in timestamp_keys if diag.get(k)), None)
+    if not ts_raw:
+        return None, f"diag has no freshness timestamp (looked for {timestamp_keys})"
+    try:
+        ts = datetime.fromisoformat(str(ts_raw).replace("Z", "+00:00"))
+    except ValueError:
+        return None, f"diag timestamp unparseable: {ts_raw!r}"
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    threshold = scenario_started_at.timestamp() - DIAG_FRESHNESS_SKEW_TOLERANCE_S
+    if ts.timestamp() < threshold:
+        return None, (f"diag timestamp {ts_raw} predates scenario start "
+                      f"{scenario_started_at.isoformat()} — stale artifact from an earlier run")
+    return diag, None
+
+
 def extract_capture_path_from_log(console_log: str, tag: str = "[CAPTURE-INFO]") -> str | None:
     """Parse outputFile= from console log CAPTURE-INFO line."""
     for line in console_log.splitlines():

--- a/scripts/mc1_regression/lib.py
+++ b/scripts/mc1_regression/lib.py
@@ -23,6 +23,40 @@ from urllib.parse import urlencode
 POLL_INTERVAL_SECONDS = 1.5
 SNAPSHOT_RE = re.compile(r"\[MC1-SNAPSHOT-BEGIN\](.*?)\[MC1-SNAPSHOT-END\]", re.DOTALL)
 
+# Scenarios where console capture from BOTH devices is a HARD precondition.
+# The 2026-07-04 tricamera run failed on the PLAYER (iPad) side while the
+# WARN-only console path had silently skipped the iPad capture — the exact
+# evidence the failure needed did not exist. Tricamera scenarios exercise the
+# player-side capture chain, so running them without the iPad console is
+# running blind.
+DUAL_CONSOLE_REQUIRED_SCENARIOS = frozenset({
+    "tricamera-capture-skeleton-proof",
+    "gopro-tricamera-smoke",
+})
+
+
+def check_dual_console_precondition(scenario_names: list[str],
+                                    console_dir: Path | str) -> list[str]:
+    """Returns human-readable errors when a requested scenario requires both
+    device console captures and one is missing; empty list = precondition holds.
+    Console log files are created by run_mc1_regression.sh BEFORE the runner
+    starts, so a missing file here means capture never started for that device
+    (not USB-connected / not visible to idevicesyslog)."""
+    required_by = [n for n in scenario_names if n in DUAL_CONSOLE_REQUIRED_SCENARIOS]
+    if not required_by:
+        return []
+    errors: list[str] = []
+    for filename, label in (("iphone_console.log", "iPhone"),
+                            ("ipad_console.log", "iPad")):
+        if not (Path(console_dir) / filename).exists():
+            errors.append(
+                f"{label} console capture missing ({filename} not found) — "
+                f"hard precondition for: {', '.join(required_by)}. "
+                f"Both devices must be USB-connected, trusted, and visible to "
+                f"idevicesyslog (idevice_id -l)."
+            )
+    return errors
+
 
 class ValidationError(RuntimeError):
     pass

--- a/scripts/mc1_regression/preflight_static_check.py
+++ b/scripts/mc1_regression/preflight_static_check.py
@@ -342,19 +342,29 @@ def check_orientation_aspect_wiring() -> None:
     critical_block_match = re.search(r"critical_ok = all\(.*?\n        \)", body, re.S)
     critical_block = critical_block_match.group(0) if critical_block_match else ""
     orientation_gate_steps = [
-        "iphone orientation consistent", "iphone effective aspect ratio is 16:9",
-        "ipad orientation consistent", "ipad effective aspect ratio is 16:9",
+        "iphone orientation consistent", "iphone effective aspect ratio matches orientation",
+        "iphone encoded aspect ratio is 16:9",
+        "ipad orientation consistent", "ipad effective aspect ratio matches orientation",
+        "ipad encoded aspect ratio is 16:9",
         "gopro preview aspect ratio is 16:9",
     ]
     scenario_asserts_ok = all(f'"{step}"' in body for step in orientation_gate_steps)
     missing_steps = [s for s in orientation_gate_steps if f'"{s}"' not in body]
-    check("scenario asserts orientation-consistency + 16:9 aspect for iPhone/iPad/GoPro",
+    check("scenario asserts orientation-consistency + orientation-aware aspect for iPhone/iPad/GoPro",
           scenario_asserts_ok,
           f"missing report.step(...) for: {missing_steps}" if not scenario_asserts_ok else "")
     # Scoped to the tricamera critical_ok block (2026-07-04 hardening) — the
     # previous whole-file regex could match a different scenario's gate.
     gated_ok = all(f'"{step}"' in critical_block for step in orientation_gate_steps)
     check("orientation/aspect assertions gate PASS (critical_ok)", gated_ok)
+
+    # The effective-aspect EXPECTATION must be orientation-aware (2026-07-04
+    # physical-run proof): a portrait-mandated run (RC checklist J / #357)
+    # records a correct 9:16 effective aspect, so an unconditional 16:9
+    # expectation is unsatisfiable there. Pin the mapping itself.
+    aware_ok = bool(re.search(r'"portrait":\s*\(9,\s*16\)', scenarios_src)) \
+        and bool(re.search(r'"landscape":\s*\(16,\s*9\)', scenarios_src))
+    check("effective-aspect expectation is orientation-aware (portrait→9:16, landscape→16:9)", aware_ok)
 
     # "No distorting stretch" is a SwiftUI layout property, not runtime data — verify the
     # GoPro preview panel uses aspectRatio(contentMode: .fit), which by definition letterboxes

--- a/scripts/mc1_regression/preflight_static_check.py
+++ b/scripts/mc1_regression/preflight_static_check.py
@@ -213,15 +213,16 @@ def check_skeleton_feed_wiring() -> None:
         check(name, ok)
 
 
-# ── CHECK 5: device routing (iPhone=instructor, iPad=player, GoPro managed_by) ──
+# ── CHECK 5: device routing (MC2-PR1 final topology: iPad=non-recording ──────
+#    instructor, iPhone=player + GoPro bridge, GoPro managed_by the player)
 
 def check_device_routing() -> None:
     lib_src = read(LIB_PY)
     ctx_match = re.search(r"class ScenarioContext:.*?(?=\n\n@dataclass|\Z)", lib_src, re.S)
-    ok_ipad = bool(ctx_match and re.search(r'ipad_role:\s*str\s*=\s*"player"', ctx_match.group(0)))
-    ok_iphone = bool(ctx_match and re.search(r'iphone_role:\s*str\s*=\s*"instructor"', ctx_match.group(0)))
-    check("ScenarioContext default: iPad role = player", ok_ipad)
-    check("ScenarioContext default: iPhone role = instructor", ok_iphone)
+    ok_ipad = bool(ctx_match and re.search(r'ipad_role:\s*str\s*=\s*"instructor"', ctx_match.group(0)))
+    ok_iphone = bool(ctx_match and re.search(r'iphone_role:\s*str\s*=\s*"player"', ctx_match.group(0)))
+    check("ScenarioContext default: iPad role = instructor (non-recording)", ok_ipad)
+    check("ScenarioContext default: iPhone role = player", ok_iphone)
 
     scenarios_src = read(SCENARIOS_PY)
     fn_match = re.search(
@@ -229,8 +230,8 @@ def check_device_routing() -> None:
         scenarios_src, re.S,
     )
     gopro_ok = bool(fn_match and re.search(
-        r'device_role="auxiliary_camera".*?managed_by_device_id=instructor_id', fn_match.group(0), re.S))
-    check("GoPro registered as auxiliary_camera managed_by instructor_id", gopro_ok)
+        r'device_role="auxiliary_camera".*?managed_by_device_id=player_id', fn_match.group(0), re.S))
+    check("GoPro registered as auxiliary_camera managed_by player_id", gopro_ok)
 
 
 # ── CHECK 6: artifact collector completeness ────────────────────────────────
@@ -274,13 +275,17 @@ def check_artifact_collectors() -> None:
         '"gopro preview stream quality"' in critical_block
     check("gopro preview stream quality gates PASS (critical_ok)", gate_ok)
 
-    # Per-panel (instructor/player/gopro) pose overlay frame-traffic collection must also
-    # be present AND gate critical_ok — same reasoning as the GoPro preview quality check.
+    # Per-panel (instructor/player/gopro) pose overlay frame-traffic collection must
+    # stay present (writer↔reader key contract pinned until MC2-PR3 removes both
+    # sides together), but per the 2026-07-12 no-MPC architecture decision the
+    # live-panel gates must NOT gate PASS — the dashboard moves to backend-polled
+    # status/thumbnail panels and this scenario is superseded by
+    # final-topology-proof in MC2-PR4.
     panel_names = ("instructor", "player", "gopro")
     pose_collected = "pose_overlay_diag" in body
-    pose_gated = all(f'"{p} panel frame traffic"' in critical_block for p in panel_names)
+    pose_not_gated = all(f'"{p} panel frame traffic"' not in critical_block for p in panel_names)
     check("pose_overlay_diag.json collected (per-panel frame traffic)", pose_collected)
-    check("per-panel frame traffic gates PASS (critical_ok) for instructor+player+gopro", pose_gated)
+    check("per-panel frame traffic is corroborating-only, NOT in critical_ok (no-MPC decision)", pose_not_gated)
 
 
 # ── CHECK 8: per-panel pose overlay diagnostics wiring (counters + export + deep link) ──
@@ -341,16 +346,19 @@ def check_orientation_aspect_wiring() -> None:
     body = fn_match.group(0) if fn_match else ""
     critical_block_match = re.search(r"critical_ok = all\(.*?\n        \)", body, re.S)
     critical_block = critical_block_match.group(0) if critical_block_match else ""
+    # MC2-PR1 final topology: the iPad is a NON-RECORDING instructor — its old
+    # orientation/aspect gates are replaced by the negative-evidence gate
+    # ("instructor no capture output"). Only the player iPhone still records
+    # on the iOS side, so orientation/aspect stays pinned for it + the GoPro.
     orientation_gate_steps = [
         "iphone orientation consistent", "iphone effective aspect ratio matches orientation",
         "iphone encoded aspect ratio is 16:9",
-        "ipad orientation consistent", "ipad effective aspect ratio matches orientation",
-        "ipad encoded aspect ratio is 16:9",
+        "instructor no capture output",
         "gopro preview aspect ratio is 16:9",
     ]
     scenario_asserts_ok = all(f'"{step}"' in body for step in orientation_gate_steps)
     missing_steps = [s for s in orientation_gate_steps if f'"{s}"' not in body]
-    check("scenario asserts orientation-consistency + orientation-aware aspect for iPhone/iPad/GoPro",
+    check("scenario asserts player orientation/aspect + instructor no-capture (MC2-PR1)",
           scenario_asserts_ok,
           f"missing report.step(...) for: {missing_steps}" if not scenario_asserts_ok else "")
     # Scoped to the tricamera critical_ok block (2026-07-04 hardening) — the

--- a/scripts/mc1_regression/preflight_static_check.py
+++ b/scripts/mc1_regression/preflight_static_check.py
@@ -390,6 +390,20 @@ def check_log_capture_config() -> None:
     check("order-based legacy-UDID guessing (head -1 / sed -n 2p) is gone",
           not order_heuristic)
 
+    # 2026-07-04 RCA: tricamera ran with the iPad console capture silently
+    # SKIPPED (WARN only) — the player-side failure left zero console evidence.
+    # Both the shell wrapper and the runner must hard-fail tricamera scenarios
+    # when either device console capture is unavailable.
+    check("run_mc1_regression.sh hard-fails tricamera scenarios without dual console capture",
+          "Dual-console hard precondition" in src and "exit 1" in src)
+    runner_src = read(REPO_ROOT / "scripts" / "mc1_regression" / "runner.py")
+    lib_src = read(REPO_ROOT / "scripts" / "mc1_regression" / "lib.py")
+    check("runner.py enforces check_dual_console_precondition before scenarios",
+          "check_dual_console_precondition" in runner_src)
+    check("lib.DUAL_CONSOLE_REQUIRED_SCENARIOS covers the tricamera proof",
+          '"tricamera-capture-skeleton-proof"' in lib_src
+          and "DUAL_CONSOLE_REQUIRED_SCENARIOS" in lib_src)
+
 
 # ── CHECK 11: pose overlay diag writer↔reader key contract ──────────────────
 #

--- a/scripts/mc1_regression/preflight_static_check.py
+++ b/scripts/mc1_regression/preflight_static_check.py
@@ -55,7 +55,9 @@ def check_deep_link_parity() -> None:
                                  re.M))
     enum_cases = {a or b for a, b in enum_cases if (a or b)}
 
-    handled_actions = set(re.findall(r'lastAction = \.(\w+)', bridge))
+    # Actions are posted via post(.case) since the sequenced-envelope refactor
+    # (P0 hardening, 2026-07-04 — replay protection).
+    handled_actions = set(re.findall(r'post\(\.(\w+)', bridge))
     dispatch_cases = set(re.findall(r'case \.(\w+)\(', lobby)) | set(re.findall(r'case \.(\w+):', lobby))
 
     missing_dispatch = handled_actions - dispatch_cases
@@ -260,19 +262,23 @@ def check_artifact_collectors() -> None:
     # corroborating evidence — a scenario that only writes the file but never checks
     # udpPacketsReceived/videoPIDFound/decodeSuccesses would let a silently-dead GoPro
     # preview report PASS.
-    gate_ok = '"gopro preview stream quality"' in body and bool(re.search(
-        r'critical_ok = all\(.*?"gopro preview stream quality".*?\)', scenarios_src, re.S,
-    ))
+    #
+    # Scoped to the tricamera scenario BODY (2026-07-04 hardening) — the previous
+    # whole-file regex matched any `critical_ok = all(` anywhere before the step
+    # string anywhere, i.e. it never actually verified THIS scenario's gate.
+    critical_block_match = re.search(r"critical_ok = all\(.*?\n        \)", body, re.S)
+    critical_block = critical_block_match.group(0) if critical_block_match else ""
+    check("tricamera scenario has a critical_ok gate block", bool(critical_block))
+
+    gate_ok = '"gopro preview stream quality"' in body and \
+        '"gopro preview stream quality"' in critical_block
     check("gopro preview stream quality gates PASS (critical_ok)", gate_ok)
 
     # Per-panel (instructor/player/gopro) pose overlay frame-traffic collection must also
     # be present AND gate critical_ok — same reasoning as the GoPro preview quality check.
     panel_names = ("instructor", "player", "gopro")
     pose_collected = "pose_overlay_diag" in body
-    pose_gated = all(
-        bool(re.search(rf'critical_ok = all\(.*?"{p} panel frame traffic".*?\)', scenarios_src, re.S))
-        for p in panel_names
-    )
+    pose_gated = all(f'"{p} panel frame traffic"' in critical_block for p in panel_names)
     check("pose_overlay_diag.json collected (per-panel frame traffic)", pose_collected)
     check("per-panel frame traffic gates PASS (critical_ok) for instructor+player+gopro", pose_gated)
 
@@ -298,7 +304,8 @@ def check_pose_overlay_diagnostics_wiring() -> None:
 
     dashboard_src = read(IOS_MC / "InstructorDashboardView.swift")
     export_ok = bool(re.search(
-        r"case \.poseOverlayDiag = action.*?PoseOverlayDiagWriter\.write\(", dashboard_src, re.S,
+        r"case \.poseOverlayDiag = envelope\.action.*?PoseOverlayDiagWriter\.write\(",
+        dashboard_src, re.S,
     ))
     check("InstructorDashboardView exports pose overlay diag on pose-overlay-diag action", export_ok)
 
@@ -327,20 +334,26 @@ def check_orientation_aspect_wiring() -> None:
           f"missing: {[f for f in consistency_fields if f not in capture_mgr_src]}" if not consistency_ok else "")
 
     scenarios_src = read(SCENARIOS_PY)
+    fn_match = re.search(
+        r"def scenario_tricamera_capture_skeleton_proof.*?(?=\ndef scenario_gopro_network_routing_diag)",
+        scenarios_src, re.S,
+    )
+    body = fn_match.group(0) if fn_match else ""
+    critical_block_match = re.search(r"critical_ok = all\(.*?\n        \)", body, re.S)
+    critical_block = critical_block_match.group(0) if critical_block_match else ""
     orientation_gate_steps = [
         "iphone orientation consistent", "iphone effective aspect ratio is 16:9",
         "ipad orientation consistent", "ipad effective aspect ratio is 16:9",
         "gopro preview aspect ratio is 16:9",
     ]
-    scenario_asserts_ok = all(f'"{step}"' in scenarios_src for step in orientation_gate_steps)
-    missing_steps = [s for s in orientation_gate_steps if f'"{s}"' not in scenarios_src]
+    scenario_asserts_ok = all(f'"{step}"' in body for step in orientation_gate_steps)
+    missing_steps = [s for s in orientation_gate_steps if f'"{s}"' not in body]
     check("scenario asserts orientation-consistency + 16:9 aspect for iPhone/iPad/GoPro",
           scenario_asserts_ok,
           f"missing report.step(...) for: {missing_steps}" if not scenario_asserts_ok else "")
-    gated_ok = all(
-        bool(re.search(rf'critical_ok = all\(.*?"{re.escape(step)}".*?\)', scenarios_src, re.S))
-        for step in orientation_gate_steps
-    )
+    # Scoped to the tricamera critical_ok block (2026-07-04 hardening) — the
+    # previous whole-file regex could match a different scenario's gate.
+    gated_ok = all(f'"{step}"' in critical_block for step in orientation_gate_steps)
     check("orientation/aspect assertions gate PASS (critical_ok)", gated_ok)
 
     # "No distorting stretch" is a SwiftUI layout property, not runtime data — verify the
@@ -364,6 +377,147 @@ def check_log_capture_config() -> None:
     check("run_mc1_regression.sh guards against iPad/iPhone UDID collision (duplicate log)", ok)
     ok_override = "IPHONE_LEGACY_UDID" in src and "IPAD_LEGACY_UDID" in src
     check("run_mc1_regression.sh supports manual UDID override env vars", ok_override)
+
+    # P0 hardening (2026-07-04): legacy UDIDs must come from a real CoreDevice→legacy
+    # mapping (devicectl list devices --json-output → hardwareProperties.udid), NOT
+    # from `idevice_id -l` enumeration order — order-based assignment silently swapped
+    # the iPhone/iPad console logs and misattributed every console-grounded check.
+    mapping_ok = "_map_legacy_udid" in src and "hardwareProperties" in src
+    check("console log capture maps legacy UDIDs via devicectl identity (not list order)",
+          mapping_ok)
+    order_heuristic = bool(re.search(r'_LEGACY_UDIDS.*\|\s*head -1', src)) or \
+        bool(re.search(r"sed -n '2p'", src))
+    check("order-based legacy-UDID guessing (head -1 / sed -n 2p) is gone",
+          not order_heuristic)
+
+
+# ── CHECK 11: pose overlay diag writer↔reader key contract ──────────────────
+#
+# P0 hardening (2026-07-04 review): the tricamera panel gate read a per-panel
+# key the Swift writer never emits, so every panel gate was a guaranteed false
+# FAIL. This check re-derives both sides of the contract from source; the same
+# contract is also pinned at test time by tests/test_diag_contract.py.
+
+def check_pose_diag_key_contract() -> None:
+    processor_src = read(IOS_MC / "LivePoseOverlayProcessor.swift")
+    snap = re.search(r"var diagnosticSnapshot: \[String: Any\] \{\s*\[(.*?)\]\s*\}",
+                     processor_src, re.S)
+    writer_keys = set(re.findall(r'"(\w+)":', snap.group(1))) if snap else set()
+    if re.search(r'd\["sourceFramesSeen"\]\s*=', processor_src):
+        writer_keys.add("sourceFramesSeen")
+    check("diagnosticSnapshot writer keys extractable", bool(writer_keys))
+
+    scenarios_src = read(SCENARIOS_PY)
+    reader_keys = set(re.findall(r'panel\.get\("(\w+)"', scenarios_src))
+    check("scenario reads at least one per-panel pose key", bool(reader_keys))
+
+    unknown = reader_keys - writer_keys
+    check(
+        "every per-panel key scenarios.py reads is emitted by PoseOverlayDiagWriter",
+        not unknown,
+        f"scenarios.py reads {sorted(unknown)} but the writer only emits "
+        f"{sorted(writer_keys)}" if unknown else "",
+    )
+    check("panel frame-traffic gate reads the writer's framesReceived counter",
+          "framesReceived" in reader_keys)
+
+
+# ── CHECK 12: stale-artifact invalidation + freshness gating ─────────────────
+
+def check_stale_artifact_protection() -> None:
+    lib_src = read(LIB_PY)
+    helpers_ok = ("def invalidate_app_container_file(" in lib_src
+                  and "def load_fresh_diag(" in lib_src
+                  and "STALE_DIAG_SENTINEL_KEY" in lib_src)
+    check("lib.py provides invalidate_app_container_file + load_fresh_diag + sentinel key",
+          helpers_ok)
+
+    scenarios_src = read(SCENARIOS_PY)
+    fn_match = re.search(
+        r"def scenario_tricamera_capture_skeleton_proof.*?(?=\ndef scenario_gopro_network_routing_diag)",
+        scenarios_src, re.S,
+    )
+    body = fn_match.group(0) if fn_match else ""
+
+    # Invalidation must run BEFORE the first device interaction (join), and its
+    # step must gate critical_ok — a failed invalidation means stale evidence
+    # cannot be ruled out.
+    inv_pos = body.find("_invalidate_stale_diags(")
+    join_pos = body.find("_join_both_devices(")
+    check("tricamera invalidates stale diag artifacts before joining devices",
+          inv_pos != -1 and join_pos != -1 and inv_pos < join_pos,
+          f"inv_pos={inv_pos} join_pos={join_pos}")
+    critical_block_match = re.search(r"critical_ok = all\(.*?\n        \)", body, re.S)
+    critical_block = critical_block_match.group(0) if critical_block_match else ""
+    check("stale-diag invalidation step gates PASS (critical_ok)",
+          '"stale diag artifacts invalidated"' in critical_block)
+
+    # Every gating diag read in the tricamera scenario must go through the
+    # freshness loader instead of raw json.loads.
+    fresh_reads = body.count("load_fresh_diag(")
+    check("tricamera gating diag reads use load_fresh_diag (>=5 call sites)",
+          fresh_reads >= 5, f"found {fresh_reads} load_fresh_diag call(s)")
+
+
+# ── CHECK 13: deep-link action replay protection (consume mechanism) ─────────
+
+def check_action_consume_mechanism() -> None:
+    bridge_src = read(IOS_MC / "MC1AutomationBridge.swift")
+    envelope_ok = ("struct MC1SequencedAction" in bridge_src
+                   and re.search(r"let seq: Int", bridge_src) is not None)
+    check("MC1AutomationBridge posts sequenced action envelopes", envelope_ok)
+    consume_ok = bool(re.search(
+        r"func consume\(_ envelope: MC1SequencedAction\) -> Bool", bridge_src))
+    check("MC1AutomationBridge.consume() exists (once-only claim per action)", consume_ok)
+
+    # Both subscribers must claim via consume() before dispatching — otherwise a
+    # @Published replay on view rebuild re-runs the last action (double GoPro
+    # shutter / spurious reset-session / clobbered pose_overlay_diag.json).
+    lobby_src = read(IOS_MC / "MultiCameraLobbyView.swift")
+    lobby_recv = re.search(r"onReceive\(MC1AutomationBridge\.shared\.\$lastAction.*?switch",
+                           lobby_src, re.S)
+    lobby_gated = bool(lobby_recv and "consume(" in lobby_recv.group(0))
+    check("MultiCameraLobbyView dispatch is gated by consume()", lobby_gated)
+
+    dash_src = read(IOS_MC / "InstructorDashboardView.swift")
+    dash_recv = re.search(
+        r"onReceive\(MC1AutomationBridge\.shared\.\$lastAction.*?PoseOverlayDiagWriter",
+        dash_src, re.S)
+    dash_gated = bool(dash_recv and "consume(" in dash_recv.group(0))
+    check("InstructorDashboardView poseOverlayDiag export is gated by consume()", dash_gated)
+
+
+# ── CHECK 14: interactive scenarios excluded from unattended `all` ───────────
+
+def check_interactive_scenarios_excluded_from_all() -> None:
+    scenarios_src = read(SCENARIOS_PY)
+    set_match = re.search(r"INTERACTIVE_SCENARIOS = \{(.*?)\}", scenarios_src, re.S)
+    declared = set(re.findall(r'"([\w-]+)"', set_match.group(1))) if set_match else set()
+    check("INTERACTIVE_SCENARIOS declared in scenarios.py", bool(declared))
+
+    # Every scenario function that calls input() must be in the interactive set.
+    # Map input() call positions back to their enclosing scenario name.
+    fn_spans: list[tuple[int, str]] = [
+        (m.start(), m.group(1)) for m in
+        re.finditer(r'    report = ScenarioReport\(name="([\w-]+)"', scenarios_src)
+    ]
+    undeclared = set()
+    for m in re.finditer(r"\binput\(", scenarios_src):
+        owner = None
+        for start, name in fn_spans:
+            if start < m.start():
+                owner = name
+        if owner and owner not in declared:
+            undeclared.add(owner)
+    check("every input()-blocking scenario is declared interactive",
+          not undeclared,
+          f"scenario(s) with input() missing from INTERACTIVE_SCENARIOS: {sorted(undeclared)}"
+          if undeclared else "")
+
+    runner_src = read(REPO_ROOT / "scripts" / "mc1_regression" / "runner.py")
+    filter_ok = "INTERACTIVE_SCENARIOS" in runner_src and bool(re.search(
+        r'k not in INTERACTIVE_SCENARIOS', runner_src))
+    check("runner.py excludes INTERACTIVE_SCENARIOS from --scenario all", filter_ok)
 
 
 # ── CHECK 10: SKIP_STATIC_PREFLIGHT can never produce a valid PASS ─────────
@@ -403,6 +557,10 @@ def main() -> int:
     check_orientation_aspect_wiring()
     check_log_capture_config()
     check_skip_preflight_cannot_pass()
+    check_pose_diag_key_contract()
+    check_stale_artifact_protection()
+    check_action_consume_mechanism()
+    check_interactive_scenarios_excluded_from_all()
 
     print("=== MC1 static preflight check ===\n")
     for line in PASSES:

--- a/scripts/mc1_regression/runner.py
+++ b/scripts/mc1_regression/runner.py
@@ -31,7 +31,7 @@ from mc1_regression.lib import (  # noqa: E402
     send_deep_link,
     utc_now_iso,
 )
-from mc1_regression.scenarios import SCENARIOS  # noqa: E402
+from mc1_regression.scenarios import INTERACTIVE_SCENARIOS, SCENARIOS  # noqa: E402
 
 _DEFAULT_INSTRUCTOR_EMAIL = "staging-instructor@lfa-staging.io"
 _DEFAULT_PLAYER_EMAIL = "staging-player1@lfa-staging.io"
@@ -72,7 +72,21 @@ def run(args: argparse.Namespace) -> int:
     preflight_url_scheme(args.iphone_udid, "iPhone")
 
     if args.scenario == "all":
-        scenario_names = [k for k in SCENARIOS.keys() if not k.startswith("gopro-")]
+        # `all` must stay unattended: exclude gopro-* (physical GoPro required)
+        # AND any scenario that blocks on operator input() (INTERACTIVE_SCENARIOS).
+        # Before this filter, tricamera-capture-skeleton-proof slipped into `all`
+        # and hung the whole run on an input() prompt (P0 hardening, 2026-07-04).
+        scenario_names = [
+            k for k in SCENARIOS.keys()
+            if not k.startswith("gopro-") and k not in INTERACTIVE_SCENARIOS
+        ]
+        excluded_interactive = [
+            k for k in SCENARIOS.keys()
+            if not k.startswith("gopro-") and k in INTERACTIVE_SCENARIOS
+        ]
+        for name in excluded_interactive:
+            print(f"NOTE: '{name}' is interactive (operator input required) — excluded "
+                  f"from 'all'. Run it explicitly: --scenario {name}")
     else:
         scenario_names = [args.scenario]
     overall_pass = True

--- a/scripts/mc1_regression/runner.py
+++ b/scripts/mc1_regression/runner.py
@@ -26,6 +26,7 @@ from mc1_regression.lib import (  # noqa: E402
     ConsoleOffsetTracker,
     ScenarioContext,
     ValidationError,
+    check_dual_console_precondition,
     login,
     preflight_url_scheme,
     send_deep_link,
@@ -55,6 +56,18 @@ def run(args: argparse.Namespace) -> int:
     out_dir = Path(args.out_dir)
     artifact = ArtifactRun(out_dir)
     offsets = ConsoleOffsetTracker(artifact)
+
+    # Dual-console hard precondition (2026-07-04 RCA): tricamera scenarios
+    # exercise the PLAYER capture chain — running them without the iPad
+    # console capture already cost one physical test day's evidence. The
+    # shell wrapper enforces this too; this is defense-in-depth for direct
+    # runner.py invocations.
+    console_errors = check_dual_console_precondition([args.scenario], artifact.console_dir)
+    if console_errors:
+        for err in console_errors:
+            print(f"ERROR: {err}")
+        print("Aborting before any scenario runs — fix USB/console capture and retry.")
+        return 2
 
     instructor_email, instructor_password, player_email, player_password = _prompt_credentials()
 

--- a/scripts/mc1_regression/scenarios.py
+++ b/scripts/mc1_regression/scenarios.py
@@ -75,6 +75,49 @@ def _aspect_ratio_matches(aspect_str, expected_w=16, expected_h=9, tolerance=0.0
     except ValueError:
         return False
 
+
+def _expected_effective_aspect(file_orientation_coarse):
+    """Orientation-aware expected EFFECTIVE (post-rotation display) aspect.
+
+    2026-07-04 physical-run proof (ffprobe on the pulled .mov files): the app
+    always encodes the sensor's landscape 1280x720 buffer and bakes rotation
+    into preferredTransform, so a portrait-mounted device's effective display
+    aspect is BY DEFINITION 9:16. The old unconditional 16:9 expectation could
+    never pass under the RC-checklist J-section portrait mandate (issue #357)
+    even though the recording itself was correct. Returns None for unknown
+    orientation — no expectation can be derived there, and "unknown" is itself
+    an evidence failure (the orientation-consistent gate catches it too).
+    """
+    return {"portrait": (9, 16), "landscape": (16, 9)}.get(file_orientation_coarse)
+
+
+def _effective_aspect_gate(meta):
+    """(ok, expected_label) for the orientation-aware effective-aspect gate."""
+    expected = _expected_effective_aspect((meta or {}).get("fileOrientationCoarse"))
+    if expected is None:
+        return False, None
+    w, h = expected
+    return _aspect_ratio_matches(meta.get("effectiveAspectRatio"), w, h), f"{w}:{h}"
+
+
+def _encoded_aspect_is_16_9(meta):
+    """16:9 check on the ENCODED buffer (actualResolution "WxH") — orientation-
+    independent, because the sensor buffer is landscape 16:9 regardless of how
+    the device is mounted. Returns None when actualResolution is absent or
+    unparseable: there is no metadata to check, so the caller skips the step
+    instead of asserting on a guess."""
+    raw = (meta or {}).get("actualResolution")
+    if not raw or "x" not in str(raw):
+        return None
+    try:
+        w_str, h_str = str(raw).lower().split("x", 1)
+        w, h = float(w_str), float(h_str)
+    except ValueError:
+        return None
+    if h == 0:
+        return None
+    return abs((w / h) - (16 / 9)) <= 0.02
+
 # After the script PATCHes session to DEVICES_READY the iOS VM needs one 3s poll
 # cycle to see the updated status + fresh revision before begin-cycle is sent.
 # CCO already retries activateSession on 409, so 4s is a safe conservative buffer.
@@ -987,25 +1030,32 @@ def scenario_tricamera_capture_skeleton_proof(ctx: ScenarioContext) -> ScenarioR
             if meta is None:
                 report.step("iphone capture metadata", False, error=stale_reason)
                 report.step("iphone orientation consistent", False, error=stale_reason)
-                report.step("iphone effective aspect ratio is 16:9", False, error=stale_reason)
+                report.step("iphone effective aspect ratio matches orientation", False, error=stale_reason)
             else:
                 file_size = meta.get("fileSizeBytes", 0) or 0
                 report.step("iphone capture metadata", file_size > 0,
                             fileSizeBytes=file_size, outputFilePath=meta.get("outputFilePath"),
                             durationSeconds=meta.get("actualDurationSeconds"),
                             codec=meta.get("actualCodec"))
-                # Orientation/aspect automatic assertions (2026-07-01 flow audit) — not just
-                # recorded in the JSON, actually checked: does the FILE's baked-in rotation
-                # match the device's own interface orientation at recording start, and is the
-                # effective (post-rotation) aspect ratio the expected 16:9?
+                # Orientation/aspect automatic assertions (2026-07-01 flow audit, made
+                # orientation-aware 2026-07-04): does the FILE's baked-in rotation match the
+                # device's own interface orientation at recording start, does the effective
+                # (post-rotation) aspect match what that orientation implies (portrait→9:16,
+                # landscape→16:9), and is the encoded sensor buffer the expected 16:9?
                 report.step("iphone orientation consistent", meta.get("orientationConsistent") is True,
                             deviceOrientationAtRecordingStart=meta.get("deviceOrientationAtRecordingStart"),
                             fileOrientationCoarse=meta.get("fileOrientationCoarse"))
-                report.step("iphone effective aspect ratio is 16:9",
-                            _aspect_ratio_matches(meta.get("effectiveAspectRatio")),
+                eff_ok, eff_expected = _effective_aspect_gate(meta)
+                report.step("iphone effective aspect ratio matches orientation", eff_ok,
+                            expectedEffectiveAspect=eff_expected,
+                            fileOrientationCoarse=meta.get("fileOrientationCoarse"),
                             effectiveAspectRatio=meta.get("effectiveAspectRatio"),
                             effectiveDisplayWidth=meta.get("effectiveDisplayWidth"),
                             effectiveDisplayHeight=meta.get("effectiveDisplayHeight"))
+                encoded_ok = _encoded_aspect_is_16_9(meta)
+                if encoded_ok is not None:
+                    report.step("iphone encoded aspect ratio is 16:9", encoded_ok,
+                                actualResolution=meta.get("actualResolution"))
         else:
             report.step("iphone capture metadata", False, error="copy_app_container_file failed")
 
@@ -1017,7 +1067,7 @@ def scenario_tricamera_capture_skeleton_proof(ctx: ScenarioContext) -> ScenarioR
             if meta is None:
                 report.step("ipad capture metadata", False, error=stale_reason)
                 report.step("ipad orientation consistent", False, error=stale_reason)
-                report.step("ipad effective aspect ratio is 16:9", False, error=stale_reason)
+                report.step("ipad effective aspect ratio matches orientation", False, error=stale_reason)
             else:
                 file_size = meta.get("fileSizeBytes", 0) or 0
                 report.step("ipad capture metadata", file_size > 0,
@@ -1027,11 +1077,17 @@ def scenario_tricamera_capture_skeleton_proof(ctx: ScenarioContext) -> ScenarioR
                 report.step("ipad orientation consistent", meta.get("orientationConsistent") is True,
                             deviceOrientationAtRecordingStart=meta.get("deviceOrientationAtRecordingStart"),
                             fileOrientationCoarse=meta.get("fileOrientationCoarse"))
-                report.step("ipad effective aspect ratio is 16:9",
-                            _aspect_ratio_matches(meta.get("effectiveAspectRatio")),
+                eff_ok, eff_expected = _effective_aspect_gate(meta)
+                report.step("ipad effective aspect ratio matches orientation", eff_ok,
+                            expectedEffectiveAspect=eff_expected,
+                            fileOrientationCoarse=meta.get("fileOrientationCoarse"),
                             effectiveAspectRatio=meta.get("effectiveAspectRatio"),
                             effectiveDisplayWidth=meta.get("effectiveDisplayWidth"),
                             effectiveDisplayHeight=meta.get("effectiveDisplayHeight"))
+                encoded_ok = _encoded_aspect_is_16_9(meta)
+                if encoded_ok is not None:
+                    report.step("ipad encoded aspect ratio is 16:9", encoded_ok,
+                                actualResolution=meta.get("actualResolution"))
         else:
             report.step("ipad capture metadata", False, error="copy_app_container_file failed")
 
@@ -1161,8 +1217,10 @@ def scenario_tricamera_capture_skeleton_proof(ctx: ScenarioContext) -> ScenarioR
                 "all 3 confirmed_stop", "timestamp sync report",
                 "gopro preview stream quality", "gopro preview aspect ratio is 16:9",
                 "instructor panel frame traffic", "player panel frame traffic", "gopro panel frame traffic",
-                "iphone orientation consistent", "iphone effective aspect ratio is 16:9",
-                "ipad orientation consistent", "ipad effective aspect ratio is 16:9",
+                "iphone orientation consistent", "iphone effective aspect ratio matches orientation",
+                "iphone encoded aspect ratio is 16:9",
+                "ipad orientation consistent", "ipad effective aspect ratio matches orientation",
+                "ipad encoded aspect ratio is 16:9",
             )
         )
         report.passed = critical_ok

--- a/scripts/mc1_regression/scenarios.py
+++ b/scripts/mc1_regression/scenarios.py
@@ -139,6 +139,35 @@ def _dump_session_state(ctx: ScenarioContext, session_uuid: str, label: str) -> 
         print(f"  [{label}] diagnostic dump failed: {e}")
 
 
+def _pull_pco_failure_diag(ctx: ScenarioContext, report: ScenarioReport,
+                           scenario_started_at) -> None:
+    """Pull the player-side PCO failure evidence (Documents/pco_failure_diag.json,
+    written by PCOFailureDiagWriter on every PlayerCaptureOrchestrator .failed
+    transition — 2026-07-04 RCA). Best-effort: turns a bare
+    "Timeout waiting for: instructor+player confirmed_start" into a concrete
+    player-side reason (e.g. captureStartTimeout with the last capture state).
+    Never raises; reported as evidence, never gates PASS."""
+    local = str(ctx.artifact.dir / "pco_failure_diag.json")
+    try:
+        if not copy_app_container_file(ctx.ipad_udid, "Documents/pco_failure_diag.json", local):
+            report.step("player pco failure diag", False,
+                        error="pco_failure_diag.json not found on iPad — player PCO "
+                              "never transitioned to .failed during this run "
+                              "(cycle never seen, or hang predates the watchdog build)")
+            return
+        diag, stale_reason = load_fresh_diag(local, scenario_started_at)
+        if diag is None:
+            report.step("player pco failure diag", False, error=stale_reason)
+            return
+        report.step("player pco failure diag", True,
+                    reason=diag.get("reason"),
+                    cycleId=diag.get("cycleId"),
+                    lastObservedCaptureState=diag.get("lastObservedCaptureState"),
+                    diagTimestamp=diag.get("timestamp"))
+    except Exception as e:  # noqa: BLE001 — evidence pull must never mask the scenario error
+        report.step("player pco failure diag", False, error=f"pull failed: {e}")
+
+
 def _mark_devices_ready(ctx: ScenarioContext, report: ScenarioReport, session_uuid: str) -> None:
     import time as _time
     # Script-driven backend transition: GET fresh revision + PATCH devices_ready.
@@ -747,6 +776,7 @@ def scenario_tricamera_capture_skeleton_proof(ctx: ScenarioContext) -> ScenarioR
             (ctx.iphone_udid, "Documents/skeleton_output.json"),
             (ctx.iphone_udid, "Documents/gopro_diag.json"),
             (ctx.ipad_udid, "Documents/capture_metadata_diag.json"),
+            (ctx.ipad_udid, "Documents/pco_failure_diag.json"),
         ])
 
         # 1. Join both devices
@@ -1141,6 +1171,11 @@ def scenario_tricamera_capture_skeleton_proof(ctx: ScenarioContext) -> ScenarioR
     except ValidationError as e:
         report.error = str(e)
         report.passed = False
+        # 2026-07-04 RCA: a bare confirmed_start timeout carried zero player-side
+        # evidence. Pull the PCO failure diag from the iPad and dump backend
+        # state so the report explains the failure, not just names it.
+        _pull_pco_failure_diag(ctx, report, scenario_started_at)
+        _dump_session_state(ctx, session_uuid, "tricamera-fail")
     return report
 
 

--- a/scripts/mc1_regression/scenarios.py
+++ b/scripts/mc1_regression/scenarios.py
@@ -31,13 +31,29 @@ from .lib import (
     extract_skeleton_path_from_log,
     get_server_time_iso,
     get_session,
+    invalidate_app_container_file,
     latest_cycle,
     list_cycles,
+    load_fresh_diag,
     poll_until,
     register_device,
     send_deep_link,
     transition_session,
+    utc_now_iso,
 )
+
+# Scenarios that block on operator input() (manual GoPro WiFi join, visual
+# checks). runner.py MUST exclude these from an unattended `--scenario all`
+# run — they only run when named explicitly (P0 hardening, 2026-07-04 review).
+INTERACTIVE_SCENARIOS = {
+    "tricamera-capture-skeleton-proof",
+    "gopro-network-routing-diag",
+    "gopro-preview-poc",
+    "gopro-combined-cycle-proof",
+    "gopro-camera-state-probe",
+    "gopro-preview-aspect-probe",
+    "gopro-preset-write-validation",
+}
 
 DEVICE_REGISTER_TIMEOUT_SECONDS = 120
 CYCLE_CONFIRM_TIMEOUT_SECONDS = 30
@@ -142,6 +158,28 @@ def _mark_devices_ready(ctx: ScenarioContext, report: ScenarioReport, session_uu
 
     print(f"Waiting {POST_DEVICES_READY_SETTLE_SECONDS}s for iOS VM to poll updated session...")
     _time.sleep(POST_DEVICES_READY_SETTLE_SECONDS)
+
+
+def _invalidate_stale_diags(ctx: ScenarioContext, report: ScenarioReport,
+                            targets: list[tuple[str, str]], run_id: str,
+                            step_name: str = "stale diag artifacts invalidated") -> bool:
+    """Overwrite every on-device diag file this scenario will gate on with a
+    stale-marker sentinel (P0 hardening — see lib.invalidate_app_container_file).
+
+    `targets` is a list of (udid, container-relative path). Records one report
+    step; returns True only if EVERY target was invalidated. A failed
+    invalidation means this run cannot distinguish fresh evidence from a
+    previous run's leftovers, so callers must treat False as gate-critical.
+    """
+    results = {}
+    all_ok = True
+    scratch = ctx.artifact.dir / "diag_sentinels"
+    for udid, relative_path in targets:
+        ok = invalidate_app_container_file(udid, relative_path, run_id, scratch)
+        results[f"{udid[:8]}:{relative_path}"] = ok
+        all_ok = all_ok and ok
+    report.step(step_name, all_ok, run_id=run_id, **results)
+    return all_ok
 
 
 def _run_one_cycle(
@@ -686,8 +724,11 @@ def scenario_tricamera_capture_skeleton_proof(ctx: ScenarioContext) -> ScenarioR
       - gopro media evidence          ([GOPRO-MEDIA-BEGIN] in iPhone log)
     """
     import time as _time
+    from datetime import datetime as _dt, timezone as _tz
 
     report = ScenarioReport(name="tricamera-capture-skeleton-proof", passed=False)
+    scenario_started_at = _dt.now(_tz.utc)
+    run_id = f"tricamera-capture-skeleton-proof-{scenario_started_at.strftime('%Y%m%dT%H%M%SZ')}"
     session = create_session(ctx.api_base, ctx.instructor_token)
     session_uuid = session["session_uuid"]
     report.session_uuid = session_uuid
@@ -695,6 +736,19 @@ def scenario_tricamera_capture_skeleton_proof(ctx: ScenarioContext) -> ScenarioR
     print(f"[proof] iPhone=instructor+GoPro, iPad=player")
 
     try:
+        # 0. Stale-artifact protection (P0 hardening): overwrite every diag file
+        #    this scenario later gates on with a sentinel, so a leftover file from
+        #    a previous run can never be read back as this run's evidence. This
+        #    step is gate-critical — if it fails, no PASS is possible.
+        _invalidate_stale_diags(ctx, report, run_id=run_id, targets=[
+            (ctx.iphone_udid, "Documents/capture_metadata_diag.json"),
+            (ctx.iphone_udid, "Documents/gopro_stream_diag.json"),
+            (ctx.iphone_udid, "Documents/pose_overlay_diag.json"),
+            (ctx.iphone_udid, "Documents/skeleton_output.json"),
+            (ctx.iphone_udid, "Documents/gopro_diag.json"),
+            (ctx.ipad_udid, "Documents/capture_metadata_diag.json"),
+        ])
+
         # 1. Join both devices
         instructor_id, player_id = _join_both_devices(ctx, report, session_uuid)
 
@@ -891,8 +945,6 @@ def scenario_tricamera_capture_skeleton_proof(ctx: ScenarioContext) -> ScenarioR
         #     the capture-info deep link fires (step 13 above).
         #     skeleton_output.json is written by SkeletonProcessor to Documents/ (fixed name).
         print("[proof] === ARTIFACT COLLECTION ===")
-        import json as _json
-        import os
 
         artifacts_dir = ctx.artifact.dir / "video_artifacts"
         artifacts_dir.mkdir(parents=True, exist_ok=True)
@@ -901,8 +953,12 @@ def scenario_tricamera_capture_skeleton_proof(ctx: ScenarioContext) -> ScenarioR
         local_iphone_meta = str(artifacts_dir / "iphone_capture_metadata.json")
         iphone_meta_ok = copy_app_container_file(ctx.iphone_udid, "Documents/capture_metadata_diag.json", local_iphone_meta)
         if iphone_meta_ok:
-            try:
-                meta = _json.loads(open(local_iphone_meta).read())
+            meta, stale_reason = load_fresh_diag(local_iphone_meta, scenario_started_at)
+            if meta is None:
+                report.step("iphone capture metadata", False, error=stale_reason)
+                report.step("iphone orientation consistent", False, error=stale_reason)
+                report.step("iphone effective aspect ratio is 16:9", False, error=stale_reason)
+            else:
                 file_size = meta.get("fileSizeBytes", 0) or 0
                 report.step("iphone capture metadata", file_size > 0,
                             fileSizeBytes=file_size, outputFilePath=meta.get("outputFilePath"),
@@ -920,8 +976,6 @@ def scenario_tricamera_capture_skeleton_proof(ctx: ScenarioContext) -> ScenarioR
                             effectiveAspectRatio=meta.get("effectiveAspectRatio"),
                             effectiveDisplayWidth=meta.get("effectiveDisplayWidth"),
                             effectiveDisplayHeight=meta.get("effectiveDisplayHeight"))
-            except Exception as e:
-                report.step("iphone capture metadata", False, error=f"parse error: {e}")
         else:
             report.step("iphone capture metadata", False, error="copy_app_container_file failed")
 
@@ -929,8 +983,12 @@ def scenario_tricamera_capture_skeleton_proof(ctx: ScenarioContext) -> ScenarioR
         local_ipad_meta = str(artifacts_dir / "ipad_capture_metadata.json")
         ipad_meta_ok = copy_app_container_file(ctx.ipad_udid, "Documents/capture_metadata_diag.json", local_ipad_meta)
         if ipad_meta_ok:
-            try:
-                meta = _json.loads(open(local_ipad_meta).read())
+            meta, stale_reason = load_fresh_diag(local_ipad_meta, scenario_started_at)
+            if meta is None:
+                report.step("ipad capture metadata", False, error=stale_reason)
+                report.step("ipad orientation consistent", False, error=stale_reason)
+                report.step("ipad effective aspect ratio is 16:9", False, error=stale_reason)
+            else:
                 file_size = meta.get("fileSizeBytes", 0) or 0
                 report.step("ipad capture metadata", file_size > 0,
                             fileSizeBytes=file_size, outputFilePath=meta.get("outputFilePath"),
@@ -944,8 +1002,6 @@ def scenario_tricamera_capture_skeleton_proof(ctx: ScenarioContext) -> ScenarioR
                             effectiveAspectRatio=meta.get("effectiveAspectRatio"),
                             effectiveDisplayWidth=meta.get("effectiveDisplayWidth"),
                             effectiveDisplayHeight=meta.get("effectiveDisplayHeight"))
-            except Exception as e:
-                report.step("ipad capture metadata", False, error=f"parse error: {e}")
         else:
             report.step("ipad capture metadata", False, error="copy_app_container_file failed")
 
@@ -969,8 +1025,11 @@ def scenario_tricamera_capture_skeleton_proof(ctx: ScenarioContext) -> ScenarioR
         gopro_stream_diag_ok = copy_app_container_file(
             ctx.iphone_udid, "Documents/gopro_stream_diag.json", local_gopro_stream_diag)
         if gopro_stream_diag_ok:
-            try:
-                stream_diag = _json.loads(open(local_gopro_stream_diag).read())
+            stream_diag, stale_reason = load_fresh_diag(local_gopro_stream_diag, scenario_started_at)
+            if stream_diag is None:
+                report.step("gopro preview stream quality", False, error=stale_reason)
+                report.step("gopro preview aspect ratio is 16:9", False, error=stale_reason)
+            else:
                 packets = stream_diag.get("udpPacketsReceived", 0) or 0
                 video_pid_found = bool(stream_diag.get("videoPIDFound", False))
                 decodes = stream_diag.get("decodeSuccesses", 0) or 0
@@ -994,9 +1053,6 @@ def scenario_tricamera_capture_skeleton_proof(ctx: ScenarioContext) -> ScenarioR
                     previewAspectRatio=stream_diag.get("previewAspectRatio"),
                     previewWidth=stream_diag.get("previewWidth"), previewHeight=stream_diag.get("previewHeight"),
                 )
-            except Exception as e:
-                report.step("gopro preview stream quality", False, error=f"parse error: {e}")
-                report.step("gopro preview aspect ratio is 16:9", False, error=f"parse error: {e}")
         else:
             report.step("gopro preview stream quality", False,
                         error="gopro_stream_diag.json not found — GoProStreamProbe.run() "
@@ -1017,23 +1073,28 @@ def scenario_tricamera_capture_skeleton_proof(ctx: ScenarioContext) -> ScenarioR
         local_pose_diag = str(artifacts_dir / "pose_overlay_diag.json")
         pose_diag_ok = copy_app_container_file(ctx.iphone_udid, "Documents/pose_overlay_diag.json", local_pose_diag)
         if pose_diag_ok:
-            try:
-                pose_diag = _json.loads(open(local_pose_diag).read())
+            pose_diag, stale_reason = load_fresh_diag(local_pose_diag, scenario_started_at)
+            if pose_diag is None:
+                for panel_name in ("instructor", "player", "gopro"):
+                    report.step(f"{panel_name} panel frame traffic", False, error=stale_reason)
+            else:
                 for panel_name in ("instructor", "player", "gopro"):
                     panel = pose_diag.get(panel_name, {}) or {}
-                    frames_received = panel.get("framesReceivedByProcessor", 0) or 0
+                    # Key contract with PoseOverlayDiagWriter (LivePoseOverlayProcessor.swift):
+                    # the writer emits "framesReceived" — pinned by
+                    # tests/test_diag_contract.py and the static preflight, after the
+                    # 2026-07-04 review found this gate reading a key the writer never
+                    # emits (guaranteed false FAIL on every physical run).
+                    frames_received = panel.get("framesReceived", 0) or 0
                     report.step(
                         f"{panel_name} panel frame traffic", frames_received >= MIN_PANEL_FRAMES,
-                        framesReceivedByProcessor=frames_received,
+                        framesReceived=frames_received,
                         sourceFramesSeen=panel.get("sourceFramesSeen"),
                         framesProcessed=panel.get("framesProcessed"),
                         visionDetectionSuccesses=panel.get("visionDetectionSuccesses"),
                         framesWithSkeletonPoints=panel.get("framesWithSkeletonPoints"),
                         lastFrameReceivedAt=panel.get("lastFrameReceivedAt"),
                     )
-            except Exception as e:
-                for panel_name in ("instructor", "player", "gopro"):
-                    report.step(f"{panel_name} panel frame traffic", False, error=f"parse error: {e}")
         else:
             for panel_name in ("instructor", "player", "gopro"):
                 report.step(f"{panel_name} panel frame traffic", False,
@@ -1044,15 +1105,15 @@ def scenario_tricamera_capture_skeleton_proof(ctx: ScenarioContext) -> ScenarioR
         local_skeleton = str(artifacts_dir / "skeleton_output.json")
         skeleton_ok = copy_app_container_file(ctx.iphone_udid, "Documents/skeleton_output.json", local_skeleton)
         if skeleton_ok:
-            try:
-                skel = _json.loads(open(local_skeleton).read())
+            skel, stale_reason = load_fresh_diag(local_skeleton, scenario_started_at)
+            if skel is None:
+                report.step("skeleton json collected", False, error=stale_reason)
+            else:
                 frames = skel.get("sampled_frames", 0) or 0
                 joints = skel.get("total_joints_detected", 0) or 0
                 report.step("skeleton json collected", frames > 0,
                             sampled_frames=frames, total_joints_detected=joints,
                             video_duration_s=skel.get("video_duration_s"))
-            except Exception as e:
-                report.step("skeleton json collected", False, error=f"parse error: {e}")
         else:
             report.step("skeleton json collected", False, error="copy_app_container_file failed — SkeletonProcessor may not have completed")
 
@@ -1063,6 +1124,9 @@ def scenario_tricamera_capture_skeleton_proof(ctx: ScenarioContext) -> ScenarioR
         critical_ok = all(
             s.get("ok") for s in report.steps
             if s["description"] in (
+                # If sentinel invalidation failed, this run cannot distinguish fresh
+                # evidence from a previous run's leftovers — no PASS is possible.
+                "stale diag artifacts invalidated",
                 "instructor+player confirmed_start", "gopro confirmed_start",
                 "all 3 confirmed_stop", "timestamp sync report",
                 "gopro preview stream quality", "gopro preview aspect ratio is 16:9",
@@ -1125,6 +1189,12 @@ def scenario_gopro_network_routing_diag(ctx: ScenarioContext) -> ScenarioReport:
     from pathlib import Path
 
     report = ScenarioReport(name="gopro-network-routing-diag", passed=False)
+    # Stale-artifact protection (P0 hardening): sentinel-overwrite every diag
+    # file this scenario reads back, so leftovers from a previous run can
+    # never be presented as this run's evidence.
+    _invalidate_stale_diags(ctx, report, run_id=f"gopro-network-routing-diag-{utc_now_iso()}", targets=[
+        (ctx.iphone_udid, "Documents/gopro_diag.json"),
+    ])
     session = create_session(ctx.api_base, ctx.instructor_token)
     session_uuid = session["session_uuid"]
     report.session_uuid = session_uuid
@@ -1347,6 +1417,12 @@ def scenario_gopro_preview_poc(ctx: ScenarioContext) -> ScenarioReport:
     from pathlib import Path
 
     report = ScenarioReport(name="gopro-preview-poc", passed=False)
+    # Stale-artifact protection (P0 hardening): sentinel-overwrite every diag
+    # file this scenario reads back, so leftovers from a previous run can
+    # never be presented as this run's evidence.
+    _invalidate_stale_diags(ctx, report, run_id=f"gopro-preview-poc-{utc_now_iso()}", targets=[
+        (ctx.iphone_udid, "Documents/gopro_stream_diag.json"),
+    ])
     session = create_session(ctx.api_base, ctx.instructor_token)
     session_uuid = session["session_uuid"]
     report.session_uuid = session_uuid
@@ -1590,6 +1666,13 @@ def scenario_gopro_combined_cycle_proof(ctx: ScenarioContext) -> ScenarioReport:
     from pathlib import Path
 
     report = ScenarioReport(name="gopro-combined-cycle-proof", passed=False)
+    # Stale-artifact protection (P0 hardening): sentinel-overwrite every diag
+    # file this scenario reads back, so leftovers from a previous run can
+    # never be presented as this run's evidence.
+    _invalidate_stale_diags(ctx, report, run_id=f"gopro-combined-cycle-proof-{utc_now_iso()}", targets=[
+        (ctx.iphone_udid, "Documents/gopro_recording_diag.json"),
+        (ctx.iphone_udid, "Documents/gopro_stream_diag.json"),
+    ])
     session = create_session(ctx.api_base, ctx.instructor_token)
     session_uuid = session["session_uuid"]
     report.session_uuid = session_uuid
@@ -1792,6 +1875,12 @@ def scenario_gopro_camera_state_probe(ctx: ScenarioContext) -> ScenarioReport:
     from pathlib import Path
 
     report = ScenarioReport(name="gopro-camera-state-probe", passed=False)
+    # Stale-artifact protection (P0 hardening): sentinel-overwrite every diag
+    # file this scenario reads back, so leftovers from a previous run can
+    # never be presented as this run's evidence.
+    _invalidate_stale_diags(ctx, report, run_id=f"gopro-camera-state-probe-{utc_now_iso()}", targets=[
+        (ctx.iphone_udid, "Documents/gopro_camera_state_diag.json"),
+    ])
     session = create_session(ctx.api_base, ctx.instructor_token)
     session_uuid = session["session_uuid"]
     report.session_uuid = session_uuid
@@ -1934,6 +2023,13 @@ def scenario_gopro_preview_aspect_probe(ctx: ScenarioContext) -> ScenarioReport:
     from pathlib import Path
 
     report = ScenarioReport(name="gopro-preview-aspect-probe", passed=False)
+    # Stale-artifact protection (P0 hardening): sentinel-overwrite every diag
+    # file this scenario reads back, so leftovers from a previous run can
+    # never be presented as this run's evidence.
+    _invalidate_stale_diags(ctx, report, run_id=f"gopro-preview-aspect-probe-{utc_now_iso()}", targets=[
+        (ctx.iphone_udid, "Documents/gopro_preview_aspect_diag.json"),
+        (ctx.iphone_udid, "Documents/gopro_stream_diag.json"),
+    ])
     session = create_session(ctx.api_base, ctx.instructor_token)
     session_uuid = session["session_uuid"]
     report.session_uuid = session_uuid
@@ -2102,6 +2198,17 @@ def scenario_gopro_preset_write_validation(ctx: ScenarioContext) -> ScenarioRepo
     from pathlib import Path
 
     report = ScenarioReport(name="gopro-preset-write-validation", passed=False)
+    # Stale-artifact protection (P0 hardening): sentinel-overwrite every diag
+    # file this scenario reads back, so leftovers from a previous run can
+    # never be presented as this run's evidence.
+    _invalidate_stale_diags(ctx, report, run_id=f"gopro-preset-write-validation-{utc_now_iso()}", targets=[
+        (ctx.iphone_udid, "Documents/gopro_preset_before_diag.json"),
+        (ctx.iphone_udid, "Documents/gopro_preset_write_diag.json"),
+        (ctx.iphone_udid, "Documents/gopro_preset_after_diag.json"),
+        (ctx.iphone_udid, "Documents/gopro_recording_diag.json"),
+        (ctx.iphone_udid, "Documents/gopro_preview_aspect_diag.json"),
+        (ctx.iphone_udid, "Documents/gopro_preset_final_diag.json"),
+    ])
     session = create_session(ctx.api_base, ctx.instructor_token)
     session_uuid = session["session_uuid"]
     report.session_uuid = session_uuid

--- a/scripts/mc1_regression/scenarios.py
+++ b/scripts/mc1_regression/scenarios.py
@@ -27,6 +27,7 @@ from .lib import (
     copy_from_device,
     create_session,
     device_recording_status,
+    device_required,
     extract_capture_path_from_log,
     extract_skeleton_path_from_log,
     get_server_time_iso,
@@ -187,15 +188,19 @@ def _pull_pco_failure_diag(ctx: ScenarioContext, report: ScenarioReport,
     """Pull the player-side PCO failure evidence (Documents/pco_failure_diag.json,
     written by PCOFailureDiagWriter on every PlayerCaptureOrchestrator .failed
     transition — 2026-07-04 RCA). Best-effort: turns a bare
-    "Timeout waiting for: instructor+player confirmed_start" into a concrete
+    "Timeout waiting for: player confirmed_start" into a concrete
     player-side reason (e.g. captureStartTimeout with the last capture state).
-    Never raises; reported as evidence, never gates PASS."""
+    Never raises; reported as evidence, never gates PASS.
+
+    MC2-PR1: the player device is resolved from the role config (final
+    topology: iPhone = player) instead of the old hardcoded iPad."""
+    player_udid = ctx.iphone_udid if ctx.iphone_role == "player" else ctx.ipad_udid
     local = str(ctx.artifact.dir / "pco_failure_diag.json")
     try:
-        if not copy_app_container_file(ctx.ipad_udid, "Documents/pco_failure_diag.json", local):
+        if not copy_app_container_file(player_udid, "Documents/pco_failure_diag.json", local):
             report.step("player pco failure diag", False,
-                        error="pco_failure_diag.json not found on iPad — player PCO "
-                              "never transitioned to .failed during this run "
+                        error="pco_failure_diag.json not found on the player device — "
+                              "player PCO never transitioned to .failed during this run "
                               "(cycle never seen, or hang predates the watchdog build)")
             return
         diag, stale_reason = load_fresh_diag(local, scenario_started_at)
@@ -262,20 +267,40 @@ def _run_one_cycle(
     print(f"Sending begin-cycle deep link to instructor (cycle {cycle_index})...")
     send_deep_link(instructor_udid, "begin-cycle")
 
+    # MC2-PR1 final topology: the instructor is a NON-RECORDING coordinator.
+    # It must never confirm — a confirm without a capture file would be
+    # fabricated evidence, so any instructor status other than "pending"
+    # fails the cycle immediately (no silent fake confirmation). The backend
+    # must also have snapshotted it with required == False (players-only
+    # required set) — both halves of the PR1 gate are asserted on every poll.
+    def _instructor_pending_guard(cyc) -> None:
+        s_inst = device_recording_status(cyc, instructor_device_id)
+        if s_inst != "pending":
+            raise ValidationError(
+                f"instructor device {instructor_device_id} has recording_status="
+                f"{s_inst!r} — a non-recording coordinator must stay 'pending'"
+            )
+        req_inst = device_required(cyc, instructor_device_id)
+        if req_inst is not False:
+            raise ValidationError(
+                f"instructor cycle_device required={req_inst!r} — the required "
+                f"set must be players-only (instructor required == False)"
+            )
+
     def confirmed_start():
         cycles = list_cycles(ctx.api_base, ctx.instructor_token, session_uuid)
         cyc = latest_cycle(cycles)
         if not cyc or cyc["cycle_index"] != cycle_index:
             return None
-        s1 = device_recording_status(cyc, instructor_device_id)
-        s2 = device_recording_status(cyc, player_device_id)
-        if s1 == "confirmed_start" and s2 == "confirmed_start":
-            return {"instructor": s1, "player": s2}
+        _instructor_pending_guard(cyc)
+        s_play = device_recording_status(cyc, player_device_id)
+        if s_play == "confirmed_start":
+            return {"player": s_play, "instructor": "pending"}
         return None
 
     try:
         confirmed = poll_until(
-            f"cycle {cycle_index} confirmed_start on both devices",
+            f"cycle {cycle_index} player confirmed_start (instructor pending)",
             CYCLE_CONFIRM_TIMEOUT_SECONDS, confirmed_start,
         )
         report.step(f"cycle {cycle_index} confirmed_start", True, **confirmed)
@@ -296,15 +321,15 @@ def _run_one_cycle(
         cyc = latest_cycle(cycles)
         if not cyc or cyc["cycle_index"] != cycle_index:
             return None
-        s1 = device_recording_status(cyc, instructor_device_id)
-        s2 = device_recording_status(cyc, player_device_id)
-        if cyc["status"] == "completed" and s1 == "confirmed_stop" and s2 == "confirmed_stop":
-            return {"instructor": s1, "player": s2}
+        _instructor_pending_guard(cyc)
+        s_play = device_recording_status(cyc, player_device_id)
+        if cyc["status"] == "completed" and s_play == "confirmed_stop":
+            return {"player": s_play, "instructor": "pending"}
         return None
 
     try:
         confirmed = poll_until(
-            f"cycle {cycle_index} confirmed_stop on both devices",
+            f"cycle {cycle_index} player confirmed_stop + completed (instructor pending)",
             CYCLE_CONFIRM_TIMEOUT_SECONDS, confirmed_stop,
         )
         report.step(f"cycle {cycle_index} confirmed_stop", True, **confirmed)
@@ -366,82 +391,127 @@ def scenario_multicycle(ctx: ScenarioContext) -> ScenarioReport:
 
 
 def scenario_capture_quality_proof(ctx: ScenarioContext) -> ScenarioReport:
-    """Capture Quality + Metadata block: runs one ordinary smoke cycle (both
-    iPad + iPhone recording locally, the proven 2-device flow), then pulls
-    capture_metadata_diag.json from BOTH devices and validates the explicit
-    720p/30fps-or-360p/30fps-fallback profile actually took effect — not the
-    old device-default `.high` preset.
+    """Capture Quality + Metadata block (MC2-PR1 final topology).
 
-    PASS criteria (per device, capture_metadata_diag.json-grounded):
+    Runs one ordinary smoke cycle — iPad = NON-RECORDING instructor, iPhone =
+    player (the only local recorder) — then:
+
+    PLAYER PASS criteria (capture_metadata_diag.json-grounded, fresh-only):
       1. actualResolution in {"1280x720", "640x360"}
       2. actualFPS within [28, 32] (nominal frame rate tolerance around 30)
       3. actualCodec is a non-empty, known value ("h264")
       4. actualOrientation is portrait/landscape, not "unknown(...)"
+
+    INSTRUCTOR PASS criterion (negative evidence, TOPO-G7 direction):
+      the instructor produced NO capture output — its capture_metadata_diag
+      is either never written this run (sentinel/stale) or fresh but with no
+      output file (outputFilePath null, no fileSizeBytes > 0). A fresh diag
+      showing a capture file on the instructor is a hard FAIL.
     """
     import json
-    from pathlib import Path
+    from datetime import datetime as _dt, timezone as _tz
 
     report = ScenarioReport(name="capture-quality-proof", passed=False)
+    scenario_started_at = _dt.now(_tz.utc)
+    run_id = f"capture-quality-proof-{scenario_started_at.strftime('%Y%m%dT%H%M%SZ')}"
     session = create_session(ctx.api_base, ctx.instructor_token)
     session_uuid = session["session_uuid"]
     report.session_uuid = session_uuid
     print(f"[capture-quality] session created: {session_uuid}")
 
+    player_udid = ctx.iphone_udid if ctx.iphone_role == "player" else ctx.ipad_udid
+    instructor_udid = ctx.ipad_udid if player_udid == ctx.iphone_udid else ctx.iphone_udid
+
     try:
+        # Stale-artifact protection: both devices' capture diag gets a sentinel
+        # so a leftover file from an earlier (pre-MC2) run can never be read
+        # back as this run's evidence — critical for the instructor negative gate.
+        sentinel_ok = _invalidate_stale_diags(ctx, report, run_id=run_id, targets=[
+            (player_udid, "Documents/capture_metadata_diag.json"),
+            (instructor_udid, "Documents/capture_metadata_diag.json"),
+        ])
+        if not sentinel_ok:
+            raise ValidationError("stale-diag invalidation failed — evidence freshness cannot be proven")
+
         instructor_id, player_id = _join_both_devices(ctx, report, session_uuid)
         _mark_devices_ready(ctx, report, session_uuid)
         ok = _run_one_cycle(ctx, report, session_uuid, instructor_id, player_id, cycle_index=0)
         if not ok:
             raise ValidationError("base smoke cycle did not complete — capture quality cannot be assessed")
 
-        send_deep_link(ctx.ipad_udid, "capture-info")
-        send_deep_link(ctx.iphone_udid, "capture-info")
+        # capture-info to BOTH: the player must show a valid capture; the
+        # instructor must show the absence of one.
+        send_deep_link(player_udid, "capture-info")
+        send_deep_link(instructor_udid, "capture-info")
         import time as _time
         _time.sleep(3)
 
-        def _check_device(udid: str, label: str) -> dict:
-            local_diag = str(ctx.artifact.dir / f"capture_metadata_diag_{label}.json")
-            if not copy_app_container_file(udid, "Documents/capture_metadata_diag.json", local_diag):
-                report.step(f"[{label}] capture_metadata_diag.json collected", False, error="copy failed")
-                raise ValidationError(f"capture_metadata_diag.json not collectable from {label}")
-            try:
-                diag = json.loads(Path(local_diag).read_text())
-            except (OSError, json.JSONDecodeError) as e:
-                report.step(f"[{label}] capture_metadata_diag.json collected", False, error=f"unparseable: {e}")
-                raise ValidationError(f"capture_metadata_diag.json from {label} unparseable: {e}")
-            report.step(f"[{label}] capture_metadata_diag.json collected", True, **diag)
-            print(f"[capture-quality] {label} diag: {json.dumps(diag, indent=2)}")
-            return diag
+        # --- Player: full quality gates (fresh diag required) ---
+        local_player_diag = str(ctx.artifact.dir / "capture_metadata_diag_player.json")
+        if not copy_app_container_file(player_udid, "Documents/capture_metadata_diag.json", local_player_diag):
+            report.step("[player] capture_metadata_diag.json collected", False, error="copy failed")
+            raise ValidationError("capture_metadata_diag.json not collectable from player")
+        diag, stale_reason = load_fresh_diag(local_player_diag, scenario_started_at)
+        if diag is None:
+            report.step("[player] capture_metadata_diag.json collected", False, error=stale_reason)
+            raise ValidationError(f"player capture diag not fresh: {stale_reason}")
+        report.step("[player] capture_metadata_diag.json collected", True, **diag)
+        print(f"[capture-quality] player diag: {json.dumps(diag, indent=2)}")
 
-        for udid, label in ((ctx.ipad_udid, "ipad"), (ctx.iphone_udid, "iphone")):
-            diag = _check_device(udid, label)
-            resolution = diag.get("actualResolution")
-            fps = diag.get("actualFPS")
-            codec = diag.get("actualCodec")
-            orientation = diag.get("actualOrientation")
+        resolution = diag.get("actualResolution")
+        fps = diag.get("actualFPS")
+        codec = diag.get("actualCodec")
+        orientation = diag.get("actualOrientation")
 
-            res_ok = resolution in ("1280x720", "640x360")
-            fps_ok = isinstance(fps, (int, float)) and 28 <= fps <= 32
-            codec_ok = codec in ("h264",)
-            orient_ok = orientation in ("portrait", "landscapeLeft", "landscapeRight", "portraitUpsideDown")
+        res_ok = resolution in ("1280x720", "640x360")
+        fps_ok = isinstance(fps, (int, float)) and 28 <= fps <= 32
+        codec_ok = codec in ("h264",)
+        orient_ok = orientation in ("portrait", "landscapeLeft", "landscapeRight", "portraitUpsideDown")
 
-            report.step(f"[{label}] resolution in {{720p,360p}}", res_ok, value=resolution)
-            report.step(f"[{label}] fps ~30", fps_ok, value=fps)
-            report.step(f"[{label}] codec explicit", codec_ok, value=codec)
-            report.step(f"[{label}] orientation known", orient_ok, value=orientation)
+        report.step("[player] resolution in {720p,360p}", res_ok, value=resolution)
+        report.step("[player] fps ~30", fps_ok, value=fps)
+        report.step("[player] codec explicit", codec_ok, value=codec)
+        report.step("[player] orientation known", orient_ok, value=orientation)
 
-            print(f"[capture-quality] {label}: resolution={'OK' if res_ok else 'FAIL'}({resolution}) "
-                  f"fps={'OK' if fps_ok else 'FAIL'}({fps}) codec={'OK' if codec_ok else 'FAIL'}({codec}) "
-                  f"orientation={'OK' if orient_ok else 'FAIL'}({orientation})")
+        print(f"[capture-quality] player: resolution={'OK' if res_ok else 'FAIL'}({resolution}) "
+              f"fps={'OK' if fps_ok else 'FAIL'}({fps}) codec={'OK' if codec_ok else 'FAIL'}({codec}) "
+              f"orientation={'OK' if orient_ok else 'FAIL'}({orientation})")
 
-            if not (res_ok and fps_ok and codec_ok and orient_ok):
-                raise ValidationError(
-                    f"{label} capture quality check failed: resolution={resolution} fps={fps} "
-                    f"codec={codec} orientation={orientation}"
-                )
+        if not (res_ok and fps_ok and codec_ok and orient_ok):
+            raise ValidationError(
+                f"player capture quality check failed: resolution={resolution} fps={fps} "
+                f"codec={codec} orientation={orientation}"
+            )
+
+        # --- Instructor: negative evidence (no capture output) ---
+        local_inst_diag = str(ctx.artifact.dir / "capture_metadata_diag_instructor.json")
+        inst_copy_ok = copy_app_container_file(
+            instructor_udid, "Documents/capture_metadata_diag.json", local_inst_diag)
+        if not inst_copy_ok:
+            # No diag at all also proves no capture — acceptable, but note it.
+            report.step("[instructor] no capture output", True,
+                        note="capture_metadata_diag.json not present on instructor")
+        else:
+            inst_diag, inst_stale = load_fresh_diag(local_inst_diag, scenario_started_at)
+            if inst_diag is None:
+                # Sentinel still in place / stale → the app never wrote capture
+                # evidence during this run → no capture happened.
+                report.step("[instructor] no capture output", True, note=inst_stale)
+            else:
+                file_size = inst_diag.get("fileSizeBytes", 0) or 0
+                output_path = inst_diag.get("outputFilePath")
+                recorded = bool(output_path) or file_size > 0
+                report.step("[instructor] no capture output", not recorded,
+                            outputFilePath=output_path, fileSizeBytes=file_size,
+                            state=inst_diag.get("state"))
+                if recorded:
+                    raise ValidationError(
+                        f"instructor produced capture output (outputFilePath={output_path!r}, "
+                        f"fileSizeBytes={file_size}) — a non-recording coordinator must not record"
+                    )
 
         report.passed = True
-        print("[capture-quality] === PASS: both devices recorded at the explicit profile ===")
+        print("[capture-quality] === PASS: player recorded at the explicit profile; instructor produced no capture ===")
 
     except ValidationError as e:
         report.error = str(e)
@@ -559,12 +629,12 @@ GOPRO_RECORD_SECONDS = 8
 
 
 def scenario_gopro_tricamera_smoke(ctx: ScenarioContext) -> ScenarioReport:
-    """3-camera smoke: iPhone (instructor+GoPro controller) + iPad (player) + GoPro, 1 cycle.
+    """3-camera smoke: iPad (non-recording instructor) + iPhone (player + GoPro bridge) + GoPro, 1 cycle.
 
-    Role model:
-      iPhone = instructor/controller + GoPro bridge (cellular keeps backend reachable)
-      iPad   = player/student camera (WiFi/wired, no SIM needed)
-      GoPro  = auxiliary camera, managed by iPhone
+    Role model (final topology, MC2-PR1):
+      iPad   = instructor / master coordinator — NO camera, NO capture file, NO confirm
+      iPhone = player camera + GoPro bridge (cellular keeps backend reachable on GoPro WiFi)
+      GoPro  = auxiliary camera, managed by the PLAYER iPhone
 
     Preconditions (physical only):
       - GoPro HERO12 powered on and in pairing/connectable state
@@ -578,28 +648,32 @@ def scenario_gopro_tricamera_smoke(ctx: ScenarioContext) -> ScenarioReport:
     session_uuid = session["session_uuid"]
     report.session_uuid = session_uuid
     print(f"[gopro-tricam] session created: {session_uuid}")
-    print(f"[gopro-tricam] role model: iPhone=instructor+GoPro, iPad=player")
+    print(f"[gopro-tricam] role model: iPad=instructor (non-recording), iPhone=player+GoPro")
 
     try:
-        # 1. Join both — iPhone as instructor, iPad as player
+        # 1. Join both — iPad as instructor, iPhone as player
         instructor_id, player_id = _join_both_devices(ctx, report, session_uuid)
+        instructor_udid = ctx.iphone_udid if ctx.iphone_role == "instructor" else ctx.ipad_udid
 
-        # 2. Register GoPro as auxiliary_camera, managed by instructor (iPhone)
-        print(f"[gopro-register] Registering GoPro managed_by instructor device_id={instructor_id}...")
+        # 2. Register GoPro as auxiliary_camera, managed by the PLAYER iPhone
+        #    (the iPhone joins the GoPro WiFi, so it must own the manager role;
+        #    registered with the player token — backend ownership check requires
+        #    the manager device's participant user to equal the caller).
+        print(f"[gopro-register] Registering GoPro managed_by player device_id={player_id}...")
         gopro_sd = register_device(
-            ctx.api_base, ctx.instructor_token, session_uuid,
+            ctx.api_base, ctx.player_token, session_uuid,
             device_role="auxiliary_camera",
             device_type="gopro",
-            device_name="GoPro HERO13 (automation)",
-            managed_by_device_id=instructor_id,
+            device_name="GoPro HERO12 (automation)",
+            managed_by_device_id=player_id,
         )
         gopro_device_id = gopro_sd["id"]
         managed_by = gopro_sd.get("managed_by_device_id")
         print(f"[gopro-register]   GoPro session_device_id={gopro_device_id} managed_by={managed_by}")
-        if managed_by != instructor_id:
-            report.step("gopro managed_by instructor", False, expected=instructor_id, actual=managed_by)
-            raise ValidationError(f"GoPro managed_by={managed_by} but expected instructor id={instructor_id}")
-        report.step("gopro registered (managed by instructor)", True, gopro_device_id=gopro_device_id, managed_by=managed_by)
+        if managed_by != player_id:
+            report.step("gopro managed_by player", False, expected=player_id, actual=managed_by)
+            raise ValidationError(f"GoPro managed_by={managed_by} but expected player id={player_id}")
+        report.step("gopro registered (managed by player)", True, gopro_device_id=gopro_device_id, managed_by=managed_by)
 
         # 3. GoPro connect on iPhone (BLE → WiFi → HTTP, in-app flow)
         #    Passes gopro_device_id so iPhone can signal ready via backend updateDeviceStatus
@@ -636,24 +710,33 @@ def scenario_gopro_tricamera_smoke(ctx: ScenarioContext) -> ScenarioReport:
         # 6. Mark devices ready
         _mark_devices_ready(ctx, report, session_uuid)
 
-        # 6. Begin cycle — instructor is iPhone
-        print("Sending begin-cycle deep link to iPhone/instructor (cycle 0)...")
-        send_deep_link(ctx.iphone_udid, "begin-cycle")
+        # 6. Begin cycle — instructor is the iPad (non-recording coordinator)
+        print("Sending begin-cycle deep link to instructor (cycle 0)...")
+        send_deep_link(instructor_udid, "begin-cycle")
 
-        # 7. Wait for iPad + iPhone confirmed_start
-        def ipad_iphone_confirmed_start():
+        # 7. Wait for PLAYER confirmed_start; the non-recording instructor must
+        #    stay "pending" — any instructor confirm is fabricated evidence.
+        def player_confirmed_start():
             cycles = list_cycles(ctx.api_base, ctx.instructor_token, session_uuid)
             cyc = latest_cycle(cycles)
             if not cyc or cyc["cycle_index"] != 0:
                 return None
-            s1 = device_recording_status(cyc, instructor_id)
-            s2 = device_recording_status(cyc, player_id)
-            if s1 == "confirmed_start" and s2 == "confirmed_start":
+            s_inst = device_recording_status(cyc, instructor_id)
+            if s_inst != "pending":
+                raise ValidationError(
+                    f"instructor recording_status={s_inst!r} — non-recording coordinator must stay 'pending'"
+                )
+            if device_required(cyc, instructor_id) is not False:
+                raise ValidationError(
+                    "instructor cycle_device is in the required set — must be players-only (MC2-PR1)"
+                )
+            s_play = device_recording_status(cyc, player_id)
+            if s_play == "confirmed_start":
                 return cyc
             return None
 
-        cycle = poll_until("iPad+iPhone confirmed_start", CYCLE_CONFIRM_TIMEOUT_SECONDS, ipad_iphone_confirmed_start)
-        report.step("ipad+iphone confirmed_start", True)
+        cycle = poll_until("player confirmed_start (instructor pending)", CYCLE_CONFIRM_TIMEOUT_SECONDS, player_confirmed_start)
+        report.step("player confirmed_start (instructor pending)", True)
 
         # 8. Verify GoPro cycle_device exists
         cycle_id = cycle["id"]
@@ -723,28 +806,37 @@ def scenario_gopro_tricamera_smoke(ctx: ScenarioContext) -> ScenarioReport:
             print("[gopro-stop] FAIL — GoPro may have disconnected during recording")
             raise
 
-        # 14. End cycle — instructor is iPhone
-        print("[end-cycle] Sending end-cycle deep link to iPhone/instructor (after GoPro stop)...")
-        send_deep_link(ctx.iphone_udid, "end-cycle")
+        # 14. End cycle — instructor iPad (after GoPro stop)
+        print("[end-cycle] Sending end-cycle deep link to instructor (after GoPro stop)...")
+        send_deep_link(instructor_udid, "end-cycle")
 
-        # 15. Wait for iPad + iPhone confirmed_stop (GoPro already confirmed)
-        def all_three_confirmed_stop():
+        # 15. Wait for both RECORDERS (player + GoPro) confirmed_stop and the
+        #     cycle completed; the non-recording instructor must stay "pending".
+        def recorders_confirmed_stop():
             cycles = list_cycles(ctx.api_base, ctx.instructor_token, session_uuid)
             cyc = latest_cycle(cycles)
             if not cyc:
                 return None
             s_inst = device_recording_status(cyc, instructor_id)
+            if s_inst != "pending":
+                raise ValidationError(
+                    f"instructor recording_status={s_inst!r} — non-recording coordinator must stay 'pending'"
+                )
+            if device_required(cyc, instructor_id) is not False:
+                raise ValidationError(
+                    "instructor cycle_device is in the required set — must be players-only (MC2-PR1)"
+                )
             s_play = device_recording_status(cyc, player_id)
             s_gp = device_recording_status(cyc, gopro_device_id)
-            if s_inst == "confirmed_stop" and s_play == "confirmed_stop" and s_gp == "confirmed_stop":
-                return {"instructor": s_inst, "player": s_play, "gopro": s_gp}
+            if cyc["status"] == "completed" and s_play == "confirmed_stop" and s_gp == "confirmed_stop":
+                return {"player": s_play, "gopro": s_gp, "instructor": "pending", "cycle_status": cyc["status"]}
             return None
 
         try:
-            result = poll_until("all 3 devices confirmed_stop", CYCLE_CONFIRM_TIMEOUT_SECONDS, all_three_confirmed_stop)
-            report.step("all 3 confirmed_stop", True, **result)
+            result = poll_until("recorders confirmed_stop + cycle completed", CYCLE_CONFIRM_TIMEOUT_SECONDS, recorders_confirmed_stop)
+            report.step("recorders confirmed_stop (instructor pending)", True, **result)
         except ValidationError as e:
-            report.step("all 3 confirmed_stop", False, error=str(e))
+            report.step("recorders confirmed_stop (instructor pending)", False, error=str(e))
             _dump_session_state(ctx, session_uuid, "tricam-stop-timeout")
             raise
 
@@ -771,29 +863,35 @@ ARTIFACT_COLLECT_SECONDS = 5
 
 
 def scenario_tricamera_capture_skeleton_proof(ctx: ScenarioContext) -> ScenarioReport:
-    """End-to-end proof: 3-camera capture + live skeleton overlay.
+    """End-to-end proof: 3-camera-topology capture cycle (MC2-PR1 role model).
 
-    iPhone=instructor+GoPro controller, iPad=player, GoPro=auxiliary.
+    Role model (final topology, 2026-07-12):
+      iPad   = instructor / non-recording coordinator — NO capture, NO confirm
+      iPhone = player (the only iOS recorder) + GoPro bridge (cellular backend)
+      GoPro  = auxiliary camera, managed by the PLAYER iPhone
 
     AUTOMATED PASS criteria (backend-grounded):
-      - instructor+player confirmed_start  (cycle_devices recording_status)
-      - gopro confirmed_start              (cycle_devices recording_status)
-      - all 3 confirmed_stop               (cycle_devices recording_status)
+      - player confirmed_start; instructor stays pending + required==False
+      - gopro confirmed_start
+      - player+gopro confirmed_stop, cycle completed, instructor still pending
       - timestamp sync report saved        (proof_cycle_timing.json written)
+      - player capture metadata fresh, orientation/aspect gates
+      - instructor produced NO capture output (negative evidence, TOPO-G7)
+      - gopro preview stream quality + 16:9 (probe runs on the player iPhone,
+        which owns the GoPro AP connection)
 
-    MANUAL VISUAL PASS criteria (human operator, cannot be automated):
-      - iPhone panel: cyan skeleton overlay visible during preview
-      - iPad panel:   cyan skeleton overlay visible during preview
-      - GoPro panel:  cyan skeleton overlay visible during preview
-        (GoPro frames are pushed via GoProStreamProbe.lastFrame → feed())
-      → Operator must screenshot the dashboard showing all 3 skeleton overlays
-        and save as: artifacts/visual_skeleton_overlay.png
+    SUPERSEDED (2026-07-12 no-MPC architektúra-döntés): the live dashboard
+    panel gates (pose_overlay_diag panel frame traffic) no longer gate PASS —
+    the dashboard moves to backend-polled status/thumbnail panels (MC2-PR3)
+    and this scenario is replaced by `final-topology-proof` in MC2-PR4. The
+    pose-overlay collection below is kept as best-effort corroborating output
+    only, so the diag writer↔reader key contract stays pinned until PR3
+    removes both sides together.
 
     CORROBORATING evidence (reported, does NOT gate PASS):
-      - iphone_capture_metadata.json  (fileSizeBytes > 0)
-      - ipad_capture_metadata.json    (fileSizeBytes > 0)
       - skeleton_output.json          (post-capture SkeletonProcessor run)
       - gopro media evidence          ([GOPRO-MEDIA-BEGIN] in iPhone log)
+      - pose_overlay_diag.json        (legacy live-panel counters, best-effort)
     """
     import time as _time
     from datetime import datetime as _dt, timezone as _tz
@@ -805,36 +903,45 @@ def scenario_tricamera_capture_skeleton_proof(ctx: ScenarioContext) -> ScenarioR
     session_uuid = session["session_uuid"]
     report.session_uuid = session_uuid
     print(f"[proof] session created: {session_uuid}")
-    print(f"[proof] iPhone=instructor+GoPro, iPad=player")
+    print(f"[proof] role model: iPad=instructor (non-recording), iPhone=player+GoPro bridge")
+
+    instructor_udid = ctx.iphone_udid if ctx.iphone_role == "instructor" else ctx.ipad_udid
+    player_udid = ctx.iphone_udid if instructor_udid == ctx.ipad_udid else ctx.ipad_udid
 
     try:
         # 0. Stale-artifact protection (P0 hardening): overwrite every diag file
         #    this scenario later gates on with a sentinel, so a leftover file from
         #    a previous run can never be read back as this run's evidence. This
         #    step is gate-critical — if it fails, no PASS is possible.
+        #    MC2-PR1: the iPad's capture diag sentinel is what makes the
+        #    "instructor produced no capture" negative gate trustworthy; the
+        #    pco_failure_diag now lives on the player iPhone.
         _invalidate_stale_diags(ctx, report, run_id=run_id, targets=[
             (ctx.iphone_udid, "Documents/capture_metadata_diag.json"),
             (ctx.iphone_udid, "Documents/gopro_stream_diag.json"),
             (ctx.iphone_udid, "Documents/pose_overlay_diag.json"),
             (ctx.iphone_udid, "Documents/skeleton_output.json"),
             (ctx.iphone_udid, "Documents/gopro_diag.json"),
+            (ctx.iphone_udid, "Documents/pco_failure_diag.json"),
             (ctx.ipad_udid, "Documents/capture_metadata_diag.json"),
-            (ctx.ipad_udid, "Documents/pco_failure_diag.json"),
         ])
 
         # 1. Join both devices
         instructor_id, player_id = _join_both_devices(ctx, report, session_uuid)
 
-        # 2. Register GoPro managed by instructor (iPhone)
-        print(f"[proof] Registering GoPro managed_by instructor device_id={instructor_id}...")
+        # 2. Register GoPro managed by the PLAYER iPhone (final topology: the
+        #    iPhone owns the GoPro AP connection; registered with the player
+        #    token because the backend ownership-check requires the manager
+        #    device's participant user to equal the caller).
+        print(f"[proof] Registering GoPro managed_by player device_id={player_id}...")
         gopro_sd = register_device(
-            ctx.api_base, ctx.instructor_token, session_uuid,
+            ctx.api_base, ctx.player_token, session_uuid,
             device_role="auxiliary_camera", device_type="gopro",
-            device_name="GoPro HERO13 (proof)",
-            managed_by_device_id=instructor_id,
+            device_name="GoPro HERO12 (proof)",
+            managed_by_device_id=player_id,
         )
         gopro_device_id = gopro_sd["id"]
-        report.step("gopro registered", True, gopro_device_id=gopro_device_id, managed_by=instructor_id)
+        report.step("gopro registered (managed by player)", True, gopro_device_id=gopro_device_id, managed_by=player_id)
 
         # 3. GoPro connect on iPhone — BLE scan + manual WiFi join required.
         #    Same pattern as gopro-network-routing-diag: send gopro-connect to
@@ -885,22 +992,32 @@ def scenario_tricamera_capture_skeleton_proof(ctx: ScenarioContext) -> ScenarioR
         _time.sleep(3)  # give stream/start HTTP request time to reach GoPro
         report.step("gopro-stream-start sent", True)
 
-        # 5. Begin cycle (instructor = iPhone)
-        print("[proof] begin-cycle → iPhone/instructor...")
-        send_deep_link(ctx.iphone_udid, "begin-cycle")
+        # 5. Begin cycle (instructor = iPad, non-recording coordinator)
+        print("[proof] begin-cycle → instructor (iPad)...")
+        send_deep_link(instructor_udid, "begin-cycle")
 
-        # 6. Wait for iPhone + iPad confirmed_start
-        def two_devices_started():
+        # 6. Wait for PLAYER confirmed_start; the instructor must stay pending
+        #    with required==False (MC2-PR1 gate — a confirm without a capture
+        #    file would be fabricated evidence).
+        def player_started_instructor_pending():
             cycles = list_cycles(ctx.api_base, ctx.instructor_token, session_uuid)
             cyc = latest_cycle(cycles)
             if not cyc or cyc["cycle_index"] != 0:
                 return None
-            s1 = device_recording_status(cyc, instructor_id)
-            s2 = device_recording_status(cyc, player_id)
-            return cyc if s1 == "confirmed_start" and s2 == "confirmed_start" else None
+            s_inst = device_recording_status(cyc, instructor_id)
+            if s_inst != "pending":
+                raise ValidationError(
+                    f"instructor recording_status={s_inst!r} — non-recording coordinator must stay 'pending'"
+                )
+            if device_required(cyc, instructor_id) is not False:
+                raise ValidationError(
+                    "instructor cycle_device is in the required set — must be players-only (MC2-PR1)"
+                )
+            s_play = device_recording_status(cyc, player_id)
+            return cyc if s_play == "confirmed_start" else None
 
-        cycle = poll_until("instructor+player confirmed_start", CYCLE_CONFIRM_TIMEOUT_SECONDS, two_devices_started)
-        report.step("instructor+player confirmed_start", True)
+        cycle = poll_until("player confirmed_start (instructor pending)", CYCLE_CONFIRM_TIMEOUT_SECONDS, player_started_instructor_pending)
+        report.step("player confirmed_start (instructor pending)", True)
         cycle_id = cycle["id"]
 
         # 7. GoPro start (iPhone)
@@ -940,25 +1057,30 @@ def scenario_tricamera_capture_skeleton_proof(ctx: ScenarioContext) -> ScenarioR
             report.step("gopro confirmed_stop", False, error=str(e))
             raise
 
-        # 10. End cycle (instructor = iPhone)
-        print("[proof] end-cycle → iPhone/instructor...")
-        send_deep_link(ctx.iphone_udid, "end-cycle")
+        # 10. End cycle (instructor = iPad)
+        print("[proof] end-cycle → instructor (iPad)...")
+        send_deep_link(instructor_udid, "end-cycle")
 
-        # 11. All 3 confirmed_stop
-        def all_stopped():
+        # 11. Both RECORDERS (player + GoPro) confirmed_stop + cycle completed;
+        #     the non-recording instructor must still be pending.
+        def recorders_stopped():
             cycles = list_cycles(ctx.api_base, ctx.instructor_token, session_uuid)
             cyc = latest_cycle(cycles)
             if not cyc:
                 return None
-            s = {
-                "instructor": device_recording_status(cyc, instructor_id),
-                "player": device_recording_status(cyc, player_id),
-                "gopro": device_recording_status(cyc, gopro_device_id),
-            }
-            return s if all(v == "confirmed_stop" for v in s.values()) else None
+            s_inst = device_recording_status(cyc, instructor_id)
+            if s_inst != "pending":
+                raise ValidationError(
+                    f"instructor recording_status={s_inst!r} — non-recording coordinator must stay 'pending'"
+                )
+            s_play = device_recording_status(cyc, player_id)
+            s_gp = device_recording_status(cyc, gopro_device_id)
+            if cyc["status"] == "completed" and s_play == "confirmed_stop" and s_gp == "confirmed_stop":
+                return {"player": s_play, "gopro": s_gp, "instructor": "pending", "cycle_status": cyc["status"]}
+            return None
 
-        result = poll_until("all 3 confirmed_stop", CYCLE_CONFIRM_TIMEOUT_SECONDS, all_stopped)
-        report.step("all 3 confirmed_stop", True, **result)
+        result = poll_until("recorders confirmed_stop + cycle completed", CYCLE_CONFIRM_TIMEOUT_SECONDS, recorders_stopped)
+        report.step("recorders confirmed_stop (instructor pending)", True, **result)
 
         # 12. Timestamp sync check
         cycles_final = list_cycles(ctx.api_base, ctx.instructor_token, session_uuid)
@@ -1059,37 +1181,27 @@ def scenario_tricamera_capture_skeleton_proof(ctx: ScenarioContext) -> ScenarioR
         else:
             report.step("iphone capture metadata", False, error="copy_app_container_file failed")
 
-        # 17b. iPad capture metadata
+        # 17b. Instructor (iPad) NEGATIVE evidence — MC2-PR1 / TOPO-G7: the
+        #      non-recording coordinator must have produced NO capture output.
+        #      Sentinel-still-in-place or missing file both prove "never wrote
+        #      capture evidence this run"; a fresh diag (steps 13/16 already sent
+        #      capture-info to the iPad) must show no output file.
         local_ipad_meta = str(artifacts_dir / "ipad_capture_metadata.json")
         ipad_meta_ok = copy_app_container_file(ctx.ipad_udid, "Documents/capture_metadata_diag.json", local_ipad_meta)
-        if ipad_meta_ok:
+        if not ipad_meta_ok:
+            report.step("instructor no capture output", True,
+                        note="capture_metadata_diag.json not present on the iPad")
+        else:
             meta, stale_reason = load_fresh_diag(local_ipad_meta, scenario_started_at)
             if meta is None:
-                report.step("ipad capture metadata", False, error=stale_reason)
-                report.step("ipad orientation consistent", False, error=stale_reason)
-                report.step("ipad effective aspect ratio matches orientation", False, error=stale_reason)
+                report.step("instructor no capture output", True, note=stale_reason)
             else:
                 file_size = meta.get("fileSizeBytes", 0) or 0
-                report.step("ipad capture metadata", file_size > 0,
-                            fileSizeBytes=file_size, outputFilePath=meta.get("outputFilePath"),
-                            durationSeconds=meta.get("actualDurationSeconds"),
-                            codec=meta.get("actualCodec"))
-                report.step("ipad orientation consistent", meta.get("orientationConsistent") is True,
-                            deviceOrientationAtRecordingStart=meta.get("deviceOrientationAtRecordingStart"),
-                            fileOrientationCoarse=meta.get("fileOrientationCoarse"))
-                eff_ok, eff_expected = _effective_aspect_gate(meta)
-                report.step("ipad effective aspect ratio matches orientation", eff_ok,
-                            expectedEffectiveAspect=eff_expected,
-                            fileOrientationCoarse=meta.get("fileOrientationCoarse"),
-                            effectiveAspectRatio=meta.get("effectiveAspectRatio"),
-                            effectiveDisplayWidth=meta.get("effectiveDisplayWidth"),
-                            effectiveDisplayHeight=meta.get("effectiveDisplayHeight"))
-                encoded_ok = _encoded_aspect_is_16_9(meta)
-                if encoded_ok is not None:
-                    report.step("ipad encoded aspect ratio is 16:9", encoded_ok,
-                                actualResolution=meta.get("actualResolution"))
-        else:
-            report.step("ipad capture metadata", False, error="copy_app_container_file failed")
+                output_path = meta.get("outputFilePath")
+                recorded = bool(output_path) or file_size > 0
+                report.step("instructor no capture output", not recorded,
+                            outputFilePath=output_path, fileSizeBytes=file_size,
+                            state=meta.get("state"))
 
         # 17c. GoPro recording evidence: media list in iPhone console log
         iphone_log_path = ctx.artifact.iphone_console_log
@@ -1204,23 +1316,25 @@ def scenario_tricamera_capture_skeleton_proof(ctx: ScenarioContext) -> ScenarioR
             report.step("skeleton json collected", False, error="copy_app_container_file failed — SkeletonProcessor may not have completed")
 
         # 18. Final PASS: all critical backend-grounded steps must be OK.
-        #     Artifact steps (capture metadata, skeleton) are corroborating evidence
-        #     and are reported but do NOT gate the PASS — backend confirmed_stop is
-        #     the authoritative proof that all 3 cameras recorded.
+        #     Artifact steps (skeleton, gopro media, legacy pose-overlay panels)
+        #     are corroborating evidence and do NOT gate the PASS.
+        #     MC2-PR1 changes: instructor confirm gates → player-only + pending
+        #     guard; iPad capture gates → "instructor no capture output"
+        #     negative gate; the live-panel frame-traffic gates are removed per
+        #     the 2026-07-12 no-MPC decision (superseded by final-topology-proof
+        #     status/thumbnail gates in MC2-PR4).
         critical_ok = all(
             s.get("ok") for s in report.steps
             if s["description"] in (
                 # If sentinel invalidation failed, this run cannot distinguish fresh
                 # evidence from a previous run's leftovers — no PASS is possible.
                 "stale diag artifacts invalidated",
-                "instructor+player confirmed_start", "gopro confirmed_start",
-                "all 3 confirmed_stop", "timestamp sync report",
+                "player confirmed_start (instructor pending)", "gopro confirmed_start",
+                "recorders confirmed_stop (instructor pending)", "timestamp sync report",
                 "gopro preview stream quality", "gopro preview aspect ratio is 16:9",
-                "instructor panel frame traffic", "player panel frame traffic", "gopro panel frame traffic",
                 "iphone orientation consistent", "iphone effective aspect ratio matches orientation",
                 "iphone encoded aspect ratio is 16:9",
-                "ipad orientation consistent", "ipad effective aspect ratio matches orientation",
-                "ipad encoded aspect ratio is 16:9",
+                "instructor no capture output",
             )
         )
         report.passed = critical_ok

--- a/scripts/mc1_regression/tests/test_aspect_gates.py
+++ b/scripts/mc1_regression/tests/test_aspect_gates.py
@@ -1,0 +1,136 @@
+"""Orientation-aware aspect-ratio gate tests (2026-07-04 physical-run fix).
+
+The first passing tricamera capture run FAILED only on the unconditional
+"effective aspect ratio is 16:9" assertion: the app correctly encodes the
+sensor's landscape 1280x720 buffer and bakes portrait rotation into
+preferredTransform (verified with ffprobe on the pulled .mov files —
+encoded 1280x720 + rotation -90 => effective display 720x1280 = 9:16).
+Under the RC-checklist J-section portrait mandate (issue #357) the 16:9
+effective expectation was therefore unsatisfiable while the recording was
+in fact correct.
+
+These tests pin the corrected gate semantics:
+  - portrait metadata  -> expected effective aspect 9:16 (PASSes on 9:16)
+  - portrait metadata  -> a 16:9 EFFECTIVE aspect now FAILs (that would mean
+    the rotation was NOT baked in)
+  - landscape metadata -> expected effective aspect 16:9 (PASSes on 16:9)
+  - the encoded-buffer check stays 16:9 regardless of orientation
+  - the GoPro preview gate (_aspect_ratio_matches default 16:9) is unchanged
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from mc1_regression.scenarios import (  # noqa: E402
+    _aspect_ratio_matches,
+    _effective_aspect_gate,
+    _encoded_aspect_is_16_9,
+    _expected_effective_aspect,
+)
+
+
+def _portrait_meta(effective="9:16"):
+    return {
+        "fileOrientationCoarse": "portrait",
+        "effectiveAspectRatio": effective,
+        "actualResolution": "1280x720",
+    }
+
+
+def _landscape_meta(effective="16:9"):
+    return {
+        "fileOrientationCoarse": "landscape",
+        "effectiveAspectRatio": effective,
+        "actualResolution": "1280x720",
+    }
+
+
+# ── expected-aspect mapping ──────────────────────────────────────────────────
+
+def test_expected_effective_aspect_portrait_is_9_16():
+    assert _expected_effective_aspect("portrait") == (9, 16)
+
+
+def test_expected_effective_aspect_landscape_is_16_9():
+    assert _expected_effective_aspect("landscape") == (16, 9)
+
+
+def test_expected_effective_aspect_unknown_has_no_expectation():
+    assert _expected_effective_aspect("unknown") is None
+    assert _expected_effective_aspect(None) is None
+
+
+# ── effective-aspect gate ────────────────────────────────────────────────────
+
+def test_portrait_9_16_effective_passes():
+    ok, expected = _effective_aspect_gate(_portrait_meta("9:16"))
+    assert ok is True
+    assert expected == "9:16"
+
+
+def test_portrait_16_9_effective_fails():
+    # A 16:9 EFFECTIVE aspect on a portrait file would mean the rotation was
+    # never baked in — exactly what the old gate wrongly demanded.
+    ok, expected = _effective_aspect_gate(_portrait_meta("16:9"))
+    assert ok is False
+    assert expected == "9:16"
+
+
+def test_landscape_16_9_effective_passes():
+    ok, expected = _effective_aspect_gate(_landscape_meta("16:9"))
+    assert ok is True
+    assert expected == "16:9"
+
+
+def test_landscape_9_16_effective_fails():
+    ok, _ = _effective_aspect_gate(_landscape_meta("9:16"))
+    assert ok is False
+
+
+def test_unknown_orientation_fails_gate():
+    ok, expected = _effective_aspect_gate({"fileOrientationCoarse": "unknown",
+                                           "effectiveAspectRatio": "16:9"})
+    assert ok is False
+    assert expected is None
+
+
+def test_missing_meta_fails_gate():
+    ok, expected = _effective_aspect_gate({})
+    assert ok is False
+    assert expected is None
+
+
+# ── encoded-buffer gate (orientation-independent 16:9) ───────────────────────
+
+def test_encoded_1280x720_is_16_9_for_both_orientations():
+    assert _encoded_aspect_is_16_9(_portrait_meta()) is True
+    assert _encoded_aspect_is_16_9(_landscape_meta()) is True
+
+
+def test_encoded_portrait_shaped_buffer_fails():
+    meta = _portrait_meta()
+    meta["actualResolution"] = "720x1280"
+    assert _encoded_aspect_is_16_9(meta) is False
+
+
+def test_encoded_missing_metadata_returns_none_step_skipped():
+    assert _encoded_aspect_is_16_9({}) is None
+    assert _encoded_aspect_is_16_9({"actualResolution": "garbage"}) is None
+
+
+# ── GoPro preview gate unchanged ─────────────────────────────────────────────
+
+def test_gopro_preview_gate_unchanged_16_9_passes():
+    assert _aspect_ratio_matches("16:9") is True
+    # near-16:9 real SPS dims still pass (tolerant numeric compare)
+    assert _aspect_ratio_matches("1280:720") is True
+
+
+def test_gopro_preview_gate_unchanged_non_16_9_fails():
+    assert _aspect_ratio_matches("9:16") is False
+    assert _aspect_ratio_matches("4:3") is False
+    assert _aspect_ratio_matches(None) is False

--- a/scripts/mc1_regression/tests/test_console_preconditions.py
+++ b/scripts/mc1_regression/tests/test_console_preconditions.py
@@ -1,0 +1,70 @@
+"""Dual-console hard precondition tests (2026-07-04 tricamera RCA).
+
+The first tricamera physical run failed on the PLAYER (iPad) side while the
+shell wrapper had silently SKIPPED the iPad console capture with a warning —
+the exact evidence the failure needed was never collected. These tests pin
+the runner-side enforcement: tricamera scenarios must refuse to run unless
+BOTH device console log files exist (created by run_mc1_regression.sh before
+the runner starts).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from mc1_regression.lib import (  # noqa: E402
+    DUAL_CONSOLE_REQUIRED_SCENARIOS,
+    check_dual_console_precondition,
+)
+
+TRICAMERA = "tricamera-capture-skeleton-proof"
+
+
+def _console_dir(tmp_path: Path, *files: str) -> Path:
+    d = tmp_path / "console"
+    d.mkdir()
+    for f in files:
+        (d / f).write_text("")
+    return d
+
+
+def test_tricamera_proof_is_dual_console_required():
+    assert TRICAMERA in DUAL_CONSOLE_REQUIRED_SCENARIOS
+    assert "gopro-tricamera-smoke" in DUAL_CONSOLE_REQUIRED_SCENARIOS
+
+
+def test_both_consoles_present_passes(tmp_path):
+    d = _console_dir(tmp_path, "iphone_console.log", "ipad_console.log")
+    assert check_dual_console_precondition([TRICAMERA], d) == []
+
+
+def test_missing_ipad_console_fails(tmp_path):
+    d = _console_dir(tmp_path, "iphone_console.log")
+    errors = check_dual_console_precondition([TRICAMERA], d)
+    assert len(errors) == 1
+    assert "iPad" in errors[0]
+    assert "ipad_console.log" in errors[0]
+    assert TRICAMERA in errors[0]
+
+
+def test_missing_both_consoles_reports_both(tmp_path):
+    d = _console_dir(tmp_path)
+    errors = check_dual_console_precondition([TRICAMERA], d)
+    assert len(errors) == 2
+    assert any("iPhone" in e for e in errors)
+    assert any("iPad" in e for e in errors)
+
+
+def test_non_tricamera_scenario_is_exempt(tmp_path):
+    d = _console_dir(tmp_path)  # no console files at all
+    assert check_dual_console_precondition(["smoke"], d) == []
+    assert check_dual_console_precondition(["all"], d) == []
+
+
+def test_scenario_list_with_mixed_names_still_enforces(tmp_path):
+    d = _console_dir(tmp_path, "iphone_console.log")
+    errors = check_dual_console_precondition(["smoke", TRICAMERA], d)
+    assert len(errors) == 1 and "iPad" in errors[0]

--- a/scripts/mc1_regression/tests/test_diag_contract.py
+++ b/scripts/mc1_regression/tests/test_diag_contract.py
@@ -1,0 +1,153 @@
+"""Writer↔reader contract tests for the MC1 diag artifacts (P0 hardening).
+
+The 2026-07-04 review found scenarios.py gating the tricamera proof on a JSON
+key ("framesReceivedByProcessor") that the Swift writer never emits (it writes
+"framesReceived") — every panel gate read 0 and the scenario could never PASS.
+These tests pin the cross-language key contract by parsing BOTH sides from
+source, so any future rename on either side fails fast in CI instead of on a
+physical test day.
+
+Also covers the stale-artifact freshness loader (lib.load_fresh_diag), which
+is the runtime half of the same evidence-integrity guarantee.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCENARIOS_PY = REPO_ROOT / "scripts" / "mc1_regression" / "scenarios.py"
+PROCESSOR_SWIFT = (REPO_ROOT / "ios" / "LFAEducationCenter" / "MultiCamera"
+                   / "LivePoseOverlayProcessor.swift")
+
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+from mc1_regression.lib import (  # noqa: E402
+    DIAG_FRESHNESS_SKEW_TOLERANCE_S,
+    STALE_DIAG_SENTINEL_KEY,
+    load_fresh_diag,
+)
+
+
+# ── Contract extraction helpers ──────────────────────────────────────────────
+
+def swift_pose_writer_keys() -> set[str]:
+    """Keys PoseOverlayDiagWriter actually emits per panel: the
+    diagnosticSnapshot dictionary literal's string keys, plus the
+    sourceFramesSeen field panelDict() adds on top."""
+    src = PROCESSOR_SWIFT.read_text(encoding="utf-8")
+    snap = re.search(r"var diagnosticSnapshot: \[String: Any\] \{\s*\[(.*?)\]\s*\}", src, re.S)
+    assert snap, "diagnosticSnapshot dictionary not found in LivePoseOverlayProcessor.swift"
+    keys = set(re.findall(r'"(\w+)":', snap.group(1)))
+    if re.search(r'd\["sourceFramesSeen"\]\s*=', src):
+        keys.add("sourceFramesSeen")
+    return keys
+
+
+def scenario_pose_reader_keys() -> set[str]:
+    """Keys the tricamera scenario reads off a per-panel dict (panel.get(...))."""
+    src = SCENARIOS_PY.read_text(encoding="utf-8")
+    return set(re.findall(r'panel\.get\("(\w+)"', src))
+
+
+# ── Contract tests ───────────────────────────────────────────────────────────
+
+def test_pose_overlay_reader_keys_are_subset_of_writer_keys():
+    writer = swift_pose_writer_keys()
+    reader = scenario_pose_reader_keys()
+    assert reader, "scenarios.py reads no per-panel keys — extraction regex broke?"
+    missing = reader - writer
+    assert not missing, (
+        f"scenarios.py reads per-panel key(s) {sorted(missing)} that "
+        f"PoseOverlayDiagWriter never writes (writer emits: {sorted(writer)}). "
+        f"This is exactly the framesReceivedByProcessor bug class — fix the key "
+        f"name on one side."
+    )
+
+
+def test_pose_overlay_gate_uses_frames_received():
+    """The frame-traffic gate must read the writer's real counter key."""
+    assert "framesReceived" in scenario_pose_reader_keys()
+
+
+def test_phantom_key_framesreceivedbyprocessor_is_gone():
+    src = SCENARIOS_PY.read_text(encoding="utf-8")
+    assert "framesReceivedByProcessor" not in src, (
+        "framesReceivedByProcessor resurfaced in scenarios.py — this key has "
+        "never existed in the Swift writer and guarantees a false FAIL."
+    )
+
+
+def test_writer_emits_all_five_diagnostic_counters():
+    expected = {"framesReceived", "framesProcessed", "visionDetectionSuccesses",
+                "framesWithSkeletonPoints", "lastFrameReceivedAt"}
+    assert expected <= swift_pose_writer_keys()
+
+
+# ── Freshness loader tests (stale-artifact protection) ───────────────────────
+
+NOW = datetime.now(timezone.utc)
+
+
+def _write(tmp_path: Path, payload: dict) -> str:
+    p = tmp_path / "diag.json"
+    p.write_text(json.dumps(payload))
+    return str(p)
+
+
+def test_fresh_diag_is_accepted(tmp_path):
+    path = _write(tmp_path, {"timestamp": NOW.isoformat(), "udpPacketsReceived": 5})
+    diag, reason = load_fresh_diag(path, NOW - timedelta(seconds=30))
+    assert reason is None
+    assert diag["udpPacketsReceived"] == 5
+
+
+def test_sentinel_is_rejected(tmp_path):
+    path = _write(tmp_path, {STALE_DIAG_SENTINEL_KEY: True,
+                             "invalidated_at": NOW.isoformat(), "run_id": "x"})
+    diag, reason = load_fresh_diag(path, NOW - timedelta(seconds=30))
+    assert diag is None
+    assert "sentinel" in reason
+
+
+def test_stale_timestamp_is_rejected(tmp_path):
+    stale_ts = NOW - timedelta(seconds=DIAG_FRESHNESS_SKEW_TOLERANCE_S + 3600)
+    path = _write(tmp_path, {"timestamp": stale_ts.isoformat()})
+    diag, reason = load_fresh_diag(path, NOW)
+    assert diag is None
+    assert "predates scenario start" in reason
+
+
+def test_missing_timestamp_is_rejected(tmp_path):
+    path = _write(tmp_path, {"udpPacketsReceived": 99})
+    diag, reason = load_fresh_diag(path, NOW)
+    assert diag is None
+    assert "no freshness timestamp" in reason
+
+
+def test_generated_at_accepted_for_skeleton_output(tmp_path):
+    """skeleton_output.json uses generated_at (SkeletonProcessor) instead of
+    timestamp — both must satisfy the freshness check."""
+    path = _write(tmp_path, {"generated_at": NOW.isoformat(), "sampled_frames": 12})
+    diag, reason = load_fresh_diag(path, NOW - timedelta(seconds=30))
+    assert reason is None
+    assert diag["sampled_frames"] == 12
+
+
+def test_swift_iso8601_zulu_format_parses(tmp_path):
+    """ISO8601DateFormatter emits e.g. 2026-07-04T10:20:30Z — the Z suffix must
+    parse (datetime.fromisoformat rejects 'Z' before Python 3.11)."""
+    zulu = NOW.strftime("%Y-%m-%dT%H:%M:%SZ")
+    path = _write(tmp_path, {"timestamp": zulu})
+    diag, reason = load_fresh_diag(path, NOW - timedelta(seconds=30))
+    assert reason is None, f"Zulu-suffixed ISO8601 must be accepted, got: {reason}"
+
+
+def test_unparseable_json_is_rejected(tmp_path):
+    p = tmp_path / "diag.json"
+    p.write_text("{not json")
+    diag, reason = load_fresh_diag(str(p), NOW)
+    assert diag is None
+    assert "unreadable" in reason

--- a/scripts/run_mc1_regression.sh
+++ b/scripts/run_mc1_regression.sh
@@ -225,6 +225,29 @@ PYEOF
   fi
 fi
 
+# ── Dual-console hard precondition (tricamera scenarios) ──────────────────
+# The 2026-07-04 tricamera run failed on the PLAYER (iPad) side while the
+# WARN-only path above had silently skipped the iPad console capture — the
+# exact evidence the failure needed was never collected. Tricamera scenarios
+# exercise the player-side capture chain, so BOTH device consoles are a hard
+# precondition: both devices must be USB-connected, trusted, and visible to
+# idevicesyslog. (runner.py re-checks this — defense in depth.)
+if [[ "${SCENARIO}" == *tricamera* ]]; then
+  if [[ -z "${IPHONE_CONSOLE_PID}" || -z "${IPAD_CONSOLE_PID}" ]]; then
+    echo
+    echo "ERROR: scenario '${SCENARIO}' requires console capture from BOTH devices."
+    echo "  iPhone console capture: $([[ -n "${IPHONE_CONSOLE_PID}" ]] && echo running || echo MISSING)"
+    echo "  iPad   console capture: $([[ -n "${IPAD_CONSOLE_PID}" ]] && echo running || echo MISSING)"
+    echo
+    echo "  Connect BOTH devices via USB, trust this Mac on each, then verify:"
+    echo "    idevice_id -l   # must list both legacy UDIDs"
+    echo "  Manual overrides: IPHONE_LEGACY_UDID / IPAD_LEGACY_UDID env vars."
+    [[ -n "${IPHONE_CONSOLE_PID}" ]] && kill "${IPHONE_CONSOLE_PID}" 2>/dev/null || true
+    [[ -n "${IPAD_CONSOLE_PID}" ]]   && kill "${IPAD_CONSOLE_PID}"   2>/dev/null || true
+    exit 1
+  fi
+fi
+
 cleanup() {
   [[ -n "${IPAD_CONSOLE_PID:-}" ]]   && kill "${IPAD_CONSOLE_PID}"   2>/dev/null || true
   [[ -n "${IPHONE_CONSOLE_PID:-}" ]] && kill "${IPHONE_CONSOLE_PID}" 2>/dev/null || true

--- a/scripts/run_mc1_regression.sh
+++ b/scripts/run_mc1_regression.sh
@@ -146,19 +146,56 @@ if [[ -z "${_IDEVICESYSLOG}" ]]; then
 elif [[ -z "${_IDEVICEID}" ]]; then
   echo "WARNING: idevice_id not found. Console capture disabled."
 else
-  # Get all legacy UDIDs visible to libimobiledevice (USB-connected only).
-  # Optional override: set IPHONE_LEGACY_UDID / IPAD_LEGACY_UDID env vars to
-  # skip auto-detection (get them via: idevice_id -l).
-  _LEGACY_UDIDS="$("${_IDEVICEID}" -l 2>/dev/null || true)"
-  if [[ -z "${IPHONE_LEGACY_UDID:-}" ]]; then
-    _IPHONE_LEGACY_UDID="$(echo "${_LEGACY_UDIDS}" | head -1)"
-  else
+  # Map each CoreDevice UUID (IPHONE_UDID/IPAD_UDID) to its libimobiledevice
+  # legacy UDID via `devicectl list devices --json-output`, whose
+  # hardwareProperties.udid IS the legacy identifier. The previous approach
+  # (idevice_id -l | head -1 / sed -n 2p) assigned logs by ENUMERATION ORDER —
+  # if the list came back iPad-first, iphone_console.log silently contained the
+  # iPad's log and every console-log-grounded check read the wrong device
+  # (P0 hardening, 2026-07-04 review). Manual override env vars still win.
+  _map_legacy_udid() {  # $1 = CoreDevice UUID → prints legacy UDID or nothing
+    local coredevice_udid="$1"
+    local json_out
+    json_out="$(mktemp)"
+    if ! xcrun devicectl list devices --json-output "${json_out}" >/dev/null 2>&1; then
+      rm -f "${json_out}"
+      return 1
+    fi
+    python3 - "${json_out}" "${coredevice_udid}" <<'PYEOF'
+import json, sys
+data = json.load(open(sys.argv[1]))
+wanted = sys.argv[2].lower()
+for dev in data.get("result", {}).get("devices", []):
+    if str(dev.get("identifier", "")).lower() == wanted:
+        legacy = (dev.get("hardwareProperties", {}) or {}).get("udid", "")
+        if legacy:
+            print(legacy)
+        break
+PYEOF
+    rm -f "${json_out}"
+  }
+
+  if [[ -n "${IPHONE_LEGACY_UDID:-}" ]]; then
     _IPHONE_LEGACY_UDID="${IPHONE_LEGACY_UDID}"
-  fi
-  if [[ -z "${IPAD_LEGACY_UDID:-}" ]]; then
-    _IPAD_LEGACY_UDID="$(echo "${_LEGACY_UDIDS}" | sed -n '2p')"
   else
+    _IPHONE_LEGACY_UDID="$(_map_legacy_udid "${IPHONE_UDID}" || true)"
+  fi
+  if [[ -n "${IPAD_LEGACY_UDID:-}" ]]; then
     _IPAD_LEGACY_UDID="${IPAD_LEGACY_UDID}"
+  else
+    _IPAD_LEGACY_UDID="$(_map_legacy_udid "${IPAD_UDID}" || true)"
+  fi
+
+  # A mapped legacy UDID must actually be visible to libimobiledevice —
+  # otherwise idevicesyslog would just sit there producing an empty log.
+  _LEGACY_UDIDS="$("${_IDEVICEID}" -l 2>/dev/null || true)"
+  if [[ -n "${_IPHONE_LEGACY_UDID}" ]] && ! grep -qi "^${_IPHONE_LEGACY_UDID}$" <<<"${_LEGACY_UDIDS}"; then
+    echo "WARNING: mapped iPhone legacy UDID ${_IPHONE_LEGACY_UDID} not visible to idevice_id -l."
+    _IPHONE_LEGACY_UDID=""
+  fi
+  if [[ -n "${_IPAD_LEGACY_UDID}" ]] && ! grep -qi "^${_IPAD_LEGACY_UDID}$" <<<"${_LEGACY_UDIDS}"; then
+    echo "WARNING: mapped iPad legacy UDID ${_IPAD_LEGACY_UDID} not visible to idevice_id -l."
+    _IPAD_LEGACY_UDID=""
   fi
 
   if [[ -z "${_IPHONE_LEGACY_UDID}" ]]; then

--- a/tests/unit/multicamera/test_capture_cycles.py
+++ b/tests/unit/multicamera/test_capture_cycles.py
@@ -102,9 +102,12 @@ def active_session(db, users):
     db.add_all([md1, md2])
     db.flush()
 
+    # Both devices are player roles so the cycle has TWO required recorders —
+    # instructor_primary is a non-recording coordinator since MC2-PR1 and would
+    # not be part of the required set (role semantics covered by CC-02).
     sd1 = SessionDevice(
         session_id=s.id, device_id=md1.id, participant_id=p_inst.id,
-        device_role="instructor_primary", status="ready",
+        device_role="player_secondary", status="ready",
     )
     sd2 = SessionDevice(
         session_id=s.id, device_id=md2.id, participant_id=p_inst.id,
@@ -142,27 +145,38 @@ class TestCreateCycle:
         assert len(cycle.cycle_devices) == 2
 
     def test_cc_02_device_snapshot_required_flags(self, db, active_session):
-        """CC-02: auxiliary_camera device gets required=False, others True."""
+        """CC-02: only player roles are required recorders (MC2-PR1).
+
+        instructor_primary is a non-recording coordinator (final topology:
+        iPad instructor without camera); auxiliary_camera completion is
+        enforced at the regression-gate level. Both get required=False.
+        """
         s, p_inst, sd1, sd2 = active_session
         tag = _uuid.uuid4().hex[:8]
         md3 = ManagedDevice(owner_user_id=p_inst.user_id, device_type="gopro", device_name=f"GoPro-{tag}")
-        db.add(md3)
+        md4 = ManagedDevice(owner_user_id=p_inst.user_id, device_type="ipad", device_name=f"iPad-inst-{tag}")
+        db.add_all([md3, md4])
         db.flush()
         sd3 = SessionDevice(
             session_id=s.id, device_id=md3.id,
             managed_by_device_id=sd1.id,
             device_role="auxiliary_camera", status="ready",
         )
-        db.add(sd3)
+        sd4 = SessionDevice(
+            session_id=s.id, device_id=md4.id, participant_id=p_inst.id,
+            device_role="instructor_primary", status="ready",
+        )
+        db.add_all([sd3, sd4])
         db.flush()
 
         svc = CycleService(db)
         cycle = svc.create_cycle(s.session_uuid, "key-cc02", p_inst.id)
 
         required_map = {ccd.session_device_id: ccd.required for ccd in cycle.cycle_devices}
-        assert required_map[sd1.id] is True
-        assert required_map[sd2.id] is True
-        assert required_map[sd3.id] is False
+        assert required_map[sd1.id] is True   # player_secondary: required recorder
+        assert required_map[sd2.id] is True   # player_primary: required recorder
+        assert required_map[sd3.id] is False  # auxiliary (GoPro): gate-enforced
+        assert required_map[sd4.id] is False  # instructor: non-recording coordinator
 
     def test_cc_03_idempotent_duplicate_key_returns_existing(self, db, active_session):
         """CC-03: duplicate idempotency_key returns existing cycle, no new row."""

--- a/tests/unit/multicamera/test_cycle_timeout.py
+++ b/tests/unit/multicamera/test_cycle_timeout.py
@@ -79,8 +79,10 @@ def _make_active_session(db):
     db.add_all([md1, md2])
     db.flush()
 
+    # Two player roles → two REQUIRED recorders (instructor_primary is a
+    # non-recording coordinator since MC2-PR1 and is not in the required set).
     sd1 = SessionDevice(session_id=s.id, device_id=md1.id, participant_id=p.id,
-                        device_role="instructor_primary", status="ready")
+                        device_role="player_secondary", status="ready")
     sd2 = SessionDevice(session_id=s.id, device_id=md2.id, participant_id=p.id,
                         device_role="player_primary", status="ready")
     db.add_all([sd1, sd2])
@@ -274,8 +276,9 @@ class TestConcurrentTimeout:
             setup_db.add(md)
             setup_db.flush()
 
+            # player role → the single REQUIRED recorder this timeout test drives
             sd = SessionDevice(session_id=s.id, device_id=md.id, participant_id=p.id,
-                               device_role="instructor_primary", status="ready")
+                               device_role="player_primary", status="ready")
             setup_db.add(sd)
             setup_db.flush()
 


### PR DESCRIPTION
# MC2-PR1 — Non-recording instructor cycles (final-topology step 1)

Final topology (2026-07-12, user-approved): **iPad = non-recording instructor/coordinator, iPhone(s) = player recorders, GoPro = auxiliary camera managed by Player A.** Same-day architecture decision: the MPC/peer-to-peer layer is being removed entirely — backend-orchestrated coordination, local recording on every camera, post-cycle upload, audio-based fine sync, status/thumbnail dashboard (MC2-PR3+).

## Scope

| Layer | Change |
|---|---|
| Backend | `cycle_service.py`: required-recorder rule → **players-only** (`player_primary`, `player_secondary`); instructor and auxiliary are never required. Idempotent confirm_stop ordering fix. |
| iOS | `CycleCaptureOrchestrator.recordsLocally` flag: non-recording coordinator drives create/schedule/stop but produces **no local capture and no confirm** (a confirm without a capture file would be fabricated evidence); `shouldAutoPrepare(.instructorPrimary) = false`; lobby/dashboard guards so the iPad never opens a capture-purpose `AVCaptureSession`. |
| iOS (physical-run fix, `95f7b6a2`) | `stopCycle()` 409 stale-revision handling — see below. |
| Harness | Scenario asserts retargeted to the final topology (instructor `required=false` + `pending`, iPad negative capture evidence); static preflight contract updated (60 checks). |
| Docs | `MC2_MINIMAL_IMPLEMENTATION_PLAN.md` + gap analysis v1.1 (no-MPC roadmap). |

**Not touched:** MPC removal itself (MC2-PR3), dual-player (MC2-PR2), GoPro retargeting (MC2-PR4), upload pipeline (MC2-PR5), sync/calibration/3D (MC3/MC4). The stop-retry fix commit (`95f7b6a2`) modified **zero backend and zero harness code** — 1 iOS source file + 3 test files only.

> Note: this branch is stacked on the P0 hardening work (PR #356 / #358 commits are included here); merging this PR to `main` carries those commits.

## Physical validation — PASS (run `20260712T161914Z_smoke`, build `mc2-pr1-v2-2026-07-12`)

iPad = instructor (non-recording) + iPhone 12 Pro = player, staging backend, cycle 36:

- Instructor cycle_device `required=false`, stayed `pending`, `started_at/stopped_at = null` → **no fake confirmation**
- Player cycle_device `required=true`, `confirmed_start` 16:19:46.436Z → `confirmed_stop` 16:19:54.899Z
- Cycle final state: `status=completed`, `result=success`
- **iPad camera OFF:** console shows zero `startRunning` (only a never-started preview object init); snapshot `capture: idle`; **0 capture files** from this session on the iPad (33 legacy files all predate the topology switch)
- **iPhone device-level evidence:** `session_dde39cc9…_device_215_2026-07-12T161946Z.mov` (8.2 MB) physically present in the app container (pulled via `devicectl`)

## First run BLOCKED → root cause → fix

The first physical run (`20260712T155629Z_smoke`) passed registration/ready/confirmed_start and **failed at stop**: `409 revision conflict (expected 2, actual 3)`, cycle stuck in `recording`.

Root cause: the non-recording coordinator caches the cycle at schedule time (revision 2). In the legacy recording-instructor model its own confirm_start response refreshed the cache; without a self-confirm, the **player's** confirm_start advances the backend cycle revision invisibly, so `stopCycle()` sent a stale revision and had no 409 handling on the stop path (unlike the ORCH-5 activate path).

Fix (`95f7b6a2`): on 409, `stopCycle()` refetches the cycle once via `listCycles` and retries once with the fresh revision; a second 409, a failed refetch, or a missing cycle is terminal (`.revisionConflict`) — no retry loop. Flagged via the existing `revisionConflictRetried` diagnostic.

**Proven in the field:** the PASS run hit a real 409 at stop (18:19:51.596) and recovered through this exact path — final snapshot shows `revision_conflict_retried: yes`.

## Tests

- `CycleCaptureOrchestratorTests` **42/42** — incl. new **CYC-RC-05..08** (stale→refetch→stop success; double-409 terminal; refetch failure terminal; missing-cycle terminal)
- Combined CCO+PCO+PCOInstructorRoleGate+CaptureAuthority **77/77**
- Backend multicamera suite 216/216 (players-only required rule), harness static preflight 60/60

## Known follow-up (out of scope here)

Orphan capture recovery/cleanup: when a stop flow fails, the player keeps recording (the first BLOCKED run left a 333 MB orphan video on the iPhone). Tracked as a separate backlog item — not handled in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
